### PR TITLE
Displaying docker image tag or SHA for edge

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -13,46 +13,20 @@ if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
 end
 
 image = System.get_env("IMAGE_TAG")
-
-branch =
-  System.get_env(
-    "BRANCH",
-    System.cmd("git", ["rev-parse", "--abbrev-ref", "HEAD"])
-    |> Tuple.to_list()
-    |> Enum.at(0)
-    |> String.replace("\n", "")
-  )
-
-commit =
-  System.get_env(
-    "COMMIT",
-    System.cmd("git", ["rev-parse", "--short", "HEAD"])
-    |> Tuple.to_list()
-    |> Enum.at(0)
-    |> String.replace("\n", "")
-  )
-
-display =
-  case image do
-    nil -> commit
-    "edge" -> commit <> " (edge)"
-    image -> image
-  end
+branch = System.get_env("BRANCH")
+commit = System.get_env("COMMIT")
 
 message =
   case image do
-    nil ->
-      "Looks like you're running Lightning outside of Docker; the last commit is #{commit} on #{branch}."
-
-    image ->
-      "You are running Lightning #{image} on the 'edge'; this image was built from commit #{commit} on #{branch}."
+    nil -> "Docker image tag not found."
+    tag -> "Running Lightning #{tag}, built from #{commit} on #{branch}."
   end
 
 config :lightning, :version,
   image: image,
   branch: branch,
   commit: commit,
-  display: display,
+  display: if(image == "edge", do: commit, else: image),
   message: message
 
 config :lightning, :email_addresses,

--- a/lib/lightning_web/components/layouts/live.html.heex
+++ b/lib/lightning_web/components/layouts/live.html.heex
@@ -14,23 +14,13 @@
                 Routes.static_path(@socket || @conn, "/images/logo-white.svg")
               }
               alt="OpenFn"
-              title={
-                "#{Application.get_env(:lightning, :version)[:message]}"
-              }
             />
           </.link>
         </div>
         <%= unless assigns[:is_first_setup] do %>
           <LayoutComponents.menu_items {assigns} />
           <div class="grow"></div>
-          <div
-            class="mx-4 px-3 py-2 pl-4 text-sm font-medium block text-primary-300"
-            title={"#{Application.get_env(:lightning, :version)[:message]}"}
-          >
-            <code>
-              <%= Application.get_env(:lightning, :version)[:display] %>
-            </code>
-          </div>
+          <LightningWeb.Components.Common.version_chip />
           <%= if @current_user.role == :superuser do %>
             <Settings.menu_item to={Routes.project_index_path(@socket, :index)}>
               <Heroicons.cog class="h-5 w-5 inline-block mr-2" />

--- a/lib/lightning_web/components/layouts/live.html.heex
+++ b/lib/lightning_web/components/layouts/live.html.heex
@@ -15,7 +15,7 @@
               }
               alt="OpenFn"
               title={
-                "Lightning v#{elem(:application.get_key(:lightning, :vsn), 1)}"
+                "#{Application.get_env(:lightning, :version)[:message]}"
               }
             />
           </.link>
@@ -25,11 +25,11 @@
           <div class="grow"></div>
           <div
             class="mx-4 px-3 py-2 pl-4 text-sm font-medium block text-primary-300"
-            title={
-            "You are running Lightning version #{elem(:application.get_key(:lightning, :vsn), 1)}"
-          }
+            title={"#{Application.get_env(:lightning, :version)[:message]}"}
           >
-            v<%= elem(:application.get_key(:lightning, :vsn), 1) %>
+            <code>
+              <%= Application.get_env(:lightning, :version)[:display] %>
+            </code>
           </div>
           <%= if @current_user.role == :superuser do %>
             <Settings.menu_item to={Routes.project_index_path(@socket, :index)}>

--- a/lib/lightning_web/components/layouts/settings.html.heex
+++ b/lib/lightning_web/components/layouts/settings.html.heex
@@ -41,10 +41,10 @@
         <div
           class="mx-4 px-3 py-2 pl-4 text-sm font-medium block text-primary-300"
           title={
-            "You are running Lightning version #{elem(:application.get_key(:lightning, :vsn), 1)}"
+            "#{Application.get_env(:lightning, :version)[:message]}"
           }
         >
