### PR TITLE
Metadata CLI Service

### DIFF
--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -27,7 +27,7 @@ const spinner = (
       cy="12"
       r="10"
       stroke="currentColor"
-      stroke-width="4"
+      strokeWidth="4"
     ></circle>
     <path
       className="opacity-75"

--- a/assets/js/editor/index.tsx
+++ b/assets/js/editor/index.tsx
@@ -9,7 +9,12 @@ interface EditorEntrypoint {
   changeEvent: string;
   field?: HTMLTextAreaElement | null;
   handleContentChange(content: string): void;
-  pushEventTo(target: HTMLElement, event: string, payload: {}): void;
+  pushEventTo(
+    target: HTMLElement,
+    event: string,
+    payload: {},
+    callback?: (reply, ref) => void
+  ): void;
   mounted(): void;
   observer: MutationObserver | null;
   render(): void;
@@ -38,6 +43,10 @@ export default {
       this.setupObserver();
       this.render();
     });
+
+    this.pushEventTo(this.el, 'request_metadata', {}, (reply, ref) => {
+      console.log({ reply, ref });
+    });
   },
   handleContentChange(content: string) {
     this.pushEventTo(this.el, this.changeEvent, { source: content });
@@ -50,7 +59,7 @@ export default {
           adaptor={adaptor}
           source={source}
           onChange={src => this.handleContentChange(src)}
-          disabled={disabled == "true"}
+          disabled={disabled == 'true'}
         />
       );
     }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "lightning",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "LGPLv3",
       "dependencies": {
         "@monaco-editor/react": "^4.4.5",
         "@openfn/describe-package": "^0.0.13",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -162,6 +162,10 @@ config :lightning, LightningWeb.Endpoint,
     compress: true
   ]
 
+if log_level = System.get_env("LOG_LEVEL") do
+  config :logger, level: log_level |> String.to_atom()
+end
+
 if config_env() == :prod do
   database_url =
     System.get_env("DATABASE_URL") ||
@@ -206,10 +210,6 @@ if config_env() == :prod do
     secret_key_base: secret_key_base,
     check_origin: origins,
     server: true
-
-  if log_level = System.get_env("LOG_LEVEL") do
-    config :logger, level: log_level |> String.to_atom()
-  end
 
   # ## Using releases
   #

--- a/config/test.exs
+++ b/config/test.exs
@@ -69,3 +69,5 @@ config :lightning, LightningWeb, allow_credential_transfer: true
 config :lightning, LightningWeb,
   allow_credential_transfer: true,
   enable_google_credential: true
+
+config :lightning, CLI, child_process_mod: FakeRambo

--- a/lib/lightning/adaptor_service.ex
+++ b/lib/lightning/adaptor_service.ex
@@ -77,6 +77,12 @@ defmodule Lightning.AdaptorService do
     @moduledoc false
     require Logger
 
