### PR TITLE
Generate a random name when creating a Workflow via the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Generate a random name for Workflows when creating one via the UI.
+  [#828](https://github.com/OpenFn/Lightning/issues/828)
+
 ## [0.5.2]
 
 ### Added

--- a/lib/lightning/name.ex
+++ b/lib/lightning/name.ex
@@ -1,0 +1,35 @@
+defmodule Lightning.Name do
+  @moduledoc """
+  Generates a random names.
+  """
+
+  @adjectives ~w(
+    autumn hidden bitter misty silent empty dry dark summer
+    icy delicate quiet white cool spring winter patient
+    twilight dawn crimson wispy weathered blue billowing
+    broken cold damp falling frosty green long late lingering
+    bold little morning muddy old red rough still small
+    sparkling throbbing shy wandering withered wild black
+    young holy solitary fragrant aged snowy proud floral
+    restless divine polished ancient purple lively nameless
+  )
+
+  @nouns ~w(
+    waterfall river breeze moon rain wind sea morning
+    snow lake sunset pine shadow leaf dawn glitter forest
+    hill cloud meadow sun glade bird brook butterfly
+    bush dew dust field fire flower firefly feather grass
+    haze mountain night pond darkness snowflake silence
+    sound sky shape surf thunder violet water wildflower
+    wave water resonance sun wood dream cherry tree fog
+    frost voice paper frog smoke star hamster
+  )
+
+  def generate(max_id \\ 9999) do
+    adjective = @adjectives |> Enum.random()
+    noun = @nouns |> Enum.random()
+    id = :rand.uniform(max_id)
+
+    [adjective, noun, id] |> Enum.join("-")
+  end
+end

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -225,7 +225,7 @@ defmodule LightningWeb.WorkflowLive do
     {:ok, %Workflows.Workflow{id: workflow_id}} =
       Workflows.create_workflow(%{
         project_id: socket.assigns.project.id,
-        name: "Untitled"
+        name: Lightning.Name.generate()
       })
 
     {:noreply,


### PR DESCRIPTION
Adds a `Lightning.Name` module that generates Heroku-style names.

## Notes for the reviewer

![image_720](https://github.com/OpenFn/Lightning/assets/144796/6da5306f-3b91-41d1-bfba-fcb4ae22c287)

I think the new module will cause our coverage to drop, but I'm not concerned - and testing `Lightning.Name` would be super tedious and arguably not prove much.

## Related issue

Fixes #828 

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
