### PR TITLE
Fix downstream jobs trigger type options,

### DIFF
--- a/lib/lightning_web/live/job_live/job_builder_components.ex
+++ b/lib/lightning_web/live/job_live/job_builder_components.ex
@@ -21,9 +21,9 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
 
   def trigger_picker(assigns) do
     trigger_type_options =
-      if assigns.form.data.type in [:on_job_success, :on_job_failure],
-        do: @flow_trigger_types,
-        else: @start_trigger_types
+      if get_field(assigns.form.source, :type) in [:webhook, :cron],
+        do: @start_trigger_types,
+        else: @flow_trigger_types
 
     assigns =
       assign(assigns,


### PR DESCRIPTION
## Any notes for the reviewer?

I have fixed the downstream jobs trigger type options, by using `get_field` function and update the trigger type options conditioning 
## Related issue

Fixes #550 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
