### PR TITLE
Job Panel resize

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -112,7 +112,44 @@ window.addEventListener('phx:page-loading-stop', () => {
   clearTimeout(topBarScheduled);
   topBarScheduled = undefined;
   topbar.hide();
+  connectResizer();
 });
+
+const connectResizer = () => {
+  const el = document.getElementById('resizer');
+  if (el && !el.connected) {
+    el.connected = true;
+
+    const savedWidth = localStorage.getItem('lightning.job-editor.width');
+    if (savedWidth) {
+      el.parentNode.style.width = `${savedWidth}%`;
+    }
+
+    // find the parent h-full element, which we'll size against
+    let parent = el.parentNode;
+    while (parent && !parent.className.match('h-full')) {
+      parent = parent.parentNode;
+    }
+    if (parent) {
+      const parentWidth = parent.getBoundingClientRect().width;
+      const parentLeft = parent.getBoundingClientRect().left;
+      let width;
+      el.addEventListener('dragend', e => {
+        localStorage.setItem('lightning.job-editor.width', width);
+      });
+      el.addEventListener('drag', e => {
+        if (e.screenX !== 0) {
+          const relativePosition = Math.max(
+            0,
+            Math.min((e.clientX - parentLeft) / parentWidth)
+          );
+          width = (1 - relativePosition) * 100;
+          el.parentNode.style.width = `${width}%`;
+        }
+      });
+    }
+  }
+};
 
 // connect if there are any LiveViews on the page
 liveSocket.connect();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -176,7 +176,7 @@ const connectWorkflowResizer = () => {
             el.parentNode.style.width = `${width}%`;
           }
         };
