### PR TITLE
Ensure terms are accepted before allowing user registration

### DIFF
--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -108,27 +108,6 @@ defmodule Lightning.Accounts do
   end
 
   @doc """
-  Registers a superuser.
-
-  ## Examples
-      iex> register_superuser(%{field: value})
-      {:ok, %User{}}
-
-      iex> register_superuser(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-  """
-
-  def register_superuser(attrs) do
-    %User{}
-    |> User.superuser_registration_changeset(attrs)
-    |> Repo.insert()
-  end
-
-  def change_superuser(%User{} = user, attrs \\ %{}) do
-    User.superuser_registration_changeset(user, attrs)
-  end
-
-  @doc """
   Gets a user by email and password.
 
   ## Examples
@@ -162,6 +141,33 @@ defmodule Lightning.Accounts do
   """
   def get_user!(id), do: Repo.get!(User, id)
 
+  @doc """
+  Registers a superuser.
+
+  ## Examples
+      iex> register_superuser(%{field: value})
+      {:ok, %User{}}
+
+      iex> register_superuser(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+
+  def register_superuser(attrs) do
+    User.superuser_registration_changeset(attrs)
+    |> Ecto.Changeset.apply_action(:insert)
+    |> case do
+      {:ok, data} ->
+        struct(User, data) |> Repo.insert()
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  def change_superuser(attrs \\ %{}) do
+    User.superuser_registration_changeset(attrs)
+  end
+
   ## User registration
 
   @doc """
@@ -180,7 +186,7 @@ defmodule Lightning.Accounts do
           {:ok, User.t()}
           | {:error, Ecto.Changeset.t(User.t()) | Ecto.Changeset.t()}
   def register_user(attrs) do
-    User.registration_changeset(attrs)
+    User.user_registration_changeset(attrs)
     |> Ecto.Changeset.apply_action(:insert)
     |> case do
       {:ok, data} ->
