### PR TITLE
Workflow Diagram: Fixes and refactors

### DIFF
--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -30,8 +30,6 @@ export const SubmitViaCtrlS = {
     window.addEventListener('keydown', this.callback);
   },
   handleEvent(e: KeyboardEvent) {
-    console.log(e);
-
     if ((e.ctrlKey || e.metaKey) && e.key === 's') {
       e.preventDefault();
       this.el.dispatchEvent(

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -23,7 +23,7 @@ import toWorkflow from './util/to-workflow';
 import { useStore } from 'zustand';
 import { shallow } from 'zustand/shallow';
 import { WorkflowContext } from '../workflow-editor/component';
-import { WorkflowProps } from '../workflow-editor/store';
+
 import { FIT_DURATION, FIT_PADDING } from './constants';
 import type { Flow, Positions } from './types';
 
@@ -38,42 +38,8 @@ type ChartCache = {
   deferSelection?: string;
 };
 
-type Workflow = Pick<WorkflowProps, 'jobs' | 'edges' | 'triggers'>;
-
 // This will take a store passed from the server and do some light transformation
 // Specifically it identifies placeholder nodes
-const identifyPlaceholders = (store: Workflow) => {
-  const { jobs, triggers, edges } = store;
-
-  const newJobs = jobs.map(item => {
-    if (!item.name && !item.body) {
-      return {
-        ...item,
-        placeholder: true,
-      };
-    }
-    return item;
-  });
-
-  const newEdges = edges.map(edge => {
-    const target = newJobs.find(({ id }) => edge.target_job_id === id);
-    if (target?.placeholder) {
-      return {
-        ...edge,
-        placeholder: true,
-      };
-    }
-    return edge;
-  });
-
-  const result = {
-    triggers,
-    jobs: newJobs,
-    edges: newEdges,
-  };
-
-  return result;
-};
 
 export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
   (props, ref) => {
@@ -83,7 +49,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
     const remove = useStore(workflowStore!, state => state.remove);
     const change = useStore(workflowStore!, state => state.change);
 
-    const _workflow = useStore(
+    const storeModel = useStore(
       workflowStore!,
       state => ({
         jobs: state.jobs,
@@ -94,8 +60,8 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
     );
 
     const workflow = useMemo(
-      () => identifyPlaceholders(_workflow),
-      [_workflow]
+      () => placeholder.identify(storeModel),
+      [storeModel]
     );
 
     const { onSelectionChange } = props;

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -38,9 +38,6 @@ type ChartCache = {
   deferSelection?: string;
 };
 
-// This will take a store passed from the server and do some light transformation
-// Specifically it identifies placeholder nodes
-
 export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
   (props, ref) => {
     const workflowStore = useContext(WorkflowContext);
@@ -76,13 +73,6 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
     });
 
     const [flow, setFlow] = useState<ReactFlowInstance>();
-
-    const setFlowInstance = useCallback(
-      (s: ReactFlowInstance) => {
-        setFlow(s);
-      },
-      [setFlow]
-    );
 
     // Respond to changes pushed into the component from outside
     // This usually means the workflow has changed or its the first load, so we don't want to animate
@@ -252,7 +242,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           nodesDraggable={false}
           nodeTypes={nodeTypes}
           onNodeClick={handleNodeClick}
-          onInit={setFlowInstance}
+          onInit={setFlow}
           deleteKeyCode={null}
           fitView
           fitViewOptions={{ padding: FIT_PADDING }}

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -79,16 +79,11 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           newModel.edges,
           chartCache.current.lastLayout
         );
+
         if (layoutId) {
           chartCache.current.lastLayout = layoutId;
           layout(newModel, setModel, flow, 200).then(positions => {
-            // trigger selection on new nodes once they've been passed back through to us
-            if (chartCache.current.deferSelection) {
-              onSelectionChange(chartCache.current.deferSelection);
-              delete chartCache.current.deferSelection;
-            }
-
-            // Bit of a hack - don't update positions until the animation has finished
+            // Note we don't update positions until the animation has finished
             chartCache.current.positions = positions;
           });
         } else {

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -82,7 +82,6 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
         );
         if (layoutId) {
           chartCache.current.lastLayout = layoutId;
-          console.log(' >> layout ', layoutId);
           layout(newModel, setModel, flow, 200).then(positions => {
             // trigger selection on new nodes once they've been passed back through to us
             if (chartCache.current.deferSelection) {
@@ -184,7 +183,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           }
         };
       }
-    }, [commitPlaceholder, ref]);
+    }, [commitPlaceholder, cancelPlaceholder, ref]);
 
     // Note that we only support a single selection
     const handleSelectionChange = useCallback(

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -144,9 +144,11 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
       (parentNode: Flow.Node) => {
         // Generate a placeholder node and edge
         const diff = placeholder.add(model, parentNode);
-
+        const [newNode] = diff.nodes;
+        // Ensure the starting position is set
+        chartCache.current.positions[newNode.id] = newNode.position;
         // Mark the new node as selected for the next render
-        chartCache.current.selectedId = diff.nodes[0].id;
+        chartCache.current.selectedId = newNode.id;
 
         // Push the changes
         add(toWorkflow(diff));

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -30,6 +30,7 @@ import shouldLayout from './util/should-layout';
 type WorkflowDiagramProps = {
   onSelectionChange: (id?: string) => void;
   store: StoreApi<WorkflowState>;
+  initialSelection?: string;
 };
 
 type ChartCache = {
@@ -40,7 +41,7 @@ type ChartCache = {
 
 export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
   (props, ref) => {
-    const { onSelectionChange, store } = props;
+    const { onSelectionChange, store, initialSelection } = props;
 
     const add = useStore(store!, state => state.add);
     const remove = useStore(store!, state => state.remove);
@@ -60,7 +61,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
     // Track positions and selection on a ref, as a passive cache, to prevent re-renders
     const chartCache = useRef<ChartCache>({
       positions: {},
-      selectedId: undefined,
+      selectedId: initialSelection,
       lastLayout: undefined,
     });
 

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -1,6 +1,6 @@
 import { NODE_HEIGHT, NODE_WIDTH } from '../constants';
 import { Lightning, Flow, Positions } from '../types';
-import { isPlaceholder } from './placeholder';
+import { identify, isPlaceholder } from './placeholder';
 
 // TODO pass in the currently selected items so that we can maintain selection
 const fromWorkflow = (
@@ -11,7 +11,10 @@ const fromWorkflow = (
   if (workflow.jobs.length == 0) {
     return { nodes: [], edges: [] };
   }
-  const allowPlaceholder = workflow.jobs.every(j => !isPlaceholder(j));
+  const workflowWithPlaceholders = identify(workflow);
+  const allowPlaceholder = workflowWithPlaceholders.jobs.every(
+    j => !isPlaceholder(j)
+  );
 
   const process = (
     items: Array<Lightning.Node | Lightning.Edge>,
@@ -72,9 +75,9 @@ const fromWorkflow = (
   const nodes = [] as Flow.Node[];
   const edges = [] as Flow.Edge[];
 
-  process(workflow.jobs, nodes, 'job');
-  process(workflow.triggers, nodes, 'trigger');
-  process(workflow.edges, edges, 'edge');
+  process(workflowWithPlaceholders.jobs, nodes, 'job');
+  process(workflowWithPlaceholders.triggers, nodes, 'trigger');
+  process(workflowWithPlaceholders.edges, edges, 'edge');
 
   return { nodes, edges };
 };

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -81,7 +81,6 @@ const fromWorkflow = (
   process(workflowWithPlaceholders.jobs, nodes, 'job');
   process(workflowWithPlaceholders.triggers, nodes, 'trigger');
   process(workflowWithPlaceholders.edges, edges, 'edge');
-  console.log(edges);
   return { nodes, edges };
 };
 

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -32,7 +32,10 @@ const fromWorkflow = (
 
       if (item.id === selectedNodeId) {
         model.selected = true;
+      } else {
+        model.selected = false;
       }
+
       if (/(job|trigger)/.test(type)) {
         const node = item as Lightning.Node;
         model.type = isPlaceholder(node) ? 'placeholder' : type;
@@ -78,7 +81,7 @@ const fromWorkflow = (
   process(workflowWithPlaceholders.jobs, nodes, 'job');
   process(workflowWithPlaceholders.triggers, nodes, 'trigger');
   process(workflowWithPlaceholders.edges, edges, 'edge');
-
+  console.log(edges);
   return { nodes, edges };
 };
 

--- a/assets/js/workflow-diagram/util/placeholder.ts
+++ b/assets/js/workflow-diagram/util/placeholder.ts
@@ -1,4 +1,5 @@
 import { Flow } from '../types';
+import { WorkflowProps } from '../workflow-editor/store';
 
 // adds a placeholder node as child of the target
 // A node can only have one placeholder at a time
@@ -27,3 +28,39 @@ export const add = (_model: Flow.Model, parentNode: Flow.Node) => {
 };
 
 export const isPlaceholder = (node: Node) => node.placeholder;
+
+type Workflow = Pick<WorkflowProps, 'jobs' | 'edges' | 'triggers'>;
+
+// Identify placeholder nodes and return a new workflow model
+export const identify = (store: Workflow) => {
+  const { jobs, triggers, edges } = store;
+
+  const newJobs = jobs.map(item => {
+    if (!item.name && !item.body) {
+      return {
+        ...item,
+        placeholder: true,
+      };
+    }
+    return item;
+  });
+
+  const newEdges = edges.map(edge => {
+    const target = newJobs.find(({ id }) => edge.target_job_id === id);
+    if (target?.placeholder) {
+      return {
+        ...edge,
+        placeholder: true,
+      };
+    }
+    return edge;
+  });
+
+  const result = {
+    triggers,
+    jobs: newJobs,
+    edges: newEdges,
+  };
+
+  return result;
+};

--- a/assets/js/workflow-diagram/util/should-layout.ts
+++ b/assets/js/workflow-diagram/util/should-layout.ts
@@ -1,0 +1,14 @@
+// This function will determine whether we should run a layout on a model
+// This generates a simple hash from the edges and compares it to the last hash
+import { Flow } from '../types';
+
+export default (edges: Flow.Edge[], lastHash?: string) => {
+  const id = edges
+    .map(e => `${e.source}-${e.target}`)
+    .sort()
+    .join('--');
+
+  if (id !== lastHash) {
+    return id;
+  }
+};

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -1,10 +1,7 @@
 import React, { createContext } from 'react';
 import { createRoot } from 'react-dom/client';
 import { StoreApi } from 'zustand';
-import {
-  WorkflowState,
-  createWorkflowStore
-} from './store';
+import { WorkflowState, createWorkflowStore } from './store';
 
 import WorkflowDiagram from '../workflow-diagram/WorkflowDiagram';
 
@@ -22,12 +19,9 @@ export function mount(
   const componentRoot = createRoot(el);
 
   function unmount() {
-    console.log('unmount');
-
     return componentRoot.unmount();
   }
 
-  console.log('render');
   componentRoot.render(
     <WorkflowContext.Provider value={workflowStore}>
       <WorkflowDiagram ref={el} onSelectionChange={onSelectionChange} />

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -17,9 +17,16 @@ export function mount(
     return componentRoot.unmount();
   }
 
+  let initialSelection;
+  const hash = window.location.hash;
+  if (hash && hash.match('id=')) {
+    initialSelection = hash.split('id=')[1];
+  }
+
   componentRoot.render(
     <WorkflowDiagram
       ref={el}
+      initialSelection={initialSelection}
       store={workflowStore}
       onSelectionChange={onSelectionChange}
     />

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -1,13 +1,8 @@
-import React, { createContext } from 'react';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { StoreApi } from 'zustand';
-import { WorkflowState, createWorkflowStore } from './store';
+import { createWorkflowStore } from './store';
 
 import WorkflowDiagram from '../workflow-diagram/WorkflowDiagram';
-
-export const WorkflowContext = createContext<StoreApi<WorkflowState> | null>(
-  null
-);
 
 type Store = ReturnType<typeof createWorkflowStore>;
 
@@ -23,9 +18,11 @@ export function mount(
   }
 
   componentRoot.render(
-    <WorkflowContext.Provider value={workflowStore}>
-      <WorkflowDiagram ref={el} onSelectionChange={onSelectionChange} />
-    </WorkflowContext.Provider>
+    <WorkflowDiagram
+      ref={el}
+      store={workflowStore}
+      onSelectionChange={onSelectionChange}
+    />
   );
 
   return { unmount };

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -105,7 +105,6 @@ export default {
     this.liveSocket.pushHistoryPatch(this.el.dataset.baseUrl!, 'push', this.el);
   },
   onSelectionChange(id?: string) {
-    console.log(id);
     if (!id) {
       console.debug('unselecting');
 

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -105,6 +105,7 @@ export default {
     this.liveSocket.pushHistoryPatch(this.el.dataset.baseUrl!, 'push', this.el);
   },
   onSelectionChange(id?: string) {
+    console.log(id);
     if (!id) {
       console.debug('unselecting');
 

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -60,7 +60,7 @@ function toRFC6902Patch(patch: ImmerPatch): Patch {
 
 export const createWorkflowStore = (
   initProps?: Partial<WorkflowProps>,
-  onChange?: (pendingAction: PendingAction) => void
+  onChange: (pendingAction: PendingAction) => void = () => {}
 ) => {
   const DEFAULT_PROPS: WorkflowProps = {
     triggers: [],
@@ -95,7 +95,6 @@ export const createWorkflowStore = (
     ...DEFAULT_PROPS,
     ...initProps,
     add: data => {
-      console.log('add', data);
       set(state =>
         proposeChanges(state, draft => {
           ['jobs', 'triggers', 'edges'].forEach(k => {
@@ -113,8 +112,8 @@ export const createWorkflowStore = (
       );
     },
     remove: data => {
-      set(state => {
-        const newState = proposeChanges(state, draft => {
+      set(state =>
+        proposeChanges(state, draft => {
           ['jobs', 'triggers', 'edges'].forEach(k => {
             const key = k as keyof WorkflowProps;
 
@@ -129,11 +128,8 @@ export const createWorkflowStore = (
               draft[key] = nextItems;
             }
           });
-        });
-
-        console.log('remove', newState);
-        return newState;
-      });
+        })
+      );
     },
     change: data => {
       set(state =>
@@ -161,6 +157,6 @@ export const createWorkflowStore = (
 
       set(state => applyPatches(state, immerPatches));
     },
-    onChange: onChange ? onChange : () => {},
+    onChange,
   }));
 };

--- a/assets/js/workflow-editor/store.ts
+++ b/assets/js/workflow-editor/store.ts
@@ -122,7 +122,7 @@ export const createWorkflowStore = (
             if (idsToRemove) {
               const nextItems: any[] = [];
               draft[key].forEach(item => {
-                if (idsToRemove.includes(item.id)) {
+                if (!idsToRemove.includes(item.id)) {
                   nextItems.push(item);
                 }
               });


### PR DESCRIPTION
This PR introduces a bunch of fixes, refactors and improvements to the workflow diagram. The cosmetic stuff will be based on top of this.

Coming back into this after a while was pretty  difficult. Complexity and various changes since I last looked haven't helped (I don't know why the store is down in the component now, but I don't intend to move it back)

* [x] Remove Context - we just don't need it (yet)
* [x] Simplify the `workflow`, `_workflow` and `model` stuff
* [x] Move some code out of Workflow Diagram (it's massive, there's way too much stuff in it)
* [x] Fix (placeholder) node removal  - this looked to be totally broken
* [x] Don't run layout on every single update
* [x] Fix edge selection
* [x] Don't blow up the chart when adding a placeholder
* [x] Accept selection on mount

I have mostly fixed the edge selection thing. There seems to be a `react-flow` bug if you: select a node, select a link, then click the background. This will cause the app to deselect the link, but note that react-flow will still style the link as selected, and will continue to do so as you click other links.

I think this is minor enough to leave open as an issue, maybe I can take time to make a nice repro and report it on react-flow. I don't think I want to spend more time on it here.