### PR TITLE
Transfer Credential Ownership

### DIFF
--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -22,7 +22,14 @@ defmodule LightningWeb.CredentialLive.FormComponent do
        all_projects: all_projects,
        changeset: changeset,
        available_projects: filter_available_projects(changeset, all_projects),
-       selected_project: ""
+       selected_project: "",
+       users:
+         Enum.map(Lightning.Accounts.list_users(), fn user ->
+           [
+             key: "#{user.first_name} #{user.last_name} (#{user.email})",
+             value: user.id
+           ]
+         end)
      )}
   end
 

--- a/lib/lightning_web/live/credential_live/form_component.html.heex
+++ b/lib/lightning_web/live/credential_live/form_component.html.heex
@@ -25,7 +25,19 @@
             class: "rounded-md w-full font-mono bg-slate-800 text-slate-50 h-96"
           ) %>
         </div>
-
+        <%= if @action in [:edit] do %>
+          <div class="mt-2">
+            <%= label(f, :owner,
+              class: "block text-sm font-medium text-secondary-700"
+            ) %>
+            <%= error_tag(f, :user_id) %>
+            <LightningWeb.Components.Form.select_field
+              form={f}
+              name={:user_id}
+              values={@users}
+            />
+          </div>
+        <% end %>
         <div class="mt-2">
           <LightningWeb.Components.Form.check_box form={f} id={:production} />
         </div>
@@ -99,11 +111,11 @@
         ) %>
       </span>
       <span>
-        <%= submit("Save",
-          phx_disable_with: "Saving...",
-          class:
-            "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-        ) %>
+        <LightningWeb.Components.Form.submit_button
+          value="Save"
+          disable_with="Saving..."
+          changeset={@changeset}
+        />
       </span>
     </div>
   </.form>

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -106,6 +106,7 @@ defmodule LightningWeb.Router do
 
       live "/credentials", CredentialLive.Index, :index
       live "/credentials/new", CredentialLive.Edit, :new
+      live "/credentials/transfer", CredentialLive.Edit, :transfer_ownership
       live "/credentials/:id", CredentialLive.Edit, :edit
 
       live "/", DashboardLive.Index, :index


### PR DESCRIPTION
This PR ships code that implements the credential transferring feature. A credential can only be transferred to another user if that user is part of all the projects where the credential is being used. Otherwise a validation error message will pop up and block the process. For now transferring a credential is a matter of editing one and changing the `user_id` field. Later we may decide the best UI for this. I made sure to not display the transferring logic when creating a new credential.