### PR TITLE
Ensure that JSON Schema inputs are rendered in the correct order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
 
 ### Fixed
 
+- Ensure JSON schema form inputs are in the same order as they are written in
+  the schema [#685](https://github.com/OpenFn/Lightning/issues/685)
+
 ## [0.4.4] - 2023-03-10
 
 ### Added

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -57,7 +57,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         }
         class="mt-4 space-y-4"
       >
-        <div :for={{field, _type} <- @schema.types} class="grid grid-cols-2">
+        <div :for={field <- @schema.fields} class="grid grid-cols-2">
           <.schema_input form={body_form} schema={@schema} field={field} />
         </div>
       </div>
@@ -68,9 +68,14 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
   defp get_schema(schema_name) do
     {:ok, schemas_path} = Application.fetch_env(:lightning, :schemas_path)
 
-    File.read!("#{schemas_path}/#{schema_name}.json")
-    |> Jason.decode!()
-    |> Credentials.Schema.new(schema_name)
+    File.read("#{schemas_path}/#{schema_name}.json")
+    |> case do
+      {:ok, raw_json} ->
+        Credentials.Schema.new(raw_json, schema_name)
+
+      {:error, reason} ->
+        raise "Error reading credential schema. Got: #{reason |> inspect()}"
+    end
   end
 
   defp create_schema_changeset(schema, params) do

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -34,7 +34,7 @@ defmodule Lightning.Credentials.SchemaTest do
         "required": ["hostUrl", "password", "username", "number"]
       }
       """
-      |> Jason.decode!()
+      |> Jason.decode!(objects: :ordered_objects)
 
     %{schema_map: schema_map}
   end
@@ -62,6 +62,8 @@ defmodule Lightning.Credentials.SchemaTest do
                username: :string,
                number: :integer
              }
+
+      assert schema.fields == [:username, :password, :hostUrl, :number]
     end
   end
 

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -171,6 +171,24 @@ defmodule LightningWeb.CredentialLiveTest do
 
       refute_redirected(new_live, ~p"/credentials")
 
+      # Check that the fields are rendered in the same order as the JSON schema
+      inputs_in_position =
+        new_live
+        |> element("#credential-form")
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.attribute("input", "name")
+
+      assert inputs_in_position == ~w(
+               credential[name]
+               credential[production]
+               credential[production]
+               credential[body][username]
+               credential[body][password]
+               credential[body][hostUrl]
+               credential[body][apiVersion]
+             )
+
       assert new_live
              |> form("#credential-form",
                credential: %{
@@ -901,7 +919,7 @@ defmodule LightningWeb.CredentialLiveTest do
   end
 
   defp wait_for_assigns(live, key) do
-    Enum.reduce_while(1..5, nil, fn n, _ ->
+    Enum.reduce_while(1..10, nil, fn n, _ ->
       {_mod, assigns} =
         Lightning.LiveViewHelpers.get_component_assigns_by(
           live,


### PR DESCRIPTION
Due to Elixirs maps not having a gaurenteed order (and therefore ExJsonSchema) a schema written to be in a certain order isn't necessarily going to be rendered out in the form in the same order.

By leveraging `Jason.OrderedObject` access behaviour we get the order of the `properties` keys when setting the list of `fields` on `%Lightning.Credentials.Schema{}`.

Fixes #685

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
