### PR TITLE
Fix for first click on a new credential type radio button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 - Fix issue creating a new credential from the Job editor where the new
   credential was not being set on the job.
   [#951](https://github.com/OpenFn/Lightning/issues/951)
+- Fix issue where checking a credential type radio button shows as unchecked on
+  first click. [#976](https://github.com/OpenFn/Lightning/issues/976)
 
 ## [v0.7.0-pre5] - 2023-07-28
 

--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -28,7 +28,7 @@ defmodule LightningWeb.CredentialLive.TypePicker do
                 <.form
                   :let={f}
                   id="credential-type-picker"
-                  for={%{}}
+                  for={%{"selected" => @selected}}
                   as={:type}
                   phx-target={@myself}
                   phx-change="type_changed"

--- a/test/support/credential_live_helpers.ex
+++ b/test/support/credential_live_helpers.ex
@@ -1,10 +1,17 @@
 defmodule LightningWeb.CredentialLiveHelpers do
   import Phoenix.LiveViewTest
+  import ExUnit.Assertions
 
   def select_credential_type(live, type) do
-    live
-    |> form("#credential-type-picker", type: %{selected: type})
-    |> render_change()
+    html =
+      live
+      |> form("#credential-type-picker", type: %{selected: type})
+      |> render_change()
+
+    assert Floki.parse_fragment!(html)
+           |> Floki.find("input[type=radio][value=#{type}][checked]")
+           |> Enum.any?(),
+           "Expected #{type} to be selected"
   end
 
   def click_continue(live) do


### PR DESCRIPTION
## Notes for the reviewer

We weren't correctly maintaining the params from the LiveView into the form, even though the LiveView had the values. The second click was a red herring, as the item was selected on the first click.

This fixes it by reflecting the selected item as `checked` from the params.

## Related issue

Fixes #976 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
