### PR TITLE
Enforce 2FA for users with MFA enabled

### DIFF
--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -204,6 +204,16 @@ defmodule Lightning.Accounts do
   end
 
   @doc """
+  Validates if the given TOTP code is valid.
+  """
+  @spec valid_user_totp?(User.t(), String.t()) :: true | false
+  def valid_user_totp?(user, code) do
+    totp = Repo.get_by!(UserTOTP, user_id: user.id)
+
+    UserTOTP.valid_totp?(totp, code)
+  end
+
+  @doc """
   Registers a superuser.
 
   ## Examples

--- a/lib/lightning/accounts/user_totp.ex
+++ b/lib/lightning/accounts/user_totp.ex
@@ -25,17 +25,21 @@ defmodule Lightning.Accounts.UserTOTP do
     |> cast(attrs, [:code])
     |> validate_required([:code, :secret])
     |> validate_format(:code, ~r/^\d{6}$/, message: "should be a 6 digit number")
-    |> maybe_validate_code()
+    |> maybe_validate_code(totp)
   end
 
-  defp maybe_validate_code(changeset) do
+  defp maybe_validate_code(changeset, totp) do
     code = get_field(changeset, :code)
-    secret = get_field(changeset, :secret)
 
-    if changeset.valid? and NimbleTOTP.valid?(secret, code) do
+    if changeset.valid? and valid_totp?(totp, code) do
       changeset
     else
       add_error(changeset, :code, "invalid code")
     end
+  end
+
+  def valid_totp?(totp, code) do
+    is_binary(code) and byte_size(code) == 6 and
+      NimbleTOTP.valid?(totp.secret, code)
   end
 end

--- a/lib/lightning_web/controllers/oidc_controller.ex
+++ b/lib/lightning_web/controllers/oidc_controller.ex
@@ -40,8 +40,21 @@ defmodule LightningWeb.OidcController do
           |> put_flash(:error, "Could not find user account")
           |> redirect(to: Routes.user_session_path(conn, :new))
 
+        %{mfa_enabled: true} = user ->
+          conn
+          |> UserAuth.log_in_user(user)
+          |> put_session(:user_totp_pending, true)
+          |> redirect(
+            to:
+              Routes.user_totp_path(conn, :new, user: %{"remember_me" => "true"})
+          )
+
         user ->
-          conn |> UserAuth.log_in_user(user, %{"remember_me" => "true"})
+          conn
+          |> UserAuth.log_in_user(user)
+          |> UserAuth.redirect_user_after_login_with_remember_me(%{
+            "remember_me" => "true"
+          })
       end
     end
   end

--- a/lib/lightning_web/controllers/user_auth.ex
+++ b/lib/lightning_web/controllers/user_auth.ex
@@ -19,9 +19,9 @@ defmodule LightningWeb.UserAuth do
   @doc """
   Logs the user in by creating a new session token.
   """
-  def log_in_user(conn, user, params \\ %{}) do
+  def log_in_user(conn, user) do
     token = Accounts.generate_user_session_token(user)
-    new_session(conn, token, params)
+    new_session(conn, token)
   end
 
   @doc """
@@ -36,22 +36,31 @@ defmodule LightningWeb.UserAuth do
   disconnected on log out. The line can be safely removed
   if you are not using LiveView.
   """
-  def new_session(conn, token, params \\ %{}) do
-    user_return_to = get_session(conn, :user_return_to)
-
+  def new_session(conn, token) do
     conn
     |> renew_session()
     |> put_session(:user_token, token)
     |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
-    |> maybe_write_remember_me_cookie(token, params)
+  end
+
+  @doc """
+  Returns to or redirects to the dashboard and potentially set remember_me token.
+  """
+  def redirect_user_after_login_with_remember_me(conn, params \\ %{}) do
+    user_return_to = get_session(conn, :user_return_to)
+
+    conn
+    |> maybe_write_remember_me_cookie(params)
+    |> delete_session(:user_return_to)
     |> redirect(to: user_return_to || signed_in_path(conn))
   end
 
-  defp maybe_write_remember_me_cookie(conn, token, %{"remember_me" => "true"}) do
+  defp maybe_write_remember_me_cookie(conn, %{"remember_me" => "true"}) do
+    token = get_session(conn, :user_token)
     put_resp_cookie(conn, @remember_me_cookie, token, @remember_me_options)
   end
 
-  defp maybe_write_remember_me_cookie(conn, _token, _params) do
+  defp maybe_write_remember_me_cookie(conn, _params) do
     conn
   end
 
@@ -71,9 +80,12 @@ defmodule LightningWeb.UserAuth do
   #     end
   #
   defp renew_session(conn) do
+    user_return_to = get_session(conn, :user_return_to)
+
     conn
     |> configure_session(renew: true)
     |> clear_session()
+    |> put_session(:user_return_to, user_return_to)
   end
 
   @doc """
