### PR TITLE
use basic CSP

### DIFF
--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -9,7 +9,7 @@ defmodule LightningWeb.Router do
     plug :fetch_live_flash
     plug :put_root_layout, {LightningWeb.LayoutView, :root}
     plug :protect_from_forgery
-    plug :put_secure_browser_headers
+    plug :put_secure_browser_headers, %{"content-security-policy" => "default-src 'self'"}
   end
 
   pipeline :api do


### PR DESCRIPTION
"Any policy is better than none" according to https://github.com/nccgroup/sobelow/issues/61#issuecomment-610660542 , and this is the recommended one.

Everything still seems to load OK on my end. Is this a sensible default?