### PR TITLE
Job editor: fix collapsed panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   [657](https://github.com/OpenFn/Lightning/issues/657)
 - Clicks on the workflow canvas were not lining up with the nodes users clicked
   on; they are now [733](https://github.com/OpenFn/Lightning/issues/733)
+- Job panel behaves better when collapsed
+  [774](https://github.com/OpenFn/Lightning/issues/774)
 
 ## [0.5.0] - 2023-04-03
 

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -43,7 +43,7 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   }
   
   return (
-    <div className="block m-2 overflow-auto">
+    <div className="block m-2 w-full overflow-auto">
       <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">{name} ({version})</h1>
       <div className="text-sm mb-4">These are the operations available for this adaptor:</div>
       {functions

--- a/assets/js/job-editor/JobEditor.tsx
+++ b/assets/js/job-editor/JobEditor.tsx
@@ -41,14 +41,17 @@ const Tabs = ({ options, onSelectionChange, verticalCollapse, initialSelection }
     }
   }
 
+  const commonStyle = 'flex'
+  const horizStyle = 'flex-space-x-2 w-full'
+  const vertStyle = 'flex-space-y-2'
+
   const style = verticalCollapse ? {
     writingMode: 'vertical-rl',
     textOrientation: 'mixed'
   } : {};
 
   return (
-    <nav className={`flex space-${verticalCollapse?'y':'x'}-2 w-full`} aria-label="Tabs" style={style}>
-       {/* TODO need to support more information in each tab */}
+    <nav className={`${commonStyle} ${verticalCollapse ? vertStyle : horizStyle}`} aria-label="Tabs" style={style}>
        {options.map(({ label, id, icon }) => {
           const style = id === selected ? 
             'bg-primary-50 text-gray-700' : 'text-gray-400 hover:text-gray-700'
@@ -117,7 +120,6 @@ export default ({ adaptor, source, disabled, metadata, onSourceChanged }: JobEdi
     }
   }, [vertical, showPanel])
 
-  // TODO too many complex style rules embedded in this - is there a better approach?
   return (<>
   <div className="cursor-pointer" >
   </div>
@@ -128,7 +130,7 @@ export default ({ adaptor, source, disabled, metadata, onSourceChanged }: JobEdi
     <div className={`${showPanel ? 'flex flex-col flex-1 overflow-auto' : ''} bg-white`}>
       <div className={
         ['flex',
-        `flex-${!vertical && !showPanel ? 'col-reverse items-center' : 'row'}`,
+        !vertical && !showPanel ? 'flex-col-reverse items-center' : 'flex-row',
         'w-full',
         'justify-items-end',
         'sticky',
@@ -143,8 +145,10 @@ export default ({ adaptor, source, disabled, metadata, onSourceChanged }: JobEdi
           onSelectionChange={handleSelectionChange}
           verticalCollapse={!vertical && !showPanel}
         />
-        <ViewColumnsIcon className={`${iconStyle} rotate-90`} onClick={toggleOrientiation} title="Toggle panel orientation"/>
-        <CollapseIcon className={iconStyle} onClick={toggleShowPanel} title="Collapse panel" />
+        <div className={`flex select-none flex-1 text-right py-2 ${!showPanel && !vertical? 'px-2 flex-col-reverse' : 'flex-row'}`}>
+          <ViewColumnsIcon className={`${iconStyle} ${!vertical ? 'rotate-90' : ''}`} onClick={toggleOrientiation} title="Toggle panel orientation"/>
+          <CollapseIcon className={iconStyle} onClick={toggleShowPanel} title="Collapse panel" />
+        </div>
       </div>
       {showPanel && 
         <div className={`flex flex-1 ${vertical ? 'overflow-auto' : 'overflow-hidden'} px-2`}>


### PR DESCRIPTION
Fix a few layout issues in the new-look job editor:

* The tabs now properly collapse in vertical layout to be just one column (with the expand toggle at the top)
* The orientation/collapse icons look a little nicer in row/horizontal layout
* Adaptor docs now fills the space properly in column layout

![image](https://user-images.githubusercontent.com/7052509/230338494-8bb9af6b-b15d-4f48-a948-e9b6e3004fad.png)
![image](https://user-images.githubusercontent.com/7052509/230338528-6035a4ef-56a3-45c5-ba04-51c3a60d8706.png)


## Related issue

Fixes #774

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
