### PR TITLE
Lay down roles and permissions - Admin settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,8 @@ and this project adheres to
 - Create credentials via a form interface\*
 - Show "projects with access" in credentials list view.
 - Show job in runs list and run view.
+- Added roles and permissions to workflows and history page
+  [#645](https://github.com/OpenFn/Lightning/issues/645)
 
 \*The form is defined by a JSON schema provided by an adaptor, in most cases:
 e.g., `language-dhis2` provides a single schema which defines the required

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -1,55 +1,59 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import Monaco from "@monaco-editor/react";
-import type { EditorProps as MonacoProps } from  "@monaco-editor/react/lib/types";
+import Monaco from '@monaco-editor/react';
+import type { EditorProps as MonacoProps } from '@monaco-editor/react/lib/types';
 
 import { fetchDTSListing, fetchFile } from '@openfn/describe-package';
 
-const DEFAULT_TEXT = '// Get started by adding operations from the API reference';
+const DEFAULT_TEXT =
+  '// Get started by adding operations from the API reference';
 
 type EditorProps = {
   source?: string;
   adaptor?: string; // fully specified adaptor name - <id>@<version>
   onChange?: (newSource: string) => void;
-}
+  disabled?: string;
+};
 
-const spinner = (<svg
-  className="animate-spin h-5 w-5 inline-block"
-  xmlns="http://www.w3.org/2000/svg"
-  fill="none"
-  viewBox="0 0 24 24"
+const spinner = (
+  <svg
+    className="animate-spin h-5 w-5 inline-block"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
   >
-  <circle
-    className="opacity-25"
-    cx="12"
-    cy="12"
-    r="10"
-    stroke="currentColor"
-    stroke-width="4"
-  >
-  </circle>
-  <path
-    className="opacity-75"
-    fill="currentColor"
-    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-  >
-  </path>
-</svg>);
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      stroke-width="4"
+    ></circle>
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+    ></path>
+  </svg>
+);
 
-const loadingIndicator = (<div className="inline-block bg-vs-dark p-2">
-  <span className="mr-2">Loading</span>
-  {spinner}
-</div>);
+const loadingIndicator = (
+  <div className="inline-block bg-vs-dark p-2">
+    <span className="mr-2">Loading</span>
+    {spinner}
+  </div>
+);
 
 // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html
 const defaultOptions: MonacoProps['options'] = {
   dragAndDrop: false,
   lineNumbersMinChars: 3,
   minimap: {
-    enabled: false
+    enabled: false,
   },
   scrollBeyondLastLine: false,
   showFoldingControls: 'always',
-  
+
   // Hide the right-hand "overview" ruler
   overviewRulerLanes: 0,
   overviewRulerBorder: false,
@@ -59,133 +63,161 @@ const defaultOptions: MonacoProps['options'] = {
 
   suggest: {
     showKeywords: false,
-  }
+  },
 };
 
 type Lib = {
   content: string;
   filePath: string;
-}
+};
 
 // TODO this can take a little while to run, we should consider giving some feedback to the user
