### PR TITLE
add a BIG sleep to determine if this is a timing issue

### DIFF
--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -123,6 +123,9 @@ defmodule Lightning.FailureAlertTest do
 
       Oban.drain_queue(Oban, queue: :workflow_failures)
 
+      # TODO: remove this with https://github.com/OpenFn/Lightning/issues/693
+      Process.sleep(250)
+
       assert_receive {:email,
                       %Swoosh.Email{
                         subject: "\"workflow-a\" failed.",
@@ -154,6 +157,9 @@ defmodule Lightning.FailureAlertTest do
       Pipeline.process(attempt_run2)
 
       Oban.drain_queue(Oban, queue: :workflow_failures)
+
+      # TODO: remove this with https://github.com/OpenFn/Lightning/issues/693
+      Process.sleep(250)
 
       assert_receive {:email, %Swoosh.Email{subject: "\"workflow-a\" failed."}},
                      1000


### PR DESCRIPTION
## Notes for the reviewer

I've added back a _BIG_ `Process.sleep` to these tests because they're still flaking and re-opened this: https://github.com/OpenFn/Lightning/issues/693

We've got to hit this with a sledgehammer to figure out, conclusively, whether this is actually a timing issue or something more nefarious/logic related.

## Related issue

Fixes #666 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
