### PR TITLE
Finish migration script for triggers & edges

### DIFF
--- a/priv/repo/migrations/20230609000000_convert_triggers_to_edges.exs
+++ b/priv/repo/migrations/20230609000000_convert_triggers_to_edges.exs
@@ -47,6 +47,10 @@ defmodule Lightning.Repo.Migrations.ConvertTriggersToEdges do
       cte.updated_at
     FROM triggers_cte AS cte
     """)
+
+    execute("""
+    delete from triggers where type in ('on_job_success', 'on_job_failure')
+    """)
   end
 
   def down do

--- a/priv/repo/migrations/20230609000000_convert_triggers_to_edges.exs
+++ b/priv/repo/migrations/20230609000000_convert_triggers_to_edges.exs
@@ -49,6 +49,10 @@ defmodule Lightning.Repo.Migrations.ConvertTriggersToEdges do
     """)
 
     execute("""
+    update jobs set trigger_id = null
+    """)
+
+    execute("""
     delete from triggers where type in ('on_job_success', 'on_job_failure')
     """)
   end


### PR DESCRIPTION
this allows @elias-ba 's SQL script for converting triggers to edges to be run as a migration, before we drop `trigger_id` from jobs and enforce new trigger types