### PR TITLE
Changes from deploy CLI integration

### DIFF
--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -38,6 +38,7 @@ defmodule Lightning.Policies.ProjectUsers do
           Lightning.Accounts.User.t(),
           Lightning.Projects.Project.t()
         ) :: boolean
+  def authorize(:access_project, %User{}, nil), do: false
   def authorize(:access_project, %User{} = user, %Project{} = project),
     do:
       is_nil(project.scheduled_deletion) and

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -39,6 +39,7 @@ defmodule Lightning.Policies.ProjectUsers do
           Lightning.Projects.Project.t()
         ) :: boolean
   def authorize(:access_project, %User{}, nil), do: false
+
   def authorize(:access_project, %User{} = user, %Project{} = project),
     do:
       is_nil(project.scheduled_deletion) and

--- a/lib/lightning_web/controllers/api/provisioning_controller.ex
+++ b/lib/lightning_web/controllers/api/provisioning_controller.ex
@@ -17,7 +17,12 @@ defmodule LightningWeb.API.ProvisioningController do
              conn.assigns.current_user,
              project
            ),
-         {:ok, project} <- Provisioner.import_document(project, params) do
+         {:ok, project} <-
+           Provisioner.import_document(
+             project,
+             conn.assigns.current_user,
+             params
+           ) do
       # TODO: check if the user is allowed to update this project
       # TODO: check if the user is allowed to provision a project
 

--- a/lib/lightning_web/controllers/api/provisioning_controller.ex
+++ b/lib/lightning_web/controllers/api/provisioning_controller.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.API.ProvisioningController do
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.Provisioning
 
-  action_fallback LightningWeb.FallbackController
+  action_fallback(LightningWeb.FallbackController)
 
   def create(conn, params) do
     with project <- get_or_build_project(params),
@@ -23,9 +23,6 @@ defmodule LightningWeb.API.ProvisioningController do
              conn.assigns.current_user,
              params
            ) do
-      # TODO: check if the user is allowed to update this project
-      # TODO: check if the user is allowed to provision a project
-
       conn
       |> put_status(:created)
       |> put_resp_header("location", ~p"/api/provision/#{project.id}")
@@ -39,7 +36,7 @@ defmodule LightningWeb.API.ProvisioningController do
          :ok <-
            Permissions.can(
              Provisioning,
-             :provision_project,
+             :describe_project,
              conn.assigns.current_user,
              project
            ) do

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -23,7 +23,7 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
   def as_json(%Job{} = job) do
     Ecto.embedded_dump(job, :json)
-    |> Map.take(~w(id adaptor enabled name)a)
+    |> Map.take(~w(id adaptor enabled body name)a)
   end
 
   def as_json(%Trigger{} = trigger) do

--- a/lib/lightning_web/controllers/fallback_controller.ex
+++ b/lib/lightning_web/controllers/fallback_controller.ex
@@ -16,9 +16,16 @@ defmodule LightningWeb.FallbackController do
 
   def call(conn, {:error, :unauthorized}) do
     conn
-    |> put_status(:not_found)
+    |> put_status(:unauthorized)
     |> put_view(LightningWeb.ErrorView)
-    |> render(:"404")
+    |> render(:"401")
+  end
+
+  def call(conn, {:error, :forbidden}) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(LightningWeb.ErrorView)
+    |> render(:"403")
   end
 
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -31,7 +31,7 @@ defmodule LightningWeb.Hooks do
        |> assign_new(:project, fn -> project end)
        |> assign_new(:projects, fn -> projects end)}
     else
-      {:halt, redirect(socket, to: "/") |> put_flash(:nav, :no_access)}
+      {:halt, redirect(socket, to: "/") |> put_flash(:nav, :not_found)}
     end
   end
 

--- a/lib/lightning_web/live/audit_live/index.ex
+++ b/lib/lightning_web/live/audit_live/index.ex
@@ -26,7 +26,7 @@ defmodule LightningWeb.AuditLive.Index do
        ), layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
