### PR TITLE
feat: admins can require MFA for their project users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Project owners can require MFA for their users
+  [892](https://github.com/OpenFn/Lightning/issues/892)
+
 ### Changed
 
 - Moved to Elixir 1.15 and Erlang 26.0.2 to sort our an annoying ElixirLS issue

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -32,6 +32,7 @@ defmodule Lightning.Accounts.User do
     field :mfa_enabled, :boolean, default: false
     field :scheduled_deletion, :utc_datetime
 
+    has_one :user_totp, Lightning.Accounts.UserTOTP
     has_many :credentials, Lightning.Credentials.Credential
     has_many :project_users, Lightning.Projects.ProjectUser
     has_many :projects, through: [:project_users, :project]

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -20,6 +20,7 @@ defmodule Lightning.Projects.Project do
     field :name, :string
     field :description, :string
     field :scheduled_deletion, :utc_datetime
+    field :requires_mfa, :boolean, default: false
 
     has_many :project_users, ProjectUser
     has_many :users, through: [:project_users, :user]
@@ -36,7 +37,7 @@ defmodule Lightning.Projects.Project do
   # TODO: schedule_deletion shouldn't be changed by user input
   def changeset(project, attrs) do
     project
-    |> cast(attrs, [:name, :description, :scheduled_deletion])
+    |> cast(attrs, [:name, :description, :scheduled_deletion, :requires_mfa])
     |> cast_assoc(:project_users)
     |> validate()
   end

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -27,17 +27,15 @@ defmodule LightningWeb.LayoutComponents do
       </div>
     <% else %>
       <%= if assigns[:projects] do %>
-      <div class="p-2 mb-4 mt-4 text-center text-primary-300 bg-primary-800">
+        <div class="p-2 mb-4 mt-4 text-center text-primary-300 bg-primary-800">
           <%= if Enum.count(@projects) > 1 do %>
             <.dropdown placement="right" label="Go to project" js_lib="live_view_js">
               <%= for project <- @projects do %>
-
-                  <.dropdown_menu_item
-                    link_type="live_redirect"
-                    to={~p"/projects/#{project.id}/w"}
-                    label={project.name}
-                  />
-
+                <.dropdown_menu_item
+                  link_type="live_redirect"
+                  to={~p"/projects/#{project.id}/w"}
+                  label={project.name}
+                />
               <% end %>
             </.dropdown>
           <% else %>

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -26,23 +26,29 @@ defmodule LightningWeb.LayoutComponents do
         <% end %>
       </div>
     <% else %>
-    <div class="p-2 mb-4 mt-4 text-center text-primary-300 bg-primary-800">
-        <%= if Enum.count(@projects) > 1 do %>
-          <.dropdown placement="right" label="Go to project" js_lib="live_view_js">
-            <%= for project <- @projects do %>
+      <%= if assigns[:projects] do %>
+      <div class="p-2 mb-4 mt-4 text-center text-primary-300 bg-primary-800">
+          <%= if Enum.count(@projects) > 1 do %>
+            <.dropdown placement="right" label="Go to project" js_lib="live_view_js">
+              <%= for project <- @projects do %>
 
-                <.dropdown_menu_item
-                  link_type="live_redirect"
-                  to={~p"/projects/#{project.id}/w"}
-                  label={project.name}
-                />
+                  <.dropdown_menu_item
+                    link_type="live_redirect"
+                    to={~p"/projects/#{project.id}/w"}
+                    label={project.name}
+                  />
 
-            <% end %>
-          </.dropdown>
-        <% else %>
-          <span class="inline-block align-middle">Select a project</span>
-        <% end %>
-      </div>
+              <% end %>
+            </.dropdown>
+          <% else %>
+            <span class="inline-block align-middle text-sm">
+              You don't have access to any projects
+            </span>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="mb-4" />
+      <% end %>
     <% end %>
 
     <%= if assigns[:project] do %>

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -28,7 +28,7 @@ defmodule LightningWeb.LayoutComponents do
     <% else %>
       <%= if assigns[:projects] do %>
         <div class="p-2 mb-4 mt-4 text-center text-primary-300 bg-primary-800">
-          <%= if Enum.count(@projects) > 1 do %>
+          <%= if Enum.count(@projects) >= 1 do %>
             <.dropdown placement="right" label="Go to project" js_lib="live_view_js">
               <%= for project <- @projects do %>
                 <.dropdown_menu_item

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -26,7 +26,23 @@ defmodule LightningWeb.LayoutComponents do
         <% end %>
       </div>
     <% else %>
-      <div class="mb-4" />
+    <div class="p-2 mb-4 mt-4 text-center text-primary-300 bg-primary-800">
+        <%= if Enum.count(@projects) > 1 do %>
+          <.dropdown placement="right" label="Go to project" js_lib="live_view_js">
+            <%= for project <- @projects do %>
+
+                <.dropdown_menu_item
+                  link_type="live_redirect"
+                  to={~p"/projects/#{project.id}/w"}
+                  label={project.name}
+                />
+
+            <% end %>
+          </.dropdown>
+        <% else %>
+          <span class="inline-block align-middle">Select a project</span>
+        <% end %>
+      </div>
     <% end %>
 
     <%= if assigns[:project] do %>
@@ -62,9 +78,6 @@ defmodule LightningWeb.LayoutComponents do
       <span class="inline-block align-middle">Dataclips</span>
     </Settings.menu_item> -->
     <% else %>
-      <Settings.menu_item to={~p"/"}>
-        <Heroicons.squares_2x2 class="h-5 w-5 inline-block mr-2" /> Projects
-      </Settings.menu_item>
       <Settings.menu_item to={~p"/profile"} active={@active_menu_item == :profile}>
         <Heroicons.user_circle class="h-5 w-5 inline-block mr-2" /> User Profile
       </Settings.menu_item>

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -55,8 +55,8 @@ defmodule LightningWeb.Hooks do
     projects = Lightning.Projects.get_projects_for_user(current_user)
 
     {:cont,
-      socket
-      |> assign_new(:projects, fn -> projects end)}
+     socket
+     |> assign_new(:projects, fn -> projects end)}
   end
 
   def on_mount(:user_scope, _, _session, socket) do

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -49,7 +49,7 @@ defmodule LightningWeb.Hooks do
     {:cont, socket}
   end
 
