### PR TITLE
Dataclip type dropdown

### DIFF
--- a/lib/lightning/invocation/dataclip.ex
+++ b/lib/lightning/invocation/dataclip.ex
@@ -75,4 +75,8 @@ defmodule Lightning.Invocation.Dataclip do
         changeset
     end
   end
+
+  def get_types do
+    @source_types
+  end
 end

--- a/lib/lightning_web/live/credential_live/form_component.html.heex
+++ b/lib/lightning_web/live/credential_live/form_component.html.heex
@@ -90,7 +90,6 @@
           to: Routes.credential_index_path(@socket, :index)
         ) %>
       </span>
-      |
       <span>
         <%= submit("Save",
           phx_disable_with: "Saving...",

--- a/lib/lightning_web/live/dataclip_live/edit.html.heex
+++ b/lib/lightning_web/live/dataclip_live/edit.html.heex
@@ -1,12 +1,17 @@
-<MainSection.header socket={@socket} title={"#{@dataclip.id || @page_title}"} />
-
-<MainSection.main>
-  <.live_component
-    module={LightningWeb.DataclipLive.FormComponent}
-    id={@dataclip.id || :new}
-    action={@live_action}
-    dataclip={@dataclip}
-    project={@project}
-    return_to={Routes.project_dataclip_index_path(@socket, :index, @project.id)}
-  />
-</MainSection.main>
+<Layout.page_content>
+  <:header>
+    <Layout.header socket={@socket} title={"#{@dataclip.id || @page_title}"} />
+  </:header>
+  <Layout.centered>
+    <.live_component
+      module={LightningWeb.DataclipLive.FormComponent}
+      id={@dataclip.id || :new}
+      action={@live_action}
+      dataclip={@dataclip}
+      project={@project}
+      return_to={
+        Routes.project_dataclip_index_path(@socket, :index, @project.id)
+      }
+    />
+  </Layout.centered>
+</Layout.page_content>

--- a/lib/lightning_web/live/dataclip_live/form_component.ex
+++ b/lib/lightning_web/live/dataclip_live/form_component.ex
@@ -8,13 +8,16 @@ defmodule LightningWeb.DataclipLive.FormComponent do
 
   @impl true
   def update(%{dataclip: dataclip, project: project} = assigns, socket) do
+    types = Lightning.Invocation.Dataclip.get_types()
+
     changeset =
       Invocation.change_dataclip(dataclip, %{"project_id" => project.id})
 
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(:changeset, changeset)}
+     |> assign(:changeset, changeset)
+     |> assign(:types, Enum.zip(types, types))}
   end
 
   @impl true

--- a/lib/lightning_web/live/dataclip_live/form_component.ex
+++ b/lib/lightning_web/live/dataclip_live/form_component.ex
@@ -5,6 +5,7 @@ defmodule LightningWeb.DataclipLive.FormComponent do
   use LightningWeb, :live_component
 
   alias Lightning.Invocation
+  import LightningWeb.Components.Form
 
   @impl true
   def update(%{dataclip: dataclip, project: project} = assigns, socket) do

--- a/lib/lightning_web/live/dataclip_live/form_component.html.heex
+++ b/lib/lightning_web/live/dataclip_live/form_component.html.heex
@@ -9,31 +9,32 @@
   >
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
+        <%= label(f, :type, class: "block text-sm font-medium text-secondary-700") %>
+        <div class="flex w-full items-center gap-2 pb-3">
+          <div class="grow">
+            <.select_field
+              selected="global"
+              form={f}
+              name={:type}
+              id="type"
+              values={@types}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="grid grid-cols-6 gap-6">
+      <div class="col-span-3">
         <%= label(f, :body, class: "block text-sm font-medium text-secondary-700") %>
         <%= textarea(f, :body,
-          class: "block w-full rounded-md",
+          class:
+            "rounded-md w-full font-mono bg-secondary-800 text-secondary-50 h-96",
           phx_debounce: "blur"
         ) %>
         <%= error_tag(f, :body,
           class:
             "mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
         ) %>
-      </div>
-    </div>
-    <div class="grid grid-cols-6 gap-6">
-      <div class="col-span-3">
-        <%= label(f, :type, class: "block text-sm font-medium text-secondary-700") %>
-        <div class="flex w-full items-center gap-2 pb-3">
-          <div class="grow">
-            <LightningWeb.Components.Form.select_field
-              form={f}
-              name={:type}
-              prompt=""
-              id="type"
-              values={@types}
-            />
-          </div>
-        </div>
       </div>
     </div>
     <div class="hidden sm:block" aria-hidden="true">
@@ -47,7 +48,6 @@
           to: Routes.project_dataclip_index_path(@socket, :index, @project)
         ) %>
       </span>
