### PR TITLE
Show workorders with runs in last 30 days by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Unless otherwise specified, only show workorders with activity in last 14 days
+  [#968](https://github.com/OpenFn/Lightning/issues/968)
+
 ### Fixed
 
 ## [v0.7.0-pre4] - 2023-07-27

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -346,8 +346,11 @@ defmodule Lightning.Invocation do
 
   def filter_run_finished_after_where(date_after) do
     case date_after do
-      d when d in ["", nil] -> dynamic(true)
-      _ -> dynamic([runs: r], r.finished_at >= ^date_after)
+      d when d in ["", nil] ->
+        dynamic(true)
+
+      _ ->
+        dynamic([runs: r], r.finished_at >= ^date_after or is_nil(r.finished_at))
     end
   end
 

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -86,7 +86,8 @@ defmodule LightningWeb.RunLive.Index do
     do: %{
       "body" => "true",
       "crash" => "true",
-      "date_after" => "",
+      "date_after" =>
+        Timex.now() |> Timex.shift(days: -30) |> DateTime.to_string(),
       "date_before" => "",
       "failure" => "true",
       "log" => "true",

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -102,33 +102,18 @@ defmodule LightningWeb.RunLive.Index do
 
   @impl true
   def handle_params(params, _url, socket) do
-    if is_nil(Map.get(params, "filters")) do
-      params = Map.put(params, "filters", socket.assigns.filters)
-
-      {:noreply,
-       socket
-       |> assign(
-         page_title: "History",
-         run: %Run{},
-         filters_changeset: filters_changeset(socket.assigns.filters)
-       )
-       |> push_patch(
-         to: ~p"/projects/#{socket.assigns.project.id}/runs?#{params}"
-       )}
-    else
-      {:noreply,
-       socket
-       |> assign(
-         page_title: "History",
-         run: %Run{},
-         filters_changeset: filters_changeset(socket.assigns.filters)
-       )
-       |> apply_action(socket.assigns.live_action, params)}
-    end
+    {:noreply,
+     socket
+     |> assign(
+       page_title: "History",
+       run: %Run{},
+       filters_changeset: filters_changeset(socket.assigns.filters)
+     )
+     |> apply_action(socket.assigns.live_action, params)}
   end
 
   defp apply_action(socket, :index, params) do
-    filters = Map.get(params, "filters") |> SearchParams.new()
+    filters = Map.get(params, "filters", init_filters()) |> SearchParams.new()
 
     socket
     |> assign(

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -166,10 +166,29 @@
               />
             </div>
             <div>
-              <div class="font-semibold my-4">
+              <div class="font-semibold mt-4">
+                Filter workorders by last run date
+              </div>
+              <div class="flex justify-between text-sm text-gray-500">
+                <div>
+                  <label>After</label>
+                  <%= datetime_local_input(f, :date_after,
+                    class:
+                      "mt-1 block w-44 rounded-md border-secondary-300 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50"
+                  ) %>
+                </div>
+                <div>
+                  <label>Before</label>
+                  <%= datetime_local_input(f, :date_before,
+                    class:
+                      "mt-1 block w-44 rounded-md border-secondary-300 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50"
+                  ) %>
+                </div>
+              </div>
+              <div class="font-semibold mt-4">
                 Filter workorders by date received
               </div>
-              <div class="flex justify-between">
+              <div class="flex justify-between text-sm text-gray-500">
                 <div>
                   <label>After</label>
                   <%= datetime_local_input(f, :wo_date_after,
@@ -184,25 +203,6 @@
                       "mt-1 block w-44 rounded-md border-secondary-300 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50"
                   ) %>
                 </div>
-              </div>
-            </div>
-            <div class="font-semibold my-4">
-              Filter workorders by last run date
-            </div>
-            <div class="flex justify-between">
-              <div>
-                <label>After</label>
-                <%= datetime_local_input(f, :date_after,
-                  class:
-                    "mt-1 block w-44 rounded-md border-secondary-300 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50"
-                ) %>
-              </div>
-              <div>
-                <label>Before</label>
-                <%= datetime_local_input(f, :date_before,
-                  class:
-                    "mt-1 block w-44 rounded-md border-secondary-300 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50"
-                ) %>
               </div>
             </div>
             <div id="status_options-container">

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -100,24 +100,24 @@ defmodule LightningWeb.RunWorkOrderTest do
         })
         |> Lightning.Repo.insert!()
 
-      {:error, {:live_redirect, %{flash: %{}, to: destination}}} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
+      # {:error, {:live_redirect, %{flash: %{}, to: destination}}} =
+      live(
+        conn,
+        Routes.project_run_index_path(conn, :index, project.id)
+      )
+      |> IO.inspect()
 
-      assert destination =~
-               "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]="
+      Routes.project_run_index_path(conn, :index, project.id)
+      |> IO.inspect()
 
-      assert destination =~
-               "&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
+      # assert destination =~
+      #          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]="
+
+      # assert destination =~
+      #          "&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
 
       {:ok, view, html} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
-        |> follow_redirect(conn)
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
 
       assert html =~ "History"
 
@@ -185,7 +185,6 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(conn)
 
       div =
         view
@@ -235,7 +234,6 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(conn)
 
       div =
         view
@@ -320,7 +318,6 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(conn)
 
       div =
         view
@@ -401,7 +398,6 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(conn)
 
       assert view
              |> has_element?(
@@ -508,7 +504,6 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(conn)
 
       div =
         view
@@ -568,11 +563,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         |> Lightning.Repo.insert!()
 
       {:ok, view, html} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
-        |> follow_redirect(conn)
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
 
       assert html =~ "Filter by workorder status"
 
@@ -649,11 +640,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         |> Lightning.Repo.insert!()
 
       {:ok, view, _html} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
-        |> follow_redirect(conn)
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
 
       div =
         view
@@ -774,11 +761,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         )
 
       {:ok, view, html} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
-        |> follow_redirect(conn)
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
 
       assert html =~ "Filter by workflow"
 
@@ -906,7 +889,6 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(conn)
 
       assert html =~ expected_d2 |> Timex.format!("{YYYY}-{0M}-{0D}")
       assert html =~ expected_d1 |> Timex.format!("{YYYY}-{0M}-{0D}")
@@ -1038,11 +1020,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         |> Lightning.Repo.insert!()
 
       {:ok, view, _html} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
-        |> follow_redirect(conn)
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
 
       div =
         view
@@ -1288,7 +1266,6 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       {:ok, view, _html} =
         live(conn, Routes.project_run_index_path(conn, :index, project.id))
-        |> follow_redirect(conn)
 
       assert view
              |> render_click("rerun", %{
@@ -1304,7 +1281,6 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       {:ok, view, _html} =
         live(conn, Routes.project_run_index_path(conn, :index, project.id))
-        |> follow_redirect(conn)
 
       assert view
              |> render_click("rerun", %{

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -100,15 +100,24 @@ defmodule LightningWeb.RunWorkOrderTest do
         })
         |> Lightning.Repo.insert!()
 
+      {:error, {:live_redirect, %{flash: %{}, to: destination}}} =
+        live(
+          conn,
+          Routes.project_run_index_path(conn, :index, project.id)
+        )
+
+      assert destination =~
+               "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]="
+
+      assert destination =~
+               "&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
+
       {:ok, view, html} =
         live(
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        |> follow_redirect(conn)
 
       assert html =~ "History"
 
@@ -176,10 +185,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{job_a.workflow.project_id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{job_a.workflow.project_id}"
-        )
+        |> follow_redirect(conn)
 
       div =
         view
@@ -229,10 +235,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{job_a.workflow.project_id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{job_a.workflow.project_id}"
-        )
+        |> follow_redirect(conn)
 
       div =
         view
@@ -317,10 +320,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{job_a.workflow.project_id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{job_a.workflow.project_id}"
-        )
+        |> follow_redirect(conn)
 
       div =
         view
@@ -401,10 +401,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{job_a.workflow.project_id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{job_a.workflow.project_id}"
-        )
+        |> follow_redirect(conn)
 
       assert view
              |> has_element?(
@@ -511,10 +508,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, job_a.workflow.project_id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{job_a.workflow.project_id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{job_a.workflow.project_id}"
-        )
+        |> follow_redirect(conn)
 
       div =
         view
@@ -578,10 +572,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        |> follow_redirect(conn)
 
       assert html =~ "Filter by workorder status"
 
@@ -662,10 +653,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        |> follow_redirect(conn)
 
       div =
         view
@@ -790,10 +778,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        |> follow_redirect(conn)
 
       assert html =~ "Filter by workflow"
 
@@ -863,6 +848,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           dataclip_id: dataclip.id
         )
 
+      expected_d1 = Timex.now() |> Timex.shift(days: -12)
+
       %{id: _attempt_id} =
         Attempt.new(%{
           work_order_id: work_order.id,
@@ -870,10 +857,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           runs: [
             %{
               job_id: job_one.id,
-              started_at:
-                DateTime.from_naive!(~N[2022-08-23 00:00:10.123456], "Etc/UTC"),
-              finished_at:
-                DateTime.from_naive!(~N[2022-08-23 00:50:10.123456], "Etc/UTC"),
+              started_at: expected_d1,
+              finished_at: expected_d1,
               exit_code: 0,
               input_dataclip_id: dataclip.id
             }
@@ -898,6 +883,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           dataclip_id: dataclip.id
         )
 
+      expected_d2 = Timex.now() |> Timex.shift(days: -10)
+
       %{id: _attempt_id} =
         Attempt.new(%{
           work_order_id: work_order.id,
@@ -905,10 +892,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           runs: [
             %{
               job_id: job_two.id,
-              started_at:
-                DateTime.from_naive!(~N[2022-08-29 00:00:10.123456], "Etc/UTC"),
-              finished_at:
-                DateTime.from_naive!(~N[2022-08-29 00:00:10.123456], "Etc/UTC"),
+              started_at: expected_d2,
+              finished_at: expected_d2,
               exit_code: 1,
               input_dataclip_id: dataclip.id
             }
@@ -921,27 +906,24 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        |> follow_redirect(conn)
 
-      assert html =~ "2022-08-23"
-      assert html =~ "2022-08-29"
+      assert html =~ expected_d2 |> Timex.format!("{YYYY}-{0M}-{0D}")
+      assert html =~ expected_d1 |> Timex.format!("{YYYY}-{0M}-{0D}")
 
-      # set date after to 2022-08-25
+      # set date after to 11 days ago, only see second workorder
 
       result =
         view
         |> element("form#run-search-form")
         |> render_submit(%{
-          "filters[date_after]" => ~N[2022-08-25 00:00:00.123456]
+          "filters[date_after]" => Timex.now() |> Timex.shift(days: -11)
         })
 
-      assert result =~ "2022-08-29"
-      refute result =~ "2022-08-23"
+      refute result =~ expected_d1 |> Timex.format!("{YYYY}-{0M}-{0D}")
+      assert result =~ expected_d2 |> Timex.format!("{YYYY}-{0M}-{0D}")
 
-      # set date before to 2022-08-28
+      # set date before to 12 days ago, only see first workorder
 
       # reset after date
       view
@@ -952,11 +934,11 @@ defmodule LightningWeb.RunWorkOrderTest do
         view
         |> element("form#run-search-form")
         |> render_submit(%{
-          "filters[date_before]" => ~N[2022-08-28 00:00:00.123456]
+          "filters[date_before]" => Timex.now() |> Timex.shift(days: -12)
         })
 
-      assert result =~ "2022-08-23"
-      refute result =~ "2022-08-29"
+      assert result =~ expected_d1 |> Timex.format!("{YYYY}-{0M}-{0D}")
+      refute result =~ expected_d2 |> Timex.format!("{YYYY}-{0M}-{0D}")
 
       # reset before date
       result =
@@ -964,8 +946,8 @@ defmodule LightningWeb.RunWorkOrderTest do
         |> element("form#run-search-form")
         |> render_submit(%{"filters[date_before]" => nil})
 
-      assert result =~ "2022-08-23"
-      assert result =~ "2022-08-29"
+      assert result =~ expected_d1 |> Timex.format!("{YYYY}-{0M}-{0D}")
+      assert result =~ expected_d2 |> Timex.format!("{YYYY}-{0M}-{0D}")
     end
 
     test "Filter by run run_log and dataclip_body", %{
@@ -996,6 +978,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           dataclip_id: dataclip.id
         )
 
+      expected_d1 = Timex.now() |> Timex.shift(days: -12)
+
       %{id: _attempt_id} =
         Attempt.new(%{
           work_order_id: work_order.id,
@@ -1003,10 +987,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           runs: [
             %{
               job_id: job_one.id,
-              started_at:
-                DateTime.from_naive!(~N[2022-08-23 00:00:10.123456], "Etc/UTC"),
-              finished_at:
-                DateTime.from_naive!(~N[2022-08-23 00:50:10.123456], "Etc/UTC"),
+              started_at: expected_d1,
+              finished_at: expected_d1 |> Timex.shift(minutes: 2),
               exit_code: 0,
               input_dataclip_id: dataclip.id
             }
@@ -1032,6 +1014,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           dataclip_id: dataclip.id
         )
 
+      expected_d2 = Timex.now() |> Timex.shift(days: -10)
+
       %{id: _attempt_id} =
         Attempt.new(%{
           work_order_id: work_order.id,
@@ -1039,10 +1023,8 @@ defmodule LightningWeb.RunWorkOrderTest do
           runs: [
             %{
               job_id: job_two.id,
-              started_at:
-                DateTime.from_naive!(~N[2022-08-29 00:00:10.123456], "Etc/UTC"),
-              finished_at:
-                DateTime.from_naive!(~N[2022-08-29 00:00:10.123456], "Etc/UTC"),
+              started_at: expected_d2,
+              finished_at: expected_d2 |> Timex.shift(minutes: 5),
               exit_code: 1,
               input_dataclip_id: dataclip.id,
               log_lines: [
@@ -1060,10 +1042,7 @@ defmodule LightningWeb.RunWorkOrderTest do
           conn,
           Routes.project_run_index_path(conn, :index, project.id)
         )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        |> follow_redirect(conn)
 
       div =
         view
@@ -1307,28 +1286,9 @@ defmodule LightningWeb.RunWorkOrderTest do
          %{conn: conn, project: project, attempt: attempt} do
       [run | _rest] = attempt.runs
 
-      params = %{
-        filters: %{
-          body: true,
-          crash: true,
-          date_after: "",
-          date_before: "",
-          failure: true,
-          log: true,
-          pending: true,
-          search_term: "",
-          success: true,
-          timeout: true,
-          wo_date_after: "",
-          wo_date_before: "",
-          workflow_id: ""
-        },
-        project_id: project.id
-      }
-
       {:ok, view, _html} =
         live(conn, Routes.project_run_index_path(conn, :index, project.id))
-        |> follow_redirect(conn, ~p"/projects/#{project}/runs?#{params}")
+        |> follow_redirect(conn)
 
       assert view
              |> render_click("rerun", %{
@@ -1342,28 +1302,9 @@ defmodule LightningWeb.RunWorkOrderTest do
          %{conn: conn, project: project, attempt: attempt} do
       [run | _rest] = attempt.runs
 
-      params = %{
-        filters: %{
-          body: true,
-          crash: true,
-          date_after: "",
-          date_before: "",
-          failure: true,
-          log: true,
-          pending: true,
-          search_term: "",
-          success: true,
-          timeout: true,
-          wo_date_after: "",
-          wo_date_before: "",
-          workflow_id: ""
-        },
-        project_id: project.id
-      }
-
       {:ok, view, _html} =
         live(conn, Routes.project_run_index_path(conn, :index, project.id))
-        |> follow_redirect(conn, ~p"/projects/#{project}/runs?#{params}")
+        |> follow_redirect(conn)
 
       assert view
              |> render_click("rerun", %{


### PR DESCRIPTION
## Why

To help with https://github.com/OpenFn/Lightning/issues/968 , this borrows a trick from platform-app. By default, show the last 30 days of activity. If the user then wants to pick a date further in the past, let them but they'll expect it to be a bit slower.

## Notes to reviewer, open questions for standup?

1. Why is there a `project_id` parameter showing up at the back of the url-bound filters when you navigate to the history page?
2. Why are we asserting redirect every single time in the tests? feels like we should assert the the redirect does what we expect once, and not repeat that test over and over (i've deleted most of them... the assertion is an optional third argument.)
3. Note that we want to return pending stuff even if we have a before date: https://github.com/OpenFn/Lightning/pull/992/files#diff-b400713bb29056407bd66ecb6e7a8663bde8d8adbf8a5a8f68f6bf3ffb8366eaR353
4. Should [this](https://github.com/OpenFn/Lightning/pull/992/files#diff-0d2174d557f95f0bf8356930daa8a2e91380ae2dc36400d9f39ef8f56cc9b8beR103-R107) really be an error? Is that how a redirect works in LiveView?

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
