### PR TITLE
Allow users to edit project digest and alerts settings

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,8 +12,7 @@ if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
   config :lightning, LightningWeb.Endpoint, server: true
 end
 
-config :lightning, :email_addresses,
-  admin: System.get_env("EMAIL_ADMIN", "admin@openfn.org")
+config :lightning, :email_addresses, admin: System.get_env("EMAIL_ADMIN", "admin@openfn.org")
 
 config :lightning, :adaptor_service,
   adaptors_path: System.get_env("ADAPTORS_PATH", "./priv/openfn")
@@ -30,7 +29,10 @@ config :lightning, Oban,
      crontab: [
        {"* * * * *", Lightning.Jobs.Scheduler},
        {"* * * * *", ObanPruner},
-       {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}}
+       {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}},
+       {"0 10 * * *", Lightning.Projects, args: %{"type" => "daily_project_digest"}},
+       {"0 10 * * MON", Lightning.Accounts, args: %{"type" => "weekly_project_digest"}},
+       {"0 10 1 * *", Lightning.Accounts, args: %{"type" => "monthly_project_digest"}}
      ]}
   ],
   shutdown_grace_period:
@@ -74,8 +76,7 @@ config :lightning,
 config :sentry,
   filter: Lightning.SentryEventFilter,
   environment_name: config_env(),
-  included_environments:
-    if(System.get_env("SENTRY_DSN"), do: [config_env()], else: [])
+  included_environments: if(System.get_env("SENTRY_DSN"), do: [config_env()], else: [])
 
 # To actually send emails you need to configure the mailer to use a real
 # adapter. You may configure the swoosh api client of your choice. We

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,7 +12,8 @@ if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
   config :lightning, LightningWeb.Endpoint, server: true
 end
 
-config :lightning, :email_addresses, admin: System.get_env("EMAIL_ADMIN", "admin@openfn.org")
+config :lightning, :email_addresses,
+  admin: System.get_env("EMAIL_ADMIN", "admin@openfn.org")
 
 config :lightning, :adaptor_service,
   adaptors_path: System.get_env("ADAPTORS_PATH", "./priv/openfn")
@@ -30,9 +31,12 @@ config :lightning, Oban,
        {"* * * * *", Lightning.Jobs.Scheduler},
        {"* * * * *", ObanPruner},
        {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}},
-       {"0 10 * * *", Lightning.Projects, args: %{"type" => "daily_project_digest"}},
-       {"0 10 * * MON", Lightning.Accounts, args: %{"type" => "weekly_project_digest"}},
-       {"0 10 1 * *", Lightning.Accounts, args: %{"type" => "monthly_project_digest"}}
+       {"0 10 * * *", Lightning.Projects,
+        args: %{"type" => "daily_project_digest"}},
+       {"0 10 * * MON", Lightning.Accounts,
+        args: %{"type" => "weekly_project_digest"}},
+       {"0 10 1 * *", Lightning.Accounts,
+        args: %{"type" => "monthly_project_digest"}}
      ]}
   ],
   shutdown_grace_period:
@@ -76,7 +80,8 @@ config :lightning,
 config :sentry,
   filter: Lightning.SentryEventFilter,
   environment_name: config_env(),
-  included_environments: if(System.get_env("SENTRY_DSN"), do: [config_env()], else: [])
+  included_environments:
+    if(System.get_env("SENTRY_DSN"), do: [config_env()], else: [])
 
 # To actually send emails you need to configure the mailer to use a real
 # adapter. You may configure the swoosh api client of your choice. We

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -97,7 +97,7 @@ defmodule Lightning.Accounts.UserNotifier do
   end
 
   defp build_email_body(data, digest) do
-    digest_lookup = %{daily: "day", monthly: "monthly", weekly: "week"}
+    digest_lookup = %{daily: "day", monthly: "month", weekly: "week"}
 
     """
     #{data.workflow_name}:

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -96,12 +96,14 @@ defmodule Lightning.Accounts.UserNotifier do
     """)
   end
 
