### PR TITLE
273 allow a user to delete a credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - Added plausible analytics
 - Allow user to click on Webhook Trigger Node to copy webhook URL on workflow
   diagram
+- Allow any user to delete a credential that they own
 
 ### Changed
 

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -234,7 +234,8 @@ defmodule Lightning.Credentials do
         join: j in assoc(r, :job),
         join: pc in assoc(j, :project_credential),
         where: pc.credential_id == ^credential.id,
-        select: r.id
+        select: r.id,
+        limit: 1
       )
 
     length(query |> Repo.all()) > 0

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -9,7 +9,8 @@ defmodule Lightning.Credentials.Audit do
       "created",
       "updated",
       "added_to_project",
-      "removed_from_project"
+      "removed_from_project",
+      "deleted"
     ]
 
   defmodule Metadata do
@@ -68,6 +69,6 @@ defmodule Lightning.Credentials.Audit do
     audit
     |> cast(attrs, [:event, :row_id, :actor_id])
     |> cast_embed(:metadata)
-    |> validate_required([:event, :row_id, :actor_id])
+    |> validate_required([:event, :actor_id])
   end
 end

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -50,15 +50,13 @@ defmodule Lightning.Credentials.Audit do
   import Ecto.Changeset
 
   alias Lightning.Accounts.User
-  alias Lightning.Credentials.Credential
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "credentials_audit" do
     field :event, :string
-
+    field :row_id, Ecto.UUID
     embeds_one :metadata, Metadata
-    belongs_to :row, Credential
     belongs_to :actor, User
 
     timestamps(updated_at: false)

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -28,12 +28,6 @@ defmodule LightningWeb.CredentialLive.Index do
     |> assign(:credential, nil)
   end
 
-  defp has_error?(changeset, field) do
-    changeset.errors
-    |> Keyword.get_values(field)
-    |> Enum.any?()
-  end
-
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
     credential = Credentials.get_credential!(id)
@@ -49,18 +43,8 @@ defmodule LightningWeb.CredentialLive.Index do
          )
          |> put_flash(:info, "Credential deleted successfully")}
 
-      {:error, changeset} ->
-        # must be a better way (traverse errors, get messages ...)
-        if has_error?(changeset, :job_using_credential) do
-          {:noreply,
-           socket
-           |> put_flash(
-             :error,
-             "Can't delete. This credential is being used by at least one job"
-           )}
-        else
-          {:noreply, socket |> put_flash(:error, "Can't delete credential")}
-        end
+      {:error, _changeset} ->
+        {:noreply, socket |> put_flash(:error, "Can't delete credential")}
     end
   end
 

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -51,17 +51,15 @@ defmodule LightningWeb.CredentialLive.Index do
 
       {:error, changeset} ->
         # must be a better way (traverse errors, get messages ...)
-        cond do
-          has_error?(changeset, :job_using_credential) ->
-            {:noreply,
-             socket
-             |> put_flash(
-               :error,
-               "Can't delete. This credential is being used by at least one job"
-             )}
-
-          true ->
-            {:noreply, socket |> put_flash(:error, "Can't delete credential")}
+        if has_error?(changeset, :job_using_credential) do
+          {:noreply,
+           socket
+           |> put_flash(
+             :error,
+             "Can't delete. This credential is being used by at least one job"
+           )}
+        else
+          {:noreply, socket |> put_flash(:error, "Can't delete credential")}
         end
     end
   end

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -43,6 +43,15 @@
                 Edit
               </.link>
             </span>
+            |
+            <span>
+              <%= link("Delete",
+                to: "#",
+                phx_click: "delete",
+                phx_value_id: credential.id,
+                data: [confirm: "Are you sure?"]
+              ) %>
+            </span>
           </.td>
         </.tr>
       <% end %>

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -49,7 +49,10 @@
                 to: "#",
                 phx_click: "delete",
                 phx_value_id: credential.id,
-                data: [confirm: "Are you sure?"]
+                data: [
+                  confirm:
+                    "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?"
+                ]
               ) %>
             </span>
           </.td>

--- a/priv/repo/migrations/20221221042025_change_project_credentials_constraint.exs
+++ b/priv/repo/migrations/20221221042025_change_project_credentials_constraint.exs
@@ -2,19 +2,11 @@ defmodule Lightning.Repo.Migrations.ChangeProjectCredentialsConstraint do
   use Ecto.Migration
 
   def change do
-    # drop constraint(:project_credentials, "project_credentials_credential_id_fkey")
-
     alter table(:project_credentials) do