-async function loadDTS(specifier: string, type: 'namespace' | 'module' = 'namespace'): Promise<Lib[]> {
+async function loadDTS(
+  specifier: string,
+  type: 'namespace' | 'module' = 'namespace'
+): Promise<Lib[]> {
   // Work out the module name from the specifier
   // (his gets a bit tricky with @openfn/ module names)
-  const nameParts = specifier.split('@')
-  nameParts.pop() // remove the version
+  const nameParts = specifier.split('@');
+  nameParts.pop(); // remove the version
   const name = nameParts.join('@');
-  
+
   let results: Lib[] = [];
   if (name !== '@openfn/language-common') {
-    const pkg = await fetchFile(`${specifier}/package.json`)
-    const commonVersion = JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
-    results = await loadDTS(`@openfn/language-common@${commonVersion}`, 'module')
+    const pkg = await fetchFile(`${specifier}/package.json`);
+    const commonVersion = JSON.parse(pkg || '{}').dependencies?.[
+      '@openfn/language-common'
+    ];
+    results = await loadDTS(
+      `@openfn/language-common@${commonVersion}`,
+      'module'
+    );
   }
 
   for await (const filePath of fetchDTSListing(specifier)) {
     if (!filePath.startsWith('node_modules')) {
-      const content = await fetchFile(`${specifier}${filePath}`)
+      const content = await fetchFile(`${specifier}${filePath}`);
       results.push({
         content: `declare ${type} "${name}" { ${content} }`,
-        filePath: `${name}${filePath}`
+        filePath: `${name}${filePath}`,
       });
     }
   }
   return results;
 }
 
-export default function Editor({ source, adaptor, onChange }: EditorProps) {
+export default function Editor({
+  source,
+  adaptor,
+  onChange,
+  disabled,
+}: EditorProps) {
   const [lib, setLib] = useState<Lib[]>();
   const [loading, setLoading] = useState(false);
   const [monaco, setMonaco] = useState<typeof Monaco>();
   const [options, setOptions] = useState(defaultOptions);
-  const listeners = useRef<{ insertSnippet?: EventListenerOrEventListenerObject}>({});
+  const listeners = useRef<{
+    insertSnippet?: EventListenerOrEventListenerObject;
+  }>({});
 
-  const handleSourceChange = useCallback((newSource: string) => {
-    if (onChange) {
-      onChange(newSource)
-    }
-  }, [onChange]);
-  
-  const handleEditorDidMount = useCallback((editor: any, monaco: typeof Monaco) => {
-    setMonaco(monaco);
+  const handleSourceChange = useCallback(
+    (newSource: string) => {
+      if (onChange) {
+        onChange(newSource);
+      }
+    },
+    [onChange]
+  );
 
-    monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
-      // This seems to be needed to track the modules in d.ts files
-      allowNonTsExtensions: true,
+  const handleEditorDidMount = useCallback(
+    (editor: any, monaco: typeof Monaco) => {
+      setMonaco(monaco);
 
-      // Disables core js libs in code completion
-      noLib: true,
-    });
+      monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
+        // This seems to be needed to track the modules in d.ts files
+        allowNonTsExtensions: true,
 
-    listeners.current.insertSnippet = (e: Event) => {
-      // Snippets are always added to the end of the job code
-      const model = editor.getModel()
-      const lastLine = model.getLineCount();
-      const eol = model.getLineLength(lastLine)
-      const op = {
-        range: new monaco.Range(lastLine, eol, lastLine, eol),
-        // @ts-ignore event typings
-        text: `\n${e.snippet}`,
-        forceMoveMarkers: true
+        // Disables core js libs in code completion
+        noLib: true,
+      });
+
+      listeners.current.insertSnippet = (e: Event) => {
+        // Snippets are always added to the end of the job code
+        const model = editor.getModel();
+        const lastLine = model.getLineCount();
+        const eol = model.getLineLength(lastLine);
+        const op = {
+          range: new monaco.Range(lastLine, eol, lastLine, eol),
+          // @ts-ignore event typings
+          text: `\n${e.snippet}`,
+          forceMoveMarkers: true,
+        };
+
+        // Append the snippet
+        // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ICodeEditor.html#executeEdits
+        editor.executeEdits('snippets', [op]);
+
+        // Ensure the snippet is fully visible
+        const newLastLine = model.getLineCount();
+        editor.revealLines(lastLine + 1, newLastLine, 0); // 0 = smooth scroll
+
+        // Set the selection to the start of the snippet
+        editor.setSelection(new monaco.Range(lastLine + 1, 0, lastLine + 1, 0));
+
+        // ensure the editor has focus
+        editor.focus();
       };
-      
-      // Append the snippet
-      // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ICodeEditor.html#executeEdits
-      editor.executeEdits("snippets", [op]);
 
-      // Ensure the snippet is fully visible
-      const newLastLine = model.getLineCount();
-      editor.revealLines(lastLine + 1, newLastLine, 0) // 0 = smooth scroll
-
-      // Set the selection to the start of the snippet
-      editor.setSelection(new monaco.Range(lastLine+1, 0, lastLine+1, 0));
-      
-      // ensure the editor has focus
-      editor.focus();
-    };
-
-    document.addEventListener('insert-snippet', listeners.current.insertSnippet);
-  }, []);
+      document.addEventListener(
+        'insert-snippet',
+        listeners.current.insertSnippet
+      );
+    },
+    []
+  );
 
   useEffect(() => {
     // Create a node to hold overflow widgets
     // This needs to be at the top level so that tooltips clip over Lightning UIs
     const overflowNode = document.createElement('div');
-    overflowNode.className = "monaco-editor widgets-overflow-container";
+    overflowNode.className = 'monaco-editor widgets-overflow-container';
     document.body.appendChild(overflowNode);
 
     setOptions({
       ...defaultOptions,
       overflowWidgetsDomNode: overflowNode,
-      fixedOverflowWidgets: true
-    })
+      fixedOverflowWidgets: true,
+      readOnly: disabled === 'true',
+    });
 
     return () => {
       overflowNode.parentNode?.removeChild(overflowNode);
       if (listeners.current?.insertSnippet) {
-        document.removeEventListener('insert-snippet', listeners.current.insertSnippet);
+        document.removeEventListener(
+          'insert-snippet',
+          listeners.current.insertSnippet
+        );
       }
-     }
+    };
   }, []);
