### PR TITLE
Lay down roles and permissions - Profile and Credentials

### DIFF
--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -53,9 +53,13 @@ defmodule LightningWeb.CredentialLive.Index do
   end
 
   defp apply_action(socket, :index, _params) do
-    socket
-    |> assign(:page_title, "Credentials")
-    |> assign(:credential, nil)
+    if socket.assigns.can_view_credentials do
+      socket
+      |> assign(:page_title, "Credentials")
+      |> assign(:credential, nil)
+    else
+      redirect(socket, to: "/") |> put_flash(:nav, :no_access)
+    end
   end
 
   @impl true
@@ -78,9 +82,7 @@ defmodule LightningWeb.CredentialLive.Index do
           {:noreply, socket |> put_flash(:error, "Can't delete credential")}
       end
     else
-      {:noreply,
-       socket
-       |> put_flash(:error, "You are not authorized to perform this action.")}
+      redirect(socket, to: "/") |> put_flash(:nav, :no_access)
     end
   end
 

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -37,23 +37,27 @@
           </.td>
           <.td>
             <span>
-              <.link navigate={
-                Routes.credential_edit_path(@socket, :edit, credential)
-              }>
-                Edit
-              </.link>
+              <%= if @can_edit_credentials do %>
+                <.link navigate={
+                  Routes.credential_edit_path(@socket, :edit, credential)
+                }>
+                  Edit
+                </.link>
+              <% end %>
             </span>
             |
             <span>