-      modify :credential_id, references(:credentials, on_delete: :delete_all, type: :binary_id), from: references(:credentials, on_delete: :nothing,  type: :binary_id)
+      modify :credential_id, references(:credentials, on_delete: :delete_all, type: :binary_id),
+        from: references(:credentials, on_delete: :nothing, type: :binary_id)
     end
 
-
-    # drop constraint(:credentials_audit, "credentials_audit_row_id_fkey")
-
-    alter table(:credentials_audit) do
-      modify :row_id, null: true, references(:credentials, on_delete: :nothing, type: :binary_id), from: references(:credentials, on_delete: :delete_all , type: :binary_id, null: false)
-    end
-
-
+    drop(constraint(:credentials_audit, "credentials_audit_row_id_fkey"))
   end
 end

--- a/priv/repo/migrations/20221221042025_change_project_credentials_constraint.exs
+++ b/priv/repo/migrations/20221221042025_change_project_credentials_constraint.exs
@@ -1,0 +1,20 @@
+defmodule Lightning.Repo.Migrations.ChangeProjectCredentialsConstraint do
+  use Ecto.Migration
+
+  def change do
+    # drop constraint(:project_credentials, "project_credentials_credential_id_fkey")
+
+    alter table(:project_credentials) do
+      modify :credential_id, references(:credentials, on_delete: :delete_all, type: :binary_id), from: references(:credentials, on_delete: :nothing,  type: :binary_id)
+    end
+
+
+    # drop constraint(:credentials_audit, "credentials_audit_row_id_fkey")
+
+    alter table(:credentials_audit) do
+      modify :row_id, null: true, references(:credentials, on_delete: :nothing, type: :binary_id), from: references(:credentials, on_delete: :delete_all , type: :binary_id, null: false)
+    end
+
+
+  end
+end

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -8,8 +8,7 @@ defmodule Lightning.CredentialsTest do
     JobsFixtures,
     CredentialsFixtures,
     AccountsFixtures,
-    ProjectsFixtures,
-    InvocationFixtures
+    ProjectsFixtures
   }
 
   import Ecto.Query

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -161,7 +161,7 @@ defmodule Lightning.CredentialsTest do
       assert credential == Credentials.get_credential!(credential.id)
     end
 
-    test "delete_credential/1 deletes the unused (by a job) credential" do
+    test "delete_credential/1 deletes a credential and removes it from associated jobs and projects" do
       user = user_fixture()
 
       project = project_fixture(user_id: user.id)

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -225,35 +225,6 @@ defmodule Lightning.CredentialsTest do
       assert job.project_credential_id == nil
     end
 
-    test "delete_credential/1 cannot delete a used credential (by a job)" do
-      user = user_fixture()
-
-      project = project_fixture()
-
-      project_credential =
-        project_credential_fixture(user_id: user.id, project_id: project.id)
-
-      job =
-        workflow_job_fixture(
-          project_id: project.id,
-          project_credential_id: project_credential.id
-        )
-
-      run_fixture(job_id: job.id)
-
-      assert {:error,
-              %Ecto.Changeset{
-                errors: [
-                  job_using_credential:
-                    {"Can't delete. This credential is being used by at least one job",
-                     []}
-                ]
-              }} =
-               Credentials.delete_credential(%Credential{
-                 id: project_credential.credential_id
-               })
-    end
-
     test "change_credential/1 returns a credential changeset" do
       user = user_fixture()
       credential = credential_fixture(user_id: user.id)

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -108,7 +108,6 @@ defmodule LightningWeb.CredentialLiveTest do
 
       refute has_element?(index_live, "#credential-#{credential.id}")
     end
-
   end
 
   describe "Clicking new from the list view" do

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -5,7 +5,8 @@ defmodule LightningWeb.CredentialLiveTest do
 
   import Lightning.{
     JobsFixtures,
-    CredentialsFixtures
+    CredentialsFixtures,
+    InvocationFixtures
   }
 
   alias LightningWeb.RouteHelpers
@@ -88,6 +89,26 @@ defmodule LightningWeb.CredentialLiveTest do
       assert html =~ credential.schema
       assert html =~ credential.name
     end
+
+    # https://github.com/OpenFn/Lightning/issues/273 - allow users to delete
+
+    test "deletes credential not used by a job", %{
+      conn: conn,
+      credential: credential
+    } do
+      {:ok, index_live, _html} =
+        live(
+          conn,
+          Routes.credential_index_path(conn, :index)
+        )
+
+      assert index_live
+             |> element("#credential-#{credential.id} a", "Delete")
+             |> render_click() =~ "Credential deleted"
+
+      refute has_element?(index_live, "#credential-#{credential.id}")
+    end
+
   end
 
   describe "Clicking new from the list view" do

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -5,8 +5,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
   import Lightning.{
     JobsFixtures,
-    CredentialsFixtures,
-    InvocationFixtures
+    CredentialsFixtures
   }
 
   alias LightningWeb.RouteHelpers

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -5,8 +5,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
   import Lightning.{
     JobsFixtures,
-    CredentialsFixtures,
-    InvocationFixtures
+    CredentialsFixtures
   }
 
   alias LightningWeb.RouteHelpers
