### PR TITLE
check if a run has started and finished

### DIFF
--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -213,7 +213,7 @@ defmodule LightningWeb.RunLive.Components do
 
     ran_for =
       cond do
-        run.finished_at ->
+        run.started_at != nil and run.finished_at != nil ->
           "#{DateTime.diff(run.finished_at, run.started_at, :millisecond)} ms"
 
         run.started_at ->


### PR DESCRIPTION
## Notes for the reviewer
Check if `run.started_at` and `run.finished_at` have datetime 

## Related issue

Fixes #690 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