-  defp build_digest(digest) do
+  defp build_email_body(data, digest) do
+    digest_lookup = %{daily: "day", monthly: "monthly", weekly: "week"}
+
     """
-    #{digest.workflow}:
-    - #{digest.successful_workorders} workorders correctly processed this month/day/week
-    - #{digest.rerun_workorders} failed work orders that were rerun and then processed correctly
-    - #{digest.failed_workorders} work orders that failed/still need addressing
+    #{data.workflow_name}:
+    - #{data.successful_workorders} workorders correctly processed this #{digest_lookup[digest]}
+    - #{data.rerun_workorders} failed work orders that were rerun and then processed correctly
+    - #{data.failed_workorders} work orders that failed/still need addressing
 
     """
   end
@@ -109,10 +111,10 @@ defmodule Lightning.Accounts.UserNotifier do
   @doc """
   Deliver a digest for a project to a user.
   """
-  def deliver_project_digest(user, project, digests) do
+  def deliver_project_digest(user, project, data, digest) do
     email = user.email
     title = "Weekly digest for project #{project.name}"
-    body = Enum.map_join(digests, fn digest -> build_digest(digest) end)
+    body = Enum.map_join(data, fn d -> build_email_body(d, digest) end)
 
     deliver(email, title, body)
   end

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -110,11 +110,10 @@ defmodule Lightning.Accounts.UserNotifier do
   Deliver a digest for a project to a user.
   """
   def deliver_project_digest(user, project, digests) do
-    body =
-      digests
-      |> Enum.map(fn digest -> build_digest(digest) end)
-      |> Enum.join("")
+    email = user.email
+    title = "Weekly digest for project #{project.name}"
+    body = Enum.map_join(digests, fn digest -> build_digest(digest) end)
 
-    deliver(user.email, "Weekly digest for project #{project.name}", body)
+    deliver(email, title, body)
   end
 end

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -95,4 +95,26 @@ defmodule Lightning.Accounts.UserNotifier do
     ==============================
     """)
   end
+
+  defp build_digest(digest) do
+    """
+    #{digest.workflow}:
+    - #{digest.successful_workorders} workorders correctly processed this month/day/week
+    - #{digest.rerun_workorders} failed work orders that were rerun and then processed correctly
+    - #{digest.failed_workorders} work orders that failed/still need addressing
+
+    """
+  end
+
+  @doc """
+  Deliver a digest for a project to a user.
+  """
+  def deliver_project_digest(user, project, digests) do
+    body =
+      digests
+      |> Enum.map(fn digest -> build_digest(digest) end)
+      |> Enum.join("")
+
+    deliver(user.email, "Weekly digest for project #{project.name}", body)
+  end
 end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -10,6 +10,7 @@ defmodule Lightning.Projects do
   alias Lightning.Projects.{Importer, Project, ProjectCredential}
   alias Lightning.Accounts.User
   alias Lightning.ExportUtils
+  alias Lightning.Workflows
 
   @doc """
   Returns the list of projects.

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -256,11 +256,10 @@ defmodule Lightning.Projects do
   end
 
   def get_project_digest(project) do
-    workflows = Workflows.get_workflows_for(project) |> IO.inspect(label: "Workflows")
+    workflows =
+      Workflows.get_workflows_for(project) |> IO.inspect(label: "Workflows")
 
-    digest =
-      Enum.map(workflows, fn workflow -> workflow_digest(workflow) end)
-      |> IO.inspect(label: "Digest")
+    digest = Enum.map(workflows, fn workflow -> workflow_digest(workflow) end)
 
     digest
   end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -259,15 +259,6 @@ defmodule Lightning.Projects do
     |> Repo.transaction()
   end
 
-  def get_project_digest(project) do
-    workflows =
-      Workflows.get_workflows_for(project) |> IO.inspect(label: "Workflows")
-
-    digest = Enum.map(workflows, fn workflow -> workflow_digest(workflow) end)
-
-    digest
-  end
-
   defp project_digest(digest) do
     project_users =
       Repo.all(

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -4,6 +4,7 @@ defmodule Lightning.Projects do
   """
 
   import Ecto.Query, warn: false
+  alias Lightning.Accounts.UserNotifier
   alias Lightning.Repo
 
   alias Lightning.Projects.{Importer, Project, ProjectCredential}

--- a/lib/lightning/projects/project_user.ex
+++ b/lib/lightning/projects/project_user.ex
@@ -23,6 +23,12 @@ defmodule Lightning.Projects.ProjectUser do
     :owner
   ])
 