-  
+
   useEffect(() => {
     if (adaptor) {
-      setLoading(true)
+      setLoading(true);
       setLib([]); // instantly clear intelligence
       loadDTS(adaptor).then(l => {
-        setLib(l)
-        setLoading(false)
+        setLib(l);
+        setLoading(false);
       });
     }
-  }, [adaptor])
+  }, [adaptor]);
 
   useEffect(() => {
     if (monaco) {
       monaco.languages.typescript.javascriptDefaults.setExtraLibs(lib);
     }
   }, [monaco, lib]);
-  
+
   return (
     <>
       <div className="text-xs text-white text-right h-0 z-10 overflow-visible relative">

--- a/assets/js/editor/index.tsx
+++ b/assets/js/editor/index.tsx
@@ -43,13 +43,14 @@ export default {
     this.pushEventTo(this.el, this.changeEvent, { source: content });
   },
   render() {
-    const { adaptor, source } = this.el.dataset;
+    const { adaptor, source, disabled } = this.el.dataset;
     if (EditorComponent) {
       this.componentRoot?.render(
         <EditorComponent
           adaptor={adaptor}
           source={source}
           onChange={src => this.handleContentChange(src)}
+          disabled={disabled}
         />
       );
     }

--- a/lib/lightning/policies/users.ex
+++ b/lib/lightning/policies/users.ex
@@ -10,6 +10,7 @@ defmodule Lightning.Policies.Users do
           :create_projects
           | :view_projects
           | :edit_projects
+          | :create_users
           | :view_users
           | :edit_users
           | :delete_users
@@ -21,6 +22,7 @@ defmodule Lightning.Policies.Users do
           | :view_credentials
           | :edit_credentials
           | :delete_credential
+          | :access_admin_space
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -38,12 +40,14 @@ defmodule Lightning.Policies.Users do
              :view_projects,
              :edit_projects,
              :create_projects,
+             :create_users,
              :view_users,
              :edit_users,
              :delete_users,
              :disable_users,
              :configure_external_auth_provider,
-             :view_credentials_audit_trail
+             :view_credentials_audit_trail,
+             :access_admin_space
            ] do
     role in [:superuser]
   end

--- a/lib/lightning_web/live/auth_providers/index.ex
+++ b/lib/lightning_web/live/auth_providers/index.ex
@@ -4,22 +4,23 @@ defmodule LightningWeb.AuthProvidersLive.Index do
   """
   use LightningWeb, :live_view
   alias Lightning.AuthProviders
+  alias Lightning.Policies.{Users, Permissions}
 
   @impl true
   def mount(_params, _session, socket) do
-    case Bodyguard.permit(
-           Lightning.AuthProviders.Policy,
-           :index,
-           socket.assigns.current_user
-         ) do
-      :ok ->
-        {:ok, socket |> assign(:active_menu_item, :authentication),
-         layout: {LightningWeb.Layouts, :settings}}
+    can_access_admin_space =
+      Users
+      |> Permissions.can(:access_admin_space, socket.assigns.current_user, {})
 
-      {:error, :unauthorized} ->
-        {:ok,
-         put_flash(socket, :error, "You can't access that page")
-         |> push_redirect(to: "/")}
+    if can_access_admin_space do
+      {:ok,
+       socket
+       |> assign(:active_menu_item, :authentication),
+       layout: {LightningWeb.Layouts, :settings}}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
     end
   end
 

--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -30,6 +30,7 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
           values={@adaptors}
           phx-change="adaptor_name_change"
           phx-target={@myself}
+          disabled={!@can_edit_job}
         />
       </div>
 
@@ -52,6 +53,7 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
           values={@versions}
           phx-change="adaptor_version_change"
           phx-target={@myself}
+          disabled={!@can_edit_job}
         />
       </div>
     </div>
@@ -59,7 +61,10 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
   end
 
   @impl true
-  def update(%{form: form, on_change: on_change}, socket) do
+  def update(
+        %{form: form, on_change: on_change, can_edit_job: can_edit_job},
+        socket
+      ) do
     {adaptor_name, version, adaptors, versions} =
       get_adaptor_version_options(Phoenix.HTML.Form.input_value(form, :adaptor))
 
@@ -70,7 +75,8 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
      |> assign(:adaptors, adaptors)
      |> assign(:versions, versions)
      |> assign(:on_change, on_change)
-     |> assign(:form, form)}
+     |> assign(:form, form)
+     |> assign(:can_edit_job, can_edit_job)}
   end
 
   @doc """

--- a/lib/lightning_web/live/job_live/job_builder_components.ex
+++ b/lib/lightning_web/live/job_live/job_builder_components.ex
@@ -57,6 +57,7 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
           name={:type}
           id="triggerType"
           values={@trigger_type_options}
+          disabled={!@can_edit_job}
         />
       <% end %>
       <%= if @webhook_url do %>
@@ -83,6 +84,7 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
             prompt=""
             id="upstream-job"
             values={Enum.map(@upstream_jobs, &{&1.name, &1.id})}
+            disabled={!@can_edit_job}
           />
         <% end %>
       <% end %>

--- a/lib/lightning_web/live/project_live/form_component.ex
+++ b/lib/lightning_web/live/project_live/form_component.ex
@@ -13,7 +13,6 @@ defmodule LightningWeb.ProjectLive.FormComponent do
   use LightningWeb, :live_component
 
   alias Lightning.Projects
-  alias Lightning.Policies.Users
   import LightningWeb.Components.Form
   import LightningWeb.Components.Common
 
@@ -21,7 +20,7 @@ defmodule LightningWeb.ProjectLive.FormComponent do
 
   @impl true
   def update(
-        %{project: project, users: users, current_user: current_user} = assigns,
+        %{project: project, users: users} = assigns,
         socket
       ) do
     changeset = Projects.change_project(project)
@@ -36,15 +35,6 @@ defmodule LightningWeb.ProjectLive.FormComponent do
        all_users: all_users,
        available_users: filter_available_users(changeset, all_users),
        selected_member: ""
-     )
-     |> assign(
-       can_edit:
-         Users
-         |> Lightning.Policies.Permissions.can(
-           :create_projects,
-           current_user,
-           {}
-         )
      )
      |> assign(
        :name,

--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -21,7 +21,7 @@
         ) %>
         <br />
         <div class="inline-block pl-2">
