### PR TITLE
Fix issue involving new jobs not getting a default cron expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 - Configure cron expressions thru a form
 - Added new Job Builder form on Workflow Diagram
 - Fixed adaptor documentation drop-down
+- Ensure new jobs with cron triggers receive a default frequency
 
 ## [0.2.0] - 2022-09-12
 

--- a/lib/lightning/jobs/scheduler.ex
+++ b/lib/lightning/jobs/scheduler.ex
@@ -29,9 +29,11 @@ defmodule Lightning.Jobs.Scheduler do
   Find and start any cronjobs that are scheduled to run for a given time
   (defaults to the current time).
   """
-  def enqueue_cronjobs(date_time \\ DateTime.utc_now()) do
+  @spec enqueue_cronjobs(DateTime.t()) :: :ok
+  def enqueue_cronjobs(), do: enqueue_cronjobs(DateTime.utc_now())
+
+  def enqueue_cronjobs(date_time) do
     date_time
-    |> DateTime.to_unix()
     |> Jobs.get_jobs_for_cron_execution()
     |> Enum.each(fn job ->
       {:ok, %{attempt_run: attempt_run}} = invoke_cronjob(job)

--- a/lib/lightning/jobs/trigger.ex
+++ b/lib/lightning/jobs/trigger.ex
@@ -71,7 +71,8 @@ defmodule Lightning.Jobs.Trigger do
   end
 
   defp validate_cron(changeset, _options \\ []) do
-    validate_change(changeset, :cron_expression, fn _, cron_expression ->
+    changeset
+    |> validate_change(:cron_expression, fn _, cron_expression ->
       Crontab.CronExpression.Parser.parse(cron_expression)
       |> case do
         {:error, error_message} ->
@@ -103,11 +104,21 @@ defmodule Lightning.Jobs.Trigger do
 
       :cron ->
         changeset
+        |> put_default(:cron_expression, "0 0 * * *")
         |> validate_cron()
         |> put_change(:upstream_job_id, nil)
 
       nil ->
         changeset
+    end
+  end
+
+  defp put_default(changeset, field, value) do
+    changeset
+    |> get_field(field)
+    |> case do
+      nil -> changeset |> put_change(field, value)
+      _ -> changeset
     end
   end
 end

--- a/lib/lightning_web/live/job_live/cron_setup_component.ex
+++ b/lib/lightning_web/live/job_live/cron_setup_component.ex
@@ -176,8 +176,8 @@ defmodule LightningWeb.JobLive.CronSetupComponent do
       end)
       |> Map.merge(%{:frequency => key})
 
-  def get_cron_expression(cron_data, prev_cron_expression) do
-    case cron_data do
+  def build_cron_expression(prev, next) do
+    case next do
       %{
         frequency: "hourly",
         hour: _hour,
@@ -215,7 +215,7 @@ defmodule LightningWeb.JobLive.CronSetupComponent do
         "#{minute} #{hour} #{monthday} * *"
 
       _ ->
-        prev_cron_expression
+        prev
     end
   end
 
@@ -235,11 +235,9 @@ defmodule LightningWeb.JobLive.CronSetupComponent do
       )
 
     cron_expression =
-      get_cron_expression(
-        cron_data,
-        socket.assigns.form
-        |> Map.get(:data)
-        |> Map.get(:trigger_cron_expression)
+      build_cron_expression(
+        socket.assigns.form |> input_value(:cron_expression),
+        cron_data
       )
 
     if Map.get(cron_data, :frequency) != "custom" do

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -325,10 +325,14 @@ defmodule LightningWeb.JobLive.JobBuilder do
         %{event: :cron_expression_changed, cron_expression: cron_expression},
         socket
       ) do
+    %{id: trigger_id} =
+      socket.assigns.changeset
+      |> Ecto.Changeset.get_field(:trigger)
+
     {:ok,
      socket
      |> assign_changeset_and_params(%{
-       "trigger" => %{"cron_expression" => cron_expression}
+       "trigger" => %{"cron_expression" => cron_expression, "id" => trigger_id}
      })}
   end
 

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -47,11 +47,9 @@ defmodule Lightning.JobsTest do
           enabled: false
         )
 
-      assert Jobs.get_jobs_for_cron_execution(
-               DateTime.utc_now()
-               |> DateTime.to_unix()
-             ) ==
-               [Jobs.get_job!(job_1.id)]
+      assert Jobs.get_jobs_for_cron_execution(DateTime.utc_now()) == [
+               Jobs.get_job!(job_1.id)
+             ]
     end
 
     test "get_job!/1 returns the job with given id" do

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -13,7 +13,7 @@ defmodule LightningWeb.EndToEndTest do
   setup :register_and_log_in_superuser
 
   defp expected_core, do: "│ ◲ ◱  @openfn/core#v1.4.8 (Node.js v18.12.0"
-  defp expected_adaptor, do: "@openfn/language-http@4.2.2"
+  defp expected_adaptor, do: "@openfn/language-http@4.2.3"
 
   test "the whole thing", %{conn: conn} do
     project = project_fixture()


### PR DESCRIPTION
When creating a new Job, and selecting "Cron" as the trigger - and then not setting any of the frequency/time options the job either didn't save (backend error) or saved with a `null` `cron_expression` in the database.

This addresses all of the above, by default a `cron_expression` is 'Daily'. In addition a regression was found when changing an existing triggers cron expression.

## Any notes for the reviewer ?

## Related issue

Fixes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
