### PR TITLE
Lay down authorization across entire app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to
 ### Fixed
 
 - Jobs panel slow for first open after restart
-  [#567](https://github.com/OpenFn/Lightning/issues/567)
+  [#567](https://github.com/OpenFn/Lightning/issues/567) =======
 
 ## [0.4.0] - 2023-02-08
 
@@ -58,6 +58,7 @@ and this project adheres to
 - Enable distributed Erlang, allowing any number of redundant Lightning nodes to
   communicate with each other.
 - Users can set up realtime alerts for a project
+- New authorization pattern accros the entire app
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,9 @@ and this project adheres to
 - Enable distributed Erlang, allowing any number of redundant Lightning nodes to
   communicate with each other.
 - Users can set up realtime alerts for a project
-- New authorization pattern accros the entire app
+- Authorization for Lightning superusers and users, and project roles
+  viewer/editor/admin/owner. See
+  [link to test file](test/lightning/permissions_test.exs) for more details.
 
 ### Changed
 

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -8,7 +8,21 @@ defmodule Lightning.Policies.ProjectUsers do
   alias Lightning.Projects.Project
   alias Lightning.Accounts.User
 
-  @type actions :: :edit_jobs
+  @type actions ::
+          :create_workflow
+          | :edit_job
+          | :create_job
+          | :delete_job
+          | :run_job
+          | :rerun_job
+          | :view_last_job_inputs
+          | :view_workorder_input
+          | :view_workorder_run
+          | :view_workorder_history
+          | :view_project_name
+          | :view_project_description
+          | :view_project_credentials
+          | :view_project_collaborators
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -25,7 +39,28 @@ defmodule Lightning.Policies.ProjectUsers do
           Lightning.Accounts.User.t(),
           Lightning.Projects.Project.t()
         ) :: boolean
-  def authorize(:edit_jobs, %User{} = user, %Project{} = project) do
-    Projects.get_project_user_role(user, project) in [:admin, :editor, :owner]
+  def authorize(action, %User{} = user, %Project{} = project)
+      when action in [
+             :create_workflow,
+             :edit_job,
+             :create_job,
+             :delete_job,
+             :run_job,
+             :rerun_job
+           ] do
+    Projects.get_project_user_role(user, project) in [:owner, :admin, :editor]
   end
+
+  def authorize(action, %User{} = user, %Project{} = project)
+      when action in [
+             :view_last_job_inputs,
+             :view_workorder_input,
+             :view_workorder_run,
+             :view_workorder_history,
+             :view_project_name,
+             :view_project_description,
+             :view_project_credentials,
+             :view_project_collaborators
+           ],
+      do: true
 end

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -10,7 +10,7 @@ defmodule Lightning.Policies.ProjectUsers do
 
   @type actions ::
           :create_workflow
-          | :edit_job
+          | :edit_jobs
           | :create_job
           | :delete_job
           | :run_job
@@ -57,7 +57,7 @@ defmodule Lightning.Policies.ProjectUsers do
   def authorize(action, %User{} = user, %Project{} = project)
       when action in [
              :create_workflow,
-             :edit_job,
+             :edit_jobs,
              :create_job,
              :delete_job,
              :run_job,

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -5,7 +5,7 @@ defmodule Lightning.Policies.ProjectUsers do
   @behaviour Bodyguard.Policy
 
   alias Lightning.Projects
-  alias Lightning.Projects.Project
+  alias Lightning.Projects.{ProjectUser, Project}
   alias Lightning.Accounts.User
 
   @type actions ::
@@ -23,6 +23,11 @@ defmodule Lightning.Policies.ProjectUsers do
           | :view_project_description
           | :view_project_credentials
           | :view_project_collaborators
+          | :delete_project
+          | :edit_digest_alerts
+          | :edit_project_name
+          | :edit_project_description
+          | :add_project_collaborator
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -39,6 +44,16 @@ defmodule Lightning.Policies.ProjectUsers do
           Lightning.Accounts.User.t(),
           Lightning.Projects.Project.t()
         ) :: boolean
+  def authorize(:delete_project, %User{} = user, %Project{} = project),
+    do: Projects.get_project_user_role(user, project) in [:owner]
+
+  def authorize(
+        :edit_digest_alerts,
+        %User{id: id} = _user,
+        %ProjectUser{user_id: user_id} = _project
+      ),
+      do: id == user_id
+
   def authorize(action, %User{} = user, %Project{} = project)
       when action in [
              :create_workflow,
@@ -47,11 +62,23 @@ defmodule Lightning.Policies.ProjectUsers do
              :delete_job,
              :run_job,
              :rerun_job
-           ] do
-    Projects.get_project_user_role(user, project) in [:owner, :admin, :editor]
-  end
+           ],
+      do:
+        Projects.get_project_user_role(user, project) in [
+          :owner,
+          :admin,
+          :editor
+        ]
 
   def authorize(action, %User{} = user, %Project{} = project)
