### PR TITLE
New Workflow

### DIFF
--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -24,7 +24,6 @@ const calculateLayout = (
   onComplete
 ) => {
   const { nodes, edges } = model;
-  console.log(model);
   const hierarchy = stratify<Node>()
     .id(d => d.id)
     // get the id of each node by searching through the edges

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -24,6 +24,7 @@ const calculateLayout = (
   onComplete
 ) => {
   const { nodes, edges } = model;
+  console.log(model);
   const hierarchy = stratify<Node>()
     .id(d => d.id)
     // get the id of each node by searching through the edges

--- a/assets/js/workflow-diagram/util/get-trigger-labels.ts
+++ b/assets/js/workflow-diagram/util/get-trigger-labels.ts
@@ -7,6 +7,13 @@ type TriggerLabels = {
 };
 
 export default ({ trigger }: TriggerNode): TriggerLabels => {
+  if (!trigger.webhookUrl && !trigger.cronExpression) {
+    return {
+      label: 'New Trigger',
+      tooltip: '',
+    };
+  }
+
   switch (trigger.type) {
     case 'webhook':
       return {

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -14,6 +14,7 @@ const identifyPlaceholders = (store: Store) => {
   const { jobs, triggers, edges } = store;
   
   const newJobs = jobs.map((item) => {
+    // TODO placeholder triggers don't have a cron/webhook type yet
     if (!item.name && !item.expression) {
       return {
         ...item,

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -31,6 +31,27 @@ interface WorkflowEditorEntrypoint extends PhoenixHook {
   selectJob(id: string): void;
 }
 
+const createNewWorkflow = () => {
+  const triggers = [
+    {
+      id: crypto.randomUUID(),
+    },
+  ];
+  const jobs = [
+    {
+      id: crypto.randomUUID(),
+    },
+  ];
+  const edges = [
+    {
+      id: crypto.randomUUID(),
+      source_trigger_id: triggers[0].id,
+      target_job_id: jobs[0].id,
+    },
+  ];
+  return { triggers, jobs, edges };
+};
+
 export default {
   mounted(this: WorkflowEditorEntrypoint) {
     this._pendingWorker = Promise.resolve();
@@ -51,6 +72,7 @@ export default {
 
     // Get the initial data from the server
     this.pushEventTo(this.el, 'get-initial-state', {}, (payload: any) => {
+      console.log(payload);
       this.workflowStore = createWorkflowStore(
         { ...payload, editJobUrl: this.editJobUrl },
         pendingChange => {
@@ -59,6 +81,12 @@ export default {
           this.processPendingChanges();
         }
       );
+
+      if (!payload.triggers.length && !payload.jobs.length) {
+        // Create a placeholder chart and push it back up to the server
+        const diff = createNewWorkflow();
+        this.workflowStore.getState().add(diff);
+      }
 
       this.componentModule.then(({ mount }) => {
         const onSelectionChange = (id?: string) => {

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -72,7 +72,6 @@ export default {
 
     // Get the initial data from the server
     this.pushEventTo(this.el, 'get-initial-state', {}, (payload: any) => {
-      console.log(payload);
       this.workflowStore = createWorkflowStore(
         { ...payload, editJobUrl: this.editJobUrl },
         pendingChange => {


### PR DESCRIPTION
Really simple stub for a new workflow, using a  "placeholder" sort of chart ready for the user to edit.

![Screenshot from 2023-05-16 11-39-48](https://github.com/OpenFn/Lightning/assets/7052509/e89a9a74-02cd-4c37-8bf7-04503bbe0279)

It doesn't do very much yet because trigger nodes aren't editable. Also you have to sub out the data in `workflow_live_new.ex` to see it,

This is all driven by the client: when an empty workflow is received, the client generates new placeholder nodes and pushes them into the store.

Once consequence of this is that the workflow is posted back to the server as soon as it's created. Given that this solution is 90% data driven I really think the server should be creating the default chart. If we wanted to do something more elaborate in the client then maybe the onus comes back down.