### PR TITLE
Move job and dataclip relations from Event to Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 - Add seed data for demo site
 - create adaptor credentials through a form
 - Redirect users to projects list page when they click on Admin Settings menu
+- Move job, project, input and output Dataclips to Run table
 
 ## [0.2.0] - 2022-09-12
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -27,7 +27,10 @@ defmodule Lightning.Invocation do
       |> Event.changeset(%{dataclip_id: dataclip_id})
     end)
     |> Multi.insert(:run, fn %{event: %Event{id: event_id}} ->
-      Run.changeset(%Run{}, %{event_id: event_id})
+      Run.changeset(%Run{}, %{
+        event_id: event_id,
+        project_id: event_attrs[:project_id]
+      })
     end)
     |> Repo.transaction()
   end
@@ -44,7 +47,10 @@ defmodule Lightning.Invocation do
       Event.changeset(%Event{}, event_attrs)
     end)
     |> Multi.insert(:run, fn %{event: %Event{id: event_id}} ->
-      Run.changeset(%Run{}, %{event_id: event_id})
+      Run.changeset(%Run{}, %{
+        event_id: event_id,
+        project_id: event_attrs[:project_id]
+      })
     end)
     |> Repo.transaction()
   end

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -26,11 +26,15 @@ defmodule Lightning.Invocation do
       Event.changeset(%Event{}, event_attrs)
       |> Event.changeset(%{dataclip_id: dataclip_id})
     end)
-    |> Multi.insert(:run, fn %{event: %Event{id: event_id}} ->
+    |> Multi.insert(:run, fn %{
+                               event: %Event{id: event_id},
+                               dataclip: %Dataclip{id: dataclip_id}
+                             } ->
       Run.changeset(%Run{}, %{
         event_id: event_id,
         project_id: event_attrs[:project_id],
-        job_id: event_attrs[:job_id]
+        job_id: event_attrs[:job_id],
+        input_dataclip_id: dataclip_id
       })
     end)
     |> Repo.transaction()
@@ -51,7 +55,8 @@ defmodule Lightning.Invocation do
       Run.changeset(%Run{}, %{
         event_id: event_id,
         project_id: event_attrs[:project_id],
-        job_id: event_attrs[:job_id]
+        job_id: event_attrs[:job_id],
+        input_dataclip_id: event_attrs[:dataclip_id]
       })
     end)
     |> Repo.transaction()

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -29,7 +29,8 @@ defmodule Lightning.Invocation do
     |> Multi.insert(:run, fn %{event: %Event{id: event_id}} ->
       Run.changeset(%Run{}, %{
         event_id: event_id,
-        project_id: event_attrs[:project_id]
+        project_id: event_attrs[:project_id],
+        job_id: event_attrs[:job_id]
       })
     end)
     |> Repo.transaction()
@@ -49,7 +50,8 @@ defmodule Lightning.Invocation do
     |> Multi.insert(:run, fn %{event: %Event{id: event_id}} ->
       Run.changeset(%Run{}, %{
         event_id: event_id,
-        project_id: event_attrs[:project_id]
+        project_id: event_attrs[:project_id],
+        job_id: event_attrs[:job_id]
       })
     end)
     |> Repo.transaction()

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -137,23 +137,15 @@ defmodule Lightning.Invocation do
   @doc """
   Query for retrieving the dataclip that was the result of a successful run.
   """
-  def get_result_dataclip_query(%Run{id: run_id}) do
-    from(d in Dataclip,
-      join: e in assoc(d, :source_event),
-      join: r in assoc(e, :run),
-      where: r.id == ^run_id and d.type == :run_result
-    )
+  def get_result_dataclip_query(%Run{} = run) do
+    Ecto.assoc(run, :output_dataclip)
   end
 
   @doc """
   Query for retrieving the dataclip that a runs starting dataclip.
   """
