### PR TITLE
dont use timex in escript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,17 @@ and this project adheres to
 
 ### Fixed
 
+- Correctly stagger demo runs to maintain order
+  [#856](https://github.com/OpenFn/Lightning/issues/856)
+- Remove `Timex` use from `SetupUtils` in favor of `DateTime` to fix issue when
+  calling it in escript.
+
 ## [0.6.0]
 
 ### Added
 
 - Create sample runs when generating sample workflow
-  ([#821](https://github.com/OpenFn/Lightning/issues/821))
+  [#821](https://github.com/OpenFn/Lightning/issues/821)
 - Added a provisioning api for creating and updating projects and their
   workflows See: [PROVISIONING.md](./PROVISIONING.md)
   [#641](https://github.com/OpenFn/Lightning/issues/641)

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -274,8 +274,8 @@ defmodule Lightning.SetupUtils do
       %{
         job_id: notify_upload_failed.id,
         exit_code: 0,
-        started_at: DateTime.utc_now() |> DateTime.add(10, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
+        started_at: DateTime.utc_now() |> DateTime.add(21, :second),
+        finished_at: DateTime.utc_now() |> DateTime.add(31, :second)
       }
     ]
 

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -183,14 +183,14 @@ defmodule Lightning.SetupUtils do
       %{
         job_id: job_2.id,
         exit_code: 1,
-        started_at: Timex.now() |> Timex.shift(seconds: 10),
-        finished_at: Timex.now() |> Timex.shift(seconds: 20)
+        started_at: DateTime.utc_now() |> DateTime.add(10, :second),
+        finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
       },
       %{
         job_id: job_3.id,
         exit_code: 0,
-        started_at: Timex.now() |> Timex.shift(seconds: 10),
-        finished_at: Timex.now() |> Timex.shift(seconds: 20)
+        started_at: DateTime.utc_now() |> DateTime.add(10, :second),
+        finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
       }
     ]
 
@@ -268,14 +268,14 @@ defmodule Lightning.SetupUtils do
       %{
         job_id: send_to_openhim.id,
         exit_code: 1,
-        started_at: Timex.now() |> Timex.shift(seconds: 10),
-        finished_at: Timex.now() |> Timex.shift(seconds: 20)
+        started_at: DateTime.utc_now() |> DateTime.add(10, :second),
+        finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
       },
       %{
         job_id: notify_upload_failed.id,
         exit_code: 0,
-        started_at: Timex.now() |> Timex.shift(seconds: 10),
-        finished_at: Timex.now() |> Timex.shift(seconds: 20)
+        started_at: DateTime.utc_now() |> DateTime.add(10, :second),
+        finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
       }
     ]
 
@@ -337,8 +337,8 @@ defmodule Lightning.SetupUtils do
       %{
         job_id: upload_to_google_sheet.id,
         exit_code: 0,
-        started_at: Timex.now() |> Timex.shift(seconds: 10),
-        finished_at: Timex.now() |> Timex.shift(seconds: 20)
+        started_at: DateTime.utc_now() |> DateTime.add(10, :second),
+        finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
       }
     ]
 
@@ -418,8 +418,8 @@ defmodule Lightning.SetupUtils do
         # Change the timestamps, logs, exit_code etc
         run
         |> Run.changeset(%{
-          started_at: Timex.now() |> Timex.shift(seconds: 10),
-          finished_at: Timex.now() |> Timex.shift(seconds: 20)
+          started_at: DateTime.utc_now() |> DateTime.add(10, :second),
+          finished_at: DateTime.utc_now() |> DateTime.add(20, :second)
         })
       end)
 


### PR DESCRIPTION
We recently added staggered runs into `SetupUtils` when creating demo data. We reached for Timex as usual, however since this function is called via escript it's not going to work.

See: https://hexdocs.pm/timex/Timex.html#module-timex-with-escript

## Related issue

There is no issue linked to the escript issue, however this PR also addresses:

Fixes #856 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