-       put_flash(socket, :error, "You can't access that page")
+       put_flash(socket, :nav, :no_access)
        |> push_redirect(to: "/")}
     end
   end

--- a/lib/lightning_web/live/auth_providers/index.ex
+++ b/lib/lightning_web/live/auth_providers/index.ex
@@ -19,7 +19,7 @@ defmodule LightningWeb.AuthProvidersLive.Index do
        layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
-       put_flash(socket, :error, "You can't access that page")
+       put_flash(socket, :nav, :no_access)
        |> push_redirect(to: "/")}
     end
   end

--- a/lib/lightning_web/live/credential_live/edit.ex
+++ b/lib/lightning_web/live/credential_live/edit.ex
@@ -94,7 +94,7 @@ defmodule LightningWeb.CredentialLive.Edit do
         users: list_users()
       )
     else
-      put_flash(socket, :error, "You can't access that page")
+      put_flash(socket, :nav, :not_found)
       |> push_redirect(to: "/")
     end
   end

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -39,7 +39,7 @@ defmodule LightningWeb.DashboardLive.Index do
           to: Routes.project_workflow_path(socket, :index, project.id)
         )
       else
-        {:halt, redirect(socket, to: "/") |> put_flash(:nav, :no_access)}
+        {:halt, redirect(socket, to: "/") |> put_flash(:nav, :not_found)}
       end
     else
       socket

--- a/lib/lightning_web/live/live_helpers.ex
+++ b/lib/lightning_web/live/live_helpers.ex
@@ -64,7 +64,7 @@ defmodule LightningWeb.LiveHelpers do
         :not_found ->
           assign(assigns,
             heading: "Not Found",
-            blurb: "Sorry, we couldn't find what you were looking for.",
+            blurb: "Sorry, we can't find anything here for you.",
             show_nav_error: true
           )
 

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -18,7 +18,7 @@ defmodule LightningWeb.ProjectLive.Index do
       {:ok, socket, layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
-       put_flash(socket, :error, "You can't access that page")
+       put_flash(socket, :nav, :no_access)
        |> push_redirect(to: "/")}
     end
   end

--- a/lib/lightning_web/live/user_live/edit.ex
+++ b/lib/lightning_web/live/user_live/edit.ex
@@ -18,7 +18,8 @@ defmodule LightningWeb.UserLive.Edit do
     if can_access_admin_space do
       {:ok,
        socket
-       |> assign(active_menu_item: :users), layout: {LightningWeb.Layouts, :settings}}
+       |> assign(active_menu_item: :users),
+       layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
        put_flash(socket, :nav, :no_access)

--- a/lib/lightning_web/live/user_live/edit.ex
+++ b/lib/lightning_web/live/user_live/edit.ex
@@ -18,11 +18,10 @@ defmodule LightningWeb.UserLive.Edit do
     if can_access_admin_space do
       {:ok,
        socket
-       |> assign(active_menu_item: :users),
-       layout: {LightningWeb.Layouts, :settings}}
+       |> assign(active_menu_item: :users), layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
-       put_flash(socket, :error, "You can't access that page")
+       put_flash(socket, :nav, :no_access)
        |> push_redirect(to: "/")}
     end
   end

--- a/lib/lightning_web/live/user_live/index.ex
+++ b/lib/lightning_web/live/user_live/index.ex
@@ -16,7 +16,8 @@ defmodule LightningWeb.UserLive.Index do
     if can_access_admin_space do
       {:ok,
        assign(socket, :users, list_users())
-       |> assign(:active_menu_item, :users), layout: {LightningWeb.Layouts, :settings}}
+       |> assign(:active_menu_item, :users),
+       layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
        put_flash(socket, :nav, :no_access)