-  def get_dataclip_query(%Run{id: run_id}) do
-    from(d in Dataclip,
-      join: e in assoc(d, :events),
-      join: r in assoc(e, :run),
-      where: r.id == ^run_id
-    )
+  def get_dataclip_query(%Run{} = run) do
+    Ecto.assoc(run, :input_dataclip)
   end
 
   @doc """

--- a/lib/lightning/invocation/dataclip.ex
+++ b/lib/lightning/invocation/dataclip.ex
@@ -18,7 +18,7 @@ defmodule Lightning.Invocation.Dataclip do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lightning.Invocation.Event
+  alias Lightning.Invocation.{Event, Run}
   alias Lightning.Projects.Project
 
   @type t :: %__MODULE__{
@@ -41,6 +41,8 @@ defmodule Lightning.Invocation.Dataclip do
     belongs_to :project, Project
     belongs_to :source_event, Event
     has_many :events, Event
+
+    has_one :source_run, Run, foreign_key: :output_dataclip_id
 
     timestamps(usec: true)
   end

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -8,6 +8,7 @@ defmodule Lightning.Invocation.Run do
   use Ecto.Schema
   import Ecto.Changeset
   alias Lightning.Invocation.Event
+  alias Lightning.Projects.Project
 
   @type t :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
@@ -23,10 +24,11 @@ defmodule Lightning.Invocation.Run do
     field :log, {:array, :string}
     field :started_at, :utc_datetime_usec
     belongs_to :event, Event
-    has_one :job, through: [:event, :job]
-    has_one :project, through: [:event, :project]
-    has_one :source_dataclip, through: [:event, :dataclip]
 
+    belongs_to :project, Project
+
+    has_one :job, through: [:event, :job]
+    has_one :source_dataclip, through: [:event, :dataclip]
     has_one :result_dataclip, through: [:event, :result_dataclip]
 
     timestamps(usec: true)
@@ -35,8 +37,15 @@ defmodule Lightning.Invocation.Run do
   @doc false
   def changeset(run, attrs) do
     run
-    |> cast(attrs, [:log, :exit_code, :started_at, :finished_at, :event_id])
+    |> cast(attrs, [
+      :log,
+      :exit_code,
+      :started_at,
+      :finished_at,
+      :event_id,
+      :project_id
+    ])
     |> foreign_key_constraint(:event_id)
-    |> validate_required([:event_id])
+    |> validate_required([:event_id, :project_id])
   end
 end

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -9,6 +9,7 @@ defmodule Lightning.Invocation.Run do
   import Ecto.Changeset
   alias Lightning.Invocation.Event
   alias Lightning.Projects.Project
+  alias Lightning.Jobs.Job
 
   @type t :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
@@ -26,8 +27,8 @@ defmodule Lightning.Invocation.Run do
     belongs_to :event, Event
 
     belongs_to :project, Project
+    belongs_to :job, Job
 
-    has_one :job, through: [:event, :job]
     has_one :source_dataclip, through: [:event, :dataclip]
     has_one :result_dataclip, through: [:event, :result_dataclip]
 
@@ -43,9 +44,10 @@ defmodule Lightning.Invocation.Run do
       :started_at,
       :finished_at,
       :event_id,
-      :project_id
+      :project_id,
+      :job_id
     ])
     |> foreign_key_constraint(:event_id)
-    |> validate_required([:event_id, :project_id])
+    |> validate_required([:event_id, :project_id, :job_id])
   end
 end

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -7,14 +7,16 @@ defmodule Lightning.Invocation.Run do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  alias Lightning.Invocation.Event
+  alias Lightning.Invocation.{Event, Dataclip}
   alias Lightning.Projects.Project
   alias Lightning.Jobs.Job
 
   @type t :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: Ecto.UUID.t() | nil,
-          event: Event.t() | Ecto.Association.NotLoaded.t() | nil
+          event: Event.t() | Ecto.Association.NotLoaded.t() | nil,
+          project: Project.t() | Ecto.Association.NotLoaded.t() | nil,
+          job: Job.t() | Ecto.Association.NotLoaded.t() | nil
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -29,7 +31,9 @@ defmodule Lightning.Invocation.Run do
     belongs_to :project, Project
     belongs_to :job, Job
 
-    has_one :source_dataclip, through: [:event, :dataclip]
+    belongs_to :input_dataclip, Dataclip
+
+    # has_one :source_dataclip, through: [:event, :dataclip]
     has_one :result_dataclip, through: [:event, :result_dataclip]
 
     timestamps(usec: true)
@@ -45,9 +49,10 @@ defmodule Lightning.Invocation.Run do
       :finished_at,
       :event_id,
       :project_id,
-      :job_id
+      :job_id,
+      :input_dataclip_id
     ])
     |> foreign_key_constraint(:event_id)
-    |> validate_required([:event_id, :project_id, :job_id])
+    |> validate_required([:event_id, :project_id, :job_id, :input_dataclip_id])
   end
 end

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -32,9 +32,10 @@ defmodule Lightning.Invocation.Run do
     belongs_to :job, Job
 
     belongs_to :input_dataclip, Dataclip
+    belongs_to :output_dataclip, Dataclip
 
     # has_one :source_dataclip, through: [:event, :dataclip]
-    has_one :result_dataclip, through: [:event, :result_dataclip]
+    # has_one :result_dataclip, through: [:event, :result_dataclip]
 
     timestamps(usec: true)
   end
@@ -50,9 +51,14 @@ defmodule Lightning.Invocation.Run do
       :event_id,
       :project_id,
       :job_id,
-      :input_dataclip_id
+      :input_dataclip_id,
+      :output_dataclip_id
     ])
+    |> cast_assoc(:output_dataclip, with: &Dataclip.changeset/2, required: false)
     |> foreign_key_constraint(:event_id)
+    |> foreign_key_constraint(:input_dataclip_id)
+    |> foreign_key_constraint(:output_dataclip_id)
+    |> foreign_key_constraint(:job_id)
     |> validate_required([:event_id, :project_id, :job_id, :input_dataclip_id])
   end
 end

--- a/lib/lightning/pipeline.ex
+++ b/lib/lightning/pipeline.ex
@@ -14,7 +14,7 @@ defmodule Lightning.Pipeline do
   alias Lightning.{Jobs, Invocation}
   alias Lightning.Invocation.Event
   alias Lightning.Repo
-  import Ecto.Query, only: [select: 3]
+  import Ecto.Query
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"event_id" => id}}) do
@@ -75,8 +75,11 @@ defmodule Lightning.Pipeline do
         |> Repo.one()
 
       :ok ->
-        Invocation.get_result_dataclip_query(run)
-        |> select([d], d.id)
+        from(d in Invocation.Dataclip,
+          join: r in assoc(d, :source_run),
+          where: r.id == ^run.id,
+          select: d.id
+        )
         |> Repo.one()
     end
   end

--- a/priv/repo/migrations/20221012121406_move_job_run_relations.exs
+++ b/priv/repo/migrations/20221012121406_move_job_run_relations.exs
@@ -1,0 +1,30 @@
+defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      add :project_id, references(:projects, on_delete: :delete_all, type: :binary_id),
+        null: false
+    end
+
+    execute(&update_runs/0, fn -> nil end)
+  end
+
+  defp update_runs() do
+    repo().query!(
+      """
+      UPDATE runs
+      SET project_id=subquery.project_id
+      FROM (
+        SELECT r.id,
+               e.project_id
+        FROM runs r
+        LEFT JOIN invocation_events e ON r.event_id = e.id
+      ) AS subquery
+      WHERE runs.id = subquery.id;
+      """,
+      [],
+      log: :info
+    )
+  end
+end

--- a/priv/repo/migrations/20221012121406_move_job_run_relations.exs
+++ b/priv/repo/migrations/20221012121406_move_job_run_relations.exs
@@ -10,6 +10,9 @@ defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
 
       add :input_dataclip_id, references(:dataclips, on_delete: :delete_all, type: :binary_id),
         null: false
+
+      add :output_dataclip_id, references(:dataclips, on_delete: :delete_all, type: :binary_id),
+        null: true
     end
 
     execute(&update_runs/0, fn -> nil end)
@@ -21,14 +24,17 @@ defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
       UPDATE runs
       SET project_id=subquery.project_id,
           job_id=subquery.job_id,
-          input_dataclip_id=subquery.dataclip_id
+          input_dataclip_id=subquery.dataclip_id,
+          output_dataclip_id=subquery.result_dataclip_id
       FROM (
         SELECT r.id,
                e.project_id,
                e.job_id,
-               e.dataclip_id
+               e.dataclip_id,
+               d.id AS result_dataclip_id
         FROM runs r
         LEFT JOIN invocation_events e ON r.event_id = e.id
+        LEFT JOIN dataclips d ON d.source_event_id = e.id
       ) AS subquery
       WHERE runs.id = subquery.id;
       """,

