### PR TITLE
temporarily make version ALWAYS visible to aide bug report screenshots

### DIFF
--- a/lib/lightning_web/components/layouts/live.html.heex
+++ b/lib/lightning_web/components/layouts/live.html.heex
@@ -23,6 +23,14 @@
         <%= unless assigns[:is_first_setup] do %>
           <LayoutComponents.menu_items {assigns} />
           <div class="grow"></div>
+          <div
+            class="mx-4 px-3 py-2 pl-4 text-sm font-medium block text-primary-300"
+            title={
+            "You are running Lightning version #{elem(:application.get_key(:lightning, :vsn), 1)}"
+          }
+          >
+            v<%= elem(:application.get_key(:lightning, :vsn), 1) %>
+          </div>
           <%= if @current_user.role == :superuser do %>
             <Settings.menu_item to={Routes.project_index_path(@socket, :index)}>
               <Heroicons.cog class="h-5 w-5 inline-block mr-2" />

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lightning.MixProject do
   def project do
     [
       app: :lightning,
-      version: "0.4.4",
+      version: "0.4.5",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),


### PR DESCRIPTION
this temporarily makes the version always visible to aide bug reports. before, you had to hover over the FN logo to see the version. now whenever someone records a loom or takes a screenshot, we'll be able to see what version they're running.