### PR TITLE
Bulk rerun work orders from start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ and this project adheres to
 
 ### Added
 
+- Ability to rerun workorders from start by selecting one of more of them from
+  the History page and clicking the "Rerun" button.
+  [#659](https://github.com/OpenFn/Lightning/issues/659)
+
 ### Changed
 
 ### Fixed
 
 ## [0.6.3]
-
-### Added
-
-### Changed
 
 ### Fixed
 
@@ -26,10 +26,6 @@ and this project adheres to
   [#866](https://github.com/OpenFn/Lightning/issues/866)
 
 ## [0.6.2]
-
-### Added
-
-### Changed
 
 ### Fixed
 
@@ -39,10 +35,6 @@ and this project adheres to
   [#859](https://github.com/OpenFn/Lightning/issues/859)
 
 ## [0.6.1]
-
-### Added
-
-### Changed
 
 ### Fixed
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -75,23 +75,16 @@ Hooks.Copy = {
   },
 };
 
-Hooks.CheckboxState ={
+// Sets the checkbox to indeterminate state if the element has the
+// `indeterminate` class
+Hooks.CheckboxIndeterminate = {
   mounted() {
-    if (this.el.classList.contains('indeterminate')) {
-      this.el.indeterminate = true;
-    } else {
-      this.el.indeterminate = false;
-    }
+    this.el.indeterminate = this.el.classList.contains('indeterminate');
   },
   updated() {
-    if (this.el.classList.contains('indeterminate')) {
-      this.el.indeterminate = true;
-    } else {
-      this.el.indeterminate = false;
-    }
-  }, 
-  
-}
+    this.el.indeterminate = this.el.classList.contains('indeterminate');
+  },
+};
 
 // @ts-ignore
 let csrfToken = document

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -75,6 +75,24 @@ Hooks.Copy = {
   },
 };
 
+Hooks.CheckboxState ={
+  mounted() {
+    if (this.el.classList.contains('indeterminate')) {
+      this.el.indeterminate = true;
+    } else {
+      this.el.indeterminate = false;
+    }
+  },
+  updated() {
+    if (this.el.classList.contains('indeterminate')) {
+      this.el.indeterminate = true;
+    } else {
+      this.el.indeterminate = false;
+    }
+  }, 
+  
+}
+
 // @ts-ignore
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")

--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -111,6 +111,12 @@ defmodule Lightning.AttemptService do
     end)
   end
 
+  @doc """
+  Creates new Attempts for each pair of corresponding AttemptRun and
+  InvocationReason.
+  """
+  @spec retry_many([AttemptRun.t()], [Lightning.InvocationReason.t()]) ::
+          Ecto.Multi.t()
   def retry_many(
         [%AttemptRun{} | _other_runs] = attempt_runs,
         [%InvocationReason{} | _other_reasons] = reasons
@@ -255,6 +261,11 @@ defmodule Lightning.AttemptService do
     |> Repo.one()
   end
 
+  @doc """
+  Returns a list of AttemptRun structs that should be rerun for the given list
+  of work order ids.
+  """
+  @spec list_for_rerun_from_start([Ecto.UUID.t()]) :: [AttemptRun.t()]
   def list_for_rerun_from_start(order_ids) when is_list(order_ids) do
     attempt_run_numbers_query =
       from(ar in AttemptRun,

--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -133,7 +133,7 @@ defmodule Lightning.AttemptService do
         Enum.map(attempt_runs, fn %{attempt: %{work_order: work_order}, run: run} ->
           %{
             work_order_id: work_order.id,
-            reason_id: reasons_map[run.id],
+            reason_id: Map.fetch!(reasons_map, run.id),
             inserted_at: now,
             updated_at: now
           }

--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -161,12 +161,13 @@ defmodule Lightning.AttemptService do
     attempt_run_numbers_query =
       from(ar in AttemptRun,
         join: att in assoc(ar, :attempt),
+        join: r in assoc(ar, :run),
         where: att.work_order_id in ^order_ids,
         select: %{
           id: ar.id,
           row_num:
             row_number()
-            |> over(partition_by: att.work_order_id, order_by: ar.inserted_at)
+            |> over(partition_by: att.work_order_id, order_by: r.started_at)
         }
       )
 

--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -117,10 +117,10 @@ defmodule Lightning.AttemptService do
       ) do
     attempt_runs =
       attempt_runs
-      |> Repo.preload(
-        run: [],
+      |> Repo.preload([
+        :run,
         attempt: [work_order: [jobs: [trigger: :upstream_job]], runs: []]
-      )
+      ])
 
     Multi.new()
     |> Multi.insert_all(
@@ -265,7 +265,10 @@ defmodule Lightning.AttemptService do
           id: ar.id,
           row_num:
             row_number()
-            |> over(partition_by: att.work_order_id, order_by: r.started_at)
+            |> over(
+              partition_by: att.work_order_id,
+              order_by: coalesce(r.started_at, r.inserted_at)
+            )
         }
       )
 

--- a/lib/lightning/demo.ex
+++ b/lib/lightning/demo.ex
@@ -12,6 +12,7 @@ defmodule Lightning.Demo do
   """
   def reset_demo do
     Lightning.Release.load_app()
+    Application.ensure_all_started(:timex)
 
     {:ok, _, _} =
       Ecto.Migrator.with_repo(Lightning.Repo, fn _repo ->

--- a/lib/lightning/demo.ex
+++ b/lib/lightning/demo.ex
@@ -12,7 +12,6 @@ defmodule Lightning.Demo do
   """
   def reset_demo do
     Lightning.Release.load_app()
-    Application.ensure_all_started(:timex)
 
     {:ok, _, _} =
       Ecto.Migrator.with_repo(Lightning.Repo, fn _repo ->

--- a/lib/lightning/invocation/workorder.ex
+++ b/lib/lightning/invocation/workorder.ex
@@ -22,6 +22,7 @@ defmodule Lightning.WorkOrder do
     belongs_to :workflow, Workflow
     belongs_to :reason, InvocationReason
     has_many :attempts, Attempt
+    has_many :jobs, through: [:workflow, :jobs]
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/lib/lightning/work_order_service.ex
+++ b/lib/lightning/work_order_service.ex
@@ -122,8 +122,10 @@ defmodule Lightning.WorkOrderService do
         select: [p.id]
       )
     end)