@@ -88,57 +87,6 @@ defmodule LightningWeb.CredentialLiveTest do
       assert html =~ "Production"
       assert html =~ credential.schema
       assert html =~ credential.name
-    end
-
-    # https://github.com/OpenFn/Lightning/issues/273 - allow users to delete
-
-    test "deletes credential not used by a job", %{
-      conn: conn,
-      credential: credential
-    } do
-      {:ok, index_live, _html} =
-        live(
-          conn,
-          Routes.credential_index_path(conn, :index)
-        )
-
-      assert index_live
-             |> element("#credential-#{credential.id} a", "Delete")
-             |> render_click() =~ "Credential deleted"
-
-      refute has_element?(index_live, "#credential-#{credential.id}")
-    end
-
-    # https://github.com/OpenFn/Lightning/issues/273 - allow users to delete
-
-    test "do not delete a credential used by a job", %{
-      conn: conn,
-      project_credential: project_credential
-    } do
-      job =
-        workflow_job_fixture(
-          project_id: project_credential.project_id,
-          project_credential_id: project_credential.id
-        )
-
-      run_fixture(job_id: job.id)
-
-      credential_id = project_credential.credential_id
-
-      Lightning.Repo.all(Lightning.Credentials.Credential)
-
-      {:ok, index_live, _html} =
-        live(
-          conn,
-          Routes.credential_index_path(conn, :index)
-        )
-
-      assert index_live
-             |> element("#credential-#{credential_id} a", "Delete")
-             |> render_click() =~
-               "This credential is being used by at least one job"
-
-      assert has_element?(index_live, "#credential-#{credential_id}")
     end
   end
 

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -2,9 +2,12 @@ defmodule LightningWeb.CredentialLiveTest do
   use LightningWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
-  import Lightning.CredentialsFixtures
 
-  import Lightning.JobsFixtures
+  import Lightning.{
+    JobsFixtures,
+    CredentialsFixtures,
+    InvocationFixtures
+  }
 
   alias LightningWeb.RouteHelpers
   alias Lightning.Credentials
@@ -88,8 +91,8 @@ defmodule LightningWeb.CredentialLiveTest do
     end
 
     # https://github.com/OpenFn/Lightning/issues/273 - allow users to delete
-    @tag :skip
-    test "deletes credential without a shared project", %{
+
+    test "deletes credential not used by a job", %{
       conn: conn,
       credential: credential
     } do
@@ -101,17 +104,42 @@ defmodule LightningWeb.CredentialLiveTest do
 
       assert index_live
              |> element("#credential-#{credential.id} a", "Delete")
-             |> render_click()
+             |> render_click() =~ "Credential deleted"
 
       refute has_element?(index_live, "#credential-#{credential.id}")
     end
 
     # https://github.com/OpenFn/Lightning/issues/273 - allow users to delete
-    @tag :skip
-    test "deletes a credential with a shared project"
-    # displays warning
-    # removes project_credential
-    # removes from any jobs that are currently using it
+
+    test "do not delete a credential used by a job", %{
+      conn: conn,
+      project_credential: project_credential
+    } do
+      job =
+        workflow_job_fixture(
+          project_id: project_credential.project_id,
+          project_credential_id: project_credential.id
+        )
+
+      run_fixture(job_id: job.id)
+
+      credential_id = project_credential.credential_id
+
+      Lightning.Repo.all(Lightning.Credentials.Credential)
+
+      {:ok, index_live, _html} =
+        live(
+          conn,
+          Routes.credential_index_path(conn, :index)
+        )
+
+      assert index_live
+             |> element("#credential-#{credential_id} a", "Delete")
+             |> render_click() =~
+               "This credential is being used by at least one job"
+
+      assert has_element?(index_live, "#credential-#{credential_id}")
+    end
   end
 
   describe "Clicking new from the list view" do


### PR DESCRIPTION
## Any notes for the reviewer ?

- Credential is considered to be undeletable if a job refering to it (via project_credential) has been ran.
- To allow "deleted" record in audit trail, we removed referential integrity (credential foreign key: row_id is now a simple field)
- needs ecto.reset or ecto.migrate

## Related issue

Fixes #273 allow a user to delete a credential

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
