### PR TITLE
start vault if not started so we can build creds during the demo setup script

### DIFF
--- a/lib/lightning/demo.ex
+++ b/lib/lightning/demo.ex
@@ -13,6 +13,10 @@ defmodule Lightning.Demo do
   def reset_demo do
     Lightning.Release.load_app()
 
+    # We must start our vault so (public) credentials can be built for the demo.
+    unless GenServer.whereis(Lightning.Vault),
+      do: Lightning.Vault.start_link()
+
     {:ok, _, _} =
       Ecto.Migrator.with_repo(Lightning.Repo, fn _repo ->
         SetupUtils.tear_down(destroy_super: true)

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -41,6 +41,16 @@ defmodule Lightning.SetupUtils do
         {:ok, nil}
       end
 
+    Lightning.Repo.insert!(%Lightning.Accounts.UserToken{
+      user_id: super_user.id,
+      context: "api",
+      token:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJKb2tlbiIsImlhdCI6MTY4
+        ODAzNzE4NSwiaXNzIjoiSm9rZW4iLCJqdGkiOiIydG1ocG8zYm0xdmR0MDZvZDgwMDAwdTEiLCJuY
+        mYiOjE2ODgwMzcxODUsInVzZXJfaWQiOiIzZjM3OGU2Yy02NjBhLTRiOTUtYWI5Ni02YmQwZGMyNj
+        NkMzMifQ.J1FnACGpqtQbmXNvyUCwCY4mS5S6CohRU3Ey-N0prP4"
+    })
+
     {:ok, admin} =
       Accounts.register_user(%{
         first_name: "Amy",


### PR DESCRIPTION
fixes #917 , and also provides a public API token (yes, public! just like the public passwords here!) for testing the CLI against the demo site.