-  def on_mount(:user_scope, _, _session, socket) do
+  def on_mount(:assign_projects, _, _session, socket) do
     %{current_user: current_user} = socket.assigns
 
     projects = Lightning.Projects.get_projects_for_user(current_user)

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -48,4 +48,18 @@ defmodule LightningWeb.Hooks do
   def on_mount(:project_scope, _, _session, socket) do
     {:cont, socket}
   end
+
+  def on_mount(:user_scope, _, _session, socket) do
+    %{current_user: current_user} = socket.assigns
+
+    projects = Lightning.Projects.get_projects_for_user(current_user)
+
+    {:cont,
+      socket
+      |> assign_new(:projects, fn -> projects end)}
+  end
+
+  def on_mount(:user_scope, _, _session, socket) do
+    {:cont, socket}
+  end
 end

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -58,8 +58,4 @@ defmodule LightningWeb.Hooks do
      socket
      |> assign_new(:projects, fn -> projects end)}
   end
-
-  def on_mount(:user_scope, _, _session, socket) do
-    {:cont, socket}
-  end
 end

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -29,14 +29,19 @@ defmodule LightningWeb.Hooks do
       ProjectUsers
       |> Permissions.can?(:access_project, current_user, project)
 
-    if can_access_project do
-      {:cont,
-       socket
-       |> assign_new(:project_user, fn -> project_user end)
-       |> assign_new(:project, fn -> project end)
-       |> assign_new(:projects, fn -> projects end)}
-    else
-      {:halt, redirect(socket, to: "/") |> put_flash(:nav, :not_found)}
+    cond do
+      can_access_project and project.requires_mfa and !current_user.mfa_enabled ->
+        {:halt, redirect(socket, to: "/mfa_required")}
+
+      can_access_project ->
+        {:cont,
+         socket
+         |> assign_new(:project_user, fn -> project_user end)
+         |> assign_new(:project, fn -> project end)
+         |> assign_new(:projects, fn -> projects end)}
+
+      true ->
+        {:halt, redirect(socket, to: "/") |> put_flash(:nav, :not_found)}
     end
   end
 

--- a/lib/lightning_web/live/credential_live/edit.ex
+++ b/lib/lightning_web/live/credential_live/edit.ex
@@ -10,6 +10,8 @@ defmodule LightningWeb.CredentialLive.Edit do
   alias Lightning.Projects
   alias Lightning.Policies.Permissions
 
