### PR TITLE
Default to lower log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- Set log level to `info` for runs. Most of the `debug` logging is useful for
+  the CLI, but not for Lightning. In the future the log level will be
+  configurable at instance > project > job level by the `superuser` and any
+  project `admin`.
+
 ## [0.4.6] - 2023-03-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Set log level to `info` for runs. Most of the `debug` logging is useful for
   the CLI, but not for Lightning. In the future the log level will be

--- a/lib/lightning/runtime/child_process.ex
+++ b/lib/lightning/runtime/child_process.ex
@@ -68,7 +68,7 @@ defmodule Lightning.Runtime.ChildProcess do
         {"-a", runspec.adaptor},
         {"-s", runspec.state_path},
         {"--no-strict-output", nil},
-        {"-l", "debug"},
+        {"-l", "info"},
         if(runspec.final_state_path, do: {"-o", runspec.final_state_path}),
         {runspec.expression_path, nil}
       ]


### PR DESCRIPTION
Until we can control log level for instances, projects, and jobs, we should default it to `info`. This will likely all change quickly with RTM and json logs, but for now it makes an easier to read job log experience.

cc @amberrignell 