-          <%= if @changeset.valid? do %>
+          <%= if (@changeset.valid?) do %>
             Your project will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
           <%= @name %></span>.
           <% end %>
@@ -105,10 +105,7 @@
         </.link>
       </span>
       <div class="inline-block">
-        <.submit_button
-          phx-disable-with="Saving"
-          disabled={!(@changeset.valid? and @can_edit)}
-        >
+        <.submit_button phx-disable-with="Saving" disabled={!@changeset.valid?}>
           Save
         </.submit_button>
       </div>

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -4,28 +4,21 @@ defmodule LightningWeb.ProjectLive.Index do
   """
   use LightningWeb, :live_view
 
-  alias Lightning.Policies.Permissions
-  alias Lightning.Policies.ProjectUsers
+  alias Lightning.Policies.{Users, ProjectUsers, Permissions}
   alias Lightning.Projects
 
   @impl true
   def mount(_params, _session, socket) do
-    case Bodyguard.permit(
-           Lightning.Projects.Policy,
-           :index,
-           socket.assigns.current_user
-         ) do
-      :ok ->
-        {:ok,
-         socket
-         |> assign(:active_menu_item, :projects)
-         |> assign(current_user: socket.assigns.current_user),
-         layout: {LightningWeb.Layouts, :settings}}
+    can_access_admin_space =
+      Users
+      |> Permissions.can(:access_admin_space, socket.assigns.current_user, {})
 
-      {:error, :unauthorized} ->
-        {:ok,
-         put_flash(socket, :error, "You can't access that page")
-         |> push_redirect(to: "/")}
+    if can_access_admin_space do
+      {:ok, socket, layout: {LightningWeb.Layouts, :settings}}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
     end
   end
 
@@ -36,13 +29,17 @@ defmodule LightningWeb.ProjectLive.Index do
 
   defp apply_action(socket, :index, _params) do
     socket
-    |> assign(:projects, Projects.list_projects())
-    |> assign(:page_title, "Projects")
+    |> assign(
+      active_menu_item: :projects,
+      projects: Projects.list_projects(),
+      page_title: "Projects"
+    )
   end
 
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
     |> assign(:page_title, "New Project")
+    |> assign(active_menu_item: :settings)
     |> assign(:project, Projects.get_project_with_users!(id))
     |> assign(:users, Lightning.Accounts.list_users())
   end
@@ -50,6 +47,7 @@ defmodule LightningWeb.ProjectLive.Index do
   defp apply_action(socket, :new, _params) do
     socket
     |> assign(:page_title, "New Project")
+    |> assign(active_menu_item: :settings)
     |> assign(:project, %Lightning.Projects.Project{})
     |> assign(:users, Lightning.Accounts.list_users())
   end

--- a/lib/lightning_web/live/project_live/index.html.heex
+++ b/lib/lightning_web/live/project_live/index.html.heex
@@ -21,7 +21,6 @@
         action={@live_action}
         project={@project}
         users={@users}
-        current_user={@current_user}
         return_to={Routes.project_index_path(@socket, :index)}
       />
     <% else %>

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -6,6 +6,7 @@ defmodule LightningWeb.RunLive.Components do
 
   attr :project, :map, required: true
   attr :attempt, :map, required: true
+  attr :can_rerun_job, :boolean, required: true
 
   def attempt_item(%{attempt: attempt} = assigns) do
     runs = attempt.runs
@@ -59,7 +60,12 @@ defmodule LightningWeb.RunLive.Components do
           </span>
           <ol class="mt-2 list-none space-y-4">
             <%= for run <- @run_list do %>
-              <.run_list_item project_id={@project.id} attempt={@attempt} run={run} />
+              <.run_list_item
+                can_rerun_job={@can_rerun_job}
+                project_id={@project.id}
+                attempt={@attempt}
+                run={run}
+              />
             <% end %>
           </ol>
         </li>
@@ -71,6 +77,7 @@ defmodule LightningWeb.RunLive.Components do
   attr :run, :map, required: true
   attr :attempt, :map, required: true
   attr :project_id, :string, required: true
+  attr :can_rerun_job, :boolean, required: true
 
   def run_list_item(assigns) do
     ~H"""
