### PR TITLE
Make the new credential modal smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 - Moved to Elixir 1.15 and Erlang 26.0.2 to sort our an annoying ElixirLS issue
   that was slowing down our engineers.
 - Update Debian base to use bookworm (Debian 12) for our Docker images
+- Change new credential modal to take up less space on the screen
+  [#931](https://github.com/OpenFn/Lightning/issues/931)
 
 ### Fixed
 

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -23,7 +23,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id="credential-#{@id}" class="@container">
+    <div id={"credential-#{@id}"} class="@container">
       <.live_component
         :if={!@type}
         module={LightningWeb.CredentialLive.TypePicker}

--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -7,16 +7,16 @@ defmodule LightningWeb.CredentialLive.TypePicker do
   def render(assigns) do
     ~H"""
     <div class="mt-10 sm:mt-0">
-      <div class="lg:grid md:grid-cols-3 md:gap-6">
-        <div class="md:col-span-1 hidden @2xl:block">
+      <div class="lg:grid lg:grid-cols-3 md:gap-6">
+        <div class="lg:col-span-1 hidden @2xl:block">
           <div class="px-4 sm:px-0">
             <p class="mt-1 text-sm text-gray-600">
               Decide which type credential you would like to create.
             </p>
           </div>
         </div>
-        <div class="mt-5 md:col-span-2 md:mt-0">
-          <div class="overflow-hidden shadow sm:rounded-md">
+        <div class="mt-5 lg:col-span-3 xl:col-span-2 md:mt-0">
+          <div class="shadow sm:rounded-md">
             <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
               <fieldset>
                 <legend class="contents text-base font-medium text-gray-900">
@@ -34,10 +34,10 @@ defmodule LightningWeb.CredentialLive.TypePicker do
                   phx-change="type_changed"
                   phx-submit="confirm_type"
                 >
-                  <div class="mt-4 space-y-4">
+                  <div class="md:columns-3 columns-2">
                     <div
                       :for={{name, key} <- @type_options}
-                      class="flex items-center"
+                      class="flex items-center pt-4"
                     >
                       <%= radio_button(f, :selected, key,
                         class:

--- a/lib/lightning_web/live/modal_portal.ex
+++ b/lib/lightning_web/live/modal_portal.ex
@@ -61,20 +61,21 @@ defmodule LightningWeb.ModalPortal do
         aria-hidden="true"
       >
       </div>
+
       <div
-        class="fixed inset-0 z-50 flex items-center justify-center px-4 my-4 overflow-hidden transform sm:px-6"
+        class="fixed inset-0 z-50 justify-center items-center flex px-4 my-4 transform sm:px-6"
         role="dialog"
         aria-modal="true"
       >
         <div
-          class={"w-full max-h-full overflow-auto bg-white shadow-lg rounded-xl dark:bg-gray-800 #{@rest[:class]}"}
+          class={"flex flex-col isolate bg-white shadow-lg rounded-xl md:min-w-[50%] min-w-full dark:bg-gray-800 #{@rest[:class]}"}
           role="document"
           phx-click-away={on_hide(@close_modal_target, @id)}
           phx-window-keydown={on_hide(@close_modal_target, @id)}
           phx-key="escape"
         >
           <!-- Header -->
-          <div class="px-5 py-3 border-b border-gray-100 dark:border-gray-700">
+          <div class="flex-none px-5 py-3 border-b border-gray-100 dark:border-gray-700">
             <div class="flex items-center justify-between">
               <div class="font-semibold text-gray-800 dark:text-gray-200">
                 <%= @title %>
@@ -85,14 +86,12 @@ defmodule LightningWeb.ModalPortal do
                 class="text-gray-400 hover:text-gray-500"
               >
                 <div class="sr-only">Close</div>
-                <svg class="w-4 h-4 fill-current">
-                  <path d="M7.95 6.536l4.242-4.243a1 1 0 111.415 1.414L9.364 7.95l4.243 4.242a1 1 0 11-1.415 1.415L7.95 9.364l-4.243 4.243a1 1 0 01-1.414-1.415L6.536 7.95 2.293 3.707a1 1 0 011.414-1.414L7.95 6.536z" />
-                </svg>
+                <Heroicons.x_mark class="w-4 h-4" />
               </button>
             </div>
           </div>
           <!-- Content -->
-          <div class="p-5">
+          <div class="grow w-full p-5 overflow-y-auto">
             <%= render_slot(@inner_block) %>
           </div>
         </div>


### PR DESCRIPTION
## Notes for the reviewer

While the ModalPortal is not adjustable, it's now a lot more respectful of the content and different media sizes. Also the scroll behaviour is improved: it scrolls the list of credential types instead of the whole modal.

I also made the list of credential types a column based layout which avoids a lot of the problems to begin with.

## Related issue

Fixes #931 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
