### PR TITLE
Scope runs and dataclips by project #170

### DIFF
--- a/test/lightning_web/live/dataclip_live_test.exs
+++ b/test/lightning_web/live/dataclip_live_test.exs
@@ -19,7 +19,7 @@ defmodule LightningWeb.DataclipLiveTest do
   describe "Index" do
     setup [:create_dataclip]
 
-    test "no access to project", %{conn: conn} do
+    test "no access to project on index", %{conn: conn} do
       project = Lightning.ProjectsFixtures.project_fixture()
 
       error =
@@ -119,6 +119,45 @@ defmodule LightningWeb.DataclipLiveTest do
 
       # We don't delete dataclips yet, we just nil the body column
       assert has_element?(index_live, "#dataclip-#{dataclip.id}")
+    end
+  end
+
+  describe "Edit" do
+    setup [:create_dataclip]
+
+    test "no access to project on edit", %{
+      conn: conn,
+      dataclip: dataclip,
+      project: project_scoped
+    } do
+      {:ok, _view, html} =
+        live(
+          conn,
+          Routes.project_dataclip_edit_path(
+            conn,
+            :edit,
+            project_scoped.id,
+            dataclip.id
+          )
+        )
+
+      assert html =~ dataclip.id
+
+      project_unscoped = Lightning.ProjectsFixtures.project_fixture()
+
+      error =
+        live(
+          conn,
+          Routes.project_dataclip_edit_path(
+            conn,
+            :edit,
+            project_unscoped.id,
+            dataclip.id
+          )
+        )
+
+      assert error ==
+               {:error, {:redirect, %{flash: %{"nav" => :no_access}, to: "/"}}}
     end
   end
 end

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1076,6 +1076,41 @@ defmodule LightningWeb.RunWorkOrderTest do
   end
 
   describe "Show" do
+    test "no access to project on show", %{
+      conn: conn,
+      project: project_scoped
+    } do
+      job = workflow_job_fixture(project_id: project_scoped.id)
+      run = run_fixture(job_id: job.id)
+
+      {:ok, _view, html} =
+        live(
+          conn,
+          Routes.project_run_show_path(conn, :show, project_scoped.id, run.id)
+        )
+
+      assert html =~ run.id
+
+      project_unscoped = Lightning.ProjectsFixtures.project_fixture()
+
+      job = workflow_job_fixture(project_id: project_scoped.id)
+      run = run_fixture(job_id: job.id)
+
+      error =
+        live(
+          conn,
+          Routes.project_run_show_path(
+            conn,
+            :show,
+            project_unscoped.id,
+            run.id
+          )
+        )
+
+      assert error ==
+               {:error, {:redirect, %{flash: %{"nav" => :no_access}, to: "/"}}}
+    end
+
     test "log_view component" do
       log_lines = ["First line", "Second line"]
 


### PR DESCRIPTION
## Any notes for the reviewer ?

Individual run and dataclip liveview are already scoped in project (with the correct on_mount hook)
Added 2 liveview tests for dataclip_edit and run_show 

## Related issue

Fixes #170 Scope runs and dataclips by project

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