@@ -111,15 +118,17 @@ defmodule LightningWeb.RunLive.Components do
               run at <%= @run.finished_at |> Calendar.strftime("%c %Z") %>
             </span>
           </.link>
-          <span
-            class="pl-2 text-indigo-400 hover:underline hover:underline-offset-2 hover:text-indigo-500 cursor-pointer"
-            phx-click="rerun"
-            phx-value-attempt_id={@attempt.id}
-            phx-value-run_id={@run.id}
-            title="Rerun workflow from here"
-          >
-            rerun
-          </span>
+          <%= if @can_rerun_job do %>
+            <span
+              class="pl-2 text-indigo-400 hover:underline hover:underline-offset-2 hover:text-indigo-500 cursor-pointer"
+              phx-click="rerun"
+              phx-value-attempt_id={@attempt.id}
+              phx-value-run_id={@run.id}
+              title="Rerun workflow from here"
+            >
+              rerun
+            </span>
+          <% end %>
         </span>
       </span>
     </li>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -26,6 +26,7 @@
               module={LightningWeb.RunLive.WorkOrderComponent}
               id={wo.id}
               project={@project}
+              current_user={@current_user}
             />
           <% end %>
         </div>

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -2,15 +2,26 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   @moduledoc """
   Workorder component
   """
+  alias Lightning.Policies.ProjectUsers
+  alias Lightning.Policies.Permissions
   alias Lightning.Invocation
   use Phoenix.Component
   use LightningWeb, :live_component
   import LightningWeb.RunLive.Components
 
   @impl true
-  def update(%{work_order: work_order, project: project}, socket) do
+  def update(
+        %{work_order: work_order, project: project, current_user: current_user},
+        socket
+      ) do
+    can_rerun_job =
+      Permissions.can(ProjectUsers, :rerun_job, current_user, project)
+
     {:ok,
-     socket |> assign(project: project) |> set_work_order_details(work_order)}
+     socket
+     |> assign(project: project)
+     |> assign(can_rerun_job: can_rerun_job)
+     |> set_work_order_details(work_order)}
   end
 
   def update(%{work_order: work_order}, socket) do
@@ -120,7 +131,11 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
       </div>
       <%= if @show_details do %>
         <%= for attempt <- @attempts do %>
-          <.attempt_item attempt={attempt} project={@project} />
+          <.attempt_item
+            can_rerun_job={@can_rerun_job}
+            attempt={attempt}
+            project={@project}
+          />
         <% end %>
       <% end %>
     </div>