--- a/priv/repo/migrations/20221012121406_move_job_run_relations.exs
+++ b/priv/repo/migrations/20221012121406_move_job_run_relations.exs
@@ -7,6 +7,9 @@ defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
         null: false
 
       add :job_id, references(:jobs, on_delete: :delete_all, type: :binary_id), null: false
+
+      add :input_dataclip_id, references(:dataclips, on_delete: :delete_all, type: :binary_id),
+        null: false
     end
 
     execute(&update_runs/0, fn -> nil end)
@@ -17,11 +20,13 @@ defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
       """
       UPDATE runs
       SET project_id=subquery.project_id,
-          job_id=subquery.job_id
+          job_id=subquery.job_id,
+          input_dataclip_id=subquery.dataclip_id
       FROM (
         SELECT r.id,
                e.project_id,
-               e.job_id
+               e.job_id,
+               e.dataclip_id
         FROM runs r
         LEFT JOIN invocation_events e ON r.event_id = e.id
       ) AS subquery

--- a/priv/repo/migrations/20221012121406_move_job_run_relations.exs
+++ b/priv/repo/migrations/20221012121406_move_job_run_relations.exs
@@ -5,6 +5,8 @@ defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
     alter table(:runs) do
       add :project_id, references(:projects, on_delete: :delete_all, type: :binary_id),
         null: false
+
+      add :job_id, references(:jobs, on_delete: :delete_all, type: :binary_id), null: false
     end
 
     execute(&update_runs/0, fn -> nil end)
@@ -14,10 +16,12 @@ defmodule Lightning.Repo.Migrations.MoveJobRunRelations do
     repo().query!(
       """
       UPDATE runs
