### PR TITLE
Fix/improve debug loggin in Runner

### DIFF
--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -24,12 +24,15 @@ defmodule Lightning.Pipeline.Runner do
 
     @impl true
     def on_finish(result, run: run, scrubber: scrubber) do
-      debug do
+      Logger.debug(fn ->
+        # coveralls-ignore-start
         result.log
-        |> Enum.each(fn line ->
-          Logger.debug("#{String.slice(run.id, -5..-1)} : #{line}")
+        |> Enum.map(fn line ->
+          "\n#{String.slice(run.id, -5..-1)} : #{line}"
         end)
-      end
+
+        # coveralls-ignore-stop
+      end)
 
       scrubbed_log = Lightning.Scrubber.scrub(scrubber, result.log)
 
@@ -40,14 +43,6 @@ defmodule Lightning.Pipeline.Runner do
       })
 
       Runner.create_dataclip_from_result(result, run)
-    end
-
-    defp debug(do: block) do
-      if Logger.compare_levels(Logger.level(), :debug) == :eq do
-        # coveralls-ignore-start
-        block.call()
-        # coveralls-ignore-stop
-      end
     end
   end
 


### PR DESCRIPTION
It appears that the conditional logging function I wrote isn't correct. 
The one liner fix would have been to remove the `.call()` from `block` in the `debug` function in Runner.

However, I think using the function argument style for `Logger.debug` is cleaner.

```
{"at": "2022-07-25T10:47:01.427386Z", "error": "** (UndefinedFunctionError) function :ok.call/0 is undefined (module :ok is not available)\n :ok.call()\n (lightning 0.1.7) lib/lightning/pipeline/runner.ex:27: Lightning.Pipeline.Runner.Handler.on_finish/2\n (lightning 0.1.7) lib/engine/run/handler.ex:90: Lightning.Pipeline.Runner.Handler.wait/1\n (lightning 0.1.7) lib/lightning/pipeline.ex:31: Lightning.Pipeline.process/1\n (oban 2.12.1) lib/oban/queue/executor.ex:128: Oban.Queue.Executor.perform/1\n (oban 2.12.1) lib/oban/queue/executor.ex:73: Oban.Queue.Executor.call/1\n (elixir 1.13.4) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2\n (elixir 1.13.4) lib/task/supervised.ex:34: Task.Supervised.reply/4\n (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3\n", "attempt": 1}
```