+      when action in [
+             :edit_project_name,
+             :edit_project_description,
+             :add_project_collaborator
+           ],
+      do: Projects.get_project_user_role(user, project) in [:owner, :admin]
+
+  def authorize(action, %User{} = _user, %Project{} = _project)
       when action in [
              :view_last_job_inputs,
              :view_workorder_input,

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -15,7 +15,7 @@ defmodule Lightning.Policies.ProjectUsers do
           | :delete_job
           | :run_job
           | :rerun_job
-          | :view_last_job_input
+          | :view_last_job_inputs
           | :view_workorder_input
           | :view_workorder_run
           | :view_workorder_history
@@ -78,7 +78,7 @@ defmodule Lightning.Policies.ProjectUsers do
            ],
       do: Projects.get_project_user_role(user, project) in [:owner, :admin]
 
-  def authorize(action, %User{} = _user, %Project{} = _project)
+  def authorize(action, %User{} = user, %Project{} = project)
       when action in [
              :view_last_job_inputs,
              :view_workorder_input,
@@ -89,5 +89,5 @@ defmodule Lightning.Policies.ProjectUsers do
              :view_project_credentials,
              :view_project_collaborators
            ],
-      do: true
+      do: Projects.is_member_of?(project, user)
 end

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -15,7 +15,7 @@ defmodule Lightning.Policies.ProjectUsers do
           | :delete_job
           | :run_job
           | :rerun_job
-          | :view_last_job_inputs
+          | :view_last_job_input
           | :view_workorder_input
           | :view_workorder_run
           | :view_workorder_history

--- a/lib/lightning/policies/users.ex
+++ b/lib/lightning/policies/users.ex
@@ -6,7 +6,18 @@ defmodule Lightning.Policies.Users do
 
   alias Lightning.Accounts.User
 