+  defenum(DigestEnum, :digest, [
+    :daily,
+    :weekly,
+    :monthly
+  ])
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "project_users" do
@@ -31,6 +37,7 @@ defmodule Lightning.Projects.ProjectUser do
     field :delete, :boolean, virtual: true
     field :failure_alert, :boolean, default: true
     field :role, RolesEnum, default: :editor
+    field :digest, DigestEnum, default: :weekly
 
     timestamps()
   end

--- a/lib/lightning/projects/project_user.ex
+++ b/lib/lightning/projects/project_user.ex
@@ -32,12 +32,12 @@ defmodule Lightning.Projects.ProjectUser do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "project_users" do
-    belongs_to :user, User
-    belongs_to :project, Project
-    field :delete, :boolean, virtual: true
-    field :failure_alert, :boolean, default: true
-    field :role, RolesEnum, default: :editor
-    field :digest, DigestEnum, default: :weekly
+    belongs_to(:user, User)
+    belongs_to(:project, Project)
+    field(:delete, :boolean, virtual: true)
+    field(:failure_alert, :boolean, default: true)
+    field(:role, RolesEnum, default: :editor)
+    field(:digest, DigestEnum, default: :weekly)
 
     timestamps()
   end
@@ -49,7 +49,7 @@ defmodule Lightning.Projects.ProjectUser do
   @doc false
   def changeset(project_user, attrs) do
     project_user
-    |> cast(attrs, [:user_id, :project_id, :role, :failure_alert])
+    |> cast(attrs, [:user_id, :project_id, :role, :digest, :failure_alert])
     |> validate_required([:user_id])
     |> unique_constraint([:project_id, :user_id],
       message: "User already a member of this project."

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -33,7 +33,7 @@ defmodule LightningWeb.ProjectLive.Settings do
        can_edit_project: can_edit_project,
        credentials: credentials,
        project_users: project_users,
-       changeset: Projects.change_project(socket.assigns.project)
+       project_changeset: Projects.change_project(socket.assigns.project)
      )}
   end
 
@@ -53,7 +53,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       |> Projects.change_project(project_params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {:noreply, assign(socket, :project_changeset, changeset)}
   end
 
   def handle_event("save", %{"project" => project_params} = _params, socket) do
@@ -69,7 +69,7 @@ defmodule LightningWeb.ProjectLive.Settings do
          |> put_flash(:info, "Project updated successfully")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply, assign(socket, :project_changeset, changeset)}
     end
   end
 end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -49,7 +49,7 @@
             </div>
             <.form
               :let={f}
-              for={@changeset}
+              for={@project_changeset}
               id="project-settings-form"
               phx-change="validate"
               phx-submit="save"
@@ -90,7 +90,7 @@
               <div class="grid grid-cols gap-6">
                 <div class="md:col-span-2">
                   <LightningWeb.Components.Form.submit_button
-                    disabled={!@changeset.valid? || !@can_edit_project}
+                    disabled={!(@project_changeset.valid? and @can_edit_project)}
                     phx-disable-with="Saving"
                   >
                     Save
@@ -149,6 +149,7 @@
             <.tr>
               <.th>Collaborator</.th>
               <.th>Role</.th>
+              <.th>Digest</.th>
             </.tr>
 
             <%= for project_user <- @project_users do %>
@@ -157,6 +158,7 @@
                   <%= project_user.user.first_name %> <%= project_user.user.last_name %>
                 </.td>
                 <.td><%= project_user.role %></.td>
+                <.td><%= project_user.digest %></.td>
               </.tr>
             <% end %>
           </.table>

--- a/priv/repo/migrations/20230131060317_add_digest_to_project_users.exs
+++ b/priv/repo/migrations/20230131060317_add_digest_to_project_users.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddDigestToProjectUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:project_users) do
+      add :digest, :string, default: "weekly", null: false
+    end
+  end
+end

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -4,6 +4,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
   import Swoosh.TestAssertions
 
   alias Lightning.Accounts.{UserNotifier, User}
+  alias Lightning.Projects.Project
 
   describe "Notification emails" do
     test "send_deletion_notification_email/1" do
