### PR TITLE
Lay down roles and permissions - Profile and Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Added roles and permissions to project settings page
   [#645](https://github.com/OpenFn/Lightning/issues/645)
+- Added roles and permissions to profile and credentials page
+  [#645](https://github.com/OpenFn/Lightning/issues/645)
 
 ### Changed
 

--- a/lib/lightning/policies/users.ex
+++ b/lib/lightning/policies/users.ex
@@ -7,22 +7,23 @@ defmodule Lightning.Policies.Users do
   alias Lightning.Accounts.User
 
   @type actions ::
-          :create_projects
-          | :view_projects
-          | :edit_projects
+          :access_admin_space
+          | :access_own_credentials
+          | :access_own_profile
+          | :change_email
+          | :change_password
+          | :configure_external_auth_provider
+          | :create_projects
           | :create_users
-          | :view_users
-          | :edit_users
+          | :delete_account
+          | :delete_credential
           | :delete_users
           | :disable_users
-          | :configure_external_auth_provider
+          | :edit_projects
+          | :edit_users
           | :view_credentials_audit_trail
-          | :change_password
-          | :delete_account
-          | :view_credentials
-          | :edit_credentials
-          | :delete_credential
-          | :access_admin_space
+          | :view_projects
+          | :view_users
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -37,28 +38,31 @@ defmodule Lightning.Policies.Users do
   @spec authorize(actions(), Lightning.Accounts.User.t(), any) :: boolean
   def authorize(action, %User{role: role}, _project)
       when action in [
-             :view_projects,
-             :edit_projects,
+             :access_admin_space,
+             :configure_external_auth_provider,
              :create_projects,
              :create_users,
-             :view_users,
-             :edit_users,
              :delete_users,
              :disable_users,
-             :configure_external_auth_provider,
+             :edit_projects,
+             :edit_users,
              :view_credentials_audit_trail,
-             :access_admin_space
+             :view_projects,
+             :view_users
            ] do
     role in [:superuser]
   end
 
   def authorize(action, %User{} = requesting_user, %User{} = authenticated_user)
       when action in [
+             :access_own_credentials,
+             :access_own_profile,
+             :change_email,
              :change_password,
              :delete_account,
-             :view_credentials,
+             :delete_credential,
              :edit_credentials,
-             :delete_credential
+             :view_credentials
            ] do
     requesting_user.id == authenticated_user.id
   end

--- a/lib/lightning_web/live/credential_live/edit.ex
+++ b/lib/lightning_web/live/credential_live/edit.ex
@@ -8,6 +8,7 @@ defmodule LightningWeb.CredentialLive.Edit do
   alias Lightning.Credentials
   alias Lightning.Credentials.Credential
   alias Lightning.Projects
+  alias Lightning.Policies.{Users, Permissions}
 
   @impl true
   def render(assigns) do
@@ -56,7 +57,21 @@ defmodule LightningWeb.CredentialLive.Edit do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    can_access_own_credentials =
+      Users
+      |> Permissions.can(
+        :access_own_credentials,
+        socket.assigns.current_user,
+        socket.assigns.current_user
+      )
+
+    if can_access_own_credentials do
+      {:ok, socket}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
+    end
   end
 
   @doc """

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -5,16 +5,31 @@ defmodule LightningWeb.CredentialLive.Index do
   use LightningWeb, :live_view
 
   alias Lightning.Credentials
+  alias Lightning.Policies.{Users, Permissions}
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok,
-     assign(
-       socket,
-       :credentials,
-       list_credentials(socket.assigns.current_user.id)
-     )
-     |> assign(:active_menu_item, :credentials)}
+    can_access_own_credentials =
+      Users
+      |> Permissions.can(
+        :access_own_credentials,
+        socket.assigns.current_user,
+        socket.assigns.current_user
+      )
+
+    if can_access_own_credentials do
+      {:ok,
+       assign(
+         socket,
+         :credentials,
+         list_credentials(socket.assigns.current_user.id)
+       )
+       |> assign(:active_menu_item, :credentials)}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
+    end
   end
 
   @impl true

--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -46,7 +46,6 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
         ) %>
         <Form.select_field
           form={:adaptor_picker}
-          disabled={!@adaptor_name}
           name={:adaptor_version}
           selected={@adaptor_version}
           id="adaptor-version"

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -134,7 +134,7 @@ defmodule LightningWeb.JobLive.JobBuilder do
                           update_cron_expression(@job_id, cron_expression)
                         end
                       }
-                      can_edit_job={@can_edit_job}
+                      disabled={!@can_edit_job}
                     />
                   <% end %>
                 </div>

--- a/lib/lightning_web/live/job_live/job_builder_components.ex
+++ b/lib/lightning_web/live/job_live/job_builder_components.ex
@@ -17,6 +17,7 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
   attr :form, :map, required: true
   attr :upstream_jobs, :list, required: true
   attr :on_cron_change, :any, required: true
+  attr :disabled, :boolean, default: true
 
   def trigger_picker(assigns) do
     trigger_type_options =
@@ -57,7 +58,7 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
           name={:type}
           id="triggerType"
           values={@trigger_type_options}
-          disabled={!@can_edit_job}
+          disabled={@disabled}
         />
       <% end %>
       <%= if @webhook_url do %>
@@ -84,7 +85,7 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
             prompt=""
             id="upstream-job"
             values={Enum.map(@upstream_jobs, &{&1.name, &1.id})}
-            disabled={!@can_edit_job}
+            disabled={@disabled}
           />
         <% end %>
       <% end %>

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -4,9 +4,25 @@ defmodule LightningWeb.ProfileLive.Edit do
   """
   use LightningWeb, :live_view
 
+  alias Lightning.Policies.{Users, Permissions}
+
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    can_access_own_profile =
+      Users
+      |> Permissions.can(
+        :access_own_profile,
+        socket.assigns.current_user,
+        socket.assigns.current_user
+      )
+
+    if can_access_own_profile do
+      {:ok, socket}
+    else
+      {:ok,
+       put_flash(socket, :error, "You can't access that page")
+       |> push_redirect(to: "/")}
+    end
   end
 
   @impl true

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -150,7 +150,7 @@ defmodule LightningWeb.WorkflowLive do
                   socket={@socket}
                   project={@project}
                   workflow={@current_workflow}
-                  can_create_job={@can_create_job}
+                  disabled={!@can_create_job}
                 />
               <% end %>
             </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -67,6 +67,7 @@ defmodule LightningWeb.WorkflowLive.Components do
   attr :socket, :map, required: true
   attr :project, :map, required: true
   attr :workflow, :map, required: true
+  attr :disabled, :boolean, default: true
 
   def create_job_panel(assigns) do
     ~H"""
@@ -76,7 +77,7 @@ defmodule LightningWeb.WorkflowLive.Components do
       </div>
       <LightningWeb.Components.Common.button
         phx-click="create-job"
-        disabled={!@can_create_job}
+        disabled={@disabled}
       >
         <div class="h-full">
           <Heroicons.plus class="h-4 w-4 inline-block" />

--- a/test/lightning/permissions_test.exs
+++ b/test/lightning/permissions_test.exs
@@ -31,6 +31,19 @@ defmodule Lightning.PermissionsTest do
 
       refute Users |> Permissions.can(:view_credentials_audit_trail, user, {})
 
+      refute Users
+             |> Permissions.can(:access_own_profile, user, another_user)
+
+      assert Users |> Permissions.can(:access_own_profile, user, user)
+
+      refute Users
+             |> Permissions.can(:access_own_credentials, user, another_user)
+
+      assert Users |> Permissions.can(:access_own_credentials, user, user)
+
+      refute Users |> Permissions.can(:change_email, user, another_user)
+      assert Users |> Permissions.can(:change_email, user, user)
+
       refute Users |> Permissions.can(:change_password, user, another_user)
       assert Users |> Permissions.can(:change_password, user, user)
 
@@ -66,6 +79,20 @@ defmodule Lightning.PermissionsTest do
 
       assert Users
              |> Permissions.can(:view_credentials_audit_trail, superuser, {})
+
+      refute Users
+             |> Permissions.can(:access_own_profile, superuser, another_user)
+
+      assert Users |> Permissions.can(:access_own_profile, superuser, superuser)
+
+      refute Users
+             |> Permissions.can(:access_own_credentials, superuser, another_user)
+
+      assert Users
+             |> Permissions.can(:access_own_credentials, superuser, superuser)
+
+      refute Users |> Permissions.can(:change_email, superuser, another_user)
+      assert Users |> Permissions.can(:change_email, superuser, superuser)
 
       refute Users |> Permissions.can(:change_password, superuser, another_user)
       assert Users |> Permissions.can(:change_password, superuser, superuser)

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -382,14 +382,11 @@ defmodule LightningWeb.RunWorkOrderTest do
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
 
-      div =
-        view
-        |> element(
-          "section#inner_content div[data-entity='work_order_list'] > div:first-child > div:last-child"
-        )
-        |> render()
-
-      assert div =~ "Failure"
+      assert view
+             |> has_element?(
+               "section#inner_content div[data-entity='work_order_list'] > div:first-child > div:last-child",
+               "Failure"
+             )
 
       assert view
              |> element(


### PR DESCRIPTION
## Notes for the reviewer

This PR ships the authorizations implemented for the features in admin settings context. See https://github.com/OpenFn/Lightning/pull/667 for plan, progress and more context

## Profile & Credentials page
For the following features, both super and normal users can perform them but only on their own resources.

- [x] Change your own password
- [x]  Delete your own account
- [x]  View own credentials
- [x]  Edit your own credentials
- [x]  Delete own credentials

## Related issue

Re #645 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