-  @type actions :: :create_projects
+  @type actions :: [
+          :create_projects,
+          :view_projects,
+          :edit_projects,
+          :create_projects,
+          :view_users,
+          :edit_users,
+          :delete_users,
+          :disable_users,
+          :configure_external_auth_provider,
+          :view_credentials_audit_trail
+        ]
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -19,7 +30,18 @@ defmodule Lightning.Policies.Users do
   for a particular action they are denied.
   """
   @spec authorize(actions(), Lightning.Accounts.User.t(), any) :: boolean
-  def authorize(:create_projects, %User{role: role}, _project) do
+  def authorize(action, %User{role: role}, _project)
+      when action in [
+             :view_projects,
+             :edit_projects,
+             :create_projects,
+             :view_users,
+             :edit_users,
+             :delete_users,
+             :disable_users,
+             :configure_external_auth_provider,
+             :view_credentials_audit_trail
+           ] do
     role in [:superuser]
   end
 end

--- a/lib/lightning/policies/users.ex
+++ b/lib/lightning/policies/users.ex
@@ -10,7 +10,6 @@ defmodule Lightning.Policies.Users do
           :create_projects
           | :view_projects
           | :edit_projects
-          | :create_projects
           | :view_users
           | :edit_users
           | :delete_users

--- a/lib/lightning/policies/users.ex
+++ b/lib/lightning/policies/users.ex
@@ -17,6 +17,11 @@ defmodule Lightning.Policies.Users do
           | :disable_users
           | :configure_external_auth_provider
           | :view_credentials_audit_trail
+          | :change_password
+          | :delete_account
+          | :view_credentials
+          | :edit_credentials
+          | :delete_credential
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -42,5 +47,16 @@ defmodule Lightning.Policies.Users do
              :view_credentials_audit_trail
            ] do
     role in [:superuser]
+  end
+
+  def authorize(action, %User{} = requesting_user, %User{} = authenticated_user)
+      when action in [
+             :change_password,
+             :delete_account,
+             :view_credentials,
+             :edit_credentials,
+             :delete_credential
+           ] do
+    requesting_user.id == authenticated_user.id
   end
 end

--- a/lib/lightning/policies/users.ex
+++ b/lib/lightning/policies/users.ex
@@ -6,18 +6,17 @@ defmodule Lightning.Policies.Users do
 
   alias Lightning.Accounts.User
 
-  @type actions :: [
-          :create_projects,
-          :view_projects,
-          :edit_projects,
-          :create_projects,
-          :view_users,
-          :edit_users,
-          :delete_users,
-          :disable_users,
-          :configure_external_auth_provider,
-          :view_credentials_audit_trail
-        ]
+  @type actions ::
+          :create_projects
+          | :view_projects
+          | :edit_projects
+          | :create_projects
+          | :view_users
+          | :edit_users
+          | :delete_users
+          | :disable_users
+          | :configure_external_auth_provider
+          | :view_credentials_audit_trail
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -49,8 +49,8 @@ defmodule LightningWeb.JobLive.JobBuilder do
     )
   end
 
-  attr :return_to, :string, required: true
-  attr :params, :map, default: %{}
+  attr(:return_to, :string, required: true)
+  attr(:params, :map, default: %{})
 
   @impl true
   def render(assigns) do
@@ -452,7 +452,7 @@ defmodule LightningWeb.JobLive.JobBuilder do
        can_edit:
          ProjectUsers
          |> Permissions.can(
-           :edit_jobs,
+           :edit_job,
            current_user,
            project
          )

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -49,8 +49,8 @@ defmodule LightningWeb.JobLive.JobBuilder do
     )
   end
 
-  attr(:return_to, :string, required: true)
-  attr(:params, :map, default: %{})
+  attr :return_to, :string, required: true
+  attr :params, :map, default: %{}
 
   @impl true
   def render(assigns) do
@@ -452,7 +452,7 @@ defmodule LightningWeb.JobLive.JobBuilder do
        can_edit:
          ProjectUsers
          |> Permissions.can(
-           :edit_job,
+           :edit_jobs,
            current_user,
            project
          )

--- a/test/lightning/permissions_test.exs
+++ b/test/lightning/permissions_test.exs
@@ -7,18 +7,78 @@ defmodule Lightning.PermissionsTest do
   alias Lightning.Policies.{Permissions, Users, ProjectUsers}
 
   setup do
-    superuser = superuser_fixture()
-    user = user_fixture()
-    %{superuser: superuser, user: user}
+    %{
+      superuser: superuser_fixture(),
+      user: user_fixture(),
+      another_user: user_fixture()
+    }
   end
 
   describe "User policies by instance-wide role" do
-    test ":user permissions", %{user: user} do
+    test ":user permissions", %{user: user, another_user: another_user} do
       refute Users |> Permissions.can(:create_projects, user, {})
+      refute Users |> Permissions.can(:view_projects, user, {})
+      refute Users |> Permissions.can(:edit_projects, user, {})
+      refute Users |> Permissions.can(:view_users, user, {})
+      refute Users |> Permissions.can(:edit_users, user, {})
+      refute Users |> Permissions.can(:delete_users, user, {})
+      refute Users |> Permissions.can(:disable_users, user, {})
+
+      refute Users
+             |> Permissions.can(:configure_external_auth_provider, user, {})
+
+      refute Users |> Permissions.can(:view_credentials_audit_trail, user, {})
+
+      refute Users |> Permissions.can(:change_password, user, another_user)
+      assert Users |> Permissions.can(:change_password, user, user)
+
+      refute Users |> Permissions.can(:delete_account, user, another_user)
+      assert Users |> Permissions.can(:delete_account, user, user)
+
+      refute Users |> Permissions.can(:view_credentials, user, another_user)
+      assert Users |> Permissions.can(:view_credentials, user, user)
+
+      refute Users |> Permissions.can(:edit_credentials, user, another_user)
+      assert Users |> Permissions.can(:edit_credentials, user, user)
+
+      refute Users |> Permissions.can(:delete_credential, user, another_user)
+      assert Users |> Permissions.can(:delete_credential, user, user)
     end
 
-    test ":superuser permissions", %{superuser: superuser} do
+    test ":superuser permissions", %{
+      superuser: superuser,
+      another_user: another_user
+    } do
       assert Users |> Permissions.can(:create_projects, superuser, {})
+      assert Users |> Permissions.can(:view_projects, superuser, {})
+      assert Users |> Permissions.can(:edit_projects, superuser, {})
+      assert Users |> Permissions.can(:view_users, superuser, {})
+      assert Users |> Permissions.can(:edit_users, superuser, {})
+      assert Users |> Permissions.can(:delete_users, superuser, {})
+      assert Users |> Permissions.can(:disable_users, superuser, {})
+
+      assert Users
+             |> Permissions.can(:configure_external_auth_provider, superuser, {})
+
+      assert Users
+             |> Permissions.can(:view_credentials_audit_trail, superuser, {})
+
+      refute Users |> Permissions.can(:change_password, superuser, another_user)
+      assert Users |> Permissions.can(:change_password, superuser, superuser)
+
+      refute Users |> Permissions.can(:delete_account, superuser, another_user)
+      assert Users |> Permissions.can(:delete_account, superuser, superuser)
+
+      refute Users |> Permissions.can(:view_credentials, superuser, another_user)
+      assert Users |> Permissions.can(:view_credentials, superuser, superuser)
+
+      refute Users |> Permissions.can(:edit_credentials, superuser, another_user)
+      assert Users |> Permissions.can(:edit_credentials, superuser, superuser)
+
+      refute Users
+             |> Permissions.can(:delete_credential, superuser, another_user)
+
+      assert Users |> Permissions.can(:delete_credential, superuser, superuser)
     end
   end
 
@@ -51,25 +111,25 @@ defmodule Lightning.PermissionsTest do
 
   describe "Project user policies by project user role" do
     test ":viewer permissions", %{project: project, viewer: viewer} do
-      refute ProjectUsers |> Permissions.can(:edit_jobs, viewer, project)
+      refute ProjectUsers |> Permissions.can(:edit_job, viewer, project)
     end
 
     test "editor permissions", %{project: project, editor: editor} do
-      assert ProjectUsers |> Permissions.can(:edit_jobs, editor, project)
+      assert ProjectUsers |> Permissions.can(:edit_job, editor, project)
     end
 
     test "admin permissions", %{project: project, admin: admin} do
-      assert ProjectUsers |> Permissions.can(:edit_jobs, admin, project)
+      assert ProjectUsers |> Permissions.can(:edit_job, admin, project)
     end
 
     test "owner permissions", %{project: project, owner: owner} do
-      assert ProjectUsers |> Permissions.can(:edit_jobs, owner, project)
+      assert ProjectUsers |> Permissions.can(:edit_job, owner, project)
     end
 
     # For things like :view_job we should be able to show that people who do not
     # have access to a project cannot view the jobs in that project.
     test "thief permissions", %{project: project, thief: thief} do
-      refute ProjectUsers |> Permissions.can(:edit_jobs, thief, project)
+      refute ProjectUsers |> Permissions.can(:edit_job, thief, project)
     end
   end
 end

--- a/test/lightning/permissions_test.exs
+++ b/test/lightning/permissions_test.exs
@@ -111,25 +111,285 @@ defmodule Lightning.PermissionsTest do
 
   describe "Project user policies by project user role" do
     test ":viewer permissions", %{project: project, viewer: viewer} do
-      refute ProjectUsers |> Permissions.can(:edit_job, viewer, project)
+      refute ProjectUsers |> Permissions.can(:create_workflow, viewer, project)
+      refute ProjectUsers |> Permissions.can(:edit_jobs, viewer, project)
+      refute ProjectUsers |> Permissions.can(:create_job, viewer, project)
+      refute ProjectUsers |> Permissions.can(:delete_job, viewer, project)
+      refute ProjectUsers |> Permissions.can(:run_job, viewer, project)
+      refute ProjectUsers |> Permissions.can(:rerun_job, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_last_job_inputs, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_input, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_run, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_history, viewer, project)
+
+      assert ProjectUsers |> Permissions.can(:view_project_name, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_description, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_credentials, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_collaborators, viewer, project)
+
+      refute ProjectUsers |> Permissions.can(:delete_project, viewer, project)
+
+      assert ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               viewer,
+               project.project_users |> Enum.at(0)
+             )
+
+      refute ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               viewer,
+               project.project_users |> Enum.at(1)
+             )
+
+      refute ProjectUsers |> Permissions.can(:edit_project_name, viewer, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_description, viewer, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:add_project_collaborator, viewer, project)
     end
 
     test "editor permissions", %{project: project, editor: editor} do
-      assert ProjectUsers |> Permissions.can(:edit_job, editor, project)
+      assert ProjectUsers |> Permissions.can(:create_workflow, editor, project)
+      assert ProjectUsers |> Permissions.can(:edit_jobs, editor, project)
+      assert ProjectUsers |> Permissions.can(:create_job, editor, project)
+      assert ProjectUsers |> Permissions.can(:delete_job, editor, project)
+      assert ProjectUsers |> Permissions.can(:run_job, editor, project)
+      assert ProjectUsers |> Permissions.can(:rerun_job, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_last_job_inputs, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_input, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_run, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_history, editor, project)
+
+      assert ProjectUsers |> Permissions.can(:view_project_name, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_description, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_credentials, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_collaborators, editor, project)
+
+      refute ProjectUsers |> Permissions.can(:delete_project, editor, project)
+
+      assert ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               editor,
+               project.project_users |> Enum.at(1)
+             )
+
+      refute ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               editor,
+               project.project_users |> Enum.at(0)
+             )
+
+      refute ProjectUsers |> Permissions.can(:edit_project_name, editor, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_description, editor, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:add_project_collaborator, editor, project)
     end
 
     test "admin permissions", %{project: project, admin: admin} do
-      assert ProjectUsers |> Permissions.can(:edit_job, admin, project)
+      assert ProjectUsers |> Permissions.can(:create_workflow, admin, project)
+      assert ProjectUsers |> Permissions.can(:edit_jobs, admin, project)
+      assert ProjectUsers |> Permissions.can(:create_job, admin, project)
+      assert ProjectUsers |> Permissions.can(:delete_job, admin, project)
+      assert ProjectUsers |> Permissions.can(:run_job, admin, project)
+      assert ProjectUsers |> Permissions.can(:rerun_job, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_last_job_inputs, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_input, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_run, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_history, admin, project)
+
+      assert ProjectUsers |> Permissions.can(:view_project_name, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_description, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_credentials, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_collaborators, admin, project)
+
+      refute ProjectUsers |> Permissions.can(:delete_project, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               admin,
+               project.project_users |> Enum.at(2)
+             )
+
+      refute ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               admin,
+               project.project_users |> Enum.at(0)
+             )
+
+      assert ProjectUsers |> Permissions.can(:edit_project_name, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:edit_project_description, admin, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:add_project_collaborator, admin, project)
     end
 
     test "owner permissions", %{project: project, owner: owner} do
-      assert ProjectUsers |> Permissions.can(:edit_job, owner, project)
+      assert ProjectUsers |> Permissions.can(:create_workflow, owner, project)
+      assert ProjectUsers |> Permissions.can(:edit_jobs, owner, project)
+      assert ProjectUsers |> Permissions.can(:create_job, owner, project)
+      assert ProjectUsers |> Permissions.can(:delete_job, owner, project)
+      assert ProjectUsers |> Permissions.can(:run_job, owner, project)
+      assert ProjectUsers |> Permissions.can(:rerun_job, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_last_job_inputs, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_input, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_run, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_workorder_history, owner, project)
+
+      assert ProjectUsers |> Permissions.can(:view_project_name, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_description, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_credentials, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:view_project_collaborators, owner, project)
+
+      assert ProjectUsers |> Permissions.can(:delete_project, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               owner,
+               project.project_users |> Enum.at(3)
+             )
+
+      refute ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               owner,
+               project.project_users |> Enum.at(0)
+             )
+
+      assert ProjectUsers |> Permissions.can(:edit_project_name, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:edit_project_description, owner, project)
+
+      assert ProjectUsers
+             |> Permissions.can(:add_project_collaborator, owner, project)
     end
 
     # For things like :view_job we should be able to show that people who do not
     # have access to a project cannot view the jobs in that project.
     test "thief permissions", %{project: project, thief: thief} do
-      refute ProjectUsers |> Permissions.can(:edit_job, thief, project)
+      refute ProjectUsers |> Permissions.can(:create_workflow, thief, project)
+      refute ProjectUsers |> Permissions.can(:create_job, thief, project)
+      refute ProjectUsers |> Permissions.can(:delete_job, thief, project)
+      refute ProjectUsers |> Permissions.can(:edit_jobs, thief, project)
+      refute ProjectUsers |> Permissions.can(:run_job, thief, project)
+      refute ProjectUsers |> Permissions.can(:rerun_job, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_last_job_inputs, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_workorder_input, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_workorder_run, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_workorder_history, thief, project)
+
+      refute ProjectUsers |> Permissions.can(:view_project_name, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_project_description, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_project_credentials, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:view_project_collaborators, thief, project)
+
+      refute ProjectUsers |> Permissions.can(:delete_project, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               thief,
+               project.project_users |> Enum.at(3)
+             )
+
+      refute ProjectUsers
+             |> Permissions.can(
+               :edit_digest_alerts,
+               thief,
+               project.project_users |> Enum.at(0)
+             )
+
+      refute ProjectUsers |> Permissions.can(:edit_project_name, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:edit_project_description, thief, project)
+
+      refute ProjectUsers
+             |> Permissions.can(:add_project_collaborator, thief, project)
     end
   end
 end


### PR DESCRIPTION
## Implementation Plan

- [x] Follow the actions and rules defined in [this spreadsheet](https://docs.google.com/spreadsheets/d/1mlWjlvVdhupI3Ph0msf9nE2K7Uoe-qklOj81cG0N19c/edit#gid=547880405) and create the associated Bodyguard policy functions in the `lib/lightning/policies/users.ex` or `lib/lightning/policies/project_users.ex` modules.
- [x] Test the `Lightning.Policies.Permissions.can/4`

Implemented authorizations
- [x] Admin settings
- [x] Profile and credentials page
- [x] Workflows
- [x] History
- [x] Project settings

## Any notes for the reviewer ?

## Related issue

Re #645 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If needed, I've updated the changelog
- [ ] Amber has QA'd this feature