--- a/lib/lightning_web/live/user_live/edit.ex
+++ b/lib/lightning_web/live/user_live/edit.ex
@@ -5,26 +5,25 @@ defmodule LightningWeb.UserLive.Edit do
   """
   use LightningWeb, :live_view
 
+  alias Lightning.Policies.{Users, Permissions}
   alias Lightning.Accounts
   alias Lightning.Accounts.User
 
   @impl true
   def mount(_params, _session, socket) do
-    case Bodyguard.permit(
-           Lightning.Accounts.Policy,
-           :index,
-           socket.assigns.current_user
-         ) do
-      :ok ->
-        {:ok,
-         socket
-         |> assign(active_menu_item: :users),
-         layout: {LightningWeb.Layouts, :settings}}
+    can_access_admin_space =
+      Users
+      |> Permissions.can(:access_admin_space, socket.assigns.current_user, {})
 
-      {:error, :unauthorized} ->
-        {:ok,
-         put_flash(socket, :error, "You can't access that page")
-         |> push_redirect(to: "/")}
+    if can_access_admin_space do
+      {:ok,
+       socket
+       |> assign(active_menu_item: :users),
+       layout: {LightningWeb.Layouts, :settings}}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
     end
   end
 

--- a/lib/lightning_web/live/user_live/form_component.html.heex
+++ b/lib/lightning_web/live/user_live/form_component.html.heex
@@ -103,6 +103,7 @@
       <div class="hidden sm:block" aria-hidden="true">
         <div class="py-5"></div>
       </div>
+
       <div class="flex items-start">
         <div class="flex items-center h-5">
           <%= checkbox(f, :disabled,
@@ -123,7 +124,6 @@
           </p>
         </div>
       </div>
-
       <div class="hidden sm:block" aria-hidden="true">
         <div class="py-5"></div>
       </div>

--- a/lib/lightning_web/live/user_live/index.ex
+++ b/lib/lightning_web/live/user_live/index.ex
@@ -4,25 +4,24 @@ defmodule LightningWeb.UserLive.Index do
   """
   use LightningWeb, :live_view
 
+  alias Lightning.Policies.{Users, Permissions}
   alias Lightning.Accounts
 
   @impl true
   def mount(_params, _session, socket) do
-    case Bodyguard.permit(
-           Lightning.Accounts.Policy,
-           :index,
-           socket.assigns.current_user
-         ) do
-      :ok ->
-        {:ok,
-         assign(socket, :users, list_users())
-         |> assign(:active_menu_item, :users),
-         layout: {LightningWeb.Layouts, :settings}}
+    can_access_admin_space =
+      Users
+      |> Permissions.can(:access_admin_space, socket.assigns.current_user, {})
 
-      {:error, :unauthorized} ->
-        {:ok,
-         put_flash(socket, :error, "You can't access that page")
-         |> push_redirect(to: "/")}
+    if can_access_admin_space do
+      {:ok,
+       assign(socket, :users, list_users())
+       |> assign(:active_menu_item, :users),
+       layout: {LightningWeb.Layouts, :settings}}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
     end
   end
 

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -4,6 +4,8 @@ defmodule LightningWeb.WorkflowLive do
 
   on_mount {LightningWeb.Hooks, :project_scope}
 
+  alias Lightning.Policies.Permissions
+  alias Lightning.Policies.ProjectUsers
   alias Lightning.Workflows
   import LightningWeb.WorkflowLive.Components
 
@@ -44,7 +46,11 @@ defmodule LightningWeb.WorkflowLive do
         <%= case @live_action do %>
           <% :index -> %>
             <LayoutComponents.centered>
-              <.workflow_list workflows={@workflows} project={@project} />
+              <.workflow_list
+                can_create_workflow={@can_create_workflow}
+                workflows={@workflows}
+                project={@project}
+              />
             </LayoutComponents.centered>
           <% :new_job -> %>
             <div class="grow">
@@ -144,6 +150,7 @@ defmodule LightningWeb.WorkflowLive do
                   socket={@socket}
                   project={@project}
                   workflow={@current_workflow}
+                  can_create_job={@can_create_job}
                 />
               <% end %>
             </div>
@@ -189,24 +196,48 @@ defmodule LightningWeb.WorkflowLive do
     project = socket.assigns.project
     LightningWeb.Endpoint.subscribe("project_space:#{project.id}")
 
+    can_create_workflow =
+      ProjectUsers
+      |> Permissions.can(
+        :create_workflow,
+        socket.assigns.current_user,
+        socket.assigns.project
+      )
+
+    can_create_job =
+      ProjectUsers
+      |> Permissions.can(
+        :create_job,
+        socket.assigns.current_user,
+        socket.assigns.project
+      )
+
     {:ok,
      socket
      |> assign(
+       can_create_workflow: can_create_workflow,
+       can_create_job: can_create_job,
        active_menu_item: :projects,
        new_credential: false,
        builder_state: %{}
      )}
   end
 
-  @impl true
-  def handle_event("copied-to-clipboard", _, socket) do
+  defp create_workflow(%{assigns: %{can_create_workflow: false}} = socket) do
     {:noreply,
      socket
-     |> put_flash(:info, "Copied webhook URL to clipboard")}
+     |> put_flash(:error, "You are not authorized to perform this action.")
+     |> push_patch(
+       to:
+         Routes.project_workflow_path(
+           socket,
+           :index,
+           socket.assigns.project.id
+         )
+     )}
   end
 
-  @impl true
-  def handle_event("create-workflow", _, socket) do
+  defp create_workflow(%{assigns: %{can_create_workflow: true}} = socket) do
     {:ok, %Workflows.Workflow{id: workflow_id}} =
       Workflows.create_workflow(%{project_id: socket.assigns.project.id})
 
