### PR TITLE
Quick-edit panels for job, trigger, edge

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -87,12 +87,11 @@ window.addEventListener('phx:page-loading-stop', () => {
 
 window.addEventListener('keydown', event => {
   const currentURL = window.location.pathname;
-  const edit_job_url = /\/projects\/(.+)\/w\/(.+)\/j\/(.+)/;
+  const edit_workflow_url = /\/projects\/(.+)\/w\/(.+)/;
   if ((event.ctrlKey || event.metaKey) && event.key === 's') {
-    if (edit_job_url.test(currentURL)) {
+    if (edit_workflow_url.test(currentURL)) {
       event.preventDefault();
-      console.log('Saving the job');
-      let form = document.querySelector("button[form='job-form']");
+      let form = document.querySelector("button[form='workflow-form']");
       form.click();
     }
   }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,7 +25,7 @@ import { Socket } from 'phoenix';
 import { LiveSocket } from 'phoenix_live_view';
 
 import topbar from '../vendor/topbar';
-import { AssocListChange, Copy, Flash } from './hooks';
+import { AssocListChange, Copy, Flash, SubmitViaCtrlS } from './hooks';
 import JobEditor from './job-editor';
 import JobEditorResizer from './job-editor-resizer/mount';
 import TabSelector from './tab-selector';
@@ -41,6 +41,7 @@ let Hooks = {
   Flash,
   AssocListChange,
   Copy,
+  SubmitViaCtrlS,
 };
 
 // @ts-ignore
@@ -83,18 +84,6 @@ window.addEventListener('phx:page-loading-stop', () => {
   clearTimeout(topBarScheduled);
   topBarScheduled = undefined;
   topbar.hide();
-});
-
-window.addEventListener('keydown', event => {
-  const currentURL = window.location.pathname;
-  const edit_workflow_url = /\/projects\/(.+)\/w\/(.+)/;
-  if ((event.ctrlKey || event.metaKey) && event.key === 's') {
-    if (edit_workflow_url.test(currentURL)) {
-      event.preventDefault();
-      let form = document.querySelector("button[form='workflow-form']");
-      form.click();
-    }
-  }
 });
 
 // connect if there are any LiveViews on the page

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -24,6 +24,19 @@ export const AssocListChange = {
   },
 } as PhoenixHook<{}, {}, HTMLSelectElement>;
 
+export const SubmitViaCtrlS = {
+  mounted() {
+    this.el.addEventListener('keydown', e => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        this.el.dispatchEvent(
+          new Event('submit', { bubbles: true, cancelable: true })
+        );
+      }
+    });
+  },
+} as PhoenixHook<{}, { to: string }>;
+
 export const Copy = {
   mounted() {
     let { to } = this.el.dataset;
@@ -36,4 +49,3 @@ export const Copy = {
     });
   },
 } as PhoenixHook<{}, { to: string }>;
-

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -26,16 +26,26 @@ export const AssocListChange = {
 
 export const SubmitViaCtrlS = {
   mounted() {
-    this.el.addEventListener('keydown', e => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
-        e.preventDefault();
-        this.el.dispatchEvent(
-          new Event('submit', { bubbles: true, cancelable: true })
-        );
-      }
-    });
+    this.callback = this.handleEvent.bind(this);
+    window.addEventListener('keydown', this.callback);
   },
-} as PhoenixHook<{}, { to: string }>;
+  handleEvent(e: KeyboardEvent) {
+    console.log(e);
+
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      this.el.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    }
+  },
+  destroyed() {
+    window.removeEventListener('keydown', this.callback);
+  },
+} as PhoenixHook<{
+  callback: (e: KeyboardEvent) => void;
+  handleEvent: (e: KeyboardEvent) => void;
+}>;
 
 export const Copy = {
   mounted() {

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -73,11 +73,11 @@
               <div class="grid grid-cols gap-6">
                 <div class="md:col-span-2">
                   <LightningWeb.Components.Form.text_area
-                    classes="mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
+                    class="mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
                     form={f}
                     disabled={!@can_edit_project_description}
                     label="Project description"
-                    id={:description}
+                    field={:description}
                   />
                   <small class="mt-2 block text-xs text-gray-600">
                     A short description of a project [max 240 characters]

--- a/lib/lightning_web/live/workflow_live.ex
+++ b/lib/lightning_web/live/workflow_live.ex
@@ -90,7 +90,6 @@ defmodule LightningWeb.WorkflowLive.Old do
               />
             </div>
             <div class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]">
-              <.resize_component id={"resizer-#{@job.id}"} />
               <div class="absolute inset-y-0 left-2 right-0 z-10 resize-x ">
                 <div class="w-auto h-full" id={"job-pane-#{@job.id}"}>
                   <.live_component

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -140,20 +140,6 @@ defmodule LightningWeb.WorkflowLive.Components do
   end
 
   attr :id, :string, required: true
-
-  def resize_component(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      phx-hook="JobEditorResizer"
-      phx-update="ignore"
-      class="h-full bg-slate-200 w-2 cursor-col-resize z-11 resize-x"
-    >
-    </div>
-    """
-  end
-
-  attr :id, :string, required: true
   attr :title, :string, required: true
   attr :cancel_url, :string, required: true
   slot :inner_block, required: true
@@ -162,11 +148,11 @@ defmodule LightningWeb.WorkflowLive.Components do
 
   def panel(assigns) do
     ~H"""
-    <div class="absolute right-0 m-4 w-1/4" id={@id}>
+    <div class="absolute right-0 sm:m-4 w-full sm:w-1/2 md:w-1/3 lg:w-1/4" id={@id}>
       <div class="divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow">
         <div class="flex px-4 py-5 sm:px-6">
-          <div class="grow">
-            <b><%= @title %></b>
+          <div class="grow font-bold">
+            <%= @title %>
           </div>
           <div class="flex-none">
             <.link patch={@cancel_url} class="justify-center hover:text-gray-500">
@@ -338,7 +324,7 @@ defmodule LightningWeb.WorkflowLive.Components do
         values={@edge_options}
         disabled={true}
       />
-      <div class="max-w-xl text-sm text-gray-500">
+      <div class="max-w-xl text-sm text-gray-500 mt-2">
         <p>Jobs connected to a trigger are always run.</p>
       </div>
     <% else %>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -12,10 +12,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   import LightningWeb.WorkflowLive.Components
 
-  on_mount {LightningWeb.Hooks, :project_scope}
+  on_mount({LightningWeb.Hooks, :project_scope})
 
-  attr :changeset, :map, required: true
-  attr :project_user, :map, required: true
+  attr(:changeset, :map, required: true)
+  attr(:project_user, :map, required: true)
 
   @impl true
   def render(assigns) do
@@ -67,123 +67,111 @@ defmodule LightningWeb.WorkflowLive.Edit do
             />
           </div>
         </div>
-        <div
+        <.form
+          :let={f}
           :if={@selected_job}
-          class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]"
-          lv-keep-style
+          id="workflow-form"
+          for={@changeset}
+          phx-submit="save"
+          phx-change="validate"
+          class="h-full"
         >
-          <.resize_component id={"resizer-#{@workflow.id}"} />
-          <div class="absolute inset-y-0 left-2 right-0 z-10 resize-x ">
-            <.form
-              :let={f}
-              id="workflow-form"
-              for={@changeset}
-              phx-submit="save"
-              phx-change="validate"
-              class="h-full"
-            >
-              <.panel id={"job-pane-#{@selected_job.id}"}>
-                <:header>
-                  <div class="grow">
-                    <%= f
-                    |> input_value(:name)
-                    |> then(fn
-                      "" -> "Untitled Job"
-                      name -> name
-                    end) %>
-                  </div>
-                  <div class="flex-none">
-                    <.link
-                      patch={~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"}
-                      class="justify-center hover:text-gray-500"
-                    >
-                      <Heroicons.x_mark solid class="h-4 w-4 inline-block" />
-                    </.link>
-                  </div>
-                </:header>
-                <!-- Show only the currently selected one -->
-                <.job_form
-                  on_change={&send_form_changed/1}
-                  form={single_inputs_for(f, :jobs, @selected_job.id)}
-                  project_user={@project_user}
-                />
-                <:footer>
-                  <button
-                    type="button"
-                    class="px-4 py-1.5 h-10 inline-flex items-center gap-x-1.5
+          <.panel
+            title={
+              single_inputs_for(f, :jobs, @selected_job.id)
+              |> input_value(:name)
+              |> then(fn
+                "" -> "Untitled Job"
+                name -> name
+              end)
+            }
+            id={"job-pane-#{@selected_job.id}"}
+            cancel_url={~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"}
+          >
+            <!-- Show only the currently selected one -->
+            <.job_form
+              on_change={&send_form_changed/1}
+              form={single_inputs_for(f, :jobs, @selected_job.id)}
+              project_user={@project_user}
+            />
+            <:footer>
+              <button
+                type="button"
+                class="px-4 py-1.5 h-10 inline-flex items-center gap-x-1.5
                     rounded-md bg-indigo-600 text-sm font-semibold text-white
                     shadow-sm hover:bg-indigo-500
                     focus-visible:outline focus-visible:outline-2
                     focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-                    phx-click="set_expanded_job"
-                    phx-value-show="true"
-                  >
-                    <Heroicons.pencil_square class="w-4 h-4 -ml-0.5" /> Edit
-                  </button>
-                </:footer>
-              </.panel>
-            </.form>
-          </div>
-        </div>
-        <div
+                phx-click="set_expanded_job"
+                phx-value-show="true"
+              >
+                <Heroicons.pencil_square class="w-4 h-4 -ml-0.5" /> Edit
+              </button>
+            </:footer>
+          </.panel>
+        </.form>
+
+        <.form
+          :let={f}
           :if={@selected_trigger}
-          class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]"
-          lv-keep-style
+          id="workflow-form"
+          for={@changeset}
+          phx-submit="save"
+          phx-change="validate"
+          class="h-full"
         >
-          <.resize_component id={"resizer-#{@workflow.id}"} />
-          <div class="absolute inset-y-0 left-2 right-0 z-10 resize-x ">
+          <.panel
+            id={"trigger-pane-#{@selected_trigger.id}"}
+            title={
+              single_inputs_for(f, :triggers, @selected_trigger.id)
+              |> input_value(:type)
+              |> to_string()
+              |> then(fn
+                "" -> "New Trigger"
+                "webhook" -> "Webhook Trigger"
+                "cron" -> "Cron Trigger"
+              end)
+            }
+            cancel_url={~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"}
+          >
             <div class="w-auto h-full" id={"trigger-pane-#{@workflow.id}"}>
-              <.form
-                :let={f}
-                id="workflow-form"
-                for={@changeset}
-                phx-submit="save"
-                phx-change="validate"
-                class="h-full"
-              >
-                <!-- Show only the currently selected one -->
-                <.trigger_form
-                  form={single_inputs_for(f, :triggers, @selected_trigger.id)}
-                  on_change={&send_form_changed/1}
-                  requires_cron_job={@selected_trigger.type == :cron}
-                  disabled={!@can_edit_job}
-                  webhook_url={webhook_url(@selected_trigger)}
-                  cancel_url={
-                    ~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"
-                  }
-                />
-              </.form>
+              <!-- Show only the currently selected one -->
+              <.trigger_form
+                form={single_inputs_for(f, :triggers, @selected_trigger.id)}
+                on_change={&send_form_changed/1}
+                requires_cron_job={@selected_trigger.type == :cron}
+                disabled={!@can_edit_job}
+                webhook_url={webhook_url(@selected_trigger)}
+                cancel_url={~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"}
+              />
             </div>
-          </div>
-        </div>
-        <div
+          </.panel>
+        </.form>
+
+        <.form
+          :let={f}
           :if={@selected_edge}
-          class="grow-0 w-1/2 relative min-w-[300px] max-w-[90%]"
-          lv-keep-style
+          id="workflow-form"
+          for={@changeset}
+          phx-submit="save"
+          phx-change="validate"
+          class="h-full"
         >
-          <.resize_component id={"resizer-#{@workflow.id}"} />
-          <div class="absolute inset-y-0 left-2 right-0 z-10 resize-x ">
+          <.panel
+            id={"edge-pane-#{@selected_edge.id}"}
+            cancel_url={~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"}
+            title="Edge"
+          >
             <div class="w-auto h-full" id={"edge-pane-#{@workflow.id}"}>
-              <.form
-                :let={f}
-                id="workflow-form"
-                for={@changeset}
-                phx-submit="save"
-                phx-change="validate"
-                class="h-full"
-              >
-                <!-- Show only the currently selected one -->
-                <.edge_form
-                  form={single_inputs_for(f, :edges, @selected_edge.id)}
-                  disabled={!@can_edit_job}
-                  cancel_url={
-                    ~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"
-                  }
-                />
-              </.form>
+              <!-- Show only the currently selected one -->
+              <.edge_form
+                form={single_inputs_for(f, :edges, @selected_edge.id)}
+                disabled={!@can_edit_job}
+                cancel_url={~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"}
+              />
             </div>
-          </div>
-        </div>
+          </.panel>
+        </.form>
       </div>
     </LayoutComponents.page_content>
     """

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -74,7 +74,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
           for={@changeset}
           phx-submit="save"
           phx-change="validate"
-          class="h-full"
         >
           <.panel
             title={
@@ -118,7 +117,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
           for={@changeset}
           phx-submit="save"
           phx-change="validate"
-          class="h-full"
         >
           <.panel
             id={"trigger-pane-#{@selected_trigger.id}"}
@@ -155,7 +153,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
           for={@changeset}
           phx-submit="save"
           phx-change="validate"
-          class="h-full"
         >
           <.panel
             id={"edge-pane-#{@selected_edge.id}"}

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -73,6 +73,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           id="workflow-form"
           for={@changeset}
           phx-submit="save"
+          phx-hook="SubmitViaCtrlS"
           phx-change="validate"
         >
           <.panel


### PR DESCRIPTION
Removes the big side-panel resizer. Leaves the resizer work in Js since we'll need it later.

@amberrignell and @stuartc , please note that the trigger form cron picker and webhook copy link are not updating on the fly, but this is the case on the base branch as well. We should merge this in and fix there during final qa testing. 

@josephjclark please note that there is a funky double-click required to open and close only the edge panel, trigger and job seem ok. I didn't fix this either but it's on the base branch too and I'm hoping you'll detect and address it during your canvas work. 

## Related issue

Fixes #911 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
