### PR TITLE
Better docs error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to
 
 ## [Unreleased]
 
-- Better code-assist and intelliense in the Job Editor
-- Fixed overflow on Job Editor Tooltips
-- Fixed auto-scroll when adding a new snippet in the Job Editor
-
 ### Added
 
 - Added a Delete job button in Inspector
@@ -29,6 +25,7 @@ and this project adheres to
 
 ### Changed
 
+- Better code-assist and intelliense in the Job Editor
 - Updated @openfn/workflow-diagram to 0.4.0
 - Make plus button part of job nodes in Workflow Diagram
 - Updated @openfn/adaptor-docs to 0.0.5
@@ -45,10 +42,13 @@ and this project adheres to
 - Rename a workflow through the page heading
 - Hide the dataclips tab for beta
 - Remove jobs list page
+- Better error handling in the docs panel
 
 ### Fixed
 
 - Don't consider disabled jobs when calculating subsequent runs
+- Fixed overflow on Job Editor Tooltips
+- Fixed auto-scroll when adding a new snippet in the Job Editor
 
 ## [0.3.1] - 2022-11-22
 

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -8,12 +8,17 @@ type DocsPanelProps = {
   onInsert?: (text: string) => void;
 }
 
+const docsLink = (<p>You can check the external docs site at 
+<a className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2" href="https://docs.openfn.org/adaptors/#where-to-find-them." target="none">docs.openfn.org/adaptors</a>.
+</p>)
+
 const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   if (!specifier) {;
     return <div>Nothing selected</div>;
   }
-
+  
   const pkg = useDocs(specifier);
+  
   if (pkg === null) {
     return <div className="block m-2">Loading docs...</div>
   }
@@ -21,14 +26,22 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
     return (
       <div className="block m-2">
         <p>Sorry, an error occurred loading the docs for this adaptor.</p>
-        <p>You can check our docs site at 
-          <a className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2" href="https://docs.openfn.org/adaptors/#where-to-find-them." target="none">docs.openfn.org/adaptors</a>.
-        </p>
+        {docsLink}    
+      </div>
+    );
+  }
+
+  const { name, version, functions } = pkg as PackageDescription;
+  if (functions.length === 0) {
+    return (
+      <div className="block m-2">
+        <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">{name} ({version})</h1>
+        <p>Sorry, docs are unavailable for this adaptor.</p>
+        {docsLink}    
       </div>
     );
   }
   
-  const { name, version, functions } = pkg as PackageDescription;
   return (
     <div className="block m-2">
       <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">{name} ({version})</h1>

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -18,7 +18,14 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
     return <div className="block m-2">Loading docs...</div>
   }
   if (pkg === false) {
-    return <div className="block m-2">Error: failed to load docs.</div>
+    return (
+      <div className="block m-2">
+        <p>Sorry, an error occurred loading the docs for this adaptor.</p>
+        <p>You can check our docs site at 
+          <a className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2" href="https://docs.openfn.org/adaptors/#where-to-find-them." target="none">docs.openfn.org/adaptors</a>.
+        </p>
+      </div>
+    );
   }
   
   const { name, version, functions } = pkg as PackageDescription;

--- a/assets/js/adaptor-docs/hooks/useDocs.tsx
+++ b/assets/js/adaptor-docs/hooks/useDocs.tsx
@@ -10,6 +10,7 @@ const useDocs = (specifier: string) => {
     describePackage(specifier, {}).then((result) => {
       setDocs(result);
     }).catch((err) => {
+      console.error(err)
       setDocs(false)
     });
   }, [specifier])


### PR DESCRIPTION
A really quick improvement to error handling in the docs panel

If we have a problem, link to the main docs site (and be a little less terse in our messaging).  I'm also logging the error to console for easier debugging.

Here's how it look now:

![image](https://user-images.githubusercontent.com/7052509/211873706-3b1ec2f8-d4f8-42dd-960f-4c0c13eae5c8.png)

This occurs when using beyonic @0.1.1

I'll fix the actual issue over in `kit` but this is a much better fallback for when something DOES go wrong.

Unfortunately the fix won't entirely solve the problem and some older adaptors will remain unsupported. For those, we  will show this message:

![image](https://user-images.githubusercontent.com/7052509/211885641-bd67e9d9-f0d4-4ebf-a7eb-2d250b365520.png)

Thanks to Amber for the idea.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