@@ -166,26 +178,34 @@ defmodule LightningWeb.UserAuth do
   they use the application at all, here would be a good place.
   """
   def require_authenticated_user(conn, _opts) do
-    if conn.assigns[:current_user] do
-      conn
-    else
-      conn
-      |> get_format()
-      |> case do
-        "json" ->
-          conn
-          |> put_status(:unauthorized)
-          |> put_view(LightningWeb.ErrorView)
-          |> render(:"401")
-          |> halt()
+    cond do
+      is_nil(conn.assigns[:current_user]) ->
+        conn
+        |> get_format()
+        |> case do
+          "json" ->
+            conn
+            |> put_status(:unauthorized)
+            |> put_view(LightningWeb.ErrorView)
+            |> render(:"401")
+            |> halt()
 
-        _ ->
-          conn
-          |> put_flash(:error, "You must log in to access this page.")
-          |> maybe_store_return_to()
-          |> redirect(to: Routes.user_session_path(conn, :new))
-          |> halt()
-      end
+          _ ->
+            conn
+            |> put_flash(:error, "You must log in to access this page.")
+            |> maybe_store_return_to()
+            |> redirect(to: Routes.user_session_path(conn, :new))
+            |> halt()
+        end
+
+      get_format(conn) == "html" && get_session(conn, :user_totp_pending) &&
+          conn.path_info != ["users", "two-factor", "app"] ->
+        conn
+        |> redirect(to: Routes.user_totp_path(conn, :new))
+        |> halt()
+
+      true ->
+        conn
     end
   end
 

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -38,6 +38,7 @@ defmodule LightningWeb.UserRegistrationController do
         conn
         |> put_flash(:info, "User created successfully.")
         |> UserAuth.log_in_user(user)
+        |> UserAuth.redirect_user_after_login_with_remember_me()
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)

--- a/lib/lightning_web/controllers/user_session_controller.ex
+++ b/lib/lightning_web/controllers/user_session_controller.ex
@@ -30,6 +30,13 @@ defmodule LightningWeb.UserSessionController do
         )
         |> render("new.html", auth_handler_url: auth_handler_url())
 
+      %User{mfa_enabled: true} = user ->
+        totp_params = Map.take(user_params, ["remember_me"])
+
+        conn
+        |> put_session(:user_totp_pending, true)
+        |> redirect(to: Routes.user_totp_path(conn, :new, user: totp_params))
+
       %User{} = user ->
         UserAuth.log_in_user(conn, user, user_params)
 

--- a/lib/lightning_web/controllers/user_session_controller.ex
+++ b/lib/lightning_web/controllers/user_session_controller.ex
@@ -34,11 +34,14 @@ defmodule LightningWeb.UserSessionController do
         totp_params = Map.take(user_params, ["remember_me"])
 
         conn
+        |> UserAuth.log_in_user(user)
         |> put_session(:user_totp_pending, true)
         |> redirect(to: Routes.user_totp_path(conn, :new, user: totp_params))
 
       %User{} = user ->
-        UserAuth.log_in_user(conn, user, user_params)
+        conn
+        |> UserAuth.log_in_user(user)
+        |> UserAuth.redirect_user_after_login_with_remember_me(user_params)
 
       _ ->
         conn
@@ -57,6 +60,7 @@ defmodule LightningWeb.UserSessionController do
       token ->
         conn
         |> UserAuth.new_session(token)
+        |> UserAuth.redirect_user_after_login_with_remember_me()
     end
   end
 

--- a/lib/lightning_web/controllers/user_totp_controller.ex
+++ b/lib/lightning_web/controllers/user_totp_controller.ex
@@ -1,0 +1,11 @@
+defmodule LightningWeb.UserTOTPController do
+  use LightningWeb, :controller
+
+  alias Lightning.Accounts
+  alias LightningWeb.UserAuth
+  alias Lightning.Accounts.User
+
+  def new(conn, _params) do
+    render(conn, "new.html", error_message: nil)
+  end
+end

--- a/lib/lightning_web/controllers/user_totp_controller.ex
+++ b/lib/lightning_web/controllers/user_totp_controller.ex
@@ -3,9 +3,40 @@ defmodule LightningWeb.UserTOTPController do
 
   alias Lightning.Accounts
   alias LightningWeb.UserAuth
-  alias Lightning.Accounts.User
 
-  def new(conn, _params) do
-    render(conn, "new.html", error_message: nil)
+  plug :redirect_if_totp_is_not_pending
+
+  @totp_session :user_totp_pending
+
+  def new(conn, params) do
+    render(conn, "new.html",
+      error_message: nil,
+      remember_me: params["user"]["remember_me"]
+    )
+  end
+
+  def create(conn, %{"user" => params}) do
+    current_user = conn.assigns.current_user
+
+    if Accounts.valid_user_totp?(current_user, params["code"]) do
+      conn
+      |> delete_session(@totp_session)
+      |> UserAuth.redirect_user_after_login_with_remember_me(params)
+    else
+      render(conn, "new.html",
+        remember_me: params["remember_me"],
+        error_message: "Invalid two-factor authentication code"
+      )
+    end
+  end
+
+  defp redirect_if_totp_is_not_pending(conn, _opts) do
+    if get_session(conn, @totp_session) do
+      conn
+    else
+      conn
+      |> redirect(to: "/")
+      |> halt()
+    end
   end
 end

--- a/lib/lightning_web/controllers/user_totp_html.ex
+++ b/lib/lightning_web/controllers/user_totp_html.ex
@@ -1,0 +1,7 @@
+defmodule LightningWeb.UserTOTPHTML do
+  @moduledoc false
+
+  use LightningWeb, :html
+
+  embed_templates "user_totp_html/*"
+end

--- a/lib/lightning_web/controllers/user_totp_html/new.html.heex
+++ b/lib/lightning_web/controllers/user_totp_html/new.html.heex
@@ -15,21 +15,16 @@
         <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
           Authentication Code
         </h1>
-        <%= if error = Phoenix.Flash.get(@flash, :error) do %>
+        <%= if @error_message do %>
           <div class="alert alert-danger" role="alert">
-            <%= error %>
+            <%= @error_message %>
           </div>
-        <% end %>
-        <%= if info = Phoenix.Flash.get(@flash, :info) do %>
-          <p class="alert alert-info" role="alert">
-            <%= info %>
-          </p>
         <% end %>
         <.form
           :let={f}
           for={@conn}
           action={Routes.user_totp_path(@conn, :create)}
-          as={:totp}
+          as={:user}
           class="space-y-4 md:space-y-6"
         >
           <div>
@@ -42,6 +37,9 @@
               placeholder: "XXXXXX"
             ) %>
           </div>
+
+          <%= hidden_input(f, :remember_me, value: @remember_me) %>
+
           <button
             type="submit"
             class="w-full text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800"

--- a/lib/lightning_web/controllers/user_totp_html/new.html.heex
+++ b/lib/lightning_web/controllers/user_totp_html/new.html.heex
@@ -1,0 +1,58 @@
+<section class="bg-gray-50 dark:bg-gray-900">
+  <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+    <a href="#" class="flex items-center mb-6">
+      <img
+        class="w-16 h-16"
+        src={Routes.static_path(@conn, "/images/logo.svg")}
+        alt="OpenFn logo"
+      />
+    </a>
+    <h1 class="text-2xl font-semibold text-gray-900 dark:text-white mb-6">
+      Two-factor authentication
+    </h1>
+    <div class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
+      <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
+        <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
+          Authentication Code
+        </h1>
+        <%= if error = Phoenix.Flash.get(@flash, :error) do %>
+          <div class="alert alert-danger" role="alert">
+            <%= error %>
+          </div>
+        <% end %>
+        <%= if info = Phoenix.Flash.get(@flash, :info) do %>
+          <p class="alert alert-info" role="alert">
+            <%= info %>
+          </p>
+        <% end %>
+        <.form
+          :let={f}
+          for={@conn}
+          action={Routes.user_totp_path(@conn, :create)}
+          as={:totp}
+          class="space-y-4 md:space-y-6"
+        >
+          <div>
+            <%= text_input(f, :code,
+              class:
+                "bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500",
+              autocomplete: "off",
+              required: true,
+              inputmode: "numeric",
+              placeholder: "XXXXXX"
+            ) %>
+          </div>
+          <button
+            type="submit"
+            class="w-full text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800"
+          >
+            Verify
+          </button>
+          <p class="text-sm font-light text-gray-500 dark:text-gray-400">
+            Open your two-factor authenticator (TOTP) app or browser extension to view your authentication code.
+          </p>
+        </.form>
+      </div>
+    </div>
+  </div>
+</section>

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -77,6 +77,9 @@ defmodule LightningWeb.Router do
   scope "/", LightningWeb do
     pipe_through [:browser, :require_authenticated_user]
 
+    get "/users/two-factor/app", UserTOTPController, :new
+    post "/users/two-factor/app", UserTOTPController, :create
+
     get "/profile/confirm_email/:token",
         UserConfirmationController,
         :confirm_email

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -154,6 +154,23 @@ defmodule Lightning.AccountsTest do
     end
   end
 
+  describe "valid_user_totp?/2" do
+    setup do
+      user = user_with_mfa_fixture()
+
+      %{totp: Accounts.get_user_totp(user), user: user}
+    end
+
+    test "returns false if the code is not valid", %{user: user} do
+      assert Accounts.valid_user_totp?(user, "invalid") == false
+    end
+
+    test "returns true for valid totp", %{user: user, totp: totp} do
+      code = NimbleTOTP.verification_code(totp.secret)
+      assert Accounts.valid_user_totp?(user, code) == true
+    end
+  end
+
   describe "delete_user_totp/1" do
     test "successfully deletes the given user TOTP and disables the mfa_flag" do
       user = user_fixture()

--- a/test/lightning_web/controllers/user_totp_controller_test.exs
+++ b/test/lightning_web/controllers/user_totp_controller_test.exs
@@ -1,0 +1,92 @@
+defmodule LightningWeb.UserTOTPControllerTest do
+  use LightningWeb.ConnCase, async: false
+
+  import Lightning.AccountsFixtures
+
+  @totp_session :user_totp_pending
+
+  setup %{conn: conn} do
+    user = user_with_mfa_fixture()
+    conn = conn |> log_in_user(user) |> put_session(@totp_session, true)
+    %{user: user, conn: conn}
+  end
+
+  describe "GET /users/two-factor/app" do
+    test "renders totp page", %{conn: conn} do
+      conn = get(conn, Routes.user_totp_path(conn, :new))
+      response = html_response(conn, 200)
+      assert response =~ "Two-factor authentication"
+    end
+
+    test "reads remember me from URL", %{conn: conn} do
+      conn =
+        get(conn, Routes.user_totp_path(conn, :new), user: [remember_me: "true"])
+
+      response = html_response(conn, 200)
+
+      assert response =~
+               ~s|<input id="user_remember_me" name="user[remember_me]" type="hidden" value="true">|
+    end
+
+    test "redirects to login if not logged in" do
+      conn = build_conn()
+
+      assert conn
+             |> get(Routes.user_totp_path(conn, :new))
+             |> redirected_to() ==
+               Routes.user_session_path(conn, :new)
+    end
+
+    test "redirects to dashboard if totp is not pending", %{conn: conn} do
+      assert conn
+             |> delete_session(@totp_session)
+             |> get(Routes.user_totp_path(conn, :new))
+             |> redirected_to() == "/"
+    end
+  end
+
+  describe "POST /users/two-factor/app" do
+    setup %{user: user, conn: conn} do
+      %{user: user, conn: conn, totp: Lightning.Accounts.get_user_totp(user)}
+    end
+
+    test "validates totp correctly", %{conn: conn, totp: totp} do
+      code = NimbleTOTP.verification_code(totp.secret)
+
+      conn =
+        post(conn, Routes.user_totp_path(conn, :create), %{
+          "user" => %{"code" => code}
+        })
+
+      assert redirected_to(conn) == "/"
+      assert get_session(conn, @totp_session) == nil
+    end
+
+    test "logs the user in with remember me", %{conn: conn, totp: totp} do
+      code = NimbleTOTP.verification_code(totp.secret)
+
+      conn =
+        post(conn, Routes.user_totp_path(conn, :create), %{
+          "user" => %{"code" => code, "remember_me" => "true"}
+        })
+
+      assert redirected_to(conn) == "/"
+      assert get_session(conn, @totp_session) == nil
+      assert conn.resp_cookies["_lightning_web_user_remember_me"]
+    end
+
+    test "logs the user in with return to", %{conn: conn, totp: totp} do
+      code = NimbleTOTP.verification_code(totp.secret)
+
+      conn =
+        conn
+        |> put_session(:user_return_to, "/return_here")
+        |> post(Routes.user_totp_path(conn, :create), %{
+          "user" => %{"code" => code}
+        })
+
+      assert redirected_to(conn) == "/return_here"
+      assert get_session(conn, @totp_session) == nil
+    end
+  end
+end

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -25,6 +25,22 @@ defmodule Lightning.AccountsFixtures do
     user
   end
 
+  def user_with_mfa_fixture(attrs \\ []) when is_list(attrs) do
+    user = user_fixture(attrs)
+
+    user_totp = %Lightning.Accounts.UserTOTP{
+      secret: NimbleTOTP.secret(),
+      user_id: user.id
+    }
+
+    valid_code = NimbleTOTP.verification_code(user_totp.secret)
+
+    {:ok, _totp} =
+      Lightning.Accounts.upsert_user_totp(user_totp, %{code: valid_code})
+
+    %{user | mfa_enabled: true}
+  end
+
   def superuser_fixture(attrs \\ []) when is_list(attrs) do
     {:ok, user} =
       attrs


### PR DESCRIPTION
## Notes for the reviewer

- [x] Add the necessary controller and html for the 2FA page
- [x] Verify the OTP
- [x] Add a plug that uses the `:user_totp_pending` session key to redirect users if at all they visit another page
- [x] Ensure `remember_me` and `return_to` sessions are working as expected


## Related issue

Fixes #891 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [X] Taylor has **QA'd** this feature
