### PR TITLE
Fix for FailureAlerter's flappy tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -97,6 +97,11 @@ config :phoenix, :json_library, Jason
 
 config :lightning, Lightning.Vault, json_library: Jason
 
+config :lightning, Lightning.FailureAlerter,
+  # 24h = 86_400_000
+  time_scale: 5 * 60_000,
+  rate_limit: 3
+
 # Disables / Hides the credential transfer feature for beta (in LightningWeb.CredentialLive.Edit)
 config :lightning, LightningWeb,
   allow_credential_transfer: false,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,11 +34,6 @@ config :lightning,
 config :lightning, Lightning.Vault,
   primary_encryption_key: "M1zzWU6Ego6jV/FUS7e/sj7yF9kRIutgR8uLQ9czrVc="
 
-config :lightning, Lightning.FailureAlerter,
-  # 24h = 86_400_000
-  time_scale: 5 * 60_000,
-  rate_limit: 3
-
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -47,7 +47,12 @@ config :lightning, Oban,
     scheduler: 1,
     workflow_failures: 1,
     background: 1,
-    runs: System.get_env("GLOBAL_RUNS_CONCURRENCY", "1") |> String.to_integer()
+    runs:
+      System.get_env(
+        "GLOBAL_RUNS_CONCURRENCY",
+        :erlang.system_info(:logical_processors_available) |> to_string()
+      )
+      |> String.to_integer()
   ]
 
 # https://plausible.io/ is an open-source, privacy-friendly alternative to
@@ -206,5 +211,5 @@ if config_env() == :test do
   # When running tests, set the number of database connections to the number
   # of cores available.
   config :lightning, Lightning.Repo,
-    pool_size: :erlang.system_info(:logical_processors_available)
+    pool_size: :erlang.system_info(:logical_processors_available) + 2
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,13 +8,17 @@ config :bcrypt_elixir, :log_rounds, 1
 # The MIX_TEST_PARTITION environment variable can be used
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
+#
+# On certain machines we get db queue timeouts, so we raise `queue_target`
+# from 50 to 100 to give the DBConnection some room to respond.
 config :lightning, Lightning.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
   database: "lightning_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 15
+  pool_size: 15,
+  queue_target: 100
 
 config :lightning, Lightning.Vault,
   primary_encryption_key: "M1zzWU6Ego6jV/FUS7e/sj7yF9kRIutgR8uLQ9czrVc="


### PR DESCRIPTION
There seems to be a very difficult to reproduce ordering of messages
from Swoosh. So I've changed the assertion from `assert_email_sent`
(which uses `assert_received`) to `assert_receive` which gives some
breathing room for out of order delivery? (_I think_).

I'm going to roll with this one for a day or three because it's non-deterministic at the moment.

## Related issue

Fixes #666

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
