### PR TITLE
Fix dropped dataclip type pill and state assembler notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to
 
 ### Fixed
 
+- Dataclip type and state assembly notice for creating new dataclip dropped
+  during refactor [#975](https://github.com/OpenFn/Lightning/issues/975)
+
 ## [v0.7.1] - 2023-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Tooltip for credential select in Job Edit form is cut off
   [#972](https://github.com/OpenFn/Lightning/issues/972)
+- Dataclip type and state assembly notice for creating new dataclip dropped
+  during refactor [#975](https://github.com/OpenFn/Lightning/issues/975)
 
 ## [v0.7.2] - 2023-08-10
 
@@ -29,9 +31,6 @@ and this project adheres to
 - NodeJs security patch [1009](https://github.com/OpenFn/Lightning/pull/1009)
 
 ### Fixed
-
-- Dataclip type and state assembly notice for creating new dataclip dropped
-  during refactor [#975](https://github.com/OpenFn/Lightning/issues/975)
 
 ## [v0.7.1] - 2023-08-04
 

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -286,6 +286,10 @@ defmodule LightningWeb.Components.Common do
     )
   end
 
+  attr :type, :atom,
+    required: true,
+    values: [:run_result, :http_request, :global, :saved_input]
+
   def dataclip_type_pill(assigns) do
     base_classes = ~w[
       px-2 py-1 rounded-full inline-block text-sm font-mono
@@ -293,7 +297,7 @@ defmodule LightningWeb.Components.Common do
 
     class =
       base_classes ++
-        case assigns[:dataclip].type do
+        case assigns[:type] do
           :run_result -> ~w[bg-purple-500 text-purple-900]
           :http_request -> ~w[bg-green-500 text-green-900]
           :global -> ~w[bg-blue-500 text-blue-900]
@@ -305,7 +309,7 @@ defmodule LightningWeb.Components.Common do
 
     ~H"""
     <div class={@class}>
-      <%= @dataclip.type %>
+      <%= @type %>
     </div>
     """
   end

--- a/lib/lightning_web/live/dataclip_live/index.html.heex
+++ b/lib/lightning_web/live/dataclip_live/index.html.heex
@@ -28,7 +28,7 @@
           <.td>
             <%= dataclip.inserted_at |> Calendar.strftime("%c %Z") %>
           </.td>
-          <.td><Common.dataclip_type_pill dataclip={dataclip} /></.td>
+          <.td><Common.dataclip_type_pill type={dataclip.type} /></.td>
           <.td>
             <code>
               <%= dataclip.body

--- a/lib/lightning_web/live/job_live/manual_run_component.ex
+++ b/lib/lightning_web/live/job_live/manual_run_component.ex
@@ -67,8 +67,8 @@ defmodule LightningWeb.JobLive.ManualRunComponent do
                 Dataclip Type
               </div>
               <div class="basis-1/2 text-right">
-                <Common.dataclip_type_pill dataclip={
-                  @selected_dataclip || %{id: "", body: [], type: :saved_input}
+                <Common.dataclip_type_pill type={
+                  (@selected_dataclip && @selected_dataclip.type) || :saved_input
                 } />
               </div>
             </div>

--- a/lib/lightning_web/live/job_live/manual_run_component.ex
+++ b/lib/lightning_web/live/job_live/manual_run_component.ex
@@ -60,17 +60,16 @@ defmodule LightningWeb.JobLive.ManualRunComponent do
         phx-submit="run"
       >
         <.dataclip_selector form={f} phx-target={@myself} dataclips={@dataclips} />
-        <div :if={is_nil(@selected_dataclip)} class="flex-1 flex flex-col">
-          <Form.text_area form={f} field={:body} phx-debounce="300" />
-        </div>
-        <div :if={@selected_dataclip} class="flex-1 flex flex-col gap-4">
+        <div class="flex-1 flex flex-col gap-4">
           <div>
             <div class="flex flex-row">
               <div class="basis-1/2 font-semibold text-secondary-700">
                 Dataclip Type
               </div>
               <div class="basis-1/2 text-right">
-                <Common.dataclip_type_pill dataclip={@selected_dataclip} />
+                <Common.dataclip_type_pill dataclip={
+                  @selected_dataclip || %{id: "", body: [], type: :saved_input}
+                } />
               </div>
             </div>
             <div class="flex flex-row mt-4">
@@ -78,7 +77,7 @@ defmodule LightningWeb.JobLive.ManualRunComponent do
                 State Assembly
               </div>
               <div class="text-right text-sm">
-                <%= if(@selected_dataclip.type == :http_request) do %>
+                <%= if(not is_nil(@selected_dataclip) and @selected_dataclip.type == :http_request) do %>
                   The JSON shown here is the <em>body</em>
                   of an HTTP request. The state assembler will place this payload into
                   <code>state.data</code>
@@ -91,10 +90,13 @@ defmodule LightningWeb.JobLive.ManualRunComponent do
               </div>
             </div>
           </div>
-          <div class="h-32 overflow-y-auto">
+          <div :if={@selected_dataclip} class="h-32 overflow-y-auto">
             <LightningWeb.RunLive.Components.log_view log={
               format_dataclip_body(@selected_dataclip)
             } />
+          </div>
+          <div :if={is_nil(@selected_dataclip)}>
+            <Form.text_area form={f} field={:body} phx-debounce="300" />
           </div>
         </div>
         <div class="flex-none flex place-content-end">
@@ -289,6 +291,7 @@ defmodule LightningWeb.JobLive.ManualRunComponent do
         dataclip
       end
 
-    socket |> assign(selected_dataclip: selected_dataclip)
+    socket
+    |> assign(selected_dataclip: selected_dataclip)
   end
 end


### PR DESCRIPTION
## Notes for the reviewer

This PR propose a fix for the dropped dataclip type pill and the state assembler notice displayed when run a job with a new custom dataclip.

![Screenshot from 2023-08-09 07-52-03](https://github.com/OpenFn/Lightning/assets/86059666/090e0a13-f88a-4873-9194-d051fc4f19df)

## Related issue

Fixes #975 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
