### PR TITLE
Allow users to edit project digest and alerts settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ### Added
 
+- Added the ability for users to receive a digest email reporting on a specified
+  project. [#638](https://github.com/OpenFn/Lightning/issues/638)
+  [#585](https://github.com/OpenFn/Lightning/issues/585)
+
 ### Changed
 
 ### Fixed

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -36,7 +36,13 @@ config :lightning, Oban,
      crontab: [
        {"* * * * *", Lightning.Jobs.Scheduler},
        {"* * * * *", ObanPruner},
-       {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}}
+       {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}},
+       {"0 10 * * *", Lightning.DigestEmailWorker,
+        args: %{"type" => "daily_project_digest"}},
+       {"0 10 * * MON", Lightning.DigestEmailWorker,
+        args: %{"type" => "weekly_project_digest"}},
+       {"0 10 1 * *", Lightning.DigestEmailWorker,
+        args: %{"type" => "monthly_project_digest"}}
      ]}
   ],
   shutdown_grace_period:

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -115,4 +115,27 @@ defmodule Lightning.Accounts.UserNotifier do
     ==============================
     """)
   end
+
+  defp build_email_body(data, digest) do
+    digest_lookup = %{daily: "day", monthly: "month", weekly: "week"}
+
+    """
+    #{data.workflow_name}:
+    - #{data.successful_workorders} workorders correctly processed this #{digest_lookup[digest]}
+    - #{data.rerun_workorders} failed work orders that were rerun and then processed correctly
+    - #{data.failed_workorders} work orders that failed/still need addressing
+
+    """
+  end
+
+  @doc """
+  Deliver a digest for a project to a user.
+  """
+  def deliver_project_digest(user, project, data, digest) do
+    email = user.email
+    title = "Weekly digest for project #{project.name}"
+    body = Enum.map_join(data, fn d -> build_email_body(d, digest) end)
+
+    deliver(email, title, body)
+  end
 end

--- a/lib/lightning/digest_email_worker.ex
+++ b/lib/lightning/digest_email_worker.ex
@@ -1,0 +1,59 @@
+defmodule Lightning.DigestEmailWorker do
+  @moduledoc false
+
+  alias Lightning.Accounts.UserNotifier
+  alias Lightning.Projects.ProjectUser
+  alias Lightning.{Workflows, Workorders, Repo}
+
+  import Ecto.Query, warn: false
+
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 1
+
+  @doc """
+  Perform, when called with %{"type" => "daily_project_digest"} will find
+  project_users with digest set to daily and send a digest email to them
+  everyday at 10am
+  """
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"type" => "daily_project_digest"}}) do
+    project_digest(:daily)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"type" => "weekly_project_digest"}}) do
+    project_digest(:weekly)
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"type" => "monthly_project_digest"}}) do
+    project_digest(:monthly)
+  end
+
+  defp project_digest(digest) do
+    project_users =
+      from(pu in ProjectUser,
+        where: pu.digest == ^digest,
+        preload: [:project, :user]
+      )
+      |> Repo.all()
+
+    Enum.each(project_users, fn pu ->
+      digest_data =
+        Workflows.get_workflows_for(pu.project)
+        |> Enum.map(fn workflow ->
+          Workorders.get_digest_data(workflow, digest)
+        end)
+
+      UserNotifier.deliver_project_digest(
+        pu.user,
+        pu.project,
+        digest_data,
+        digest
+      )
+    end)
+
+    {:ok, %{project_users: project_users}}
+  end
+end

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -9,25 +9,26 @@ defmodule Lightning.Policies.ProjectUsers do
   alias Lightning.Accounts.User
 
   @type actions ::
-          :create_workflow
-          | :edit_jobs
+          :add_project_collaborator
           | :create_job
+          | :create_workflow
           | :delete_job
-          | :run_job
-          | :rerun_job
-          | :view_last_job_inputs
-          | :view_workorder_input
-          | :view_workorder_run
-          | :view_workorder_history
-          | :view_project_name
-          | :view_project_description
-          | :view_project_credentials
-          | :view_project_collaborators
           | :delete_project
           | :edit_digest_alerts
-          | :edit_project_name
+          | :edit_jobs
           | :edit_project_description
-          | :add_project_collaborator
+          | :edit_project_name
+          | :edit_project_user
+          | :rerun_job
+          | :run_job
+          | :view_last_job_inputs
+          | :view_project_collaborators
+          | :view_project_credentials
+          | :view_project_description
+          | :view_project_name
+          | :view_workorder_history
+          | :view_workorder_input
+          | :view_workorder_run
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -90,4 +91,11 @@ defmodule Lightning.Policies.ProjectUsers do
              :view_project_collaborators
            ],
       do: Projects.is_member_of?(project, user)
+
+  def authorize(
+        :edit_project_user,
+        %User{id: id} = _user,
+        %ProjectUser{user_id: user_id} = _project_user
+      ),
+      do: id == user_id
 end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -4,6 +4,7 @@ defmodule Lightning.Projects do
   """
 
   import Ecto.Query, warn: false
