### PR TITLE
Fix CHANGELOG - authorization not implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,6 @@ and this project adheres to
 - Enable distributed Erlang, allowing any number of redundant Lightning nodes to
   communicate with each other.
 - Users can set up realtime alerts for a project
-- Authorization for Lightning superusers and users, and project roles
-  viewer/editor/admin/owner. See
-  [link to test file](test/lightning/permissions_test.exs) for more details.
 
 ### Changed
 


### PR DESCRIPTION
@elias-ba , @stuartc - authorization has not been implemented for any of the user behaviors described in the test file. We need to get this _out_ of the changelog and, when https://github.com/OpenFn/Lightning/issues/645 is closed this change should go in the "Unreleased" section