@@ -14,6 +15,58 @@ defmodule Lightning.Accounts.UserNotifierTest do
       assert_email_sent(
         subject: "Lightning Account Deletion",
         to: "real@email.com"
+      )
+    end
+
+    test "deliver_project_digest/4" do
+      user = %User{email: "real@email.com"}
+      project = %Project{name: "Real Project"}
+
+      data = [
+        %{
+          workflow_name: "Workflow A",
+          successful_workorders: 12,
+          rerun_workorders: 6,
+          failed_workorders: 3
+        },
+        %{
+          workflow_name: "Workflow B",
+          successful_workorders: 10,
+          rerun_workorders: 0,
+          failed_workorders: 0
+        },
+        %{
+          workflow_name: "Workflow C",
+          successful_workorders: 3,
+          rerun_workorders: 0,
+          failed_workorders: 7
+        }
+      ]
+
+      digest_type = :daily
+
+      UserNotifier.deliver_project_digest(user, project, data, digest_type)
+
+      assert_email_sent(
+        subject: "Weekly digest for project #{project.name}",
+        to: user.email,
+        text_body: """
+        Workflow A:
+        - 12 workorders correctly processed this day
+        - 6 failed work orders that were rerun and then processed correctly
+        - 3 work orders that failed/still need addressing
+
+        Workflow B:
+        - 10 workorders correctly processed this day
+        - 0 failed work orders that were rerun and then processed correctly
+        - 0 work orders that failed/still need addressing
+
+        Workflow C:
+        - 3 workorders correctly processed this day
+        - 0 failed work orders that were rerun and then processed correctly
+        - 7 work orders that failed/still need addressing
+
+        """
       )
     end
   end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -5,8 +5,6 @@ defmodule Lightning.ProjectsTest do
   alias Lightning.Projects.Project
 
   import Lightning.ProjectsFixtures
-  # import Lightning.WorkflowsFixtures
-  import Lightning.InvocationFixtures
   import Lightning.AccountsFixtures
   import Lightning.CredentialsFixtures
 
