### PR TITLE
Create new project for user on registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,6 @@ LIGHTNING_LISTEN_ADDRESS=0.0.0.0
 #DOCKER_POSTGRES_MEMORY=0
 #DOCKER_WEB_CPUS=0
 #DOCKER_WEB_MEMORY=0
+
+# Give this variable the value of true if you want the system to create a sample project for a new registered user
+INIT_PROJECT_FOR_NEW_USER=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - Drop "configuration" key from Run output dataclips after completion
 - Ability to 'rerun' a run from the Run list
 - Attempts and Runs update themselves in the Runs list
+- Configure a project and workflow for a new registering user
 
 ### Changed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -58,6 +58,11 @@ config :lightning,
        System.get_env("QUEUE_RESULT_RETENTION_PERIOD", "60")
        |> String.to_integer()
 
+config :lightning,
+       :init_project_for_new_user,
+       System.get_env("INIT_PROJECT_FOR_NEW_USER", "false")
+       |> String.to_atom()
+
 # If you've booted up with a SENTRY_DSN environment variable, use Sentry!
 config :sentry,
   filter: Lightning.SentryEventFilter,

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -83,7 +83,7 @@ defmodule Lightning.Accounts.User do
 
   defp validate_email(changeset) do
     changeset
-    |> validate_required([:email])
+    |> validate_required([:email, :first_name])
     |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/,
       message: "must have the @ sign and no spaces"
     )

--- a/lib/lightning/demo.ex
+++ b/lib/lightning/demo.ex
@@ -53,22 +53,31 @@ defmodule Lightning.Demo do
         password: "welcome123"
       })
 
+    %{project: openhie_project, workflow: openhie_workflow, jobs: openhie_jobs} =
+      create_openhie_project([
+        %{user_id: admin.id, role: :admin},
+        %{user_id: editor.id, role: :editor},
+        %{user_id: viewer.id, role: :viewer}
+      ])
+
+    %{project: dhis2_project, workflow: dhis2_workflow, jobs: dhis2_jobs} =
+      create_dhis2_project([
+        %{user_id: admin.id, role: :admin}
+      ])
+
+    %{
+      users: [super_user, admin, editor, viewer],
+      projects: [openhie_project, dhis2_project],
+      workflows: [openhie_workflow, dhis2_workflow],
+      jobs: openhie_jobs ++ dhis2_jobs
+    }
+  end
+
+  def create_openhie_project(project_users) do
     {:ok, openhie_project} =
       Projects.create_project(%{
         name: "openhie-project",
-        project_users: [
-          %{user_id: admin.id, role: :admin},
-          %{user_id: editor.id, role: :editor},
-          %{user_id: viewer.id, role: :viewer}
-        ]
-      })
-
-    {:ok, dhis2_project} =
-      Projects.create_project(%{
-        name: "dhis2-project",
-        project_users: [
-          %{user_id: admin.id, role: :admin}
-        ]
+        project_users: project_users
       })
 
     {:ok, openhie_workflow} =
@@ -116,6 +125,25 @@ defmodule Lightning.Demo do
         workflow_id: openhie_workflow.id
       })
 
+    %{
+      project: openhie_project,
+      workflow: openhie_workflow,
+      jobs: [
+        fhir_standard_data,
+        send_to_openhim,
+        notify_upload_successful,
+        notify_upload_failed
+      ]
+    }
+  end
+
+  def create_dhis2_project(project_users) do
+    {:ok, dhis2_project} =
+      Projects.create_project(%{
+        name: "dhis2-project",
+        project_users: project_users
+      })
+
     {:ok, dhis2_workflow} =
       Workflows.create_workflow(%{
         name: "DHIS2 to Sheets",
@@ -141,17 +169,9 @@ defmodule Lightning.Demo do
       })
 
     %{
-      users: [super_user, admin, editor, viewer],
-      projects: [openhie_project, dhis2_project],
-      workflows: [openhie_workflow, dhis2_workflow],
-      jobs: [
-        fhir_standard_data,
-        send_to_openhim,
-        notify_upload_successful,
-        notify_upload_failed,
-        get_dhis2_data,
-        upload_to_google_sheet
-      ]
+      project: dhis2_project,
+      workflow: dhis2_workflow,
+      jobs: [get_dhis2_data, upload_to_google_sheet]
     }
   end
 

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -1,4 +1,4 @@
-defmodule Lightning.Demo do
+defmodule Lightning.SetupUtils do
   @moduledoc """
   Demo encapsulates logic for setting up initial data for the demo site
   """
@@ -7,7 +7,7 @@ defmodule Lightning.Demo do
 
   import Ecto.Query
 
