### PR TITLE
Refocus diagram on layout change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
   diagram
 - Allow any user to delete a credential that they own
 - Create any credential through a form except for OAuth
+- Refit all diagram nodes on browser and container resize
 
 ### Changed
 

--- a/assets/js/workflow-diagram/component.tsx
+++ b/assets/js/workflow-diagram/component.tsx
@@ -14,6 +14,7 @@ export function mount(el: Element | DocumentFragment) {
   function update({ onNodeClick, onPaneClick, onJobAddClick }: UpdateParams) {
     return componentRoot.render(
       <WorkflowDiagram
+        ref={el}
         className="h-8"
         onJobAddClick={onJobAddClick}
         onNodeClick={onNodeClick}

--- a/assets/js/workflow-diagram/component.tsx
+++ b/assets/js/workflow-diagram/component.tsx
@@ -29,5 +29,10 @@ export function mount(el: Element | DocumentFragment) {
 
   componentRoot.render(<h1>Loading</h1>);
 
-  return { update, unmount, setProjectSpace: Store.setProjectSpace };
+  return {
+    update,
+    unmount,
+    setProjectSpace: Store.setProjectSpace,
+    setSelectedNode: Store.selectNode,
+  };
 }

--- a/assets/js/workflow-diagram/index.ts
+++ b/assets/js/workflow-diagram/index.ts
@@ -77,6 +77,7 @@ export default {
   },
   destroyed() {
     console.debug('Unmounting WorkflowDiagram component');
+
     this.observer?.disconnect();
     this.component?.unmount();
   },

--- a/assets/js/workflow-diagram/src/index.tsx
+++ b/assets/js/workflow-diagram/src/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import JobNode from './nodes/JobNode';
 import OperationNode from './nodes/OperationNode';
 import TriggerWorkflowNode from './nodes/TriggerWorkflowNode';
-import type { ProjectSpace } from './types';
 
 import EmptyWorkflowNode from './nodes/EmptyWorkflowNode';
 import ReactFlow, { Node, ReactFlowProvider } from 'react-flow-renderer';
@@ -20,21 +19,19 @@ const nodeTypes = {
 const WorkflowDiagram = React.forwardRef<
   Element,
   {
-    projectSpace: ProjectSpace;
     onJobAddClick?: (node: Node<NodeData>) => void;
     onNodeClick?: (event: React.MouseEvent, node: Node<NodeData>) => void;
     onPaneClick?: (event: React.MouseEvent) => void;
   }
->(({ projectSpace, onNodeClick, onPaneClick, onJobAddClick }, ref) => {
-  const { nodes, edges, onNodesChange, onEdgesChange, onSelectedNodeChange } =
-    Store.useStore();
+>(({ onNodeClick, onPaneClick, onJobAddClick }, ref) => {
+  const { nodes, edges, onNodesChange, onEdgesChange } = Store.useStore();
 
   const handleNodeClick = useCallback(
     (event: React.MouseEvent, node: Node<NodeData>) => {
       const plusIds = new Set(['plusButton', 'plusIcon']);
-      if (plusIds.has(event.target.id) && onJobAddClick) {
-        event.stopPropagation();
+      event.stopPropagation();
 
+      if (plusIds.has(event.target.id) && onJobAddClick) {
         onJobAddClick(node);
       } else {
         if (onNodeClick) {
@@ -59,12 +56,6 @@ const WorkflowDiagram = React.forwardRef<
     }
   }, [ref]);
 
-  useEffect(() => {
-    if (projectSpace) {
-      Store.setProjectSpace(projectSpace);
-    }
-  }, [projectSpace]);
-
   return (
     <ReactFlowProvider>
       <ReactFlow
@@ -74,7 +65,7 @@ const WorkflowDiagram = React.forwardRef<
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
-        onSelectionChange={onSelectedNodeChange}
+        // onSelectionChange={onSelectedNodeChange}
         // onConnect={onConnect}
         // If we let folks drag, we have to save new visual configuration...
         nodesDraggable={false}

--- a/assets/js/workflow-diagram/src/layout/factories.ts
+++ b/assets/js/workflow-diagram/src/layout/factories.ts
@@ -25,6 +25,7 @@ export function triggerNodeFactory(job: Job, workflow: Workflow): FlowElkNode {
     __flowProps__: {
       data,
       type: 'trigger',
+      selectable: false,
     },
     width: 190,
     height: 70,

--- a/assets/js/workflow-diagram/src/layout/flow-nodes.tsx
+++ b/assets/js/workflow-diagram/src/layout/flow-nodes.tsx
@@ -22,6 +22,7 @@ export function toFlowNode(node: FlowElkNode, parent?: FlowElkNode): Node {
       width: node.width,
       zIndex: isContainer ? -1 : 1,
     },
+    selectable: node.__flowProps__.selectable ? true : false,
     position: { x: node.x || 0, y: node.y || 0 },
     ...nodeData(node),
     ...nodeType(node),

--- a/assets/js/workflow-diagram/src/layout/types.ts
+++ b/assets/js/workflow-diagram/src/layout/types.ts
@@ -22,6 +22,7 @@ export type NodeData = {
 export interface NodeFlowProps {
   data: NodeData;
   type: string;
+  selectable?: boolean;
 }
 
 export interface FlowElkNode extends ElkNode {

--- a/assets/js/workflow-diagram/src/store.ts
+++ b/assets/js/workflow-diagram/src/store.ts
@@ -5,6 +5,7 @@ import {
   EdgeChange,
   Node,
   NodeChange,
+  NodeSelectionChange,
   OnEdgesChange,
   OnNodesChange,
   OnSelectionChangeFunc,
@@ -25,7 +26,7 @@ type RFState = {
   onEdgesChange: OnEdgesChange;
   onSelectedNodeChange: OnSelectionChangeFunc;
   reactFlowInstance: ReactFlowInstance | null;
-  selectedNode: Node | undefined;
+  selectedNode: string | undefined;
 };
 
 export const useStore = create<RFState>((set, get) => ({
@@ -43,23 +44,46 @@ export const useStore = create<RFState>((set, get) => ({
       edges: applyEdgeChanges(changes, get().edges),
     });
   },
-  onSelectedNodeChange: ({ nodes }: { nodes: Node[] }) => {
-    set({ selectedNode: nodes[0] });
-  },
+  onSelectedNodeChange: (_data: { nodes: Node[] }) => {},
   reactFlowInstance: null,
   selectedNode: undefined,
 }));
 
+function markSelected(nodes: Node[], selectedNode: string | undefined) {
+  if (!selectedNode) {
+    return nodes;
+  }
+
+  return nodes.map(node => {
+    if (selectedNode == node.id) {
+      return {
+        ...node,
+        selected: true,
+      };
+    }
+
+    return node;
+  });
+}
+
 export async function setProjectSpace(
-  projectSpace: ProjectSpace
+  projectSpace: ProjectSpace | string
 ): Promise<void> {
+  if (typeof projectSpace == 'string') {
+    projectSpace = JSON.parse(atob(projectSpace)) as ProjectSpace;
+  }
   let elkNode: FlowElkNode = toElkNode(projectSpace);
 
   elkNode = await doLayout(elkNode);
 
   const [nodes, edges] = toFlow(elkNode);
 
-  useStore.setState({ nodes, edges, projectSpace, elkNode });
+  useStore.setState({
+    nodes: markSelected(nodes, useStore.getState().selectedNode),
+    edges,
+    projectSpace,
+    elkNode,
+  });
 }
 
 export async function addWorkspace(workflow: Workflow) {
@@ -97,3 +121,30 @@ export const fitView = debounce(() => {
     reactFlowInstance.fitView({ duration: 250 });
   }
 }, 250);
+
+export function unselectAllNodes() {
+  const nodes = useStore.getState().nodes;
+  const changes: NodeSelectionChange[] = nodes.map(({ id }) => ({
+    id,
+    type: 'select',
+    selected: false,
+  }));
+
+  useStore.setState({ nodes: applyNodeChanges(changes, nodes) });
+}
+
+export function selectNode(selectedId: string) {
+  const nodes = useStore.getState().nodes;
+  const changes: NodeSelectionChange[] = nodes.map(node => {
+    return {
+      id: node.id,
+      type: 'select',
+      selected: selectedId == node.id,
+    };
+  });
+
+  useStore.setState({
+    nodes: applyNodeChanges(changes, nodes),
+    selectedNode: selectedId,
+  });
+}

--- a/assets/js/workflow-diagram/src/store.ts
+++ b/assets/js/workflow-diagram/src/store.ts
@@ -7,6 +7,8 @@ import {
   NodeChange,
   OnEdgesChange,
   OnNodesChange,
+  OnSelectionChangeFunc,
+  ReactFlowInstance,
 } from 'react-flow-renderer';
 import { ProjectSpace, Workflow } from './types';
 import create from 'zustand';
@@ -21,6 +23,9 @@ type RFState = {
   projectSpace: ProjectSpace | null;
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
+  onSelectedNodeChange: OnSelectionChangeFunc;
+  reactFlowInstance: ReactFlowInstance | null;
+  selectedNode: Node | undefined;
 };
 
 export const useStore = create<RFState>((set, get) => ({
@@ -38,6 +43,11 @@ export const useStore = create<RFState>((set, get) => ({
       edges: applyEdgeChanges(changes, get().edges),
     });
   },
+  onSelectedNodeChange: ({ nodes }: { nodes: Node[] }) => {
+    set({ selectedNode: nodes[0] });
+  },
+  reactFlowInstance: null,
+  selectedNode: undefined,
 }));
 
 export async function setProjectSpace(
@@ -67,3 +77,23 @@ export async function addWorkspace(workflow: Workflow) {
 
   useStore.setState({ nodes, edges, elkNode });
 }
+
+export function setReactFlowInstance(rf: ReactFlowInstance) {
+  useStore.setState({ reactFlowInstance: rf });
+}
+
+function debounce(fun: () => void, t: number | undefined) {
+  let timeout: string | number | NodeJS.Timeout | undefined;
+  return () => {
+    clearTimeout(timeout);
+    timeout = setTimeout(fun, t);
+  };
+}
+
+export const fitView = debounce(() => {
+  let reactFlowInstance = useStore.getState().reactFlowInstance;
+
+  if (reactFlowInstance) {
+    reactFlowInstance.fitView({ duration: 250 });
+  }
+}, 250);

--- a/assets/test/fixtures/single-workflow-elknode.json
+++ b/assets/test/fixtures/single-workflow-elknode.json
@@ -25,6 +25,7 @@
         {
           "id": "A-trigger",
           "__flowProps__": {
+            "selectable": false,
             "data": {
               "label": "Webhook",
               "trigger": {

--- a/assets/test/fixtures/single-workflow-nodeedges.json
+++ b/assets/test/fixtures/single-workflow-nodeedges.json
@@ -11,6 +11,7 @@
         "x": 15,
         "y": 15
       },
+      "selectable": false,
       "data": {
         "hasChildren": true,
         "id": "wf-one",
@@ -41,6 +42,7 @@
           "name": "Workflow One"
         }
       },
+      "selectable": false,
       "type": "trigger",
       "parentNode": "wf-one",
       "extent": "parent"
@@ -63,6 +65,7 @@
         "workflowId": "wf-one"
       },
       "type": "job",
+      "selectable": false,
       "parentNode": "wf-one",
       "extent": "parent"
     },
@@ -82,6 +85,7 @@
         "label": "create"
       },
       "type": "operation",
+      "selectable": false,
       "parentNode": "A",
       "extent": "parent"
     },
@@ -101,6 +105,7 @@
         "label": "fn"
       },
       "type": "operation",
+      "selectable": false,
       "parentNode": "A",
       "extent": "parent"
     },
@@ -120,6 +125,7 @@
         "label": "upsert"
       },
       "type": "operation",
+      "selectable": false,
       "parentNode": "A",
       "extent": "parent"
     },
@@ -141,6 +147,7 @@
         "workflowId": "wf-one"
       },
       "type": "job",
+      "selectable": false,
       "parentNode": "wf-one",
       "extent": "parent"
     },
@@ -162,6 +169,7 @@
         "workflowId": "wf-one"
       },
       "type": "job",
+      "selectable": false,
       "parentNode": "wf-one",
       "extent": "parent"
     },
@@ -183,6 +191,7 @@
         "workflowId": "wf-one"
       },
       "type": "job",
+      "selectable": false,
       "parentNode": "wf-one",
       "extent": "parent"
     },
@@ -202,6 +211,7 @@
         "label": "fn"
       },
       "type": "operation",
+      "selectable": false,
       "parentNode": "E",
       "extent": "parent"
     },
@@ -221,6 +231,7 @@
         "label": "upsert"
       },
       "type": "operation",
+      "selectable": false,
       "parentNode": "E",
       "extent": "parent"
     }

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -58,6 +58,7 @@ defmodule LightningWeb.WorkflowLive do
                   )
                 }
                 id={@current_workflow.id}
