### PR TITLE
Attempt to fix DBConnection errors in tests

### DIFF
--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -211,10 +211,12 @@ defmodule Lightning.ProjectsTest do
         )
         |> Repo.transaction()
 
-      Lightning.WorkOrderService.retry_attempt_run(
-        p1_work_order.attempt_run,
-        p1_user
-      )
+      Oban.Testing.with_testing_mode(:inline, fn ->
+        Lightning.WorkOrderService.retry_attempt_run(
+          p1_work_order.attempt_run,
+          p1_user
+        )
+      end)
 
       Lightning.WorkOrderService.multi_for(
         :webhook,

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1,6 +1,5 @@
 defmodule LightningWeb.RunWorkOrderTest do
   use LightningWeb.ConnCase, async: true
-  use Oban.Testing, repo: Lightning.Repo
 
   import Phoenix.LiveViewTest
 


### PR DESCRIPTION
This a take at fixing inconsistant errors like this:

```
14:34:38.332 [error] Postgrex.Protocol (#PID<0.1092.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.5018.0> exited
```

There appears to be (in this case) related to an Oban process still in
progress and the test shuts down - taking the Repo with it; leaving a
DBConnection with a query in flight.

## Notes for the reviewer



## Related issue

Fixes #

## Review checklist

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Amber has **QA'd** this feature
