### PR TITLE
A Dockerfile for devs; better README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ POSTGRES_DB="lightning_${MIX_ENV}"
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}"
 
 # Generate a secure key, see ./DEPLOYMENT.md
-PRIMARY_ENCRYPTION_KEY=generateYourOwnSecureKey
+PRIMARY_ENCRYPTION_KEY=0bJ9w+hn4ebQrsCaWXuA9JY49fP9kbHmywGd5K7k+/s=
 
 # Should Docker restart your containers if they go down in unexpected ways?
 #DOCKER_RESTART_POLICY=unless-stopped

--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,8 @@ POSTGRES_DB="lightning_${MIX_ENV}"
 # database settings above
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}"
 
-PRIMARY_ENCRYPTION_KEY=
+# Generate a secure key, see ./DEPLOYMENT.md
+PRIMARY_ENCRYPTION_KEY=generateYourOwnSecureKey
 
 # Should Docker restart your containers if they go down in unexpected ways?
 #DOCKER_RESTART_POLICY=unless-stopped

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "proseWrap": "always", "printWidth": 80 }

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -29,7 +29,8 @@ Note that for secure deployments, it's recommended to use a combination of
 - `PRIMARY_ENCRYPTION_KEY` - a base64 encoded 32 character long string.
   See [Encryption](#encryption).
 - `ADAPTORS_PATH` - where you store your locally installed adaptors
-- `LIGHTNING_LISTEN_ADDRESS`": "0.0.0.0",
+- `LIGHTNING_LISTEN_ADDRESS`" - the address the web server should bind to,
+  defaults to `0.0.0.0`
 - `LOG_LEVEL` - how noisy you want the logs to be (e.g. `debug`, `info`)
 - `MIX_ENV` - your mix env, likely `prod` for deployment
 - `NODE_ENV` - node env, likely `production` for deployment

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,10 +16,26 @@ mix lightning.gen_encryption_key
 0bJ9w+hn4ebQrsCaWXuA9JY49fP9kbHmywGd5K7k+/s=
 ```
 
-Copy your key (NOT THIS ONE) and set it as `PRIMARY_ENCRYPTION_KEY` in your
+Copy your key _(NOT THIS ONE)_ and set it as `PRIMARY_ENCRYPTION_KEY` in your
 environment.
 
 ## Environment Variables
 
-- `PRIMARY_ENCRYPTION_KEY`  
-  Base64 encoded 32 character long string. See [Encryption](#encryption).
+Note that for secure deployments, it's recommended to use a combination of
+`secrets` and `configMaps` to generate secure environment variables.
+
+- `SECRET_KEY_BASE` - a secret key used as a base to generate secrets for
+  encrypting and signing data.
+- `PRIMARY_ENCRYPTION_KEY` - a base64 encoded 32 character long string.
+  See [Encryption](#encryption).
+- `ADAPTORS_PATH` - where you store your locally installed adaptors
+- `LIGHTNING_LISTEN_ADDRESS`": "0.0.0.0",
+- `LOG_LEVEL` - how noisy you want the logs to be (e.g. `debug`, `info`)
+- `MIX_ENV` - your mix env, likely `prod` for deployment
+- `NODE_ENV` - node env, likely `production` for deployment
+- `ORIGINS` - the allowed origins for web traffic to the backend
+- `PORT` - the port your Phoenix app runs on
+- `SENTRY_DSN` - if using Sentry for error monitoring, your DSN
+- `URL_HOST` - the host, used for writing urls (e.g., `demo.openfn.org`)
+- `URL_PORT` - the port, usually `443` for production
+- `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,24 +2,24 @@
 
 ## Encryption
 
-Lightning enforces encryption at rest for Credentials, for which an 
-encryption key must be provided when running in production.
+Lightning enforces encryption at rest for Credentials, for which an encryption
+key must be provided when running in production.
 
-The key is expected to be a randomized set of bytes, 32 long; and Base64
-encoded when setting the environment variable.
+The key is expected to be a randomized set of bytes, 32 long; and Base64 encoded
+when setting the environment variable.
 
-There is a mix task that can generate keys in the correct shape for use
-as an environment variable:
+There is a mix task that can generate keys in the correct shape for use as an
+environment variable:
 
 ```sh
 mix lightning.gen_encryption_key
 0bJ9w+hn4ebQrsCaWXuA9JY49fP9kbHmywGd5K7k+/s=
 ```
 
-Copy the key and set it as `PRIMARY_ENCRYPTION_KEY` in your environment.
+Copy your key (NOT THIS ONE) and set it as `PRIMARY_ENCRYPTION_KEY` in your
+environment.
 
 ## Environment Variables
 
 - `PRIMARY_ENCRYPTION_KEY`  
   Base64 encoded 32 character long string. See [Encryption](#encryption).
-

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,117 @@
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian instead of
+# Alpine to avoid DNS resolution issues in production.
+#
+# https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=ubuntu
+# https://hub.docker.com/_/ubuntu?tab=tags
+#
+#
+# This file is based on these images:
+#
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20210902-slim - for the release image
+#   - https://pkgs.org/ - resource for finding needed packages
+#   - Ex: hexpm/elixir:1.13.2-erlang-24.2.1-debian-bullseye-20210902-slim
+#
+ARG ELIXIR_VERSION=1.13.4
+ARG OTP_VERSION=24.2.1
+ARG DEBIAN_VERSION=bullseye-20210902-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} as dev
+
+# install build and dev dependencies
+RUN apt-get update -y && apt-get install -y \
+  build-essential curl git inotify-tools
+
+# isntall nodejs using nodesource
+# https://github.com/nodesource/distributions/blob/master/README.md#deb
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
+
+RUN apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# prepare build dir
+WORKDIR /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+  mix local.rebar --force
+
+# set build ENV
+
+ARG MIX_ENV="dev"
+ENV MIX_ENV=${MIX_ENV}
+
+COPY mix.* ./
+RUN mix deps.get --only $MIX_ENV
+
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config config
+RUN mix deps.compile
+
+COPY priv priv
+RUN mix openfn.install.runtime
+
+COPY lib lib
+COPY bin bin
+COPY assets assets
+RUN npm install --prefix assets
+
+
+ENTRYPOINT ["/app/bin/entrypoint"]
+
+ARG PORT
+EXPOSE ${PORT}
+
+CMD ["mix", "phx.server"]
+
+################################################################################
+
+# TODO push the builder layer into a 'prod' layer, and prepend it with a 'builder'
+# layer that does the releases build
+
+FROM ${BUILDER_IMAGE} as builder
+
+# compile assets
+RUN mix assets.deploy
+
+# Compile the release
+COPY lib lib
+
+RUN mix compile
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /app/_build/prod/rel/lightning ./
+
+USER nobody
+
+CMD ["/app/bin/server"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -15,20 +15,20 @@
 ARG ELIXIR_VERSION=1.13.4
 ARG OTP_VERSION=24.2.1
 ARG DEBIAN_VERSION=bullseye-20210902-slim
+ARG NODE_VERSION=16.15.1
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
 FROM ${BUILDER_IMAGE} as dev
+ARG NODE_VERSION
 
 # install build and dev dependencies
 RUN apt-get update -y && apt-get install -y \
   build-essential curl git inotify-tools
 
-# isntall nodejs using nodesource
-# https://github.com/nodesource/distributions/blob/master/README.md#deb
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
+COPY bin/install_node bin/install_node
+RUN bin/install_node ${NODE_VERSION}
 
 RUN apt-get clean && rm -f /var/lib/apt/lists/*_*
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
 By default the application will be running at
 [localhost:4000](http://localhost:4000/).
 
-You can then rebuild and run with `docker compose build` and `docker compose up`. See ["Problems with Docker"](#problems-with-docker) for additional
-troubleshooting help. Note that you can also create your own `docker-compose.yml` file, configuring a postgres database and using a [pre-built image](https://hub.docker.com/repository/docker/openfn/lightning)
+You can then rebuild and run with `docker compose build` and
+`docker compose up`. See ["Problems with Docker"](#problems-with-docker) for
+additional troubleshooting help. Note that you can also create your own
+`docker-compose.yml` file, configuring a postgres database and using a
+[pre-built image](https://hub.docker.com/repository/docker/openfn/lightning)
 from Dockerhub.
 
 ## **Deploy** on external infrastructure

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
 
 ## **Run** via Docker
 
-1. Install [Docker](https://docs.docker.com/engine/install/)
+1. Install the latest version of [Docker](https://docs.docker.com/engine/install/)
 2. Clone the repo using git
 3. Copy the `.env.example` file to `.env`
 4. Run `docker compose run --rm web mix ecto.migrate`
@@ -157,6 +157,18 @@ You can generate the HTML and EPUB documentation locally using:
 ## Troubleshooting
 
 ### Problems with Docker
+
+#### Versions
+
+The build may not work on old versions of Docker and Docker compose. It has been
+tested against:
+
+```
+Docker version 20.10.17, build 100c701
+Docker Compose version v2.6.0
+```
+
+#### Starting from scratch
 
 If you're actively working with docker, you start experiencing issues, and you
 would like to start from scratch you can clean up everything and start over like

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ your Postgres setup and your ENVs.
 
 #### Database Setup
 
-**If you're already using Postgres**, run `createdb lightning_dev` to create a
-new database for use with Lightning.
+If you're already using Postgres locally, create a new database called
+`lightning_dev`, for example.
 
-**If you'd rather use Docker** to set up a Postgres DB, create a new volume and
+If you'd rather use Docker to set up a Postgres DB, create a new volume and
 image:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
 - If you want to [_**CONTRIBUTE**_](#contribute-to-this-project) to the project,
   we recommend setting up Elixir on your local machine.
 
-### **Run** via Docker
+## **Run** via Docker
 
 1. Install [Docker](https://docs.docker.com/engine/install/)
 2. Clone the repo using git

--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
 
 ## Getting Started
 
-If you only want to **run** Lightning on your own server, we recommend using
-Docker.
-
-If you want to **deploy** Lightning, we recommend Docker builds and Kubernetes.
-
-If you want to **contribute** to the project, we recommend setting up Elixir on
-your local machine.
+- If you only want to [_**RUN**_](#run-via-docker) Lightning on your own server,
+  we recommend using Docker.
+- If you want to [_**DEPLOY**_](#deploy-on-external-infrastructure) Lightning,
+  we recommend Docker builds and Kubernetes.
+- If you want to [_**CONTRIBUTE**_](#contribute-to-this-project) to the project,
+  we recommend setting up Elixir on your local machine.
 
 ### **Run** via Docker
 

--- a/README.md
+++ b/README.md
@@ -18,23 +18,14 @@ projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
 1. Install [Docker](https://docs.docker.com/engine/install/)
 2. Clone the repo using git
 3. Copy the `.env.example` file to `.env`
-4. Run docker compose with either a
-   [pre-built image](https://hub.docker.com/repository/docker/openfn/lightning)
-   or building your own.
-
-| Option         | Command                                                                    |
-| -------------- | -------------------------------------------------------------------------- |
-| Pre-built      | `docker compose run --rm web mix ecto.migrate`                             |
-| Build your own | `docker compose run -f docker-compose.build.yml --rm web mix ecto.migrate` |
-
-Once you've done that, run `docker compose up` every time you want to start up
-the server.
+4. Run `docker compose run --rm web mix ecto.migrate`
 
 By default the application will be running at
 [localhost:4000](http://localhost:4000/).
 
-See ["Problems with Docker"](#problems-with-docker) for additional
-troubleshooting help.
+You can then rebuild and run with `docker compose build` and `docker compose up`. See ["Problems with Docker"](#problems-with-docker) for additional
+troubleshooting help. Note that you can also create your own `docker-compose.yml` file, configuring a postgres database and using a [pre-built image](https://hub.docker.com/repository/docker/openfn/lightning)
+from Dockerhub.
 
 ## **Deploy** on external infrastructure
 
@@ -95,6 +86,7 @@ mix local.rebar --force
 mix ecto.create # Create a development database in Postgres
 mix ecto.migrate
 mix openfn.install.runtime
+npm install --prefix assets
 ```
 
 ### Run the app

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
    [pre-built image](https://hub.docker.com/repository/docker/openfn/lightning)
    or building your own.
 
-| Option    | Command                                                                    |
-| --------- | -------------------------------------------------------------------------- |
-| Pre-built | `docker compose run --rm web mix ecto.migrate`                             |
-| BYO       | `docker compose run -f docker-compose.build.yml --rm web mix ecto.migrate` |
+| Option         | Command                                                                    |
+| -------------- | -------------------------------------------------------------------------- |
+| Pre-built      | `docker compose run --rm web mix ecto.migrate`                             |
+| Build your own | `docker compose run -f docker-compose.build.yml --rm web mix ecto.migrate` |
 
 Once you've done that, run `docker compose up` every time you want to start up
 the server.

--- a/README.md
+++ b/README.md
@@ -2,60 +2,71 @@
 
 Lightning extends the existing [OpenFn](https://www.openfn.org) Digital Public
 Good, providing a web UI to visually manage complex workflow automation
-projects.
+projects. Learn more about OpenFn at [docs.openfn.org](https://docs.openfn.org).
 
-## Deployment
+## Getting Started
+
+If you only want to **run** Lightning on your own server, we recommend using
+Docker.
+
+If you want to **deploy** Lightning, we recommend Docker builds and Kubernetes.
+
+If you want to **contribute** to the project, we recommend setting up Elixir on
+your local machine.
+
+### **Run** via Docker
+
+1. Install [Docker](https://docs.docker.com/engine/install/)
+2. Clone the repo using git
+3. Copy the `.env.example` file to `.env`
+4. Run docker compose with either a
+   [pre-built image](https://hub.docker.com/repository/docker/openfn/lightning)
+   or building your own.
+
+| Option    | Command                                                                    |
+| --------- | -------------------------------------------------------------------------- |
+| Pre-built | `docker compose run --rm web mix ecto.migrate`                             |
+| BYO       | `docker compose run -f docker-compose.build.yml --rm web mix ecto.migrate` |
+
+Once you've done that, run `docker compose up` every time you want to start up
+the server.
+
+By default the application will be running at
+[localhost:4000](http://localhost:4000/).
+
+See ["Problems with Docker"](#problems-with-docker) for additional
+troubleshooting help.
+
+## **Deploy** on external infrastructure
 
 See [Deployment](DEPLOYMENT.md) for more detailed information.
 
-## Setting up
+## **Contribute** to this project
 
-The easiest way to set up Lightning is via Docker. We have included the
-necessary files to get everything setup using Docker Compose.
+Lightning is built in [Elixir](https://elixir-lang.org/), harnessing the
+[Phoenix Framework](https://www.phoenixframework.org/). Currently, the only
+unbundled dependency is a [PostgreSQL](https://www.postgresql.org/) database.
 
-If you'd like to contribute or set things up locally for development, checkout the [Contributing](#contributing) section.
+### Set up your environment
 
-### Steps
-
-- Install [Docker](https://docs.docker.com/engine/install/)
-- Check out the repo using git
-- Copy the `.env.example` file to `.env`
-- Run `docker compose run --rm web mix ecto.migrate`  
-  This will build the container, and set the database up with the up to date schema.
-
-Once you've done that, you can run `docker compose up` every time you want to
-start up the server.
-
-By default the application will be available from [localhost:4000](http://localhost:4000/).
-
-### Troubleshooting
-
-If you're actively working with docker, start experiencing issues and would like
-to start from scratch you can clean up everything and start over like this:
+#### Clone the repo and set ENVs
 
 ```sh
-# To remove any ignored files and reset your .env to it's example
-git clean -fdx && cp .env.example .env
-# You can skip the line below if you want to keep your database
-docker compose down --rmi all --volumes
-
-docker compose build --no-cache web && \
-  docker compose create --force-recreate
-
-docker compose run --rm web mix ecto.migrate
-docker compose up
+git clone git@github.com:OpenFn/Lightning.git
+cd Lightning
+cp .env.example .env # and adjust as necessary!
 ```
 
-## Contributing
+Take note of database names and ports in particular—they've got to match across
+your Postgres setup and your ENVs.
 
-We appreciate any contribution to Lightning.
+#### Database Setup
 
-### Setting up locally
+**If you're already using Postgres**, run `createdb lightning_dev` to create a
+new database for use with Lightning.
 
-**Database**
-
-Ensure you have a PostgreSQL database setup and running, here is an example
-to get it running quickly using docker.
+**If you'd rather use Docker** to set up a Postgres DB, create a new volume and
+image:
 
 ```sh
 docker volume create lightning-postgres-data
@@ -70,11 +81,12 @@ docker create \
 docker start lightning-postgres
 ```
 
-**Elixir & Ecto**
+#### Elixir & Ecto Setup
 
-We use [asdf](https://github.com/asdf-vm/asdf) to help with our local environments.
-Included in the repo is a `.tool-versions` file that is read by asdf in order
-to dynamically make the specified versions of Elixir and Erlang available.
+We use [asdf](https://github.com/asdf-vm/asdf) to configure our local
+environments. Included in the repo is a `.tool-versions` file that is read by
+asdf in order to dynamically make the specified versions of Elixir and Erlang
+available.
 
 ```sh
 asdf install  # Install language versions
@@ -88,10 +100,17 @@ mix openfn.install.runtime
 
 ### Run the app
 
-Lightning is a web app. To run it, start the development server by running `mix phx.server`.
-Once the server has started, head to [`localhost:4000`](http://localhost:4000) in your browser.
+Lightning is a web app. To run it in interactive Elixir mode, start the
+development server by running with your environment variables by running:
 
-## Running Tests
+```sh
+env $(cat .env | grep -v "#" | xargs ) iex -S mix phx.server
+```
+
+Once the server has started, head to [`localhost:4000`](http://localhost:4000)
+in your browser.
+
+### Run the tests
 
 Before the first time running the tests, you need a test database setup.
 
@@ -105,9 +124,10 @@ And then after that run the tests using:
 MIX_ENV=test mix test
 ```
 
-We also have `test.watch` installed which can be used to rerun the tests on file changes.
+We also have `test.watch` installed which can be used to rerun the tests on file
+changes.
 
-## Security and Standards
+### Security and Standards
 
 We use a host of common Elixir static analysis tools to help us avoid common
 pitfalls and make sure we keep everything clean and consistent.
@@ -118,23 +138,45 @@ In addition to our test suite, you can run the following commands:
   Code formatting checker, run again without the `--check-formatted` flag to
   have your code automatically changed.
 - `mix dialyzer`  
-  Static analysis for type mismatches and other common warnings.
-  See [dialyxir](https://github.com/jeremyjh/dialyxir).
+  Static analysis for type mismatches and other common warnings. See
+  [dialyxir](https://github.com/jeremyjh/dialyxir).
 - `mix credo`  
-  Static analysis for consistency, and coding standards.
-  See [Credo](https://github.com/rrrene/credo).
+  Static analysis for consistency, and coding standards. See
+  [Credo](https://github.com/rrrene/credo).
 - `mix sobelow`  
-  Check for commonly known security exploits. See [Sobelow](https://sobelow.io/).
+  Check for commonly known security exploits. See
+  [Sobelow](https://sobelow.io/).
 - `MIX_ENV=test mix coveralls`  
-  Test coverage reporter. This command also runs the test suite, and can be
-  used in place of `mix test` when checking everything before pushing your code.
-  See [excoveralls](https://github.com/parroty/excoveralls).
+  Test coverage reporter. This command also runs the test suite, and can be used
+  in place of `mix test` when checking everything before pushing your code. See
+  [excoveralls](https://github.com/parroty/excoveralls).
 
 > For convenience there is a `verify` mix task that runs all of the above and
 > defaults the `MIX_ENV` to `test`.
 
-## Generating Documentation
+### Generating Documentation
 
 You can generate the HTML and EPUB documentation locally using:
 
 `mix docs` and opening `doc/index.html` in your browser.
+
+## Troubleshooting
+
+### Problems with Docker
+
+If you're actively working with docker, you start experiencing issues, and you
+would like to start from scratch you can clean up everything and start over like
+this:
+
+```sh
+# To remove any ignored files and reset your .env to it's example
+git clean -fdx && cp .env.example .env
+# You can skip the line below if you want to keep your database
+docker compose down --rmi all --volumes
+
+docker compose build --no-cache web && \
+  docker compose create --force-recreate
+
+docker compose run --rm web mix ecto.migrate
+docker compose up
+```

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -17,8 +17,9 @@ config :lightning, Lightning.Repo,
 # with esbuild to bundle .js and .css sources.
 config :lightning, LightningWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
-  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  # Change to `ip: {127, 0, 0, 1}` to block access from other machines.
+  # Note that this may interfere with Docker networking.
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
           cpus: "${DOCKER_WEB_CPUS:-0}"
           memory: "${DOCKER_WEB_MEMORY:-0}"
     healthcheck:
-      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/}"
+      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}"
       interval: "60s"
       timeout: "3s"
       start_period: "5s"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 x-lightning: &default-app
   build:
+    dockerfile: Dockerfile-dev
     context: "."
     target: "${MIX_ENV:-dev}"
     args:
@@ -38,7 +39,7 @@ services:
           cpus: "${DOCKER_WEB_CPUS:-0}"
           memory: "${DOCKER_WEB_MEMORY:-0}"
     healthcheck:
-      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}"
+      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/}"
       interval: "60s"
       timeout: "3s"
       start_period: "5s"


### PR DESCRIPTION
This proposes a new `README` and a `Dockerfile-dev` for building development docker images. @elias-ba , @stuartc , care to kick the tires and let me know what you think?

This addresses #208 , @NickGowdy , and works properly on my linux machine, but is a little complex in that it involves maintaining two different `Dockerfiles`, one for building the released images to Dockerhub and the other for building developer friendly* images. In the future, maybe we could combine them?

Biggest change is the README... in short:
1. if you just want to **run**, use docker
2. if you want to **deploy**, see the deployment file (work in progress)
3. if you want to **contribute**, set up a DB however you like then run it as a mix app (with IEX)

Thoughts?

*Stu, the dev friendly one is just what you'd set up back in April with a few small version and npm changes.