### PR TITLE
Better placeholders

### DIFF
--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -8,7 +8,7 @@ import createCompletionProvider from './magic-completion';
 // static imports for core lib
 import dts_es5 from './lib/es5.min.dts';
 
-const DEFAULT_TEXT = '// Get started by adding operations from the API reference\n';
+export const DEFAULT_TEXT = '// Get started by adding operations from the API reference\n';
 
 type EditorProps = {
   source?: string;

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -3,7 +3,7 @@ import ReactFlow, { Node, ReactFlowProvider,  applyNodeChanges, ReactFlowInstanc
 
 import layout from './layout'
 import nodeTypes from './nodes';
-import * as placeholder from './util/add-placeholder';
+import * as placeholder from './util/placeholder';
 import fromWorkflow from './util/from-workflow';
 import toWorkflow from './util/to-workflow';
 import throttle from './util/throttle';

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -102,6 +102,11 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
     // We nee to ignore this
     chartCache.current.ignoreNextSelection = true
 
+    // If the editor is currently open, update the selection to show the new node
+    if (chartCache.current.selectedId) {
+      chartCache.current.deferSelection = diff.nodes[0].id
+    }
+
     // Mark the new node as selected for the next render
     chartCache.current.selectedId = diff.nodes[0].id
 

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -87,7 +87,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>((props, ref) 
 
     // reactflow will fire a selection change event after the click
     // (regardless of whether the node is selected)
-    // We nee to ignore this
+    // We need to ignore this
     chartCache.current.ignoreNextSelection = true
 
     // If the editor is currently open, update the selection to show the new node

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -26,7 +26,7 @@ type ChartCache = {
   deferSelection?: string;
 }
 
-export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
+export default React.forwardRef<HTMLElement, WorkflowDiagramProps>((props, ref) => {
   const { workflow, onAdd, onChange, onSelectionChange } = props;
   const [model, setModel] = useState<Flow.Model>({ nodes: [], edges: [] });
   
@@ -37,8 +37,6 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
     selectedId: undefined,
     ignoreNextSelection: false,
   })
-
-  const root = useRef<HTMLElement>()
 
   const [flow, setFlow] = useState<ReactFlowInstance>();
 
@@ -54,11 +52,8 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
     const newModel = fromWorkflow(workflow, positions, selectedId);
 
     //console.log('UPDATING WORKFLOW', newModel, selectedId);
-    console.log(workflow)
     if (flow && newModel.nodes.length) {
       layout(newModel, setModel, flow, 200).then((positions) => {
-        console.log(positions)
-        
         // trigger selection on new nodes once they've been passed back through to us
         if (chartCache.current.deferSelection) {
           onSelectionChange(chartCache.current.deferSelection)
@@ -117,17 +112,16 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
   }, [onChange]);
 
   useEffect(() => {
-    if (root.current) {
-      
-      root.current.addEventListener<any>('commit-placeholder', commitNode);
+    if (ref) {
+      ref.addEventListener<any>('commit-placeholder', commitNode);
 
       return () => {
-        if (root.current) {
-          root.current.removeEventListener<any>('commit-placeholder', commitNode);
+        if (ref) {
+          ref.removeEventListener<any>('commit-placeholder', commitNode);
         }
       }
     }
-  }, [commitNode, root])
+  }, [commitNode, ref])
 
   // Note that we only support a single selection
   const handleSelectionChange = useCallback(({ nodes, edges }: Flow.Model) => {
@@ -171,22 +165,20 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
   
   return (
     <ReactFlowProvider>
-      <div className="relative h-full flex" ref={root}> 
-        <ReactFlow
-          proOptions={{ account: 'paid-pro', hideAttribution: true }}
-          nodes={model.nodes}
-          edges={model.edges}
-          onSelectionChange={handleSelectionChange}
-          onNodesChange={onNodesChange}
-          nodesDraggable={false}
-          nodeTypes={nodeTypes}
-          onNodeClick={handleNodeClick}
-          onInit={setFlowInstance}
-          deleteKeyCode={null}
-          fitView
-          fitViewOptions={{ padding: FIT_PADDING }}
-        />
-      </div>
+      <ReactFlow
+        proOptions={{ account: 'paid-pro', hideAttribution: true }}
+        nodes={model.nodes}
+        edges={model.edges}
+        onSelectionChange={handleSelectionChange}
+        onNodesChange={onNodesChange}
+        nodesDraggable={false}
+        nodeTypes={nodeTypes}
+        onNodeClick={handleNodeClick}
+        onInit={setFlowInstance}
+        deleteKeyCode={null}
+        fitView
+        fitViewOptions={{ padding: FIT_PADDING }}
+      />
     </ReactFlowProvider>
   );
 })

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -12,10 +12,11 @@ import throttle from './util/throttle';
 type WorkflowDiagramProps = {
   workflow: Workflow;
   onSelectionChange: (id: string) => void;
-  requestChange: () => void;
+  onAdd: (diff: Partial<Workflow>) => void;
+  onChange: (diff: Partial<Workflow>) => void;
 }
 export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
-  const { workflow, requestChange, onSelectionChange } = props;
+  const { workflow, onAdd, onChange, onSelectionChange } = props;
   const [model, setModel] = useState({ nodes: [], edges: [] });
   
   // Track positions and selection on a ref, as a passive cache, to prevent re-renders
@@ -35,8 +36,8 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
         // Select the placeholder on next render
         chartCache.current.deferSelection = id;
 
-        // Update the store (TODO signature is awful)
-        requestChange?.('change', [id, 'jobs', { name }]);
+        // Update the store
+        onChange?.({ jobs: [{ id, name }]});
       };
       root.current.addEventListener('commit-placeholder', fn);
 
@@ -108,8 +109,8 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
     chartCache.current.selectedId = diff.nodes[0].id
 
     // Push the changes
-    requestChange?.('add', toWorkflow(diff));
-  }, [requestChange]);
+    onAdd?.(toWorkflow(diff));
+  }, [onAdd]);
 
   // Note that we only support a single selection
   const handleSelectionChange = useCallback(({ nodes, edges }) => {

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -12,7 +12,7 @@ import throttle from './util/throttle';
 type WorkflowDiagramProps = {
   workflow: Workflow;
   onSelectionChange: (id: string) => void;
-  requestChange: (id: string) => void;
+  requestChange: () => void;
 }
 export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
   const { workflow, requestChange, onSelectionChange } = props;
@@ -25,6 +25,29 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
     selectedId: undefined,
     ignoreNextSelection: undefined, // awful workaround because I can't control selection
   })
+
+  const root = useRef()
+
+  useEffect(() => {
+    if (root.current) {
+      const fn = (evt) => {
+        const { id, name } = evt.detail;
+        // Select the placeholder on next render
+        chartCache.current.deferSelection = id;
+
+        // Update the store (TODO signature is awful)
+        requestChange?.('change', [id, 'jobs', { name }]);
+
+      };
+      root.current.addEventListener('commit-placeholder', fn);
+
+      return () => {
+        if (root.current) {
+          root.current.removeEventListener('commit-placeholder', fn);
+        }
+      }
+    }
+  }, [root])
 
   const [flow, setFlow] = useState<ReactFlowInstance>();
 
