### PR TITLE
workflow-diagram: quick fix to flaky icons

### DIFF
--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -28,6 +28,7 @@ export const create = (parentNode: Flow.Node) => {
     },
     data: {
       body: DEFAULT_TEXT,
+      adaptor: '@openfn/language-common@latest',
     },
   });
 


### PR DESCRIPTION
This is not a good fix, but I don't have the bandwidth today to go deeper.

This is a bandaid to the problem of icons on new workflow nodes occasionally vanished.

The issue occurs because committed placeholder jobs are not given an adaptor until they are fed back into the app from the server. That is, the client creates a job like `{ id, name, body }`, which the server accepts as a patch, converts into a job like `{ id, name, body, adaptor }`, and sends back to the store.

Somehow those updated jobs from the server don't get fed into the app properly - they miss a render, basically, and so don't get assigned an adaptor.

This may be related to saving? It likely means that something is broken in the sync, which would affect concurrency, and may affect future server-side defaulting.

Anyway: as a quick fix I've set the default adaptor in the placeholder node, so that the client always has an adaptor and so always shows an icon.

It's a band-aid. We can accept or wait until I have time to look into a better fix next week.