+                selected_node={@selected_node_id}
                 encoded_project_space={@encoded_project_space}
               />
             </div>
@@ -97,6 +98,7 @@ defmodule LightningWeb.WorkflowLive do
                   )
                 }
                 id={@current_workflow.id}
+                selected_node={@job.id}
                 encoded_project_space={@encoded_project_space}
               />
             </div>
@@ -285,6 +287,7 @@ defmodule LightningWeb.WorkflowLive do
           "upstream_job_id" => upstream_job.id
         }
       },
+      selected_node_id: upstream_job.id,
       current_workflow: workflow,
       encoded_project_space: encode_project_space(workflow),
       page_title: "Workflows"
@@ -304,6 +307,7 @@ defmodule LightningWeb.WorkflowLive do
       job_params: %{
         "trigger" => %{"type" => :webhook}
       },
+      selected_node_id: nil,
       current_workflow: workflow,
       workflow:
         Workflows.Workflow.changeset(workflow, %{

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -42,7 +42,28 @@ defmodule LightningWeb.WorkflowLive do
           </:title>
         </Layout.header>
       </:header>
-      <div class="relative h-full">
+      <div class="relative h-full flex">
+        <%= if @show_canvas do %>
+          <div class="grow">
+            <div
+              phx-hook="WorkflowDiagram"
+              class="h-full w-full"
+              id={"hook-#{@project.id}"}
+              phx-update="ignore"
+              base-path={
+                Routes.project_workflow_path(
+                  @socket,
+                  :show,
+                  @project.id,
+                  @current_workflow.id
+                )
+              }
+              data-project-space={@encoded_project_space}
+            >
+            </div>
+          </div>
+        <% end %>
+
         <%= case @live_action do %>
           <% :index -> %>
             <Layout.centered>
@@ -75,24 +96,26 @@ defmodule LightningWeb.WorkflowLive do
               </div>
             </div>
           <% :edit_job -> %>
-            <div class="absolute w-1/2 inset-y-0 right-0 z-10">
-              <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
-                <.live_component
-                  module={LightningWeb.JobLive.JobBuilder}
-                  id={"builder-#{@job.id}"}
-                  job={@job}
-                  project={@project}
-                  current_user={@current_user}
-                  builder_state={@builder_state}
-                  return_to={
-                    Routes.project_workflow_path(
-                      @socket,
-                      :show,
-                      @project.id,
-                      @current_workflow.id
-                    )
-                  }
-                />
+            <div class="grow-0 w-1/2 relative">
+              <div class="absolute w-full inset-y-0 z-10">
+                <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
+                  <.live_component
+                    module={LightningWeb.JobLive.JobBuilder}
+                    id={"builder-#{@job.id}"}
+                    job={@job}
+                    project={@project}
+                    current_user={@current_user}
+                    builder_state={@builder_state}
+                    return_to={
+                      Routes.project_workflow_path(
+                        @socket,
+                        :show,
+                        @project.id,
+                        @current_workflow.id
+                      )
+                    }
+                  />
+                </div>
               </div>
             </div>
           <% :show -> %>
@@ -143,24 +166,15 @@ defmodule LightningWeb.WorkflowLive do
             </div>
           <% _ -> %>
         <% end %>
-        <%= if @show_canvas do %>
-          <div
-            phx-hook="WorkflowDiagram"
-            class="h-full w-full"
-            id={"hook-#{@project.id}"}
-            phx-update="ignore"
-            base-path={
-              Routes.project_workflow_path(
-                @socket,
-                :show,
-                @project.id,
-                @current_workflow.id
-              )
-            }
-            data-project-space={@encoded_project_space}
-          >
-          </div>
-        <% end %>
+        <%!-- <div class="flex-none w-14 h-14 ...">
+    01
+    </div>
+    <div class="grow h-14 ...">
+    02
+    </div>
+    <div class="flex-none w-14 h-14 ...">
+    03
+    </div> --%>
       </div>
     </Layout.page_content>
     """

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -88,6 +88,7 @@ defmodule LightningWeb.WorkflowLive.Components do
 
   attr :id, :string, required: true
   attr :encoded_project_space, :string, required: true
+  attr :selected_node, :string, default: nil
   attr :base_path, :string, required: true
 
   def workflow_diagram(assigns) do
@@ -98,6 +99,7 @@ defmodule LightningWeb.WorkflowLive.Components do
       id={"hook-#{@id}"}
       phx-update="ignore"
       base-path={@base_path}
+      data-selected-node={@selected_node}
       data-project-space={@encoded_project_space}
     >
     </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -52,4 +52,55 @@ defmodule LightningWeb.WorkflowLive.Components do
     </div>
     """
   end
+
+  attr :socket, :map, required: true
+  attr :project, :map, required: true
+  attr :workflow, :map, required: true
+
+  def create_job_panel(assigns) do
+    ~H"""
+    <div class="w-1/2 h-16 text-center my-16 mx-auto pt-4">
+      <div class="text-sm font-semibold text-gray-500 pb-4">
+        Create your first job to get started.
+      </div>
+      <div class="text-xs text-gray-400">
+        <.link patch={
+          Routes.project_workflow_path(
+            @socket,
+            :new_job,
+            @project.id,
+            @workflow.id
+          )
+        }>
+          <Common.button>
+            <div class="h-full">
+              <Heroicons.plus class="h-4 w-4 inline-block" />
+              <span class="inline-block align-middle">
+                Create job
+              </span>
+            </div>
+          </Common.button>
+        </.link>
+      </div>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :encoded_project_space, :string, required: true
+  attr :base_path, :string, required: true
+
+  def workflow_diagram(assigns) do
+    ~H"""
+    <div
+      phx-hook="WorkflowDiagram"
+      class="h-full w-full"
+      id={"hook-#{@id}"}
+      phx-update="ignore"
+      base-path={@base_path}
+      data-project-space={@encoded_project_space}
+    >
+    </div>
+    """
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -104,7 +104,7 @@ defmodule Lightning.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup"],
+      setup: ["deps.get", "lightning.install_runtime", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],


### PR DESCRIPTION
## Any notes for the reviewer ?

This change observes changes to the containing element and triggers a 'fitView' - which is the same behaviour when seeing the diagram for the first time.

This means it will respond to browser window size changes and when the Job panel appears.

It should be noted that if a user moves and/or zooms around, the fitView function will essentially reset the view.

We can discuss later about how we might want to improve this, such as remembering the last position the view had, and return to that. There is a lot we can do around this behaviour like zooming and focusing and zooming back out etc, but it requires some careful logic.

Unless we want that (or something different now), let's chat.

## Related issue

Fixes #483 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
