### PR TITLE
Prevent project viewers from deleting workflows

### DIFF
--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -16,6 +16,7 @@ defmodule Lightning.Policies.ProjectUsers do
           | :delete_job
           | :access_project
           | :delete_project
+          | :delete_workflow
           | :create_workflow
           | :edit_project_name
           | :edit_digest_alerts
@@ -67,6 +68,7 @@ defmodule Lightning.Policies.ProjectUsers do
              :edit_job,
              :create_job,
              :delete_job,
+             :delete_workflow,
              :run_job,
              :rerun_job,
              :provision_project

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -44,6 +44,7 @@ defmodule LightningWeb.WorkflowLive do
             <LayoutComponents.centered>
               <.workflow_list
                 can_create_workflow={@can_create_workflow}
+                can_delete_workflow={@can_delete_workflow}
                 workflows={@workflows}
                 project={@project}
               />

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -15,6 +15,7 @@ defmodule LightningWeb.WorkflowLive.Components do
         <%= for workflow <- @workflows do %>
           <.workflow_card
             can_create_workflow={@can_create_workflow}
+            can_delete_workflow={@can_delete_workflow}
             workflow={%{workflow | name: workflow.name || "Untitled"}}
             project={@project}
           />
@@ -51,7 +52,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             ) %>
           </p>
         </div>
-        <%= if @can_create_workflow do %>
+        <%= if @can_delete_workflow do %>
           <div class="flex-shrink-0 pr-2">
             <div class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-transparent text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
               <%= link(

--- a/lib/lightning_web/live/workflow_live/workflow_name_editor.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_name_editor.ex
@@ -7,7 +7,12 @@ defmodule LightningWeb.WorkflowLive.WorkflowNameEditor do
 
   @impl true
   def update(
-        %{workflow: workflow, return_to: return_to, project: project},
+        %{
+          workflow: workflow,
+          can_delete: can_delete,
+          return_to: return_to,
+          project: project
+        },
         socket
       ) do
     changeset = Workflows.change_workflow(workflow, %{})
@@ -15,6 +20,7 @@ defmodule LightningWeb.WorkflowLive.WorkflowNameEditor do
     {:ok,
      socket
      |> assign(
+       can_delete: can_delete,
        workflow: workflow,
        changeset: changeset,
        return_to: return_to,
@@ -48,25 +54,6 @@ defmodule LightningWeb.WorkflowLive.WorkflowNameEditor do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :changeset, changeset)}
-    end
-  end
-
-  def handle_event("delete_workflow", %{"id" => id}, socket) do
-    Workflows.get_workflow!(id)
-    |> Workflows.mark_for_deletion()
-    |> case do
-      {:ok, _} ->
-        {
-          :noreply,
-          socket
-          |> assign(
-            workflows: Workflows.get_workflows_for(socket.assigns.project)
-          )
-          |> put_flash(:info, "Workflow deleted successfully")
-        }
-
-      {:error, _changeset} ->
-        {:noreply, socket |> put_flash(:error, "Can't delete workflow")}
     end
   end
 
@@ -104,7 +91,8 @@ defmodule LightningWeb.WorkflowLive.WorkflowNameEditor do
         </.form>
       </div>
 
-      <%= link(
+      <%= if @can_delete do %>
+        <%= link(
             to: Routes.project_workflow_path(
                         @socket,
                         :index,
@@ -119,7 +107,8 @@ defmodule LightningWeb.WorkflowLive.WorkflowNameEditor do
             class: "p-2 ml-1 mt-1"
 
             ) do %>
-        <Icon.trash class="h-6 w-6 text-slate-300 hover:text-rose-700" />
+          <Icon.trash class="h-6 w-6 text-slate-300 hover:text-rose-700" />
+        <% end %>
       <% end %>
     </div>
     """

--- a/lib/lightning_web/live/workflow_live_new.ex
+++ b/lib/lightning_web/live/workflow_live_new.ex
@@ -8,9 +8,9 @@ defmodule LightningWeb.WorkflowNewLive do
 
   import LightningWeb.WorkflowLive.Components
 
-  on_mount({LightningWeb.Hooks, :project_scope})
+  on_mount {LightningWeb.Hooks, :project_scope}
 
-  attr(:changeset, :map, required: true)
+  attr :changeset, :map, required: true
 
   @impl true
   def render(assigns) do

--- a/test/lightning/policies/project_user_permissions_test.exs
+++ b/test/lightning/policies/project_user_permissions_test.exs
@@ -102,7 +102,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
   end
 
   describe "Project users with the :viewer role" do
-    test "cannot create workflows, create / edit / delete / run / rerun jobs, and edit the project name or description",
+    test "cannot create / delete workflows, create / edit / delete / run / rerun jobs, and edit the project name or description",
          %{
            project: project,
            viewer: viewer
@@ -111,6 +111,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_job
         create_workflow
         delete_job
+        delete_workflow
         edit_job
         edit_project_description
         edit_project_name
@@ -122,7 +123,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
   end
 
   describe "Project users with the :editor role" do
-    test "can create workflows and create / edit / delete / run / rerun jobs in the project",
+    test "can create / delete workflows and create / edit / delete / run / rerun jobs in the project",
          %{
            project: project,
            editor: editor
@@ -131,6 +132,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_job
         create_workflow
         delete_job
+        delete_workflow
         edit_job
         provision_project
         rerun_job
@@ -151,7 +153,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
   end
 
   describe "Project users with the :admin role" do
-    test "can create workflows, create / edit / delete / run / rerun jobs, edit the project name, and edit the project description.",
+    test "can create / delete workflows, create / edit / delete / run / rerun jobs, edit the project name, and edit the project description.",
          %{
            project: project,
            admin: admin
@@ -160,6 +162,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
           create_job
           create_workflow
           delete_job
+          delete_workflow
           edit_job
           edit_project_description
           edit_project_name
@@ -171,7 +174,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
   end
 
   describe "Project users with the :owner role" do
-    test "can create workflows, create / edit / delete / run / rerun jobs, edit the project name, and edit the project description.",
+    test "can create / delete workflows, create / edit / delete / run / rerun jobs, edit the project name, and edit the project description.",
          %{
            project: project,
            owner: owner
@@ -180,6 +183,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_job
         create_workflow
         delete_job
+        delete_workflow
         edit_job
         edit_project_description
         edit_project_name

--- a/test/lightning_web/live/workflow_live_test.exs
+++ b/test/lightning_web/live/workflow_live_test.exs
@@ -533,6 +533,22 @@ defmodule LightningWeb.WorkflowLiveTest do
   end
 
   describe "delete_workflow" do
+    test "project viewer can't delete a workflow in that project",
+         %{
+           conn: conn,
+           project: project
+         } do
+      workflow = workflow_fixture(name: "the workflow", project_id: project.id)
+      {conn, _user} = setup_project_user(conn, project, :viewer)
+
+      {:ok, view, _html} =
+        live(conn, Routes.project_workflow_path(conn, :index, project.id))
+
+      assert view
+             |> render_click("delete_workflow", %{"id" => workflow.id}) =~
+               "You are not authorized to perform this action."
+    end
+
     test "delete a workflow on project index page",
          %{
            conn: conn,


### PR DESCRIPTION
## Notes for the reviewer

This PR ships a fix for preventing project viewers to delete workflows.

NB: I also deleted a duplicated `handle_event("delete_workflow", params, socket)`. It didn't break any tests but we can chat about it during standup.

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Taylor has **QA'd** this feature