+  alias Lightning.Projects.ProjectUser
   alias Lightning.Repo
 
   alias Lightning.Projects.{Importer, Project, ProjectCredential}
@@ -40,6 +41,24 @@ defmodule Lightning.Projects do
   def get_project!(id), do: Repo.get!(Project, id)
 
   def get_project(id), do: Repo.get(Project, id)
+
+  @doc """
+  Gets a single project_user.
+
+  Raises `Ecto.NoResultsError` if the ProjectUser does not exist.
+
+  ## Examples
+
+      iex> get_project_user!(123)
+      %ProjectUser{}
+
+      iex> get_project_user!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_project_user!(id), do: Repo.get!(ProjectUser, id)
+
+  def get_project_user(id), do: Repo.get(ProjectUser, id)
 
   @doc """
   Gets a single project with it's members via `project_users`.
@@ -91,6 +110,24 @@ defmodule Lightning.Projects do
   def update_project(%Project{} = project, attrs) do
     project
     |> Project.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Updates a project user.
+
+  ## Examples
+
+      iex> update_project_user(project_user, %{field: new_value})
+      {:ok, %ProjectUser{}}
+
+      iex> update_project_user(projectUser, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_project_user(%ProjectUser{} = project_user, attrs) do
+    project_user
+    |> ProjectUser.changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/lightning/projects/project_user.ex
+++ b/lib/lightning/projects/project_user.ex
@@ -23,6 +23,13 @@ defmodule Lightning.Projects.ProjectUser do
     :owner
   ])
 
+  defenum(DigestEnum, :digest, [
+    :never,
+    :daily,
+    :weekly,
+    :monthly
+  ])
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "project_users" do
@@ -31,6 +38,7 @@ defmodule Lightning.Projects.ProjectUser do
     field :delete, :boolean, virtual: true
     field :failure_alert, :boolean, default: true
     field :role, RolesEnum, default: :editor
+    field :digest, DigestEnum, default: :weekly
 
     timestamps()
   end
@@ -42,7 +50,7 @@ defmodule Lightning.Projects.ProjectUser do
   @doc false
   def changeset(project_user, attrs) do
     project_user