-      |
       <span>
         <%= submit("Save",
           phx_disable_with: "Saving...",

--- a/lib/lightning_web/live/dataclip_live/form_component.html.heex
+++ b/lib/lightning_web/live/dataclip_live/form_component.html.heex
@@ -23,14 +23,17 @@
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
         <%= label(f, :type, class: "block text-sm font-medium text-secondary-700") %>
-        <%= text_input(f, :type,
-          class: "block w-full rounded-md",
-          phx_debounce: "blur"
-        ) %>
-        <%= error_tag(f, :type,
-          class:
-            "mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
-        ) %>
+        <div class="flex w-full items-center gap-2 pb-3">
+          <div class="grow">
+            <LightningWeb.Components.Form.select_field
+              form={f}
+              name={:type}
+              prompt=""
+              id="type"
+              values={@types}
+            />
+          </div>
+        </div>
       </div>
     </div>
     <div class="hidden sm:block" aria-hidden="true">

--- a/lib/lightning_web/live/dataclip_live/index.html.heex
+++ b/lib/lightning_web/live/dataclip_live/index.html.heex
@@ -1,55 +1,58 @@
-<MainSection.header socket={@socket} title={@page_title}>
-  <%= live_redirect to: Routes.project_dataclip_edit_path(@socket, :new, @project.id) do %>
-    <Common.button>
-      <div class="h-full">
-        <Icon.plus class="h-4 w-4 inline-block" />
-        <span class="inline-block align-middle">New Dataclip</span>
-      </div>
-    </Common.button>
-  <% end %>
-</MainSection.header>
-
-<MainSection.main>
-  <.table>
-    <.tr>
-      <.th>Created</.th>
-      <.th>Type</.th>
-      <.th>Body</.th>
-      <.th>Actions</.th>
-    </.tr>
-
-    <%= for dataclip <- @page.entries do %>
-      <.tr id={"dataclip-#{dataclip.id}"}>
-        <.td>
-          <%= dataclip.inserted_at |> Calendar.strftime("%c") %>
-        </.td>
-        <.td><.type_pill dataclip={dataclip} /></.td>
-        <.td><%= dataclip.body %></.td>
-
-        <.td>
-          <span>
-            <%= live_redirect("Edit",
-              to:
-                Routes.project_dataclip_edit_path(
-                  @socket,
-                  :edit,
-                  @project.id,
-                  dataclip
-                )
-            ) %>
-          </span>
-          |
-          <span>
-            <%= link("Delete",
-              to: "#",
-              phx_click: "delete",
-              phx_value_id: dataclip.id,
-              data: [confirm: "Are you sure?"]
-            ) %>
-          </span>
-        </.td>
+<Layout.page_content>
+  <:header>
+    <Layout.header socket={@socket} title={@page_title}>
+      <%= live_redirect to: Routes.project_dataclip_edit_path(@socket, :new, @project.id) do %>
+        <Common.button>
+          <div class="h-full">
+            <Heroicons.Solid.plus class="h-4 w-4 inline-block" />
+            <span class="inline-block align-middle">New Dataclip</span>
+          </div>
+        </Common.button>
+      <% end %>
+    </Layout.header>
+  </:header>
+  <Layout.centered>
+    <.table>
+      <.tr>
+        <.th>Created</.th>
+        <.th>Type</.th>
+        <.th>Body</.th>
+        <.th>Actions</.th>
       </.tr>
-    <% end %>
-  </.table>
-  <LightningWeb.Pagination.pagination_bar page={@page} url={@pagination_path} />
-</MainSection.main>
+
+      <%= for dataclip <- @page.entries do %>
+        <.tr id={"dataclip-#{dataclip.id}"}>
+          <.td>
+            <%= dataclip.inserted_at |> Calendar.strftime("%c") %>
+          </.td>
+          <.td><.type_pill dataclip={dataclip} /></.td>
+          <.td><%= dataclip.body %></.td>
+
+          <.td>
+            <span>
+              <%= live_redirect("Edit",
+                to:
+                  Routes.project_dataclip_edit_path(
+                    @socket,
+                    :edit,
+                    @project.id,
+                    dataclip
+                  )
+              ) %>
+            </span>
+            |
+            <span>
+              <%= link("Delete",
+                to: "#",
+                phx_click: "delete",
+                phx_value_id: dataclip.id,
+                data: [confirm: "Are you sure?"]
+              ) %>
+            </span>
+          </.td>
+        </.tr>
+      <% end %>
+    </.table>
+    <LightningWeb.Pagination.pagination_bar page={@page} url={@pagination_path} />
+  </Layout.centered>
+</Layout.page_content>


### PR DESCRIPTION
Closes #186 

Two important things in this PR:

1. We're no longer using Petal. So all check boxes in the issue #186  about Petal should be removed.
2. In the Form component we 2 select components. The <.select> component doesn't accept the form attribute and I couldn't make it work with that attribute. After some time investigating I found out that we have another component named <.select_field> which seems easier to use and accepts the form attribute. That component is also being used in the Jobs module. So I finally used that one to achieve my work. But I wanna raise the discussion here.

- Why do we have two components for doing select ?
- What is the main difference between the two ?
- Which one are we going to drop and which are we going to use ?

@stuartc and @taylordowns2000 