-    |> Multi.run(:broadcast, fn %{attempt: attempt, project_id: project_id} ->
+    |> Multi.run(:broadcast, fn _repo,
+                                %{attempt: attempt, project_id: project_id} ->
       broadcast(project_id, %Events.AttemptCreated{attempt: attempt})
+      {:ok, nil}
     end)
   end
 

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -3,6 +3,7 @@ defmodule LightningWeb.RunLive.Components do
   use LightningWeb, :component
   import LightningWeb.RouteHelpers
   alias Lightning.Pipeline
+  alias Lightning.Workorders.SearchParams
   alias Phoenix.LiveView.JS
 
   attr :project, :map, required: true
@@ -531,6 +532,8 @@ defmodule LightningWeb.RunLive.Components do
   attr :total_entries, :integer, required: true
   attr :all_selected?, :boolean, required: true
   attr :selected_count, :integer, required: true
+  attr :filters, SearchParams, required: true
+  attr :workflows, :list, required: true
   attr :show, :boolean, default: false
 
   def bulk_rerun_modal(assigns) do
@@ -714,8 +717,10 @@ defmodule LightningWeb.RunLive.Components do
   defp humanize_workflow(filter, workflows) do
     case filter do
       %{workflow_id: workflow_id} ->
-        workflow = Enum.find(workflows, &(&1.id == workflow_id))
-        "for #{workflow.name} workflow"
+        {workflow, _id} =
+          Enum.find(workflows, fn {_name, id} -> id == workflow_id end)
+
+        "for #{workflow} workflow"
 
       _other ->
         ""

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -662,13 +662,13 @@ defmodule LightningWeb.RunLive.Components do
   defp humanize_wo_dates(filter) do
     case filter do
       %{wo_date_after: date_after, wo_date_before: date_before} ->
-        "received between #{date_before} and #{date_after}"
+        "received between #{humanize_datetime(date_before)} and #{humanize_datetime(date_after)}"
 
       %{wo_date_after: date_after} ->
-        "received after #{date_after}"
+        "received after #{humanize_datetime(date_after)}"
 
       %{wo_date_before: date_before} ->
-        "received before #{date_before}"
+        "received before #{humanize_datetime(date_before)}"
 
       _other ->
         ""
@@ -678,13 +678,13 @@ defmodule LightningWeb.RunLive.Components do
   defp humanize_run_dates(filter) do
     case filter do
       %{date_after: date_after, date_before: date_before} ->
-        "which was last run between #{date_before} and #{date_after}"
+        "which was last run between #{humanize_datetime(date_before)} and #{humanize_datetime(date_after)}"
 
       %{date_after: date_after} ->
-        "which was last run after #{date_after}"
+        "which was last run after #{humanize_datetime(date_after)}"
 
       %{date_before: date_before} ->
-        "which was last run before #{date_before}"
+        "which was last run before #{humanize_datetime(date_before)}"
 
       _other ->
         ""
@@ -715,7 +715,7 @@ defmodule LightningWeb.RunLive.Components do
   defp humanize_status(filter) do
     case filter do
       %{status: [_1, _2 | _rest] = statuses} ->
-        "having statuses of #{Enum.map_join(statuses, " or ", fn status -> "'#{humanize_field(status)}'" end)}"
+        "having a status of either #{Enum.map_join(statuses, " or ", fn status -> "'#{humanize_field(status)}'" end)}"
 
       %{status: [status]} ->
         "having a status of '#{humanize_field(status)}'"
@@ -731,6 +731,10 @@ defmodule LightningWeb.RunLive.Components do
       :body -> "Input Body"
       other -> other |> to_string |> String.capitalize()
     end
+  end
+
+  defp humanize_datetime(date) do
+    Timex.format!(date, "{D}/{M}/{YY} at {h12}:{m}{am}")
   end
 
   def show_modal(js \\ %JS{}, id) when is_binary(id) do

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -588,12 +588,14 @@ defmodule LightningWeb.RunLive.Components do
             >
               <button
                 type="button"
+                phx-click="bulk-rerun-selected"
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
               >
                 Rerun selected (<%= @selected_count %> workorders) from start
               </button>
               <button
                 type="button"
+                phx-click="bulk-rerun-all"
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
                 Rerun ALL (<%= @total_entries %> ) from start
@@ -622,6 +624,7 @@ defmodule LightningWeb.RunLive.Components do
             >
               <button
                 type="button"
+                phx-click="bulk-rerun-selected"
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
                 Rerun selected (<%= @selected_count %> workorders) from start

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -606,7 +606,7 @@ defmodule LightningWeb.RunLive.Components do
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
-                Rerun ALL (<%= @total_entries %> ) from start
+                Rerun ALL (<%= @total_entries %> workorders) from start
               </button>
               <div class="relative col-start-1 col-end-3">
                 <div class="absolute inset-0 flex items-center" aria-hidden="true">

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -621,7 +621,7 @@ defmodule LightningWeb.RunLive.Components do
               </div>
               <button
                 type="button"
-                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
+                class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
                 phx-click={hide_modal(@id)}
               >
                 Cancel
@@ -642,7 +642,7 @@ defmodule LightningWeb.RunLive.Components do
               </button>
               <button
                 type="button"
-                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
+                class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
                 phx-click={hide_modal(@id)}
               >
                 Cancel

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -542,6 +542,7 @@ defmodule LightningWeb.RunLive.Components do
       role="dialog"
       aria-modal="true"
       phx-mounted={@show && show_modal(@id)}
+      phx-remove={hide_modal(@id)}
     >
       <div
         id={"#{@id}-bg"}
@@ -588,14 +589,18 @@ defmodule LightningWeb.RunLive.Components do
             >
               <button
                 type="button"
-                phx-click="bulk-rerun-selected"
+                phx-click="bulk-rerun"
+                phx-value-type="selected"
+                phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
               >
                 Rerun selected (<%= @selected_count %> workorders) from start
               </button>
               <button
                 type="button"
-                phx-click="bulk-rerun-all"
+                phx-click="bulk-rerun"
+                phx-value-type="all"
+                phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
                 Rerun ALL (<%= @total_entries %> ) from start
@@ -624,7 +629,9 @@ defmodule LightningWeb.RunLive.Components do
             >
               <button
                 type="button"
-                phx-click="bulk-rerun-selected"
+                phx-click="bulk-rerun"
+                phx-value-type="selected"
+                phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
                 Rerun selected (<%= @selected_count %> workorders) from start

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -741,9 +741,9 @@ defmodule LightningWeb.RunLive.Components do
   end
 
   defp humanize_field(search_field) do
-    case search_field do
-      :log -> "Logs"
-      :body -> "Input Body"
+    case to_string(search_field) do
+      "log" -> "Logs"
+      "body" -> "Input Body"
       other -> other |> to_string |> String.capitalize()
     end
   end

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -462,8 +462,6 @@ defmodule LightningWeb.RunLive.Components do
     """
   end
 
-  alias Phoenix.LiveView.JS
-
   def switch_section(section) do
     JS.hide(to: "[id$=_section]:not([id=#{section}_section])")
     |> JS.set_attribute({"data-active", "false"},
@@ -525,5 +523,252 @@ defmodule LightningWeb.RunLive.Components do
     assign(assigns,
       classes: @base_classes ++ classes ++ List.wrap(assigns[:class])
     )
+  end
+
+  # BULK RERUN
+  attr :id, :string, required: true
+  attr :page_number, :integer, required: true
+  attr :total_entries, :integer, required: true
+  attr :all_selected?, :boolean, required: true
+  attr :selected_count, :integer, required: true
+  attr :show, :boolean, default: false
+
+  def bulk_rerun_modal(assigns) do
+    ~H"""
+    <div
+      class="relative z-10 hidden"
+      aria-labelledby={"#{@id}-title"}
+      id={@id}
+      role="dialog"
+      aria-modal="true"
+      phx-mounted={@show && show_modal(@id)}
+    >
+      <div
+        id={"#{@id}-bg"}
+        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+      >
+      </div>
+
+      <div
+        aria-labelledby={"#{@id}-title"}
+        class="fixed inset-0 z-10 overflow-y-auto"
+      >
+        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <.focus_wrap
+            id={"#{@id}-container"}
+            phx-mounted={@show && show_modal(@id)}
+            phx-window-keydown={hide_modal(@id)}
+            phx-key="escape"
+            phx-click-away={hide_modal(@id)}
+            class="hidden relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6"
+          >
+            <div id={"#{@id}-content"} class="mt-3 text-center sm:mt-5">
+              <h3
+                class="text-base font-semibold leading-6 text-gray-900"
+                id={"#{@id}-title"}
+              >
+                Run Selected Workers
+              </h3>
+              <div class="mt-2">
+                <p class="text-sm text-gray-500">
+                  <%= if @all_selected? do %>
+                    You've selected the <%= @selected_count %> work orders from page <%= @page_number %> of results for workorders matching the following query: <%= humanize_search_params(
+                      @filters,
+                      @workflows
+                    ) %>. There are a total of <%= @total_entries %> work orders matching this query.
+                  <% else %>
+                    You've selected <%= @selected_count %> work orders to rerun from the start (first job). This will create a new attempt for these within the same work order
+                  <% end %>
+                </p>
+              </div>
+            </div>
+            <div
+              :if={@all_selected? and @total_entries > 1}
+              class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
+            >
+              <button
+                type="button"
+                class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
+              >
+                Rerun selected (<%= @selected_count %> workorders) from start
+              </button>
+              <button
+                type="button"
+                class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
+              >
+                Rerun ALL (<%= @total_entries %> ) from start
+              </button>
+              <div class="relative col-start-1 col-end-3">
+                <div class="absolute inset-0 flex items-center" aria-hidden="true">
+                  <div class="w-full border-t border-gray-300"></div>
+                </div>
+                <div class="relative flex justify-center">
+                  <span class="bg-white px-2 text-sm text-gray-500">
+                    OR
+                  </span>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
+                phx-click={hide_modal(@id)}
+              >
+                Cancel
+              </button>
+            </div>
+            <div
+              :if={!@all_selected? or @total_entries == 1}
+              class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
+            >
+              <button
+                type="button"
+                class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
+              >
+                Rerun selected (<%= @selected_count %> workorders) from start
+              </button>
+              <button
+                type="button"
+                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
+                phx-click={hide_modal(@id)}
+              >
+                Cancel
+              </button>
+            </div>
+          </.focus_wrap>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp humanize_search_params(filters, workflows) do
+    filter =
+      filters
+      |> Map.from_struct()
+      |> Enum.reject(fn {_key, val} -> is_nil(val) end)
+      |> Enum.into(%{})
+
+    params = [
+      humanize_wo_dates(filter),
+      humanize_workflow(filter, workflows),
+      humanize_run_dates(filter),
+      humanize_search_term(filter),
+      humanize_status(filter)
+    ]
+
+    params |> Enum.reject(&(&1 == "")) |> Enum.join(", ")
+  end
+
+  defp humanize_wo_dates(filter) do
+    case filter do
+      %{wo_date_after: date_after, wo_date_before: date_before} ->
+        "received between #{date_before} and #{date_after}"
+
+      %{wo_date_after: date_after} ->
+        "received after #{date_after}"
+
+      %{wo_date_before: date_before} ->
+        "received before #{date_before}"
+
+      _other ->
+        ""
+    end
+  end
+
+  defp humanize_run_dates(filter) do
+    case filter do
+      %{date_after: date_after, date_before: date_before} ->
+        "which was last run between #{date_before} and #{date_after}"
+
+      %{date_after: date_after} ->
+        "which was last run after #{date_after}"
+
+      %{date_before: date_before} ->
+        "which was last run before #{date_before}"
+
+      _other ->
+        ""
+    end
+  end
+
+  defp humanize_search_term(filter) do
+    case filter do
+      %{search_term: search_term, search_fields: [_h | _t] = search_fields} ->
+        "whose run #{Enum.map_join(search_fields, " and ", &humanize_field/1)} contain #{search_term}"
+
+      _other ->
+        ""
+    end
+  end
+
+  defp humanize_workflow(filter, workflows) do
+    case filter do
+      %{workflow_id: workflow_id} ->
+        workflow = Enum.find(workflows, &(&1.id == workflow_id))
+        "for #{workflow.name} workflow"
+
+      _other ->
+        ""
+    end
+  end
+
+  defp humanize_status(filter) do
+    case filter do
+      %{status: [_1, _2 | _rest] = statuses} ->
+        "having statuses of #{Enum.map_join(statuses, " or ", fn status -> "'#{humanize_field(status)}'" end)}"
+
+      %{status: [status]} ->
+        "having a status of '#{humanize_field(status)}'"
+
+      _other ->
+        ""
+    end
+  end
+
+  defp humanize_field(search_field) do
+    case search_field do
+      :log -> "Logs"
+      :body -> "Input Body"
+      other -> other |> to_string |> String.capitalize()
+    end
+  end
+
+  def show_modal(js \\ %JS{}, id) when is_binary(id) do
+    js
+    |> JS.show(to: "##{id}")
+    |> JS.show(
+      to: "##{id}-bg",
+      transition:
+        {"transition-all transform ease-out duration-300", "opacity-0",
+         "opacity-100"}
+    )
+    |> JS.show(
+      to: "##{id}-container",
+      transition:
+        {"transition-all transform ease-out duration-300",
+         "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
+         "opacity-100 translate-y-0 sm:scale-100"}
+    )
+    |> JS.focus_first(to: "##{id}-content")
+  end
+
+  def hide_modal(js \\ %JS{}, id) do
+    js
+    |> JS.hide(
+      to: "##{id}-bg",
+      transition:
+        {"transition-all transform ease-in duration-200", "opacity-100",
+         "opacity-0"}
+    )
+    |> JS.hide(
+      to: "##{id}-container",
+      time: 200,
+      transition:
+        {"transition-all transform ease-in duration-200",
+         "opacity-100 translate-y-0 sm:scale-100",
+         "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"}
+    )
+    |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
+    |> JS.pop_focus()
   end
 end

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -598,7 +598,10 @@ defmodule LightningWeb.RunLive.Components do
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
               >