-    |> cast(attrs, [:user_id, :project_id, :role, :failure_alert])
+    |> cast(attrs, [:user_id, :project_id, :role, :digest, :failure_alert])
     |> validate_required([:user_id])
     |> unique_constraint([:project_id, :user_id],
       message: "User already a member of this project."

--- a/lib/lightning/workorders.ex
+++ b/lib/lightning/workorders.ex
@@ -1,0 +1,125 @@
+defmodule Lightning.Workorders do
+  @moduledoc false
+  import Ecto.Query, warn: false
+
+  alias Lightning.Repo
+
+  @doc """
+  Get a map of counts for successful, rerun and failed Workorders for a given
+  digest.
+  """
+  def get_digest_data(workflow, digest)
+      when digest in [:daily, :weekly, :monthly] do
+    %{
+      workflow_name: workflow.name,
+      successful_workorders:
+        successful_workorders_query(workflow, digest) |> Repo.one(),
+      rerun_workorders: rerun_workorders_query(workflow, digest) |> Repo.one(),
+      failed_workorders: failed_workorders_query(workflow, digest) |> Repo.one()
+    }
+  end
+
+  defp filter_digest(digest) do
+    from_date =
+      case digest do
+        :monthly ->
+          Timex.now() |> Timex.shift(months: -1) |> Timex.beginning_of_month()
+
+        :daily ->
+          Timex.now() |> Timex.beginning_of_day()
+
+        :weekly ->
+          Timex.now() |> Timex.shift(days: -7) |> Timex.beginning_of_week()
+      end
+
+    dynamic([r], r.finished_at >= ^from_date)
+  end
+
+  defp successful_workorders_query(workflow, digest) do
+    from(wo in Lightning.WorkOrder,
+      join: w in assoc(wo, :workflow),
+      as: :workflow,
+      join: att in assoc(wo, :attempts),
+      on: wo.id == att.work_order_id,
+      join: r in assoc(att, :runs),
+      as: :runs,
+      join:
+        run in subquery(
+          from(r in Lightning.Invocation.Run,
+            join: att in assoc(r, :attempts),
+            group_by: [att.id, r.exit_code],
+            where: r.exit_code == 0,
+            where: ^filter_digest(digest),
+            select: %{
+              attempt_id: att.id
+            }
+          )
+        ),
+      on: att.id == run.attempt_id,
+      where: w.id == ^workflow.id,
+      select: count(w.id)
+    )
+  end
+
+  defp rerun_workorders_query(workflow, digest) do
+    from(
+      attempt in Lightning.Attempt,
+      as: :attempts,
+      where:
+        1 <
+          subquery(
+            from(wo in Lightning.WorkOrder,
+              join: w in assoc(wo, :workflow),
+              as: :workflow,
+              join: att in assoc(wo, :attempts),
+              on: wo.id == att.work_order_id,
+              join: r in assoc(att, :runs),
+              as: :runs,
+              join:
+                run in subquery(
+                  from(r in Lightning.Invocation.Run,
+                    join: att in assoc(r, :attempts),
+                    group_by: [att.id, r.exit_code],
+                    where: r.exit_code == 0,
+                    where: ^filter_digest(digest),
+                    select: %{
+                      attempt_id: att.id
+                    }
+                  )
+                ),
+              on: att.id == run.attempt_id,
+              where: w.id == ^workflow.id,
+              where: parent_as(:attempts).work_order_id == wo.id,
+              select: count(wo.id)
+            )
+          ),
+      select: count(attempt.id)
+    )
+  end
+
+  defp failed_workorders_query(workflow, digest) do
+    from(wo in Lightning.WorkOrder,
+      join: w in assoc(wo, :workflow),
+      as: :workflow,
+      join: att in assoc(wo, :attempts),
+      on: wo.id == att.work_order_id,
+      join: r in assoc(att, :runs),
+      as: :runs,
+      join:
+        run in subquery(
+          from(r in Lightning.Invocation.Run,
+            join: att in assoc(r, :attempts),
+            group_by: [att.id, r.exit_code],
+            where: r.exit_code != 0,
+            where: ^filter_digest(digest),
+            select: %{
+              attempt_id: att.id
+            }
+          )
+        ),
+      on: att.id == run.attempt_id,
+      where: w.id == ^workflow.id,
+      select: count(w.id)
+    )
+  end
+end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -49,7 +49,7 @@
             </div>
             <.form
               :let={f}
-              for={@changeset}
+              for={@project_changeset}
               id="project-settings-form"
               phx-change="validate"
               phx-submit="save"
@@ -90,7 +90,7 @@
               <div class="grid grid-cols gap-6">
                 <div class="md:col-span-2">
                   <LightningWeb.Components.Form.submit_button
-                    disabled={!@changeset.valid? || !@can_edit_project}
+                    disabled={!(@project_changeset.valid? and @can_edit_project)}
                     phx-disable-with="Saving"
                   >
                     Save
@@ -149,14 +149,30 @@
             <.tr>
               <.th>Collaborator</.th>
               <.th>Role</.th>
+              <.th>Failure Alert</.th>
+              <.th>Digest</.th>
             </.tr>
 
             <%= for project_user <- @project_users do %>
               <.tr id={"project_user-#{project_user.id}"}>
                 <.td>
-                  <%= project_user.user.first_name %> <%= project_user.user.last_name %>
+                  <.user project_user={project_user} />
                 </.td>
-                <.td><%= project_user.role %></.td>
+                <.td>
+                  <.role project_user={project_user} />
+                </.td>
+                <.td>
+                  <.failure_alert
+                    current_user={@current_user}
+                    project_user={project_user}
+                  />
+                </.td>
+                <.td>
+                  <.digest
+                    current_user={@current_user}
+                    project_user={project_user}
+                  />
+                </.td>
               </.tr>
             <% end %>
           </.table>

--- a/priv/repo/migrations/20230131060317_add_digest_to_project_users.exs
+++ b/priv/repo/migrations/20230131060317_add_digest_to_project_users.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddDigestToProjectUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:project_users) do
+      add :digest, :string, default: "weekly", null: false
+    end
+  end
+end

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -4,6 +4,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
   import Swoosh.TestAssertions
 
   alias Lightning.Accounts.{UserNotifier, User}