-        document.addEventListener('mousemove', dragListener);
+        document.addEventListener('pointermove', dragListener);
       });
 
       document.addEventListener('pointerup', () => {
@@ -185,7 +185,7 @@ const connectWorkflowResizer = () => {
           mask.parentNode.removeChild(mask);
           localStorage.setItem('lightning.job-editor.width', width);
           document.dispatchEvent(new Event('update-layout'));
-          document.removeEventListener('mousemove', dragListener);
+          document.removeEventListener('pointermove', dragListener);
           dragListener = null;
         }
       });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -137,8 +137,7 @@ const addDragMask = () => {
 const disconnectWorkflowResizer = () => {
   const el = document.getElementById('resizer');
   if (el) {
-    // el.removeEventListener('dragend', dragEndListener);
-    // el.removeEventListener('drag', dragListener);
+    el.removeEventListener('pointerdown', pointerDownListner);
   }
 };
 
@@ -161,7 +160,7 @@ const connectWorkflowResizer = () => {
       const parentLeft = parentBounds.left;
       let width;
 
-      el.addEventListener('pointerdown', () => {
+      const pointerDownListener = () => {
         addDragMask();
         dragListener = e => {
           if (e.screenX !== 0) {
@@ -177,7 +176,8 @@ const connectWorkflowResizer = () => {
           }
         };
         document.addEventListener('pointermove', dragListener);
-      });
+      };
+      el.addEventListener('pointerdown', pointerDownListener);
 
       document.addEventListener('pointerup', () => {
         if (dragListener) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,7 +29,7 @@ import JobEditor from './job-editor';
 import WorkflowDiagram from './workflow-diagram';
 import TabSelector from './tab-selector';
 
-let dragEndListener;
+let pointerDownListener;
 let dragListener;
 
 let Hooks = {
@@ -137,7 +137,7 @@ const addDragMask = () => {
 const disconnectWorkflowResizer = () => {
   const el = document.getElementById('resizer');
   if (el) {
-    el.removeEventListener('pointerdown', pointerDownListner);
+    el.removeEventListener('pointerdown', pointerDownListener);
   }
 };
 
@@ -160,7 +160,7 @@ const connectWorkflowResizer = () => {
       const parentLeft = parentBounds.left;
       let width;
 
-      const pointerDownListener = () => {
+      pointerDownListener = () => {
         addDragMask();
         dragListener = e => {
           if (e.screenX !== 0) {
@@ -183,7 +183,9 @@ const connectWorkflowResizer = () => {
         if (dragListener) {
           const mask = document.getElementById('drag-mask');
           mask.parentNode.removeChild(mask);
-          localStorage.setItem('lightning.job-editor.width', width);
+          if (width) {
+            localStorage.setItem('lightning.job-editor.width', width);
+          }
           document.dispatchEvent(new Event('update-layout'));
           document.removeEventListener('pointermove', dragListener);
           dragListener = null;

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -191,11 +191,10 @@ export default function Editor({ source, adaptor, onChange, metadata }: EditorPr
       editor.focus();
     };
     
-    // This is a temporary (and poor) solution to make the editor respond to resizing
+    // Force the editor to resize
     listeners.current.updateLayout = (e: Event) => {
       editor.layout({ width: 0, height: 0});
-      setTimeout(
-      editor.layout, 1)
+      editor.layout();
     }
 
     document.addEventListener('insert-snippet', listeners.current.insertSnippet);

--- a/assets/js/job-editor-resizer/mount.ts
+++ b/assets/js/job-editor-resizer/mount.ts
@@ -1,0 +1,93 @@
+// The drag mask stops the cursor interacting with the page while dragging
+const addDragMask = () => {
+  const dragMask = document.createElement('div');
+  dragMask.id = 'drag-mask';
+  dragMask.style.position = 'absolute';
+  dragMask.style.left = '0';
+  dragMask.style.right = '0';
+  dragMask.style.top = '0';
+  dragMask.style.bottom = '0';
+  dragMask.style.userSelect = 'none';
+  dragMask.style.zIndex = '999';
+  dragMask.style.cursor = 'ew-resize';
+  document.body.appendChild(dragMask);
+};
+
+interface ResizerHook {
+  el: HTMLElement;
+  container: HTMLElement;
+  mounted(): void;
+  destroyed(): void;
+
+  onPointerDown(): void;
+  onPointerUp(): void;
+  onPointerMove(): void;
+  dragListener?(): void;
+
+  containerBounds: DOMRect;
+  width?: number;
+}
+
+const hook = {
+  onPointerDown(this: ResizerHook, e: any) {
+    this.containerBounds = this.container.getBoundingClientRect();
+    addDragMask();
+
+    const onMove = e => this.onPointerMove(e);
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener(
+      'pointerup',
+      () => {
+        document.removeEventListener('pointermove', onMove);
+        this.onPointerUp();
+      },
+      {
+        once: true,
+      }
+    );
+  },
+  onPointerUp(this: ResizerHook) {
+    const mask = document.getElementById('drag-mask');
+    if (mask) {
+      (mask.parentNode as HTMLElement).removeChild(mask);
+      if (this.width) {
+        localStorage.setItem('lightning.job-editor.width', `${this.width}`);
+      }
+      document.dispatchEvent(new Event('update-layout'));
+    }
+  },
+  onPointerMove(this: ResizerHook, e: any) {
+    const parent = this.el.parentNode! as HTMLElement;
+    const { width: containerWidth, left: containerLeft } = this.containerBounds;
+    if (e.screenX !== 0) {
+      // Work out the mouse position relative to the parent
+      const relativePosition = Math.max(
+        0,
+        Math.min((e.clientX - containerLeft) / containerWidth)
+      );
+      // Invert the postion
+      this.width = (1 - relativePosition) * 100;
+      // Update the width
+      parent.style.width = `${this.width}%`;
+    }
+  },
+  mounted(this: ResizerHook) {
+    const savedWidth = localStorage.getItem('lightning.job-editor.width');
+    const parent = this.el.parentNode! as HTMLElement;
+
+    let container: HTMLElement = parent;
+    while (container && !container.className.match('h-full')) {
+      container = container.parentNode as HTMLElement;
+    }
+    this.container = container;
+
+    if (parent) {
+      if (savedWidth) {
+        parent.style.width = `${savedWidth}%`;
+      }
+    }
+    this.el.addEventListener('pointerdown', e => this.onPointerDown(e));
+  },
+} as ResizerHook;
+
+export default hook;

--- a/assets/js/job-editor-resizer/mount.ts
+++ b/assets/js/job-editor-resizer/mount.ts
@@ -72,7 +72,6 @@ const hook = {
     }
   },
   mounted(this: ResizerHook) {
-    const savedWidth = localStorage.getItem('lightning.job-editor.width');
     const parent = this.el.parentNode! as HTMLElement;
 
     let container: HTMLElement = parent;
@@ -81,6 +80,7 @@ const hook = {
     }
     this.container = container;
 
+    const savedWidth = localStorage.getItem('lightning.job-editor.width');
     if (parent) {
       if (savedWidth) {
         parent.style.width = `${savedWidth}%`;

--- a/assets/js/job-editor-resizer/mount.ts
+++ b/assets/js/job-editor-resizer/mount.ts
@@ -53,6 +53,7 @@ const hook = {
       if (this.width) {
         localStorage.setItem('lightning.job-editor.width', `${this.width}`);
       }
+      // triggers a layout in monaco
       document.dispatchEvent(new Event('update-layout'));
     }
   },

--- a/assets/js/job-editor/JobEditor.tsx
+++ b/assets/js/job-editor/JobEditor.tsx
@@ -22,7 +22,7 @@ const settings = persistedSettings ? JSON.parse(persistedSettings) : {
 
 const persistSettings = () => localStorage.setItem('lightning.job-editor.settings', JSON.stringify(settings))
 
-const iconStyle = "inline cursor-pointer h-6 w-6 mr-1"
+const iconStyle = "inline cursor-pointer h-6 w-6 mr-1 hover:text-primary-600"
 
 type TabSpec = {
   label: string,
@@ -107,9 +107,11 @@ export default ({ adaptor, source, onSourceChanged }: JobEditorProps) => {
     }
   };
 
+  // Force monaco editor to re-layout
   const resize = () => {
-    // terrible solution to resizing the editor
-    document.dispatchEvent(new Event('update-layout'));
+    setTimeout(() => {
+      document.dispatchEvent(new Event('update-layout'));
+    }, 2)
   };
 
   const CollapseIcon = useMemo(() => {
@@ -146,8 +148,8 @@ export default ({ adaptor, source, onSourceChanged }: JobEditorProps) => {
           onSelectionChange={handleSelectionChange}
           verticalCollapse={!vertical && !showPanel}
         />
-        <ViewColumnsIcon className={iconStyle} onClick={toggleOrientiation} />
-        <CollapseIcon className={iconStyle} onClick={toggleShowPanel} />
+        <ViewColumnsIcon className={`${iconStyle} rotate-90`} onClick={toggleOrientiation} title="Toggle panel orientation"/>
+        <CollapseIcon className={iconStyle} onClick={toggleShowPanel} title="Collapse panel" />
       </div>
       {showPanel && 
         <div className={`flex flex-1 ${vertical ? 'overflow-auto' : 'overflow-hidden'} px-2`}>

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -42,7 +42,6 @@ export default {
     });
   },
   handleContentChange(content: string) {
-    console.log(' > ', content)
     this.pushEventTo(this.el, this.changeEvent, { source: content });
   },
   render() {

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -175,10 +175,10 @@ defmodule LightningWeb.JobLive.JobBuilder do
           </LightningWeb.Components.Common.panel_content>
           <LightningWeb.Components.Common.panel_content for_hash="editor">
             <.job_editor_component
-                adaptor={@resolved_job_adaptor}
-                source={@job_body}
-                id={"job-editor-#{@job_id}"}
-                target={@myself}
+              adaptor={@resolved_job_adaptor}
+              source={@job_body}
+              id={"job-editor-#{@job_id}"}
+              target={@myself}
             />
           </LightningWeb.Components.Common.panel_content>
           <LightningWeb.Components.Common.panel_content for_hash="output">

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -102,8 +102,9 @@ defmodule LightningWeb.WorkflowLive do
                 encoded_project_space={@encoded_project_space}
               />
             </div>
-            <div class="grow-0 w-1/2 relative">
-              <div class="absolute w-full inset-y-0 z-10">
+            <div class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]">
+              <div id="resizer" class="h-full bg-slate-200 w-4 cursor-col-resize z-11" draggable />
+              <div class="absolute w-full inset-y-0 z-10 resize-x ml-2">
                 <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
                   <.live_component
                     module={LightningWeb.JobLive.JobBuilder}

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -103,7 +103,7 @@ defmodule LightningWeb.WorkflowLive do
               />
             </div>
             <div class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]">
-              <div id="resizer" class="h-full bg-slate-200 w-4 cursor-col-resize z-11" draggable />
+              <div id="resizer" class="h-full bg-slate-200 w-4 cursor-col-resize z-11 resize-x"/>
               <div class="absolute w-full inset-y-0 z-10 resize-x ml-2">
                 <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
                   <.live_component

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -103,7 +103,10 @@ defmodule LightningWeb.WorkflowLive do
               />
             </div>
             <div class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]">
-              <div id="resizer" class="h-full bg-slate-200 w-4 cursor-col-resize z-11 resize-x"/>
+              <div
+                id="resizer"
+                class="h-full bg-slate-200 w-4 cursor-col-resize z-11 resize-x"
+              />
               <div class="absolute w-full inset-y-0 z-10 resize-x ml-2">
                 <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
                   <.live_component

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -103,11 +103,8 @@ defmodule LightningWeb.WorkflowLive do
               />
             </div>
             <div class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]">
-              <div
-                id="resizer"
-                class="h-full bg-slate-200 w-4 cursor-col-resize z-11 resize-x"
-              />
-              <div class="absolute w-full inset-y-0 z-10 resize-x ml-2">
+              <.resize_component />
+              <div class="absolute inset-y-0 left-2 right-0 z-10 resize-x ">
                 <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
                   <.live_component
                     module={LightningWeb.JobLive.JobBuilder}

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -103,7 +103,7 @@ defmodule LightningWeb.WorkflowLive do
               />
             </div>
             <div class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]">
-              <.resize_component />
+              <.resize_component id={"resizer-#{@job.id}"} />
               <div class="absolute inset-y-0 left-2 right-0 z-10 resize-x ">
                 <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
                   <.live_component

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -117,10 +117,12 @@ defmodule LightningWeb.WorkflowLive.Components do
     """
   end
 
+  attr :id, :string, required: true
+
   def resize_component(assigns) do
     ~H"""
       <div
-        id="resizer"
+        id={@id}
         phx-hook="JobEditorResizer"
         phx-update="ignore"
         class="h-full bg-slate-200 w-2 cursor-col-resize z-11 resize-x"

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -116,4 +116,15 @@ defmodule LightningWeb.WorkflowLive.Components do
     </div>
     """
   end
+
+  def resize_component(assigns) do
+    ~H"""
+      <div
+        id="resizer"
+        phx-hook="JobEditorResizer"
+        phx-update="ignore"
+        class="h-full bg-slate-200 w-2 cursor-col-resize z-11 resize-x"
+      />
+    """
+  end
 end

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -121,12 +121,13 @@ defmodule LightningWeb.WorkflowLive.Components do
 
   def resize_component(assigns) do
     ~H"""
-      <div
-        id={@id}
-        phx-hook="JobEditorResizer"
-        phx-update="ignore"
-        class="h-full bg-slate-200 w-2 cursor-col-resize z-11 resize-x"
-      />
+    <div
+      id={@id}
+      phx-hook="JobEditorResizer"
+      phx-update="ignore"
+      class="h-full bg-slate-200 w-2 cursor-col-resize z-11 resize-x"
+    >
+    </div>
     """
   end
 end


### PR DESCRIPTION
This PR implements a resizer, allowing you to change the relative sizes of the workflow diagram and the job editor.

It would close #681

This inserts a draggable div and, on when it is dragged, resizes the parent node to fit the drag position. 

A mask is inserted under the cursor to help prevent nasty interactions with the rest of the page as you drrag.

There is a min and max width set on the panel size - the max is a bit arbitrary.

Some notes:

* If you drag outside the page, page text gets select weirdly. I am unsure how to prevent this
* The size is only persisted in client javascript, so while the page is loading you may see the panel jump
* The workflow dialog looks awful when narrow but I think that's just how it is.