-      SET project_id=subquery.project_id
+      SET project_id=subquery.project_id,
+          job_id=subquery.job_id
       FROM (
         SELECT r.id,
-               e.project_id
+               e.project_id,
+               e.job_id
         FROM runs r
         LEFT JOIN invocation_events e ON r.event_id = e.id
       ) AS subquery

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -235,16 +235,18 @@ defmodule Lightning.InvocationTest do
 
     test "create_run/1 with valid data creates a run" do
       project = project_fixture()
+      dataclip = dataclip_fixture(project_id: project.id)
       job = job_fixture(project_id: project.id)
 
-      event = event_fixture(project_id: project.id)
+      event = event_fixture(project_id: project.id, dataclip_id: dataclip.id)
 
       assert {:ok, %Run{} = run} =
                Invocation.create_run(
                  Map.merge(@valid_attrs, %{
                    event_id: event.id,
                    project_id: project.id,
-                   job_id: job.id
+                   job_id: job.id,
+                   input_dataclip_id: dataclip.id
                  })
                )
 

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -5,6 +5,7 @@ defmodule Lightning.InvocationTest do
   alias Lightning.Repo
   import Lightning.InvocationFixtures
   import Lightning.ProjectsFixtures
+  import Lightning.JobsFixtures
 
   describe "invocation" do
     import Lightning.JobsFixtures
@@ -233,13 +234,17 @@ defmodule Lightning.InvocationTest do
     end
 
     test "create_run/1 with valid data creates a run" do
