### PR TITLE
Bulk rerun workorders from a specific job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 - Add public API token to the demo site setup script
 - Check and renew OAuth credentials when running a job
   [#646](https://github.com/OpenFn/Lightning/issues/646)
+- Add feature to bulk rerun work orders from a specific step in their workflow;
+  e.g., "rerun these 50 work orders, starting each at step 4."
+  [#906](https://github.com/OpenFn/Lightning/pull/906)
 
 ### Fixed
 

--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -329,7 +329,6 @@ defmodule Lightning.AttemptService do
     last_attempts_query =
       from(att in Lightning.Attempt,
         join: r in assoc(att, :runs),
-        on: r.job_id == ^job_id,
         where: att.work_order_id in ^order_ids,
         group_by: att.work_order_id,
         select: %{

--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -291,8 +291,10 @@ defmodule Lightning.AttemptService do
       from(ar in AttemptRun,
         join: arn in subquery(attempt_run_numbers_query),
         on: ar.id == arn.id,
+        join: att in assoc(ar, :attempt),
+        join: wo in assoc(att, :work_order),
         where: arn.row_num == 1,
-        order_by: ar.inserted_at,
+        order_by: [asc: wo.inserted_at],
         preload: [
           :attempt,
           run:
@@ -340,13 +342,14 @@ defmodule Lightning.AttemptService do
     attempt_runs_query =
       from(ar in AttemptRun,
         join: att in assoc(ar, :attempt),
+        join: wo in assoc(att, :work_order),
         join: last in subquery(last_attempts_query),
         on:
           last.work_order_id == att.work_order_id and
             att.inserted_at == last.last_inserted_at,
         join: r in assoc(ar, :run),
         on: r.job_id == ^job_id,
-        order_by: ar.inserted_at,
+        order_by: [asc: wo.inserted_at],
         preload: [
           attempt: att,
           run: r

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -471,6 +471,7 @@ defmodule Lightning.Invocation do
         ),
       select: %{
         id: wo.id,
+        workflow_id: wo.workflow_id,
         last_finished_at:
           fragment(
             "nullif(max(coalesce(?, 'infinity')), 'infinity')",
@@ -549,6 +550,7 @@ defmodule Lightning.Invocation do
          Enum.map(current_value, fn e ->
            %{
              id: e.id,
+             workflow_id: e.workflow_id,
              last_finished_at:
                if is_nil(e.last_finished_at) do
                  nil

--- a/lib/lightning/jobs.ex
+++ b/lib/lightning/jobs.ex
@@ -224,7 +224,10 @@ defmodule Lightning.Jobs do
   @spec list_jobs_for_workflow(Workflow.t()) :: [Job.t(), ...] | []
   def list_jobs_for_workflow(%Workflow{id: workflow_id}) do
     query =
-      from j in Job, where: j.workflow_id == ^workflow_id, select: [:id, :name]
+      from j in Job,
+        where: j.workflow_id == ^workflow_id,
+        order_by: j.name,
+        select: [:id, :name]
 
     Repo.all(query)
   end

--- a/lib/lightning/jobs.ex
+++ b/lib/lightning/jobs.ex
@@ -6,7 +6,6 @@ defmodule Lightning.Jobs do
   import Ecto.Query, warn: false
   alias Lightning.Repo
 
-  alias Lightning.Attempt
   alias Lightning.Jobs.{Job, Trigger, Query}
   alias Lightning.Projects.Project
   alias Lightning.Workflows.Workflow
@@ -222,28 +221,10 @@ defmodule Lightning.Jobs do
     Job.changeset(job, attrs)
   end
 
-  @spec list_jobs_for_workflow(Workflow.t()) ::
-          [
-            %{
-              :id => Ecto.UUID.t(),
-              :name => String.t(),
-              :workorder_count => Integer.t()
-            },
-            ...
-          ]
-          | []
+  @spec list_jobs_for_workflow(Workflow.t()) :: [Job.t(), ...] | []
   def list_jobs_for_workflow(%Workflow{id: workflow_id}) do
     query =
-      from at in Attempt,
-        join: r in assoc(at, :runs),
-        join: j in assoc(r, :job),
-        group_by: j.id,
-        where: j.workflow_id == ^workflow_id,
-        select: %{
-          id: j.id,
-          name: j.name,
-          work_orders_count: count(at.work_order_id, :distinct)
-        }
+      from j in Job, where: j.workflow_id == ^workflow_id, select: [:id, :name]
 
     Repo.all(query)
   end

--- a/lib/lightning/work_order_service.ex
+++ b/lib/lightning/work_order_service.ex
@@ -249,7 +249,7 @@ defmodule Lightning.WorkOrderService do
   def create_work_order(attrs \\ %{}) do
     %WorkOrder{}
     |> WorkOrder.changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert(returning: true)
   end
 
   def build(workflow, reason) do

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -258,7 +258,17 @@ defmodule LightningWeb.RunLive.Index do
         %{assigns: %{page: page}} = socket
       ) do
     selection = String.to_existing_atom(selection)
-    work_orders = if selection, do: Enum.map(page.entries, & &1.id), else: []
+
+    work_orders =
+      if selection do
+        Enum.reduce(page.entries, %{}, fn entry, acc ->
+          Map.update(acc, entry.workflow_id, [entry.id], fn existing ->
+            [entry.id | existing]
+          end)
+        end)
+      else
+        %{}
+      end
 
     update_component_selections(page.entries, selection)
 

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -186,11 +186,11 @@ defmodule LightningWeb.RunLive.Index do
 
   @impl true
   def handle_info(
-        {:selection_toggled, {%{id: id, workflow_id: workflow_id}, selection}},
+        {:selection_toggled, {%{id: id, workflow_id: workflow_id}, selected?}},
         %{assigns: assigns} = socket
       ) do
     work_orders =
-      if selection do
+      if selected? do
         [%{id: id, workflow_id: workflow_id} | assigns.selected_work_orders]
       else
         assigns.selected_work_orders -- [%{id: id, workflow_id: workflow_id}]

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -190,6 +190,12 @@ defmodule LightningWeb.RunLive.Index do
         {:selection_toggled, {%{id: id, workflow_id: workflow_id}, selection}},
         %{assigns: assigns} = socket
       ) do
+    # TODO: clean up this naming and adopt a simpler, more explicit approach.
+    # Note that this is not a list of work_orders. It's a map with 0 or many
+    # keys. Each key is a workflow_id, and the value for each key is a list of
+    # workorders. We might consider a list of {workorder, workflow} tuples or a
+    # list of %{wo: id, wf: id} maps. (Or, since we've found the bug and fixed
+    # it via the Map.reject line below, we might also leave this as is.)
     work_orders =
       Map.update(
         assigns.selected_work_orders,
@@ -203,6 +209,7 @@ defmodule LightningWeb.RunLive.Index do
           end
         end
       )
+      |> Map.reject(fn {_key, val} -> val == [] end)
 
     {:noreply, assign(socket, selected_work_orders: work_orders)}
   end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -71,6 +71,7 @@ defmodule LightningWeb.RunLive.Index do
        work_orders: [],
        selected_work_orders: %{},
        can_rerun_job: can_rerun_job,
+       active_modal: nil,
        pagination_path:
          &Routes.project_run_index_path(
            socket,
@@ -273,6 +274,15 @@ defmodule LightningWeb.RunLive.Index do
     update_component_selections(page.entries, selection)
 
     {:noreply, assign(socket, selected_work_orders: work_orders)}
+  end
+
+  def handle_event(
+        "toggle_modal",
+        %{"modal" => modal},
+        %{assigns: assigns} = socket
+      ) do
+    active_modal = if assigns.active_modal == modal, do: nil, else: modal
+    {:noreply, assign(socket, active_modal: active_modal)}
   end
 
   def handle_event("search", %{"filters" => filters} = _params, socket) do

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -244,11 +244,13 @@ defmodule LightningWeb.RunLive.Index do
       false ->
         {:noreply,
          socket
+         |> assign(active_modal: nil)
          |> put_flash(:error, "You are not authorized to perform this action.")}
 
       {:ok, %{reasons: {0, []}}} ->
         {:noreply,
          socket
+         |> assign(active_modal: nil)
          |> put_flash(
            :error,
            "Oops! The chosen step hasn't been run in the latest attempts of any of the selected workorders"
@@ -257,6 +259,7 @@ defmodule LightningWeb.RunLive.Index do
       {:error, _changes} ->
         {:noreply,
          socket
+         |> assign(active_modal: nil)
          |> put_flash(:error, "Oops! an error occured during retries.")}
     end
   end
@@ -373,6 +376,12 @@ defmodule LightningWeb.RunLive.Index do
   defp selected_workflow_count(selected_orders_map) do
     selected_orders_map
     |> Enum.filter(fn {_key, val} -> Enum.count(val) >= 1 end)
+    |> Enum.count()
+  end
+
+  defp selected_workorder_count(selected_orders_map) do
+    selected_orders_map
+    |> flattened_selections()
     |> Enum.count()
   end
 

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -90,7 +90,7 @@
         pages={@page.total_pages}
         total_entries={@page.total_entries}
         all_selected?={all_selected?(@selected_work_orders, @page.entries)}
-        selected_count={selected_workflow_count(@selected_work_orders)}
+        selected_count={selected_workorder_count(@selected_work_orders)}
         filters={SearchParams.new(@filters)}
         workflows={@workflows}
       />
@@ -99,7 +99,7 @@
           module={LightningWeb.RunLive.RerunJobComponent}
           id="bulk-rerun-from-job-modal"
           total_entries={@page.total_entries}
-          selected_count={selected_workflow_count(@selected_work_orders)}
+          selected_count={selected_workorder_count(@selected_work_orders)}
           all_selected?={all_selected?(@selected_work_orders, @page.entries)}
           workflow_id={@selected_work_orders |> Map.keys() |> hd()}
           show={true}

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -47,6 +47,7 @@
                   </button>
                   <button
                     :if={selected_workflow_count(@selected_work_orders) == 1}
+                    id="bulk-rerun-from-job-modal-trigger"
                     type="button"
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
                     phx-click="toggle_modal"
@@ -57,7 +58,7 @@
                 <% end %>
               </div>
             </div>
-            <div class={"py-3 px-4 font-medium flex items-center #{if @selected_work_orders != [], do: "hidden"}"}>
+            <div class={"py-3 px-4 font-medium flex items-center #{if selected_workflow_count(@selected_work_orders) > 0, do: "hidden"}"}>
               Reason
             </div>
             <div class="py-3 px-4 font-medium flex items-center">Input</div>
@@ -89,7 +90,7 @@
         pages={@page.total_pages}
         total_entries={@page.total_entries}
         all_selected?={all_selected?(@selected_work_orders, @page.entries)}
-        selected_count={Enum.count(@selected_work_orders)}
+        selected_count={selected_workflow_count(@selected_work_orders)}
         filters={SearchParams.new(@filters)}
         workflows={@workflows}
       />
@@ -98,7 +99,7 @@
           module={LightningWeb.RunLive.RerunJobComponent}
           id="bulk-rerun-from-job-modal"
           total_entries={@page.total_entries}
-          selected_workorders={flattened_selections(@selected_work_orders)}
+          selected_count={selected_workflow_count(@selected_work_orders)}
           all_selected?={all_selected?(@selected_work_orders, @page.entries)}
           workflow_id={@selected_work_orders |> Map.keys() |> hd()}
           show={true}

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -39,7 +39,9 @@
                   <button
                     type="button"
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                    phx-click={Components.show_modal("bulk-rerun-modal")}
+                    phx-click={
+                      Components.show_modal("bulk-rerun-from-start-modal")
+                    }
                   >
                     Rerun
                   </button>
@@ -47,7 +49,8 @@
                     :if={selected_workflow_count(@selected_work_orders) == 1}
                     type="button"
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                    phx-click=""
+                    phx-click="toggle_modal"
+                    phx-value-modal="bulk-rerun-from-job-modal"
                   >
                     Rerun from...
                   </button>
@@ -81,7 +84,7 @@
         />
       </div>
       <Components.bulk_rerun_modal
-        id="bulk-rerun-modal"
+        id="bulk-rerun-from-start-modal"
         page_number={@page.page_number}
         pages={@page.total_pages}
         total_entries={@page.total_entries}
@@ -90,6 +93,17 @@
         filters={SearchParams.new(@filters)}
         workflows={@workflows}
       />
+      <div :if={@active_modal == "bulk-rerun-from-job-modal"}>
+        <.live_component
+          module={LightningWeb.RunLive.RerunJobComponent}
+          id="bulk-rerun-from-job-modal"
+          total_entries={@page.total_entries}
+          selected_workorders={flattened_selections(@selected_work_orders)}
+          all_selected?={all_selected?(@selected_work_orders, @page.entries)}
+          workflow_id={@selected_work_orders |> Map.keys() |> hd()}
+          show={true}
+        />
+      </div>
       <div class="w-96 bg-gray-200 ml-4 p-4 pt-0 sticky top-0 self-start rounded-md">
         <.form
           :let={f}

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -102,6 +102,7 @@
           selected_count={selected_workorder_count(@selected_work_orders)}
           all_selected?={all_selected?(@selected_work_orders, @page.entries)}
           workflow_id={@selected_work_orders |> Map.keys() |> hd()}
+          pages={@page.total_pages}
           show={true}
         />
       </div>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -12,7 +12,7 @@
       >
         <div class="sticky top-0 bg-gray-100 text-xs uppercase text-gray-400 dark:text-gray-400">
           <div class="grid grid-cols-6 gap-0">
-            <div class={"py-3 px-4 font-medium relative flex items-center #{if @selected_work_orders != [], do: "col-span-2"}"}>
+            <div class={"py-3 px-4 font-medium relative flex items-center #{unless none_selected?(@selected_work_orders), do: "col-span-2"}"}>
               <div class="">
                 <.form
                   :let={f}
@@ -33,7 +33,7 @@
                 </.form>
               </div>
               <div class="ml-3">
-                <%= if @selected_work_orders == [] do %>
+                <%= if none_selected?(@selected_work_orders) do %>
                   Workflow
                 <% else %>
                   <button
@@ -41,7 +41,15 @@
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
                     phx-click={Components.show_modal("bulk-rerun-modal")}
                   >
-                    Rerun from start
+                    Rerun
+                  </button>
+                  <button
+                    :if={selected_workflow_count(@selected_work_orders) == 1}
+                    type="button"
+                    class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                    phx-click=""
+                  >
+                    Rerun from...
                   </button>
                 <% end %>
               </div>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -50,8 +50,9 @@
                     id="bulk-rerun-from-job-modal-trigger"
                     type="button"
                     class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                    phx-click="toggle_modal"
-                    phx-value-modal="bulk-rerun-from-job-modal"
+                    phx-click={
+                      Components.show_modal("bulk-rerun-from-job-modal")
+                    }
                   >
                     Rerun from...
                   </button>
@@ -94,18 +95,17 @@
         filters={SearchParams.new(@filters)}
         workflows={@workflows}
       />
-      <div :if={@active_modal == "bulk-rerun-from-job-modal"}>
-        <.live_component
-          module={LightningWeb.RunLive.RerunJobComponent}
-          id="bulk-rerun-from-job-modal"
-          total_entries={@page.total_entries}
-          selected_count={selected_workorder_count(@selected_work_orders)}
-          all_selected?={all_selected?(@selected_work_orders, @page.entries)}
-          workflow_id={@selected_work_orders |> Map.keys() |> hd()}
-          pages={@page.total_pages}
-          show={true}
-        />
-      </div>
+
+      <.live_component
+        :if={selected_workflow_count(@selected_work_orders) == 1}
+        module={LightningWeb.RunLive.RerunJobComponent}
+        id="bulk-rerun-from-job-modal"
+        total_entries={@page.total_entries}
+        selected_count={selected_workorder_count(@selected_work_orders)}
+        all_selected?={all_selected?(@selected_work_orders, @page.entries)}
+        workflow_id={@selected_work_orders |> hd() |> Map.get(:workflow_id)}
+        pages={@page.total_pages}
+      />
       <div class="w-96 bg-gray-200 ml-4 p-4 pt-0 sticky top-0 self-start rounded-md">
         <.form
           :let={f}

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -41,10 +41,6 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
     {:noreply, assign(socket, selected_job: selected_job)}
   end
 
-  def handle_event("bulk-rerun", _attrs, socket) do
-    {:noreply, socket}
-  end
-
   def render(assigns) do
     ~H"""
     <div
@@ -123,8 +119,8 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                 type="button"
                 phx-click="bulk-rerun"
                 phx-value-type="selected"
+                phx-value-job={@selected_job.id}
                 phx-disable-with="Running..."
-                phx-target={@myself}
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
               >
                 Rerun <%= @selected_count %> selected workorder<%= if @selected_count >
@@ -136,8 +132,8 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                 type="button"
                 phx-click="bulk-rerun"
                 phx-value-type="all"
+                phx-value-job={@selected_job.id}
                 phx-disable-with="Running..."
-                phx-target={@myself}
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >
                 Rerun all <%= @total_entries %> matching workorders from selected job
@@ -169,6 +165,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                 type="button"
                 phx-click="bulk-rerun"
                 phx-value-type="selected"
+                phx-value-job={@selected_job.id}
                 phx-disable-with="Running..."
                 class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
               >

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -159,8 +159,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               <button
                 type="button"
                 class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
-                phx-click="toggle_modal"
-                phx-value-modal={@id}
+                phx-click={hide_modal(@id)}
               >
                 Cancel
               </button>
@@ -186,8 +185,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               <button
                 type="button"
                 class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
-                phx-click="toggle_modal"
-                phx-value-modal={@id}
+                phx-click={hide_modal(@id)}
               >
                 Cancel
               </button>

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -11,7 +11,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
   def update(
         %{
           total_entries: _count,
-          selected_workorders: wo_list,
+          selected_count: _selected_count,
           workflow_id: workflow_id
         } = assigns,
         socket
@@ -21,13 +21,13 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
 
     {:ok,
      socket
-     |> assign(assigns)
      |> assign(
-       selected_count: Enum.count(wo_list),
+       show: false,
        workflow: workflow,
        workflow_jobs: jobs,
        selected_job: hd(jobs)
-     )}
+     )
+     |> assign(assigns)}
   end
 
   def handle_event(
@@ -116,6 +116,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
             >
               <button
+                id="rerun-selected-from-job-trigger"
                 type="button"
                 phx-click="bulk-rerun"
                 phx-value-type="selected"
@@ -129,6 +130,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                                                                       else: "" %> from selected job
               </button>
               <button
+                id="rerun-all-from-job-trigger"
                 type="button"
                 phx-click="bulk-rerun"
                 phx-value-type="all"
@@ -162,6 +164,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
             >
               <button
+                id="rerun-selected-from-job-trigger"
                 type="button"
                 phx-click="bulk-rerun"
                 phx-value-type="selected"

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -118,7 +118,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               </div>
             </div>
             <div
-              :if={@all_selected? and @total_entries > 1}
+              :if={@all_selected? and @total_entries > 1 and @pages > 1}
               class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
             >
               <button
@@ -166,7 +166,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               </button>
             </div>
             <div
-              :if={!@all_selected? or @total_entries == 1}
+              :if={!@all_selected? or @total_entries == 1 or @pages == 1}
               class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
             >
               <button

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -7,7 +7,6 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
   import LightningWeb.RunLive.Components, only: [hide_modal: 1, show_modal: 1]
   alias Lightning.Jobs
   alias Lightning.Workflows
-  alias Phoenix.LiveView.JS
 
   def update(
         %{
@@ -108,7 +107,7 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                           for={"job_#{job.id}"}
                           class="ml-3 block text-sm font-medium leading-6 text-gray-900"
                         >
-                          <%= job.name %> (<%= job.work_orders_count %> work orders)
+                          <%= job.name %>
                         </label>
                       </div>
                     <% end %>
@@ -116,7 +115,10 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                 </fieldset>
               </div>
             </div>
-            <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+            <div
+              :if={@all_selected? and @total_entries > 1}
+              class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
+            >
               <button
                 type="button"
                 phx-click="bulk-rerun"
@@ -153,6 +155,31 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
               <button
                 type="button"
                 class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
+                phx-click="toggle_modal"
+                phx-value-modal={@id}
+              >
+                Cancel
+              </button>
+            </div>
+            <div
+              :if={!@all_selected? or @total_entries == 1}
+              class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
+            >
+              <button
+                type="button"
+                phx-click="bulk-rerun"
+                phx-value-type="selected"
+                phx-disable-with="Running..."
+                class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
+              >
+                Rerun <%= @selected_count %> selected workorder<%= if @selected_count >
+                                                                        1,
+                                                                      do: "s",
+                                                                      else: "" %> from selected job
+              </button>
+              <button
+                type="button"
+                class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
                 phx-click="toggle_modal"
                 phx-value-modal={@id}
               >

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -82,33 +82,35 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                 <p class="text-sm text-gray-500">
                   Find all runs that include this step, and rerun from there
                 </p>
-                <fieldset class="mt-4">
-                  <legend class="sr-only">Workflow Job</legend>
-                  <div class="space-y-4">
-                    <%= for job <- @workflow_jobs do %>
-                      <div class="flex items-center">
-                        <input
-                          id={"job_#{job.id}"}
-                          name="job"
-                          type="radio"
-                          phx-change="select_job"
-                          phx-target={@myself}
-                          class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                          value={job.id}
-                          checked={
-                            if job.id == @selected_job.id, do: "checked", else: false
-                          }
-                        />
-                        <label
-                          for={"job_#{job.id}"}
-                          class="ml-3 block text-sm font-medium leading-6 text-gray-900"
-                        >
-                          <%= job.name %>
-                        </label>
-                      </div>
-                    <% end %>
-                  </div>
-                </fieldset>
+                <form phx-change="select_job" phx-target={@myself}>
+                  <fieldset class="mt-4">
+                    <legend class="sr-only">Workflow Job</legend>
+                    <div class="space-y-4">
+                      <%= for job <- @workflow_jobs do %>
+                        <div class="flex items-center">
+                          <input
+                            id={"job_#{job.id}"}
+                            name="job"
+                            type="radio"
+                            class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                            value={job.id}
+                            checked={
+                              if job.id == @selected_job.id,
+                                do: "checked",
+                                else: false
+                            }
+                          />
+                          <label
+                            for={"job_#{job.id}"}
+                            class="ml-3 block text-sm font-medium leading-6 text-gray-900"
+                          >
+                            <%= job.name %>
+                          </label>
+                        </div>
+                      <% end %>
+                    </div>
+                  </fieldset>
+                </form>
               </div>
             </div>
             <div

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -82,7 +82,11 @@ defmodule LightningWeb.RunLive.RerunJobComponent do
                 <p class="text-sm text-gray-500">
                   Find all runs that include this step, and rerun from there
                 </p>
-                <form phx-change="select_job" phx-target={@myself}>
+                <form
+                  id="select-job-for-rerun-form"
+                  phx-change="select_job"
+                  phx-target={@myself}
+                >
                   <fieldset class="mt-4">
                     <legend class="sr-only">Workflow Job</legend>
                     <div class="space-y-4">

--- a/lib/lightning_web/live/run_live/rerun_job_component.ex
+++ b/lib/lightning_web/live/run_live/rerun_job_component.ex
@@ -1,0 +1,168 @@
+defmodule LightningWeb.RunLive.RerunJobComponent do
+  @moduledoc """
+  Rerun job component
+  """
+
+  use LightningWeb, :live_component
+  import LightningWeb.RunLive.Components, only: [hide_modal: 1, show_modal: 1]
+  alias Lightning.Jobs
+  alias Lightning.Workflows
+  alias Phoenix.LiveView.JS
+
+  def update(
+        %{
+          total_entries: _count,
+          selected_workorders: wo_list,
+          workflow_id: workflow_id
+        } = assigns,
+        socket
+      ) do
+    workflow = Workflows.get_workflow!(workflow_id)
+    jobs = Jobs.list_jobs_for_workflow(workflow)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(
+       selected_count: Enum.count(wo_list),
+       workflow: workflow,
+       workflow_jobs: jobs,
+       selected_job: hd(jobs)
+     )}
+  end
+
+  def handle_event(
+        "select_job",
+        %{"job" => job_id},
+        %{assigns: assigns} = socket
+      ) do
+    selected_job =
+      Enum.find(assigns.workflow_jobs, fn job -> job.id == job_id end)
+
+    {:noreply, assign(socket, selected_job: selected_job)}
+  end
+
+  def handle_event("bulk-rerun", _attrs, socket) do
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="relative z-10 hidden"
+      aria-labelledby={"#{@id}-title"}
+      id={@id}
+      role="dialog"
+      aria-modal="true"
+      phx-mounted={@show && show_modal(@id)}
+      phx-remove={hide_modal(@id)}
+    >
+      <div
+        id={"#{@id}-bg"}
+        class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+      >
+      </div>
+
+      <div
+        aria-labelledby={"#{@id}-title"}
+        class="fixed inset-0 z-10 overflow-y-auto"
+      >
+        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <.focus_wrap
+            id={"#{@id}-container"}
+            phx-mounted={@show && show_modal(@id)}
+            phx-window-keydown={hide_modal(@id)}
+            phx-key="escape"
+            phx-click-away={hide_modal(@id)}
+            class="hidden relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6"
+          >
+            <div id={"#{@id}-content"} class="mt-3 text-center sm:mt-5">
+              <h3
+                class="text-base font-semibold leading-6 text-gray-900"
+                id={"#{@id}-title"}
+              >
+                Run from a specific step
+              </h3>
+              <div class="mt-2">
+                <p class="text-sm text-gray-500">
+                  Find all runs that include this step, and rerun from there
+                </p>
+                <fieldset class="mt-4">
+                  <legend class="sr-only">Workflow Job</legend>
+                  <div class="space-y-4">
+                    <%= for job <- @workflow_jobs do %>
+                      <div class="flex items-center">
+                        <input
+                          id={"job_#{job.id}"}
+                          name="job"
+                          type="radio"
+                          phx-change="select_job"
+                          phx-target={@myself}
+                          class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                          value={job.id}
+                          checked={
+                            if job.id == @selected_job.id, do: "checked", else: false
+                          }
+                        />
+                        <label
+                          for={"job_#{job.id}"}
+                          class="ml-3 block text-sm font-medium leading-6 text-gray-900"
+                        >
+                          <%= job.name %> (<%= job.work_orders_count %> work orders)
+                        </label>
+                      </div>
+                    <% end %>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+            <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+              <button
+                type="button"
+                phx-click="bulk-rerun"
+                phx-value-type="selected"
+                phx-disable-with="Running..."
+                phx-target={@myself}
+                class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-1"
+              >
+                Rerun <%= @selected_count %> selected workorder<%= if @selected_count >
+                                                                        1,
+                                                                      do: "s",
+                                                                      else: "" %> from selected job
+              </button>
+              <button
+                type="button"
+                phx-click="bulk-rerun"
+                phx-value-type="all"
+                phx-disable-with="Running..."
+                phx-target={@myself}
+                class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:col-start-2"
+              >
+                Rerun all <%= @total_entries %> matching workorders from selected job
+              </button>
+              <div class="relative col-start-1 col-end-3">
+                <div class="absolute inset-0 flex items-center" aria-hidden="true">
+                  <div class="w-full border-t border-gray-300"></div>
+                </div>
+                <div class="relative flex justify-center">
+                  <span class="bg-white px-2 text-sm text-gray-500">
+                    OR
+                  </span>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="mt-3 inline-flex w-full justify-center items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:col-end-3 sm:mt-0"
+                phx-click="toggle_modal"
+                phx-value-modal={@id}
+              >
+                Cancel
+              </button>
+            </div>
+          </.focus_wrap>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/priv/repo/migrations/20230705100814_modify_timestamps_to_include_usec.exs
+++ b/priv/repo/migrations/20230705100814_modify_timestamps_to_include_usec.exs
@@ -1,0 +1,30 @@
+defmodule Lightning.Repo.Migrations.ModifyTimestampsToIncludeUsec do
+  use Ecto.Migration
+
+  def change do
+    alter table("attempts") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("attempt_runs") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("dataclips") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("runs") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("work_orders") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+  end
+end

--- a/test/lightning/attempt_service_test.exs
+++ b/test/lightning/attempt_service_test.exs
@@ -226,32 +226,14 @@ defmodule Lightning.AttemptServiceTest do
     test "only the first attempt (oldest) is listed for each work order, ordered
           by workorder creation date, oldest to newest",
          %{
-           project: project,
            jobs: jobs,
            workflow: workflow
          } do
+      work_order_1 = work_order_fixture(workflow_id: workflow.id)
+      work_order_2 = work_order_fixture(workflow_id: workflow.id)
+      dataclip = dataclip_fixture()
+
       now = Timex.now()
-      reason = reason_fixture(project_id: project.id)
-
-      work_order_1 =
-        %Lightning.WorkOrder{
-          workflow_id: workflow.id,
-          reason_id: reason.id,
-          inserted_at: Timex.shift(now, seconds: -100),
-          updated_at: now
-        }
-        |> Lightning.Repo.insert!(returning: true)
-
-      work_order_2 =
-        %Lightning.WorkOrder{
-          workflow_id: workflow.id,
-          reason_id: reason.id,
-          inserted_at: now,
-          updated_at: now
-        }
-        |> Lightning.Repo.insert!(returning: true)
-
-      dataclip = dataclip_fixture(project_id: project.id)
 
       [work_order_1, work_order_2]
       |> Enum.each(fn work_order ->
@@ -315,32 +297,13 @@ defmodule Lightning.AttemptServiceTest do
           associated with the job, ordered by workorder creation date, oldest to
           newest",
          %{
-           project: project,
            jobs: jobs,
            workflow: workflow
          } do
-      now = Timex.now()
-      reason = reason_fixture(project_id: project.id)
+      work_order_1 = work_order_fixture(workflow_id: workflow.id)
+      work_order_2 = work_order_fixture(workflow_id: workflow.id)
 
-      work_order_1 =
-        %Lightning.WorkOrder{
-          workflow_id: workflow.id,
-          reason_id: reason.id,
-          inserted_at: Timex.shift(now, seconds: -100),
-          updated_at: now
-        }
-        |> Lightning.Repo.insert!(returning: true)
-
-      work_order_2 =
-        %Lightning.WorkOrder{
-          workflow_id: workflow.id,
-          reason_id: reason.id,
-          inserted_at: now,
-          updated_at: now
-        }
-        |> Lightning.Repo.insert!(returning: true)
-
-      dataclip = dataclip_fixture(project_id: project.id)
+      dataclip = dataclip_fixture()
 
       # First Attempts with all Jobs
       [_attempt_1_work_order_1, attempt_1_work_order_2] =
@@ -425,7 +388,7 @@ defmodule Lightning.AttemptServiceTest do
       assert second_attempt_run_in_list.attempt.work_order_id == work_order_2.id
 
       assert first_attempt_run_in_list.id == attempt_run2.id
-      assert second_attempt_run_in_list.id == attempt_run.id
+      assert first_attempt_run_in_list.id == attempt_run.id
     end
   end
 end

--- a/test/lightning/attempt_service_test.exs
+++ b/test/lightning/attempt_service_test.exs
@@ -226,14 +226,32 @@ defmodule Lightning.AttemptServiceTest do
     test "only the first attempt (oldest) is listed for each work order, ordered
           by workorder creation date, oldest to newest",
          %{
+           project: project,
            jobs: jobs,
            workflow: workflow
          } do
-      work_order_1 = work_order_fixture(workflow_id: workflow.id)
-      work_order_2 = work_order_fixture(workflow_id: workflow.id)
-      dataclip = dataclip_fixture()
-
       now = Timex.now()
+      reason = reason_fixture(project_id: project.id)
+
+      work_order_1 =
+        %Lightning.WorkOrder{
+          workflow_id: workflow.id,
+          reason_id: reason.id,
+          inserted_at: Timex.shift(now, seconds: -100),
+          updated_at: now
+        }
+        |> Lightning.Repo.insert!(returning: true)
+
+      work_order_2 =
+        %Lightning.WorkOrder{
+          workflow_id: workflow.id,
+          reason_id: reason.id,
+          inserted_at: now,
+          updated_at: now
+        }
+        |> Lightning.Repo.insert!(returning: true)
+
+      dataclip = dataclip_fixture(project_id: project.id)
 
       [work_order_1, work_order_2]
       |> Enum.each(fn work_order ->
@@ -297,13 +315,32 @@ defmodule Lightning.AttemptServiceTest do
           associated with the job, ordered by workorder creation date, oldest to
           newest",
          %{
+           project: project,
            jobs: jobs,
            workflow: workflow
          } do
-      work_order_1 = work_order_fixture(workflow_id: workflow.id)
-      work_order_2 = work_order_fixture(workflow_id: workflow.id)
+      now = Timex.now()
+      reason = reason_fixture(project_id: project.id)
 
-      dataclip = dataclip_fixture()
+      work_order_1 =
+        %Lightning.WorkOrder{
+          workflow_id: workflow.id,
+          reason_id: reason.id,
+          inserted_at: Timex.shift(now, seconds: -100),
+          updated_at: now
+        }
+        |> Lightning.Repo.insert!(returning: true)
+
+      work_order_2 =
+        %Lightning.WorkOrder{
+          workflow_id: workflow.id,
+          reason_id: reason.id,
+          inserted_at: now,
+          updated_at: now
+        }
+        |> Lightning.Repo.insert!(returning: true)
+
+      dataclip = dataclip_fixture(project_id: project.id)
 
       # First Attempts with all Jobs
       [_attempt_1_work_order_1, attempt_1_work_order_2] =
@@ -388,7 +425,7 @@ defmodule Lightning.AttemptServiceTest do
       assert second_attempt_run_in_list.attempt.work_order_id == work_order_2.id
 
       assert first_attempt_run_in_list.id == attempt_run2.id
-      assert first_attempt_run_in_list.id == attempt_run.id
+      assert second_attempt_run_in_list.id == attempt_run.id
     end
   end
 end

--- a/test/lightning/attempt_service_test.exs
+++ b/test/lightning/attempt_service_test.exs
@@ -281,4 +281,102 @@ defmodule Lightning.AttemptServiceTest do
              |> Enum.count() == 2
     end
   end
+
+  describe "list_for_rerun_from_job/2" do
+    setup do
+      workflow_scenario()
+    end
+
+    test "returns the AttemptRuns for the latest Attempt of each work order associated with the job",
+         %{
+           jobs: jobs,
+           workflow: workflow
+         } do
+      work_order_1 = work_order_fixture(workflow_id: workflow.id)
+      work_order_2 = work_order_fixture(workflow_id: workflow.id)
+      dataclip = dataclip_fixture()
+
+      # First Attempts with all Jobs
+      [_attempt_1_work_order_1, attempt_1_work_order_2] =
+        Enum.map([work_order_1, work_order_2], fn work_order ->
+          runs =
+            Enum.map(
+              Map.values(jobs),
+              fn j ->
+                %{
+                  job_id: j.id,
+                  input_dataclip_id: dataclip.id,
+                  exit_code: 0
+                }
+              end
+            )
+
+          Lightning.Attempt.new(%{
+            work_order_id: work_order.id,
+            reason_id: work_order.reason_id,
+            runs: runs
+          })
+          |> Repo.insert!()
+        end)
+
+      # Second Attempt For Work Order 1
+      # Job d is missing
+      dataclip2 = dataclip_fixture()
+
+      runs =
+        Enum.map([jobs.a, jobs.b, jobs.c, jobs.e, jobs.f], fn j ->
+          %{
+            job_id: j.id,
+            input_dataclip_id: dataclip2.id,
+            exit_code: 0
+          }
+        end)
+
+      attempt_2_work_order_1 =
+        Attempt.new(%{
+          work_order_id: work_order_1.id,
+          reason_id: work_order_1.reason_id,
+          runs: runs
+        })
+        |> Repo.insert!()
+
+      # Only the attempt for work order2 will be listed
+      assert [attempt_run] =
+               AttemptService.list_for_rerun_from_job(
+                 [
+                   work_order_1.id,
+                   work_order_2.id
+                 ],
+                 jobs.d.id
+               )
+
+      assert attempt_run.attempt_id == attempt_1_work_order_2.id
+
+      ## create the missing attempt run
+      attempt_run2 =
+        Lightning.AttemptRun.new(%{
+          attempt_id: attempt_2_work_order_1.id,
+          run: %{
+            job_id: jobs.d.id,
+            input_dataclip_id: dataclip2.id,
+            exit_code: 0
+          }
+        })
+        |> Repo.insert!()
+
+      attempt_runs =
+        AttemptService.list_for_rerun_from_job(
+          [
+            work_order_1.id,
+            work_order_2.id
+          ],
+          jobs.d.id
+        )
+
+      assert Enum.count(attempt_runs) == 2
+
+      assert Enum.any?(attempt_runs, fn atr -> atr.id == attempt_run2.id end)
+      assert Enum.any?(attempt_runs, fn atr -> atr.id == attempt_run.id end)
+    end
+  end
 end

--- a/test/lightning/attempt_service_test.exs
+++ b/test/lightning/attempt_service_test.exs
@@ -388,7 +388,7 @@ defmodule Lightning.AttemptServiceTest do
       assert second_attempt_run_in_list.attempt.work_order_id == work_order_2.id
 
       assert first_attempt_run_in_list.id == attempt_run2.id
-      assert first_attempt_run_in_list.id == attempt_run.id
+      assert second_attempt_run_in_list.id == attempt_run.id
     end
   end
 end

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -341,10 +341,26 @@ defmodule Lightning.InvocationTest do
         ).entries()
 
       expected_order = [
-        %{id: wo_four.id, last_finished_at: run_four.finished_at},
-        %{id: wo_three.id, last_finished_at: run_three.finished_at},
-        %{id: wo_two.id, last_finished_at: run_two.finished_at},
-        %{id: wo_one.id, last_finished_at: run_one.finished_at}
+        %{
+          id: wo_four.id,
+          last_finished_at: run_four.finished_at,
+          workflow_id: workflow.id
+        },
+        %{
+          id: wo_three.id,
+          last_finished_at: run_three.finished_at,
+          workflow_id: workflow.id
+        },
+        %{
+          id: wo_two.id,
+          last_finished_at: run_two.finished_at,
+          workflow_id: workflow.id
+        },
+        %{
+          id: wo_one.id,
+          last_finished_at: run_one.finished_at,
+          workflow_id: workflow.id
+        }
       ]
 
       assert expected_order == simplified_result
@@ -611,9 +627,21 @@ defmodule Lightning.InvocationTest do
       # all work_orders in page_one are ordered by finished_at
 
       expected_order = [
-        %{id: wf3_wo3.id, last_finished_at: wf3_run3.finished_at},
-        %{id: wf3_wo2.id, last_finished_at: wf3_run2.finished_at},
-        %{id: wf3_wo1.id, last_finished_at: wf3_run1.finished_at}
+        %{
+          id: wf3_wo3.id,
+          last_finished_at: wf3_run3.finished_at,
+          workflow_id: job3.workflow_id
+        },
+        %{
+          id: wf3_wo2.id,
+          last_finished_at: wf3_run2.finished_at,
+          workflow_id: job3.workflow_id
+        },
+        %{
+          id: wf3_wo1.id,
+          last_finished_at: wf3_run1.finished_at,
+          workflow_id: job3.workflow_id
+        }
       ]
 
       assert expected_order == page_one_result
@@ -635,9 +663,21 @@ defmodule Lightning.InvocationTest do
 
       # all work_orders in page_two are ordered by finished_at
       expected_order = [
-        %{id: wf2_wo3.id, last_finished_at: wf2_run3.finished_at},
-        %{id: wf2_wo2.id, last_finished_at: wf2_run2.finished_at},
-        %{id: wf2_wo1.id, last_finished_at: wf2_run1.finished_at}
+        %{
+          id: wf2_wo3.id,
+          last_finished_at: wf2_run3.finished_at,
+          workflow_id: job2.workflow_id
+        },
+        %{
+          id: wf2_wo2.id,
+          last_finished_at: wf2_run2.finished_at,
+          workflow_id: job2.workflow_id
+        },
+        %{
+          id: wf2_wo1.id,
+          last_finished_at: wf2_run1.finished_at,
+          workflow_id: job2.workflow_id
+        }
       ]
 
       assert expected_order == page_two_result
@@ -659,9 +699,21 @@ defmodule Lightning.InvocationTest do
 
       # all work_orders in page_three are ordered by finished_at
       expected_order = [
-        %{id: wf1_wo3.id, last_finished_at: wf1_run3.finished_at},
-        %{id: wf1_wo2.id, last_finished_at: wf1_run2.finished_at},
-        %{id: wf1_wo1.id, last_finished_at: wf1_run1.finished_at}
+        %{
+          id: wf1_wo3.id,
+          last_finished_at: wf1_run3.finished_at,
+          workflow_id: job1.workflow_id
+        },
+        %{
+          id: wf1_wo2.id,
+          last_finished_at: wf1_run2.finished_at,
+          workflow_id: job1.workflow_id
+        },
+        %{
+          id: wf1_wo1.id,
+          last_finished_at: wf1_run1.finished_at,
+          workflow_id: job1.workflow_id
+        }
       ]
 
       assert expected_order == page_three_result

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1940,7 +1940,6 @@ defmodule LightningWeb.RunWorkOrderTest do
       assert render(view) =~
                "Find all runs that include this step, and rerun from there"
 
-
       view
       |> form("#select-job-for-rerun-form")
       |> render_change(%{job: jobs.a.id})

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1938,7 +1938,9 @@ defmodule LightningWeb.RunWorkOrderTest do
       assert render(view) =~
                "Find all runs that include this step, and rerun from there"
 
-      view |> element("#job_#{jobs.a.id}") |> render_change()
+      view
+      |> form("#select-job-for-rerun-form")
+      |> render_change(%{job: jobs.a.id})
 
       result = view |> element("#rerun-all-from-job-trigger") |> render_click()
 
@@ -1952,7 +1954,9 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       view |> element("#bulk-rerun-from-job-modal-trigger") |> render_click()
 
-      view |> element("#job_#{jobs.a.id}") |> render_change()
+      view
+      |> form("#select-job-for-rerun-form")
+      |> render_change(%{job: jobs.a.id})
 
       result =
         view |> element("#rerun-selected-from-job-trigger") |> render_click()

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1928,7 +1928,9 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       refute html =~ "Find all runs that include this step, and rerun from there"
 
-      render_change(view, "toggle_all_selections", %{all_selections: true})
+      view
+      |> form("##{work_order_1.id}-selection-form")
+      |> render_change(%{selected: true})
 
       refute render(view) =~
                "Find all runs that include this step, and rerun from there"
@@ -1938,21 +1940,6 @@ defmodule LightningWeb.RunWorkOrderTest do
       assert render(view) =~
                "Find all runs that include this step, and rerun from there"
 
-      view
-      |> form("#select-job-for-rerun-form")
-      |> render_change(%{job: jobs.a.id})
-
-      result = view |> element("#rerun-all-from-job-trigger") |> render_click()
-
-      {:ok, view, html} = follow_redirect(result, conn)
-
-      assert html =~ "New attempts enqueued for 2 workorders"
-
-      view
-      |> form("##{work_order_1.id}-selection-form")
-      |> render_change(%{selected: true})
-
-      view |> element("#bulk-rerun-from-job-modal-trigger") |> render_click()
 
       view
       |> form("#select-job-for-rerun-form")
@@ -1977,6 +1964,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           total_entries: 25,
           all_selected?: true,
           selected_count: 5,
+          pages: 2,
           filters: %SearchParams{},
           workflow_id: workflow.id
         )
@@ -1996,6 +1984,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           total_entries: 25,
           all_selected?: true,
           selected_count: 5,
+          pages: 2,
           filters: %SearchParams{},
           workflow_id: workflow.id
         )
@@ -2014,6 +2003,26 @@ defmodule LightningWeb.RunWorkOrderTest do
           total_entries: 25,
           all_selected?: false,
           selected_count: 5,
+          pages: 2,
+          filters: %SearchParams{},
+          workflow_id: workflow.id
+        )
+
+      refute html =~ "Rerun all 25 matching workorders from selected job"
+      assert html =~ "Rerun 5 selected workorders from selected job"
+    end
+
+    test "only 1 run button is present when total pages is 1", %{
+      workflow: workflow
+    } do
+      html =
+        render_component(
+          LightningWeb.RunLive.RerunJobComponent,
+          id: "bulk-rerun-from-start-modal",
+          total_entries: 25,
+          all_selected?: true,
+          selected_count: 5,
+          pages: 1,
           filters: %SearchParams{},
           workflow_id: workflow.id
         )


### PR DESCRIPTION
## Notes for the reviewer

## Implementation Plan
### UI 
- [x] Display rerun from... button when the selected workorders are only for a single workflow
- [x] Add confirmation modal
- [x] Order the steps accordingly in the modal
- [x] Add relevant tests
### LOGIC
- [x] Add function to filter attempt runs based on given job_id

## Related issue

Fixes #833 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
