### PR TITLE
Rename users_tokens to user_tokens

### DIFF
--- a/lib/lightning/accounts/user_token.ex
+++ b/lib/lightning/accounts/user_token.ex
@@ -38,7 +38,7 @@ defmodule Lightning.Accounts.UserToken do
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
-  schema "users_tokens" do
+  schema "user_tokens" do
     field :token, :binary
     field :context, :string
     field :sent_to, :string

--- a/priv/repo/migrations/20220817063920_rename_users_tokens.exs
+++ b/priv/repo/migrations/20220817063920_rename_users_tokens.exs
@@ -1,0 +1,38 @@
+defmodule Lightning.Repo.Migrations.RenameUsersTokens do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:users_tokens), to: table(:user_tokens))
+
+    rename_constraint("user_tokens",
+      from: "users_tokens_user_id_fkey",
+      to: "user_tokens_user_id_fkey"
+    )
+
+    rename_index(from: "users_tokens_pkey", to: "user_tokens_pkey")
+    rename_index(from: "users_tokens_context_token_index", to: "user_tokens_context_token_index")
+    rename_index(from: "users_tokens_user_id_index", to: "user_tokens_user_id_index")
+  end
+
+  defp rename_constraint(table, from: from, to: to) do
+    execute(
+      """
+      ALTER TABLE #{table} RENAME CONSTRAINT "#{from}" TO "#{to}";
+      """,
+      """
+      ALTER TABLE #{table} RENAME CONSTRAINT "#{to}" TO "#{from}";
+      """
+    )
+  end
+
+  defp rename_index(from: from, to: to) do
+    execute(
+      """
+      ALTER INDEX #{from} RENAME TO #{to};
+      """,
+      """
+      ALTER INDEX #{to} RENAME TO #{from};
+      """
+    )
+  end
+end


### PR DESCRIPTION
Compounded table names should be singular-plural, so `users_tokens` has been renamed to `user_tokens` - all indexes and constraints have been renamed as well.