@@ -153,52 +151,6 @@ defmodule Lightning.ProjectsTest do
       {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
 
       assert generated_yaml == expected_yaml
-    end
-  end
-
-  describe "Project digest" do
-    test "Gets daily project digest data and sends email to users" do
-      # user_to_delete =
-      #   user_fixture(scheduled_deletion: DateTime.utc_now() |> Timex.shift(seconds: -10))
-
-      # user_fixture(scheduled_deletion: DateTime.utc_now() |> Timex.shift(seconds: 10))
-
-      # count_before = Repo.all(User) |> Enum.count()
-
-      # user_1 = user_fixture()
-      # user_2 = user_fixture()
-      # user_3 = user_fixture()
-
-      # project_1 = project_fixture(project_users: [%{user_id: user_1.id, digest: :daily}])
-      # project_2 = project_fixture(project_users: [%{user_id: user_2.id, digest: :monthly}])
-      # project_3 = project_fixture(project_users: [%{user_id: user_3.id, digest: :weekly}])
-
-      # workflow_1 = workflow_fixture()
-
-      work_order_fixture() |> IO.inspect()
-
-      # {:ok, %{users_deleted: users_deleted}} =
-      Projects.perform(%Oban.Job{args: %{"type" => "daily_project_digest"}})
-
-      # assert count_before - 1 == Repo.all(User) |> Enum.count()
-      # assert 1 == users_deleted |> Enum.count()
-
-      # assert user_to_delete.id == users_deleted |> Enum.at(0) |> Map.get(:id)
-    end
-
-    test "get_project_digest/3 returns a digest for a given project" do
-      user = user_fixture()
-
-      project =
-        full_project_fixture(
-          project_users: [%{user_id: user.id, digest: :daily}]
-        )
-
-      # |> Repo.preload(project_users: [:user])
-
-      Projects.get_project_digest(project)
-
-      assert 1 == 1
     end
   end
 end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -62,15 +62,18 @@ defmodule Lightning.ProjectsTest do
       %{id: user_id} = user_fixture()
       valid_attrs = %{name: "some-name", project_users: [%{user_id: user_id}]}
 
-      assert {:ok, %Project{id: project_id} = project} = Projects.create_project(valid_attrs)
+      assert {:ok, %Project{id: project_id} = project} =
+               Projects.create_project(valid_attrs)
 
       assert project.name == "some-name"
 
-      assert [%{project_id: ^project_id, user_id: ^user_id}] = project.project_users
+      assert [%{project_id: ^project_id, user_id: ^user_id}] =
+               project.project_users
     end
 
     test "create_project/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Projects.create_project(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} =
+               Projects.create_project(@invalid_attrs)
 
       assert {:error, %Ecto.Changeset{}} =
                Projects.create_project(%{"name" => "Can't have spaces!"})
@@ -80,7 +83,8 @@ defmodule Lightning.ProjectsTest do
       project = project_fixture()
       update_attrs = %{name: "some-updated-name"}
 
-      assert {:ok, %Project{} = project} = Projects.update_project(project, update_attrs)
+      assert {:ok, %Project{} = project} =
+               Projects.update_project(project, update_attrs)
 
       assert project.name == "some-updated-name"
     end
@@ -88,7 +92,8 @@ defmodule Lightning.ProjectsTest do
     test "update_project/2 with invalid data returns error changeset" do
       project = project_fixture() |> unload_relation(:project_users)
 
-      assert {:error, %Ecto.Changeset{}} = Projects.update_project(project, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} =
+               Projects.update_project(project, @invalid_attrs)
 
       assert project == Projects.get_project!(project.id)
     end
@@ -112,7 +117,9 @@ defmodule Lightning.ProjectsTest do
       other_user = user_fixture()
 
       project_1 =
-        project_fixture(project_users: [%{user_id: user.id}, %{user_id: other_user.id}])
+        project_fixture(
+          project_users: [%{user_id: user.id}, %{user_id: other_user.id}]
+        )
         |> Repo.reload()
 
       project_2 =
@@ -183,8 +190,9 @@ defmodule Lightning.ProjectsTest do
       user = user_fixture()
 
       project =
-        full_project_fixture(project_users: [%{user_id: user.id, digest: :daily}])
-        |> IO.inspect()
+        full_project_fixture(
+          project_users: [%{user_id: user.id, digest: :daily}]
+        )
 
       # |> Repo.preload(project_users: [:user])
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -153,4 +153,76 @@ defmodule Lightning.ProjectsTest do
       assert generated_yaml == expected_yaml
     end
   end
+
+  describe "The default Oban function Projects.perform/1" do
+    test "finds all project users of a project that has a digest of :daily, :weekly, and :monthly" do
+      user_1 = user_fixture()
+      user_2 = user_fixture()
+      user_3 = user_fixture()
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :daily},
+          %{user_id: user_2.id, digest: :daily},
+          %{user_id: user_3.id, digest: :weekly}
+        ]
+      )
+
+      {:ok, %{project_users: daily_project_users}} =
+        Projects.perform(%Oban.Job{args: %{"type" => "daily_project_digest"}})
+
+      {:ok, %{project_users: weekly_project_users}} =
+        Projects.perform(%Oban.Job{args: %{"type" => "weekly_project_digest"}})
+
+      {:ok, %{project_users: monthly_project_users}} =
+        Projects.perform(%Oban.Job{args: %{"type" => "monthly_project_digest"}})
+
+      assert daily_project_users |> length() == 2
+      assert weekly_project_users |> length() == 1
+      assert monthly_project_users |> length() == 0
+    end
+
+    test "finds all project users of different projects that has a digest of :daily, :weekly, and :monthly" do
+      user_1 = user_fixture()
+      user_2 = user_fixture()
+      user_3 = user_fixture()
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :daily},
+          %{user_id: user_2.id, digest: :weekly},
+          %{user_id: user_3.id, digest: :monthly}
+        ]
+      )
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :monthly},
+          %{user_id: user_2.id, digest: :weekly},
+          %{user_id: user_3.id, digest: :daily}
+        ]
+      )
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :monthly},
+          %{user_id: user_2.id, digest: :daily},
+          %{user_id: user_3.id, digest: :weekly}
+        ]
+      )
+
+      {:ok, %{project_users: daily_project_users}} =
+        Projects.perform(%Oban.Job{args: %{"type" => "daily_project_digest"}})
+
+      {:ok, %{project_users: weekly_project_users}} =
+        Projects.perform(%Oban.Job{args: %{"type" => "weekly_project_digest"}})
+
+      {:ok, %{project_users: monthly_project_users}} =
+        Projects.perform(%Oban.Job{args: %{"type" => "monthly_project_digest"}})
+
+      assert daily_project_users |> length() == 3
+      assert weekly_project_users |> length() == 3
+      assert monthly_project_users |> length() == 3
+    end
+  end
 end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -37,9 +37,11 @@ defmodule Lightning.WorkflowsTest do
       project = ProjectsFixtures.project_fixture()
       valid_attrs = %{name: "some-name", project_id: project.id}
 
