### PR TITLE
Link runs directly to credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 - Add `workflow_edges` table in preparation for new workflow editor
   implementation [#794](https://github.com/OpenFn/Lightning/issues/794)
+- Stamped `credential_id` on run directly for easier auditing of the history
+  interface. Admins can now see which credential was used to run a run.
+  [#800](https://github.com/OpenFn/Lightning/issues/800)
 
 ### Changed
 

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -11,6 +11,7 @@ defmodule Lightning.Invocation.Run do
 
   alias Lightning.Invocation.Dataclip
   alias Lightning.Jobs.Job
+  alias Lightning.Credentials.Credential
   alias Lightning.{AttemptRun, Attempt}
 
   @type t :: %__MODULE__{
@@ -27,6 +28,7 @@ defmodule Lightning.Invocation.Run do
     field :log, {:array, :string}
     field :started_at, :utc_datetime_usec
     belongs_to :job, Job
+    belongs_to :credential, Credential
 
     belongs_to :input_dataclip, Dataclip
     belongs_to :output_dataclip, Dataclip
@@ -68,6 +70,7 @@ defmodule Lightning.Invocation.Run do
       :started_at,
       :finished_at,
       :job_id,
+      :credential_id,
       :input_dataclip_id,
       :output_dataclip_id
     ])

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -233,15 +233,35 @@ defmodule LightningWeb.RunLive.Components do
           "Not started."
       end
 
+    run_credential =
+      if Ecto.assoc_loaded?(run.credential) && run.credential,
+        do: "#{run.credential.name} (owned by #{run.credential.user.email})",
+        else: nil
+
+    run_job =
+      if Ecto.assoc_loaded?(run.job) && run.job,
+        do: "#{run.job.name}",
+        else: run.job_id
+
     assigns =
       assigns
       |> assign(
         run_finished_at: run_finished_at,
+        run_credential: run_credential,
+        run_job: run_job,
         ran_for: ran_for
       )
 
     ~H"""
     <div class="flex flex-col gap-2">
+      <div class="flex gap-4 flex-row text-sm" id={"job-#{@run.id}"}>
+        <div class="basis-1/2 font-semibold text-secondary-700">Job</div>
+        <div class="basis-1/2 text-right"><%= @run_job %></div>
+      </div>
+      <div class="flex gap-4 flex-row text-sm" id={"job-#{@run.id}"}>
+        <div class="basis-1/2 font-semibold text-secondary-700">Credential</div>
+        <div class="basis-1/2 text-right"><%= @run_credential || "n/a" %></div>
+      </div>
       <div class="flex gap-4 flex-row text-sm" id={"finished-at-#{@run.id}"}>
         <div class="basis-1/2 font-semibold text-secondary-700">Finished</div>
         <div class="basis-1/2 text-right"><%= @run_finished_at %></div>

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -238,10 +238,7 @@ defmodule LightningWeb.RunLive.Components do
         do: "#{run.credential.name} (owned by #{run.credential.user.email})",
         else: nil
 
-    run_job =
-      if Ecto.assoc_loaded?(run.job) && run.job,
-        do: "#{run.job.name}",
-        else: run.job_id
+    run_job = get_in(run, [Access.key!(:job), Access.key(:name, run.job_id)])
 
     assigns =
       assigns

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -29,7 +29,7 @@ defmodule LightningWeb.RunLive.Show do
     run =
       from(r in Run,
         where: r.id == ^id,
-        preload: [:output_dataclip, :input_dataclip]
+        preload: [:output_dataclip, :input_dataclip, :job, [credential: [:user]]]
       )
       |> Lightning.Repo.one()
 

--- a/priv/repo/migrations/20230419234837_add_credential_id_to_runs.exs
+++ b/priv/repo/migrations/20230419234837_add_credential_id_to_runs.exs
@@ -1,0 +1,11 @@
+defmodule Lightning.Repo.Migrations.AddCredentialIdToRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      add(:credential_id, references(:credentials, on_delete: :nothing, type: :binary_id),
+        null: true
+      )
+    end
+  end
+end

--- a/test/lightning/pipeline_test.exs
+++ b/test/lightning/pipeline_test.exs
@@ -86,16 +86,18 @@ defmodule Lightning.PipelineTest do
           body: ~s[fn(state => { return {...state, extra: "data"} })]
         )
 
+      %{id: project_credential_id, credential_id: credential_id} =
+        project_credential_fixture(
+          name: "my credential",
+          body: %{"apiToken" => "secret123"}
+        )
+
       %{id: _downstream_job_id} =
         job_fixture(
           trigger: %{type: :on_job_success, upstream_job_id: job.id},
           body: ~s[fn(state => state)],
           workflow_id: job.workflow_id,
-          project_credential_id:
-            project_credential_fixture(
-              name: "my credential",
-              body: %{"credential" => "body"}
-            ).id
+          project_credential_id: project_credential_id
         )
 
       %{id: _disabled_downstream_job_id} =
@@ -149,6 +151,8 @@ defmodule Lightning.PipelineTest do
         |> Repo.one!()
 
       assert expected_run.input_dataclip_id == output_dataclip_id
+
+      assert expected_run.credential_id == credential_id
 
       assert %{
                "data" => %{}

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -73,9 +73,6 @@ defmodule Lightning.Factories do
   defp put_assocs(changeset, %{__struct__: struct} = record) do
     struct.__schema__(:associations)
     |> Enum.reduce(changeset, fn association_name, changeset ->
-      # association = struct.__schema__(:association, association_name)
-      # IO.inspect({association, Map.get(record, association_name)})
-
       case Map.get(record, association_name) do
         %Ecto.Association.NotLoaded{} ->
           changeset

--- a/test/support/fixtures/jobs_fixtures.ex
+++ b/test/support/fixtures/jobs_fixtures.ex
@@ -6,6 +6,7 @@ defmodule Lightning.JobsFixtures do
 
   import Lightning.ProjectsFixtures
   import Lightning.WorkflowsFixtures
+  import Lightning.CredentialsFixtures
 
   @doc """
   Generate a job.
@@ -48,6 +49,12 @@ defmodule Lightning.JobsFixtures do
         [:project_id, :id, :name]
       )
 
+    project_credential =
+      project_credential_fixture(
+        name: "my first cred",
+        body: %{"shhh" => "secret-stuff"}
+      )
+
     attrs =
       attrs
       |> Enum.into(%{
@@ -55,6 +62,7 @@ defmodule Lightning.JobsFixtures do
         enabled: true,
         name: "some name",
         adaptor: "@openfn/language-common",
+        project_credential_id: project_credential.id,
         trigger: %{type: "webhook"}
       })
 


### PR DESCRIPTION
## Notes for the reviewer

@stuartc , this is a funky one with implications here on #800 and also on #799. I think that stamping the `credential_id` onto the run (for now with the on_start call, later with some even emitted from the RTM) is actually a really reasonable part of our usability/history (for audit) generation.

This gets around the frustration our v1 users have when they don't know which credential was used for a particular run if the job's credential has been changed recently. Note that it doesn't help you instantly see when a credential itself has been edited, but that can be done via the audit trail and this makes that journey to discovery easier.

<img width="798" alt="image" src="https://user-images.githubusercontent.com/8732845/233354484-c5108a2a-890b-445a-a317-9aa4442cab6e.png">


see #799 for why users _cant_ be deleted if their credentials have been used in runs that still exist on the system.

## Related issue

Fixes #800 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
