### PR TITLE
Split Schema into Schema and SchemaDocument

### DIFF
--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -1,7 +1,7 @@
 defmodule Lightning.Credentials.Schema do
   @moduledoc """
-  Dynamic changeset module which uses a JsonSchema (parsed with `ExJsonSchema`)
-  to validate credentials based on the schema provided.
+  Structure that can parse JsonSchemas (using `ExJsonSchema`) and validate
+  changesets for a given schema.
   """
 
   alias ExJsonSchema.Validator
@@ -16,7 +16,6 @@ defmodule Lightning.Credentials.Schema do
 
   defstruct [:name, :root, :types, :fields]
 
-  # TODO: split the changeset stuff and "schema struct" into different modules
   @spec new(json_schema :: %{String.t() => any()}, name :: String.t() | nil) ::
           __MODULE__.t()
   def new(json_schema, name \\ nil) when is_map(json_schema) do
@@ -27,10 +26,9 @@ defmodule Lightning.Credentials.Schema do
     struct!(__MODULE__, name: name, root: root, types: types, fields: fields)
   end
 
-  # TODO: takes a schema and a changeset and applies validation errors
   @spec validate(changeset :: Ecto.Changeset.t(), schema :: __MODULE__.t()) ::
           Ecto.Changeset.t()
-  def validate(changeset, schema = %__MODULE__{}) do
+  def validate(changeset, %__MODULE__{} = schema) do
     validation =
       Validator.validate(
         schema.root,
@@ -48,7 +46,6 @@ defmodule Lightning.Credentials.Schema do
   end
 
   defp error_to_changeset(%{path: path, error: error}, changeset) do
-    # TODO: perhaps we don't use atoms here?
     field = String.slice(path, 2..-1) |> String.to_existing_atom()
 
     case error do

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -3,40 +3,38 @@ defmodule Lightning.Credentials.Schema do
   Dynamic changeset module which uses a JsonSchema (parsed with `ExJsonSchema`)
   to validate credentials based on the schema provided.
   """
+
   alias ExJsonSchema.Validator
-  import Ecto.Changeset
+  alias Ecto.Changeset
 
   @type t :: %__MODULE__{
-          schema_root: ExJsonSchema.Schema.Root.t(),
+          name: String.t() | nil,
+          root: ExJsonSchema.Schema.Root.t(),
           types: Ecto.Changeset.types(),
-          data: Ecto.Changeset.data()
+          fields: [String.t()]
         }
 
-  defstruct [:schema_root, :types, :data]
+  defstruct [:name, :root, :types, :fields]
 
-  @spec new(schema :: %{String.t() => any()}, data :: %{String.t() => any()}) ::
+  # TODO: split the changeset stuff and "schema struct" into different modules
+  @spec new(json_schema :: %{String.t() => any()}, name :: String.t() | nil) ::
           __MODULE__.t()
-  def new(schema, data \\ %{}) when is_map(schema) do
-    if is_nil(data) do
-      raise "#{__MODULE__}.new/2 got nil for data, expects a map."
-    end
+  def new(json_schema, name \\ nil) when is_map(json_schema) do
+    root = ExJsonSchema.Schema.resolve(json_schema)
+    types = get_types(root)
+    fields = Map.keys(types)
 
-    schema_root = ExJsonSchema.Schema.resolve(schema)
-    types = get_types(schema_root)
-    data = build_body(types, data)
-
-    struct!(__MODULE__, schema_root: schema_root, types: types, data: data)
+    struct!(__MODULE__, name: name, root: root, types: types, fields: fields)
   end
 
-  def changeset(%__MODULE__{} = schema, attrs) do
-    changeset =
-      {schema.data, schema.types}
-      |> cast(attrs, Map.keys(schema.types))
-
+  # TODO: takes a schema and a changeset and applies validation errors
+  @spec validate(changeset :: Ecto.Changeset.t(), schema :: __MODULE__.t()) ::
+          Ecto.Changeset.t()
+  def validate(changeset, schema = %__MODULE__{}) do
     validation =
       Validator.validate(
-        schema.schema_root,
-        apply_changes(changeset) |> stringify_keys(),
+        schema.root,
+        Changeset.apply_changes(changeset) |> stringify_keys(),
         error_formatter: false
       )
 
@@ -50,27 +48,28 @@ defmodule Lightning.Credentials.Schema do
   end
 
   defp error_to_changeset(%{path: path, error: error}, changeset) do
+    # TODO: perhaps we don't use atoms here?
     field = String.slice(path, 2..-1) |> String.to_existing_atom()
 
     case error do
       %{expected: "uri"} ->
-        add_error(changeset, field, "expected to be a URI")
+        Changeset.add_error(changeset, field, "expected to be a URI")
 
       %{missing: fields} ->
         Enum.reduce(fields, changeset, fn field, changeset ->
-          add_error(changeset, field, "can't be blank")
+          Changeset.add_error(changeset, field, "can't be blank")
         end)
 
       %{actual: 0, expected: _} ->
-        add_error(changeset, field, "can't be blank")
+        Changeset.add_error(changeset, field, "can't be blank")
 
       %{actual: "null", expected: expected} when is_list(expected) ->
-        add_error(changeset, field, "can't be blank")
+        Changeset.add_error(changeset, field, "can't be blank")
     end
   end
 
-  defp get_types(schema_root) do
-    schema_root.schema
+  defp get_types(root) do
+    root.schema
     |> Map.get("properties", [])
     |> Enum.map(fn {k, properties} ->
       {k |> String.to_atom(),
@@ -78,14 +77,6 @@ defmodule Lightning.Credentials.Schema do
     end)
     |> Enum.reverse()
     |> Map.new()
-  end
-
-  @spec build_body(types :: Ecto.Changeset.types(), initial :: map()) ::
-          Ecto.Changeset.data()
-  def build_body(types, initial) do
-    Map.new(types, fn {k, _type} ->
-      {k, Map.get(initial, k |> to_string(), nil)}
-    end)
   end
 
   defp stringify_keys(data) when is_map(data) do

--- a/lib/lightning/credentials/schema_document.ex
+++ b/lib/lightning/credentials/schema_document.ex
@@ -1,0 +1,10 @@
+defmodule Lightning.Credentials.SchemaDocument do
+  alias Lightning.Credentials.Schema
+  import Ecto.Changeset
+
+  def changeset(document, attrs, schema: schema = %Schema{}) do
+    {document, schema.types}
+    |> cast(attrs, schema.fields)
+    |> Schema.validate(schema)
+  end
+end

--- a/lib/lightning/credentials/schema_document.ex
+++ b/lib/lightning/credentials/schema_document.ex
@@ -1,4 +1,9 @@
 defmodule Lightning.Credentials.SchemaDocument do
+  @moduledoc """
+  Provides facilities to dynamically create and validate a changeset for a given
+  [Schema](`Lightning.Credentials.Schema`)
+  """
+
   alias Lightning.Credentials.Schema
   import Ecto.Changeset
 

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -67,16 +67,17 @@ defmodule LightningWeb.CredentialLive.FormComponent do
      |> assign_new(:show_project_credentials, fn -> true end)}
   end
 
-  defp read_schema(schema) do
+  defp get_schema(schema_name) do
     {:ok, schemas_path} = Application.fetch_env(:lightning, :schemas_path)
 
-    File.read!("#{schemas_path}/#{schema}.json")
+    File.read!("#{schemas_path}/#{schema_name}.json")
     |> Jason.decode!()
+    |> Credentials.Schema.new(schema_name)
   end
 
-  def schema_input(schema_root, changeset, field) do
+  def schema_input(schema = %Credentials.Schema{}, changeset, field) do
     properties =
-      schema_root.schema
+      schema.root.schema
       |> Map.get("properties")
       |> Map.get(field |> to_string())
 
@@ -152,12 +153,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
         socket |> assign(schema: nil, schema_changeset: nil)
 
       schema_type ->
-        schema =
-          Credentials.Schema.new(
-            read_schema(schema_type),
-            socket.assigns.changeset |> fetch_field!(:body) || %{}
-          )
-
+        schema = get_schema(schema_type)
         schema_changeset = create_schema_changeset(schema, params)
 
         changeset =
@@ -183,7 +179,9 @@ defmodule LightningWeb.CredentialLive.FormComponent do
   end
 
   defp create_schema_changeset(schema, params) do
-    Credentials.Schema.changeset(schema, params |> Map.get("body", %{}))
+    Credentials.SchemaDocument.changeset(%{}, params |> Map.get("body", %{}),
+      schema: schema
+    )
   end
 
   defp create_changeset(credential, params) do

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -75,7 +75,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
     |> Credentials.Schema.new(schema_name)
   end
 
-  def schema_input(schema = %Credentials.Schema{}, changeset, field) do
+  def schema_input(%Credentials.Schema{} = schema, changeset, field) do
     properties =
       schema.root.schema
       |> Map.get("properties")

--- a/lib/lightning_web/live/credential_live/form_component.html.heex
+++ b/lib/lightning_web/live/credential_live/form_component.html.heex
@@ -44,7 +44,7 @@
                 ) %>
               <% s when byte_size(s) > 0 -> %>
                 <%= for {field, _type} <- @schema.types do %>
-                  <%= schema_input(@schema.schema_root, @schema_changeset, field) %>
+                  <%= schema_input(@schema, @schema_changeset, field) %>
                 <% end %>
               <% _ -> %>
                 <p>Select a credential type</p>

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -46,7 +46,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
 
   @impl true
   def preload(list_of_assigns) do
-    # TODO this gets called when using `send_update` as well.
     ids = Enum.map(list_of_assigns, & &1.id)
 
     work_orders =

--- a/mix.exs
+++ b/mix.exs
@@ -137,38 +137,22 @@ defmodule Lightning.MixProject do
       homepage_url: "https://openfn.github.io/Lightning",
       groups_for_modules: [
         Accounts: [
-          Lightning.Accounts,
-          Lightning.Accounts.Policy,
-          Lightning.Accounts.UserNotifier,
-          Lightning.Accounts.UserToken,
-          Lightning.Accounts.User
+          ~r/Lightning.Accounts/
         ],
         Credentials: [
-          Lightning.Credentials,
-          Lightning.Credentials.Credential,
-          Lightning.Credentials.Policy
+          ~r/Lightning.Credentials/
         ],
-        Invocation: [
-          Lightning.Invocation,
-          Lightning.Invocation.Dataclip,
-          Lightning.Invocation.Event,
-          Lightning.Invocation.Run
+        Invocations: [
+          ~r/Lightning.Invocation/
         ],
         Pipeline: [
           ~r/Lightning.Pipeline/
         ],
         Jobs: [
-          Lightning.Jobs,
-          Lightning.Jobs.Job,
-          Lightning.Jobs.Query,
-          Lightning.Jobs.Trigger
+          ~r/Lightning.Jobs/
         ],
         Projects: [
-          Lightning.Projects,
-          Lightning.Projects.Project,
-          Lightning.Projects.Policy,
-          Lightning.Projects.ProjectCredential,
-          Lightning.Projects.ProjectUser
+          ~r/Lightning.Projects/
         ],
         Runtime: [
           ~r/Lightning.Runtime/


### PR DESCRIPTION
This gives us a pattern to later dynamically set changeset options when dealing with Credential bodies.

## Related issue

Re: #536

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
