### PR TITLE
Prove that uninvited members cannot view things in projects

### DIFF
--- a/test/lightning/permissions_test.exs
+++ b/test/lightning/permissions_test.exs
@@ -27,6 +27,7 @@ defmodule Lightning.PermissionsTest do
     admin = user_fixture()
     owner = user_fixture()
     editor = user_fixture()
+    thief = user_fixture()
 
     project =
       project_fixture(
@@ -43,7 +44,8 @@ defmodule Lightning.PermissionsTest do
       viewer: viewer,
       admin: admin,
       owner: owner,
-      editor: editor
+      editor: editor,
+      thief: thief
     }
   end
 
@@ -62,6 +64,12 @@ defmodule Lightning.PermissionsTest do
 
     test "owner permissions", %{project: project, owner: owner} do
       assert ProjectUsers |> Permissions.can(:edit_jobs, owner, project)
+    end
+
+    # For things like :view_job we should be able to show that people who do not
+    # have access to a project cannot view the jobs in that project.
+    test "thief permissions", %{project: project, thief: thief} do
+      refute ProjectUsers |> Permissions.can(:edit_jobs, thief, project)
     end
   end
 end


### PR DESCRIPTION
@stuartc , @elias-ba , this is what i'd like to be able to show with `thief` - we use this same concept in the v1