### PR TITLE
Make plus button part of job nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 ### Changed
 
 - Updated @openfn/workflow-diagram to 0.4.0
+- Make plus button part of job nodes in Workflow Diagram
 
 ### Fixed
 
@@ -33,7 +34,6 @@ and this project adheres to
 - Configure cron expressions through a form
 - View runs grouped by work orders and attempts
 - Run an existing Job with any dataclip uuid from the Job form
-- Make plus button part of job nodes in Workflow Diagram
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 ### Changed
 
+- Updated @openfn/workflow-diagram to 0.4.0
+
 ### Fixed
 
 ## [0.3.1] - 2022-11-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 - Configure cron expressions through a form
 - View runs grouped by work orders and attempts
 - Run an existing Job with any dataclip uuid from the Job form
+- Make plus button part of job nodes in Workflow Diagram
 
 ### Changed
 

--- a/assets/js/workflow-diagram/component.tsx
+++ b/assets/js/workflow-diagram/component.tsx
@@ -4,16 +4,18 @@ import WorkflowDiagram, { Store } from '@openfn/workflow-diagram';
 
 type UpdateParams = {
   onNodeClick(event: MouseEvent, node: any): void;
+  onJobAddClick(node: any): void;
   onPaneClick(event: MouseEvent): void;
-}
+};
 
 export function mount(el: Element | DocumentFragment) {
   const componentRoot = createRoot(el);
 
-  function update({ onNodeClick, onPaneClick }: UpdateParams) {
+  function update({ onNodeClick, onPaneClick, onJobAddClick }: UpdateParams) {
     return componentRoot.render(
       <WorkflowDiagram
         className="h-8"
+        onJobAddClick={onJobAddClick}
         onNodeClick={onNodeClick}
         onPaneClick={onPaneClick}
       />

--- a/assets/js/workflow-diagram/index.ts
+++ b/assets/js/workflow-diagram/index.ts
@@ -48,18 +48,20 @@ export default {
       const projectSpace = this.updateProjectSpace();
 
       this.component.update({
-        onNodeClick: (_event, node) => {
+        onNodeClick: (event, node) => {
           switch (node.type) {
             case 'job':
-              this.selectJob(node.data.id);
+              const plusIds = new Set(['plusButton', 'plusIcon']);
+              const target = event.target as HTMLElement;
+              if (plusIds.has(target.id)) {
+                this.addJob(node.data.id);
+              } else {
+                this.selectJob(node.data.id);
+              }
               break;
 
             case 'workflow':
               this.selectWorkflow(node.data.id);
-              break;
-
-            case 'add':
-              this.addJob(node.data.parentId);
               break;
           }
         },

--- a/assets/js/workflow-diagram/index.ts
+++ b/assets/js/workflow-diagram/index.ts
@@ -48,16 +48,13 @@ export default {
       const projectSpace = this.updateProjectSpace();
 
       this.component.update({
+        onJobAddClick: node => {
+          this.addJob(node.data.id);
+        },
         onNodeClick: (event, node) => {
           switch (node.type) {
             case 'job':
-              const plusIds = new Set(['plusButton', 'plusIcon']);
-              const target = event.target as HTMLElement;
-              if (plusIds.has(target.id)) {
-                this.addJob(node.data.id);
-              } else {
-                this.selectJob(node.data.id);
-              }
+              this.selectJob(node.data.id);
               break;
 
             case 'workflow':

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -12,7 +12,7 @@
         "@monaco-editor/react": "^4.4.5",
         "@openfn/adaptor-docs": "0.0.3",
         "@openfn/describe-package": "0.0.9",
-        "@openfn/workflow-diagram": "0.0.9",
+        "@openfn/workflow-diagram": "0.4.0",
         "@tailwindcss/container-queries": "^0.1.0",
         "@tailwindcss/forms": "^0.5.3",
         "alpinejs": "^2.8.2",
@@ -28,11 +28,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -168,11 +168,12 @@
       }
     },
     "node_modules/@openfn/workflow-diagram": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@openfn/workflow-diagram/-/workflow-diagram-0.0.9.tgz",
-      "integrity": "sha512-9W2qxlTSITXqY34gabb04lOtd8B9ZvovTvnk8CFLeZwkUzt1XmofNA+q4H8264iG2brwhGKDacSchQdt94KqHg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@openfn/workflow-diagram/-/workflow-diagram-0.4.0.tgz",
+      "integrity": "sha512-i+f2VBJWVnH+xrK3xW3hqEnan3coMTqbyPPomvjPrcCPWRXiHZ8VF39d4WfwmZjbHZa8aNaTpoqvQjPnaK1Z0g==",
       "dependencies": {
         "classcat": "^5.0.4",
+        "cronstrue": "^2.14.0",
         "elkjs": "^0.8.2",
         "react-flow-renderer": "^10.3.16",
         "zustand": "^4.1.1"
@@ -1107,6 +1108,14 @@
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.19.0.tgz",
+      "integrity": "sha512-sXgnAKlUZUJEDddD6jB7U/NbSpNnLAXghoNtPgn/UepuKaIPUFbBJ8IUKkthuzpfms/XqdVLklRwgktNn5i/eg==",
+      "bin": {
+        "cronstrue": "bin/cli.js"
       }
     },
     "node_modules/cross-fetch": {
@@ -3914,6 +3923,7 @@
       "version": "10.3.17",
       "resolved": "https://registry.npmjs.org/react-flow-renderer/-/react-flow-renderer-10.3.17.tgz",
       "integrity": "sha512-bywiqVErlh5kCDqw3x0an5Ur3mT9j9CwJsDwmhmz4i1IgYM1a0SPqqEhClvjX+s5pU4nHjmVaGXWK96pwsiGcQ==",
+      "deprecated": "react-flow-renderer has been renamed to reactflow, please use this package from now on https://reactflow.dev/docs/guides/migrate-to-v11/",
       "dependencies": {
         "@babel/runtime": "^7.18.9",
         "@types/d3": "^7.4.0",
@@ -4008,9 +4018,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/remark-parse": {
       "version": "10.0.1",
@@ -5190,11 +5200,11 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@esbuild/android-arm": {
@@ -5280,11 +5290,12 @@
       }
     },
     "@openfn/workflow-diagram": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@openfn/workflow-diagram/-/workflow-diagram-0.0.9.tgz",
-      "integrity": "sha512-9W2qxlTSITXqY34gabb04lOtd8B9ZvovTvnk8CFLeZwkUzt1XmofNA+q4H8264iG2brwhGKDacSchQdt94KqHg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@openfn/workflow-diagram/-/workflow-diagram-0.4.0.tgz",
+      "integrity": "sha512-i+f2VBJWVnH+xrK3xW3hqEnan3coMTqbyPPomvjPrcCPWRXiHZ8VF39d4WfwmZjbHZa8aNaTpoqvQjPnaK1Z0g==",
       "requires": {
         "classcat": "^5.0.4",
+        "cronstrue": "^2.14.0",
         "elkjs": "^0.8.2",
         "react-flow-renderer": "^10.3.16",
         "zustand": "^4.1.1"
@@ -6042,6 +6053,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="
+    },
+    "cronstrue": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.19.0.tgz",
+      "integrity": "sha512-sXgnAKlUZUJEDddD6jB7U/NbSpNnLAXghoNtPgn/UepuKaIPUFbBJ8IUKkthuzpfms/XqdVLklRwgktNn5i/eg=="
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -7766,9 +7782,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "remark-parse": {
       "version": "10.0.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -10,9 +10,9 @@
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.4.5",
-    "@openfn/describe-package": "0.0.9",
     "@openfn/adaptor-docs": "0.0.3",
-    "@openfn/workflow-diagram": "0.0.9",
+    "@openfn/describe-package": "0.0.9",
+    "@openfn/workflow-diagram": "0.4.0",
     "@tailwindcss/container-queries": "^0.1.0",
     "@tailwindcss/forms": "^0.5.3",
     "alpinejs": "^2.8.2",


### PR DESCRIPTION
## Any notes for the reviewer ?

This PR can't be merge unless [this one](https://github.com/OpenFn/kit/pull/102) is merged and a new version of Kit is cut and used in Lightning.

To test the work in this PR, you need to:

1. Have Kit working in local
2. In Kit switch to the branch `396-plus-icon-job-nodes`
3. In Kit run the following commands `cd packages/workflow-diagram && pnpm build && pnpm pack`, they will produce a tarball you can use in Lightning
4. In Lightning (in the branch `396-plus-icon-job-nodes`) run the following commands `npm uninstall --prefix assets @openfn/workflow-diagram && npm add --prefix assets <path/to/tarball/in/kit>`

## Related issue

Fixes #396 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
