### PR TITLE
[WIP] 214 credentials side menu

### DIFF
--- a/lib/lightning_web/templates/layout/menu_items.html.heex
+++ b/lib/lightning_web/templates/layout/menu_items.html.heex
@@ -46,4 +46,17 @@
     <Icon.dataclips class="h-5 w-5 inline-block mr-2" />
     <span class="inline-block align-middle">Dataclips</span>
   </Settings.menu_item>
+  <% else %>
+  <Settings.menu_item
+    to={Routes.user_settings_path(@socket, :edit)}
+  >
+    <Heroicons.Outline.cog class="h-5 w-5 inline-block mr-2" />
+    User Profile
+  </Settings.menu_item>
+  <Settings.menu_item
+    to={Routes.credential_index_path(@socket, :index)}
+  >
+    <Heroicons.Outline.key class="h-5 w-5 inline-block mr-2" />
+    Credentials
+  </Settings.menu_item>
 <% end %>


### PR DESCRIPTION
## Description 
A work in progress, Added **Credentials** and one for **User Profile** links on the side menu when there is no `assigns[:project]` 

![Screenshot from 2022-08-10 16-27-08](https://user-images.githubusercontent.com/6592749/183915546-e46dc3f5-b9e8-49d7-986a-de5bd4cd1b3c.png)

Refer to #214 