-                Rerun <%= @selected_count %> selected workorders from start
+                Rerun <%= @selected_count %> selected workorder<%= if @selected_count >
+                                                                        1,
+                                                                      do: "s",
+                                                                      else: "" %> from start
               </button>
               <button
                 type="button"
@@ -638,7 +641,10 @@ defmodule LightningWeb.RunLive.Components do
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
-                Rerun <%= @selected_count %> selected workorders from start
+                Rerun <%= @selected_count %> selected workorder<%= if @selected_count >
+                                                                        1,
+                                                                      do: "s",
+                                                                      else: "" %> from start
               </button>
               <button
                 type="button"

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -529,6 +529,7 @@ defmodule LightningWeb.RunLive.Components do
   # BULK RERUN
   attr :id, :string, required: true
   attr :page_number, :integer, required: true
+  attr :pages, :integer, required: true
   attr :total_entries, :integer, required: true
   attr :all_selected?, :boolean, required: true
   attr :selected_count, :integer, required: true
@@ -576,12 +577,12 @@ defmodule LightningWeb.RunLive.Components do
               <div class="mt-2">
                 <p class="text-sm text-gray-500">
                   <%= if @all_selected? do %>
-                    You've selected the <%= @selected_count %> work orders from page <%= @page_number %> of results for workorders matching the following query: <%= humanize_search_params(
+                    You've selected all <%= @selected_count %> workorders from page <%= @page_number %> of <%= @pages %>. There are a total of <%= @total_entries %> that match your current query: <%= humanize_search_params(
                       @filters,
                       @workflows
