### PR TITLE
Scrub Secrets From Run Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Added a Delete job button in Inspector
 - Filter workflow runs by text/value in run logs or input body
+- Drop "configuration" key from Run output dataclips after completion
 
 ### Changed
 

--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -120,18 +120,7 @@ defmodule Lightning.Pipeline.Runner do
   """
   @spec scrub_result(body :: map()) :: map()
   def scrub_result(%{} = body) do
-    case Map.get(body, :configuration) do
-      nil ->
-        body
-
-      map ->
-        safe_body = body
-
-        Map.keys(map)
-        |> Enum.each(fn k -> Map.put(safe_body, k, "***") end)
-
-        safe_body
-    end
+    Map.delete(body, "configuration")
   end
 
   @doc """

--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -115,6 +115,26 @@ defmodule Lightning.Pipeline.Runner do
   end
 
   @doc """
+  Scrubs values from all keys in configuration, will be replaced by extensions
+  to scrubber.ex, which is currently only used for logs.
+  """
+  @spec scrub_result(body :: map()) :: map()
+  def scrub_result(%{} = body) do
+    case Map.get(body, :configuration) do
+      nil ->
+        body
+
+      map ->
+        safe_body = body
+
+        Map.keys(map)
+        |> Enum.each(fn k -> Map.put(safe_body, k, "***") end)
+
+        safe_body
+    end
+  end
+
+  @doc """
   Creates a dataclip linked to the run that just finished.
   If either the file doesn't exist or there is a JSON decoding error, it logs
   and returns an error tuple.
@@ -136,7 +156,7 @@ defmodule Lightning.Pipeline.Runner do
         output_dataclip: %{
           project_id: job.workflow.project_id,
           type: :run_result,
-          body: body
+          body: scrub_result(body)
         }
       })
     else

--- a/test/lightning/pipeline_test.exs
+++ b/test/lightning/pipeline_test.exs
@@ -73,7 +73,6 @@ defmodule Lightning.PipelineTest do
       assert expected_run.input_dataclip_id == dataclip.id
 
       assert %{
-               "configuration" => %{"credential" => "body"},
                "data" => %{},
                "error" => error
              } = expected_run.output_dataclip.body
@@ -158,12 +157,10 @@ defmodule Lightning.PipelineTest do
       assert expected_run.input_dataclip_id == output_dataclip_id
 
       assert %{
-               "configuration" => %{"credential" => "body"},
                "data" => %{}
              } = expected_run.output_dataclip.body
 
       assert %{
-               "configuration" => %{"credential" => "body"},
                "data" => %{},
                "extra" => "data"
              } = expected_run.output_dataclip.body


### PR DESCRIPTION
## Any notes for the reviewer ?
@stuartc FYI we finally went with your suggestion of remove the `:configuration` key out of the run result. It's much simpler and more secure 😄 

## Related issue

Fixes #454 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
