### PR TITLE
Crash when clicking trigger after creating a new workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 
 - Fix issue when deleting nodes from the workflow editor
   [#830](https://github.com/OpenFn/Lightning/issues/830)
+- Fix issue when clicking a trigger on a new/unsaved workflow
+  [#954](https://github.com/OpenFn/Lightning/issues/954)
 
 ## [0.6.7] - 2023-07-13
 

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -232,6 +232,11 @@ defmodule LightningWeb.WorkflowLive.Components do
   attr :on_change, :any, required: true
 
   def trigger_form(assigns) do
+    assigns =
+      assign(assigns,
+        type: assigns.form.source |> Ecto.Changeset.get_field(:type)
+      )
+
     ~H"""
     <%= hidden_inputs_for(@form) %>
     <div class="col-span-6 @md:col-span-4">
@@ -258,7 +263,7 @@ defmodule LightningWeb.WorkflowLive.Components do
           disabled={@disabled}
         />
       <% end %>
-      <%= case @form |> input_value(:type) do %>
+      <%= case @type do %>
         <% :cron -> %>
           <div class="hidden sm:block" aria-hidden="true">
             <div class="py-2"></div>


### PR DESCRIPTION
Fix issue when clicking a trigger on a new/unsaved workflow

## Related issue

Fixes #954

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
