### PR TITLE
Remove the prompt for the user roles, which removes the extra space i…

### DIFF
--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -69,7 +69,6 @@
                   form={member_form}
                   name={:role}
                   id="role"
-                  prompt=""
                   values={["editor", "viewer", "admin"]}
                 />
               </div>


### PR DESCRIPTION
## Notes for the reviewer

Removed the `Prompt` which was causing an extra blank space when editing the role of a user in a project


## Related issue

Fixes #717

## Checklist before requesting a review

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
