### PR TITLE
Reintroduce layout components to fix diagram overscroll

### DIFF
--- a/lib/lightning_web.ex
+++ b/lib/lightning_web.ex
@@ -107,6 +107,7 @@ defmodule LightningWeb do
       alias PetalComponents.Heroicons
 
       alias LightningWeb.Components
+      alias Components.Layout
       alias Components.MainSection
       alias Components.Settings
       alias Components.Common

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -78,32 +78,4 @@ defmodule LightningWeb.Components.Common do
     </div>
     """
   end
-
-  # https://play.tailwindcss.com/r7kBDT2cJY?layout=horizontal
-  def page_content(assigns) do
-    ~H"""
-    <div class="flex h-full w-full flex-col">
-      <%= render_slot(@header) %>
-      <div class="flex-auto bg-secondary-100 relative">
-        <div class="overflow-y-auto absolute top-0 bottom-0 left-0 right-0">
-          <%= render_slot(@inner_block) %>
-        </div>
-      </div>
-    </div>
-    """
-  end
-
-  def header(assigns) do
-    ~H"""
-    <div class="flex-none bg-white shadow-sm z-10">
-      <div class="max-w-7xl mx-auto h-20 sm:px-6 lg:px-8 flex items-center">
-        <h1 class="text-3xl font-bold text-secondary-900">
-          <%= @title %>
-        </h1>
-        <div class="grow"></div>
-        <%= if assigns[:inner_block], do: render_slot(@inner_block) %>
-      </div>
-    </div>
-    """
-  end
 end

--- a/lib/lightning_web/live/components/layout.ex
+++ b/lib/lightning_web/live/components/layout.ex
@@ -1,0 +1,76 @@
+defmodule LightningWeb.Components.Layout do
+  @moduledoc """
+  Layout Components
+  """
+  use LightningWeb, :component
+
+  # https://play.tailwindcss.com/r7kBDT2cJY?layout=horizontal
+  def page_content(assigns) do
+    ~H"""
+    <div class="flex h-full w-full flex-col">
+      <%= render_slot(@header) %>
+      <div class="flex-auto bg-secondary-100 relative">
+        <section
+          id="inner_content"
+          class="overflow-y-auto absolute top-0 bottom-0 left-0 right-0"
+        >
+          <%= render_slot(@inner_block) %>
+        </section>
+      </div>
+    </div>
+    """
+  end
+
+  def header(assigns) do
+    ~H"""
+    <div class="flex-none bg-white shadow-sm z-10">
+      <div class="max-w-7xl mx-auto h-20 sm:px-6 lg:px-8 flex items-center">
+        <h1 class="text-3xl font-bold text-secondary-900">
+          <%= @title %>
+        </h1>
+        <div class="grow"></div>
+        <%= if assigns[:inner_block], do: render_slot(@inner_block) %>
+        <%= if assigns[:socket] do %>
+          <div class="w-5" />
+          <.dropdown js_lib="live_view_js">
+            <:trigger_element>
+              <div class="inline-flex items-center justify-center w-full align-middle focus:outline-none">
+                <.avatar size="sm" />
+                <Heroicons.Solid.chevron_down class="w-4 h-4 ml-1 -mr-1 text-secondary-400 dark:text-secondary-100" />
+              </div>
+            </:trigger_element>
+            <.dropdown_menu_item
+              link_type="live_redirect"
+              to={Routes.user_settings_path(@socket, :edit)}
+            >
+              <Heroicons.Outline.cog class="w-5 h-5 text-secondary-500" />
+              User Profile
+            </.dropdown_menu_item>
+            <.dropdown_menu_item
+              link_type="live_redirect"
+              to={Routes.credential_index_path(@socket, :index)}
+            >
+              <Heroicons.Outline.key class="w-5 h-5 text-secondary-500" />
+              Credentials
+            </.dropdown_menu_item>
+            <.dropdown_menu_item
+              link_type="live_redirect"
+              to={Routes.user_session_path(@socket, :delete)}
+            >
+              <Heroicons.Outline.logout class="w-5 h-5 text-secondary-500" /> Logout
+            </.dropdown_menu_item>
+          </.dropdown>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  def centered(assigns) do
+    ~H"""
+    <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+end

--- a/lib/lightning_web/live/dashboard_live/index.html.heex
+++ b/lib/lightning_web/live/dashboard_live/index.html.heex
@@ -1,16 +1,19 @@
-<MainSection.header socket={@socket} title={@page_title} />
-
-<%= if @live_action == :index do %>
-  <%= if @projects == nil do %>
-    <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-      No project found, please talk to your administrator.
-    </div>
+<Layout.page_content>
+  <:header>
+    <Layout.header title={@page_title} socket={@socket} />
+  </:header>
+  <%= if @live_action == :index do %>
+    <%= if @projects == nil do %>
+      <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        No project found, please talk to your administrator.
+      </div>
+    <% end %>
+  <% else %>
+    <.live_component
+      module={LightningWeb.Components.WorkflowDiagram}
+      id={@project.id}
+      project={@project}
+      selected_id={@selected_id}
+    />
   <% end %>
-<% else %>
-  <.live_component
-    module={LightningWeb.Components.WorkflowDiagram}
-    id={@project.id}
-    project={@project}
-    selected_id={@selected_id}
-  />
-<% end %>
+</Layout.page_content>

--- a/lib/lightning_web/live/job_live/edit.html.heex
+++ b/lib/lightning_web/live/job_live/edit.html.heex
@@ -1,12 +1,15 @@
-<MainSection.header socket={@socket} title={"#{@job.name}"} />
-
-<MainSection.main>
-  <.live_component
-    module={LightningWeb.JobLive.BigFormComponent}
-    id={@job.id || :new}
-    action={@live_action}
-    job={@job}
-    project={@project}
-    return_to={Routes.project_job_index_path(@socket, :index, @project.id)}
-  />
-</MainSection.main>
+<Layout.page_content>
+  <:header>
+    <Layout.header title={@job.name} socket={@socket} />
+  </:header>
+  <Layout.centered>
+    <.live_component
+      module={LightningWeb.JobLive.BigFormComponent}
+      id={@job.id || :new}
+      action={@live_action}
+      job={@job}
+      project={@project}
+      return_to={Routes.project_job_index_path(@socket, :index, @project.id)}
+    />
+  </Layout.centered>
+</Layout.page_content>

--- a/lib/lightning_web/live/job_live/index.html.heex
+++ b/lib/lightning_web/live/job_live/index.html.heex
@@ -1,91 +1,102 @@
-<MainSection.header socket={@socket} title={@page_title} />
-
-<MainSection.main>
-  <%= if @live_action == :show do %>
-    <.show_job {assigns} />
-  <% end %>
-
-  <%= if @live_action in [:new, :edit] do %>
-    <.live_component
-      module={LightningWeb.JobLive.BigFormComponent}
-      id={@job.id || :new}
-      title={@page_title}
-      action={@live_action}
-      job={@job}
-      project={@project}
-      return_to={Routes.project_job_index_path(@socket, :index, @project.id)}
-    />
-  <% end %>
-  <%= if @live_action == :index do %>
-    <.table>
-      <.tr>
-        <.th>Name</.th>
-        <.th>Body</.th>
-        <.th>Webhook URL</.th>
-        <.th>Enabled</.th>
-        <.th>Actions</.th>
-      </.tr>
-      <%= for job <- @page.entries do %>
-        <.tr id={"job-#{job.id}"}>
-          <.td class="col-span-2"><%= job.name %></.td>
-          <.td class="col-span-3"><%= job.body %></.td>
-          <.td class="col-span-4">
-            <%= if job.trigger.type == :webhook do %>
-              <.button
-                title="Click to copy the webhook url"
-                onclick="(function(e) {  navigator.clipboard.writeText(e.target.innerText); e.preventDefault(); })(event)"
-              >
-                <%= Routes.webhooks_url(@socket, :create, [job.id]) %>
-              </.button>
-            <% end %>
-          </.td>
-          <.td class="col-span-1"><%= job.enabled %></.td>
-          <.td class="col-span-2">
-            <span>
-              <%= live_redirect("Show",
-                to:
-                  Routes.project_job_index_path(
-                    @socket,
-                    :show,
-                    @project.id,
-                    job
-                  )
-              ) %>
-            </span>
-            |
-            <span>
-              <%= live_redirect("Edit",
-                to:
-                  Routes.project_job_edit_path(
-                    @socket,
-                    :edit,
-                    @project.id,
-                    job
-                  ),
-                class: "button"
-              ) %>
-            </span>
-            |
-            <span>
-              <%= link("Delete",
-                to: "#",
-                phx_click: "delete",
-                phx_value_id: job.id,
-                data: [confirm: "Are you sure?"]
-              ) %>
-            </span>
-          </.td>
-        </.tr>
+<Layout.page_content>
+  <:header>
+    <Layout.header title={@page_title} socket={@socket}>
+      <%= if @live_action == :index do %>
+        <%= live_patch to: Routes.project_job_index_path(@socket, :new, @project.id) do %>
+          <Common.button>
+            <div class="h-full">
+              <Icon.plus class="h-4 w-4 inline-block" />
+              <span class="inline-block align-middle">New Job</span>
+            </div>
+          </Common.button>
+        <% end %>
       <% end %>
-    </.table>
+    </Layout.header>
+  </:header>
+  <Layout.centered>
+    <%= if @live_action == :show do %>
+      <.show_job {assigns} />
+    <% end %>
 
-    <.divider />
-    <span>
-      <%= live_patch("New Job",
-        to: Routes.project_job_index_path(@socket, :new, @project.id)
-      ) %>
-    </span>
-    <.divider />
-    <LightningWeb.Pagination.pagination_bar page={@page} url={@pagination_path} />
-  <% end %>
-</MainSection.main>
+    <%= if @live_action in [:new, :edit] do %>
+      <.live_component
+        module={LightningWeb.JobLive.BigFormComponent}
+        id={@job.id || :new}
+        title={@page_title}
+        action={@live_action}
+        job={@job}
+        project={@project}
+        return_to={Routes.project_job_index_path(@socket, :index, @project.id)}
+      />
+    <% end %>
+    <%= if @live_action == :index do %>
+      <.table>
+        <.tr>
+          <.th>Name</.th>
+          <.th>Body</.th>
+          <.th>Webhook URL</.th>
+          <.th>Enabled</.th>
+          <.th>Actions</.th>
+        </.tr>
+        <%= for job <- @page.entries do %>
+          <.tr id={"job-#{job.id}"}>
+            <.td class="col-span-2"><%= job.name %></.td>
+            <.td class="col-span-3"><%= job.body %></.td>
+            <.td class="col-span-4">
+              <%= if job.trigger.type == :webhook do %>
+                <.button
+                  title="Click to copy the webhook url"
+                  onclick="(function(e) {  navigator.clipboard.writeText(e.target.innerText); e.preventDefault(); })(event)"
+                >
+                  <%= Routes.webhooks_url(@socket, :create, [job.id]) %>
+                </.button>
+              <% end %>
+            </.td>
+            <.td class="col-span-1"><%= job.enabled %></.td>
+            <.td class="col-span-2">
+              <span>
+                <%= live_redirect("Show",
+                  to:
+                    Routes.project_job_index_path(
+                      @socket,
+                      :show,
+                      @project.id,
+                      job
+                    )
+                ) %>
+              </span>
+              |
+              <span>
+                <%= live_redirect("Edit",
+                  to:
+                    Routes.project_job_edit_path(
+                      @socket,
+                      :edit,
+                      @project.id,
+                      job
+                    ),
+                  class: "button"
+                ) %>
+              </span>
+              |
+              <span>
+                <%= link("Delete",
+                  to: "#",
+                  phx_click: "delete",
+                  phx_value_id: job.id,
+                  data: [confirm: "Are you sure?"]
+                ) %>
+              </span>
+            </.td>
+          </.tr>
+        <% end %>
+      </.table>
+
+      <.divider />
+      <LightningWeb.Pagination.pagination_bar
+        page={@page}
+        url={@pagination_path}
+      />
+    <% end %>
+  </Layout.centered>
+</Layout.page_content>

--- a/test/lightning_web/live/job_live_test.exs
+++ b/test/lightning_web/live/job_live_test.exs
@@ -40,7 +40,7 @@ defmodule LightningWeb.JobLiveTest do
 
       assert html =~ "Jobs"
 
-      table = view |> element("section#inner") |> render()
+      table = view |> element("section#inner_content") |> render()
       assert table =~ "job-#{job.id}"
       refute table =~ "job-#{other_job.id}"
     end


### PR DESCRIPTION
All pages need to be migrated to this pattern:

```heex
<Layout.page_content>
  <:header>
    <!-- Same header as before -->
    <Layout.header title={@page_title} socket={@socket} />
  </:header>

  <Layout.centered>
  <!-- Main inner content -->
  </Layout.centered>
</Layout.page_content>
```