### PR TITLE
align run duration with oban timeout and grace period

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,14 @@ ORIGINS=//localhost:*
 # SENTRY_DSN=https://some-url.ingest.sentry.io/some-id
 
 # ==============================================================================
+# <><><> JOB EXECUTION SETTINGS <><><>
+
+# You can configure the max run duration for jobs in milliseconds. This should
+# be lower than the pod termination grace period if using Kubernetes.
+MAX_RUN_DURATION=20000
+# ------------------------------------------------------------------------------
+
+# ==============================================================================
 # <><><> DATABASE SETTINGS <><><>
 
 # Disable SSL connections for Postgres

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -26,8 +26,8 @@ Note that for secure deployments, it's recommended to use a combination of
 
 - `SECRET_KEY_BASE` - a secret key used as a base to generate secrets for
   encrypting and signing data.
-- `PRIMARY_ENCRYPTION_KEY` - a base64 encoded 32 character long string.
-  See [Encryption](#encryption).
+- `PRIMARY_ENCRYPTION_KEY` - a base64 encoded 32 character long string. See
+  [Encryption](#encryption).
 - `ADAPTORS_PATH` - where you store your locally installed adaptors
 - `LIGHTNING_LISTEN_ADDRESS`" - the address the web server should bind to,
   defaults to `0.0.0.0`
@@ -40,3 +40,5 @@ Note that for secure deployments, it's recommended to use a combination of
 - `URL_HOST` - the host, used for writing urls (e.g., `demo.openfn.org`)
 - `URL_PORT` - the port, usually `443` for production
 - `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)
+- `MAX_RUN_DURATION` - the maximum time (in milliseconds) that jobs are allowed
+  to run (keep this below your termination_grace_period if using kubernetes)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -38,13 +38,20 @@ config :lightning, Oban,
        {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}}
      ]}
   ],
-  shutdown_grace_period: 15_000,
+  shutdown_grace_period:
+    System.get_env("MAX_RUN_DURATION", "60000")
+    |> String.to_integer(),
   dispatch_cooldown: 100,
   queues: [
     scheduler: 1,
     background: 1,
     runs: System.get_env("GLOBAL_RUNS_CONCURRENCY", "1") |> String.to_integer()
   ]
+
+config :lightning,
+       :max_run_duration,
+       System.get_env("MAX_RUN_DURATION", "60000")
+       |> String.to_integer()
 
 config :lightning,
        :queue_result_retention_period,

--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -94,7 +94,7 @@ defmodule Lightning.Pipeline.Runner do
       env: %{
         "PATH" => "#{adaptors_path}/bin:#{System.get_env("PATH")}"
       },
-      timeout: 60_000
+      timeout: Application.get_env(:lightning, :max_run_duration)
     }
 
     Handler.start(


### PR DESCRIPTION
This brings _some_ of the shutdown grace from OpenFn.org over to Lightning. We still need a dynamic queue service which unsubscribes nodes across larger clusters, but if we run with a single copy of the app during alpha and beta (which will be nice to get a sense of the load that a single node can tolerate) this should prevent us from exiting during running jobs when we restart nodes/perform upgrades.