+  alias Lightning.Projects.Project
 
   describe "Notification emails" do
     test "send_deletion_notification_email/1" do
@@ -14,6 +15,58 @@ defmodule Lightning.Accounts.UserNotifierTest do
       assert_email_sent(
         subject: "Lightning Account Deletion",
         to: "real@email.com"
+      )
+    end
+
+    test "deliver_project_digest/4" do
+      user = %User{email: "real@email.com"}
+      project = %Project{name: "Real Project"}
+
+      data = [
+        %{
+          workflow_name: "Workflow A",
+          successful_workorders: 12,
+          rerun_workorders: 6,
+          failed_workorders: 3
+        },
+        %{
+          workflow_name: "Workflow B",
+          successful_workorders: 10,
+          rerun_workorders: 0,
+          failed_workorders: 0
+        },
+        %{
+          workflow_name: "Workflow C",
+          successful_workorders: 3,
+          rerun_workorders: 0,
+          failed_workorders: 7
+        }
+      ]
+
+      digest_type = :daily
+
+      UserNotifier.deliver_project_digest(user, project, data, digest_type)
+
+      assert_email_sent(
+        subject: "Weekly digest for project #{project.name}",
+        to: user.email,
+        text_body: """
+        Workflow A:
+        - 12 workorders correctly processed this day
+        - 6 failed work orders that were rerun and then processed correctly
+        - 3 work orders that failed/still need addressing
+
+        Workflow B:
+        - 10 workorders correctly processed this day
+        - 0 failed work orders that were rerun and then processed correctly
+        - 0 work orders that failed/still need addressing
+
+        Workflow C:
+        - 3 workorders correctly processed this day
+        - 0 failed work orders that were rerun and then processed correctly
+        - 7 work orders that failed/still need addressing
+
+        """
       )
     end
   end

--- a/test/lightning/digest_email_worker_test.exs
+++ b/test/lightning/digest_email_worker_test.exs
@@ -1,0 +1,58 @@
+defmodule Lightning.DigestEmailWorkerTest do
+  use Lightning.DataCase, async: true
+
+  import Lightning.ProjectsFixtures
+  import Lightning.AccountsFixtures
+  alias Lightning.DigestEmailWorker
+
+  describe "perform/1" do
+    test "all project users of different project that have a digest of :daily, :weekly, and :monthly" do
+      user_1 = user_fixture()
+      user_2 = user_fixture()
+      user_3 = user_fixture()
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :daily},
+          %{user_id: user_2.id, digest: :weekly},
+          %{user_id: user_3.id, digest: :monthly}
+        ]
+      )
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :monthly},
+          %{user_id: user_2.id, digest: :daily},
+          %{user_id: user_3.id, digest: :daily}
+        ]
+      )
+
+      project_fixture(
+        project_users: [
+          %{user_id: user_1.id, digest: :weekly},
+          %{user_id: user_2.id, digest: :daily},
+          %{user_id: user_3.id, digest: :weekly}
+        ]
+      )
+
+      {:ok, %{project_users: daily_project_users}} =
+        DigestEmailWorker.perform(%Oban.Job{
+          args: %{"type" => "daily_project_digest"}
+        })
+
+      {:ok, %{project_users: weekly_project_users}} =
+        DigestEmailWorker.perform(%Oban.Job{
+          args: %{"type" => "weekly_project_digest"}
+        })
+
+      {:ok, %{project_users: monthly_project_users}} =
+        DigestEmailWorker.perform(%Oban.Job{
+          args: %{"type" => "monthly_project_digest"}
+        })
+
+      assert daily_project_users |> length() == 4
+      assert weekly_project_users |> length() == 3
+      assert monthly_project_users |> length() == 2
+    end
+  end
+end

