### PR TITLE
Lay down roles and permissions - Project settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Added roles and permissions to project settings page
+  [#645](https://github.com/OpenFn/Lightning/issues/645)
+
 ### Changed
 
 - Improved errors when decoding encryption keys for use with Cloak.

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -54,6 +54,9 @@ defmodule LightningWeb.ProjectLive.Index do
     |> assign(:users, Lightning.Accounts.list_users())
   end
 
+  # TODO: this results in n+1 queries, we need to precalculate the permissions
+  # and have zipped list of projects and the permissions so when we iterate
+  # over them in the templace we don't generate n number of queries
   def can_delete_project(current_user, project),
     do: ProjectUsers |> Permissions.can(:delete_project, current_user, project)
 end

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -4,6 +4,8 @@ defmodule LightningWeb.ProjectLive.Index do
   """
   use LightningWeb, :live_view
 
+  alias Lightning.Policies.Permissions
+  alias Lightning.Policies.ProjectUsers
   alias Lightning.Projects
 
   @impl true
@@ -51,4 +53,7 @@ defmodule LightningWeb.ProjectLive.Index do
     |> assign(:project, %Lightning.Projects.Project{})
     |> assign(:users, Lightning.Accounts.list_users())
   end
+
+  def can_delete_project(current_user, project),
+    do: ProjectUsers |> Permissions.can(:delete_project, current_user, project)
 end

--- a/lib/lightning_web/live/project_live/index.html.heex
+++ b/lib/lightning_web/live/project_live/index.html.heex
@@ -32,19 +32,22 @@
             class: "p-4 h-14 flex w-64 text-primary-500"
           ) %>
           <div class="grow h-14 border-r border-slate-100"></div>
-          <div class="flex h-14 w-12 items-center justify-center">
-            <div class="h-14 inline-block"></div>
-            <%= link(
+          <%= if can_delete_project(@current_user, project) do %>
+            <div class="flex h-14 w-12 items-center justify-center">
+              <div class="h-14 inline-block"></div>
+              <%= link(
                   to: "#",
+                  id: "delete-#{project.id}",
                   phx_click: "delete",
                   phx_value_id: project.id,
                   data: [confirm: "Are you sure?"],
                   class: "inline-block align-middle"
 
                 ) do %>
-              <Icon.trash class="h-6 w-6 text-slate-300 hover:text-rose-700" />
-            <% end %>
-          </div>
+                <Icon.trash class="h-6 w-6 text-slate-300 hover:text-rose-700" />
+              <% end %>
+            </div>
+          <% end %>
         </Common.item_bar>
       <% end %>
     <% end %>

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -54,7 +54,7 @@ defmodule LightningWeb.ProjectLive.Settings do
        ),
        do:
          ProjectUsers
-         |> Permissions.can(:edit_project_user, current_user, project_user)
+         |> Permissions.can(:edit_digest_alerts, current_user, project_user)
 
   defp can_edit_project(socket),
     do:
@@ -154,8 +154,15 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def failure_alert(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        can_edit_project_user:
+          can_edit_project_user(assigns.current_user, assigns.project_user)
+      )
+
     ~H"""
-    <%= if can_edit_project_user(@current_user, @project_user) do %>
+    <%= if @can_edit_project_user do %>
       <.form
         :let={form}
         for={%{}}

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -4,51 +4,62 @@ defmodule LightningWeb.ProjectLive.Settings do
   """
   use LightningWeb, :live_view
 
-  alias Lightning.Policies.Permissions
-  alias Lightning.Accounts.User
   alias Lightning.Policies.ProjectUsers
   alias Lightning.Projects.ProjectUser
+  alias Lightning.Policies.Permissions
+  alias Lightning.Accounts.User
   alias Lightning.{Projects, Credentials}
 
   on_mount {LightningWeb.Hooks, :project_scope}
 
   @impl true
   def mount(_params, _session, socket) do
-    can_edit_project =
-      case Bodyguard.permit(
-             Lightning.Projects.Policy,
-             :edit,
-             socket.assigns.current_user,
-             socket.assigns.project
-           ) do
-        :ok -> true
-        {:error, :unauthorized} -> false
-      end
-
     project_users =
       Projects.get_project_with_users!(socket.assigns.project.id).project_users
 
     credentials = Credentials.list_credentials(socket.assigns.project)
 
+    can_edit_project_name =
+      ProjectUsers
+      |> Permissions.can(
+        :edit_project_name,
+        socket.assigns.current_user,
+        socket.assigns.project
+      )
+
+    can_edit_project_description =
+      ProjectUsers
+      |> Permissions.can(
+        :edit_project_description,
+        socket.assigns.current_user,
+        socket.assigns.project
+      )
+
     {:ok,
      socket
      |> assign(
        active_menu_item: :settings,
-       can_edit_project: can_edit_project,
        credentials: credentials,
        project_users: project_users,
        current_user: socket.assigns.current_user,
-       project_changeset: Projects.change_project(socket.assigns.project)
+       project_changeset: Projects.change_project(socket.assigns.project),
+       can_edit_project_name: can_edit_project_name,
+       can_edit_project_description: can_edit_project_description
      )}
   end
 
-  def can_edit_project_user(
-        %User{} = current_user,
-        %ProjectUser{} = project_user
-      ) do
-    ProjectUsers
-    |> Permissions.can(:edit_project_user, current_user, project_user)
-  end
+  defp can_edit_project_user(
+         %User{} = current_user,
+         %ProjectUser{} = project_user
+       ),
+       do:
+         ProjectUsers
+         |> Permissions.can(:edit_project_user, current_user, project_user)
+
+  defp can_edit_project(socket),
+    do:
+      socket.assigns.can_edit_project_name and
+        socket.assigns.can_edit_project_description
 
   @impl true
   def handle_params(params, _url, socket) do
@@ -70,7 +81,13 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event("save", %{"project" => project_params}, socket) do
-    save_project(socket, project_params)
+    if can_edit_project(socket) do
+      save_project(socket, project_params)
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "You are not authorized to perform this action.")}
+    end
   end
 
   def handle_event(

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -61,7 +61,7 @@
                 <div class="md:col-span-2">
                   <LightningWeb.Components.Form.text_field
                     form={f}
-                    disabled={!@can_edit_project}
+                    disabled={!@can_edit_project_name}
                     label="Project name"
                     id={:name}
                   />
@@ -75,7 +75,7 @@
                   <LightningWeb.Components.Form.text_area
                     classes="mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
                     form={f}
-                    disabled={!@can_edit_project}
+                    disabled={!@can_edit_project_description}
                     label="Project description"
                     id={:description}
                   />
@@ -90,7 +90,10 @@
               <div class="grid grid-cols gap-6">
                 <div class="md:col-span-2">
                   <LightningWeb.Components.Form.submit_button
-                    disabled={!(@project_changeset.valid? and @can_edit_project)}
+                    disabled={
+                      !(@project_changeset.valid? and @can_edit_project_name and
+                          @can_edit_project_description)
+                    }
                     phx-disable-with="Saving"
                   >
                     Save

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -376,6 +376,9 @@ defmodule LightningWeb.ProjectLiveTest do
              )
 
       assert view |> has_element?("button[disabled][type=submit]")
+
+      assert view |> render_click("save", %{"project" => %{}}) =~
+               "You are not authorized to perform this action."
     end
 
     test "project members can edit their own digest frequency and failure alert settings",

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -72,6 +72,35 @@ defmodule LightningWeb.ProjectLiveTest do
       assert_patch(index_live, Routes.project_index_path(conn, :index))
       assert render(index_live) =~ "Project created successfully"
     end
+
+    test "Only project owners can delete projects", %{
+      conn: conn,
+      project: project
+    } do
+      delete_button = "#delete-#{project.id}"
+
+      conn =
+        setup_project_user(
+          conn,
+          project,
+          Lightning.AccountsFixtures.superuser_fixture(),
+          :editor
+        )
+
+      {:ok, view, _html} = live(conn, Routes.project_index_path(conn, :index))
+      refute view |> element(delete_button) |> has_element?()
+
+      conn =
+        setup_project_user(
+          conn,
+          project,
+          Lightning.AccountsFixtures.superuser_fixture(),
+          :owner
+        )
+
+      {:ok, view, _html} = live(conn, Routes.project_index_path(conn, :index))
+      assert view |> element(delete_button) |> has_element?()
+    end
   end
 
   describe "projects picker dropdown" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -117,4 +117,22 @@ defmodule LightningWeb.ConnCase do
     |> Phoenix.ConnTest.init_test_session(%{})
     |> Plug.Conn.put_session(:user_token, token)
   end
+
+  @doc """
+  Setup helper that creates a user adds them as project user with a given role and logs them them in
+  """
+  def setup_project_user(conn, project, user, role) do
+    project_users =
+      project.project_users
+      |> Enum.concat([
+        %Lightning.Projects.ProjectUser{user_id: user.id, role: role}
+      ])
+
+    {:ok, _project} =
+      Lightning.Projects.Project.changeset(project, %{})
+      |> Ecto.Changeset.put_assoc(:project_users, project_users)
+      |> Lightning.Repo.update()
+
+    log_in_user(conn, user)
+  end
 end


### PR DESCRIPTION
## Notes for the reviewer

This PR ships the authorizations implemented for the features in project settings context. See https://github.com/OpenFn/Lightning/pull/667 for plan, progress and more context

#### Project settings
- [x] View project name - every project member can do that
- [x] View description - every project member can do that
- [x] Edit project name - only project owners and project admins can do that. For project editors and project viewers the project name field is disabled and the edit action is forbidden.
- [x] Edit project description - only project owners and admins can do that. For project editors and project viewers the project name field is disabled and the edit action is forbidden.
- [x] Delete a project - only project owners can do that. For all other project members the delete button is not visible and the action is forbidden
- [x] View project credentials page - all project members can do that
- [x] View project collaborators page - all project members can do that
- [x] Edit digest and alerts for themselves - all project members can do that
- [x] edit digest and alerts for others - no project member can edit digest and alerts for other project members

## Related issue

Re #645 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Amber has **QA'd** this feature
