### PR TITLE
Ignore :call_with_opaque warnings on Handler for now

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,8 @@
 [
   # Remove when next version of postgrex is released.
   # https://github.com/elixir-ecto/postgrex/issues/651
-  {"deps/postgrex/lib/postgrex/type_module.ex", :improper_list_constr}
+  {"deps/postgrex/lib/postgrex/type_module.ex", :improper_list_constr},
+  {"lib/lightning/runtime/handler.ex", :no_return},
+  {"lib/lightning/runtime/handler.ex", :call_with_opaque},
+  {"lib/lightning/task_worker.ex", :call_with_opaque}
 ]


### PR DESCRIPTION
## Notes for the reviewer

I order to fix this issue, we need to refactor the Handler module to use the `handle_info` callbacks (instead of the `receive` match), so that we can both block for the caller and still have our loosely coupled processes for logging and scrubbing.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