@@ -45,7 +68,6 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
         
         // trigger selection on new nodes once they've been passed back through to us
         if (chartCache.current.deferSelection) {
-          console.log('defer selection')
           onSelectionChange(chartCache.current.deferSelection)
           delete chartCache.current.deferSelection;
         }
@@ -64,21 +86,6 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
       setModel({ nodes: newNodes, edges: model.edges });
     }, [setModel, model]);
 
-  const handleKeyDown = useCallback((evt) => {
-    if (evt.code === 'Enter') {
-      const id = evt.target.dataset.placeholder;
-      console.log('trap enter', id)
-      if (id) {
-        // This is so messy.... we're fighting react-flow's native selection
-        // After ENTER was pressed on a placeholder, but before the change is commited,
-        // When the next chart comes in, we need to ensure this new node is selected
-        chartCache.current.selectedId = id;
-        chartCache.current.deferSelection = id;
-        // ... but we also need to ignore the event that comes out of react-flow itself
-        chartCache.current.ignoreNextSelection = true
-      }
-    }
-  }, [chartCache]);
 
   const handleNodeClick = useCallback((event: React.MouseEvent, node: Node<NodeData>) => {
     event.stopPropagation();
@@ -92,28 +99,19 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
   const addNode = useCallback((parentNode: Node) => {
     // Generate a placeholder node and edge
     const diff = placeholder.add(model, parentNode);
-    // const newNode = diff.nodes[0];
-
-    // Don't change selection right now until the placeholder is converted
     
     // reactflow will fire a selection change event after the click
     // (regardless of whether the node is selected)
-    // We essentially want to ignore that change and set the new placeholder as the selection
+    // We nee to ignore this
     chartCache.current.ignoreNextSelection = true
-    // chartCache.current.selectedId = newNode.id;
 
-    // Request a selection change when the node is passed back in
-    // We have to do this because of how Lightning handles selection through the URL
-    // (if we send the change too early, Lightning won't see the node and can't select it)
-    // chartCache.current.deferSelection = newNode.id;
-
-    // Push the changes to Lightning
-    requestChange?.(toWorkflow(diff));
+    // Push the changes
+    requestChange?.('add', toWorkflow(diff));
   }, [requestChange]);
 
   // Note that we only support a single selection
   const handleSelectionChange = useCallback(({ nodes, edges }) => {
-    console.log('> handleSelectionChange', nodes.map(({ id }) => id))
+    // console.log('> handleSelectionChange', nodes.map(({ id }) => id))
     const { selectedId, ignoreNextSelection } = chartCache.current;
     const newSelectedId = nodes.length ? nodes[0].id : (edges.length ? edges[0].id : undefined)
     if (ignoreNextSelection) {
@@ -151,21 +149,24 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
     }
   }, [flow, ref]);
   
-  return <ReactFlowProvider>
-      <ReactFlow
-        proOptions={{ account: 'paid-pro', hideAttribution: true }}
-        nodes={model.nodes}
-        edges={model.edges}
-        onSelectionChange={handleSelectionChange}
-        onNodesChange={onNodesChange}
-        nodesDraggable={false}
-        nodeTypes={nodeTypes}
-        onNodeClick={handleNodeClick}
-        onKeyUp={handleKeyDown}
-        onInit={setFlowInstance}
-        deleteKeyCode={null}
-        fitView
-        fitViewOptions={{ padding: FIT_PADDING }}
-      />
+  return (
+    <ReactFlowProvider>
+      <div className="relative h-full flex" ref={root}> 
+        <ReactFlow
+          proOptions={{ account: 'paid-pro', hideAttribution: true }}
+          nodes={model.nodes}
+          edges={model.edges}
+          onSelectionChange={handleSelectionChange}
+          onNodesChange={onNodesChange}
+          nodesDraggable={false}
+          nodeTypes={nodeTypes}
+          onNodeClick={handleNodeClick}
+          onInit={setFlowInstance}
+          deleteKeyCode={null}
+          fitView
+          fitViewOptions={{ padding: FIT_PADDING }}
+        />
+      </div>
     </ReactFlowProvider>
+  );
 })

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -37,7 +37,6 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
 
         // Update the store (TODO signature is awful)
         requestChange?.('change', [id, 'jobs', { name }]);
-
       };
       root.current.addEventListener('commit-placeholder', fn);
 