+  on_mount({LightningWeb.Hooks, :user_scope})
+
   @impl true
   def render(assigns) do
     ~H"""

--- a/lib/lightning_web/live/credential_live/edit.ex
+++ b/lib/lightning_web/live/credential_live/edit.ex
@@ -10,7 +10,7 @@ defmodule LightningWeb.CredentialLive.Edit do
   alias Lightning.Projects
   alias Lightning.Policies.Permissions
 
-  on_mount({LightningWeb.Hooks, :user_scope})
+  on_mount({LightningWeb.Hooks, :assign_projects})
 
   @impl true
   def render(assigns) do

--- a/lib/lightning_web/live/credential_live/edit.ex
+++ b/lib/lightning_web/live/credential_live/edit.ex
@@ -10,7 +10,7 @@ defmodule LightningWeb.CredentialLive.Edit do
   alias Lightning.Projects
   alias Lightning.Policies.Permissions
 
-  on_mount({LightningWeb.Hooks, :assign_projects})
+  on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def render(assigns) do

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -6,6 +6,8 @@ defmodule LightningWeb.CredentialLive.Index do
 
   alias Lightning.Credentials
 
+  on_mount({LightningWeb.Hooks, :user_scope})
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.CredentialLive.Index do
 
   alias Lightning.Credentials
 
-  on_mount({LightningWeb.Hooks, :user_scope})
+  on_mount({LightningWeb.Hooks, :assign_projects})
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.CredentialLive.Index do
 
   alias Lightning.Credentials
 
-  on_mount({LightningWeb.Hooks, :assign_projects})
+  on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.DashboardLive.Index do
   alias Lightning.Projects
   alias Lightning.Policies.{Permissions, ProjectUsers}
 
-  on_mount({LightningWeb.Hooks, :project_scope})
+  on_mount {LightningWeb.Hooks, :project_scope}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.ProfileLive.Edit do
   """
   use LightningWeb, :live_view
 
-  on_mount({LightningWeb.Hooks, :assign_projects})
+  on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -4,6 +4,8 @@ defmodule LightningWeb.ProfileLive.Edit do
   """
   use LightningWeb, :live_view
 
+  on_mount({LightningWeb.Hooks, :user_scope})
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok, socket |> assign(:active_menu_item, :profile)}

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.ProfileLive.Edit do
   """
   use LightningWeb, :live_view
 
-  on_mount({LightningWeb.Hooks, :user_scope})
+  on_mount({LightningWeb.Hooks, :assign_projects})
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/project_live/mfa_required.ex
+++ b/lib/lightning_web/live/project_live/mfa_required.ex
@@ -6,6 +6,8 @@ defmodule LightningWeb.ProjectLive.MFARequired do
 
   on_mount __MODULE__
 
+  on_mount({LightningWeb.Hooks, :user_scope})
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok, assign(socket, active_menu_item: nil)}

--- a/lib/lightning_web/live/project_live/mfa_required.ex
+++ b/lib/lightning_web/live/project_live/mfa_required.ex
@@ -1,0 +1,20 @@
+defmodule LightningWeb.ProjectLive.MFARequired do
+  @moduledoc """
+  Liveview for project access denied error messages
+  """
+  use LightningWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, active_menu_item: nil)}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    apply_action(socket, socket.assigns.live_action, params)
+  end
+
+  defp apply_action(socket, :index, _params) do
+    {:noreply, socket |> assign(page_title: "MFA Required for Project")}
+  end
+end

--- a/lib/lightning_web/live/project_live/mfa_required.ex
+++ b/lib/lightning_web/live/project_live/mfa_required.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.ProjectLive.MFARequired do
 
   on_mount __MODULE__
 
-  on_mount({LightningWeb.Hooks, :user_scope})
+  on_mount({LightningWeb.Hooks, :assign_projects})
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/project_live/mfa_required.ex
+++ b/lib/lightning_web/live/project_live/mfa_required.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.ProjectLive.MFARequired do
 
   on_mount __MODULE__
 