+    @doc """
+    List all adaptors in the given directory.
+
+    This function is called when the service starts up in order to query
+    which adaptors are already installed.
+    """
     @callback list_local(path :: String.t()) :: list(Adaptor.t())
     def list_local(path, _depth \\ 4) when is_binary(path) do
       System.cmd("npm", ~w[list --global --json --long --prefix #{path}], env: [])
@@ -86,6 +92,9 @@ defmodule Lightning.AdaptorService do
           |> String.trim()
           |> Jason.decode!()
           |> Map.get("dependencies", %{})
+          |> Map.filter(fn {local_name, _} ->
+            local_name |> String.starts_with?("@openfn")
+          end)
           |> Enum.map(fn {local_name, details} ->
             %Adaptor{
               name: details["name"],

--- a/lib/lightning/cli.ex
+++ b/lib/lightning/cli.ex
@@ -1,0 +1,107 @@
+defmodule Lightning.CLI do
+  require Logger
+  @config Application.compile_env(:lightning, CLI, child_process_mod: Rambo)
+
+  defmodule Result do
+    @type t :: %__MODULE__{
+            start_time: integer(),
+            end_time: integer(),
+            logs: list(),
+            status: integer()
+          }
+
+    defstruct start_time: nil, end_time: nil, logs: [], status: nil
+
+    def new(data) when is_map(data) do
+      struct!(__MODULE__, data)
+    end
+
+    def parse(result, extra \\ []) do
+      new(%{
+        logs: decode(result.out),
+        status: result.status,
+        start_time: extra[:start_time],
+        end_time: extra[:end_time]
+      })
+    end
+
+    def get_messages(%__MODULE__{logs: logs}) do
+      logs
+      |> Enum.reduce([], fn l, messages ->
+        if Map.keys(l) == ["message"] do
+          messages ++ l["message"]
+        else
+          messages
+        end
+      end)
+    end
+
+    defp decode(stdout) do
+      stdout
+      |> String.split("\n")
+      |> Enum.filter(&String.match?(&1, ~r/^{.+}$/))
+      |> Enum.map(&Jason.decode/1)
+      |> Enum.map(fn
+        {:ok, res} -> res
+        {:error, _} -> nil
+      end)
+      |> Enum.reject(&is_nil/1)
+    end
+  end
+
+  @spec execute(command :: String.t()) :: Result.t()
+  def execute(command) do
+    start_time = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+    {_, result} = run("/usr/bin/env", ["sh", "-c", command], opts())
+
+    end_time = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+    Result.parse(
+      result,
+      start_time: start_time,
+      end_time: end_time
+    )
+  end
+
+  @spec metadata(state :: map(), adaptor_path :: String.t()) :: Result.t()
+  def metadata(state, adaptor_path) when is_binary(adaptor_path) do
+    state = Jason.encode_to_iodata!(state)
+
+    execute(
+      ~s(openfn metadata --log-json -S '#{state}' -a #{adaptor_path} --log debug)
+    )
+  end
+
+  defp opts() do
+    adaptors_path =
+      Application.get_env(:lightning, :adaptor_service, [])
+      |> Keyword.get(:adaptors_path)
+
+    env = %{
+      "NODE_PATH" => adaptors_path,
+      "PATH" => "#{adaptors_path}/bin:#{System.get_env("PATH")}"
+    }
+
+    [timeout: nil, log: true, env: env]
+  end
+
+  defp run(command, args, opts) do
+    log_command(command, args, opts)
+    @config[:child_process_mod].run(command, args, opts)
+  end
+
+  defp log_command(command, args, opts) do
+    Logger.debug(fn ->
+      # coveralls-ignore-start
+      """
+      env:
+      #{Enum.map_join(opts[:env], " ", fn {k, v} -> "#{k}=#{v}" end)}
+      cmd:
+      #{command} #{args}
+      """
+
+      # coveralls-ignore-stop
+    end)
+  end
+end

--- a/lib/lightning/cli.ex
+++ b/lib/lightning/cli.ex
@@ -1,8 +1,42 @@
 defmodule Lightning.CLI do
+  @moduledoc """
+  Module providing facilities to make calls to the OpenFn CLI.
+
+  See [@openfn/cli](https://github.com/OpenFn/kit/tree/main/packages/cli#openfncli)
+  """
   require Logger
   @config Application.compile_env(:lightning, CLI, child_process_mod: Rambo)
 
   defmodule Result do
+    @moduledoc """
+    Struct that wraps the output of an OpenFn CLI call.
+
+    Containing the keys:
+
+    - `start_time`
+    - `end_time`
+    - `status`
+    - `logs`
+
+    ## Logs
+
+    The OpenFn CLI returns JSON formatted log lines, which are decoded and added
+    to a `Result` struct.
+
+    There are two kinds of output:
+
+    ```
+    {"level":"<<level>>","name":"<<module>>","message":"..."],"time":<<timestamp>>}
+    ```
+
+    These are usually for general logging, and debugging.
+
+    ```
+    {"message":["<<message|filepath|output>>"]}
+    ```
+
+    The above is the equivalent of the output of a command
+    """
     @type t :: %__MODULE__{
             start_time: integer(),
             end_time: integer(),
@@ -25,6 +59,10 @@ defmodule Lightning.CLI do
       })
     end
 
+    @doc """
+    Returns `message` type log lines from a `Result`.
+    """
+    @spec get_messages(Result.t()) :: [String.t()]
     def get_messages(%__MODULE__{logs: logs}) do
       logs
       |> Enum.reduce([], fn l, messages ->
@@ -49,6 +87,9 @@ defmodule Lightning.CLI do
     end
   end
 
+  @doc """
+  Execute a command in a child process and parse the results.
+  """
   @spec execute(command :: String.t()) :: Result.t()
   def execute(command) do
     start_time = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
@@ -64,6 +105,9 @@ defmodule Lightning.CLI do
     )
   end
 
+  @doc """
+  Retrieve metadata for a given adaptor and configuation.
+  """
   @spec metadata(state :: map(), adaptor_path :: String.t()) :: Result.t()
   def metadata(state, adaptor_path) when is_binary(adaptor_path) do
     state = Jason.encode_to_iodata!(state)

--- a/lib/lightning/metadata_service.ex
+++ b/lib/lightning/metadata_service.ex
@@ -1,0 +1,50 @@
+defmodule Lightning.MetadataService do
+  @moduledoc """
+  Retrieves metadata for a given credential and adaptor using the OpenFn CLI.
+  """
+
+  @adaptor_service :adaptor_service
+
+  alias Lightning.AdaptorService
+  alias Lightning.Credentials.Credential
+  alias Lightning.CLI
+
+  @doc """
+  Retrieve metadata for a given adaptor and credential.
+
+  The adaptor must be an npm specification.
+  """
+  @spec fetch(adaptor :: String.t(), Credential.t()) :: map()
+  def fetch(adaptor, %Credential{body: credential_body}) do
+    with {:ok, adaptor_path} <- get_adaptor_path(adaptor),
+         res <- CLI.metadata(credential_body, adaptor_path),
+         {:ok, path} <- get_output_path(res) do
+      path
+      |> File.read()
+      |> case do
+        {:ok, body} -> Jason.decode!(body)
+        e -> e
+      end
+    end
+  end
+
+  defp get_adaptor_path(adaptor) do
+    case AdaptorService.find_adaptor(@adaptor_service, adaptor) do
+      nil -> {:error, :no_matching_adaptor}
+      %{path: path} -> {:ok, path}
+    end
+  end
+
+  defp get_output_path(result) do
+    path =
+      result
+      |> CLI.Result.get_messages()
+      |> List.first()
+
+    if path do
+      {:ok, path}
+    else
+      {:error, :no_metadata_result}
+    end
+  end
+end

--- a/lib/lightning/metadata_service.ex
+++ b/lib/lightning/metadata_service.ex
@@ -57,7 +57,7 @@ defmodule Lightning.MetadataService do
   defp parse_body(body) do
     Jason.decode(body)
     |> case do
-      {:error, e} -> {:error, %Error{type: "invalid_json"}}
+      {:error, _error} -> {:error, %Error{type: "invalid_json"}}
       res -> res
     end
   end

--- a/lib/lightning/task_worker.ex
+++ b/lib/lightning/task_worker.ex
@@ -1,0 +1,80 @@
+defmodule Lightning.TaskWorker do
+  @moduledoc """
+  A TaskWorker with concurrency limits.
+
+  A simple concurrency limiter that wraps `Task.Supervisor`, which already does
+  have the ability to specify `max_children`; it throws an error when
+  that limit is exceeded.
+  """
+  use GenServer
+
+  @impl true
+  def init(opts \\ []) do
+    opts =
+      [max_tasks: System.schedulers_online()]
+      |> Keyword.merge(opts)
+
+    {:ok, task_sup} = Task.Supervisor.start_link()
+
+    {:ok, %{task_sup: task_sup, max_tasks: opts[:max_tasks], task_count: 0}}
+  end
+
+  @impl true
+  def handle_call(:checkout, _from, state) do
+    if state.task_count >= state.max_tasks do
+      {:reply, {:error, :too_many_processes}, state}
+    else
+      {:reply, {:ok, state.task_sup},
+       %{state | task_count: state.task_count + 1}}
+    end
+  end
+
+  def handle_call(:get_status, _from, state) do
+    {:reply, {:ok, state}, state}
+  end
+
+  @impl true
+  def handle_call(:checkin, _from, state) do
+    {:reply, :ok, %{state | task_count: state.task_count - 1}}
+  end
+
+  def start_link(opts \\ [name: nil]) do
+    {opts, init_opts} = Keyword.split(opts, [:name])
+    GenServer.start_link(__MODULE__, init_opts, opts)
+  end
+
+  @spec start_task(worker :: GenServer.name(), (() -> any)) ::
+          {:error, :too_many_processes} | any
+  def start_task(worker, fun) when is_function(fun, 0) do
+    GenServer.call(worker, :checkout)
+    |> case do
+      {:ok, task_sup} ->
+        %Task{ref: task_ref} = Task.Supervisor.async_nolink(task_sup, fun)
+
+        receive do
+          {^task_ref, res} ->
+            Process.demonitor(task_ref, [:flush])
+            # By sending another message to the server, we create a tiny buffer
+            # that slows the calls to `:checkout` which in turn gives us a tiny
+            # gap between `count_children` calls.
+            GenServer.call(worker, :checkin)
+
+            res
+
+          {:DOWN, ^task_ref, :process, _pid, reason} ->
+            GenServer.call(worker, :checkin)
+            {:error, reason}
+
+          res ->
+            res
+        end
+
+      any ->
+        any
+    end
+  end
+
+  def get_status(worker) do
+    GenServer.call(worker, :get_status)
+  end
+end

--- a/lib/lightning_web/live/job_live/job_builder.ex
+++ b/lib/lightning_web/live/job_live/job_builder.ex
@@ -286,6 +286,22 @@ defmodule LightningWeb.JobLive.JobBuilder do
     {:noreply, socket |> assign_changeset_and_params(%{"body" => source})}
   end
 
+  def handle_event("request_metadata", _params, socket) do
+    res =
+      case socket.assigns.job do
+        %{credential: nil} ->
+          %{"error" => "no_credential"}
+
+        %{adaptor: nil} ->
+          %{"error" => "no_adaptor"}
+
+        %{adaptor: adaptor, credential: credential} ->
+          Lightning.MetadataService.fetch(adaptor, credential)
+      end
+
+    {:reply, res, socket}
+  end
+
   def handle_event("open_new_credential", _params, socket) do
     LightningWeb.ModalPortal.show_modal(
       LightningWeb.CredentialLive.CredentialEditModal,

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -412,17 +412,16 @@ defmodule LightningWeb.WorkflowLive do
   end
 
   defp apply_action(socket, :edit_job, %{"job_id" => job_id}) do
-    job = Lightning.Jobs.get_job!(job_id)
-
-    %Lightning.Jobs.Job{workflow: workflow} =
-      job |> Lightning.Repo.preload(:workflow)
+    job =
+      Lightning.Jobs.get_job!(job_id)
+      |> Lightning.Repo.preload([:workflow, :credential])
 
     socket
     |> assign(
       active_menu_item: :overview,
       job: job,
-      current_workflow: workflow,
-      encoded_project_space: encode_project_space(workflow),
+      current_workflow: job.workflow,
+      encoded_project_space: encode_project_space(job.workflow),
       page_title: "Workflows"
     )
   end

--- a/lib/mix/tasks/install_runtime.ex
+++ b/lib/mix/tasks/install_runtime.ex
@@ -33,16 +33,11 @@ defmodule Mix.Tasks.Lightning.InstallRuntime do
 
     package_list = packages() |> Enum.join(" ")
 
-    System.cmd(
+    Rambo.run(
       "/usr/bin/env",
-      [
-        "sh",
-        "-c",
-        "npm install --prefix $NODE_PATH --global #{package_list}"
-      ],
-      env: [{"NODE_PATH", @default_path}],
-      stderr_to_stdout: true,
-      into: IO.stream(:stdio, :line)
+      ["sh", "-c", "npm install --prefix $NODE_PATH --global #{package_list}"],
+      log: true,
+      env: %{"NODE_PATH" => @default_path}
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -139,6 +139,7 @@ defmodule Lightning.MixProject do
       extras: [
         "README.md": [title: "Lightning"],
         "DEPLOYMENT.md": [title: "Deployment"],
+        "benchmarking/BENCHMARKING.md": [title: "Benchmarking"],
         "CHANGELOG.md": [title: "Changelog"]
       ],
       source_url: "https://github.com/OpenFn/lightning",

--- a/test/lightning/cli_test.exs
+++ b/test/lightning/cli_test.exs
@@ -1,0 +1,95 @@
+defmodule Lightning.CLITest do
+  use ExUnit.Case, async: true
+
+  alias Lightning.CLI
+
+  test "any command" do
+    CLI.execute("foo")
+
+    assert {"foo",
+            [
+              timeout: nil,
+              log: true,
+              env: %{
+                "NODE_PATH" => "./priv/openfn",
+                "PATH" => "./priv/openfn/bin:" <> _
+              }
+            ]} = expect_command()
+  end
+
+  describe "metadata/2" do
+    test "with incorrect state" do
+      state = %{"foo" => "bar"}
+      adaptor_path = "/tmp/foo"
+
+      FakeRambo.Helpers.stub_run(
+        {:ok,
+         %{
+           status: 1,
+           out:
+             "{\"level\":\"debug\",\"name\":\"CLI\",\"message\":[\"Load state...\"]}\n{\"level\":\"success\",\"name\":\"CLI\",\"message\":[\"Read state from stdin\"]}\n{\"level\":\"debug\",\"name\":\"CLI\",\"message\":[\"state:\",{}]}\n{\"level\":\"success\",\"name\":\"CLI\",\"message\":[\"Generating metadata\"]}\n{\"level\":\"info\",\"name\":\"CLI\",\"message\":[\"config:\",null]}\n",
+           err:
+             "{\"level\":\"error\",\"name\":\"CLI\",\"message\":[\"ERROR: Invalid configuration passed\"]}\n"
+         }}
+      )
+
+      res = CLI.metadata(state, adaptor_path)
+
+      expected_command =
+        ~s(openfn metadata --log-json -S '{"foo":"bar"}' -a #{adaptor_path} --log debug)
+
+      {command, opts} = expect_command()
+
+      assert command == expected_command
+
+      assert [
+               timeout: nil,
+               log: true,
+               env: %{
+                 "NODE_PATH" => "./priv/openfn",
+                 "PATH" => "./priv/openfn/bin:" <> _
+               }
+             ] = opts
+
+      assert res
+    end
+
+    test "with correct state" do
+      state = %{"foo" => "bar"}
+      adaptor_path = "/tmp/foo"
+
+      stdout = """
+      {"level":"debug","name":"CLI","message":["Load state..."],"time":1679664658127}
+      {"level":"success","name":"CLI","message":["Read state from stdin"],"time":1679664658128}
+      {"level":"debug","name":"CLI","message":["state:",{"configuration":{"hostUrl":"****","password":"****","username":"****"}}],"time":1679664658128}
+      {"level":"success","name":"CLI","message":["Generating metadata"],"time":1679664658128}
+      {"level":"info","name":"CLI","message":["config:",{"hostUrl":"https://play.dhis2.org/2.36.6","password":"district","username":"admin"}],"time":1679664658128}
+      {"level":"debug","name":"CLI","message":["config hash: ","b57c9a0c121b0a835b25436133e69221035602da3ff9981e1fcf2d6128aec622"],"time":1679664658128}
+      {"level":"debug","name":"CLI","message":["loading adaptor from","/lightning/priv/openfn/lib/node_modules/@openfn/language-dhis2-3.2.8/dist/index.cjs"],"time":1679664658129}
+      {"level":"info","name":"CLI","message":["Metadata function found. Generating metadata..."],"time":1679664658252}
+      Using latest available version of the DHIS2 api on this server.
+      Using latest available version of the DHIS2 api on this server.
+      Using latest available version of the DHIS2 api on this server.
+      {"level":"success","name":"CLI","message":"Done!"],"time":1679664662562}
+      {"message":["/tmp/openfn/repo/meta/b57c9a0c121b0a835b25436133e69221035602da3ff9981e1fcf2d6128aec622.json"]}
+      """
+
+      FakeRambo.Helpers.stub_run({:ok, %{status: 0, out: stdout, err: ""}})
+
+      res = CLI.metadata(state, adaptor_path)
+
+      assert res.status == 0
+      assert res.end_time - res.start_time >= 0
+
+      assert CLI.Result.get_messages(res) == [
+               "/tmp/openfn/repo/meta/b57c9a0c121b0a835b25436133e69221035602da3ff9981e1fcf2d6128aec622.json"
+             ]
+    end
+  end
+
+  defp expect_command() do
+    assert_received {"/usr/bin/env", ["sh", "-c", command], opts}
+
+    {command, opts}
+  end
+end

--- a/test/lightning/metadata_service_test.exs
+++ b/test/lightning/metadata_service_test.exs
@@ -25,15 +25,25 @@ defmodule Lightning.MetadataServiceTest do
     test "returns an error when the adaptor doesn't exist" do
       credential = credential_fixture()
 
-      assert {:error, :no_matching_adaptor} ==
-               MetadataService.fetch("@openfn/language-foo", credential)
+      assert MetadataService.fetch("@openfn/language-foo", credential) == {
+               :error,
+               %Lightning.MetadataService.Error{
+                 type: "no_matching_adaptor",
+                 __exception__: true
+               }
+             }
     end
 
     test "returns an error when the cli failed" do
       credential = credential_fixture()
 
-      assert MetadataService.fetch("@openfn/language-common", credential) ==
-               {:error, :no_metadata_result}
+      assert MetadataService.fetch("@openfn/language-common", credential) == {
+               :error,
+               %Lightning.MetadataService.Error{
+                 type: "no_metadata_result",
+                 __exception__: true
+               }
+             }
     end
   end
 end

--- a/test/lightning/metadata_service_test.exs
+++ b/test/lightning/metadata_service_test.exs
@@ -1,0 +1,37 @@
+defmodule Lightning.MetadataServiceTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.MetadataService
+  import Lightning.CredentialsFixtures
+
+  describe "fetch/2" do
+    test "returns the metadata when it exists" do
+      path = Temp.open!(%{suffix: ".json"}, &IO.write(&1, ~s({"foo": "bar"})))
+
+      stdout = """
+      {"message":["#{path}"]}
+      """
+
+      FakeRambo.Helpers.stub_run({:ok, %{status: 0, out: stdout, err: ""}})
+      credential = credential_fixture()
+
+      assert MetadataService.fetch("@openfn/language-common", credential) == %{
+               "foo" => "bar"
+             }
+    end
+
+    test "returns an error when the adaptor doesn't exist" do
+      credential = credential_fixture()
+
+      assert {:error, :no_matching_adaptor} ==
+               MetadataService.fetch("@openfn/language-foo", credential)
+    end
+
+    test "returns an error when the cli failed" do
+      credential = credential_fixture()
+
+      assert MetadataService.fetch("@openfn/language-common", credential) ==
+               {:error, :no_metadata_result}
+    end
+  end
+end

--- a/test/lightning/metadata_service_test.exs
+++ b/test/lightning/metadata_service_test.exs
@@ -15,9 +15,11 @@ defmodule Lightning.MetadataServiceTest do
       FakeRambo.Helpers.stub_run({:ok, %{status: 0, out: stdout, err: ""}})
       credential = credential_fixture()
 
-      assert MetadataService.fetch("@openfn/language-common", credential) == %{
-               "foo" => "bar"
-             }
+      assert MetadataService.fetch("@openfn/language-common", credential) ==
+               {:ok,
+                %{
+                  "foo" => "bar"
+                }}
     end
 
     test "returns an error when the adaptor doesn't exist" do

--- a/test/lightning/task_worker_test.exs
+++ b/test/lightning/task_worker_test.exs
@@ -1,0 +1,31 @@
+defmodule Lightning.TaskWorkerTest do
+  use ExUnit.Case, async: true
+
+  alias Lightning.TaskWorker
+
+  test "can limit how many tasks are executed at once" do
+    task_worker = start_supervised!({Lightning.TaskWorker, [max_tasks: 2]})
+
+    results =
+      Enum.map(1..5, fn i ->
+        Task.async(fn ->
+          TaskWorker.start_task(task_worker, fn ->
+            Process.sleep(1)
+            i
+          end)
+        end)
+      end)
+      |> Task.await_many(100)
+
+    assert results == [
+             1,
+             2,
+             {:error, :too_many_processes},
+             {:error, :too_many_processes},
+             {:error, :too_many_processes}
+           ]
+
+    assert {:ok, %{max_tasks: 2, task_count: 0, task_sup: _sup}} =
+             TaskWorker.get_status(task_worker)
+  end
+end

--- a/test/support/fake_rambo.ex
+++ b/test/support/fake_rambo.ex
@@ -1,0 +1,17 @@
+defmodule FakeRambo do
+  @moduledoc """
+  Mock implementation of Rambo
+
+  Uses the current process to retrieve overridden responses.
+  """
+  defmodule Helpers do
+    def stub_run(res) do
+      Process.put(:res, res)
+    end
+  end
+
+  def run(command, args, opts) do
+    send(self(), {command, args, opts})
+    Process.get(:res, {:ok, %{out: "", status: 0}})
+  end
+end


### PR DESCRIPTION
Building out a module for calling out the to OpenFn CLI getting metadata.

- [x] Limit concurrency
- [x] Call the CLI with the correct arguments.
- [ ] Provide useful errors for later use in the front end when the CLI or the CLI Worker throws errors.
- [x] Add a `handle_event` handler to the JobBuilder that can respond with metadata when requested. (to sync with @josephjclark)
- [ ] Provide a recommended path _or_ solution that caters for caching.

## Related issue

Fixes #621

## Checklist before requesting a review

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
