### PR TITLE
Fix monaco jumping cursor

### DIFF
--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -72,6 +72,7 @@ export default function Editor({ source, adaptor, onChange }: EditorProps) {
   
   useEffect(() => {
     if (adaptor) {
+      setLib([]); // instantly clear intelligence
       loadDTS(adaptor).then(l => setLib(l));
     }
   }, [adaptor])

--- a/lib/lightning_web/live/job_live/inspector_form_component.ex
+++ b/lib/lightning_web/live/job_live/inspector_form_component.ex
@@ -155,6 +155,7 @@ defmodule LightningWeb.JobLive.InspectorFormComponent do
               class="rounded-md border border-secondary-300 shadow-sm h-96 bg-vs-dark"
               data-adaptor={Phoenix.HTML.Form.input_value(f, :adaptor)}
               data-hidden-input={Phoenix.HTML.Form.input_id(f, :body)}
+              data-job-id={@id}
             />
             <Form.hidden_input form={f} id={:body} />
           </div>


### PR DESCRIPTION
Monaco is currently broken in two hilarious ways!

1) Every keystroke is triggering the MutationObserver to fire, which causes the component to re-render like mad, which (for some reason but perhaps not surprisingly) is causing the cursor to skip around.

2) If you select multiple jobs in in the workflow editor, Monaco will update - but only if the adaptor happens to be different. This isn't very good.

This MR fixes this by tightening up the MutationObserver logic and explicitly tracking the selected job id.

Also, as a bonus, when changing adaptors, we now instantly clear out the type definitions in Monaco before we go and look for the new dts. This means intellisense will update immediately and drop the old adaptor types instead of waiting for the new stuff to come down.