### PR TITLE
fix: change timestamp fields to contain usec

### DIFF
--- a/priv/repo/migrations/20230705100814_modify_timestamps_to_include_usec.exs
+++ b/priv/repo/migrations/20230705100814_modify_timestamps_to_include_usec.exs
@@ -1,0 +1,30 @@
+defmodule Lightning.Repo.Migrations.ModifyTimestampsToIncludeUsec do
+  use Ecto.Migration
+
+  def change do
+    alter table("attempts") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("attempt_runs") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("dataclips") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("runs") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+
+    alter table("work_orders") do
+      modify :inserted_at, :naive_datetime_usec, from: :naive_datetime
+      modify :updated_at, :naive_datetime_usec, from: :naive_datetime
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer

The database tables fields were defined without  `usec`. By default, the `timestamps()` function in `Ecto.Migration` generates fields of type `:naive_datetime`. 

Below is a link to the docs: https://hexdocs.pm/ecto_sql/Ecto.Migration.html#timestamps/1