-      event = event_fixture()
+      project = project_fixture()
+      job = job_fixture(project_id: project.id)
+
+      event = event_fixture(project_id: project.id)
 
       assert {:ok, %Run{} = run} =
                Invocation.create_run(
                  Map.merge(@valid_attrs, %{
                    event_id: event.id,
-                   project_id: project_fixture().id
+                   project_id: project.id,
+                   job_id: job.id
                  })
                )
 

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -73,7 +73,7 @@ defmodule Lightning.InvocationTest do
       assert Invocation.get_dataclip(dataclip.id) == dataclip
       assert Invocation.get_dataclip(Ecto.UUID.generate()) == nil
 
-      run = run_fixture(event_id: event.id)
+      run = run_fixture(event_id: event.id, input_dataclip_id: dataclip.id)
 
       assert Invocation.get_dataclip(run) == dataclip
     end

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -187,6 +187,7 @@ defmodule Lightning.InvocationTest do
     alias Lightning.Invocation.Run
 
     import Lightning.InvocationFixtures
+    import Lightning.ProjectsFixtures
 
     @invalid_attrs %{event_id: nil}
     @valid_attrs %{
@@ -206,11 +207,13 @@ defmodule Lightning.InvocationTest do
       event = event_fixture(project_id: project.id)
 
       first_run =
-        run_fixture(event_id: event.id)
+        run_fixture(event_id: event.id, project_id: project.id)
         |> shift_inserted_at!(days: -1)
         |> Repo.preload(:job)
 
-      second_run = run_fixture(event_id: event.id) |> Repo.preload(:job)
+      second_run =
+        run_fixture(event_id: event.id, project_id: project.id)
+        |> Repo.preload(:job)
 
       assert Invocation.list_runs_for_project(project).entries == [
                second_run,
@@ -234,7 +237,10 @@ defmodule Lightning.InvocationTest do
 
       assert {:ok, %Run{} = run} =
                Invocation.create_run(
-                 Map.merge(@valid_attrs, %{event_id: event.id})
+                 Map.merge(@valid_attrs, %{
+                   event_id: event.id,
+                   project_id: project_fixture().id
+                 })
                )
 
       assert run.exit_code == 42

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -440,11 +440,11 @@ defmodule Lightning.JobsTest do
         %Jobs.Job{id: job.id}
         |> Lightning.Invocation.Query.last_successful_run_for_job()
         |> Repo.one()
-        |> Repo.preload(:source_dataclip)
+        |> Repo.preload(:input_dataclip)
         |> Repo.preload(:result_dataclip)
 
-      assert run.source_dataclip.type == :global
-      assert run.source_dataclip.body == %{}
+      assert run.input_dataclip.type == :global
+      assert run.input_dataclip.body == %{}
     end
 
     test "enqueue_cronjobs/1 enqueues a cron job that has been run before" do
@@ -463,7 +463,7 @@ defmodule Lightning.JobsTest do
         %Jobs.Job{id: job.id}
         |> Lightning.Invocation.Query.last_successful_run_for_job()
         |> Repo.one()
-        |> Repo.preload(:source_dataclip)
+        |> Repo.preload(:input_dataclip)
         |> Repo.preload(:result_dataclip)
 
       _result = Scheduler.enqueue_cronjobs()
@@ -472,14 +472,14 @@ defmodule Lightning.JobsTest do
         %Jobs.Job{id: job.id}
         |> Lightning.Invocation.Query.last_successful_run_for_job()
         |> Repo.one()
-        |> Repo.preload(:source_dataclip)
+        |> Repo.preload(:input_dataclip)
         |> Repo.preload(:result_dataclip)
 
-      assert old.source_dataclip.type == :http_request
-      assert old.source_dataclip.body == %{}
+      assert old.input_dataclip.type == :http_request
+      assert old.input_dataclip.body == %{}
 
-      assert new.source_dataclip.type == :run_result
-      assert new.source_dataclip.body == old.result_dataclip.body
+      assert new.input_dataclip.type == :run_result
+      assert new.input_dataclip.body == old.result_dataclip.body
       assert new.result_dataclip.body == %{"changed" => true}
     end
   end

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -441,7 +441,7 @@ defmodule Lightning.JobsTest do
         |> Lightning.Invocation.Query.last_successful_run_for_job()
         |> Repo.one()
         |> Repo.preload(:input_dataclip)
-        |> Repo.preload(:result_dataclip)
+        |> Repo.preload(:output_dataclip)
 
       assert run.input_dataclip.type == :global
       assert run.input_dataclip.body == %{}
@@ -464,7 +464,7 @@ defmodule Lightning.JobsTest do
         |> Lightning.Invocation.Query.last_successful_run_for_job()
         |> Repo.one()
         |> Repo.preload(:input_dataclip)
-        |> Repo.preload(:result_dataclip)
+        |> Repo.preload(:output_dataclip)
 
       _result = Scheduler.enqueue_cronjobs()
 
@@ -473,14 +473,14 @@ defmodule Lightning.JobsTest do
         |> Lightning.Invocation.Query.last_successful_run_for_job()
         |> Repo.one()
         |> Repo.preload(:input_dataclip)
-        |> Repo.preload(:result_dataclip)
+        |> Repo.preload(:output_dataclip)
 
       assert old.input_dataclip.type == :http_request
       assert old.input_dataclip.body == %{}
 
       assert new.input_dataclip.type == :run_result
-      assert new.input_dataclip.body == old.result_dataclip.body
-      assert new.result_dataclip.body == %{"changed" => true}
+      assert new.input_dataclip.body == old.output_dataclip.body
+      assert new.output_dataclip.body == %{"changed" => true}
     end
   end
 end

--- a/test/lightning/pipeline/runner_test.exs
+++ b/test/lightning/pipeline/runner_test.exs
@@ -50,9 +50,9 @@ defmodule Lightning.Pipeline.RunnerTest do
 
     run =
       Repo.reload!(run)
-      |> Repo.preload(:result_dataclip)
+      |> Repo.preload(:output_dataclip)
 
-    assert run.result_dataclip.body == expected_state
+    assert run.output_dataclip.body == expected_state
 
     refute is_nil(run.started_at)
     refute is_nil(run.finished_at)

--- a/test/lightning/pipeline_test.exs
+++ b/test/lightning/pipeline_test.exs
@@ -28,14 +28,20 @@ defmodule Lightning.PipelineTest do
         )
 
       event = event_fixture(job_id: job.id)
-      run_fixture(event_id: event.id)
+
+      run_fixture(
+        event_id: event.id,
+        project_id: event.project_id,
+        job_id: job.id,
+        input_dataclip_id: event.dataclip_id
+      )
 
       Pipeline.process(event)
 
-      expected_event =
-        from(e in Lightning.Invocation.Event,
-          where: e.job_id == ^downstream_job_id,
-          preload: [:result_dataclip]
+      expected_run =
+        from(r in Lightning.Invocation.Run,
+          where: r.job_id == ^downstream_job_id,
+          preload: [:output_dataclip]
         )
         |> Repo.one!()
 
@@ -43,7 +49,7 @@ defmodule Lightning.PipelineTest do
                "configuration" => %{"credential" => "body"},
                "data" => %{},
                "error" => error
-             } = expected_event.result_dataclip.body
+             } = expected_run.output_dataclip.body
 
       error = Enum.slice(error, 0..4)
 