@@ -99,11 +98,14 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
   const addNode = useCallback((parentNode: Node) => {
     // Generate a placeholder node and edge
     const diff = placeholder.add(model, parentNode);
-    
+
     // reactflow will fire a selection change event after the click
     // (regardless of whether the node is selected)
     // We nee to ignore this
     chartCache.current.ignoreNextSelection = true
+
+    // Mark the new node as selected for the next render
+    chartCache.current.selectedId = diff.nodes[0].id
 
     // Push the changes
     requestChange?.('add', toWorkflow(diff));

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -11,13 +11,13 @@ import { DEFAULT_TEXT } from '../editor/Editor';
 
 import { FIT_DURATION, FIT_PADDING } from './constants';
 import type { Lightning, Flow, Positions } from './types';
-import { RemoveArgs } from '../workflow-editor/store';
+import { AddArgs, ChangeArgs, RemoveArgs } from '../workflow-editor/store';
 
 type WorkflowDiagramProps = {
   workflow: Lightning.Workflow;
   onSelectionChange: (id?: string) => void;
-  onAdd: (diff: Partial<Lightning.Workflow>) => void;
-  onChange: (diff: { jobs: Array<Partial<Lightning.JobNode>>}) => void;
+  onAdd: (diff: AddArgs) => void;
+  onChange: (diff: ChangeArgs) => void;
   onRemove: (diff: RemoveArgs) => void;
 }
 
@@ -77,13 +77,13 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>((props, ref) 
     }, [setModel, model]);
 
 
-  const handleNodeClick = useCallback((event: React.MouseEvent, node: Lightning.Node) => {
+  const handleNodeClick = useCallback((event: React.MouseEvent, node: Flow.Node) => {
     if ((event.target as HTMLElement).closest('[name=add-node]')) {
       addNode(node);
     }
   }, [model])
   
-  const addNode = useCallback((parentNode: Lightning.Node) => {
+  const addNode = useCallback((parentNode: Flow.Node) => {
     // Generate a placeholder node and edge
     const diff = placeholder.add(model, parentNode);
 

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -88,11 +88,8 @@ export default React.forwardRef<Element, WorkflowDiagramProps>((props, ref) => {
 
 
   const handleNodeClick = useCallback((event: React.MouseEvent, node: Node<NodeData>) => {
-    event.stopPropagation();
-    event.preventDefault()
     if (event.target.closest('[name=add-node]')) {
       addNode(node);
-      // TODO how do I stop selection changing here?
     }
   }, [model])
   

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -1,28 +1,22 @@
-import { getRectOfNodes, Node, Edge } from 'reactflow';
+import { getRectOfNodes, Node, ReactFlowInstance } from 'reactflow';
 import { stratify, tree } from 'd3-hierarchy';
 import { timer } from 'd3-timer';
-import {
-  FIT_DURATION,
-  FIT_PADDING,
-  NODE_HEIGHT,
-  NODE_WIDTH,
-} from './constants';
+
+import { FIT_PADDING, NODE_HEIGHT, NODE_WIDTH } from './constants';
+import { Flow, Positions } from './types';
 
 const layout = tree<Node>()
   // the node size configures the spacing between the nodes ([width, height])
-  .nodeSize([200, 150])
+  .nodeSize([240, 150])
   // this is needed for creating equal space between all nodes
   .separation(() => 1);
 
-type Model = { nodes: Node[]; edges: Edge[] };
-
-const calculateLayout = (
-  model: Model,
-  update,
-  flow,
-  duration: number | false = 500,
-  onComplete
-) => {
+const calculateLayout = async (
+  model: Flow.Model,
+  update: (newModel: Flow.Model) => any,
+  flow: ReactFlowInstance,
+  duration: number | false = 500
+): Promise<Positions> => {
   const { nodes, edges } = model;
   const hierarchy = stratify<Node>()
     .id(d => d.id)
@@ -36,111 +30,97 @@ const calculateLayout = (
     ...d.data,
     position: { x: d.x, y: d.y },
     // Ensure nodes have a width/height so that we can later do a fit to bounds
-    width: d.width || NODE_WIDTH,
-    height: d.height || NODE_HEIGHT,
+    width: NODE_WIDTH,
+    height: NODE_HEIGHT,
   }));
 
   const newModel = { nodes: newNodes, edges };
+
+  const finalPositions = newNodes.reduce((obj, next) => {
+    obj[next.id] = next.position;
+    return obj;
+  }, {} as Positions);
 
   const hasOldPositions = nodes.find(n => n.position);
 
   // If the old model had no positions, this is a first load and we should not animate
   if (hasOldPositions && duration) {
-    animate(model, newModel, update, flow, duration, onComplete);
+    await animate(model, newModel, update, flow, duration);
   } else {
     update(newModel);
-
-    // TODO deal with this
-    if (onComplete) {
-      const positions = newNodes.reduce((obj, next) => {
-        obj[next.id] = next.position;
-        return obj;
-      }, {});
-      onComplete(positions);
-    }
   }
 
-  // TODO deal with this
-  return newNodes.reduce((obj, next) => {
-    obj[next.id] = next.position;
-    return obj;
-  }, {});
+  return finalPositions;
 };
 
 export default calculateLayout;
 
 export const animate = (
-  from,
-  to,
-  setModel,
-  flowInstance,
-  duration = 500,
-  onComplete
+  from: Flow.Model,
+  to: Flow.Model,
+  setModel: (newModel: Flow.Model) => void,
+  flowInstance: ReactFlowInstance,
+  duration = 500
 ) => {
-  const transitions = to.nodes.map(node => {
-    // We usually animate a node from its previous position
-    let animateFrom = from.nodes.find(({ id }) => id === node.id);
-    if (!animateFrom || !animateFrom.position) {
-      // But if this a node node, animate from its parent (source)
-      const edge = from.edges.find(({ target }) => target === node.id);
-      animateFrom = from.nodes.find(({ id }) => id === edge.source);
-    }
-    return {
-      id: node.id,
-      from: animateFrom.position || { x: 0, y: 0 },
-      to: node.position,
-      node,
-    };
-  });
+  return new Promise<void>(resolve => {
+    const transitions = to.nodes.map(node => {
+      // We usually animate a node from its previous position
+      let animateFrom = from.nodes.find(({ id }) => id === node.id);
+      if (!animateFrom || !animateFrom.position) {
+        // But if this a new node, animate from its parent (source)
+        const edge = from.edges.find(({ target }) => target === node.id);
+        animateFrom = from.nodes.find(({ id }) => id === edge!.source);
+      }
+      return {
+        id: node.id,
+        from: animateFrom!.position || { x: 0, y: 0 },
+        to: node.position,
+        node,
+      };
+    });
 
-  let isFirst = true;
+    let isFirst = true;
 
-  // create a timer to animate the nodes to their new positions
-  const t = timer((elapsed: number) => {
-    const s = elapsed / duration;
+    // create a timer to animate the nodes to their new positions
+    const t = timer((elapsed: number) => {
+      const s = elapsed / duration;
 
-    const currNodes = transitions.map(({ node, from, to }) => ({
-      ...node,
-      position: {
-        // simple linear interpolation
-        x: from.x + (to.x - from.x) * s,
-        y: from.y + (to.y - from.y) * s,
-      },
-    }));
-    setModel({ edges: to.edges, nodes: currNodes });
-
-    if (isFirst) {
-      // Synchronise a fit to the final position with the same duration
-      const bounds = getRectOfNodes(to.nodes);
-      flowInstance.fitBounds(bounds, { duration, padding: FIT_PADDING });
-      isFirst = false;
-    }
-
-    // this is the final step of the animation
-    if (elapsed > duration) {
-      // we are moving the nodes to their destination
-      // this needs to happen to avoid glitches
-      const finalNodes = transitions.map(({ node, to }) => ({
+      const currNodes = transitions.map(({ node, from, to }) => ({
         ...node,
         position: {
-          x: to.x,
-          y: to.y,
+          // simple linear interpolation
+          x: from.x + (to.x - from.x) * s,
+          y: from.y + (to.y - from.y) * s,
         },
       }));
+      setModel({ edges: to.edges, nodes: currNodes });
 
-      setModel({ edges: to.edges, nodes: finalNodes });
-
-      // stop the animation
-      t.stop();
-
-      // TODO deal with this
-      if (onComplete) {
-        const positions = to.nodes.reduce((obj, next) => {
-          obj[next.id] = next.position;
-          return obj;
-        }, {});
-        onComplete(positions);
+      if (isFirst) {
+        // Synchronise a fit to the final position with the same duration
+        const bounds = getRectOfNodes(to.nodes);
+        flowInstance.fitBounds(bounds, { duration, padding: FIT_PADDING });
+        isFirst = false;
       }
-    }
+
+      // this is the final step of the animation
+      if (elapsed > duration) {
+        // we are moving the nodes to their destination
+        // this needs to happen to avoid glitches
+        const finalNodes = transitions.map(({ node, to }) => ({
+          ...node,
+          position: {
+            x: to.x,
+            y: to.y,
+          },
+        }));
+
+        setModel({ edges: to.edges, nodes: finalNodes });
+
+        // stop the animation
+        t.stop();
+
+        resolve();
+      }
+    });
   });
 };

--- a/assets/js/workflow-diagram/nodes/Job.tsx
+++ b/assets/js/workflow-diagram/nodes/Job.tsx
@@ -10,11 +10,11 @@ const JobNode = ({
   sourcePosition = Position.Bottom,
   ...props
 }: NodeProps<NodeData>) => {
-  const toolbar = () => <PlusButton />
+  const toolbar = () => props.data?.allowPlaceholder && <PlusButton />
 
   return (<Node
     {...props}
-    label={props.data?.label}
+    label={props.data?.name}
     targetPosition={targetPosition}
     sourcePosition={sourcePosition}
     toolbar={toolbar}

--- a/assets/js/workflow-diagram/nodes/Node.tsx
+++ b/assets/js/workflow-diagram/nodes/Node.tsx
@@ -7,7 +7,6 @@ type NodeData = any;
 const Node = ({
   label,
   labelClass = '',
-  outerClass,
   tooltip,
   interactive = true,
   data,
@@ -19,7 +18,7 @@ const Node = ({
 }: NodeProps<NodeData>) => {
   return (
     <div
-      className={outerClass || [
+      className={[
         'group',
         'bg-white',
         interactive ? 'cursor-pointer' : 'cursor-default',

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -17,14 +17,23 @@ const PlaceholderJobNode = ({
 
   const textRef = useRef()
 
+  const commit = () => {
+    // Dispatch an event up to the WorkflowDiagram
+    // This works better than interfacing to the store correctly
+    // because the Workflow Diagram can control selection
+    const e = new CustomEvent('commit-placeholder', {
+      bubbles: true,
+      detail: {
+        id,
+        name:  textRef.current.value
+      }
+    });
+    textRef.current.dispatchEvent(e);
+  }
+
   const handleKeyDown = (evt) => {
     if (evt.code === 'Enter') {
-      evt.sourceNodeId = id;
-      // Have to do this after render else the event won't propagate (?)
-      // What if I was to use a CustomEvent?
-      setTimeout(() => {
-        handleCommit();
-      }, 150) // what is the magic number?
+      commit();  
     }
     if (evt.code === 'Escape') {
       handleCancel();
@@ -33,15 +42,10 @@ const PlaceholderJobNode = ({
 
   // TODO what if a name hasn't been entered?
   const handleCommit = () => {
-    console.log('commit')
-    const { change } = store?.getState()
-    change(id, 'jobs', {
-      name: textRef.current.value
-    })
+    commit()
   }
 
   const handleCancel = () => {
-    console.log('cancel')
     const { remove, edges } = store?.getState()
     const e = edges.find(({ target_job_id }) => target_job_id === id)
     remove({ jobs: [id], edges: [e.id] });

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -48,9 +48,9 @@ const PlaceholderJobNode = ({
   }
 
   const handleCancel = () => {
-    const { remove, edges } = store?.getState()
+    const { remove, edges } = store?.getState()!
     const e = edges.find(({ target_job_id }) => target_job_id === id)
-    remove({ jobs: [id], edges: [e.id] });
+    remove({ jobs: [id], edges: [e!.id] });
   }
 
   return (

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -8,6 +8,8 @@ import { WorkflowContext } from '../../workflow-editor/component';
 
 type NodeData = any;
 
+const iconStyle = "mx-1 text-primary-500 hover:text-primary-900"
+
 const PlaceholderJobNode = ({
   id,
   selected,
@@ -92,7 +94,7 @@ const PlaceholderJobNode = ({
             'text-center',
           ].filter(Boolean).join(' ')}
         >
-          <XMarkIcon className="mx-1 text-primary-600" onClick={handleCancel}/>
+          <XMarkIcon className={`${iconStyle}`} title="Cancel creation of this job" onClick={handleCancel}/>
           <input
             type="text"
             ref={textRef}
@@ -101,7 +103,7 @@ const PlaceholderJobNode = ({
             className={['line-clamp-2', 'align-middle','focus:outline-none','focus:ring-0', 'border-none', 'bg-transparent', 'text-center', 'text-xs'].join(' ')}
             onKeyDown={handleKeyDown}
           />
-          <CheckCircleIcon className="mx-1 text-primary-600" onClick={handleCommit}/>
+          <CheckCircleIcon className={`${iconStyle}`} title="Create this job" onClick={handleCommit}/>
         </div>
       </div>
     </div>

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -17,12 +17,16 @@ const PlaceholderJobNode = ({
 
   const textRef = useRef()
 
-  const handleKeyDown = ({ code }) => {
-    console.log('keydown', code)
-    if (code === 'Enter') {
-      handleCommit();
+  const handleKeyDown = (evt) => {
+    if (evt.code === 'Enter') {
+      evt.sourceNodeId = id;
+      // Have to do this after render else the event won't propagate (?)
+      // What if I was to use a CustomEvent?
+      setTimeout(() => {
+        handleCommit();
+      }, 150) // what is the magic number?
     }
-    if (code === 'Escape') {
+    if (evt.code === 'Escape') {
       handleCancel();
     }
   };
@@ -89,6 +93,7 @@ const PlaceholderJobNode = ({
             type="text"
             ref={textRef}
             autoFocus
+            data-placeholder={id}
             className={['line-clamp-2', 'align-middle','focus:outline-none','focus:ring-0', 'border-none', 'bg-transparent', 'text-center', 'text-xs'].join(' ')}
             onKeyDown={handleKeyDown}
           />

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -1,40 +1,102 @@
-import React, { memo } from 'react';
-import { Position, NodeProps } from 'reactflow';
-import Node from './Node';
+import React, { memo, useContext, useRef } from 'react';
+import { Handle, NodeProps } from 'reactflow';
+import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
+
+// Sketchy dep
+import { WorkflowContext } from '../../workflow-editor/component';
 
 type NodeData = any;
 
 const PlaceholderJobNode = ({
-  targetPosition = Position.Top,
-  sourcePosition = Position.Bottom,
+  id,
   selected,
-  ...props
+  targetPosition,
 }: NodeProps<NodeData>) => {
+  const store = useContext(WorkflowContext)
 
-  return (<Node
-    {...props}
-    selected={selected}
-    label="New Job"
-    outerClass={[
-      'group',
-      'bg-transparent',
-      'cursor-pointer',
-      'h-full',
-      'p-1',
-      'rounded-md',
-      'shadow-sm',
-      'text-center',
-      'text-xs',
-      'border-dashed',
-      'border-2',
-      'border-indigo-500',
-      selected ? 'border-opacity-70' : 'border-opacity-30',
-    ].join(' ')}
-    labelClass={`text-indigo-500 ${selected ? "text-opacity-90" : "text-opacity-50"}`}
-    targetPosition={targetPosition}
-    sourcePosition={sourcePosition}
-  />)
- 
+  const textRef = useRef()
+
+  const handleKeyDown = ({ code }) => {
+    console.log('keydown', code)
+    if (code === 'Enter') {
+      handleCommit();
+    }
+    if (code === 'Escape') {
+      handleCancel();
+    }
+  };
+
+  // TODO what if a name hasn't been entered?
+  const handleCommit = () => {
+    console.log('commit')
+    const { change } = store?.getState()
+    change(id, 'jobs', {
+      name: textRef.current.value
+    })
+  }
+
+  const handleCancel = () => {
+    console.log('cancel')
+    const { remove, edges } = store?.getState()
+    const e = edges.find(({ target_job_id }) => target_job_id === id)
+    remove({ jobs: [id], edges: [e.id] });
+  }
+
+  return (
+    <div
+      className={[
+        'group',
+        'bg-transparent',
+        'cursor-pointer',
+        'h-full',
+        'p-1',
+        'rounded-md',
+        'shadow-sm',
+        'text-center',
+        'text-xs',
+        'border-dashed',
+        'border-2',
+        'border-indigo-500',
+        selected ? 'border-opacity-70' : 'border-opacity-30'
+      ].join(' ')}
+      style={{ width: `${NODE_WIDTH}px`, height: `${NODE_HEIGHT}px` }}
+    >
+      <Handle
+        type="target"
+        position={targetPosition}
+        isConnectable
+        style={{ visibility: 'hidden', border: 'none', height: 0, top: 0 }}
+      />
+      <div
+        className={[
+          'h-full',
+          'text-center',
+          'items-center',
+        ].filter(Boolean).join(' ')}
+      >
+        <div
+          className={[
+            'flex',
+            'flex-row',
+            'justify-center',
+            'h-full',
+            'text-center',
+          ].filter(Boolean).join(' ')}
+        >
+          <XMarkIcon className="mx-1 text-primary-600" onClick={handleCancel}/>
+          <input
+            type="text"
+            ref={textRef}
+            autoFocus
+            className={['line-clamp-2', 'align-middle','focus:outline-none','focus:ring-0', 'border-none', 'bg-transparent', 'text-center', 'text-xs'].join(' ')}
+            onKeyDown={handleKeyDown}
+          />
+          <CheckCircleIcon className="mx-1 text-primary-600" onClick={handleCommit}/>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 PlaceholderJobNode.displayName = 'PlaceholderJobNode';

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useContext, useRef } from 'react';
-import { Handle, NodeProps } from 'reactflow';
+import React, { memo, useCallback, useRef } from 'react';
+import { Handle, NodeProps, Position } from 'reactflow';
 import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 
@@ -21,9 +21,8 @@ const dispatch = (el: HTMLElement, eventName: 'commit-placeholder' | 'cancel-pla
 const PlaceholderJobNode = ({
   id,
   selected,
-  targetPosition,
 }: NodeProps<NodeData>) => {
-  const textRef = useRef()
+  const textRef = useRef<HTMLInputElement>()
 
   const handleKeyDown = (evt) => {
     if (evt.code === 'Enter') {
@@ -35,16 +34,17 @@ const PlaceholderJobNode = ({
   };
 
   // TODO what if a name hasn't been entered?
-  const handleCommit = () => {
-    dispatch(textRef.current, 'commit-placeholder', { id,  name:  textRef.current.value })
-  }
+  const handleCommit = useCallback(() => {
+    if (textRef.current) {
+      dispatch(textRef.current, 'commit-placeholder', { id,  name:  textRef.current.value })
+    }
+  }, [textRef])
 
-  const handleCancel = () => {
-    dispatch(textRef.current, 'cancel-placeholder', { id })
-    // const { remove, edges } = store?.getState()!
-    // const e = edges.find(({ target_job_id }) => target_job_id === id)
-    // remove({ jobs: [id], edges: [e!.id] });
-  }
+  const handleCancel = useCallback(() => {
+    if (textRef.current) {
+      dispatch(textRef.current, 'cancel-placeholder', { id })
+    }
+  }, [textRef])
 
   return (
     <div
@@ -67,7 +67,7 @@ const PlaceholderJobNode = ({
     >
       <Handle
         type="target"
-        position={targetPosition}
+        position={Position.Top}
         isConnectable
         style={{ visibility: 'hidden', border: 'none', height: 0, top: 0 }}
       />

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -24,7 +24,7 @@ export namespace Lightning {
   export type TriggerNode = CronTrigger | WebhookTrigger;
 
   export interface JobNode extends Node {
-    body: string;
+    body?: string;
   }
 
   export interface Edge {

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -1,42 +1,66 @@
+import type * as ReactFlow from 'reactflow';
+
 // This all describes the lightning view of a workflow
+export namespace Lightning {
+  export interface Node {
+    id: string;
+    name: string;
+    workflowId: string;
 
-export interface Node {
-  id: string;
-  name: string;
-  workflowId: string;
+    // Not technically from Lightning, but we'll infer this and scribble it
+    placeholder?: boolean;
+  }
+
+  export interface CronTrigger extends Node {
+    type: 'cron';
+    cronExpression: string;
+  }
+
+  export interface WebhookTrigger extends Node {
+    type: 'webhook';
+    webhookUrl: string;
+  }
+
+  export type TriggerNode = CronTrigger | WebhookTrigger;
+
+  export interface JobNode extends Node {
+    body: string;
+  }
+
+  export interface Edge {
+    id: string;
+    source_job_id?: string;
+    source_trigger_id?: string;
+    target_job_id?: string;
+    name: string;
+    condition?: string;
+    error_path?: boolean;
+    errors: any;
+  }
+
+  export type Workflow = {
+    id?: string;
+    changeId?: string;
+    triggers: TriggerNode[];
+    jobs: JobNode[];
+    edges: Edge[];
+  };
 }
 
-type CronTrigger = {
-  type: 'cron';
-  cronExpression: string;
-};
+export namespace Flow {
+  export type Node = ReactFlow.Node;
 
-type WebhookTrigger = {
-  type: 'webhook';
-  webhookUrl: string;
-};
+  export type Edge = ReactFlow.Edge;
 
-export interface TriggerNode extends Node {
-  trigger: CronTrigger | WebhookTrigger;
+  export type Model = {
+    nodes: Node[];
+    edges: Edge[];
+  };
 }
 
-export interface JobNode extends Node {}
-
-export interface Edge {
-  id: string;
-  source_job_id?: string;
-  source_trigger_id?: string;
-  target_job_id?: string;
-  name: string;
-  condition?: string;
-  error_path?: boolean;
-  errors: any;
-}
-
-export type Workflow = {
-  id: string;
-  changeId?: string;
-  triggers: TriggerNode[];
-  jobs: JobNode[];
-  edges: Edge[];
+export type Positions = {
+  [nodeId: string]: { x: number; y: number };
 };
+
+
+type CustomEvent 

--- a/assets/js/workflow-diagram/util/add-placeholder.ts
+++ b/assets/js/workflow-diagram/util/add-placeholder.ts
@@ -16,13 +16,11 @@ export const add = (model: any, node: Node) => {
   newModel.nodes.push({
     id,
     position: node.position,
-    placeholder: true,
   });
   newModel.edges.push({
     id: `${node.id}-${id}`,
     source: node.id,
     target: id,
-    placeholder: true,
   });
   return newModel;
 };

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -13,6 +13,7 @@ const fromWorkflow = (
   if (workflow.jobs.length == 0) {
     return { nodes: [], edges: [] };
   }
+  const allowPlaceholder = workflow.jobs.every(j => !isPlaceholder(j));
 
   const process = (
     items: Array<Node | Edge>,
@@ -22,7 +23,12 @@ const fromWorkflow = (
     items.forEach(item => {
       const model: any = {
         id: item.id,
+        data: {
+          name: item.name || item.id,
+          item: item,
+        },
       };
+
       if (item.id === selectedNodeId) {
         model.selected = true;
       }
@@ -30,12 +36,19 @@ const fromWorkflow = (
         model.type = isPlaceholder(item) ? 'placeholder' : type;
 
         if (positions && positions[item.id]) {
-          // console.log('adding position for ' + item.id, positions[item.id]);
           model.position = positions[item.id];
         }
 
         model.width = NODE_WIDTH;
         model.height = NODE_HEIGHT;
+
+        model.data.allowPlaceholder = allowPlaceholder;
+
+        if (type === 'trigger') {
+          model.data.trigger = {
+            type: item.type,
+          };
+        }
       } else {
         let edge = item as Edge;
         model.source = edge.source_trigger_id || edge.source_job_id;
@@ -53,14 +66,6 @@ const fromWorkflow = (
         }
       }
 
-      model.data = {
-        ...item,
-        label: item.name || item.id,
-        // TMP
-        trigger: {
-          type: 'webhook',
-        },
-      };
       collection.push(model);
     });
   };

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -24,7 +24,7 @@ const fromWorkflow = (
       const model: any = {
         id: item.id,
         data: {
-          name: item.name || item.id,
+          name: item.name,
           item: item,
         },
       };

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -1,6 +1,6 @@
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { Lightning, Flow, Positions } from '../types';
-import { isPlaceholder } from './add-placeholder';
+import { isPlaceholder } from './placeholder';
 
 // TODO pass in the currently selected items so that we can maintain selection
 const fromWorkflow = (

--- a/assets/js/workflow-diagram/util/placeholder.ts
+++ b/assets/js/workflow-diagram/util/placeholder.ts
@@ -1,4 +1,4 @@
-import { Lightning, Flow } from '../types';
+import { Flow } from '../types';
 
 // adds a placeholder node as child of the target
 // A node can only have one placeholder at a time
@@ -6,7 +6,7 @@ import { Lightning, Flow } from '../types';
 // created, we replace the placeholder with the real thing
 
 // Model is a react-flow chart model
-export const add = (model: Flow.Model, node: Flow.Node) => {
+export const add = (model: Flow.Model, parentNode: Flow.Node) => {
   const newModel: any = {
     nodes: [],
     edges: [],
@@ -15,11 +15,11 @@ export const add = (model: Flow.Model, node: Flow.Node) => {
   const id = crypto.randomUUID();
   newModel.nodes.push({
     id,
-    position: node.position,
+    position: parentNode.position,
   });
   newModel.edges.push({
-    id: `${node.id}-${id}`,
-    source: node.id,
+    id: `${parentNode.id}-${id}`,
+    source: parentNode.id,
     target: id,
   });
   return newModel;

--- a/assets/js/workflow-diagram/util/placeholder.ts
+++ b/assets/js/workflow-diagram/util/placeholder.ts
@@ -1,4 +1,4 @@
-import { Node, Workflow } from '../types';
+import { Lightning, Flow } from '../types';
 
 // adds a placeholder node as child of the target
 // A node can only have one placeholder at a time
@@ -6,7 +6,7 @@ import { Node, Workflow } from '../types';
 // created, we replace the placeholder with the real thing
 
 // Model is a react-flow chart model
-export const add = (model: any, node: Node) => {
+export const add = (model: Flow.Model, node: Flow.Node) => {
   const newModel: any = {
     nodes: [],
     edges: [],
@@ -25,11 +25,4 @@ export const add = (model: any, node: Node) => {
   return newModel;
 };
 
-// Do we have a placeholder associated with this node?
-export const exists = (model: any, node: Node) => {};
-
 export const isPlaceholder = (node: Node) => node.placeholder;
-
-// Conver a node from a placeholder to a normal node
-// Assign it a UUID
-export const convert = (model: any) => {};

--- a/assets/js/workflow-diagram/util/to-workflow.ts
+++ b/assets/js/workflow-diagram/util/to-workflow.ts
@@ -1,41 +1,48 @@
-import { Workflow } from '../types';
+import { Lightning, Flow } from '../types';
 
-const model = model => {
-  const workflow: Workflow = {
+// This converts an internal react flow model back to a Lighting representation
+// Used for diffing when something changes
+// TODO how strict does this need to be? Can we lose information through this?
+// I think the store means we can be flexible and only convert stuff we want to edit
+// (stuff like body and adaptor we can ignore)
+const model = (model: Flow.Model) => {
+  const workflow: Lightning.Workflow = {
+    // What about the id? Do we need it? Did we lose it?
     triggers: [],
     jobs: [],
     edges: [],
   };
 
   model.nodes.forEach(node => {
-    const wfNode = {
+    const wfNode: Partial<Lightning.Node> = {
       id: node.id,
-      label: node.data?.label,
+      name: node.data?.name,
+      // TODO workflow id?
     };
 
     if (node.type === 'trigger') {
-      workflow.triggers.push(wfNode);
+      // TODO
+      workflow.triggers.push(wfNode as Lightning.TriggerNode);
     } else {
-      workflow.jobs.push(wfNode);
+      workflow.jobs.push(wfNode as Lightning.JobNode);
     }
   });
 
   model.edges.forEach(edge => {
     const source = model.nodes.find(({ id }) => id === edge.source);
 
-    const wfEdge = {
+    const wfEdge: Partial<Lightning.Edge> = {
       id: edge.id,
       target_job_id: edge.target,
     };
 
     if (source && source.type === 'trigger') {
       wfEdge.source_trigger_id = edge.source;
-      wfEdge.trigger = edge.data.trigger || {};
     } else {
       wfEdge.source_job_id = edge.source;
     }
 
-    workflow.edges.push(wfEdge);
+    workflow.edges.push(wfEdge as Lightning.Edge);
   });
 
   return workflow;

--- a/assets/js/workflow-diagram/util/to-workflow.ts
+++ b/assets/js/workflow-diagram/util/to-workflow.ts
@@ -12,13 +12,6 @@ const model = model => {
       id: node.id,
       label: node.data?.label,
     };
-    if (node.placeholder) {
-      // TODO this is a transient property, should not persist. I think?
-      // If we don't persist, and the id doesn't use a convention (because changing id on the fly causes bigtime issues)
-      // How do we recognise a saved placeholder?
-      // Well I guess we can infer it if there's no label or expression
-      wfNode.placeholder = true;
-    }
 
     if (node.type === 'trigger') {
       workflow.triggers.push(wfNode);
@@ -34,14 +27,6 @@ const model = model => {
       id: edge.id,
       target_job_id: edge.target,
     };
-
-    if (edge.placeholder) {
-      // TODO this is a transient property, should not persist. I think?
-      // If we don't persist, and the id doesn't use a convention (because changing id on the fly causes bigtime issues)
-      // How do we recognise a saved placeholder?
-      // Well I guess we can infer it if there's no label or expression
-      wfEdge.placeholder = true;
-    }
 
     if (source && source.type === 'trigger') {
       wfEdge.source_trigger_id = edge.source;

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -63,16 +63,15 @@ export function mount(
 
     const handleSelectionChange = (id: string) => {
       onSelectionChange?.(id);
-    }
+    };
 
-    const handleRequestChange = (type: 'add' | 'update', diff) => {
-      if (type === 'add') {
-        add(diff)
-      } else {
-        // TODO this needs cleaning up
-        change(...diff)
-      }
-    }
+    const handleAdd = (diff: Partial<Workflow>) => {
+      add(diff)
+    };
+
+    const handleChange = (diff: Partial<Workflow>) => {
+      change(diff)
+    };
 
     componentRoot.render(
       <WorkflowContext.Provider value={workflowStore}>
@@ -80,7 +79,9 @@ export function mount(
           ref={el}
           workflow={identifyPlaceholders(model)}
           onSelectionChange={handleSelectionChange}
-          requestChange={handleRequestChange}/>
+          onAdd={handleAdd}
+          onChange={handleChange}
+        />
       </WorkflowContext.Provider>
     );
   }

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -58,18 +58,22 @@ export function mount(
   }
 
   function render(model: Workflow) {
-    const { add, change } = workflowStore.getState();
+    const { add, change, remove } = workflowStore.getState();
 
     const handleSelectionChange = (id: string) => {
       onSelectionChange?.(id);
     };
 
     const handleAdd = (diff: Partial<Workflow>) => {
-      add(diff)
+      add(diff);
     };
 
     const handleChange = (diff: Partial<Workflow>) => {
-      change(diff)
+      change(diff);
+    };
+
+    const handleRemove = (diff: Partial<Workflow>) => {
+      remove(diff);
     };
 
     componentRoot.render(
@@ -80,6 +84,7 @@ export function mount(
           onSelectionChange={handleSelectionChange}
           onAdd={handleAdd}
           onChange={handleChange}
+          onRemove={handleRemove}
         />
       </WorkflowContext.Provider>
     );

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -59,14 +59,19 @@ export function mount(
   }
 
   function render(model: Workflow) {
-    const { add } = workflowStore.getState();
+    const { add, change } = workflowStore.getState();
 
     const handleSelectionChange = (id: string) => {
       onSelectionChange?.(id);
     }
 
-    const handleRequestChange = (diff) => {
-      add(diff)
+    const handleRequestChange = (type: 'add' | 'update', diff) => {
+      if (type === 'add') {
+        add(diff)
+      } else {
+        // TODO this needs cleaning up
+        change(...diff)
+      }
     }
 
     componentRoot.render(

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -5,6 +5,8 @@ import { WorkflowState, createWorkflowStore, WorkflowProps } from './store';
 
 import WorkflowDiagram from '../workflow-diagram/WorkflowDiagram'
 
+export const WorkflowContext = createContext<StoreApi<WorkflowState> | null>(null);
+
 type Store = ReturnType<typeof createWorkflowStore>;
 type Workflow = Pick<WorkflowProps, 'jobs' | 'edges' | 'triggers'>;
 
@@ -68,12 +70,13 @@ export function mount(
     }
 
     componentRoot.render(
-      // TODO listen to change events from the diagram and upadte the store accordingly
-      <WorkflowDiagram
-        ref={el}
-        workflow={identifyPlaceholders(model)}
-        onSelectionChange={handleSelectionChange}
-        requestChange={handleRequestChange}/>
+      <WorkflowContext.Provider value={workflowStore}>
+        <WorkflowDiagram
+          ref={el}
+          workflow={identifyPlaceholders(model)}
+          onSelectionChange={handleSelectionChange}
+          requestChange={handleRequestChange}/>
+      </WorkflowContext.Provider>
     );
   }
 

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { createRoot } from 'react-dom/client';
 import { StoreApi, useStore } from 'zustand';
-import { WorkflowState, createWorkflowStore, WorkflowProps } from './store';
+import { WorkflowState, createWorkflowStore, WorkflowProps, RemoveArgs, ChangeArgs, AddArgs } from './store';
 
 import WorkflowDiagram from '../workflow-diagram/WorkflowDiagram'
 
@@ -12,7 +12,7 @@ type Workflow = Pick<WorkflowProps, 'jobs' | 'edges' | 'triggers'>;
 
 // This will take a store passed from the server and do some light transformation
 // Specifically it identifies placeholder nodes
-const identifyPlaceholders = (store: Store) => {
+const identifyPlaceholders = (store: Workflow) => {
   const { jobs, triggers, edges } = store;
   
   const newJobs = jobs.map((item) => {
@@ -60,31 +60,15 @@ export function mount(
   function render(model: Workflow) {
     const { add, change, remove } = workflowStore.getState();
 
-    const handleSelectionChange = (id: string) => {
-      onSelectionChange?.(id);
-    };
-
-    const handleAdd = (diff: Partial<Workflow>) => {
-      add(diff);
-    };
-
-    const handleChange = (diff: Partial<Workflow>) => {
-      change(diff);
-    };
-
-    const handleRemove = (diff: Partial<Workflow>) => {
-      remove(diff);
-    };
-
     componentRoot.render(
       <WorkflowContext.Provider value={workflowStore}>
         <WorkflowDiagram
           ref={el}
           workflow={identifyPlaceholders(model)}
-          onSelectionChange={handleSelectionChange}
-          onAdd={handleAdd}
-          onChange={handleChange}
-          onRemove={handleRemove}
+          onSelectionChange={onSelectionChange}
+          onAdd={add}
+          onChange={change}
+          onRemove={remove}
         />
       </WorkflowContext.Provider>
     );

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -16,8 +16,7 @@ const identifyPlaceholders = (store: Store) => {
   const { jobs, triggers, edges } = store;
   
   const newJobs = jobs.map((item) => {
-    // TODO placeholder triggers don't have a cron/webhook type yet
-    if (!item.name && !item.expression) {
+    if (!item.name && !item.body) {
       return {
         ...item,
         placeholder: true

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -132,11 +132,15 @@ export const createWorkflowStore = (
         })
       );
     },
-    change: (id, type, diff) => {
+    change: data => {
       set(state =>
         proposeChanges(state, draft => {
-          const item = draft[type].find(i => i.id === id);
-          Object.assign(item, diff);
+          for (const type in data) {
+            for (const change of data[type]) {
+              const item = draft[type].find(i => i.id === change.id);
+              Object.assign(item, change);
+            }
+          }
         })
       );
     },

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -5,6 +5,12 @@ import type { Lightning } from '../workflow-diagram/types';
 
 enablePatches();
 
+export type RemoveArgs = {
+  jobs?: string[];
+  triggers?: string[];
+  edges?: string[];
+};
+
 export type WorkflowProps = {
   triggers: Lightning.TriggerNode[];
   jobs: Lightning.JobNode[];
@@ -15,11 +21,7 @@ export type WorkflowProps = {
 export interface WorkflowState extends WorkflowProps {
   add: (data: Partial<WorkflowProps>) => void;
   change: (data: Partial<WorkflowProps>) => void;
-  remove: (data: {
-    jobs?: string[];
-    triggers?: string[];
-    edges?: string[];
-  }) => void;
+  remove: (data: RemoveArgs) => void;
   addEdge: (edge: Lightning.Edge) => void;
   addJob: (job: Lightning.JobNode) => void;
   addTrigger: (node: Lightning.TriggerNode) => void;

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -11,6 +11,10 @@ export type RemoveArgs = {
   edges?: string[];
 };
 
+export type ChangeArgs = Partial<Omit<WorkflowProps, 'editJobUrl'>>;
+
+export type AddArgs = ChangeArgs;
+
 export type WorkflowProps = {
   triggers: Lightning.TriggerNode[];
   jobs: Lightning.JobNode[];
@@ -19,8 +23,8 @@ export type WorkflowProps = {
 };
 
 export interface WorkflowState extends WorkflowProps {
-  add: (data: Partial<Omit<WorkflowProps, 'editJobUrl'>>) => void;
-  change: (data: Partial<Omit<WorkflowProps, 'editJobUrl'>>) => void;
+  add: (data: AddArgs) => void;
+  change: (data: ChangeArgs) => void;
   remove: (data: RemoveArgs) => void;
   onChange: (pendingAction: PendingAction) => void;
   applyPatches: (patches: Patch[]) => void;

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -19,8 +19,8 @@ export type WorkflowProps = {
 };
 
 export interface WorkflowState extends WorkflowProps {
-  add: (data: Partial<WorkflowProps>) => void;
-  change: (data: Partial<WorkflowProps>) => void;
+  add: (data: Partial<Omit<WorkflowProps, 'editJobUrl'>>) => void;
+  change: (data: Partial<Omit<WorkflowProps, 'editJobUrl'>>) => void;
   remove: (data: RemoveArgs) => void;
   onChange: (pendingAction: PendingAction) => void;
   applyPatches: (patches: Patch[]) => void;
@@ -122,10 +122,16 @@ export const createWorkflowStore = (
     change: data => {
       set(state =>
         proposeChanges(state, draft => {
-          for (const type in data) {
-            for (const change of data[type]) {
-              const item = draft[type].find(i => i.id === change.id);
-              Object.assign(item, change);
+          for (const [t, changes] of Object.entries(data)) {
+            const type = t as 'jobs' | 'triggers' | 'edges';
+            for (const change of changes) {
+              const current = draft[type] as Array<
+                Lightning.Node | Lightning.Edge
+              >;
+              const item = current.find(i => i.id === change.id);
+              if (item) {
+                Object.assign(item, change);
+              }
             }
           }
         })

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -113,6 +113,25 @@ export const createWorkflowStore = (
         })
       );
     },
+    // remove one or more things by id
+    remove: data => {
+      set(state =>
+        proposeChanges(state, draft => {
+          ['jobs', 'triggers', 'edges'].forEach(key => {
+            if (data[key]) {
+              const newCollection = [];
+              draft[key].forEach(item => {
+                if (!data[key].includes(item.id)) {
+                  newCollection.push(item);
+                }
+              });
+              console.log(newCollection);
+              draft[key] = newCollection;
+            }
+          });
+        })
+      );
+    },
     change: (id, type, diff) => {
       set(state =>
         proposeChanges(state, draft => {

--- a/lib/lightning/jobs/job.ex
+++ b/lib/lightning/jobs/job.ex
@@ -41,8 +41,7 @@ defmodule Lightning.Jobs.Job do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "jobs" do
-    field :body, :string,
-      default: "// Get started by adding operations from your adaptor here"
+    field :body, :string
 
     field :enabled, :boolean, default: true
     field :name, :string

--- a/lib/lightning_web/live/workflow_live/workflow_params.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_params.ex
@@ -78,7 +78,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParams do
         jobs:
           changeset
           |> Ecto.Changeset.get_change(:jobs)
-          |> to_serializable([:id, :name, :adaptor, :enabled]),
+          |> to_serializable([:id, :name, :adaptor, :body, :enabled]),
         triggers:
           changeset
           |> Ecto.Changeset.get_change(:triggers)


### PR DESCRIPTION
Experimental PR for better placeholder nodes.
![image](https://github.com/OpenFn/Lightning/assets/7052509/892e5c02-0f15-4499-876d-1d590c6a5a71)

The new placeholder has commit and cancel options and steals focus, instantly demanding a name. Escape and Enter will commit or remove the placeholder.

This makes it quicker, easier, and more satisfying to sketch out new jobs in a workflow. It also helps makes placeholders a bit more transient, encouraging a name to be set early (so you're less likely to create a chart with many placeholders).

This video uses the keyboard to create an cancel a couple of placeholders:

https://github.com/OpenFn/Lightning/assets/7052509/f517c34f-f7f1-4e66-b500-8e799c2d76e2

## Issues

There are some UX-y issues which I've managed to mitigate:

* Only one placeholder can be created at a time, which prevents all sorts of cleanup issues.
* If the side panel is open, adding a new node does not open the side panel. But if the panel is already visible, adding a new node will update the panel's contents. I do not want to hide the panel, even though it would be a bit neater, because the chart will jump all over the place.
* The placeholder node and side panel act differently. As soon as the side panel is edited, the placeholder status is replaced. But with the placeholder's own text input, the node isn't created until enter is pressed. The UX in the diagram is WAY nicer. Controlling the Lightning form is harder and out of my control.
* Later, in Lightning, we may consider a special Placeholder side panel form, which only lets you edit the name of the node, and doesn't save until you hit enter.
* For large workflows, the auto-zoom doesn't work very well, and the text input in the node gets very small. But this is not likely to be a problem in practice.
* When a node is first committed, we set a empty job expression on it. This isn't ideal, but it prevents the node reverting back to a placeholder state when its name is removed (which can easily happen and looks very bad). 

IMPORTANT NOTE: To get this last bit working I've removed the default job string from `lib/lighting/jobs/job.ex`. If this is unacceptable we're gonna need another solution.

There is one bug on this branch I can't really fix:

Pressing enter while the new form has focus will trigger an error, as the form posts to a URL that doesn't exist. This might crop up as you're adding nodes.

## Next steps

I've raised #843 for more keyboard control, but that's not something to worry about right now.