### PR TITLE
Editor: Loading Indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to
 - Don't consider disabled jobs when calculating subsequent runs
 - Fixed overflow on Job Editor Tooltips
 - Fixed auto-scroll when adding a new snippet in the Job Editor
+- Fixed common operation typings in Job Editor
 
 ## [0.3.1] - 2022-11-22
 

--- a/assets/css/monaco-style-overrides.css
+++ b/assets/css/monaco-style-overrides.css
@@ -25,8 +25,3 @@
 .monaco-editor .line-numbers.active-line-number {
   color: white !important;
 }
-
-.lightning-status-bar {
-  /* color: white;
-  text-align: right; */
-}

--- a/assets/css/monaco-style-overrides.css
+++ b/assets/css/monaco-style-overrides.css
@@ -25,3 +25,8 @@
 .monaco-editor .line-numbers.active-line-number {
   color: white !important;
 }
+
+.lightning-status-bar {
+  /* color: white;
+  text-align: right; */
+}

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -12,6 +12,34 @@ type EditorProps = {
   onChange?: (newSource: string) => void;
 }
 
+const spinner = (<svg
+  className="animate-spin h-5 w-5 inline-block"
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  >
+  <circle
+    className="opacity-25"
+    cx="12"
+    cy="12"
+    r="10"
+    stroke="currentColor"
+    stroke-width="4"
+  >
+  </circle>
+  <path
+    className="opacity-75"
+    fill="currentColor"
+    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+  >
+  </path>
+</svg>);
+
+const loadingIndicator = (<div className="inline-block bg-vs-dark p-2">
+  <span className="mr-2">Loading</span>
+  {spinner}
+</div>);
+
 // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html
 const defaultOptions: MonacoProps['options'] = {
   dragAndDrop: false,
@@ -68,6 +96,7 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
 
 export default function Editor({ source, adaptor, onChange }: EditorProps) {
   const [lib, setLib] = useState<Lib[]>();
+  const [loading, setLoading] = useState(false);
   const [monaco, setMonaco] = useState<typeof Monaco>();
   const [options, setOptions] = useState(defaultOptions);
   const listeners = useRef<{ insertSnippet?: EventListenerOrEventListenerObject}>({});
@@ -142,8 +171,12 @@ export default function Editor({ source, adaptor, onChange }: EditorProps) {
   
   useEffect(() => {
     if (adaptor) {
+      setLoading(true)
       setLib([]); // instantly clear intelligence
-      loadDTS(adaptor).then(l => setLib(l));
+      loadDTS(adaptor).then(l => {
+        setLib(l)
+        setLoading(false)
+      });
     }
   }, [adaptor])
 
@@ -153,13 +186,19 @@ export default function Editor({ source, adaptor, onChange }: EditorProps) {
     }
   }, [monaco, lib]);
   
-  return (<Monaco
-    defaultLanguage="javascript"
-    loading=""
-    theme="vs-dark"
-    value={source || DEFAULT_TEXT}
-    options={options}
-    onMount={handleEditorDidMount}
-    onChange={handleSourceChange}
-  />)
+  return (
+    <>
+      <div className="text-xs text-white text-right pr-2 h-0 z-10 overflow-visible relative">
+        {loading && loadingIndicator}
+      </div>
+      <Monaco
+        defaultLanguage="javascript"
+        theme="vs-dark"
+        value={source || DEFAULT_TEXT}
+        options={options}
+        onMount={handleEditorDidMount}
+        onChange={handleSourceChange}
+      />
+    </>
+  );
 }

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -48,7 +48,7 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
   const name = nameParts.join('@');
   
   let results: Lib[] = [];
-  if (name && name !== '@openfn/language-common') {
+  if (name !== '@openfn/language-common') {
     const pkg = await fetchFile(`${specifier}/package.json`)
     const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
     results = await loadDTS(`@openfn/language-common@${commonVersion}`, 'module')

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -188,7 +188,7 @@ export default function Editor({ source, adaptor, onChange }: EditorProps) {
   
   return (
     <>
-      <div className="text-xs text-white text-right pr-2 h-0 z-10 overflow-visible relative">
+      <div className="text-xs text-white text-right h-0 z-10 overflow-visible relative">
         {loading && loadingIndicator}
       </div>
       <Monaco

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -53,32 +53,6 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
     const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
     results = await loadDTS(`@openfn/language-common@${commonVersion}`, 'module')
   }
-  // if (name && name !== '@openfn/language-common') {
-  //   // // so this works (without a filename!)
-  //   // results.push({
-  //   //   content: `declare module "@openfn/language-common" {
-  //   //     /** hello */
-  //   //     export function fn(x: number): number ;
-  //   //   }`
-  //   // })
-
-  //   const pkg = await fetchFile(`${specifier}/package.json`)
-  //   const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
-  //   if (commonVersion) {
-  //     // const common = await loadDTS(`@openfn/language-common@${commonVersion}`)
-  //     // results.push(...common)
-  //     for await (const filePath of fetchDTSListing(`@openfn/language-common@${commonVersion}`)) {
-  //       if (!filePath.startsWith('node_modules') && !filePath.endsWith('beta.d.ts')) {
-  //       // if (filePath.endsWith('Adaptor.d.ts')) {
-  //         const content = await fetchFile(`@openfn/language-common@${commonVersion}${filePath}`)
-  //         results.push({
-  //           content: `declare namespace "@openfn/language-common" { ${content} }`,
-  //           // filePath
-  //         });
-  //       }
-  //     }
-  //   }
-  // }
 
   for await (const filePath of fetchDTSListing(specifier)) {
     if (!filePath.startsWith('node_modules')) {
@@ -89,7 +63,6 @@ async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namesp
       });
     }
   }
-  console.log(results)
   return results;
 }
 


### PR DESCRIPTION
Had a bit of time at EOD to nibble at this little UX issue.

It can take a while for the editor for load type definitions and provide type assist. So I've added a little floating loading indicator to just to show that it's busy.

Note that this is branched off of `fix-common-typings` but I can always rebase if neccessary.

Here it is:

![image](https://user-images.githubusercontent.com/7052509/212971802-9e571d0e-39cb-495a-aa0c-faa63f1808ca.png)

It'll overlap reasonably gracefully on smaller screens

![image](https://user-images.githubusercontent.com/7052509/212972514-5fb1ead9-ad7a-4f20-b3af-050208e3283b.png)

## Related issue

No related issue

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