@@ -222,6 +253,47 @@ defmodule LightningWeb.WorkflowLive do
            workflow_id
          )
      )}
+  end
+
+  @impl true
+  def handle_event("copied-to-clipboard", _, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, "Copied webhook URL to clipboard")}
+  end
+
+  @impl true
+  def handle_event(
+        "create-job",
+        _,
+        %{assigns: %{can_create_job: true}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> push_patch(
+       to:
+         Routes.project_workflow_path(
+           socket,
+           :new_job,
+           socket.assigns.project.id,
+           socket.assigns.current_workflow.id
+         )
+     )}
+  end
+
+  def handle_event(
+        "create-job",
+        _,
+        %{assigns: %{can_create_job: false}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "You are not authorized to perform this action.")}
+  end
+
+  @impl true
+  def handle_event("create-workflow", _, socket) do
+    create_workflow(socket)
   end
 
   @impl true

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.WorkflowLive.Components do
     ~H"""
     <div class="w-full">
       <div class="w-full flex flex-wrap gap-4">
-        <.create_workflow_card />
+        <.create_workflow_card can_create_workflow={@can_create_workflow} />
         <%= for workflow <- @workflows do %>
           <.workflow_card
             workflow={%{workflow | name: workflow.name || "Untitled"}}
@@ -53,12 +53,12 @@ defmodule LightningWeb.WorkflowLive.Components do
       <div class="font-bold mb-2">Create a new workflow</div>
       <div class="">Create a new workflow for your organisation</div>
       <div>
-        <button
+        <LightningWeb.Components.Common.button
           phx-click="create-workflow"
-          class="focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2"
+          disabled={!@can_create_workflow}
         >
           Create a workflow
-        </button>
+        </LightningWeb.Components.Common.button>
       </div>
     </div>
     """
@@ -74,25 +74,17 @@ defmodule LightningWeb.WorkflowLive.Components do
       <div class="text-sm font-semibold text-gray-500 pb-4">
         Create your first job to get started.
       </div>
-      <div class="text-xs text-gray-400">
-        <.link patch={
-          Routes.project_workflow_path(
-            @socket,
-            :new_job,
-            @project.id,
-            @workflow.id
-          )
-        }>
-          <Common.button>
-            <div class="h-full">
-              <Heroicons.plus class="h-4 w-4 inline-block" />
-              <span class="inline-block align-middle">
-                Create job
-              </span>
-            </div>
-          </Common.button>
-        </.link>
-      </div>
+      <LightningWeb.Components.Common.button
+        phx-click="create-job"
+        disabled={!@can_create_job}
+      >
+        <div class="h-full">
+          <Heroicons.plus class="h-4 w-4 inline-block" />
+          <span class="inline-block align-middle">
+            Create job
+          </span>
+        </div>
+      </LightningWeb.Components.Common.button>
     </div>
     """
   end

--- a/test/lightning/permissions_test.exs
+++ b/test/lightning/permissions_test.exs
@@ -19,10 +19,12 @@ defmodule Lightning.PermissionsTest do
       refute Users |> Permissions.can(:create_projects, user, {})
       refute Users |> Permissions.can(:view_projects, user, {})
       refute Users |> Permissions.can(:edit_projects, user, {})
+      refute Users |> Permissions.can(:create_users, user, {})
       refute Users |> Permissions.can(:view_users, user, {})
       refute Users |> Permissions.can(:edit_users, user, {})
       refute Users |> Permissions.can(:delete_users, user, {})
       refute Users |> Permissions.can(:disable_users, user, {})
+      refute Users |> Permissions.can(:access_admin_space, user, {})
 
       refute Users
              |> Permissions.can(:configure_external_auth_provider, user, {})
@@ -52,10 +54,12 @@ defmodule Lightning.PermissionsTest do
       assert Users |> Permissions.can(:create_projects, superuser, {})
       assert Users |> Permissions.can(:view_projects, superuser, {})
       assert Users |> Permissions.can(:edit_projects, superuser, {})
+      assert Users |> Permissions.can(:create_users, superuser, {})
       assert Users |> Permissions.can(:view_users, superuser, {})
       assert Users |> Permissions.can(:edit_users, superuser, {})
       assert Users |> Permissions.can(:delete_users, superuser, {})
       assert Users |> Permissions.can(:disable_users, superuser, {})
+      assert Users |> Permissions.can(:access_admin_space, superuser, {})
 
       assert Users
              |> Permissions.can(:configure_external_auth_provider, superuser, {})

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -8,8 +8,7 @@ defmodule LightningWeb.AuditLiveTest do
 
     test "cannot access the audit trail", %{conn: conn} do
       {:ok, _index_live, html} =
-        live(conn, Routes.audit_index_path(conn, :index))
-        |> follow_redirect(conn, "/")
+        live(conn, ~p"/settings/audit") |> follow_redirect(conn, "/")
 
       assert html =~ "You can&#39;t access that page"
     end

--- a/test/lightning_web/live/auth_providers_live_test.exs
+++ b/test/lightning_web/live/auth_providers_live_test.exs
@@ -9,12 +9,12 @@ defmodule LightningWeb.AuthProvidersLiveTest do
   describe "index for superuser" do
     setup :register_and_log_in_superuser
 
-    test "a regular user cannot access the auth providers page", %{
+    test "super users can access the auth providers page", %{
       conn: conn
     } do
       {:ok, _index_live, html} =
-        live(conn, Routes.auth_providers_index_path(conn, :edit))
-        |> follow_redirect(conn, Routes.auth_providers_index_path(conn, :new))
+        live(conn, ~p"/settings/authentication")
+        |> follow_redirect(conn, ~p"/settings/authentication/new")
 
       assert html =~ "Users"
       assert html =~ "Back"
@@ -28,7 +28,7 @@ defmodule LightningWeb.AuthProvidersLiveTest do
       conn: conn
     } do
       {:ok, _index_live, html} =
-        live(conn, Routes.auth_providers_index_path(conn, :edit))
+        live(conn, ~p"/settings/authentication")
         |> follow_redirect(conn, "/")
 
       assert html =~ "You can&#39;t access that page"

--- a/test/lightning_web/live/job_live/manual_run_component_test.exs
+++ b/test/lightning_web/live/job_live/manual_run_component_test.exs
@@ -273,7 +273,15 @@ defmodule LightningWeb.JobLive.ManualRunComponentTest do
              job: job,
              current_user: user,
              on_run: nil,
-             builder_state: %{job_id: job.id, dataclip: d3}
+             builder_state: %{job_id: job.id, dataclip: d3},
+             can_edit_job: true,
+             return_to:
+               Routes.project_workflow_path(
+                 conn,
+                 :show,
+                 project.id,
+                 job.workflow_id
+               )
            ) =~ "<option selected value=\"#{d3.id}\">#{d3.id}</option>"
 
     assert render_component(LightningWeb.JobLive.ManualRunComponent,
@@ -283,7 +291,15 @@ defmodule LightningWeb.JobLive.ManualRunComponentTest do
              job: job,
              current_user: user,
              on_run: nil,
-             builder_state: %{job_id: job.id, dataclip: d4}
+             builder_state: %{job_id: job.id, dataclip: d4},
+             can_edit_job: true,
+             return_to:
+               Routes.project_workflow_path(
+                 conn,
+                 :show,
+                 project.id,
+                 job.workflow_id
+               )
            ) =~ "<option selected value=\"#{d4.id}\">#{d4.id}</option>"
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -29,6 +29,8 @@ defmodule LightningWeb.ConnCase do
       import Phoenix.ConnTest
       import LightningWeb.ConnCase
 
+      alias Lightning.Projects.ProjectUser
+      alias Lightning.Projects.ProjectUser
       alias LightningWeb.Router.Helpers, as: Routes
 
       import Lightning.ModelHelpers
@@ -103,6 +105,26 @@ defmodule LightningWeb.ConnCase do
       )
 
     %{project: project}
+  end
+
+  @doc """
+  Setup helper that creates a user adds them as project user with a given role and logs them them in
+  """
+  def setup_project_user(conn, project, role) do
+    user = Lightning.AccountsFixtures.user_fixture()
+
+    project_users =
+      project.project_users
+      |> Enum.concat([
+        %Lightning.Projects.ProjectUser{user_id: user.id, role: role}
+      ])
+
+    {:ok, _project} =
+      Lightning.Projects.Project.changeset(project, %{})
+      |> Ecto.Changeset.put_assoc(:project_users, project_users)
+      |> Lightning.Repo.update()
+
+    log_in_user(conn, user)
   end
 
   @doc """


### PR DESCRIPTION
## Notes for the reviewer

This PR ships the authorizations implemented for the features in admin settings context. See [#667](https://github.com/OpenFn/Lightning/pull/667) for plan, progress and more context

#### Admin settings
For the following features, only super users can access / perform them. Normal users are kicked out when they try to access / perform them
- [x] View projects
- [x] Edit projects
- [x] Create projects
- [x] View users
- [x] Edit users
- [x] Schedule users for deletion
- [x] Disable users
- [x] Configure an external auth provider
- [x] View credentials audit trail

## Related issue

Re #645 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Amber has **QA'd** this feature
