### PR TITLE
Check and renew OAuth credentials when running a job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Check and renew OAuth credentials when running a job
+  [#646](https://github.com/OpenFn/Lightning/issues/646)
+
 ### Changed
 
 ### Fixed

--- a/config/config.exs
+++ b/config/config.exs
@@ -112,7 +112,7 @@ config :lightning, Lightning.FailureAlerter,
 # Disables / Hides the credential transfer feature for beta (in LightningWeb.CredentialLive.Edit)
 config :lightning, LightningWeb,
   allow_credential_transfer: false,
-  enable_google_credential: false
+  enable_google_credential: true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/lightning/auth_providers/google.ex
+++ b/lib/lightning/auth_providers/google.ex
@@ -10,14 +10,18 @@ defmodule Lightning.AuthProviders.Google do
 
     @primary_key false
     embedded_schema do
-      field :access_token, :string
-      field :refresh_token, :string
-      field :expires_at, :integer
-      field :scope, :string
+      field(:access_token, :string)
+      field(:refresh_token, :string)
+      field(:expires_at, :integer)
+      field(:scope, :string)
     end
 
     def new(attrs) do
       changeset(attrs) |> apply_changes()
+    end
+
+    def from_oauth2_token(%OAuth2.AccessToken{} = token) do
+      Map.from_struct(token) |> new()
     end
 
     @doc false
@@ -79,10 +83,15 @@ defmodule Lightning.AuthProviders.Google do
   end
 
   # Use the the refresh token to get a new access token.
+  @spec refresh_token(
+          %{:token => any, optional(any) => any} | OAuth2.Client.t(),
+          OAuth2.AccessToken.t() | %{refresh_token: binary()}
+        ) ::
+          {:error, binary | %{body: binary | list | map, code: integer}}
+          | {:ok, nil | OAuth2.AccessToken.t()}
   def refresh_token(client, token) do
     OAuth2.Client.refresh_token(%{client | token: token})
     |> case do
-      # TODO: we should get an expires_in/expires_at from the response?
       {:ok, %{token: token}} ->
         {:ok, token}
 

--- a/lib/lightning/auth_providers/google.ex
+++ b/lib/lightning/auth_providers/google.ex
@@ -10,10 +10,10 @@ defmodule Lightning.AuthProviders.Google do
 
     @primary_key false
     embedded_schema do
-      field(:access_token, :string)
-      field(:refresh_token, :string)
-      field(:expires_at, :integer)
-      field(:scope, :string)
+      field :access_token, :string
+      field :refresh_token, :string
+      field :expires_at, :integer
+      field :scope, :string
     end
 
     def new(attrs) do

--- a/lib/lightning/auth_providers/google.ex
+++ b/lib/lightning/auth_providers/google.ex
@@ -78,9 +78,11 @@ defmodule Lightning.AuthProviders.Google do
     OAuth2.Client.get_token(client, params)
   end
 
+  # Use the the refresh token to get a new access token.
   def refresh_token(client, token) do
     OAuth2.Client.refresh_token(%{client | token: token})
     |> case do
+      # TODO: we should get an expires_in/expires_at from the response?
       {:ok, %{token: token}} ->
         {:ok, token}
 

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -283,21 +283,19 @@ defmodule Lightning.Credentials do
     project_credentials -- project_users
   end
 
+  # TODO: this doesn't need to be Google specific. It should work for any standard OAuth2 credential.
   @spec maybe_refresh_token(nil | Lightning.Credentials.Credential.t()) ::
-          nil
-          | {:error, :invalid_config}
-          | Lightning.Credentials.Credential.t()
+          {:error, :invalid_config}
           | {:ok, Lightning.Credentials.Credential.t()}
   def maybe_refresh_token(%Credential{schema: "googlesheets"} = credential) do
-    %{expires_at: expires_at, refresh_token: refresh_token} =
-      credential.body |> Google.TokenBody.new()
+    token_body = Google.TokenBody.new(credential.body)
 
-    if still_fresh(expires_at) do
-      credential
+    if still_fresh(token_body) do
+      {:ok, credential}
     else
       with {:ok, %OAuth2.Client{} = client} <- Google.build_client(),
            {:ok, %OAuth2.AccessToken{} = token} <-
-             Google.refresh_token(client, %{refresh_token: refresh_token}),
+             Google.refresh_token(client, token_body),
            token <- Google.TokenBody.from_oauth2_token(token) do
         Credentials.update_credential(credential, %{
           body: token |> Lightning.Helpers.json_safe()
@@ -306,13 +304,14 @@ defmodule Lightning.Credentials do
     end
   end
 
-  def maybe_refresh_token(%Credential{} = credential),
-    do: credential
+  def maybe_refresh_token(%Credential{} = credential), do: {:ok, credential}
+  def maybe_refresh_token(nil), do: {:ok, nil}
 
-  def maybe_refresh_token(nil),
-    do: nil
-
-  defp still_fresh(expires_at, threshold \\ 5, time_unit \\ :minute) do
+  defp still_fresh(
+         %{expires_at: expires_at},
+         threshold \\ 5,
+         time_unit \\ :minute
+       ) do
     current_time = DateTime.utc_now()
     expiration_time = DateTime.from_unix!(expires_at)
 

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -56,6 +56,10 @@ defmodule Lightning.Helpers do
   """
   def json_safe(nil), do: nil
 
+  def json_safe(data) when is_struct(data) do
+    data |> Map.from_struct() |> json_safe()
+  end
+
   def json_safe(map) when is_map(map) do
     map
     |> Enum.map(fn {k, v} -> {Atom.to_string(k), json_safe(v)} end)

--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -110,6 +110,16 @@ defmodule Lightning.Pipeline.Runner do
         samples: Lightning.Credentials.sensitive_values_for(run.job.credential)
       )
 
+    # what if this fails? do we want to fail the run?
+    # how would the run fail, if we throw an exception here would that have
+    # good enough logs?
+    # if we silently fail, the job _should_ fail, but we would have to figure out
+    # that renewal was the reason.
+    Lightning.Credentials.refresh_credential(run.job.credential)
+
+    # call a function that checks if the credential is of type "googlesheets"
+    # then check if it needs to be updated.
+
     state = Lightning.Pipeline.StateAssembler.assemble(run)
 
     %{path: path} = find_or_install_adaptor(adaptor)

--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -110,16 +110,7 @@ defmodule Lightning.Pipeline.Runner do
         samples: Lightning.Credentials.sensitive_values_for(run.job.credential)
       )
 
-    # what if this fails? do we want to fail the run?
-    # how would the run fail, if we throw an exception here would that have
-    # good enough logs?
-    # if we silently fail, the job _should_ fail, but we would have to figure out
-    # that renewal was the reason.
-
-    run = maybe_refresh_run_credential(run)
-
-    # call a function that checks if the credential is of type "googlesheets"
-    # then check if it needs to be updated.
+    Lightning.Credentials.maybe_refresh_token(run.job.credential)
 
     state = Lightning.Pipeline.StateAssembler.assemble(run)
 
@@ -237,19 +228,6 @@ defmodule Lightning.Pipeline.Runner do
       adaptor
     else
       adaptor
-    end
-  end
-
-  defp maybe_refresh_run_credential(run) do
-    case Lightning.Credentials.maybe_refresh_token(run.job.credential) do
-      {:ok, credential} ->
-        {:ok, updated_run} =
-          Invocation.update_run(run, %{credential_id: credential.id})
-
-        updated_run
-
-      _ ->
-        run
     end
   end
 end

--- a/lib/lightning/pipeline/runner.ex
+++ b/lib/lightning/pipeline/runner.ex
@@ -115,7 +115,8 @@ defmodule Lightning.Pipeline.Runner do
     # good enough logs?
     # if we silently fail, the job _should_ fail, but we would have to figure out
     # that renewal was the reason.
-    Lightning.Credentials.refresh_credential(run.job.credential)
+
+    run = maybe_refresh_run_credential(run)
 
     # call a function that checks if the credential is of type "googlesheets"
     # then check if it needs to be updated.
@@ -236,6 +237,19 @@ defmodule Lightning.Pipeline.Runner do
       adaptor
     else
       adaptor
+    end
+  end
+
+  defp maybe_refresh_run_credential(run) do
+    case Lightning.Credentials.maybe_refresh_token(run.job.credential) do
+      {:ok, credential} ->
+        {:ok, updated_run} =
+          Invocation.update_run(run, %{credential_id: credential.id})
+
+        updated_run
+
+      _ ->
+        run
     end
   end
 end

--- a/test/lightning/auth_providers/google_test.exs
+++ b/test/lightning/auth_providers/google_test.exs
@@ -4,19 +4,21 @@ defmodule Lightning.AuthProviders.GoogleTest do
 
   alias Lightning.AuthProviders.Google
 
-  setup do
-    bypass = Bypass.open()
-
-    Lightning.ApplicationHelpers.put_temporary_env(:lightning, :oauth_clients,
-      google: [wellknown_url: "http://localhost:#{bypass.port}/auth/.well-known"]
-    )
-
-    expect_wellknown(bypass)
-
-    {:ok, bypass: bypass, endpoint_url: "http://localhost:#{bypass.port}"}
-  end
-
   describe "get_wellknown/0" do
+    setup do
+      bypass = Bypass.open()
+
+      Lightning.ApplicationHelpers.put_temporary_env(:lightning, :oauth_clients,
+        google: [
+          wellknown_url: "http://localhost:#{bypass.port}/auth/.well-known"
+        ]
+      )
+
+      expect_wellknown(bypass)
+
+      {:ok, bypass: bypass, endpoint_url: "http://localhost:#{bypass.port}"}
+    end
+
     test "pulls the .well-known from the path specified in the Application", %{
       bypass: bypass
     } do
@@ -33,7 +35,36 @@ defmodule Lightning.AuthProviders.GoogleTest do
     end
   end
 
+  describe "from_oauth2_token/1" do
+    test "converts OAuth2.AccessToken to a map" do
+      token = %OAuth2.AccessToken{
+        access_token: "ya29.a0AWY7CknfkidjXaoDTuNi",
+        expires_at: "4786203",
+        refresh_token: "1//03dATMQTmE5NSCgYIARAAGAMSNwF"
+      }
+
+      result = Google.TokenBody.from_oauth2_token(token)
+
+      assert is_map(result)
+      assert Map.get(result, :access_token) == "ya29.a0AWY7CknfkidjXaoDTuNi"
+      assert Map.get(result, :expires_at) == 4_786_203
+      assert Map.get(result, :refresh_token) == "1//03dATMQTmE5NSCgYIARAAGAMSNwF"
+    end
+  end
+
   describe "refresh_token" do
-    Google.refresh_token(...)
+    setup do
+      bypass = Bypass.open()
+
+      Lightning.ApplicationHelpers.put_temporary_env(:lightning, :oauth_clients,
+        google: [
+          wellknown_url: "http://localhost:#{bypass.port}/auth/.well-known"
+        ]
+      )
+
+      expect_wellknown(bypass)
+
+      {:ok, bypass: bypass, endpoint_url: "http://localhost:#{bypass.port}"}
+    end
   end
 end

--- a/test/lightning/auth_providers/google_test.exs
+++ b/test/lightning/auth_providers/google_test.exs
@@ -32,4 +32,8 @@ defmodule Lightning.AuthProviders.GoogleTest do
                "#{endpoint_url(bypass)}/userinfo_endpoint"
     end
   end
+
+  describe "refresh_token" do
+    Google.refresh_token(...)
+  end
 end

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -296,7 +296,7 @@ defmodule Lightning.CredentialsTest do
   describe "maybe_refresh_token/1" do
     test "doesn't refresh non OAuth credentials" do
       credential = CredentialsFixtures.credential_fixture()
-      refreshed_credential = Credentials.maybe_refresh_token(credential)
+      {:ok, refreshed_credential} = Credentials.maybe_refresh_token(credential)
       assert credential == refreshed_credential
     end
 
@@ -315,7 +315,7 @@ defmodule Lightning.CredentialsTest do
           schema: "googlesheets"
         )
 
-      refreshed_credential = Credentials.maybe_refresh_token(credential)
+      {:ok, refreshed_credential} = Credentials.maybe_refresh_token(credential)
 
       assert refreshed_credential.body["access_token"] ==
                credential.body["access_token"]
@@ -356,13 +356,12 @@ defmodule Lightning.CredentialsTest do
 
       {:ok, refreshed_credential} = Credentials.maybe_refresh_token(credential)
 
-      refute refreshed_credential.body["access_token"] ==
-               credential.body["access_token"]
-
-      assert refreshed_credential.body["expires_at"] >
-               credential.body["expires_at"]
-
       assert refreshed_credential != credential
+
+      new_expiry = refreshed_credential.body["expires_at"]
+
+      assert is_integer(new_expiry)
+      assert new_expiry > DateTime.to_unix(DateTime.utc_now()) + 10 * 60
     end
   end
 end

--- a/test/support/bypass_helpers.ex
+++ b/test/support/bypass_helpers.ex
@@ -1,22 +1,30 @@
 defmodule Lightning.BypassHelpers do
   @moduledoc false
 
+  def build_wellknown(bypass, attrs \\ %{}) do
+    Map.merge(
+      %{
+        "authorization_endpoint" =>
+          "#{endpoint_url(bypass)}/authorization_endpoint",
+        "token_endpoint" => "#{endpoint_url(bypass)}/token_endpoint",
+        "userinfo_endpoint" => "#{endpoint_url(bypass)}/userinfo_endpoint"
+      },
+      attrs
+    )
+  end
+
   @doc """
   Add a well-known endpoint expectation. Used to test AuthProviders
   """
-  def expect_wellknown(bypass) do
+  def expect_wellknown(bypass, wellknown \\ nil)
+
+  def expect_wellknown(bypass, nil) do
+    expect_wellknown(bypass, build_wellknown(bypass))
+  end
+
+  def expect_wellknown(bypass, wellknown) do
     Bypass.expect(bypass, "GET", "auth/.well-known", fn conn ->
-      Plug.Conn.resp(
-        conn,
-        200,
-        %{
-          "authorization_endpoint" =>
-            "#{endpoint_url(bypass)}/authorization_endpoint",
-          "token_endpoint" => "#{endpoint_url(bypass)}/token_endpoint",
-          "userinfo_endpoint" => "#{endpoint_url(bypass)}/userinfo_endpoint"
-        }
-        |> Jason.encode!()
-      )
+      Plug.Conn.resp(conn, 200, wellknown |> Jason.encode!())
     end)
   end
 

--- a/test/support/bypass_helpers.ex
+++ b/test/support/bypass_helpers.ex
@@ -44,7 +44,11 @@ defmodule Lightning.BypassHelpers do
   def expect_token(bypass, wellknown, token) do
     body =
       token ||
-        %{"access_token" => "blah", "refresh_token" => "blerg"}
+        %{
+          "access_token" => "blah",
+          "refresh_token" => "blerg",
+          "expires_in" => 3600
+        }
         |> Jason.encode!()
 
     expect_token(bypass, wellknown, {200, body})

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -47,6 +47,10 @@ defmodule Lightning.Factories do
     struct!(Lightning.Attempt, attrs)
   end
 
+  def build(:credential, attrs) do
+    struct!(Lightning.Credentials.Credential, attrs)
+  end
+
   def build(:reason, attrs) do
     struct!(Lightning.InvocationReason, attrs)
   end


### PR DESCRIPTION
## Steps

- [x] ~~Write a function that can tell the difference between a token that is about to expire and one that is not~~
- [x] Write a test for `Google.refresh_token()`
- [x] Write `Credentials.maybe_refresh_token/` which takes a credential and checks if its token is about to expire and renew it and update the credential, otherwise return the same credential.
- [x] Write a test for `Credentials.maybe_refresh_token/1`. That test should capture the scenario when a credential is not about to expire (return the same credential) and the one when a credential is about to expire (renew it, update its body, and return it)
- [x] Make sure when running a job that requires an OAuth credential, the access_token is refreshed. That requires calling `Credentials.maybe_refresh_token/1` in the runner module.

## Notes to reviewer

**@stuartc @zacck for some reasons I can't figure out, Dialyzer is complaining about missing @spec on the `Google.refresh_token/2` and `Credentials.maybe_refresh_token/1` functions. I have made sure to write / edit the @spec of all those two function but still can't pass Dialyzer's warnings about this.**


## Related issue  #646

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Taylor has **QA'd** this feature
