### PR TITLE
Ensure credential schemas load from the correct path in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added a `SCHEMAS_PATH` environment variable to override the default folder
+  location for credential schemas [#604](https://github.com/OpenFn/Lightning/issues/604)
+
 ## [0.4.0] - 2023-02-08
 
 ### Added

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,25 +24,30 @@ environment.
 Note that for secure deployments, it's recommended to use a combination of
 `secrets` and `configMaps` to generate secure environment variables.
 
-- `SECRET_KEY_BASE` - a secret key used as a base to generate secrets for
-  encrypting and signing data.
-- `PRIMARY_ENCRYPTION_KEY` - a base64 encoded 32 character long string. See
-  [Encryption](#encryption).
 - `ADAPTORS_PATH` - where you store your locally installed adaptors
-- `LISTEN_ADDRESS`" - the address the web server should bind to,
-  defaults to `127.0.0.1` to block access from other machines.
-- `LOG_LEVEL` - how noisy you want the logs to be (e.g. `debug`, `info`)
-- `MIX_ENV` - your mix env, likely `prod` for deployment
-- `NODE_ENV` - node env, likely `production` for deployment
-- `ORIGINS` - the allowed origins for web traffic to the backend
-- `PORT` - the port your Phoenix app runs on
-- `SENTRY_DSN` - if using Sentry for error monitoring, your DSN
-- `URL_HOST` - the host, used for writing urls (e.g., `demo.openfn.org`)
-- `URL_PORT` - the port, usually `443` for production
-- `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)
-- `MAX_RUN_DURATION` - the maximum time (in milliseconds) that jobs are allowed
-  to run (keep this below your termination_grace_period if using kubernetes)
+- `DISABLE_DB_SSL` - in production the use of an SSL conntection to Postgres is
+  required by default, setting this to `"true"` allows unencrypted connections
+  to the database. This is strongly discouraged in real production environment.
 - `K8S_HEADLESS_SERVICE` - this environment variable is automatically set if
   you're running on GKE and it is used to establish an Erlang node cluster. Note
   that if you're _not_ using Kubernetes, the "gossip" strategy is used for
   establish clusters.
+- `LISTEN_ADDRESS`" - the address the web server should bind to, defaults to
+  `127.0.0.1` to block access from other machines.
+- `LOG_LEVEL` - how noisy you want the logs to be (e.g. `debug`, `info`)
+- `MAX_RUN_DURATION` - the maximum time (in milliseconds) that jobs are allowed
+  to run (keep this below your termination_grace_period if using kubernetes)
+- `MIX_ENV` - your mix env, likely `prod` for deployment
+- `NODE_ENV` - node env, likely `production` for deployment
+- `ORIGINS` - the allowed origins for web traffic to the backend
+- `PORT` - the port your Phoenix app runs on
+- `PRIMARY_ENCRYPTION_KEY` - a base64 encoded 32 character long string. See
+  [Encryption](#encryption).
+- `SCHEMAS_PATH` - path to the credential schemas that provide forms for
+  different adaptors
+- `SECRET_KEY_BASE` - a secret key used as a base to generate secrets for
+  encrypting and signing data.
+- `SENTRY_DSN` - if using Sentry for error monitoring, your DSN
+- `URL_HOST` - the host, used for writing urls (e.g., `demo.openfn.org`)
+- `URL_PORT` - the port, usually `443` for production
+- `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,4 +113,6 @@ COPY --from=builder --chown=lightning:root /app/priv/schemas ./priv/schemas
 
 USER lightning
 
+ENV SCHEMAS_PATH="/app/priv/schemas"
+
 CMD /app/bin/server

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,6 +18,11 @@ config :lightning, :email_addresses,
 config :lightning, :adaptor_service,
   adaptors_path: System.get_env("ADAPTORS_PATH", "./priv/openfn")
 
+config :lightning,
+  schemas_path:
+    System.get_env("SCHEMAS_PATH") ||
+      Application.get_env(:lightning, :schemas_path) || "./priv"
+
 config :lightning, Oban,
   repo: Lightning.Repo,
   plugins: [

--- a/lib/lightning/release.ex
+++ b/lib/lightning/release.ex
@@ -1,9 +1,12 @@
 defmodule Lightning.Release do
+  require Logger
+
   @moduledoc """
   Used for executing DB release tasks when run in production without Mix
   installed.
   """
   @app :lightning
+  @repo Lightning.Repo
 
   def migrate do
     load_app()
@@ -11,6 +14,24 @@ defmodule Lightning.Release do
     for repo <- repos() do
       {:ok, _, _} =
         Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def create_db do
+    @repo.__adapter__().storage_up(@repo.config)
+    |> case do
+      :ok ->
+        Logger.info("Database created successfully")
+        :ok
+
+      {:error, :already_up} ->
+        Logger.info("Database already up.")
+        :ok
+
+      {:error, e} ->
+        Logger.error("Encountered an error during database creation")
+        Logger.error(e)
+        {:error, e}
     end
   end
 
@@ -27,6 +48,7 @@ defmodule Lightning.Release do
 
   def load_app do
     Application.ensure_all_started(:ssl)
-    Application.load(@app)
+    Application.ensure_all_started(@repo)
+    # Application.load(@app)
   end
 end

--- a/lib/lightning/release.ex
+++ b/lib/lightning/release.ex
@@ -49,6 +49,5 @@ defmodule Lightning.Release do
   def load_app do
     Application.ensure_all_started(:ssl)
     Application.ensure_all_started(@repo)
-    # Application.load(@app)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lightning.MixProject do
   def project do
     [
       app: :lightning,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),

--- a/test/lightning/install_schemas_test.exs
+++ b/test/lightning/install_schemas_test.exs
@@ -11,6 +11,8 @@ defmodule Lightning.InstallSchemasTest do
   @ok_200 {:ok, 200, "headers", :client}
   @ok_400 {:ok, 400, "headers", :client}
 
+  @schemas_path Application.compile_env(:lightning, :schemas_path)
+
   describe "install_schemas mix task" do
     setup do
       stub(:hackney)
@@ -62,8 +64,12 @@ defmodule Lightning.InstallSchemasTest do
       File
       |> expect(:rm_rf, fn _ -> nil end)
       |> expect(:mkdir_p, fn _ -> nil end)
-      |> expect(:open!, fn "priv/schemas/asana.json", [:write] -> nil end)
-      |> expect(:open!, fn "priv/schemas/primero.json", [:write] -> nil end)
+      |> expect(:open!, fn "test/fixtures/schemas/asana.json", [:write] ->
+        nil
+      end)
+      |> expect(:open!, fn "test/fixtures/schemas/primero.json", [:write] ->
+        nil
+      end)
       |> expect(:close, 2, fn _ -> nil end)
 
       IO
@@ -80,7 +86,7 @@ defmodule Lightning.InstallSchemasTest do
       expect(File, :mkdir_p, fn _ -> {:error, "error occured"} end)
 
       assert_raise RuntimeError,
-                   "Couldn't create the schemas directory: priv/schemas/, got :error occured.",
+                   "Couldn't create the schemas directory: test/fixtures/schemas, got :error occured.",
                    fn ->
                      InstallSchemas.run([])
                    end
@@ -101,7 +107,7 @@ defmodule Lightning.InstallSchemasTest do
       end)
 
       assert_raise RuntimeError, "Unable to access @openfn/language-asana", fn ->
-        InstallSchemas.persist_schema("@openfn/language-asana")
+        InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
       end
     end
 
@@ -121,7 +127,7 @@ defmodule Lightning.InstallSchemasTest do
 
       {_result, log} =
         with_log(fn ->
-          InstallSchemas.persist_schema("@openfn/language-asana")
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
         end)
 
       assert log =~


### PR DESCRIPTION
The issue here appears to be that the `pwd` when in a production release that the path is `/app/bin`. 

However the schemas are located in `/app/priv/schemas`, so the relative path `./priv/schemas` doesn't return anything.

- - -

- I've managed to get the docker image running locally but the `pwd` appears to be correct.
- I'm going to have the path be set in one place - and expand it in `runtime.exs`
  Perhaps there is some other process changing the `pwd`?
- ~~I still need to access the app via a browser to see if something is changing the `pwd`.~~
  I'm not sure _where_ exactly this happens but I can confirm when starting the web application without a shell/iex :shrug: .
- ~~There were some challenges getting the image running in production mode locally which I need to document~~

- [x] Add a `create_db` function to the `Release` module to make setting things up easier locally.

- - -

### Notes

I've documented the `DB_DISABLE_SSL` enviroment variable which is useful for running in production mode locally.

I found an Erlang function under the `:code` module called `priv_dir/1` which returns the priv dir for a given release. Interestingly it seems that our `priv` directory is copied into the release directory - and then we copy our priv directory into the container; essentially duplicating our adaptors and schemas.

In the future I think it would be a good idea to either use the releases priv directory, or we only install the adaptors and schemas _after_ the release is built.

- - -
## Related issue

Fixes #604

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