--- a/test/lightning/permissions_test.exs
+++ b/test/lightning/permissions_test.exs
@@ -164,11 +164,21 @@ defmodule Lightning.PermissionsTest do
 
       refute ProjectUsers
              |> Permissions.can(:add_project_collaborator, viewer, project)
+
+      viewer_project_user = project.project_users |> Enum.at(0)
+      editor_project_user = project.project_users |> Enum.at(1)
+
+      assert ProjectUsers
+             |> Permissions.can(:edit_project_user, viewer, viewer_project_user)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_user, viewer, editor_project_user)
     end
 
     test "editor permissions", %{project: project, editor: editor} do
       assert ProjectUsers |> Permissions.can(:create_workflow, editor, project)
       assert ProjectUsers |> Permissions.can(:edit_jobs, editor, project)
+
       assert ProjectUsers |> Permissions.can(:create_job, editor, project)
       assert ProjectUsers |> Permissions.can(:delete_job, editor, project)
       assert ProjectUsers |> Permissions.can(:run_job, editor, project)
@@ -220,6 +230,15 @@ defmodule Lightning.PermissionsTest do
 
       refute ProjectUsers
              |> Permissions.can(:add_project_collaborator, editor, project)
+
+      viewer_project_user = project.project_users |> Enum.at(0)
+      editor_project_user = project.project_users |> Enum.at(1)
+
+      assert ProjectUsers
+             |> Permissions.can(:edit_project_user, editor, editor_project_user)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_user, editor, viewer_project_user)
     end
 
     test "admin permissions", %{project: project, admin: admin} do
@@ -276,6 +295,15 @@ defmodule Lightning.PermissionsTest do
 
       assert ProjectUsers
              |> Permissions.can(:add_project_collaborator, admin, project)
+
+      viewer_project_user = project.project_users |> Enum.at(0)
+      admin_project_user = project.project_users |> Enum.at(2)
+
+      assert ProjectUsers
+             |> Permissions.can(:edit_project_user, admin, admin_project_user)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_user, admin, viewer_project_user)
     end
 
     test "owner permissions", %{project: project, owner: owner} do
@@ -332,6 +360,15 @@ defmodule Lightning.PermissionsTest do
 
       assert ProjectUsers
              |> Permissions.can(:add_project_collaborator, owner, project)
+
+      viewer_project_user = project.project_users |> Enum.at(0)
+      owner_project_user = project.project_users |> Enum.at(3)
+
+      assert ProjectUsers
+             |> Permissions.can(:edit_project_user, owner, owner_project_user)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_user, owner, viewer_project_user)
     end
 
     # For things like :view_job we should be able to show that people who do not

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -1,13 +1,13 @@
 defmodule Lightning.WorkflowsTest do
   use Lightning.DataCase, async: true
 
-  alias Lightning.Workflows
-  alias Lightning.Workflows.Workflow
-  alias Lightning.Jobs
-
-  alias Lightning.WorkflowsFixtures
-  alias Lightning.JobsFixtures
-  alias Lightning.ProjectsFixtures
+  alias Lightning.{
+    Workflows,
+    Jobs,
+    WorkflowsFixtures,
+    JobsFixtures,
+    ProjectsFixtures
+  }
 
   describe "workflows" do
     test "list_workflows/0 returns all workflows" do
@@ -35,8 +35,7 @@ defmodule Lightning.WorkflowsTest do
       project = ProjectsFixtures.project_fixture()
       valid_attrs = %{name: "some-name", project_id: project.id}
 
-      assert {:ok, %Workflow{} = workflow} =
-               Workflows.create_workflow(valid_attrs)
+      assert {:ok, workflow} = Workflows.create_workflow(valid_attrs)
 
       assert {:error, %Ecto.Changeset{} = changeset} =
                Workflows.create_workflow(valid_attrs)
@@ -54,8 +53,7 @@ defmodule Lightning.WorkflowsTest do
       workflow = WorkflowsFixtures.workflow_fixture()
       update_attrs = %{name: "some-updated-name"}
 
-      assert {:ok, %Workflow{} = workflow} =
-               Workflows.update_workflow(workflow, update_attrs)
+      assert {:ok, workflow} = Workflows.update_workflow(workflow, update_attrs)
 
       assert workflow.name == "some-updated-name"
     end
