### PR TITLE
abbreviate standard adaptors

### DIFF
--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -69,12 +69,22 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
      |> assign(:form, form)}
   end
 
+  defp display_name_for_adaptor(name) do
+    if String.starts_with?(name, "@openfn/language-") do
+      # Show most relevant slice of the name for standard adaptors
+      {String.slice(name, 17..-1), name}
+    else
+      # Display full adaptor names for non-standard OpenFn adaptors
+      name
+    end
+  end
+
   def get_adaptor_version_options(adaptor) do
     # Gets @openfn/language-foo@1.2.3 or @openfn/language-foo
 
     adaptor_names =
       Lightning.AdaptorRegistry.all()
-      |> Enum.map(&Map.get(&1, :name))
+      |> Enum.map(&display_name_for_adaptor(&1.name))
       |> Enum.sort()
 
     {module_name, version, versions} =

--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -69,7 +69,14 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
      |> assign(:form, form)}
   end
 
-  defp display_name_for_adaptor(name) do
+  @doc """
+  Converts standard adaptor names into "label","value" lists and returns
+  non-standard names as merely "value"; both can be passed directly into a
+  select option list.
+  """
+  @spec display_name_for_adaptor(String.t()) ::
+          String.t() | {String.t(), String.t()}
+  def display_name_for_adaptor(name) do
     if String.starts_with?(name, "@openfn/language-") do
       # Show most relevant slice of the name for standard adaptors
       {String.slice(name, 17..-1), name}

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -79,7 +79,7 @@ defmodule LightningWeb.JobLive.JobBuilder do
             >
               <div class="md:grid md:grid-cols-4 md:gap-4 @container">
                 <div class="md:col-span-2">
-                  <Form.text_field form={f} id={:name} />
+                  <Form.text_field form={f} label="Job Name" id={:name} />
                 </div>
                 <div class="md:col-span-2">
                   <Form.check_box form={f} id={:enabled} />
@@ -148,7 +148,7 @@ defmodule LightningWeb.JobLive.JobBuilder do
                 data-change-event="job_body_changed"
                 phx-target={@myself}
               />
-              <div class="flex-1 overflow-auto" style="max-width: 400px;">
+              <div class="flex-1 overflow-auto">
                 <.docs_component adaptor={@job_adaptor} />
               </div>
             </div>

--- a/test/lightning_web/live/job_live_test.exs
+++ b/test/lightning_web/live/job_live_test.exs
@@ -6,6 +6,8 @@ defmodule LightningWeb.JobLiveTest do
   import Lightning.ProjectsFixtures
   import Lightning.CredentialsFixtures
 
+  alias LightningWeb.JobLive.AdaptorPicker
+
   setup :register_and_log_in_user
   setup :create_project_for_current_user
 
@@ -51,6 +53,19 @@ defmodule LightningWeb.JobLiveTest do
                  conn,
                  Routes.project_job_index_path(conn, :index, project.id)
                )
+    end
+  end
+
+  describe "The adaptor picker" do
+    test "abbreviates standard adaptors via display_name_for_adaptor/1" do
+      assert AdaptorPicker.display_name_for_adaptor("@openfn/language-abc") ==
+               {"abc", "@openfn/language-abc"}
+
+      assert AdaptorPicker.display_name_for_adaptor("@openfn/adaptor-xyz") ==
+               "@openfn/adaptor-xyz"
+
+      assert AdaptorPicker.display_name_for_adaptor("@other_org/some_module") ==
+               "@other_org/some_module"
     end
   end
 end


### PR DESCRIPTION
## Any notes for the reviewer ?

Less technical users find it confusing to see so much duplicated "@openfn/language-" text on the dropdown. If accepted, this would only display that full name for _non-standard_ adaptors — i.e., those hosted by other npm orgs with other naming conventions.

## Related issue

Amber feedback from user interviews

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [x] Amber has QA'd this feature
