### PR TITLE
Editor: Fix common typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to
 - Don't consider disabled jobs when calculating subsequent runs
 - Fixed overflow on Job Editor Tooltips
 - Fixed auto-scroll when adding a new snippet in the Job Editor
+- Fixed common operation typings in Job Editor
 
 ## [0.3.1] - 2022-11-22
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -48,7 +48,7 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
   const name = nameParts.join('@');
   
   let results: Lib[] = [];
-  if (name && name !== '@openfn/language-common') {
+  if (name !== '@openfn/language-common') {
     const pkg = await fetchFile(`${specifier}/package.json`)
     const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
     results = await loadDTS(`@openfn/language-common@${commonVersion}`, 'module')

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -53,32 +53,6 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
     const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
     results = await loadDTS(`@openfn/language-common@${commonVersion}`, 'module')
   }
-  // if (name && name !== '@openfn/language-common') {
-  //   // // so this works (without a filename!)
-  //   // results.push({
-  //   //   content: `declare module "@openfn/language-common" {
-  //   //     /** hello */
-  //   //     export function fn(x: number): number ;
-  //   //   }`
-  //   // })
-
-  //   const pkg = await fetchFile(`${specifier}/package.json`)
-  //   const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
-  //   if (commonVersion) {
-  //     // const common = await loadDTS(`@openfn/language-common@${commonVersion}`)
-  //     // results.push(...common)
-  //     for await (const filePath of fetchDTSListing(`@openfn/language-common@${commonVersion}`)) {
-  //       if (!filePath.startsWith('node_modules') && !filePath.endsWith('beta.d.ts')) {
-  //       // if (filePath.endsWith('Adaptor.d.ts')) {
-  //         const content = await fetchFile(`@openfn/language-common@${commonVersion}${filePath}`)
-  //         results.push({
-  //           content: `declare namespace "@openfn/language-common" { ${content} }`,
-  //           // filePath
-  //         });
-  //       }
-  //     }
-  //   }
-  // }
 
   for await (const filePath of fetchDTSListing(specifier)) {
     if (!filePath.startsWith('node_modules')) {
@@ -89,7 +63,6 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
       });
     }
   }
-  console.log(results)
   return results;
 }
 


### PR DESCRIPTION
In the Job Editor, any operations exported straight outta common were failing to pick up types.

That's fundamentally because we download types for the main adaptor - not its dependencies.

This fix is basically to load `common` for any adaptors that list it as a dependency (quick caveat, some adaptors use `language-common` instead of `@openfn/language-common`, and these won't work. I don't intend to fix that).

Looks like a simple solution, but it took me a long time to get down to this. fileNames ended up being critical - I had to prefix the path with a module name, presumably to prevent overriding `index.d.ts`).

And I don't really understand why the main import is a `namespace` and common has to be a `module`. I think they're both modules?? In a standalone Monaco with some simple test typings, everything works with modules. Yet here I need a namespace. Pretty suspicious tbh.

But!

It seems really flaky. Sometime the tooltip appears, sometimes not. Sometimes the first line won't show a tooltip (??). Sometimes its's OK.

I'm struggling to find an explanation or a reproduction. I don't think this PR makes it any worse, so maybe we should merge it and see.

## Related issue

Fixes #596

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