@@ -66,7 +64,7 @@ defmodule Lightning.WorkflowsTest do
       job_1 = JobsFixtures.job_fixture(workflow_id: workflow.id)
       job_2 = JobsFixtures.job_fixture(workflow_id: workflow.id)
 
-      assert {:ok, %Workflow{}} = Workflows.delete_workflow(workflow)
+      assert {:ok, %Workflows.Workflow{}} = Workflows.delete_workflow(workflow)
 
       assert_raise Ecto.NoResultsError, fn ->
         Workflows.get_workflow!(workflow.id)

--- a/test/lightning/workorders_test.exs
+++ b/test/lightning/workorders_test.exs
@@ -1,0 +1,144 @@
+defmodule Lightning.WorkordersTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.{
+    AccountsFixtures,
+    InvocationFixtures,
+    JobsFixtures,
+    ProjectsFixtures,
+    WorkflowsFixtures,
+    Workorders
+  }
+
+  describe "Project digest" do
+    test "Gets project digest data" do
+      user = AccountsFixtures.user_fixture()
+
+      project =
+        ProjectsFixtures.project_fixture(
+          project_users: [%{user_id: user.id, digest: :daily}]
+        )
+
+      workflow = WorkflowsFixtures.workflow_fixture(project_id: project.id)
+
+      job =
+        JobsFixtures.job_fixture(
+          project_id: project.id,
+          workflow_id: workflow.id
+        )
+
+      workorder_1 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
+      workorder_2 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
+      reason = InvocationFixtures.reason_fixture(trigger_id: job.trigger.id)
+
+      create_run(workorder_1, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 0,
+        finished_at: Timex.now()
+      })
+
+      create_run(workorder_2, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 0,
+        finished_at: Timex.now()
+      })
+
+      assert Workorders.get_digest_data(workflow, :daily) == %{
+               failed_workorders: 0,
+               rerun_workorders: 0,
+               successful_workorders: 2,
+               workflow_name: workflow.name
+             }
+
+      workorder_1 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
+      workorder_2 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
+      workorder_3 =
+        InvocationFixtures.work_order_fixture(workflow_id: workflow.id)
+
+      create_run(workorder_1, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 0,
+        finished_at: Timex.now()
+      })
+
+      create_run(workorder_2, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 1,
+        finished_at: Timex.now()
+      })
+
+      create_run(workorder_3, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 1,
+        finished_at: Timex.now()
+      })
+
+      create_run(workorder_3, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 1,
+        finished_at: Timex.now() |> Timex.shift(days: -7)
+      })
+
+      create_run(workorder_3, reason, %{
+        project_id: project.id,
+        job_id: job.id,
+        input_dataclip_id: reason.dataclip_id,
+        exit_code: 0,
+        finished_at:
+          Timex.now()
+          |> Timex.shift(months: -1)
+          |> Timex.beginning_of_month()
+          |> Timex.shift(hours: 4)
+      })
+
+      assert Workorders.get_digest_data(workflow, :daily) == %{
+               failed_workorders: 2,
+               rerun_workorders: 0,
+               successful_workorders: 3,
+               workflow_name: workflow.name
+             }
+
+      assert Workorders.get_digest_data(workflow, :weekly) == %{
+               failed_workorders: 3,
+               rerun_workorders: 0,
+               successful_workorders: 3,
+               workflow_name: workflow.name
+             }
+
+      assert Workorders.get_digest_data(workflow, :monthly) == %{
+               failed_workorders: 3,
+               rerun_workorders: 0,
+               successful_workorders: 4,
+               workflow_name: workflow.name
+             }
+    end
+  end
+
+  defp create_run(workorder, reason, run_params) do
+    Lightning.AttemptService.build_attempt(workorder, reason)
+    |> Ecto.Changeset.put_assoc(:runs, [
+      Lightning.Invocation.Run.changeset(%Lightning.Invocation.Run{}, run_params)
+    ])
+    |> Repo.insert()
+  end
+end


### PR DESCRIPTION
## Implementation plan

The idea of using forms / ecto.changesets in this context was not the best one in terms of performance. Instead I am using the phoenix bindings and listening the click events on these components (selectbox for digest values and checkbox for failure alerts). For every click I send I get the id of the current project user and the value of the component. With these values I update the project user and reassign it to the liveview socket. The logic of all this will be controlled by the roles and permissions.

## Any notes for the reviewer ?

## Related issue

Fixes #638 and #585 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
