### PR TITLE
fix failure alert emails

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -98,7 +98,6 @@ config :phoenix, :json_library, Jason
 config :lightning, Lightning.Vault, json_library: Jason
 
 config :lightning, Lightning.FailureAlerter,
-  # 24h = 86_400_000
   time_scale: 5 * 60_000,
   rate_limit: 3
 

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -32,4 +32,16 @@ defmodule Lightning.Helpers do
       {:ok, body_map} -> body_map
     end
   end
+
+  @doc """
+  Converts milliseconds (integer) to a human duration, such as "1 minute" or
+  "45 years, 6 months, 5 days, 21 hours, 12 minutes, 34 seconds" using
+  `Timex.Format.Duration.Formatters.Humanized.format()`.
+  """
+  @spec ms_to_human(integer) :: String.t() | {:error, :invalid_duration}
+  def ms_to_human(milliseconds) do
+    milliseconds
+    |> Timex.Duration.from_milliseconds()
+    |> Timex.Format.Duration.Formatters.Humanized.format()
+  end
 end

--- a/lib/lightning/pipeline/failure_alerter.ex
+++ b/lib/lightning/pipeline/failure_alerter.ex
@@ -62,6 +62,8 @@ defmodule Lightning.FailureAlerter do
         Lightning.FailureEmail.deliver_failure_email(recipient.email, %{
           work_order_id: work_order_id,
           count: count,
+          time_scale: time_scale,
+          rate_limit: rate_limit,
           run: run,
           workflow_name: workflow_name,
           workflow_id: workflow_id,

--- a/lib/lightning/pipeline/failure_email.ex
+++ b/lib/lightning/pipeline/failure_email.ex
@@ -5,7 +5,11 @@ defmodule Lightning.FailureEmail do
   alias Lightning.Mailer
 
   defp failure_subject(%{name: name}, failure_count) do
-    "#{failure_count}th failure for workflow #{name}"
+    if failure_count < 2 do
+      "#{name} failed."
+    else
+      "#{name} has failed #{failure_count} times in the last 24 hours."
+    end
   end
 
   def deliver_failure_email(email, body_data) do

--- a/lib/lightning/pipeline/failure_email.ex
+++ b/lib/lightning/pipeline/failure_email.ex
@@ -8,9 +8,9 @@ defmodule Lightning.FailureEmail do
 
   defp failure_subject(%{name: name}, failure_count, time_scale) do
     if failure_count < 2 do
-      "#{name} failed."
+      "\"#{name}\" failed."
     else
-      "#{name} has failed #{failure_count} times in the last #{ms_to_human(time_scale)}."
+      "\"#{name}\" has failed #{failure_count} times in the last #{ms_to_human(time_scale)}."
     end
   end
 
@@ -30,7 +30,11 @@ defmodule Lightning.FailureEmail do
       )
       |> render_body(
         "failure_alert.html",
-        Map.put(body_data, :duration, ms_to_human(body_data[:time_scale]))
+        Map.put(
+          body_data,
+          :duration,
+          ms_to_human(body_data[:time_scale])
+        )
       )
 
     Mailer.deliver(email)

--- a/lib/lightning/pipeline/failure_email.ex
+++ b/lib/lightning/pipeline/failure_email.ex
@@ -18,7 +18,9 @@ defmodule Lightning.FailureEmail do
     email =
       new()
       |> to(email)
-      |> from({"Lightning", Application.get_env(:lightning, :email_addresses)[:admin]})
+      |> from(
+        {"Lightning", Application.get_env(:lightning, :email_addresses)[:admin]}
+      )
       |> subject(
         failure_subject(
           %{name: body_data[:workflow_name]},

--- a/lib/lightning/pipeline/failure_email.ex
+++ b/lib/lightning/pipeline/failure_email.ex
@@ -2,13 +2,15 @@ defmodule Lightning.FailureEmail do
   @moduledoc false
   use Phoenix.Swoosh, view: Lightning.FailureNotifierView
 
+  import Lightning.Helpers, only: [ms_to_human: 1]
+
   alias Lightning.Mailer
 
-  defp failure_subject(%{name: name}, failure_count) do
+  defp failure_subject(%{name: name}, failure_count, time_scale) do
     if failure_count < 2 do
       "#{name} failed."
     else
-      "#{name} has failed #{failure_count} times in the last 24 hours."
+      "#{name} has failed #{failure_count} times in the last #{ms_to_human(time_scale)}."
     end
   end
 
@@ -16,13 +18,18 @@ defmodule Lightning.FailureEmail do
     email =
       new()
       |> to(email)
-      |> from(
-        {"Lightning", Application.get_env(:lightning, :email_addresses)[:admin]}
-      )
+      |> from({"Lightning", Application.get_env(:lightning, :email_addresses)[:admin]})
       |> subject(
-        failure_subject(%{name: body_data[:workflow_name]}, body_data[:count])
+        failure_subject(
+          %{name: body_data[:workflow_name]},
+          body_data[:count],
+          body_data[:time_scale]
+        )
       )
-      |> render_body("failure_alert.html", body_data)
+      |> render_body(
+        "failure_alert.html",
+        Map.put(body_data, :duration, ms_to_human(body_data[:time_scale]))
+      )
 
     Mailer.deliver(email)
   end

--- a/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
+++ b/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
@@ -1,7 +1,8 @@
 <div>
   <p>Hi <%= @recipient.first_name %>,</p>
   <p>
-    Word order <%= @work_order_id %> failed for workflow "<%= @workflow_name %>" with the following logs:
+    Word order <code><%= @work_order_id %></code>
+    failed for workflow "<%= @workflow_name %>" with the following logs:
   </p>
   <div style="background-color: #ededed; padding: 16px; margin: 8px 0">
     <%= @run.log %>
@@ -13,8 +14,7 @@
     <p>
       Note that attempts for this workflow have failed <%= @count %> times in
       the last <%= @duration %>. We will only send <%= @rate_limit %> failure
-      alerts for <em>this</em>
-      workflow every <%= @duration %> to avoid cluttering your inbox.
+      alerts for this workflow ("<%= @workflow_name %>") at most every <%= @duration %> to avoid cluttering your inbox.
     </p>
   <% end %>
 </div>

--- a/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
+++ b/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
@@ -11,9 +11,10 @@
   </p>
   <%= if @count > 1 do %>
     <p>
-      Note that this workflow has failed <%= @count %> times in the last <%= @time_scale /
-        (1000 * 60 * 60) %> hours. We will only send <%= @rate_limit %> alerts every <%= @time_scale /
-        (1000 * 60 * 60) %> hours to avoid cluttering your inbox.
+      Note that attempts for this workflow have failed <%= @count %> times in
+      the last <%= @duration %>. We will only send <%= @rate_limit %> failure
+      alerts for <em>this</em>
+      workflow every <%= @duration %> to avoid cluttering your inbox.
     </p>
   <% end %>
 </div>

--- a/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
+++ b/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
@@ -1,14 +1,19 @@
 <div>
   <p>Hi <%= @recipient.first_name %>,</p>
   <p>
-    Word order <%= @work_order_id %> failed for workflow <%= @workflow_name %> with the following logs:
+    Word order <%= @work_order_id %> failed for workflow "<%= @workflow_name %>" with the following logs:
   </p>
   <div style="background-color: #ededed; padding: 16px; margin: 8px 0">
-    <%= @run.log %>>
+    <%= @run.log %>
   </div>
-  Please view it <a href={@run_url}>here</a>
-  to debug the issue.
   <p>
-    *This is the <%= @count %>th failure in the last 24 hours. If the workflow has more than 5 failed runs in the last 24 hours, you will stop receiving these alerts.
+    Click <a href={@run_url}>here</a> to view the run.
   </p>
+  <%= if @count > 1 do %>
+    <p>
+      Note that this workflow has failed <%= @count %> times in the last <%= @time_scale /
+        (1000 * 60 * 60) %> hours. We will only send <%= @rate_limit %> alerts every <%= @time_scale /
+        (1000 * 60 * 60) %> hours to avoid cluttering your inbox.
+    </p>
+  <% end %>
 </div>

--- a/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
+++ b/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
@@ -2,13 +2,10 @@
   <p>Hi <%= @recipient.first_name %>,</p>
   <p>
     Word order <code><%= @work_order_id %></code>
-    failed for workflow "<%= @workflow_name %>" with the following logs:
+    failed for workflow "<%= @workflow_name %>".
   </p>
-  <div style="background-color: #ededed; padding: 16px; margin: 8px 0">
-    <%= @run.log %>
-  </div>
   <p>
-    Click <a href={@run_url}>here</a> to view the run.
+    Click <a href={@run_url}>here</a> to inspect the run or view the logs below.
   </p>
   <%= if @count > 1 do %>
     <p>
@@ -17,4 +14,11 @@
       alerts for this workflow ("<%= @workflow_name %>") at most every <%= @duration %> to avoid cluttering your inbox.
     </p>
   <% end %>
+  <p>
+    <pre style="background-color: #ededed; padding: 16px; margin: 8px 0">
+      <%= Enum.map(@run.log, fn(line) -> %>
+        <%= line %>
+      <% end) %>
+    </pre>
+  </p>
 </div>

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -126,7 +126,7 @@ defmodule Lightning.FailureAlertTest do
 
       assert_receive {:email,
                       %Swoosh.Email{
-                        subject: "workflow-a failed.",
+                        subject: "\"workflow-a\" failed.",
                         html_body: html_body
                       }}
 
@@ -136,13 +136,13 @@ defmodule Lightning.FailureAlertTest do
       assert html_body =~
                "/projects/#{project.id}/runs/#{attempt_run.run_id}"
 
-      s2 = "workflow-a has failed 2 times in the last #{period}."
+      s2 = "\"workflow-a\" has failed 2 times in the last #{period}."
       assert_receive {:email, %Swoosh.Email{subject: ^s2}}
 
-      s3 = "workflow-a has failed 3 times in the last #{period}."
+      s3 = "\"workflow-a\" has failed 3 times in the last #{period}."
       assert_receive {:email, %Swoosh.Email{subject: ^s3}}
 
-      s4 = "workflow-a has failed 4 times in the last #{period}."
+      s4 = "\"workflow-a\" has failed 4 times in the last #{period}."
       refute_receive {:email, %Swoosh.Email{subject: ^s4}}
     end
 
@@ -156,15 +156,15 @@ defmodule Lightning.FailureAlertTest do
       Oban.drain_queue(Oban, queue: :workflow_failures)
       Process.sleep(100)
 
-      assert_receive {:email, %Swoosh.Email{subject: "workflow-a failed."}}
+      assert_receive {:email, %Swoosh.Email{subject: "\"workflow-a\" failed."}}
 
-      s2 = "workflow-a has failed 2 times in the last #{period}."
+      s2 = "\"workflow-a\" has failed 2 times in the last #{period}."
       assert_receive {:email, %Swoosh.Email{subject: ^s2}}
 
-      s3 = "workflow-a has failed 3 times in the last #{period}."
+      s3 = "\"workflow-a\" has failed 3 times in the last #{period}."
       assert_receive {:email, %Swoosh.Email{subject: ^s3}}
 
-      assert_receive {:email, %Swoosh.Email{subject: "workflow-b failed."}}
+      assert_receive {:email, %Swoosh.Email{subject: "\"workflow-b\" failed."}}
     end
 
     test "does not send failure emails to users who have unsubscribed" do
@@ -212,7 +212,7 @@ defmodule Lightning.FailureAlertTest do
 
       Pipeline.process(attempt_run)
 
-      refute_email_sent(subject: "workflow-a failed.")
+      refute_email_sent(subject: "\"workflow-a\" failed.")
     end
 
     test "does not increment the rate-limiter counter when an email is not delivered.",
@@ -225,7 +225,7 @@ defmodule Lightning.FailureAlertTest do
       {:ok, {0, ^rate_limit, _, _, _}} =
         Hammer.inspect_bucket(work_order.workflow_id, time_scale, rate_limit)
 
-      assert_email_sent(subject: "workflow-a failed.")
+      assert_email_sent(subject: "\"workflow-a\" failed.")
 
       stub(Lightning.FailureEmail, :deliver_failure_email, fn _, _ ->
         {:error}
@@ -233,7 +233,7 @@ defmodule Lightning.FailureAlertTest do
 
       Pipeline.process(attempt_run)
 
-      refute_email_sent(subject: "workflow-a failed.")
+      refute_email_sent(subject: "\"workflow-a\" failed.")
 
       # nothing changed
       {:ok, {0, ^rate_limit, _, _, _}} =

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -11,18 +11,24 @@ defmodule Lightning.FailureAlertTest do
   import Lightning.ProjectsFixtures
   import Lightning.AccountsFixtures
 
+  import Lightning.Helpers, only: [ms_to_human: 1]
+
   import Swoosh.TestAssertions
 
-  # for test purpose we'll config to 3 emails within 1mn
-
-  describe "failure_alert" do
+  describe "FailureAlert" do
     setup do
       user = user_fixture()
       project = project_fixture(project_users: [%{user_id: user.id}])
 
+      # for test purpose we'll config to 3 emails within 1mn
+      period =
+        Application.get_env(:lightning, Lightning.FailureAlerter)
+        |> Keyword.get(:time_scale)
+        |> ms_to_human()
+
       job =
         workflow_job_fixture(
-          workflow_name: "specific-workflow",
+          workflow_name: "workflow-a",
           project_id: project.id,
           body: ~s[fn(state => { throw new Error("I'm supposed to fail.") })]
         )
@@ -57,9 +63,9 @@ defmodule Lightning.FailureAlertTest do
 
       job2 =
         workflow_job_fixture(
-          workflow_name: "another-workflow",
+          workflow_name: "workflow-b",
           project_id: project.id,
-          body: ~s[fn(state => { throw new Error("I'm supposed to fail.") })]
+          body: ~s[fn(state => { throw new Error("I also fail.") })]
         )
 
       work_order2 = work_order_fixture(workflow_id: job2.workflow_id)
@@ -91,6 +97,7 @@ defmodule Lightning.FailureAlertTest do
         |> Repo.insert()
 
       %{
+        period: period,
         user: user,
         project: project,
         attempt_run: attempt_run,
@@ -99,78 +106,68 @@ defmodule Lightning.FailureAlertTest do
       }
     end
 
-    test "failing workflow sends failure email to user having failure_alert to true",
-         %{project: project, attempt_run: attempt_run, work_order: work_order} do
-      # 1/3 within 1mn
+    test "sends a limited number of failure alert emails to a subscribed user.",
+         %{
+           project: project,
+           attempt_run: attempt_run,
+           work_order: work_order,
+           period: period
+         } do
+      # The first three failed runs for this workflow will trigger emails.
       Pipeline.process(attempt_run)
-      # 2/3 within 1mn
       Pipeline.process(attempt_run)
-      # 3/3 within 1mn
       Pipeline.process(attempt_run)
-      # rate limit reached -> won't send email
+
+      # And the 4th, when the rate limit is reached, will NOT trigger a 4th email.
       Pipeline.process(attempt_run)
 
       Oban.drain_queue(Oban, queue: :workflow_failures)
+      Process.sleep(100)
 
       assert_receive {:email,
                       %Swoosh.Email{
-                        subject: "specific-workflow failed.",
+                        subject: "workflow-a failed.",
                         html_body: html_body
                       }}
 
-      assert html_body =~ "specific-workflow"
+      assert html_body =~ "workflow-a"
       assert html_body =~ work_order.id
 
       assert html_body =~
                "/projects/#{project.id}/runs/#{attempt_run.run_id}"
 
-      assert_receive {:email,
-                      %Swoosh.Email{
-                        subject:
-                          "specific-workflow has failed 2 times in the last 24 hours."
-                      }}
+      s2 = "workflow-a has failed 2 times in the last #{period}."
+      assert_receive {:email, %Swoosh.Email{subject: ^s2}}
 
-      assert_receive {:email,
-                      %Swoosh.Email{
-                        subject:
-                          "specific-workflow has failed 3 times in the last 24 hours."
-                      }}
+      s3 = "workflow-a has failed 3 times in the last #{period}."
+      assert_receive {:email, %Swoosh.Email{subject: ^s3}}
 
-      refute_receive {:email,
-                      %Swoosh.Email{
-                        subject:
-                          "specific-workflow has failed 4 times in the last 24 hours."
-                      }}
+      s4 = "workflow-a has failed 4 times in the last #{period}."
+      refute_receive {:email, %Swoosh.Email{subject: ^s4}}
     end
 
-    test "failing workflow sends email even if another workflow hits rate limit within the same time scale",
-         %{attempt_run: attempt_run, attempt_run2: attempt_run2} do
+    test "sends a failure alert email for a workflow even if another workflow has been rate limited.",
+         %{attempt_run: attempt_run, attempt_run2: attempt_run2, period: period} do
       Pipeline.process(attempt_run)
       Pipeline.process(attempt_run)
       Pipeline.process(attempt_run)
       Pipeline.process(attempt_run2)
 
       Oban.drain_queue(Oban, queue: :workflow_failures)
+      Process.sleep(100)
 
-      assert_receive {:email,
-                      %Swoosh.Email{subject: "specific-workflow failed."}}
+      assert_receive {:email, %Swoosh.Email{subject: "workflow-a failed."}}
 
-      assert_receive {:email,
-                      %Swoosh.Email{
-                        subject:
-                          "specific-workflow has failed 2 times in the last 24 hours."
-                      }}
+      s2 = "workflow-a has failed 2 times in the last #{period}."
+      assert_receive {:email, %Swoosh.Email{subject: ^s2}}
 
-      assert_receive {:email,
-                      %Swoosh.Email{
-                        subject:
-                          "specific-workflow has failed 3 times in the last 24 hours."
-                      }}
+      s3 = "workflow-a has failed 3 times in the last #{period}."
+      assert_receive {:email, %Swoosh.Email{subject: ^s3}}
 
-      assert_receive {:email, %Swoosh.Email{subject: "another-workflow failed."}}
+      assert_receive {:email, %Swoosh.Email{subject: "workflow-b failed."}}
     end
 
-    test "failing workflow does not send failure email to user having failure_alert to false" do
+    test "does not send failure emails to users who have unsubscribed" do
       user = user_fixture()
 
       project =
@@ -180,7 +177,7 @@ defmodule Lightning.FailureAlertTest do
 
       job =
         workflow_job_fixture(
-          workflow_name: "specific-workflow",
+          workflow_name: "workflow-a",
           project_id: project.id,
           body: ~s[fn(state => { throw new Error("I'm supposed to fail.") })]
         )
@@ -215,10 +212,10 @@ defmodule Lightning.FailureAlertTest do
 
       Pipeline.process(attempt_run)
 
-      refute_email_sent(subject: "specific-workflow failed.")
+      refute_email_sent(subject: "workflow-a failed.")
     end
 
-    test "not delivered email does not change the remaining count",
+    test "does not increment the rate-limiter counter when an email is not delivered.",
          %{attempt_run: attempt_run, work_order: work_order} do
       [time_scale: time_scale, rate_limit: rate_limit] =
         Application.fetch_env!(:lightning, Lightning.FailureAlerter)
@@ -228,7 +225,7 @@ defmodule Lightning.FailureAlertTest do
       {:ok, {0, ^rate_limit, _, _, _}} =
         Hammer.inspect_bucket(work_order.workflow_id, time_scale, rate_limit)
 
-      assert_email_sent(subject: "specific-workflow failed.")
+      assert_email_sent(subject: "workflow-a failed.")
 
       stub(Lightning.FailureEmail, :deliver_failure_email, fn _, _ ->
         {:error}
@@ -236,7 +233,7 @@ defmodule Lightning.FailureAlertTest do
 
       Pipeline.process(attempt_run)
 
-      refute_email_sent(subject: "specific-workflow failed.")
+      refute_email_sent(subject: "workflow-a failed.")
 
       # nothing changed
       {:ok, {0, ^rate_limit, _, _, _}} =

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -122,13 +122,13 @@ defmodule Lightning.FailureAlertTest do
       Pipeline.process(attempt_run)
 
       Oban.drain_queue(Oban, queue: :workflow_failures)
-      Process.sleep(100)
 
       assert_receive {:email,
                       %Swoosh.Email{
                         subject: "\"workflow-a\" failed.",
                         html_body: html_body
-                      }}
+                      }},
+                     1000
 
       assert html_body =~ "workflow-a"
       assert html_body =~ work_order.id
@@ -137,13 +137,13 @@ defmodule Lightning.FailureAlertTest do
                "/projects/#{project.id}/runs/#{attempt_run.run_id}"
 
       s2 = "\"workflow-a\" has failed 2 times in the last #{period}."
-      assert_receive {:email, %Swoosh.Email{subject: ^s2}}
+      assert_receive {:email, %Swoosh.Email{subject: ^s2}}, 1000
 
       s3 = "\"workflow-a\" has failed 3 times in the last #{period}."
-      assert_receive {:email, %Swoosh.Email{subject: ^s3}}
+      assert_receive {:email, %Swoosh.Email{subject: ^s3}}, 1000
 
       s4 = "\"workflow-a\" has failed 4 times in the last #{period}."
-      refute_receive {:email, %Swoosh.Email{subject: ^s4}}
+      refute_receive {:email, %Swoosh.Email{subject: ^s4}}, 100
     end
 
     test "sends a failure alert email for a workflow even if another workflow has been rate limited.",
@@ -154,17 +154,18 @@ defmodule Lightning.FailureAlertTest do
       Pipeline.process(attempt_run2)
 
       Oban.drain_queue(Oban, queue: :workflow_failures)
-      Process.sleep(100)
 
-      assert_receive {:email, %Swoosh.Email{subject: "\"workflow-a\" failed."}}
+      assert_receive {:email, %Swoosh.Email{subject: "\"workflow-a\" failed."}},
+                     1000
 
       s2 = "\"workflow-a\" has failed 2 times in the last #{period}."
-      assert_receive {:email, %Swoosh.Email{subject: ^s2}}
+      assert_receive {:email, %Swoosh.Email{subject: ^s2}}, 1000
 
       s3 = "\"workflow-a\" has failed 3 times in the last #{period}."
-      assert_receive {:email, %Swoosh.Email{subject: ^s3}}
+      assert_receive {:email, %Swoosh.Email{subject: ^s3}}, 1000
 
-      assert_receive {:email, %Swoosh.Email{subject: "\"workflow-b\" failed."}}
+      assert_receive {:email, %Swoosh.Email{subject: "\"workflow-b\" failed."}},
+                     1000
     end
 
     test "does not send failure emails to users who have unsubscribed" do


### PR DESCRIPTION
This PR fixes the failure alert email language, and makes their behavior slightly more natural.

## Notes for the reviewer

1. @amberrignell , please check out the language here, paying careful attention to typos, clarity, and tone. Use `http://localhost:4000/dev/mailbox/` to view the emails sent by your app running on `localhost`.
2. @stuartc , it flaked again so I've used a sleep and opened this issue: https://github.com/OpenFn/Lightning/issues/693

## Related issue

Fixes #628 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Amber has **QA'd** this feature