--- a/lib/lightning_web/live/user_live/index.ex
+++ b/lib/lightning_web/live/user_live/index.ex
@@ -16,11 +16,10 @@ defmodule LightningWeb.UserLive.Index do
     if can_access_admin_space do
       {:ok,
        assign(socket, :users, list_users())
-       |> assign(:active_menu_item, :users),
-       layout: {LightningWeb.Layouts, :settings}}
+       |> assign(:active_menu_item, :users), layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
-       put_flash(socket, :error, "You can't access that page")
+       put_flash(socket, :nav, :no_access)
        |> push_redirect(to: "/")}
     end
   end

--- a/test/lightning_web/controllers/api/job_controller_test.exs
+++ b/test/lightning_web/controllers/api/job_controller_test.exs
@@ -44,14 +44,14 @@ defmodule LightningWeb.API.JobControllerTest do
              ]
     end
 
-    test "responds with a 404 when I don't have access", %{conn: conn} do
+    test "responds with a 401 when I don't have access", %{conn: conn} do
       other_project = project_fixture()
 
       conn = get(conn, ~p"/api/projects/#{other_project.id}/jobs")
 
-      response = json_response(conn, 404)
+      response = json_response(conn, 401)
 
-      assert response == %{"error" => "Not Found"}
+      assert response == %{"error" => "Unauthorized"}
     end
 
     test "lists all jobs", %{conn: conn, job: job} do

--- a/test/lightning_web/controllers/api/project_controller_test.exs
+++ b/test/lightning_web/controllers/api/project_controller_test.exs
@@ -82,7 +82,7 @@ defmodule LightningWeb.API.ProjectControllerTest do
     test "with token for other project", %{conn: conn} do
       other_project = project_fixture()
       conn = get(conn, ~p"/api/projects/#{other_project.id}")
-      assert json_response(conn, 404) == %{"error" => "Not Found"}
+      assert json_response(conn, 401) == %{"error" => "Unauthorized"}
     end
 
     test "shows the project", %{conn: conn, project: project} do

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -216,13 +216,13 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
              "All workflows should belong to the same project"
     end
 
-    test "returns a 404 if not authorized", %{conn: conn} do
+    test "returns a 401 if not authorized", %{conn: conn} do
       %{id: project_id} = Lightning.Factories.insert(:project)
 
       conn = get(conn, ~p"/api/provision/#{project_id}")
-      response = json_response(conn, 404)
+      response = json_response(conn, 401)
 
-      assert response == %{"error" => "Not Found"}
+      assert response == %{"error" => "Unauthorized"}
     end
   end
 

--- a/test/lightning_web/controllers/api/run_controller_test.exs
+++ b/test/lightning_web/controllers/api/run_controller_test.exs
@@ -56,14 +56,14 @@ defmodule LightningWeb.API.RunControllerTest do
       refute MapSet.subset?(other_run_ids, all_run_ids)
     end
 
-    test "responds with a 404 when I don't have access", %{conn: conn} do
+    test "responds with a 401 when I don't have access", %{conn: conn} do
       other_project = project_fixture()
 
       conn = get(conn, ~p"/api/projects/#{other_project.id}/runs")
 
-      response = json_response(conn, 404)
+      response = json_response(conn, 401)
 