@@ -94,7 +100,13 @@ defmodule Lightning.PipelineTest do
         )
 
       event = event_fixture(job_id: job.id)
-      run_fixture(event_id: event.id)
+
+      run_fixture(
+        event_id: event.id,
+        project_id: event.project_id,
+        job_id: job.id,
+        input_dataclip_id: event.dataclip_id
+      )
 
       Pipeline.process(event)
 

--- a/test/lightning_web/controllers/webhooks_controller_test.exs
+++ b/test/lightning_web/controllers/webhooks_controller_test.exs
@@ -14,9 +14,9 @@ defmodule LightningWeb.WebhooksControllerTest do
     conn = post(conn, "/i/#{job.id}", message)
     assert %{"event_id" => _, "run_id" => run_id} = json_response(conn, 200)
 
-    %{source_dataclip: %{body: body}} =
+    %{input_dataclip: %{body: body}} =
       Invocation.get_run!(run_id)
-      |> Repo.preload(:source_dataclip)
+      |> Repo.preload(:input_dataclip)
 
     assert body == message
 

--- a/test/lightning_web/live/run_live_test.exs
+++ b/test/lightning_web/live/run_live_test.exs
@@ -7,12 +7,14 @@ defmodule LightningWeb.RunLiveTest do
   defp create_run(%{project: project}) do
     run =
       run_fixture(
+        project_id: project.id,
         event_id: event_fixture(project_id: project.id).id,
         log: ["First Run"]
       )
 
     finished_run =
       run_fixture(
+        project_id: project.id,
         event_id: event_fixture(project_id: project.id).id,
         log: ["Finished Run"],
         started_at: DateTime.add(DateTime.utc_now(), -1, :second),
@@ -22,6 +24,7 @@ defmodule LightningWeb.RunLiveTest do
     # Add a bunch of other runs to invoke pagination with more than one page.
     Enum.each(0..10, fn _ ->
       run_fixture(
+        project_id: project.id,
         event_id: event_fixture(project_id: project.id).id,
         log: ["Finished Run"],
         started_at: DateTime.add(DateTime.utc_now(), -1, :second),

--- a/test/support/fixtures/invocation_fixtures.ex
+++ b/test/support/fixtures/invocation_fixtures.ex
@@ -54,6 +54,12 @@ defmodule Lightning.InvocationFixtures do
   def run_fixture(attrs \\ []) when is_list(attrs) do
     {event_attrs, attrs} = Keyword.pop(attrs, :event_attrs, [])
 
+    attrs =
+      attrs
+      |> Keyword.put_new_lazy(:project_id, fn ->
+        Lightning.ProjectsFixtures.project_fixture().id
+      end)
+
     {:ok, run} =
       attrs
       |> Keyword.put_new_lazy(:event_id, fn -> event_fixture(event_attrs).id end)

--- a/test/support/fixtures/invocation_fixtures.ex
+++ b/test/support/fixtures/invocation_fixtures.ex
@@ -62,6 +62,9 @@ defmodule Lightning.InvocationFixtures do
 
     {:ok, run} =
       attrs
+      |> Keyword.put_new_lazy(:job_id, fn ->
+        Lightning.JobsFixtures.job_fixture(project_id: attrs[:project_id]).id
+      end)
       |> Keyword.put_new_lazy(:event_id, fn -> event_fixture(event_attrs).id end)
       |> Enum.into(%{
         exit_code: nil,

--- a/test/support/fixtures/invocation_fixtures.ex
+++ b/test/support/fixtures/invocation_fixtures.ex
@@ -66,6 +66,9 @@ defmodule Lightning.InvocationFixtures do
         Lightning.JobsFixtures.job_fixture(project_id: attrs[:project_id]).id
       end)
       |> Keyword.put_new_lazy(:event_id, fn -> event_fixture(event_attrs).id end)
+      |> Keyword.put_new_lazy(:input_dataclip_id, fn ->
+        dataclip_fixture(project_id: attrs[:project_id]).id
+      end)
       |> Enum.into(%{
         exit_code: nil,
         finished_at: nil,


### PR DESCRIPTION
## Any notes for the reviewer ?

This requires a migration, that currently is safe to rollback.
Several relationships that were on Event (and still currently are) have been copied/moved
to runs - this impacts several parts of the system such as determining the next state and saving the output state; along with creating a run and fetching it's related job.

All tests are passing but given the relative complexity of this area of the application, special attention should be given to the `Invocation` and `Pipeline` modules.

## Related issue

Fixes #356 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
