### PR TITLE
Detect when encryption keys are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Improved errors when decoding encryption keys for use with Cloak.
+  [#684](https://github.com/OpenFn/Lightning/issues/684)
+
 ### Fixed
 
 ## [0.4.4] - 2023-03-10
@@ -25,8 +28,6 @@ and this project adheres to
 ### Changed
 
 ### Fixed
-
-- A bug with new credential creation has been fixed.
 
 ## [0.4.3] - 2023-03-06
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -121,6 +121,15 @@ port =
     p when is_integer(p) -> p
   end
 
+# Use the `PRIMARY_ENCRYPTION_KEY` env variable if available, else fall back
+# to defaults.
+# Defaults are set for `dev` and `test` modes.
+config :lightning, Lightning.Vault,
+  primary_encryption_key:
+    System.get_env("PRIMARY_ENCRYPTION_KEY") ||
+      Application.get_env(:lightning, Lightning.Vault, [])
+      |> Keyword.get(:primary_encryption_key, nil)
+
 # Binding to loopback ipv4 address prevents access from other machines.
 # http: [ip: {0, 0, 0, 0}, port: 4000],
 # Set `http.ip` to {127, 0, 0, 1} to block access from other machines.

--- a/test/lightning/vault_test.exs
+++ b/test/lightning/vault_test.exs
@@ -12,9 +12,25 @@ defmodule Lightning.VaultTest do
     end)
   end
 
+  @tag :capture_log
   test "enforces a primary encryption key" do
-    assert_raise RuntimeError, fn ->
+    assert_raise RuntimeError, ~r/Primary encryption key not found/, fn ->
       Lightning.Vault.init([])
     end
+
+    assert_raise RuntimeError,
+                 ~r/Encountered an error when decoding the primary encryption key./,
+                 fn ->
+                   Lightning.Vault.init(primary_encryption_key: "xxx")
+                 end
+
+    assert_raise RuntimeError,
+                 ~r/Primary encryption key is invalid/,
+                 fn ->
+                   Lightning.Vault.init(
+                     primary_encryption_key:
+                       48 |> :crypto.strong_rand_bytes() |> Base.encode64()
+                   )
+                 end
   end
 end


### PR DESCRIPTION
Fixes #684

Encryption keys (for AES GCM) must be exactly 256-bits in size. When Lightning.Vault starts up it now checks for:

- That the key can be correctly decoded
- A key must be exactly 256-bits in size

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