-              <%= link("Delete",
-                to: "#",
-                phx_click: "delete",
-                phx_value_id: credential.id,
-                data: [
-                  confirm:
-                    "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?"
-                ]
-              ) %>
+              <%= if @can_delete_credential do %>
+                <%= link("Delete",
+                  to: "#",
+                  phx_click: "delete",
+                  phx_value_id: credential.id,
+                  data: [
+                    confirm:
+                      "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?"
+                  ]
+                ) %>
+              <% end %>
             </span>
           </.td>
         </.tr>

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -4,9 +4,36 @@ defmodule LightningWeb.ProfileLive.Edit do
   """
   use LightningWeb, :live_view
 
+  alias Lightning.Accounts
+  alias Lightning.Policies.{Users, Permissions}
+
   @impl true
-  def mount(_params, _session, socket) do
-    {:ok, socket}
+  def mount(_params, session, socket) do
+    authenticated_user =
+      Accounts.get_user_by_session_token(session["user_token"])
+
+    can_delete_account =
+      Users
+      |> Permissions.can(
+        :delete_account,
+        socket.assigns.current_user,
+        authenticated_user
+      )
+
+    can_change_password =
+      Users
+      |> Permissions.can(
+        :change_password,
+        socket.assigns.current_user,
+        authenticated_user
+      )
+
+    {:ok,
+     socket
+     |> assign(
+       can_delete_account: can_delete_account,
+       can_change_password: can_change_password
+     )}
   end
 
   @impl true
@@ -26,8 +53,15 @@ defmodule LightningWeb.ProfileLive.Edit do
   end
 
   defp apply_action(socket, :delete, user) do
-    socket
-    |> assign(:page_title, "User Profile")
-    |> assign(:user, user)
+    if socket.assigns.can_delete_account do
+      socket
+      |> assign(:page_title, "User Profile")
+      |> assign(:user, user)
+    else
+      socket
+      |> assign(:page_title, "User Profile")
+      |> assign(:user, socket.assigns.current_user)
+      |> put_flash(:error, "You are not authorized to perform this action.")
+    end
   end
 end

--- a/lib/lightning_web/live/profile_live/edit.html.heex
+++ b/lib/lightning_web/live/profile_live/edit.html.heex
@@ -11,6 +11,8 @@
       title={@page_title}
       action={@live_action}
       user={@user}
+      can_delete_account={@can_delete_account}
+      can_change_password={@can_change_password}
       return_to={Routes.profile_edit_path(@socket, :edit)}
     />
   </Layout.centered>

--- a/lib/lightning_web/live/profile_live/form_component.ex
+++ b/lib/lightning_web/live/profile_live/form_component.ex
@@ -5,16 +5,26 @@ defmodule LightningWeb.ProfileLive.FormComponent do
   use LightningWeb, :live_component
 
   alias Lightning.Accounts
+  alias Lightning.Policies.{Users, Permissions}
 
   @impl true
   def update(%{user: user, action: action}, socket) do
+    IO.inspect(user, label: "user")
+    IO.inspect(socket.assigns, label: "user2")
     {:ok,
      socket
      |> assign(
        password_changeset: Accounts.change_user_password(user),
        email_changeset: user |> Accounts.validate_change_user_email(%{}),
        user: user,
-       action: action
+       action: action,
+       can_delete_account:
+         Users
+         |> Permissions.can(
+           :delete_account,
+           user,
+           {}
+         )
      )}
   end
 

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -5,6 +5,7 @@
       id={@user.id}
       user={@user}
       logout={true}
+      can_delete_account={@can_delete_account}
       return_to={Routes.profile_edit_path(@socket, :edit)}
     />
   <% end %>
@@ -156,11 +157,13 @@
         </.link>
       </span>
       <span>
-        <%= submit("Update password",
-          phx_disable_with: "Saving...",
-          class:
-            "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-        ) %>
+        <%= if @can_change_password do %>
+          <%= submit("Update password",
+            phx_disable_with: "Saving...",
+            class:
+              "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+          ) %>
+        <% end %>
       </span>
     </div>
     <div class="hidden sm:block" aria-hidden="true">

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -168,13 +168,15 @@
     </div>
   </.form>
   <div>
-    <.link navigate={Routes.profile_edit_path(@socket, :delete, @user)}>
-      <button
-        type="button"
-        class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-danger-500 hover:bg-danger-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-danger-500"
-      >
-        Delete my account
-      </button>
-    </.link>
+    <%= if @can_delete_account do %>
+      <.link navigate={Routes.profile_edit_path(@socket, :delete, @user)}>
+        <button
+          type="button"
+          class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-danger-500 hover:bg-danger-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-danger-500"
+        >
+          Delete my account
+        </button>
+      </.link>
+    <% end %>
   </div>
 </div>

--- a/lib/lightning_web/live/user_live/index.html.heex
+++ b/lib/lightning_web/live/user_live/index.html.heex
@@ -19,6 +19,7 @@
         id={@user.id}
         user={@user}
         logout={false}
+        can_delete_account={@can_delete_account}
         return_to={Routes.user_index_path(@socket, :index)}
       />
     <% end %>

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -56,6 +56,18 @@ defmodule LightningWeb.ProfileLiveTest do
       {:ok, profile_live, _html} =
         live(conn, Routes.profile_edit_path(conn, :edit))
 
+      IO.inspect(conn, label: "conn")
+      # html =
+      #   render_component(LightningWeb.ProfileLive.FormComponent,
+      #     id: run,
+      #     title: "User Profile",
+      #     action: :edit,
+      #     user: false,
+      #     can_delete_account: true,
+      #     can_change_password: true
+      #   )
+      #   |> Floki.parse_fragment!()
+
       assert profile_live
              |> form("#password_form", user: @invalid_empty_password_attrs)
              |> render_change() =~ "can&#39;t be blank"

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -56,18 +56,6 @@ defmodule LightningWeb.ProfileLiveTest do
       {:ok, profile_live, _html} =
         live(conn, Routes.profile_edit_path(conn, :edit))
 
-      IO.inspect(conn, label: "conn")
-      # html =
-      #   render_component(LightningWeb.ProfileLive.FormComponent,
-      #     id: run,
-      #     title: "User Profile",
-      #     action: :edit,
-      #     user: false,
-      #     can_delete_account: true,
-      #     can_change_password: true
-      #   )
-      #   |> Floki.parse_fragment!()
-
       assert profile_live
              |> form("#password_form", user: @invalid_empty_password_attrs)
              |> render_change() =~ "can&#39;t be blank"


### PR DESCRIPTION
## Profile & Credentials page
For the following features, both super and normal users can perform them but only on their own resources.

- [x] Change your own password
- [x]  Delete your own account
- [x]  View own credentials
- [x]  Edit your own credentials
- [x]  Delete own credentials

Notes
- Currently, credentials are listed based on the user who created them regardless of the role, This makes it hard to test for `:view_credentials, :edit_credentials, :delete_credentials`

## Checklist before requesting a review

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