-  on_mount({LightningWeb.Hooks, :assign_projects})
+  on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/project_live/mfa_required.ex
+++ b/lib/lightning_web/live/project_live/mfa_required.ex
@@ -4,9 +4,21 @@ defmodule LightningWeb.ProjectLive.MFARequired do
   """
   use LightningWeb, :live_view
 
+  on_mount __MODULE__
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok, assign(socket, active_menu_item: nil)}
+  end
+
+  def on_mount(:default, _params, _session, socket) do
+    %{current_user: current_user} = socket.assigns
+
+    if current_user.mfa_enabled do
+      {:halt, redirect(socket, to: "/")}
+    else
+      {:cont, socket}
+    end
   end
 
   @impl true

--- a/lib/lightning_web/live/project_live/mfa_required.html.heex
+++ b/lib/lightning_web/live/project_live/mfa_required.html.heex
@@ -4,7 +4,7 @@
     </LayoutComponents.header>
   </:header>
   <LayoutComponents.centered>
-    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
       <div>
         <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
           <div class="sm:flex sm:items-start">

--- a/lib/lightning_web/live/project_live/mfa_required.html.heex
+++ b/lib/lightning_web/live/project_live/mfa_required.html.heex
@@ -1,0 +1,59 @@
+<LayoutComponents.page_content>
+  <:header>
+    <LayoutComponents.header current_user={@current_user}>
+    </LayoutComponents.header>
+  </:header>
+  <LayoutComponents.centered>
+    <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+      <div>
+        <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+          <div class="sm:flex sm:items-start">
+            <div class="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+              <svg
+                class="h-6 w-6 text-red-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+              <h3 class="text-base font-semibold leading-6 text-gray-900">
+                <%= @page_title %>
+              </h3>
+              <div class="mt-2">
+                <p class="text-sm text-gray-500">
+                  This project requires all members to enabled multi-factor authentication.
+                  Please enable MFA for
+                  <.link
+                    navigate={~p"/profile"}
+                    class="text-blue-600 dark:text-blue-500 hover:underline"
+                  >
+                    your account
+                  </.link>
+                  in order to gain access.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+            <.link
+              role="button"
+              navigate={~p"/profile"}
+              class="inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:ml-3 sm:w-auto"
+            >
+              Visit your account
+            </.link>
+          </div>
+        </div>
+      </div>
+    </div>
+  </LayoutComponents.centered>
+</LayoutComponents.page_content>

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -119,7 +119,10 @@ defmodule LightningWeb.ProjectLive.Settings do
 
   def handle_event("toggle-mfa", _params, socket) do
     if can_edit_project(socket.assigns) do
-      project = toggle_project_mfa(socket)
+      project = socket.assigns.project
+
+      {:ok, project} =
+        Projects.update_project(project, %{requires_mfa: !project.requires_mfa})
 
       {:noreply,
        socket
@@ -292,14 +295,5 @@ defmodule LightningWeb.ProjectLive.Settings do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :project_changeset, changeset)}
     end
-  end
-
-  defp toggle_project_mfa(socket) do
-    project = socket.assigns.project
-
-    {:ok, project} =
-      Projects.update_project(project, %{requires_mfa: !project.requires_mfa})
-
-    project
   end
 end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -10,7 +10,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   alias Lightning.Accounts.User
   alias Lightning.{Projects, Credentials}
 
-  on_mount({LightningWeb.Hooks, :project_scope})
+  on_mount {LightningWeb.Hooks, :project_scope}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -34,6 +34,13 @@
               <Heroicons.users class="h-5 w-5 inline-block mr-2" />
               <span class="inline-block align-middle">Collaboration</span>
             </LightningWeb.Components.Common.tab_item>
+            <LightningWeb.Components.Common.tab_item
+              orientation="vertical"
+              hash="security"
+            >
+              <Heroicons.lock_closed class="h-5 w-5 inline-block mr-2" />
+              <span class="inline-block align-middle">Security</span>
+            </LightningWeb.Components.Common.tab_item>
           </LightningWeb.Components.Common.tab_bar>
         </div>
       </div>
@@ -253,6 +260,50 @@
               </.tr>
             <% end %>
           </.table>
+        </LightningWeb.Components.Common.panel_content>
+
+        <LightningWeb.Components.Common.panel_content for_hash="security">
+          <div>
+            <h6 class="font-medium text-black">Project Security</h6>
+            <small class="block my-1 text-xs text-gray-600">
+              View and manage security settings for this project.
+            </small>
+          </div>
+          <div class="hidden sm:block" aria-hidden="true">
+            <div class="py-2"></div>
+          </div>
+          <%= if can_edit_project(assigns) do %>
+            <div class="flex items-center justify-between mb-5">
+              <span class="flex flex-grow flex-col">
+                <span
+                  class="text-sm font-medium leading-6 text-gray-900"
+                  id="require-mfa-label"
+                >
+                  Require Multi-Factor Authentication
+                </span>
+                <span class="text-sm text-gray-500" id="require-mfa-description">
+                  This adds an additional layer of security to your project by requiring
+                  all project members to have enabled Multi-Factor Authentication in order to access it.
+                </span>
+              </span>
+              <button
+                id="toggle-mfa-switch"
+                type="button"
+                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+                role="switch"
+                phx-click="toggle-mfa"
+                aria-checked={@project.requires_mfa}
+                aria-labelledby="require-mfa-label"
+                aria-describedby="require-mfa-description"
+              >
+                <span
+                  aria-hidden="true"
+                  class={"#{if @project.requires_mfa, do: "translate-x-5", else: "translate-x-0"} pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}
+                >
+                </span>
+              </button>
+            </div>
+          <% end %>
         </LightningWeb.Components.Common.panel_content>
       </div>
     </div>

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -28,7 +28,7 @@ defmodule LightningWeb.RunLive.Index do
     pending: :boolean
   }
 
-  on_mount({LightningWeb.Hooks, :project_scope})
+  on_mount {LightningWeb.Hooks, :project_scope}
 
   @impl true
   def mount(params, _session, socket) do

--- a/lib/lightning_web/live/tokens_live/index.ex
+++ b/lib/lightning_web/live/tokens_live/index.ex
@@ -8,7 +8,7 @@ defmodule LightningWeb.TokensLive.Index do
   alias Lightning.Policies.Users
   alias Lightning.Accounts
 
-  on_mount({LightningWeb.Hooks, :user_scope})
+  on_mount({LightningWeb.Hooks, :assign_projects})
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/tokens_live/index.ex
+++ b/lib/lightning_web/live/tokens_live/index.ex
@@ -8,7 +8,7 @@ defmodule LightningWeb.TokensLive.Index do
   alias Lightning.Policies.Users
   alias Lightning.Accounts
 
-  on_mount({LightningWeb.Hooks, :assign_projects})
+  on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/tokens_live/index.ex
+++ b/lib/lightning_web/live/tokens_live/index.ex
@@ -8,6 +8,8 @@ defmodule LightningWeb.TokensLive.Index do
   alias Lightning.Policies.Users
   alias Lightning.Accounts
 
+  on_mount({LightningWeb.Hooks, :user_scope})
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -105,6 +105,8 @@ defmodule LightningWeb.Router do
     end
 
     live_session :default, on_mount: LightningWeb.InitAssigns do
+      live "/mfa_required", ProjectLive.MFARequired, :index
+
       scope "/projects/:project_id", as: :project do
         live "/jobs", JobLive.Index, :index
 

--- a/priv/repo/migrations/20230727160506_add_require_mfa_to_projects_table.exs
+++ b/priv/repo/migrations/20230727160506_add_require_mfa_to_projects_table.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddRequireMfaToProjectsTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :requires_mfa, :boolean, default: false
+    end
+  end
+end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -13,6 +13,7 @@ defmodule Lightning.AccountsTest do
 
   alias Lightning.Accounts.{User, UserToken, UserTOTP}
   import Lightning.AccountsFixtures
+  import Lightning.Factories
 
   test "has_activity_in_projects?/1 returns true if user is has activity in a project (is associated to invocation reasons) and false otherwise." do
     user = AccountsFixtures.user_fixture()
@@ -156,7 +157,7 @@ defmodule Lightning.AccountsTest do
 
   describe "valid_user_totp?/2" do
     setup do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
 
       %{totp: Accounts.get_user_totp(user), user: user}
     end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -112,7 +112,7 @@ defmodule Lightning.ProjectsTest do
     end
 
     test "update_project/2 updates the MFA requirement" do
-      project = project_fixture()
+      project = insert(:project)
 
       refute project.requires_mfa
       update_attrs = %{requires_mfa: true}

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -111,6 +111,18 @@ defmodule Lightning.ProjectsTest do
       assert project.name == "some-updated-name"
     end
 
+    test "update_project/2 updates the MFA requirement" do
+      project = project_fixture()
+
+      refute project.requires_mfa
+      update_attrs = %{requires_mfa: true}
+
+      assert {:ok, %Project{} = project} =
+               Projects.update_project(project, update_attrs)
+
+      assert project.requires_mfa
+    end
+
     test "update_project/2 with invalid data returns error changeset" do
       project = project_fixture() |> unload_relation(:project_users)
 

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -302,7 +302,7 @@ defmodule Lightning.WorkflowsTest do
 
       assert length(results) == 2
 
-      assert results |> Enum.map(& &1.id) == [w1.id, w2.id]
+      assert results |> MapSet.new(& &1.id) == [w1, w2] |> MapSet.new(& &1.id)
 
       for workflow <- results do
         assert is_nil(workflow.deleted_at)

--- a/test/lightning_web/controllers/oidc_controller_test.exs
+++ b/test/lightning_web/controllers/oidc_controller_test.exs
@@ -3,6 +3,8 @@ defmodule LightningWeb.OidcControllerTest do
 
   import Lightning.BypassHelpers
   import Lightning.AccountsFixtures
+  import Lightning.Factories
+
   alias Lightning.AuthProviders
 
   def setup_handler(_) do
@@ -90,7 +92,7 @@ defmodule LightningWeb.OidcControllerTest do
          } do
       expect_token(bypass, handler.wellknown)
 
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
 
       expect_userinfo(bypass, handler.wellknown, %{"email" => user.email})
 

--- a/test/lightning_web/controllers/user_session_controller_test.exs
+++ b/test/lightning_web/controllers/user_session_controller_test.exs
@@ -2,6 +2,8 @@ defmodule LightningWeb.UserSessionControllerTest do
   use LightningWeb.ConnCase, async: false
 
   import Lightning.AccountsFixtures
+  import Lightning.Factories
+
   alias Lightning.AuthProviders
 
   def create_handler(endpoint_url) do
@@ -136,7 +138,7 @@ defmodule LightningWeb.UserSessionControllerTest do
 
     test "logs the user in but marks totp as pending for users wth MFA enabled",
          %{conn: conn} do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{
@@ -200,7 +202,7 @@ defmodule LightningWeb.UserSessionControllerTest do
 
     test "a user with MFA logging in with remember is redirected to TOTP page with remember_me query param",
          %{conn: conn} do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
 
       conn =
         post(conn, Routes.user_session_path(conn, :create), %{

--- a/test/lightning_web/controllers/user_totp_controller_test.exs
+++ b/test/lightning_web/controllers/user_totp_controller_test.exs
@@ -1,12 +1,12 @@
 defmodule LightningWeb.UserTOTPControllerTest do
   use LightningWeb.ConnCase, async: false
 
-  import Lightning.AccountsFixtures
+  import Lightning.Factories
 
   @totp_session :user_totp_pending
 
   setup %{conn: conn} do
-    user = user_with_mfa_fixture()
+    user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
     conn = conn |> log_in_user(user) |> put_session(@totp_session, true)
     %{user: user, conn: conn}
   end

--- a/test/lightning_web/live/dataclip_live_test.exs
+++ b/test/lightning_web/live/dataclip_live_test.exs
@@ -2,8 +2,8 @@ defmodule LightningWeb.DataclipLiveTest do
   use LightningWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
-  import Lightning.AccountsFixtures
   import Lightning.InvocationFixtures
+  import Lightning.Factories
 
   defp create_dataclip(%{project: project}) do
     dataclip = dataclip_fixture(project_id: project.id)
@@ -47,18 +47,16 @@ defmodule LightningWeb.DataclipLiveTest do
          %{
            conn: conn
          } do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
       conn = log_in_user(conn, user)
 
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
+      project =
+        insert(:project,
           requires_mfa: true,
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+          project_users: [%{user: user, role: :admin}]
+        )
 
-      dataclip_fixture(project_id: project.id)
-      dataclip_fixture(project_id: project.id)
+      insert_list(2, :dataclip, project: project)
 
       {:ok, _view, html} =
         live(

--- a/test/lightning_web/live/mfa_required_live_test.exs
+++ b/test/lightning_web/live/mfa_required_live_test.exs
@@ -2,7 +2,7 @@ defmodule LightningWeb.MFARequiredLiveTest do
   use LightningWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
-  import Lightning.AccountsFixtures
+  import Lightning.Factories
 
   setup :register_and_log_in_user
   setup :create_project_for_current_user
@@ -21,7 +21,7 @@ defmodule LightningWeb.MFARequiredLiveTest do
       conn: conn,
       project: project
     } do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
       conn = setup_project_user(conn, project, user, :editor)
 
       assert {:error, {:redirect, %{to: "/"}}} = live(conn, "/mfa_required")

--- a/test/lightning_web/live/mfa_required_live_test.exs
+++ b/test/lightning_web/live/mfa_required_live_test.exs
@@ -1,0 +1,30 @@
+defmodule LightningWeb.MFARequiredLiveTest do
+  use LightningWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Lightning.AccountsFixtures
+
+  setup :register_and_log_in_user
+  setup :create_project_for_current_user
+
+  describe "Index" do
+    test "displays the right copy", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/mfa_required")
+
+      assert html =~
+               "This project requires all members to enabled multi-factor authentication"
+
+      assert view |> element(~s{[href="/profile"]}) |> has_element?()
+    end
+
+    test "redirects to / if user already has mfa enabled", %{
+      conn: conn,
+      project: project
+    } do
+      user = user_with_mfa_fixture()
+      conn = setup_project_user(conn, project, user, :editor)
+
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, "/mfa_required")
+    end
+  end
+end

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -240,11 +240,7 @@ defmodule LightningWeb.ProfileLiveTest do
     end
 
     test "user can successfully add MFA to their account", %{conn: conn} do
-      Application.put_env(
-        :lightning,
-        :totp_client,
-        LightningTest.TOTP
-      )
+      Application.put_env(:lightning, :totp_client, LightningTest.TOTP)
 
       {:ok, view, _html} = live(conn, Routes.profile_edit_path(conn, :edit))
 
@@ -314,11 +310,7 @@ defmodule LightningWeb.ProfileLiveTest do
     end
 
     test "user can successfully setup another device", %{conn: conn} do
-      Application.put_env(
-        :lightning,
-        :totp_client,
-        LightningTest.TOTP
-      )
+      Application.put_env(:lightning, :totp_client, LightningTest.TOTP)
 
       {:ok, view, _html} = live(conn, Routes.profile_edit_path(conn, :edit))
 

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -218,13 +218,6 @@ defmodule LightningWeb.ProfileLiveTest do
     end
   end
 
-  defmodule LightningWeb.ProfileLiveTest.TOTP do
-    def secret do
-      <<4, 70, 0, 227, 26, 97, 234, 162, 13, 44, 36, 56, 102, 50, 59, 143, 157,
-        4, 157, 18>>
-    end
-  end
-
   describe "MFA Component for a user without MFA enabled" do
     setup :register_and_log_in_user
 
@@ -250,7 +243,7 @@ defmodule LightningWeb.ProfileLiveTest do
       Application.put_env(
         :lightning,
         :totp_client,
-        LightningWeb.ProfileLiveTest.TOTP
+        LightningTest.TOTP
       )
 
       {:ok, view, _html} = live(conn, Routes.profile_edit_path(conn, :edit))
@@ -262,7 +255,7 @@ defmodule LightningWeb.ProfileLiveTest do
 
       assert view |> form("#set_totp_form") |> has_element?()
 
-      secret = LightningWeb.ProfileLiveTest.TOTP.secret()
+      secret = LightningTest.TOTP.secret()
       valid_code = NimbleTOTP.verification_code(secret)
 
       view
@@ -324,7 +317,7 @@ defmodule LightningWeb.ProfileLiveTest do
       Application.put_env(
         :lightning,
         :totp_client,
-        LightningWeb.ProfileLiveTest.TOTP
+        LightningTest.TOTP
       )
 
       {:ok, view, _html} = live(conn, Routes.profile_edit_path(conn, :edit))
@@ -336,7 +329,7 @@ defmodule LightningWeb.ProfileLiveTest do
 
       assert view |> form("#set_totp_form") |> has_element?()
 
-      secret = LightningWeb.ProfileLiveTest.TOTP.secret()
+      secret = LightningTest.TOTP.secret()
       valid_code = NimbleTOTP.verification_code(secret)
 
       view

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -491,11 +491,10 @@ defmodule LightningWeb.ProjectLiveTest do
            conn: conn,
            user: user
          } do
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+      project =
+        insert(:project,
+          project_users: [%{user: user, role: :admin}]
+        )
 
       {:ok, _view, html} =
         live(
@@ -699,11 +698,10 @@ defmodule LightningWeb.ProjectLiveTest do
            conn: conn,
            user: user
          } do
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+      project =
+        insert(:project,
+          project_users: [%{user: user, role: :admin}]
+        )
 
       {:ok, view, html} =
         live(
@@ -722,11 +720,10 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       user: user
     } do
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+      project =
+        insert(:project,
+          project_users: [%{user: user, role: :admin}]
+        )
 
       ~w(editor viewer)a
       |> Enum.each(fn role ->

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -491,10 +491,7 @@ defmodule LightningWeb.ProjectLiveTest do
            conn: conn,
            user: user
          } do
-      project =
-        insert(:project,
-          project_users: [%{user: user, role: :admin}]
-        )
+      project = insert(:project, project_users: [%{user: user, role: :admin}])
 
       {:ok, _view, html} =
         live(

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -4,6 +4,7 @@ defmodule LightningWeb.ProjectLiveTest do
   import Phoenix.LiveViewTest
   import Lightning.ProjectsFixtures
   import Lightning.AccountsFixtures
+  import Lightning.Factories
 
   @create_attrs %{
     raw_name: "some name"
@@ -750,15 +751,14 @@ defmodule LightningWeb.ProjectLiveTest do
          %{
            conn: conn
          } do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
       conn = log_in_user(conn, user)
 
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
+      project =
+        insert(:project,
           requires_mfa: true,
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+          project_users: [%{user: user, role: :admin}]
+        )
 
       {:ok, _view, html} =
         live(

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -32,14 +32,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         })
 
       {:ok, _view, html} =
-        live(
-          conn,
-          Routes.project_run_index_path(conn, :index, project.id)
-        )
-        |> follow_redirect(
-          conn,
-          "/projects/#{project.id}/runs?filters[body]=true&filters[crash]=true&filters[date_after]=&filters[date_before]=&filters[failure]=true&filters[log]=true&filters[pending]=true&filters[search_term]=&filters[success]=true&filters[timeout]=true&filters[wo_date_after]=&filters[wo_date_before]=&filters[workflow_id]=&project_id=#{project.id}"
-        )
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
 
       assert html =~ "History"
 

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -6,7 +6,6 @@ defmodule LightningWeb.RunWorkOrderTest do
   alias Lightning.Attempt
   alias Lightning.Workorders.SearchParams
 
-  import Lightning.AccountsFixtures
   import Lightning.JobsFixtures
   import Lightning.InvocationFixtures
   import Lightning.WorkflowsFixtures
@@ -21,15 +20,14 @@ defmodule LightningWeb.RunWorkOrderTest do
          %{
            conn: conn
          } do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
       conn = log_in_user(conn, user)
 
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
+      project =
+        insert(:project,
           requires_mfa: true,
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+          project_users: [%{user: user, role: :admin}]
+        )
 
       {:ok, _view, html} =
         live(conn, Routes.project_run_index_path(conn, :index, project.id))

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -25,20 +25,15 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       user = user_with_mfa_fixture()
       conn = log_in_user(conn, user)
 
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
+      project =
+        insert(:project,
           requires_mfa: true,
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+          project_users: [%{user: user, role: :admin}]
+        )
 
       create_workflow(%{project: project})
 
-      {:ok, view, _html} =
-        live(
-          conn,
-          ~p"/projects/#{project.id}/w"
-        )
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project}/w")
 
       assert element(view, "#workflows-#{project.id}", "No workflows yet")
 
@@ -47,10 +42,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
         {conn, _user} = setup_project_user(conn, project, role)
 
         assert {:error, {:redirect, %{to: "/mfa_required"}}} =
-                 live(
-                   conn,
-                   ~p"/projects/#{project.id}/w"
-                 )
+                 live(conn, ~p"/projects/#{project}/w")
       end)
     end
 
@@ -123,20 +115,15 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       user = user_with_mfa_fixture()
       conn = log_in_user(conn, user)
 
-      {:ok, project} =
-        Lightning.Projects.create_project(%{
-          name: "project-1",
+      project =
+        insert(:project,
           requires_mfa: true,
-          project_users: [%{user_id: user.id, role: :admin}]
-        })
+          project_users: [%{user: user, role: :admin}]
+        )
 
       create_workflow(%{project: project})
 
-      {:ok, _view, html} =
-        live(
-          conn,
-          ~p"/projects/#{project.id}/w"
-        )
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project}/w")
 
       assert html =~ "Create new workflow"
 
@@ -145,10 +132,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
         {conn, _user} = setup_project_user(conn, project, role)
 
         assert {:error, {:redirect, %{to: "/mfa_required"}}} =
-                 live(
-                   conn,
-                   ~p"/projects/#{project.id}/w"
-                 )
+                 live(conn, ~p"/projects/#{project}/w")
       end)
     end
   end

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -2,7 +2,6 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
   use LightningWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
-  import Lightning.AccountsFixtures
   import Lightning.Factories
   import Lightning.WorkflowLive.Helpers
 
@@ -22,7 +21,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
          %{
            conn: conn
          } do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
       conn = log_in_user(conn, user)
 
       project =
@@ -112,7 +111,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
          %{
            conn: conn
          } do
-      user = user_with_mfa_fixture()
+      user = insert(:user, mfa_enabled: true, user_totp: build(:user_totp))
       conn = log_in_user(conn, user)
 
       project =

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -80,6 +80,12 @@ defmodule Lightning.Factories do
     }
   end
 
+  def user_totp_factory do
+    %Lightning.Accounts.UserTOTP{
+      secret: NimbleTOTP.secret()
+    }
+  end
+
   # ----------------------------------------------------------------------------
   # Helpers
   # ----------------------------------------------------------------------------

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -25,22 +25,6 @@ defmodule Lightning.AccountsFixtures do
     user
   end
 
-  def user_with_mfa_fixture(attrs \\ []) when is_list(attrs) do
-    user = user_fixture(attrs)
-
-    user_totp = %Lightning.Accounts.UserTOTP{
-      secret: NimbleTOTP.secret(),
-      user_id: user.id
-    }
-
-    valid_code = NimbleTOTP.verification_code(user_totp.secret)
-
-    {:ok, _totp} =
-      Lightning.Accounts.upsert_user_totp(user_totp, %{code: valid_code})
-
-    %{user | mfa_enabled: true}
-  end
-
   def superuser_fixture(attrs \\ []) when is_list(attrs) do
     {:ok, user} =
       attrs

--- a/test/support/totp_adapter.ex
+++ b/test/support/totp_adapter.ex
@@ -1,0 +1,6 @@
+  defmodule LightningTest.TOTP do
+    def secret do
+      <<4, 70, 0, 227, 26, 97, 234, 162, 13, 44, 36, 56, 102, 50, 59, 143, 157,
+        4, 157, 18>>
+    end
+  end

--- a/test/support/totp_adapter.ex
+++ b/test/support/totp_adapter.ex
@@ -1,6 +1,8 @@
-  defmodule LightningTest.TOTP do
-    def secret do
-      <<4, 70, 0, 227, 26, 97, 234, 162, 13, 44, 36, 56, 102, 50, 59, 143, 157,
-        4, 157, 18>>
-    end
+defmodule LightningTest.TOTP do
+  @moduledoc false
+
+  def secret do
+    <<4, 70, 0, 227, 26, 97, 234, 162, 13, 44, 36, 56, 102, 50, 59, 143, 157, 4,
+      157, 18>>
   end
+end


### PR DESCRIPTION
## Notes for the reviewer

- [x] Add `requires_mfa` field to `projects` table
- [x] Add security tab to project settings page
- [x] Use `can_edit_project` permission to determine who can toggle MFA
- [x] add relevant tests


## Related issue

Fixes #892 
Fixes #893 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