-      assert response == %{"error" => "Not Found"}
+      assert response == %{"error" => "Unauthorized"}
     end
 
     test "lists all runs for the current user", %{

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -10,7 +10,7 @@ defmodule LightningWeb.AuditLiveTest do
       {:ok, _index_live, html} =
         live(conn, ~p"/settings/audit") |> follow_redirect(conn, "/")
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, you don&#39;t have access to that."
     end
   end
 

--- a/test/lightning_web/live/auth_providers_live_test.exs
+++ b/test/lightning_web/live/auth_providers_live_test.exs
@@ -31,7 +31,7 @@ defmodule LightningWeb.AuthProvidersLiveTest do
         live(conn, ~p"/settings/authentication")
         |> follow_redirect(conn, "/")
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, you don&#39;t have access to that."
     end
   end
 

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -330,7 +330,7 @@ defmodule LightningWeb.CredentialLiveTest do
         |> follow_redirect(conn)
         |> follow_redirect(conn)
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, we can&#39;t find anything here for you."
     end
 
     test "marks a credential for use in a 'production' system", %{

--- a/test/lightning_web/live/dataclip_live_test.exs
+++ b/test/lightning_web/live/dataclip_live_test.exs
@@ -22,7 +22,7 @@ defmodule LightningWeb.DataclipLiveTest do
         live(conn, Routes.project_dataclip_index_path(conn, :index, project.id))
 
       assert error ==
-               {:error, {:redirect, %{flash: %{"nav" => :no_access}, to: "/"}}}
+               {:error, {:redirect, %{flash: %{"nav" => :not_found}, to: "/"}}}
     end
 
     test "lists all dataclips", %{
@@ -155,7 +155,7 @@ defmodule LightningWeb.DataclipLiveTest do
         )
 
       assert error ==
-               {:error, {:redirect, %{flash: %{"nav" => :no_access}, to: "/"}}}
+               {:error, {:redirect, %{flash: %{"nav" => :not_found}, to: "/"}}}
     end
   end
 end

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -22,7 +22,7 @@ defmodule LightningWeb.ProjectLiveTest do
       {:ok, _index_live, html} =
         live(conn, ~p"/settings/projects") |> follow_redirect(conn, "/")
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, you don&#39;t have access to that."
     end
 
     test "cannot access the new page", %{conn: conn} do
@@ -30,7 +30,7 @@ defmodule LightningWeb.ProjectLiveTest do
         live(conn, ~p"/settings/projects/new")
         |> follow_redirect(conn, "/")
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, you don&#39;t have access to that."
     end
   end
 
@@ -390,7 +390,7 @@ defmodule LightningWeb.ProjectLiveTest do
                conn,
                Routes.project_workflow_path(conn, :index, project_3.id)
              ) ==
-               {:error, {:redirect, %{flash: %{"nav" => :no_access}, to: "/"}}}
+               {:error, {:redirect, %{flash: %{"nav" => :not_found}, to: "/"}}}
     end
   end
 

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -266,7 +266,7 @@ defmodule LightningWeb.UserLiveTest do
         live(conn, Routes.user_index_path(conn, :index))
         |> follow_redirect(conn, "/")
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, you don&#39;t have access to that."
     end
 
     test "a regular user cannot access a user edit page", %{
@@ -277,7 +277,7 @@ defmodule LightningWeb.UserLiveTest do
         live(conn, Routes.user_edit_path(conn, :edit, user.id))
         |> follow_redirect(conn, "/")
 
-      assert html =~ "You can&#39;t access that page"
+      assert html =~ "Sorry, you don&#39;t have access to that."
     end
   end
 end

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1143,7 +1143,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         )
 
       assert error ==
-               {:error, {:redirect, %{flash: %{"nav" => :no_access}, to: "/"}}}
+               {:error, {:redirect, %{flash: %{"nav" => :not_found}, to: "/"}}}
     end
 
     test "log_view component" do

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -25,6 +25,16 @@ defmodule Lightning.Factories do
     |> merge_attributes(attrs)
   end
 
+  def build(:user, attrs) do
+    struct!(Lightning.Accounts.User, %{
+      email: "user#{System.unique_integer()}@example.com",
+      password: "hello world!",
+      first_name: "anna",
+      hashed_password: Bcrypt.hash_pwd_salt("hello world!")
+    })
+    |> merge_attributes(attrs)
+  end
+
   def build(:run, attrs) do
     struct!(Lightning.Invocation.Run, %{
       job: build(:job),


### PR DESCRIPTION
**Notable changes**

Changing unauthorized API responses from 404s to 401s.

This is necessary because we need to be able to tell the difference
between problems with the users API key (not their project or their role
isn't correct) and _actually_ new projects so that the state merging
works correctly.

## Notes for the reviewer



## Related issue

Re: https://github.com/OpenFn/kit/issues/245

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Taylor has **QA'd** this feature
