### PR TITLE
Fix click back after editing `project`

### DIFF
--- a/lib/lightning_web/live/live_helpers.ex
+++ b/lib/lightning_web/live/live_helpers.ex
@@ -34,7 +34,10 @@ defmodule LightningWeb.LiveHelpers do
 
     ~H"""
     <%= if info = live_flash(@flash, :info) do %>
-      <div class="fixed flex justify-center bottom-3 right-0 left-0 z-[100]" id={@id}>
+      <div
+        class="fixed w-fit mx-auto flex justify-center bottom-3 right-0 left-0 z-[100]"
+        id={@id}
+      >
         <p
           class="bg-blue-200 border-blue-300 border opacity-75 py-4 px-5 rounded-md drop-shadow-lg"
           role="alert"
@@ -57,7 +60,10 @@ defmodule LightningWeb.LiveHelpers do
 
     ~H"""
     <%= if error = live_flash(@flash, :error) do %>
-      <div class="fixed flex justify-center bottom-3 right-0 left-0 z-[100]" id={@id}>
+      <div
+        class="fixed w-fit mx-auto flex justify-center bottom-3 right-0 left-0 z-[100]"
+        id={@id}
+      >
         <p
           class="bg-red-300 border-red-400 text-red-900 border opacity-75 py-4 px-5 rounded-md drop-shadow-lg"
           role="alert"


### PR DESCRIPTION
## Any notes for the reviewer ?
styled  then `info` and `error` alert boxes to fit the content and stay at the center on bottom 

## Related issue

Fixes #406 

### Screenshot
https://www.loom.com/share/35d2356def79418a8c03cc8fd5f1dea8
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