-      assert {:ok, %Workflow{} = workflow} = Workflows.create_workflow(valid_attrs)
+      assert {:ok, %Workflow{} = workflow} =
+               Workflows.create_workflow(valid_attrs)
 
-      assert {:error, %Ecto.Changeset{} = changeset} = Workflows.create_workflow(valid_attrs)
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Workflows.create_workflow(valid_attrs)
 
       assert %{
                name: [
@@ -54,7 +56,8 @@ defmodule Lightning.WorkflowsTest do
       workflow = WorkflowsFixtures.workflow_fixture()
       update_attrs = %{name: "some-updated-name"}
 
-      assert {:ok, %Workflow{} = workflow} = Workflows.update_workflow(workflow, update_attrs)
+      assert {:ok, %Workflow{} = workflow} =
+               Workflows.update_workflow(workflow, update_attrs)
 
       assert workflow.name == "some-updated-name"
     end
@@ -147,10 +150,14 @@ defmodule Lightning.WorkflowsTest do
       assert w2.deleted_at == nil
 
       assert (w1
-              |> Repo.preload(jobs: [:credential, :workflow, trigger: [:upstream_job]])) in results
+              |> Repo.preload(
+                jobs: [:credential, :workflow, trigger: [:upstream_job]]
+              )) in results
 
       assert (w2
-              |> Repo.preload(jobs: [:credential, :workflow, trigger: [:upstream_job]])) in results
+              |> Repo.preload(
+                jobs: [:credential, :workflow, trigger: [:upstream_job]]
+              )) in results
 
       assert length(results) == 2
     end
@@ -208,13 +215,24 @@ defmodule Lightning.WorkflowsTest do
       user = AccountsFixtures.user_fixture()
 
       project =
-        ProjectsFixtures.project_fixture(project_users: [%{user_id: user.id, digest: :daily}])
+        ProjectsFixtures.project_fixture(
+          project_users: [%{user_id: user.id, digest: :daily}]
+        )
 
       workflow = WorkflowsFixtures.workflow_fixture(project_id: project.id)
-      job = JobsFixtures.job_fixture(project_id: project.id, workflow_id: workflow.id)
 
-      workorder_1 = InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
-      _workorder_2 = InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+      job =
+        JobsFixtures.job_fixture(
+          project_id: project.id,
+          workflow_id: workflow.id
+        )
+
+      workorder_1 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
+      _workorder_2 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
       reason = InvocationFixtures.reason_fixture(trigger_id: job.trigger.id)
 
       create_run(workorder_1, reason, %{
@@ -249,7 +267,8 @@ defmodule Lightning.WorkflowsTest do
         finished_at: Timex.now()
       })
 
-      Workflows.get_digest_data(workflow |> Repo.preload(:work_orders), :daily) |> IO.inspect()
+      Workflows.get_digest_data(workflow |> Repo.preload(:work_orders), :daily)
+      |> IO.inspect()
     end
   end
 


### PR DESCRIPTION
## Implementation plan

I am thinking of associating every row in the project settings > collaboration page to a form / changeset, and update the digest and/or alerts values in the database. This seems to me the best approach to avoid modals or second pages. I am a little bit concerned by the performance of this in the UI.

**Question to @stuartc and all team**: Is the idea of having as many forms as rows in a liveview page acceptable ? Is there any better way to approach this from a liveview perspective ? I haven't done any googling yet and this is probably the first idea of my not-well-woken-up brain.

## Any notes for the reviewer ?

## Related issue

Fixes #638 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
