### PR TITLE
add missing changelog entry and link to app in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   save new or updated jobs job panel will _not_ close. (Click elsewhere in the
   canvas or click the "Close" button to close.)
   [#568](https://github.com/OpenFn/Lightning/issues/568)
+- Add filtered search params to the history page URL
+  [#660](https://github.com/OpenFn/Lightning/issues/660)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,23 @@ Use Lightning to visually build, execute and manage workflows.
 
 ![Screenshot 2023-03-15 at 13 01 13](https://user-images.githubusercontent.com/36554605/225275565-99c94f3b-3057-4185-9086-58015c28e77f.png)
 
-## Demo 
+## Demo
 
 Watch a quick demo here: https://www.youtube.com/watch?v=BNaxlHAWb5I
 
-Explore our [demo app*](https://demo.openfn.org/) with username:
+Explore our [demo app\*](https://demo.openfn.org/) with username:
 `demo@openfn.org`, password: `welcome123`, or read through the
-[features](#features) section to view screenshots of the app. 
+[features](#features) section to view screenshots of the app.
 
-_*Note that the demo app refreshes daily, so do not configure workflows you want to save._
+_\*Note that the demo app refreshes daily, so do not configure workflows you
+want to save._
+
+## Register for a Beta account
+
+Register for a Beta account at [app.openfn.org](https://app.openfn.org/) and go
+through the
+[quick-start guide](https://docs.openfn.org/documentation/build/lightning-quick-start)
+to get familiar with the app.
 
 ## README Contents
 


### PR DESCRIPTION
@taylordowns2000 adding a link to app.openfn.org and the quick start guide in the readme, plus a missing changelog entry for the search history url params
