### PR TITLE
Don't add cast fragments if the search_term is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Don't add cast fragments if the search_term is nil
+  [#968](https://github.com/OpenFn/Lightning/issues/968)
+
 ### Fixed
 
 ## [v0.7.0-pre2] - 2023-07-26


### PR DESCRIPTION
## Notes for the reviewer

This offers a tiny performance improvement _when_ a user doesn't enter in any search terms.

## Related issue

There are several other (albeit more difficult) improvements that need to be made in order to satisfy #968 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