-  @spec setup(nil | maybe_improper_list | map) :: %{
+  @spec setup_demo(nil | maybe_improper_list | map) :: %{
           jobs: [...],
           projects: [atom | %{:id => any, optional(any) => any}, ...],
           users: [atom | %{:id => any, optional(any) => any}, ...],
@@ -16,7 +16,7 @@ defmodule Lightning.Demo do
   @doc """
   Creates initial data and returns the created records.
   """
-  def setup(opts \\ [create_super: false]) do
+  def setup_demo(opts \\ [create_super: false]) do
     {:ok, super_user} =
       if opts[:create_super] do
         Accounts.register_superuser(%{
@@ -70,6 +70,55 @@ defmodule Lightning.Demo do
       projects: [openhie_project, dhis2_project],
       workflows: [openhie_workflow, dhis2_workflow],
       jobs: openhie_jobs ++ dhis2_jobs
+    }
+  end
+
+  def create_starter_project(name, project_users) do
+    {:ok, project} =
+      Projects.create_project(%{
+        name: name,
+        project_users: project_users
+      })
+
+    {:ok, workflow} =
+      Workflows.create_workflow(%{
+        name: "Sample Workflow",
+        project_id: project.id
+      })
+
+    {:ok, job_1} =
+      Jobs.create_job(%{
+        name: "Check if age is over 18 mo",
+        body:
+          "fn(state => state.data.age_in_months > 18 ? state: throw 'Not eligible.');",
+        adaptor: "@openfn/language-http",
+        trigger: %{type: "webhook"},
+        workflow_id: workflow.id
+      })
+
+    {:ok, job_2} =
+      Jobs.create_job(%{
+        name: "Convert to OHIE standard",
+        body:
+          "fn(state => ({ name: state.data.age, age: state.data.age_in_months });",
+        adaptor: "@openfn/language-common",
+        trigger: %{type: "on_job_success", upstream_job_id: job_1.id},
+        workflow_id: workflow.id
+      })
+
+    {:ok, job_3} =
+      Jobs.create_job(%{
+        name: "Load to DHIS2",
+        body: "fn(state => state);",
+        adaptor: "@openfn/language-dhis2",
+        trigger: %{type: "on_job_success", upstream_job_id: job_2.id},
+        workflow_id: workflow.id
+      })
+
+    %{
+      project: project,
+      workflow: workflow,
+      jobs: [job_1, job_2, job_3]
     }
   end
 

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -10,8 +10,14 @@ defmodule LightningWeb.UserRegistrationController do
     render(conn, "new.html", changeset: changeset)
   end
 
-  defp create_initial_project(%Lightning.Accounts.User{id: user_id}) do
-    Lightning.Demo.create_openhie_project([%{user_id: user_id, role: :admin}])
+  defp create_initial_project(%Lightning.Accounts.User{
+         id: user_id,
+         first_name: first_name
+       }) do
+    Lightning.SetupUtils.create_starter_project(
+      "#{String.downcase(first_name)}-demo",
+      [%{user_id: user_id, role: :admin}]
+    )
   end
 
   def create(conn, %{"user" => user_params}) do

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -10,6 +10,10 @@ defmodule LightningWeb.UserRegistrationController do
     render(conn, "new.html", changeset: changeset)
   end
 
+  defp create_initial_project(%Lightning.Accounts.User{id: user_id}) do
+    Lightning.Demo.create_openhie_project([%{user_id: user_id, role: :admin}])
+  end
+
   def create(conn, %{"user" => user_params}) do
     case Accounts.register_user(user_params) do
       {:ok, user} ->
@@ -18,6 +22,10 @@ defmodule LightningWeb.UserRegistrationController do
             user,
             &Routes.user_confirmation_url(conn, :edit, &1)
           )
+
+        if Application.get_env(:lightning, :init_project_for_new_user) do
+          create_initial_project(user)
+        end
 
         conn
         |> put_flash(:info, "User created successfully.")

--- a/priv/repo/demo.exs
+++ b/priv/repo/demo.exs
@@ -10,5 +10,5 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-Lightning.Demo.tear_down(destroy_super: true)
-Lightning.Demo.setup(create_super: true)
+Lightning.SetupUtils.tear_down(destroy_super: true)
+Lightning.SetupUtils.setup_demo(create_super: true)

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -120,6 +120,7 @@ defmodule Lightning.AccountsTest do
       {:ok, user} =
         Accounts.register_superuser(%{
           email: email,
+          first_name: "Sizwe",
           password: valid_user_password()
         })
 
@@ -136,7 +137,7 @@ defmodule Lightning.AccountsTest do
       assert %Ecto.Changeset{} =
                changeset = Accounts.change_user_registration(%User{})
 
-      assert changeset.required == [:password, :email]
+      assert changeset.required == [:password, :email, :first_name]
     end
 
     test "allows fields to be set" do
@@ -159,7 +160,7 @@ defmodule Lightning.AccountsTest do
   describe "change_user_email/2" do
     test "returns a user changeset" do
       assert %Ecto.Changeset{} = changeset = Accounts.change_user_email(%User{})
-      assert changeset.required == [:email]
+      assert changeset.required == [:email, :first_name]
     end
   end
 

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -1,4 +1,4 @@
-defmodule Lightning.DemoTest do
+defmodule Lightning.SetupUtilsTest do
   use Lightning.DataCase, async: true
 
   alias Lightning.Accounts
@@ -9,7 +9,7 @@ defmodule Lightning.DemoTest do
 
   describe "Setup demo site seed data" do
     setup do
-      Lightning.Demo.setup(create_super: true)
+      Lightning.SetupUtils.setup_demo(create_super: true)
     end
 
     test "all initial data is present in database", %{
@@ -101,7 +101,7 @@ defmodule Lightning.DemoTest do
 
   describe "Tear down demo data" do
     setup do
-      Lightning.Demo.setup(create_super: true)
+      Lightning.SetupUtils.setup_demo(create_super: true)
     end
 
     test "all initial data gets wiped out of database" do
@@ -110,7 +110,7 @@ defmodule Lightning.DemoTest do
       assert Lightning.Workflows.list_workflows() |> Enum.count() == 2
       assert Lightning.Jobs.list_jobs() |> Enum.count() == 6
 
-      Lightning.Demo.tear_down(destroy_super: true)
+      Lightning.SetupUtils.tear_down(destroy_super: true)
 
       assert Lightning.Accounts.list_users() |> Enum.count() == 0
       assert Lightning.Projects.list_projects() |> Enum.count() == 0
@@ -124,7 +124,7 @@ defmodule Lightning.DemoTest do
       assert Lightning.Workflows.list_workflows() |> Enum.count() == 2
       assert Lightning.Jobs.list_jobs() |> Enum.count() == 6
 
-      Lightning.Demo.tear_down(destroy_super: false)
+      Lightning.SetupUtils.tear_down(destroy_super: false)
 
       assert Lightning.Accounts.list_users() |> Enum.count() == 1
       assert Lightning.Projects.list_projects() |> Enum.count() == 0

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -39,7 +39,27 @@ defmodule LightningWeb.UserRegistrationControllerTest do
       conn = get(conn, "/")
       response = html_response(conn, 200)
       # assert response =~ email
+
       assert response =~ "Log out</span>"
+    end
+
+    test "creates account and initial project and logs the user in", %{
+      conn: conn
+    } do
+      Application.put_env(:lightning, :init_project_for_new_user, true)
+
+      conn =
+        get(
+          post(conn, Routes.user_registration_path(conn, :create), %{
+            "user" => valid_user_attributes(email: unique_user_email())
+          }),
+          "/"
+        )
+
+      assert conn.assigns.current_user
+             |> Ecto.assoc(:projects)
+             |> Lightning.Repo.one!()
+             |> Map.get(:name) == "openhie-project"
     end
 
     test "render errors for invalid data", %{conn: conn} do

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -51,7 +51,11 @@ defmodule LightningWeb.UserRegistrationControllerTest do
       conn =
         get(
           post(conn, Routes.user_registration_path(conn, :create), %{
-            "user" => valid_user_attributes(email: unique_user_email())
+            "user" =>
+              valid_user_attributes(
+                email: unique_user_email(),
+                first_name: "Emory"
+              )
           }),
           "/"
         )
@@ -59,7 +63,7 @@ defmodule LightningWeb.UserRegistrationControllerTest do
       assert conn.assigns.current_user
              |> Ecto.assoc(:projects)
              |> Lightning.Repo.one!()
-             |> Map.get(:name) == "openhie-project"
+             |> Map.get(:name) == "emory-demo"
     end
 
     test "render errors for invalid data", %{conn: conn} do

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -6,11 +6,13 @@ defmodule Lightning.AccountsFixtures do
 
   def unique_user_email, do: "user#{System.unique_integer()}@example.com"
   def valid_user_password, do: "hello world!"
+  def valid_first_name, do: "Anna"
 
   def valid_user_attributes(attrs \\ []) when is_list(attrs) do
     Enum.into(attrs, %{
       email: unique_user_email(),
-      password: valid_user_password()
+      password: valid_user_password(),
+      first_name: valid_first_name()
     })
   end
 


### PR DESCRIPTION
## Any notes for the reviewer ?

This PR ships code that allows to create sample project for a new registered user. The feature is enabled thru the `INIT_PROJECT_FOR_NEW_USER` environment variable. If that variable is set to `true` then whenever a user is creating an account, the system will create a project named `openhie_project` and configure a sample workflow in it (the one in demo.ex). cc @amberrignell 

## Related issue

Fixes #430 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
