### PR TITLE
Rename export your project from version control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Version control in project settings is now named Export your project
+  [#1015](https://github.com/OpenFn/Lightning/issues/1015)
+
 ### Fixed
 
 ## [v0.7.2] - 2023-08-10

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -123,7 +123,7 @@
           </div>
           <div id="project-settings-#" class="bg-white p-4 rounded-md">
             <div>
-              <h6 class="font-medium text-black">Version control</h6>
+              <h6 class="font-medium text-black">Export your Project</h6>
               <p class="block my-1 text-xs text-gray-600">
                 Export your project as code, to save this version or edit your project locally.
               </p>


### PR DESCRIPTION
## Notes for the reviewer
Simple UI change, changed wording on project settings/ setup page to `Export your project` rather than version control as we are introducing a new version control feature

## Related issue

Fixes #1015 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