-                    ) %>. There are a total of <%= @total_entries %> work orders matching this query.
+                    ) %>.
                   <% else %>
-                    You've selected <%= @selected_count %> work orders to rerun from the start (first job). This will create a new attempt for these within the same work order
+                    You've selected <%= @selected_count %> workorders to rerun from the start. This will create a new attempt for each selected workorder.
                   <% end %>
                 </p>
               </div>
@@ -597,7 +598,7 @@ defmodule LightningWeb.RunLive.Components do
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
               >
-                Rerun selected (<%= @selected_count %> workorders) from start
+                Rerun <%= @selected_count %> selected workorders from start
               </button>
               <button
                 type="button"
@@ -606,7 +607,7 @@ defmodule LightningWeb.RunLive.Components do
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
-                Rerun ALL (<%= @total_entries %> workorders) from start
+                Rerun all <%= @total_entries %> matching workorders from start
               </button>
               <div class="relative col-start-1 col-end-3">
                 <div class="absolute inset-0 flex items-center" aria-hidden="true">
@@ -637,7 +638,7 @@ defmodule LightningWeb.RunLive.Components do
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
-                Rerun selected (<%= @selected_count %> workorders) from start
+                Rerun <%= @selected_count %> selected workorders from start
               </button>
               <button
                 type="button"

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -588,7 +588,7 @@ defmodule LightningWeb.RunLive.Components do
               </div>
             </div>
             <div
-              :if={@all_selected? and @total_entries > 1}
+              :if={@all_selected? and @total_entries > 1 and @pages > 1}
               class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
             >
               <button
@@ -631,7 +631,7 @@ defmodule LightningWeb.RunLive.Components do
               </button>
             </div>
             <div
-              :if={!@all_selected? or @total_entries == 1}
+              :if={!@all_selected? or @total_entries == 1 or @pages == 1}
               class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
             >
               <button

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -188,7 +188,8 @@ defmodule LightningWeb.RunLive.Index do
         socket
       ) do
     if socket.assigns.can_rerun_job do
