### PR TITLE
Add job from diagram

### DIFF
--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -16,6 +16,7 @@ defmodule Lightning.Accounts do
   alias Lightning.Credentials
   alias Lightning.Projects
 
+  @spec purge_user(id :: Ecto.UUID.t()) :: :ok
   def purge_user(id) do
     Logger.debug(fn -> "Purging user ##{id}..." end)
 

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -59,6 +59,25 @@ defmodule LightningWeb.WorkflowLive do
     )
   end
 
+  defp apply_action(socket, :new_job, %{"upstream_id" => upstream_id}) do
+    upstream_job = Lightning.Jobs.get_job!(upstream_id)
+
+    job = %Lightning.Jobs.Job{
+      project_id: socket.assigns.project.id,
+      trigger: %Lightning.Jobs.Trigger{
+        type: :on_job_success,
+        upstream_job_id: upstream_job.id
+      }
+    }
+
+    socket
+    |> assign(
+      active_menu_item: :overview,
+      job: job,
+      page_title: socket.assigns.project.name
+    )
+  end
+
   defp apply_action(socket, :edit_job, %{"job_id" => job_id}) do
     job = Lightning.Jobs.get_job!(job_id)
 
@@ -103,6 +122,25 @@ defmodule LightningWeb.WorkflowLive do
       </:header>
       <div class="relative h-full">
         <%= case @live_action do %>
+          <% :new_job -> %>
+            <div class="absolute top-0 right-0 m-2 z-10">
+              <div class="w-80 bg-white rounded-md shadow-xl ring-1 ring-black ring-opacity-5 p-3">
+                <.live_component
+                  module={LightningWeb.JobLive.InspectorFormComponent}
+                  id="new-job"
+                  job={@job}
+                  action={:new}
+                  project={@project}
+                  return_to={
+                    Routes.project_workflow_path(
+                      @socket,
+                      :show,
+                      @project.id
+                    )
+                  }
+                />
+              </div>
+            </div>
           <% :edit_job -> %>
             <div class="absolute top-0 right-0 m-2 z-10">
               <div class="w-80 bg-white rounded-md shadow-xl ring-1 ring-black ring-opacity-5 p-3">

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -104,6 +104,7 @@ defmodule LightningWeb.Router do
         live "/dataclips/new", DataclipLive.Edit, :new
         live "/dataclips/:id/edit", DataclipLive.Edit, :edit
 
+        live "/j/new", WorkflowLive, :new_job
         live "/j/:job_id", WorkflowLive, :edit_job
         live "/w/:workflow_id", WorkflowLive, :edit_workflow
         live "/", WorkflowLive, :show

--- a/test/support/fixtures/jobs_fixtures.ex
+++ b/test/support/fixtures/jobs_fixtures.ex
@@ -12,10 +12,15 @@ defmodule Lightning.JobsFixtures do
   """
   @spec job_fixture(attrs :: []) :: Lightning.Jobs.Job.t()
   def job_fixture(attrs \\ []) when is_list(attrs) do
-    {:ok, job} =
+    attrs =
       attrs
       |> Keyword.put_new_lazy(:project_id, fn -> project_fixture().id end)
-      |> Keyword.put_new_lazy(:workflow_id, fn -> workflow_fixture().id end)
+
+    {:ok, job} =
+      attrs
+      |> Keyword.put_new_lazy(:workflow_id, fn ->
+        workflow_fixture(project_id: attrs[:project_id]).id
+      end)
       |> Enum.into(%{
         body: "fn(state => state)",
         enabled: true,


### PR DESCRIPTION
Closes #145

This gives us a first pass approach; when clicking the "+" button on the diagram, it shows the inspector with two fields pre-filled on the trigger, `upstream_id` and `type` ("on_job_success").
