### PR TITLE
Add more tests to workflows creation

### DIFF
--- a/lib/lightning/jobs/job.ex
+++ b/lib/lightning/jobs/job.ex
@@ -91,6 +91,7 @@ defmodule Lightning.Jobs.Job do
 
   defp maybe_add_workflow(%Ecto.Changeset{valid?: true} = changeset) do
     {
+      changeset.data.trigger |> Map.get(:type),
       get_field(changeset, :workflow_id),
       with %Ecto.Changeset{} = trigger_changeset <-
              get_change(changeset, :trigger),
@@ -101,7 +102,9 @@ defmodule Lightning.Jobs.Job do
       end
     }
     |> case do
-      {nil, trigger_type} when trigger_type in [:cron, :webhook] ->
+      # case: having a brand new cron or webhook job should always put assoc a workflow to a job
+      {nil, nil, current_trigger_type}
+      when current_trigger_type in [:cron, :webhook] ->
         changeset
         |> put_assoc(
           :workflow,
@@ -113,45 +116,32 @@ defmodule Lightning.Jobs.Job do
           )
         )
 
-      {workflow_id, trigger_type}
-      when trigger_type in [:cron, :webhook] and workflow_id != nil ->
-        case changeset.data.trigger |> Map.get(:type) do
-          x when x in [:cron, :webhook] ->
-            changeset
-
-          x when x in [:on_job_success, :on_job_failure] ->
-            {:ok, %Workflow{id: id}} =
-              Workflows.create_workflow(%{
-                project_id: get_field(changeset, :project_id)
-              })
-
-            changeset
-            |> put_change(
-              :workflow_id,
-              id
-            )
-
-          _ ->
-            changeset
-        end
-
-      {_workflow_id, trigger_type}
-      when trigger_type in [:on_job_success, :on_job_failure] ->
+      # case: creating a brand new flow job, or changing a flow jobs type should always assign the downstream job's workflow to it's parent workflow
+      {_initial_trigger_type, _workflow_id, current_trigger_type}
+      when current_trigger_type in [:on_job_success, :on_job_failure] ->
         upstream_job =
           get_change(changeset, :trigger)
           |> get_field(:upstream_job_id)
-          |> case do
-            nil -> nil
-            job_id -> Jobs.get_job(job_id)
-          end
+          |> Jobs.get_job()
 
-        if is_nil(upstream_job) do
-          changeset
-        else
-          changeset |> put_change(:workflow_id, upstream_job.workflow_id)
-        end
+        changeset |> put_change(:workflow_id, upstream_job.workflow_id)
 
-      {_, _} ->
+      # case: converting a downstream job to a webhook or cron job, should always create a new workflow and assign that to it
+      {initial_trigger_type, _, current_trigger_type}
+      when initial_trigger_type in [:on_job_success, :on_job_failure] and
+             current_trigger_type in [:cron, :webhook] ->
+        {:ok, %Workflow{id: id}} =
+          Workflows.create_workflow(%{
+            project_id: get_field(changeset, :project_id)
+          })
+
+        changeset
+        |> put_change(
+          :workflow_id,
+          id
+        )
+
+      {_, _, _} ->
         changeset
     end
   end

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -228,7 +228,7 @@ defmodule Lightning.JobsTest do
     test "update_job/2 from upstream_job A (in workflow 1) to upstream_job B (in workflow 2) changes the updated job's workflow_id to 2" do
       project_id = project_fixture().id
 
-      {:ok, %Job{} = parent_job_1} =
+      {:ok, %Job{} = upstream_job_1} =
         Jobs.create_job(%{
           body: "some body",
           enabled: true,
@@ -238,7 +238,7 @@ defmodule Lightning.JobsTest do
           project_id: project_id
         })
 
-      {:ok, %Job{} = parent_job_2} =
+      {:ok, %Job{} = upstream_job_2} =
         Jobs.create_job(%{
           body: "some body",
           enabled: true,
@@ -254,22 +254,22 @@ defmodule Lightning.JobsTest do
           enabled: true,
           name: "some name",
           adaptor: "@openfn/language-common",
-          trigger: %{type: "on_job_success", upstream_job_id: parent_job_1.id},
+          trigger: %{type: "on_job_success", upstream_job_id: upstream_job_1.id},
           project_id: project_id
         })
 
-      assert downstream_job_a.workflow_id == parent_job_1.workflow_id
+      assert downstream_job_a.workflow_id == upstream_job_1.workflow_id
 
       {:ok, %Job{} = downstream_job_a} =
         Jobs.update_job(downstream_job_a, %{
           trigger: %{
             id: downstream_job_a.trigger.id,
             type: "on_job_success",
-            upstream_job_id: parent_job_2.id
+            upstream_job_id: upstream_job_2.id
           }
         })
 
-      assert downstream_job_a.workflow_id == parent_job_2.workflow_id
+      assert downstream_job_a.workflow_id == upstream_job_2.workflow_id
     end
 
     test "update_job/2 from upstream_job A (in workflow 1) to cron or webhook creates a new workflow and changes the updated job's workflow_id to THAT new workflow" do

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -300,13 +300,15 @@ defmodule Lightning.JobsTest do
       workflows_before = Workflows.list_workflows()
       count_workflows_before = Enum.count(workflows_before)
 
-      {:ok, %Job{} = webhook_job} =
+      {:ok, %Job{} = downstream_job} =
         Jobs.update_job(downstream_job, %{
           trigger: %{
             id: downstream_job.trigger.id,
             type: "webhook"
           }
         })
+
+      assert downstream_job.trigger.upstream_job_id == nil
 
       workflows_after = Workflows.list_workflows()
       count_workflows_after = Enum.count(workflows_after)
@@ -316,13 +318,13 @@ defmodule Lightning.JobsTest do
 
       assert Enum.member?(
                Enum.map(workflows_before, fn w -> w.id end),
-               webhook_job.workflow_id
+               downstream_job.workflow_id
              )
              |> Kernel.not()
 
       assert Enum.member?(
                Enum.map(workflows_after, fn w -> w.id end),
-               webhook_job.workflow_id
+               downstream_job.workflow_id
              )
     end
 


### PR DESCRIPTION
This PR improves the `maybe_add_workflow` function which decides how to assign a job to a Workflow depending on it's Trigger type.

Closes #239 