@@ -200,8 +206,8 @@ defmodule Lightning.Accounts do
       %Ecto.Changeset{data: %User{}}
 
   """
-  def change_user_registration(%User{} = user, attrs \\ %{}) do
-    User.registration_changeset(attrs, hash_password: false)
+  def change_user_registration(attrs \\ %{}) do
+    User.user_registration_changeset(attrs, hash_password: false)
   end
 
   def change_user_details(%User{} = user, attrs \\ %{}) do

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -164,11 +164,19 @@ defmodule Lightning.Accounts do
     end
   end
 
-  def change_superuser(attrs \\ %{}) do
-    User.superuser_registration_changeset(attrs)
-  end
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking superuser changes.
 
-  ## User registration
+  ## Examples
+
+      iex> change_superuser_registration(user)
+      %Ecto.Changeset{data: %User{}}
+
+  """
+  @spec change_superuser_registration(any) :: Ecto.Changeset.t()
+  def change_superuser_registration(attrs \\ %{}) do
+    User.superuser_registration_changeset(attrs, hash_password: false)
+  end
 
   @spec register_user(
           :invalid

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -170,6 +170,10 @@ defmodule Lightning.Accounts do
 
   ## User registration
 
+  @spec register_user(
+          :invalid
+          | %{optional(:__struct__) => none, optional(atom | binary) => any}
+        ) :: any
   @doc """
   Registers a user.
 
@@ -182,9 +186,6 @@ defmodule Lightning.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec register_user(attrs :: %{optional(binary) => binary}) ::
-          {:ok, User.t()}
-          | {:error, Ecto.Changeset.t(User.t()) | Ecto.Changeset.t()}
   def register_user(attrs) do
     User.user_registration_changeset(attrs)
     |> Ecto.Changeset.apply_action(:insert)

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -176,10 +176,19 @@ defmodule Lightning.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec register_user(attrs :: %{optional(binary) => binary}) ::
+          {:ok, User.t()}
+          | {:error, Ecto.Changeset.t(User.t()) | Ecto.Changeset.t()}
   def register_user(attrs) do
-    %User{}
-    |> User.registration_changeset(attrs)
-    |> Repo.insert()
+    User.registration_changeset(attrs)
+    |> Ecto.Changeset.apply_action(:insert)
+    |> case do
+      {:ok, data} ->
+        struct(User, data) |> Repo.insert()
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   @doc """
@@ -192,7 +201,7 @@ defmodule Lightning.Accounts do
 
   """
   def change_user_registration(%User{} = user, attrs \\ %{}) do
-    User.registration_changeset(user, attrs, hash_password: false)
+    User.registration_changeset(attrs, hash_password: false)
   end
 
   def change_user_details(%User{} = user, attrs \\ %{}) do

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -83,7 +83,7 @@ defmodule Lightning.Accounts.User do
       if terms_accepted do
         []
       else
-        [terms_accepted: "You must accept the terms and conditions"]
+        [terms_accepted: "Please accept the terms and conditions to register."]
       end
     end)
   end

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -38,7 +38,7 @@ defmodule Lightning.Accounts.User do
     timestamps()
   end
 
-  @common_registration_props %{
+  @common_registration_attrs %{
     first_name: :string,
     last_name: :string,
     email: :string,
@@ -67,12 +67,12 @@ defmodule Lightning.Accounts.User do
   """
   def user_registration_changeset(attrs, opts \\ []) do
     {%{},
-     Map.merge(@common_registration_props, %{
+     Map.merge(@common_registration_attrs, %{
        terms_accepted: :boolean
      })}
     |> cast(
       attrs,
-      Map.keys(@common_registration_props) ++
+      Map.keys(@common_registration_attrs) ++
         [
           :terms_accepted
         ]
@@ -112,12 +112,12 @@ defmodule Lightning.Accounts.User do
   """
   def superuser_registration_changeset(attrs, opts \\ []) do
     {%{},
-     Map.merge(@common_registration_props, %{
+     Map.merge(@common_registration_attrs, %{
        role: :string
      })}
     |> cast(
       attrs,
-      Map.keys(@common_registration_props) ++
+      Map.keys(@common_registration_attrs) ++
         [
           :role
         ]
@@ -147,9 +147,6 @@ defmodule Lightning.Accounts.User do
     changeset
     |> validate_required([:password])
     |> validate_length(:password, min: 8, max: 72)
-    # |> validate_format(:password, ~r/[a-z]/, message: "at least one lower case character")
-    # |> validate_format(:password, ~r/[A-Z]/, message: "at least one upper case character")
-    # |> validate_format(:password, ~r/[!?@#$%^&*_0-9]/, message: "at least one digit or punctuation character")
     |> maybe_hash_password(opts)
   end
 

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -43,7 +43,9 @@ defmodule Lightning.Accounts.User do
     last_name: :string,
     email: :string,
     password: :string,
-    hashed_password: :string
+    hashed_password: :string,
+    disabled: :boolean,
+    scheduled_deletion: :utc_datetime
   }
 
   @doc """

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -2,7 +2,7 @@ defmodule Lightning.Accounts.User do
   @moduledoc """
   The User model.
   """
-  alias Lightning.Accounts.User
+  alias __MODULE__
 
   use Ecto.Schema
   import Ecto.Changeset
@@ -111,17 +111,10 @@ defmodule Lightning.Accounts.User do
       Defaults to `true`.
   """
   def superuser_registration_changeset(attrs, opts \\ []) do
-    {%{},
-     Map.merge(@common_registration_attrs, %{
-       role: :string
-     })}
-    |> cast(
-      attrs,
-      Map.keys(@common_registration_attrs) ++
-        [
-          :role
-        ]
-    )
+    registration_fields = Map.merge(@common_registration_attrs, %{role: :string})
+
+    {%{}, registration_fields}
+    |> cast(attrs, Map.keys(registration_fields))
     |> validate_email()
     |> validate_password(opts)
     |> put_change(:role, :superuser)

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -2,11 +2,10 @@ defmodule LightningWeb.UserRegistrationController do
   use LightningWeb, :controller
 
   alias Lightning.Accounts
-  alias Lightning.Accounts.User
   alias LightningWeb.UserAuth
 
   def new(conn, _params) do
-    changeset = Accounts.change_user_registration(%User{})
+    changeset = Accounts.change_user_registration()
     render(conn, "new.html", changeset: changeset)
   end
 

--- a/lib/lightning_web/live/first_setup_live/superuser.ex
+++ b/lib/lightning_web/live/first_setup_live/superuser.ex
@@ -28,7 +28,7 @@ defmodule LightningWeb.FirstSetupLive.Superuser do
         socket
       ) do
     changeset =
-      Accounts.change_superuser(registration_params)
+      Accounts.change_superuser_registration(registration_params)
       |> Ecto.Changeset.validate_confirmation(:password)
       |> Ecto.Changeset.validate_length(:password, min: 8)
       |> Map.put(:action, :validate)
@@ -71,7 +71,7 @@ defmodule LightningWeb.FirstSetupLive.Superuser do
 
       socket
       |> assign(:registration, registration)
-      |> assign(:changeset, Accounts.change_superuser())
+      |> assign(:changeset, Accounts.change_superuser_registration())
     end
   end
 end

--- a/lib/lightning_web/live/first_setup_live/superuser.ex
+++ b/lib/lightning_web/live/first_setup_live/superuser.ex
@@ -28,8 +28,7 @@ defmodule LightningWeb.FirstSetupLive.Superuser do
         socket
       ) do
     changeset =
-      socket.assigns.registration
-      |> Accounts.change_superuser(registration_params)
+      Accounts.change_superuser(registration_params)
       |> Ecto.Changeset.validate_confirmation(:password)
       |> Ecto.Changeset.validate_length(:password, min: 8)
       |> Map.put(:action, :validate)
@@ -72,7 +71,7 @@ defmodule LightningWeb.FirstSetupLive.Superuser do
 
       socket
       |> assign(:registration, registration)
-      |> assign(:changeset, registration |> Accounts.change_superuser())
+      |> assign(:changeset, Accounts.change_superuser())
     end
   end
 end

--- a/lib/lightning_web/templates/user_registration/new.html.heex
+++ b/lib/lightning_web/templates/user_registration/new.html.heex
@@ -9,6 +9,7 @@
     <div id="register">
       <.form
         :let={f}
+        as="user"
         for={@changeset}
         action={Routes.user_registration_path(@conn, :create)}
       >
@@ -55,22 +56,33 @@
                 />
               </div>
 
-              <.check_box
-                form={f}
-                id={:i_acknowledge_that_this_is_lightning_beta}
-              >
-                <br />
-                <span class="text-xs text-secondary-500">
-                  Lightning is still in Beta, therefore
-                  <b>
-                    we strongly advise against building out production workflows
-                  </b>
-                  until the official release of Lightning. <br />
-                  By registering for an account, you’ll be given your own project, which you can use <em> free of charge until further notice</em>.
-                  All credentials, jobs and workflows you create will only be visible to you.
-                </span>
-              </.check_box>
-
+              <div class="flex items-start">
+                <div class="flex items-center h-5">
+                  <%= checkbox(f, :terms_accepted,
+                    class:
+                      "focus:ring-primary-500 h-4 w-4 text-primary-600 text-sm border-secondary-300 rounded"
+                  ) %>
+                </div>
+                <div class="ml-3 text-sm">
+                  <%= label(f, "Terms and conditions",
+                    class: "font-medium text-secondary-700"
+                  ) %>
+                  <br />
+                  <span class="text-xs text-secondary-500">
+                    Lightning is still in Beta, therefore
+                    <b>
+                      we strongly advise against building out production workflows
+                    </b>
+                    until the official release of Lightning. <br />
+                    By registering for an account, you’ll be given your own project, which you can use <em> free of charge until further notice</em>.
+                    All credentials, jobs and workflows you create will only be visible to you.
+                  </span>
+                </div>
+              </div>
+              <%= error_tag(f, :terms_accepted,
+                class:
+                  "mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm text-sm border-secondary-300 rounded-md"
+              ) %>
               <LightningWeb.Components.Form.submit_button>
                 Register
               </LightningWeb.Components.Form.submit_button>

--- a/lib/lightning_web/views/user_registration_view.ex
+++ b/lib/lightning_web/views/user_registration_view.ex
@@ -1,4 +1,3 @@
 defmodule LightningWeb.UserRegistrationView do
   use LightningWeb, :view
-  import LightningWeb.Components.Form
 end

--- a/test/lightning/accounts/user_test.exs
+++ b/test/lightning/accounts/user_test.exs
@@ -28,4 +28,12 @@ defmodule Lightning.Accounts.UserTest do
       assert errors[:scheduled_deletion_email] == nil
     end
   end
+
+  describe "superuser_registration_changeset/1" do
+    test "puts role change in changeset" do
+      assert User.superuser_registration_changeset(%{})
+             |> Ecto.Changeset.get_change(:role) ==
+               :superuser
+    end
+  end
 end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -71,6 +71,20 @@ defmodule Lightning.AccountsTest do
              } = errors_on(changeset)
     end
 
+    test "requires terms and conditions to be accepted" do
+      {:error, changeset} = Accounts.register_user(%{terms_accepted: false})
+
+      assert %{
+               terms_accepted: [
+                 "Please accept the terms and conditions to register."
+               ]
+             } = errors_on(changeset)
+
+      {:error, changeset} = Accounts.register_user(%{terms_accepted: true})
+
+      assert %{} = errors_on(changeset)
+    end
+
     test "validates email and password when given" do
       {:error, changeset} =
         Accounts.register_user(%{email: "not valid", password: "not valid"})

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -114,6 +114,34 @@ defmodule Lightning.AccountsTest do
   end
 
   describe "register_superuser/1" do
+    test "requires email and password to be set" do
+      {:error, changeset} = Accounts.register_superuser(%{})
+
+      assert %{
+               password: ["can't be blank"],
+               email: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "validates email and password when given" do
+      {:error, changeset} =
+        Accounts.register_superuser(%{email: "not valid", password: "not valid"})
+
+      assert %{
+               email: ["must have the @ sign and no spaces"]
+             } = errors_on(changeset)
+    end
+
+    test "validates maximum values for email and password for security" do
+      too_long = String.duplicate("db@db.sn", 100)
+
+      {:error, changeset} =
+        Accounts.register_superuser(%{email: too_long, password: too_long})
+
+      assert "should be at most 160 character(s)" in errors_on(changeset).email
+      assert "should be at most 72 character(s)" in errors_on(changeset).password
+    end
+
     test "registers users with a hashed password and sets role to :superuser" do
       email = unique_user_email()
 

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -114,7 +114,7 @@ defmodule Lightning.AccountsTest do
   end
 
   describe "register_superuser/1" do
-    test "registers users with a hashed password and sets role to :admin" do
+    test "registers users with a hashed password and sets role to :superuser" do
       email = unique_user_email()
 
       {:ok, user} =
@@ -145,6 +145,30 @@ defmodule Lightning.AccountsTest do
 
       changeset =
         Accounts.change_user_registration(
+          valid_user_attributes(email: email, password: password)
+        )
+
+      assert changeset.valid?
+      assert get_change(changeset, :email) == email
+      assert get_change(changeset, :password) == password
+      assert is_nil(get_change(changeset, :hashed_password))
+    end
+  end
+
+  describe "change_superuser_registration/2" do
+    test "returns a changeset" do
+      assert %Ecto.Changeset{} =
+               changeset = Accounts.change_superuser_registration()
+
+      assert changeset.required == [:password, :email, :first_name]
+    end
+
+    test "allows fields to be set" do
+      email = unique_user_email()
+      password = valid_user_password()
+
+      changeset =
+        Accounts.change_superuser_registration(
           valid_user_attributes(email: email, password: password)
         )
 

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -134,8 +134,7 @@ defmodule Lightning.AccountsTest do
 
   describe "change_user_registration/2" do
     test "returns a changeset" do
-      assert %Ecto.Changeset{} =
-               changeset = Accounts.change_user_registration(%User{})
+      assert %Ecto.Changeset{} = changeset = Accounts.change_user_registration()
 
       assert changeset.required == [:password, :email, :first_name]
     end
@@ -146,7 +145,6 @@ defmodule Lightning.AccountsTest do
 
       changeset =
         Accounts.change_user_registration(
-          %User{},
           valid_user_attributes(email: email, password: password)
         )
 

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -80,5 +80,16 @@ defmodule LightningWeb.UserRegistrationControllerTest do
       assert response =~ "Register"
       assert response =~ "must have the @ sign and no spaces"
     end
+
+    test "render errors for terms and conditions not accepted", %{conn: conn} do
+      conn =
+        post(conn, Routes.user_registration_path(conn, :create), %{
+          "user" => %{"terms_accepted" => false}
+        })
+
+      response = html_response(conn, 200)
+      assert response =~ "Register"
+      assert response =~ "You must accept the terms and conditions"
+    end
   end
 end

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -89,7 +89,7 @@ defmodule LightningWeb.UserRegistrationControllerTest do
 
       response = html_response(conn, 200)
       assert response =~ "Register"
-      assert response =~ "You must accept the terms and conditions"
+      assert response =~ "Please accept the terms and conditions to register."
     end
   end
 end


### PR DESCRIPTION
## Any notes for the reviewer 

## Implementation plan
- [x] Change User registration to use schemaless changeset
- [x] Track the changes on the terms and conditions checkbox
- [x] Add validation error on the changeset when the terms and conditions are not accepted (variable is not true), this error should block the registration process
- [x] Add UI changes to place the error message right above the register button
- [x] Write a phoenix controller tests to test the scenario above

PS: The user registration page is not using liveview; it uses the regular phoenix controllers. Currently all validations requires page reloading (checked with @amberrignell and @stuartc about this plan and it seemed the right thing to do)

Given that we're now using schemaless changesets for user registration, most of the tests are failing. I need to address those

**QUESTION: Should superusers also accept terms and conditions before registering for an account ?**

## Related issue

Fixes #531 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [x] Amber has QA'd this feature
