### PR TITLE
adaptor-docs fixes

### DIFF
--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -15,10 +15,10 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
 
   const pkg = useDocs(specifier);
   if (pkg === null) {
-    return <div>Loading...</div>
+    return <div className="block m-2">Loading docs...</div>
   }
   if (pkg === false) {
-    return <div>Failed to load docs.</div>
+    return <div className="block m-2">Error: failed to load docs.</div>
   }
   
   const { name, version, functions } = pkg as PackageDescription;

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { PackageDescription } from '@openfn/describe-package';
-import useDocs from './useDocs';
+import useDocs from '../hooks/useDocs';
 import Function from './render/Function';
 
 type DocsPanelProps = {
@@ -24,8 +24,8 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   const { name, version, functions } = pkg as PackageDescription;
   return (
     <div className="block m-2">
-      <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">{name} v{version}</h1>
-      <div className="text-sm mb-4">API reference:</div>
+      <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">{name} ({version})</h1>
+      <div className="text-sm mb-4">These are the operations available for this adaptor:</div>
       {functions
         .sort((a, b) => {
           if (a.name > b.name) return 1;

--- a/assets/js/adaptor-docs/components/render/Function.tsx
+++ b/assets/js/adaptor-docs/components/render/Function.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { FunctionDescription } from '@openfn/describe-package';
+import { marked } from 'marked';
 
 type RenderFunctionProps = {
   fn: FunctionDescription;
@@ -45,7 +46,6 @@ type ExampleProps = {
 }
 
 const Example = ({ eg, onInsert }: ExampleProps) => {
-  console.log(eg)
   let code = '';
   let caption;
   if (typeof eg === 'string') {
@@ -75,14 +75,13 @@ const Example = ({ eg, onInsert }: ExampleProps) => {
 }
 
 const RenderFunction = ({ fn, onInsert }: RenderFunctionProps) => {
-  console.log(fn)
   return (
     <details>
       <summary className="text-m text-secondary-700 mb-1 cursor-pointer marker:text-slate-600 marker:text-sm">
         <span className="relative top-px">{getSignature(fn)}</span>
       </summary>
       <div className="block mb-4 pl-4">
-        <p className="block text-sm">{fn.description}</p>
+        <p className="block text-sm" dangerouslySetInnerHTML={{ __html: marked.parse(fn.description)}}></p>
         {fn.examples.map((eg, idx) =>
           <Example eg={eg} onInsert={onInsert} key={`${fn.name}-eg-${idx}`} />
         )}

--- a/assets/js/adaptor-docs/components/render/Function.tsx
+++ b/assets/js/adaptor-docs/components/render/Function.tsx
@@ -38,7 +38,44 @@ const PreButton = ({ label, onClick, tooltip }: PreButtonFunctionProps) =>
     {label}
   </button>
 
+type ExampleProps = {
+  // TODO the string format is already deprecated
+  eg: string |  { code: string, caption?: string };
+  onInsert?: (text: string) => void;
+}
+
+const Example = ({ eg, onInsert }: ExampleProps) => {
+  console.log(eg)
+  let code = '';
+  let caption;
+  if (typeof eg === 'string') {
+    code = eg;
+  } else {
+    code = eg.code;
+    caption = eg.caption;
+  }
+  return (
+    <section>
+      <label className="block text-sm text-secondary-700 mt-2">
+        Example{ caption && `: ${caption}`}
+      </label>
+      <div style={{ marginTop: '-6px'}}>
+        <div className="w-full px-5 text-right" style={{ height: '13px'}}>
+          <PreButton label="COPY" onClick={() => doCopy(code)} tooltip="Copy this example to the clipboard"/>
+          {onInsert && <PreButton label="ADD" onClick={() => onInsert(code)} tooltip="Add this snippet to the end of the code"/>}
+        </div>
+        <pre
+          className="rounded-md pl-4 pr-30 py-2 mx-4 my-0 font-mono bg-slate-100 border-2 border-slate-200 text-slate-800 min-h-full text-xs overflow-x-auto"
+          >
+            {code}
+        </pre>
+      </div>
+      </section>
+  )
+}
+
 const RenderFunction = ({ fn, onInsert }: RenderFunctionProps) => {
+  console.log(fn)
   return (
     <details>
       <summary className="text-m text-secondary-700 mb-1 cursor-pointer marker:text-slate-600 marker:text-sm">
@@ -46,19 +83,8 @@ const RenderFunction = ({ fn, onInsert }: RenderFunctionProps) => {
       </summary>
       <div className="block mb-4 pl-4">
         <p className="block text-sm">{fn.description}</p>
-        {fn.examples.length > 0 && <label className="block text-sm">Example:</label>}
         {fn.examples.map((eg, idx) =>
-          <div key={`${fn.name}-eg-${idx}`} style={{ marginTop: '-6px'}}>
-            <div className="w-full px-5 text-right" style={{ height: '13px'}}>
-              <PreButton label="COPY" onClick={() => doCopy(eg)} tooltip="Copy this example to the clipboard"/>
-              {onInsert && <PreButton label="ADD" onClick={() => onInsert(eg)} tooltip="Add this snippet to the end of the code"/>}
-            </div>
-            <pre
-              className="rounded-md pl-4 pr-30 py-2 mx-4 my-0 font-mono bg-slate-100 border-2 border-slate-200 text-slate-800 min-h-full text-xs overflow-x-auto"
-              >
-                {eg}
-            </pre>
-          </div>
+          <Example eg={eg} onInsert={onInsert} key={`${fn.name}-eg-${idx}`} />
         )}
         </div>
     </details>

--- a/assets/js/adaptor-docs/hooks/useDocs.tsx
+++ b/assets/js/adaptor-docs/hooks/useDocs.tsx
@@ -8,6 +8,7 @@ const useDocs = (specifier: string) => {
   useEffect(() => {
     setDocs(null); // Reset docs when the specifier changes
     describePackage(specifier, {}).then((result) => {
+      console.log(result)
       setDocs(result);
     });
   }, [specifier])

--- a/assets/js/adaptor-docs/hooks/useDocs.tsx
+++ b/assets/js/adaptor-docs/hooks/useDocs.tsx
@@ -8,8 +8,9 @@ const useDocs = (specifier: string) => {
   useEffect(() => {
     setDocs(null); // Reset docs when the specifier changes
     describePackage(specifier, {}).then((result) => {
-      console.log(result)
       setDocs(result);
+    }).catch((err) => {
+      setDocs(false)
     });
   }, [specifier])
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -74,9 +74,12 @@ export default function Editor({ source, adaptor, onChange }: EditorProps) {
 
     const handleInsertSnippet = (e: Event) => {
       // Snippets are always added to the end of the job code
-      const lastLine = editor.getModel().getLineCount();
+      const model = editor.getModel()
+      const lastLine = model.getLineCount();
+      const eol = model.getLineLength(lastLine)
       const op = {
-        range: new monaco.Range(lastLine, 0, lastLine, 0),
+        // TODO need to be in the end col...
+        range: new monaco.Range(lastLine, eol, lastLine, eol),
         // @ts-ignore event typings
         text: `\n${e.snippet}`,
         forceMoveMarkers: true
@@ -87,7 +90,7 @@ export default function Editor({ source, adaptor, onChange }: EditorProps) {
       editor.executeEdits("snippets", [op]);
 
       // Ensure the snippet is fully visible
-      const newLastLine = editor.getModel().getLineCount();
+      const newLastLine = editor.model.getLineCount();
       editor.revealLines(lastLine + 1, newLastLine, 0) // 0 = smooth scroll
 
       // Set the selection to the start of the snippet

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,12 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "@monaco-editor/react": "^4.4.5",
-        "@openfn/describe-package": "^0.0.10",
+        "@openfn/describe-package": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
         "@tailwindcss/container-queries": "^0.1.0",
         "@tailwindcss/forms": "^0.5.3",
         "classcat": "^5.0.4",
         "cronstrue": "^2.14.0",
         "elkjs": "^0.8.2",
+        "marked": "^4.2.4",
         "monaco-editor": "^0.34.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -24,6 +25,7 @@
         "zustand": "^4.1.0"
       },
       "devDependencies": {
+        "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
         "ava": "^5.1.0",
@@ -152,9 +154,10 @@
       }
     },
     "node_modules/@openfn/describe-package": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.10.tgz",
-      "integrity": "sha512-JEeO2/pXXaUfXlB6YXCHtUEDp7Jgjv0GG17EOXSho6g/QOJi8aPAHBCLbxd/sXal1rdVo9EsL/nQMNeRMdRITA==",
+      "version": "0.0.11",
+      "resolved": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
+      "integrity": "sha512-vLA7ziLHg9ftihoCRINilV5I6dl2ckdLD1oXN3asd7wqvWUjMaEcM3BmyVbwL7IpQzHvCI1zJJH1uf3j/gOR8w==",
+      "license": "ISC",
       "dependencies": {
         "@typescript/vfs": "^1.3.5",
         "cross-fetch": "^3.1.5",
@@ -452,6 +455,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/marked": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz",
+      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==",
+      "dev": true
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -2097,6 +2106,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
+      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/matcher": {
@@ -4577,9 +4597,8 @@
       }
     },
     "@openfn/describe-package": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.10.tgz",
-      "integrity": "sha512-JEeO2/pXXaUfXlB6YXCHtUEDp7Jgjv0GG17EOXSho6g/QOJi8aPAHBCLbxd/sXal1rdVo9EsL/nQMNeRMdRITA==",
+      "version": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
+      "integrity": "sha512-vLA7ziLHg9ftihoCRINilV5I6dl2ckdLD1oXN3asd7wqvWUjMaEcM3BmyVbwL7IpQzHvCI1zJJH1uf3j/gOR8w==",
       "requires": {
         "@typescript/vfs": "^1.3.5",
         "cross-fetch": "^3.1.5",
@@ -4868,6 +4887,12 @@
       "requires": {
         "@types/unist": "*"
       }
+    },
+    "@types/marked": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz",
+      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==",
+      "dev": true
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -6062,6 +6087,11 @@
       "requires": {
         "p-defer": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
+      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA=="
     },
     "matcher": {
       "version": "5.0.0",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@monaco-editor/react": "^4.4.5",
-        "@openfn/describe-package": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
+        "@openfn/describe-package": "^0.0.12",
         "@tailwindcss/container-queries": "^0.1.0",
         "@tailwindcss/forms": "^0.5.3",
         "classcat": "^5.0.4",
@@ -154,10 +154,9 @@
       }
     },
     "node_modules/@openfn/describe-package": {
-      "version": "0.0.11",
-      "resolved": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
-      "integrity": "sha512-vLA7ziLHg9ftihoCRINilV5I6dl2ckdLD1oXN3asd7wqvWUjMaEcM3BmyVbwL7IpQzHvCI1zJJH1uf3j/gOR8w==",
-      "license": "ISC",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.12.tgz",
+      "integrity": "sha512-39dF2HxIkTvnhilHM2X05SuX5d8wG/rXAUxEyoWZRmeQHgeBLJ2La5aOSEf8/kdwREHccaJtTjUTcHcFn5jVmg==",
       "dependencies": {
         "@typescript/vfs": "^1.3.5",
         "cross-fetch": "^3.1.5",
@@ -4597,8 +4596,9 @@
       }
     },
     "@openfn/describe-package": {
-      "version": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
-      "integrity": "sha512-vLA7ziLHg9ftihoCRINilV5I6dl2ckdLD1oXN3asd7wqvWUjMaEcM3BmyVbwL7IpQzHvCI1zJJH1uf3j/gOR8w==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.12.tgz",
+      "integrity": "sha512-39dF2HxIkTvnhilHM2X05SuX5d8wG/rXAUxEyoWZRmeQHgeBLJ2La5aOSEf8/kdwREHccaJtTjUTcHcFn5jVmg==",
       "requires": {
         "@typescript/vfs": "^1.3.5",
         "cross-fetch": "^3.1.5",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,12 +11,13 @@
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.4.5",
-    "@openfn/describe-package": "^0.0.10",
+    "@openfn/describe-package": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
     "@tailwindcss/container-queries": "^0.1.0",
     "@tailwindcss/forms": "^0.5.3",
     "classcat": "^5.0.4",
     "cronstrue": "^2.14.0",
     "elkjs": "^0.8.2",
+    "marked": "^4.2.4",
     "monaco-editor": "^0.34.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
@@ -25,6 +26,7 @@
     "zustand": "^4.1.0"
   },
   "devDependencies": {
+    "@types/marked": "^4.0.8",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "ava": "^5.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@monaco-editor/react": "^4.4.5",
-    "@openfn/describe-package": "file:../../kit/dist/openfn-describe-package-0.0.11.tgz",
+    "@openfn/describe-package": "^0.0.12",
     "@tailwindcss/container-queries": "^0.1.0",
     "@tailwindcss/forms": "^0.5.3",
     "classcat": "^5.0.4",


### PR DESCRIPTION
Several fixes to adaptor docs.

Note that this is branched off #505 and so is targeted at that (for now)

* [x] #503 Render examples with captions
* [x] Fix  some strange behaviour with add (adding multple items should work better now)
* [x]  #502 Render markdown
* [x] Handle errors a bit better (especially with @latest)

## Error handling

if you set an adaptor to `latest` and go to the editor, the docs panel will fail to load. Well, actually, it'll just say "loading" forever.

That issue will be fixed separately. But for now you'll at least see an error message should something go wrong.

![image](https://user-images.githubusercontent.com/7052509/207572820-448b1549-5a98-4df1-9219-1a84f922671f.png)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
