### PR TITLE
Test if a user can delete account that’s not theirs

### DIFF
--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -148,7 +148,7 @@ defmodule LightningWeb.ProfileLiveTest do
 
     test "allows a user to schedule their own account for deletion", %{
       conn: conn,
-      user: user
+      user: {user, user2}
     } do
       {:ok, profile_live, html} =
         live(conn, Routes.profile_edit_path(conn, :edit))
@@ -182,6 +182,22 @@ defmodule LightningWeb.ProfileLiveTest do
       )
       |> render_submit()
       |> follow_redirect(conn, Routes.user_session_path(conn, :delete))
+
+      {:ok, new_live, _html} =
+        profile_live
+        |> element("a", "Delete my account")
+        |> render_click()
+        |> follow_redirect(
+          conn,
+          Routes.profile_edit_path(conn, :delete, user2)
+        )
+
+      assert new_live
+             |> form("#scheduled_deletion_form",
+               user: user.email
+             )
+             |> render_change() =~
+               "This email doesn&#39;t match your current email"
 
       assert_email_sent(subject: "Lightning Account Deletion", to: user.email)
     end


### PR DESCRIPTION
## Notes for the reviewer

Assert that validation shows up on the form and user unable to delete an account that’s not theirs

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