-      AttemptService.get_for_rerun(attempt_id, run_id)
+      attempt_id
+      |> AttemptService.get_for_rerun(run_id)
       |> WorkOrderService.retry_attempt_run(socket.assigns.current_user)
 
       {:noreply, socket}

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -222,7 +222,10 @@ defmodule LightningWeb.RunLive.Index do
            handle_bulk_rerun(socket, type) do
       {:noreply,
        socket
-       |> put_flash(:info, "#{count} jobs have been set for rerun successfully")
+       |> put_flash(
+         :info,
+         "New attempt#{if count > 1, do: "s", else: ""} enqueued for #{count} workorder#{if count > 1, do: "s", else: ""}"
+       )
        |> push_navigate(
          to:
            ~p"/projects/#{socket.assigns.project.id}/runs?#{%{filters: socket.assigns.filters}}"

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -10,6 +10,7 @@ defmodule LightningWeb.RunLive.Index do
   alias Lightning.WorkOrderService
   alias Lightning.{AttemptService, Invocation}
   alias Lightning.Invocation.Run
+  alias Phoenix.LiveView.JS
 
   @filters_types %{
     search_term: :string,
@@ -265,5 +266,15 @@ defmodule LightningWeb.RunLive.Index do
         event: :selection_toggled
       )
     end
+  end
+
+  def show_modal(js \\ %JS{}) do
+    js
+    |> JS.remove_class("hidden", to: "#confirmation-modal")
+  end
+
+  def hide_modal(js \\ %JS{}) do
+    js
+    |> JS.add_class("hidden", to: "#confirmation-modal")
   end
 end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -239,23 +239,6 @@ defmodule LightningWeb.RunLive.Index do
     end
   end
 
-  defp handle_bulk_rerun(socket, "selected") do
-    socket.assigns.selected_work_orders
-    |> AttemptService.list_for_rerun_from_start()
-    |> WorkOrderService.retry_attempt_runs(socket.assigns.current_user)
-  end
-
-  defp handle_bulk_rerun(socket, "all") do
-    filter = SearchParams.new(socket.assigns.filters)
-
-    socket.assigns.project
-    |> Invocation.list_work_orders_for_project_query(filter)
-    |> Lightning.Repo.all()
-    |> Enum.map(& &1.id)
-    |> AttemptService.list_for_rerun_from_start()
-    |> WorkOrderService.retry_attempt_runs(socket.assigns.current_user)
-  end
-
   def handle_event(
         "toggle_all_selections",
         %{"all_selections" => selection},
@@ -288,6 +271,23 @@ defmodule LightningWeb.RunLive.Index do
      |> push_patch(
        to: ~p"/projects/#{socket.assigns.project.id}/runs?#{%{filters: filters}}"
      )}
+  end
+
+  defp handle_bulk_rerun(socket, "selected") do
+    socket.assigns.selected_work_orders
+    |> AttemptService.list_for_rerun_from_start()
+    |> WorkOrderService.retry_attempt_runs(socket.assigns.current_user)
+  end
+
+  defp handle_bulk_rerun(socket, "all") do
+    filter = SearchParams.new(socket.assigns.filters)
+
+    socket.assigns.project
+    |> Invocation.list_work_orders_for_project_query(filter)
+    |> Lightning.Repo.all()
+    |> Enum.map(& &1.id)
+    |> AttemptService.list_for_rerun_from_start()
+    |> WorkOrderService.retry_attempt_runs(socket.assigns.current_user)
   end
 
   defp all_selected?(work_orders, entries) do

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -10,6 +10,7 @@ defmodule LightningWeb.RunLive.Index do
   alias Lightning.WorkOrderService
   alias Lightning.{AttemptService, Invocation}
   alias Lightning.Invocation.Run
+  alias LightningWeb.RunLive.Components
   alias Phoenix.LiveView.JS
 
   @filters_types %{
@@ -266,15 +267,5 @@ defmodule LightningWeb.RunLive.Index do
         event: :selection_toggled
       )
     end
-  end
-
-  def show_modal(js \\ %JS{}) do
-    js
-    |> JS.remove_class("hidden", to: "#confirmation-modal")
-  end
-
-  def hide_modal(js \\ %JS{}) do
-    js
-    |> JS.add_class("hidden", to: "#confirmation-modal")
   end
 end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -217,7 +217,7 @@ defmodule LightningWeb.RunLive.Index do
   end
 
   def handle_event("bulk-rerun", %{"type" => type}, socket) do
-    with true <- socket.assigns.can_rerun_job,
+    with true <- socket.assigns.can_rerun_job |> IO.inspect(),
          {:ok, _changes} <- handle_bulk_rerun(socket, type) do
       {:noreply,
        socket

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -11,7 +11,6 @@ defmodule LightningWeb.RunLive.Index do
   alias Lightning.{AttemptService, Invocation}
   alias Lightning.Invocation.Run
   alias LightningWeb.RunLive.Components
-  alias Phoenix.LiveView.JS
 
   @filters_types %{
     search_term: :string,
@@ -208,6 +207,20 @@ defmodule LightningWeb.RunLive.Index do
       attempt_id
       |> AttemptService.get_for_rerun(run_id)
       |> WorkOrderService.retry_attempt_run(socket.assigns.current_user)
+
+      {:noreply, socket}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "You are not authorized to perform this action.")}
+    end
+  end
+
+  def handle_event("bulk-rerun-selected", _attrs, socket) do
+    if socket.assigns.can_rerun_job do
+      socket.assigns.selected_work_orders
+      |> AttemptService.list_for_rerun_from_start()
+      |> WorkOrderService.retry_attempt_runs(socket.assigns.current_user)
 
       {:noreply, socket}
     else

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -218,10 +218,11 @@ defmodule LightningWeb.RunLive.Index do
 
   def handle_event("bulk-rerun", %{"type" => type}, socket) do
     with true <- socket.assigns.can_rerun_job,
-         {:ok, _changes} <- handle_bulk_rerun(socket, type) do
+         {:ok, %{attempt_runs: {count, _attempt_runs}}} <-
+           handle_bulk_rerun(socket, type) do
       {:noreply,
        socket
-       |> put_flash(:info, "Jobs have been set for rerun successfully")
+       |> put_flash(:info, "#{count} jobs have been set for rerun successfully")
        |> push_navigate(
          to:
            ~p"/projects/#{socket.assigns.project.id}/runs?#{%{filters: socket.assigns.filters}}"

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -217,7 +217,7 @@ defmodule LightningWeb.RunLive.Index do
   end
 
   def handle_event("bulk-rerun", %{"type" => type}, socket) do
-    with true <- socket.assigns.can_rerun_job |> IO.inspect(),
+    with true <- socket.assigns.can_rerun_job,
          {:ok, _changes} <- handle_bulk_rerun(socket, type) do
       {:noreply,
        socket

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -20,6 +20,18 @@
             <div class="py-3 px-4 font-medium">Status</div>
           </div>
         </div>
+        <div>
+          <input
+            type="checkbox"
+            class="left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+          />
+          <button
+            type="button"
+            class="rounded bg-indigo-600 px-2 py-1 text-xs font-semibold text-white shadow-sm"
+          >
+            Rerun
+          </button>
+        </div>
         <div data-entity="work_order_list" class="bg-gray-100">
           <%= for wo <- @page.entries do %>
             <.live_component

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -39,6 +39,7 @@
                   <button
                     type="button"
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                    phx-click={show_modal()}
                   >
                     Rerun from start
                   </button>
@@ -71,10 +72,13 @@
       </div>
 
       <div
-        class="relative z-10"
+        class="relative z-10 hidden"
         aria-labelledby="modal-title"
+        id="confirmation-modal"
         role="dialog"
         aria-modal="true"
+        phx-remove={hide_modal()}
+        phx-click-away={hide_modal()}
       >
         <!--
     Background backdrop, show/hide based on modal state.
@@ -128,7 +132,7 @@
                   type="button"
                   class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
                 >
-                  Rerun ALL (12 workorders) from start
+                  Rerun ALL (<%= @page.total_entries %> ) from start
                 </button>
                 <div class="relative col-start-1 col-end-3">
                   <div
@@ -147,6 +151,7 @@
                 <button
                   type="button"
                   class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
+                  phx-click={hide_modal()}
                 >
                   Cancel
                 </button>
@@ -287,3 +292,6 @@
     </div>
   </LayoutComponents.centered>
 </LayoutComponents.page_content>
+
+<pre> <%= inspect(@page, pretty: true) %> </pre>
+<pre> <%= inspect(@selected_work_orders, pretty: true) %> </pre>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -12,7 +12,7 @@
       >
         <div class="sticky top-0 bg-gray-100 text-xs uppercase text-gray-400 dark:text-gray-400">
           <div class="grid grid-cols-6 gap-0">
-            <div class={"py-3 px-4 font-medium relative flex items-start #{if partially_selected?(@selected_work_orders, @page.entries), do: "col-span-2"}"}>
+            <div class={"py-3 px-4 font-medium relative flex items-start #{if @selected_work_orders != [], do: "col-span-2"}"}>
               <div class="">
                 <.form
                   :let={f}
@@ -45,7 +45,7 @@
                 <% end %>
               </div>
             </div>
-            <div class={"py-3 px-4 font-medium #{if partially_selected?(@selected_work_orders, @page.entries), do: "hidden"}"}>
+            <div class={"py-3 px-4 font-medium #{if @selected_work_orders != [], do: "hidden"}"}>
               Reason
             </div>
             <div class="py-3 px-4 font-medium">Input</div>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -12,25 +12,23 @@
       >
         <div class="sticky top-0 bg-gray-100 text-xs uppercase text-gray-400 dark:text-gray-400">
           <div class="grid grid-cols-6 gap-0">
-            <div class="py-3 px-4 font-medium">Workflow</div>
+            <div class="py-3 px-4 font-medium relative flex items-start">
+              <div class="">
+                <input
+                  type="checkbox"
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                />
+              </div>
+              <div class="ml-3">
+                Workflow
+              </div>
+            </div>
             <div class="py-3 px-4 font-medium">Reason</div>
             <div class="py-3 px-4 font-medium">Input</div>
             <div class="py-3 px-4 font-medium">Received</div>
             <div class="py-3 px-4 font-medium">Lastest Run Finished</div>
             <div class="py-3 px-4 font-medium">Status</div>
           </div>
-        </div>
-        <div>
-          <input
-            type="checkbox"
-            class="left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
-          />
-          <button
-            type="button"
-            class="rounded bg-indigo-600 px-2 py-1 text-xs font-semibold text-white shadow-sm"
-          >
-            Rerun
-          </button>
         </div>
         <div data-entity="work_order_list" class="bg-gray-100">
           <%= for wo <- @page.entries do %>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -39,7 +39,7 @@
                   <button
                     type="button"
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                    phx-click={show_modal()}
+                    phx-click={Components.show_modal("bulk-rerun-modal")}
                   >
                     Rerun from start
                   </button>
@@ -70,97 +70,15 @@
           url={@pagination_path}
         />
       </div>
-
-      <div
-        class="relative z-10 hidden"
-        aria-labelledby="modal-title"
-        id="confirmation-modal"
-        role="dialog"
-        aria-modal="true"
-        phx-remove={hide_modal()}
-        phx-click-away={hide_modal()}
-      >
-        <!--
-    Background backdrop, show/hide based on modal state.
-
-    Entering: "ease-out duration-300"
-      From: "opacity-0"
-      To: "opacity-100"
-    Leaving: "ease-in duration-200"
-      From: "opacity-100"
-      To: "opacity-0"
-  -->
-        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity">
-        </div>
-
-        <div class="fixed inset-0 z-10 overflow-y-auto">
-          <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-            <!--
-        Modal panel, show/hide based on modal state.
-
-        Entering: "ease-out duration-300"
-          From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          To: "opacity-100 translate-y-0 sm:scale-100"
-        Leaving: "ease-in duration-200"
-          From: "opacity-100 translate-y-0 sm:scale-100"
-          To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-      -->
-            <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
-              <div>
-                <div class="mt-3 text-center sm:mt-5">
-                  <h3
-                    class="text-base font-semibold leading-6 text-gray-900"
-                    id="modal-title"
-                  >
-                    Run Selected Workers
-                  </h3>
-                  <div class="mt-2">
-                    <p class="text-sm text-gray-500">
-                      You've selected the 12 work orders from page 1 of results for workorders matching the following query: received between x and y date, for workflow A, with a status of 'Failed'. There are a total of 32 work orders matching this query.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-                <button
-                  type="button"
-                  class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
-                >
-                  Rerun selected (<%= Enum.count(@selected_work_orders) %> workorders) from start
-                </button>
-                <button
-                  type="button"
-                  class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
-                >
-                  Rerun ALL (<%= @page.total_entries %> ) from start
-                </button>
-                <div class="relative col-start-1 col-end-3">
-                  <div
-                    class="absolute inset-0 flex items-center"
-                    aria-hidden="true"
-                  >
-                    <div class="w-full border-t border-gray-300"></div>
-                  </div>
-                  <div class="relative flex justify-center">
-                    <span class="bg-white px-2 text-sm text-gray-500">
-                      OR
-                    </span>
-                  </div>
-                </div>
-
-                <button
-                  type="button"
-                  class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
-                  phx-click={hide_modal()}
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
+      <Components.bulk_rerun_modal
+        id="bulk-rerun-modal"
+        page_number={@page.page_number}
+        total_entries={@page.total_entries}
+        all_selected?={all_selected?(@selected_work_orders, @page.entries)}
+        selected_count={Enum.count(@selected_work_orders)}
+        filters={SearchParams.new(@filters)}
+        workflows={@workflows}
+      />
       <div class="w-96 bg-gray-200 ml-4 p-4 pt-0 sticky top-0 self-start rounded-md">
         <.form
           :let={f}
@@ -292,6 +210,3 @@
     </div>
   </LayoutComponents.centered>
 </LayoutComponents.page_content>
-
-<pre> <%= inspect(@page, pretty: true) %> </pre>
-<pre> <%= inspect(@selected_work_orders, pretty: true) %> </pre>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -26,7 +26,7 @@
                 >
                   <%= checkbox(f, :all_selections,
                     id: "select_all",
-                    phx_hook: "CheckboxState",
+                    phx_hook: "CheckboxIndeterminate",
                     class:
                       "left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 #{if partially_selected?(@selected_work_orders, @page.entries), do: "indeterminate"}"
                   ) %>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -12,7 +12,7 @@
       >
         <div class="sticky top-0 bg-gray-100 text-xs uppercase text-gray-400 dark:text-gray-400">
           <div class="grid grid-cols-6 gap-0">
-            <div class={"py-3 px-4 font-medium relative flex items-start #{if @selected_work_orders != [], do: "col-span-2"}"}>
+            <div class={"py-3 px-4 font-medium relative flex items-center #{if @selected_work_orders != [], do: "col-span-2"}"}>
               <div class="">
                 <.form
                   :let={f}
@@ -46,13 +46,15 @@
                 <% end %>
               </div>
             </div>
-            <div class={"py-3 px-4 font-medium #{if @selected_work_orders != [], do: "hidden"}"}>
+            <div class={"py-3 px-4 font-medium flex items-center #{if @selected_work_orders != [], do: "hidden"}"}>
               Reason
             </div>
-            <div class="py-3 px-4 font-medium">Input</div>
-            <div class="py-3 px-4 font-medium">Received</div>
-            <div class="py-3 px-4 font-medium">Lastest Run Finished</div>
-            <div class="py-3 px-4 font-medium">Status</div>
+            <div class="py-3 px-4 font-medium flex items-center">Input</div>
+            <div class="py-3 px-4 font-medium flex items-center">Received</div>
+            <div class="py-3 px-4 font-medium flex items-center">
+              Lastest Run Finished
+            </div>
+            <div class="py-3 px-4 font-medium flex items-center">Status</div>
           </div>
         </div>
         <div data-entity="work_order_list" class="bg-gray-100">

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -69,6 +69,93 @@
           url={@pagination_path}
         />
       </div>
+
+      <div
+        class="relative z-10"
+        aria-labelledby="modal-title"
+        role="dialog"
+        aria-modal="true"
+      >
+        <!--
+    Background backdrop, show/hide based on modal state.
+
+    Entering: "ease-out duration-300"
+      From: "opacity-0"
+      To: "opacity-100"
+    Leaving: "ease-in duration-200"
+      From: "opacity-100"
+      To: "opacity-0"
+  -->
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity">
+        </div>
+
+        <div class="fixed inset-0 z-10 overflow-y-auto">
+          <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <!--
+        Modal panel, show/hide based on modal state.
+
+        Entering: "ease-out duration-300"
+          From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          To: "opacity-100 translate-y-0 sm:scale-100"
+        Leaving: "ease-in duration-200"
+          From: "opacity-100 translate-y-0 sm:scale-100"
+          To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+      -->
+            <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <div>
+                <div class="mt-3 text-center sm:mt-5">
+                  <h3
+                    class="text-base font-semibold leading-6 text-gray-900"
+                    id="modal-title"
+                  >
+                    Run Selected Workers
+                  </h3>
+                  <div class="mt-2">
+                    <p class="text-sm text-gray-500">
+                      You've selected the 12 work orders from page 1 of results for workorders matching the following query: received between x and y date, for workflow A, with a status of 'Failed'. There are a total of 32 work orders matching this query.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+                <button
+                  type="button"
+                  class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
+                >
+                  Rerun selected (<%= Enum.count(@selected_work_orders) %> workorders) from start
+                </button>
+                <button
+                  type="button"
+                  class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
+                >
+                  Rerun ALL (12 workorders) from start
+                </button>
+                <div class="relative col-start-1 col-end-3">
+                  <div
+                    class="absolute inset-0 flex items-center"
+                    aria-hidden="true"
+                  >
+                    <div class="w-full border-t border-gray-300"></div>
+                  </div>
+                  <div class="relative flex justify-center">
+                    <span class="bg-white px-2 text-sm text-gray-500">
+                      OR
+                    </span>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="w-96 bg-gray-200 ml-4 p-4 pt-0 sticky top-0 self-start rounded-md">
         <.form
           :let={f}

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -12,18 +12,42 @@
       >
         <div class="sticky top-0 bg-gray-100 text-xs uppercase text-gray-400 dark:text-gray-400">
           <div class="grid grid-cols-6 gap-0">
-            <div class="py-3 px-4 font-medium relative flex items-start">
+            <div class={"py-3 px-4 font-medium relative flex items-start #{if partially_selected?(@selected_work_orders, @page.entries), do: "col-span-2"}"}>
               <div class="">
-                <input
-                  type="checkbox"
-                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                />
+                <.form
+                  :let={f}
+                  for={
+                    %{
+                      "all_selections" =>
+                        all_selected?(@selected_work_orders, @page.entries)
+                    }
+                  }
+                  phx-change="toggle_all_selections"
+                >
+                  <%= checkbox(f, :all_selections,
+                    id: "select_all",
+                    phx_hook: "CheckboxState",
+                    class:
+                      "left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 #{if partially_selected?(@selected_work_orders, @page.entries), do: "indeterminate"}"
+                  ) %>
+                </.form>
               </div>
               <div class="ml-3">
-                Workflow
+                <%= if @selected_work_orders == [] do %>
+                  Workflow
+                <% else %>
+                  <button
+                    type="button"
+                    class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                  >
+                    Rerun from start
+                  </button>
+                <% end %>
               </div>
             </div>
-            <div class="py-3 px-4 font-medium">Reason</div>
+            <div class={"py-3 px-4 font-medium #{if partially_selected?(@selected_work_orders, @page.entries), do: "hidden"}"}>
+              Reason
+            </div>
             <div class="py-3 px-4 font-medium">Input</div>
             <div class="py-3 px-4 font-medium">Received</div>
             <div class="py-3 px-4 font-medium">Lastest Run Finished</div>
@@ -58,7 +82,7 @@
             <div class="font-semibold mt-4">
               Search associated runs
               <Common.tooltip
-                id="trigger-tooltip"
+                id="associated-runs-trigger-tooltip"
                 title="Find workorders containing the search term in their
                   associated run logs or inputs. Coming soon: pinpoint the run
                   (inside an attempt & workorder) which contains your search
@@ -152,7 +176,7 @@
               <div class="font-semibold mt-4">
                 Filter by workorder status
                 <Common.tooltip
-                  id="trigger-tooltip"
+                  id="workorder-status-trigger-tooltip"
                   title="Filter workorders based on their status. (I.e., the status of the last run in any attempt for that workorder.)"
                   class="inline-block"
                 />

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -73,6 +73,7 @@
       <Components.bulk_rerun_modal
         id="bulk-rerun-modal"
         page_number={@page.page_number}
+        pages={@page.total_pages}
         total_entries={@page.total_entries}
         all_selected?={all_selected?(@selected_work_orders, @page.entries)}
         selected_count={Enum.count(@selected_work_orders)}

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -80,7 +80,12 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
       class="my-4 grid grid-cols-6 gap-0 rounded-lg bg-white"
     >
       <div class={"my-auto p-4 font-medium text-gray-900 dark:text-white #{unless @show_details, do: "truncate"}"}>
-        <%= @workflow_name %>
+        <input
+          type="checkbox"
+          class="left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+          id={@work_order.id}
+        />
+        <label for={@work_order.id}><%= @workflow_name %></label>
       </div>
       <div class="my-auto p-4"><%= @work_order.reason.type %></div>
       <div class="my-auto p-4">

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -114,6 +114,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
             for={selection_params(@work_order, @entry_selected)}
             phx-change="toggle_selection"
             phx-target={@myself}
+            id={"#{@work_order.id}-selection-form"}
           >
             <%= checkbox(f, :selected,
               id: "select_#{@work_order.id}",

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -102,9 +102,12 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
     ~H"""
     <div
       data-entity="work_order"
-      class="my-4 grid grid-cols-6 gap-0 rounded-lg bg-white"
+      class={"my-4 grid grid-cols-6 gap-0 rounded-lg #{if @entry_selected, do: "bg-gray-50", else: "bg-white"}"}
     >
       <div class={"my-auto p-4 font-medium text-gray-900 dark:text-white relative flex items-start #{unless @show_details, do: "truncate"}"}>
+        <%= if @entry_selected do %>
+          <div class="absolute inset-y-0 left-0 w-0.5 bg-indigo-600"></div>
+        <% end %>
         <div class="">
           <.form
             :let={f}

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -79,13 +79,16 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
       data-entity="work_order"
       class="my-4 grid grid-cols-6 gap-0 rounded-lg bg-white"
     >
-      <div class={"my-auto p-4 font-medium text-gray-900 dark:text-white #{unless @show_details, do: "truncate"}"}>
-        <input
-          type="checkbox"
-          class="left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
-          id={@work_order.id}
-        />
-        <label for={@work_order.id}><%= @workflow_name %></label>
+      <div class={"my-auto p-4 font-medium text-gray-900 dark:text-white relative flex items-start #{unless @show_details, do: "truncate"}"}>
+        <div class="">
+          <input
+            type="checkbox"
+            class="left-4 top-1/2  h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+          />
+        </div>
+        <div class="ml-3">
+          <%= @workflow_name %>
+        </div>
       </div>
       <div class="my-auto p-4"><%= @work_order.reason.type %></div>
       <div class="my-auto p-4">

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1539,11 +1539,11 @@ defmodule LightningWeb.RunWorkOrderTest do
           )
         )
 
-      # All work orders have been selected
+      # All work orders have been selected, but there's only one page
       html =
         render_change(view, "toggle_all_selections", %{all_selections: true})
 
-      assert html =~ "Rerun all 2 matching workorders from start"
+      refute html =~ "Rerun all 2 matching workorders from start"
       assert html =~ "Rerun 2 selected workorders from start"
 
       view

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1470,7 +1470,7 @@ defmodule LightningWeb.RunWorkOrderTest do
       result = render_click(view, "bulk-rerun", %{type: "all"})
       {:ok, view, html} = follow_redirect(result, conn)
 
-      assert html =~ "2 jobs have been set for rerun successfully"
+      assert html =~ "New attempts enqueued for 2 workorders"
 
       view
       |> form("##{work_order_b.id}-selection-form")
@@ -1478,7 +1478,7 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       result = render_click(view, "bulk-rerun", %{type: "selected"})
       {:ok, _view, html} = follow_redirect(result, conn)
-      assert html =~ "1 jobs have been set for rerun successfully"
+      assert html =~ "New attempt enqueued for 1 workorder"
     end
 
     test "selecting all work orders in the page prompts the user to rerun all runs",
@@ -1543,8 +1543,8 @@ defmodule LightningWeb.RunWorkOrderTest do
       html =
         render_change(view, "toggle_all_selections", %{all_selections: true})
 
-      assert html =~ "Rerun ALL (2 workorders) from start"
-      assert html =~ "Rerun selected (2 workorders) from start"
+      assert html =~ "Rerun all 2 matching workorders from start"
+      assert html =~ "Rerun 2 selected workorders from start"
 
       view
       |> form("##{work_order_b.id}-selection-form")
@@ -1552,8 +1552,8 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       # uncheck 1 work order
       updated_html = render(view)
-      refute updated_html =~ "Rerun ALL (2 workorders) from start"
-      assert updated_html =~ "Rerun selected (1 workorders) from start"
+      refute updated_html =~ "Rerun all 2 matching workorders from start"
+      assert updated_html =~ "Rerun 1 selected workorders from start"
     end
   end
 
@@ -1564,6 +1564,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           &LightningWeb.RunLive.Components.bulk_rerun_modal/1,
           id: "bulk-rerun-modal",
           page_number: 1,
+          pages: 3,
           total_entries: 25,
           all_selected?: true,
           selected_count: 5,
@@ -1571,8 +1572,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           workflows: [{"Workflow a", "someid"}]
         )
 
-      assert html =~ "Rerun ALL (25 workorders) from start"
-      assert html =~ "Rerun selected (5 workorders) from start"
+      assert html =~ "Rerun all 25 matching workorders from start"
+      assert html =~ "Rerun 5 selected workorders from start"
     end
 
     test "only 1 run button present when some entries have been selected" do
@@ -1588,14 +1589,15 @@ defmodule LightningWeb.RunWorkOrderTest do
           workflows: [{"Workflow a", "someid"}]
         )
 
-      refute html =~ "Rerun ALL (25 workorders) from start"
-      assert html =~ "Rerun selected (5 workorders) from start"
+      refute html =~ "Rerun all 25 matching workorders from start"
+      assert html =~ "Rerun 5 selected workorders from start"
     end
 
     test "the filter queries are displayed correctly when all entries have been selected" do
       assigns = %{
         id: "bulk-rerun-modal",
         page_number: 1,
+        pages: 3,
         total_entries: 25,
         all_selected?: true,
         selected_count: 5,

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1553,7 +1553,7 @@ defmodule LightningWeb.RunWorkOrderTest do
       # uncheck 1 work order
       updated_html = render(view)
       refute updated_html =~ "Rerun all 2 matching workorders from start"
-      assert updated_html =~ "Rerun 1 selected workorders from start"
+      assert updated_html =~ "Rerun 1 selected workorder from start"
     end
   end
 


### PR DESCRIPTION
## Implementation Plan
### UI 
- [x] Add an unselected checkbox to the first column (to the left of 'Workflow') to every row in the workflows history table
- [x] Display rerun from start when any of the checkboxes is checked
- [x] Check all the checkboxes in the table when the top-level heading checkbox is selected
- [x] Uncheck the checkboxes when the user changes the filter
- [x] Add confirmation modal
- [x] Add relevant tests
### LOGIC
- [x] Add function to rerun work orders selected by the user. ??

## Notes for the reviewer


## Related issue

Fixes #659 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Amber has **QA'd** this feature
