### PR TITLE
Fix tooltips in Monaco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## [Unreleased]
 
 - Better code-assist and intelliense in the Job Editor
+- Fixed overflow on Job Editor Tooltips
+- Fixed auto-scroll when adding a new snippet in the Job Editor
 
 ### Added
 


### PR DESCRIPTION
Hovering over text at the top of the Monaco editor in the Job Editor panel can result in the tooltip being clipped.

![image](https://user-images.githubusercontent.com/7052509/210805409-ce13d5c7-0277-4e52-8083-a38b4f5ab2e2.png)

This PR fixes it so that the whole tooltip is always visible.

![image](https://user-images.githubusercontent.com/7052509/210806047-0c0edcc1-530e-4263-b35b-8601cbcf4eb1.png)


The problem is caused by zindex and overflow controls in the parenting dom hierarchy. Fixing the parent page will result in overflow hell and I'm not up for that.

Instead, we can tell Monaco to render its tooltips and menus outside of its own dom.

The Editor component will, on mount, attach a div container to `document.body` and render its overlays in there. It will be a good citizen and remove this extra div when unmounted.

While I was in the area, I caught a couple of issues in the snippet code, so I've fixed those. I'll call them out in comments.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