-          v<%= elem(:application.get_key(:lightning, :vsn), 1) %>
+          <code><%= Application.get_env(:lightning, :version)[:display] %></code>
         </div>
         <Settings.menu_item to={Routes.dashboard_index_path(@socket, :index)}>
           <Icon.left class="h-5 w-5 inline-block mr-2" />

--- a/lib/lightning_web/components/layouts/settings.html.heex
+++ b/lib/lightning_web/components/layouts/settings.html.heex
@@ -38,14 +38,7 @@
           <span class="inline-block align-middle">Audit</span>
         </Settings.menu_item>
         <div class="grow"></div>
-        <div
-          class="mx-4 px-3 py-2 pl-4 text-sm font-medium block text-primary-300"
-          title={
-            "#{Application.get_env(:lightning, :version)[:message]}"
-          }
-        >
-          <code><%= Application.get_env(:lightning, :version)[:display] %></code>
-        </div>
+        <LightningWeb.Components.Common.version_chip />
         <Settings.menu_item to={Routes.dashboard_index_path(@socket, :index)}>
           <Icon.left class="h-5 w-5 inline-block mr-2" />
           <span class="inline-block align-middle">Back</span>

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -4,6 +4,26 @@ defmodule LightningWeb.Components.Common do
 
   alias Phoenix.LiveView.JS
 
+  def version_chip(assigns) do
+    if Application.get_env(:lightning, :version)[:image] do
+      ~H"""
+      <div
+        <div
+        class="p-2 mb-1 mt-1 text-center"
+        title={
+          "#{Application.get_env(:lightning, :version)[:message]}"
+        }
+      >
+        <code class="px-2 py-1 opacity-20 text-sm font-medium bg-gray-200 rounded-md font-mono text-indigo-500">
+          <%= Application.get_env(:lightning, :version)[:display] %>
+        </code>
+      </div>
+      """
+    else
+      ~H""
+    end
+  end
+
   attr :id, :string, required: true
   attr :title, :string, required: true
   attr :class, :string, default: ""

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -5,23 +5,28 @@ defmodule LightningWeb.Components.Common do
   alias Phoenix.LiveView.JS
 
   def version_chip(assigns) do
-    if Application.get_env(:lightning, :version)[:image] do
-      ~H"""
+    ~H"""
+    <div
       <div
-        <div
-        class="p-2 mb-1 mt-1 text-center"
-        title={
-          "#{Application.get_env(:lightning, :version)[:message]}"
-        }
-      >
-        <code class="px-2 py-1 opacity-20 text-sm font-medium bg-gray-200 rounded-md font-mono text-indigo-500">
-          <%= Application.get_env(:lightning, :version)[:display] %>
-        </code>
-      </div>
-      """
-    else
-      ~H""
-    end
+      class="p-2 mb-1 mt-1 text-center"
+      title={
+        "#{Application.get_env(:lightning, :version)[:message]}"
+      }
+    >
+      <%= case Application.get_env(:lightning, :version)[:type] do %>
+        <% :release -> %>
+          <Heroicons.check_badge class="h-4 w-4 inline-block" />
+        <% :edge -> %>
+          <Heroicons.cube class="h-4 w-4 inline-block" />
+        <% :warn -> %>
+          <Heroicons.exclamation_triangle class="h-4 w-4 inline-block" />
+        <% :no_docker -> %>
+      <% end %>
+      <code class="px-2 py-1 opacity-20 text-sm font-medium bg-gray-200 rounded-md font-mono text-indigo-500">
+        <%= Application.get_env(:lightning, :version)[:display] %>
+      </code>
+    </div>
+    """
   end
 
   attr :id, :string, required: true


### PR DESCRIPTION
Display commit sha for edge, tag for tagged version, and nothing for when stuff is being run outside of an official OpenFn docker image. (I had some fancy stuff in there to grab the current SHA and BRANCH using `System.cmd("git", ...)` but it felt messy _and_ might be misleading as someone could be running via mix and have plenty of un-committed changes messing with their app.

BTW, since Docker is the recommended way to run the app this feels way better than relying on mix.exs and `:application.get_key(:lightning, :vsn)`. That could change if we move to other kinds of deployment, but Docker is pretty standard across the DPG community.