### PR TITLE
358 Add convenience function InvocationReasons.build(trigger, dataclip)

### DIFF
--- a/lib/lightning/reasons.ex
+++ b/lib/lightning/reasons.ex
@@ -6,6 +6,28 @@ defmodule Lightning.InvocationReasons do
   import Ecto.Query, warn: false
   alias Lightning.Repo
   alias Lightning.InvocationReason
+  alias Lightning.Invocation.Dataclip
+  alias Lightning.Jobs.Trigger
+
+  def build(%Trigger{type: type, id: trigger_id}, %Dataclip{id: dataclip_id}) do
+    case type do
+      type when type in [:webhook, :cron] ->
+        %InvocationReason{}
+        |> InvocationReason.changeset(%{
+          type: type,
+          trigger_id: trigger_id,
+          dataclip_id: dataclip_id
+        })
+
+      _ ->
+        %InvocationReason{}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(
+          :type,
+          "Type must be either :webhook or :cron"
+        )
+    end
+  end
 
   @doc """
   Creates a reason.

--- a/lib/lightning/workorder_service.ex
+++ b/lib/lightning/workorder_service.ex
@@ -6,7 +6,6 @@ defmodule Lightning.WorkOrderService do
   import Ecto.Query, warn: false
   alias Lightning.Repo
   alias Lightning.WorkOrder
-  alias Lightning.Invocation.{Event, Run}
 
   @doc """
   Creates a workorder.

--- a/test/lightning/reasons_test.exs
+++ b/test/lightning/reasons_test.exs
@@ -27,5 +27,30 @@ defmodule Lightning.InvocationReasonsTest do
       assert {:ok, %InvocationReason{}} =
                InvocationReasons.create_reason(valid_attrs)
     end
+
+    test "build/2 with trigger of type :webhook or :cron returns a valid reason" do
+      dataclip = dataclip_fixture()
+
+      assert %Ecto.Changeset{valid?: true} =
+               InvocationReasons.build(
+                 job_fixture(trigger: %{type: :webhook}).trigger,
+                 dataclip
+               )
+
+      assert %Ecto.Changeset{valid?: true} =
+               InvocationReasons.build(
+                 job_fixture(trigger: %{type: :cron}).trigger,
+                 dataclip
+               )
+
+      assert %Ecto.Changeset{
+               valid?: false,
+               errors: [type: {"Type must be either :webhook or :cron", []}]
+             } =
+               InvocationReasons.build(
+                 job_fixture(trigger: %{type: :on_job_success}).trigger,
+                 dataclip
+               )
+    end
   end
 end


### PR DESCRIPTION
## Any notes for the reviewer ?

## Related issue
#358 

Fixes #
358 Todo: Create convenience function/s for InvocationReasons
that takes a trigger and a dataclip and given the trigger type, build a reason with either a webhook or cron type.
InvocationReasons.build(trigger, dataclip) => Ecto.Changeset...

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
