### PR TITLE
GitHub cert fixes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -47,9 +47,15 @@ github_app_id =
     Application.get_env(:lightning, :github_app, [])
     |> Keyword.get(:app_id, nil)
 
+github_app_name =
+  System.get_env("GITHUB_APP_NAME") ||
+    Application.get_env(:lightning, :github_app, [])
+    |> Keyword.get(:app_id, nil)
+
 config :lightning, :github_app,
   cert: decoded_cert,
-  app_id: github_app_id
+  app_id: github_app_id,
+  app_name: github_app_name
 
 config :lightning, :image_info,
   image_tag: image_tag,

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -329,9 +329,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event("run_sync", params, %{assigns: %{current_user: u}} = socket) do
-    user_name = u.first_name <> " " <> u.last_name
-
-    case VersionControl.run_sync(params["id"], user_name) do
+    case VersionControl.run_sync(params["id"], u.email) do
       {:ok, :fired} ->
         {:noreply, socket |> put_flash(:info, "Sync Initialized")}
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -2,6 +2,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   @moduledoc """
   Index Liveview for Runs
   """
+  alias Lightning.VersionControl.GithubClient
   use LightningWeb, :live_view
 
   alias Lightning.VersionControl
@@ -246,28 +247,58 @@ defmodule LightningWeb.ProjectLive.Settings do
     user_id = socket.assigns.current_user.id
     project_id = socket.assigns.project.id
 
-    {:ok, _connection} =
-      VersionControl.create_github_connection(%{
-        user_id: user_id,
-        project_id: project_id
-      })
+    case Application.get_env(:lightning, :github_app) |> Map.new() do
+      %{app_name: nil} ->
+        # Send to sentry and show cozy error
 
-    {:noreply, redirect(socket, external: "https://github.com/apps/openfn")}
+        GithubClient.send_sentry_error("Github App Name Misconfigured")
+
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           "Sorry, it seems that the GitHub App Name has not been properly configured for this instance of Lighting. Please contact the instance administrator"
+         )}
+
+      %{app_name: app_name} ->
+        {:ok, _connection} =
+          VersionControl.create_github_connection(%{
+            user_id: user_id,
+            project_id: project_id
+          })
+
+        {:noreply,
+         redirect(socket, external: "https://github.com/apps/#{app_name}")}
+    end
   end
 
   def handle_event("reinstall_app", _, socket) do
     user_id = socket.assigns.current_user.id
     project_id = socket.assigns.project.id
 
-    {:ok, _} = VersionControl.remove_github_connection(project_id)
+    case Application.get_env(:lightning, :github_app) |> Map.new() do
+      %{app_name: nil} ->
+        GithubClient.send_sentry_error("Github App Name Misconfigured")
 
-    {:ok, _connection} =
-      VersionControl.create_github_connection(%{
-        user_id: user_id,
-        project_id: project_id
-      })
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           "Sorry, it seems that the GitHub App Name has not been properly configured for this instance of Lighting. Please contact the instance administrator"
+         )}
 
-    {:noreply, redirect(socket, external: "https://github.com/apps/openfn")}
+      %{app_name: app_name} ->
+        {:ok, _} = VersionControl.remove_github_connection(project_id)
+
+        {:ok, _connection} =
+          VersionControl.create_github_connection(%{
+            user_id: user_id,
+            project_id: project_id
+          })
+
+        {:noreply,
+         redirect(socket, external: "https://github.com/apps/#{app_name}")}
+    end
   end
 
   def handle_event("delete_repo_connection", _, socket) do

--- a/test/lightning/version_control/github_client_test.exs
+++ b/test/lightning/version_control/github_client_test.exs
@@ -12,7 +12,11 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
   describe "Non success Github Client" do
     setup do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       Tesla.Mock.mock(fn env ->
         case env.url do
@@ -78,7 +82,11 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
   describe "Github Client" do
     setup do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       Tesla.Mock.mock(fn env ->
         case env.url do

--- a/test/lightning/version_control/github_client_test.exs
+++ b/test/lightning/version_control/github_client_test.exs
@@ -12,7 +12,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
   describe "Non success Github Client" do
     setup do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       Tesla.Mock.mock(fn env ->
         case env.url do
@@ -26,7 +26,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
             %Tesla.Env{status: 404}
 
           "https://api.github.com/repos/some/repo/branches" ->
-            %Tesla.Env{status: 201}
+            %Tesla.Env{status: 400}
         end
       end)
     end
@@ -37,7 +37,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
       assert {:error,
               %{
                 message:
-                  "Invalid installation ID, ensure to use the ID provided by Github"
+                  "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
               }} =
                VersionControl.fetch_installation_repos(p_repo.project_id)
     end
@@ -48,7 +48,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
       assert {:error,
               %{
                 message:
-                  "Invalid Github PEM KEY, ensure to use the KEY provided by Github"
+                  "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
               }} =
                VersionControl.run_sync(p_repo.project_id, "some-user-name")
     end
@@ -59,7 +59,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
       assert {:error,
               %{
                 message:
-                  "Invalid installation ID, ensure to use the ID provided by Github"
+                  "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
               }} =
                VersionControl.fetch_repo_branches(p_repo.project_id, p_repo.repo)
     end
@@ -70,7 +70,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
       assert {:error,
               %{
                 message:
-                  "Invalid installation ID, ensure to use the ID provided by Github"
+                  "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
               }} =
                VersionControl.fetch_installation_repos(p_repo.project_id)
     end
@@ -78,12 +78,12 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
   describe "Github Client" do
     setup do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       Tesla.Mock.mock(fn env ->
         case env.url do
           "https://api.github.com/app/installations/some-id/access_tokens" ->
-            %Tesla.Env{status: 200, body: %{"token" => "some-token"}}
+            %Tesla.Env{status: 201, body: %{"token" => "some-token"}}
 
           "https://api.github.com/installation/repositories" ->
             %Tesla.Env{

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -439,7 +439,11 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       {:ok, _view, html} =
         live(
@@ -456,7 +460,11 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       insert(:project_repo, %{
         project: project,
@@ -480,7 +488,11 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       insert(:project_repo, %{
         project: project,
@@ -496,7 +508,8 @@ defmodule LightningWeb.ProjectLiveTest do
           ~p"/projects/#{project.id}/settings#vcs"
         )
 
-      assert render(view) =~ "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
+      assert render(view) =~
+               "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
     end
 
     @tag role: :admin
@@ -505,7 +518,11 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       insert(:project_repo, %{
         project: project,
@@ -521,7 +538,8 @@ defmodule LightningWeb.ProjectLiveTest do
           ~p"/projects/#{project.id}/settings#vcs"
         )
 
-      assert render(view) =~ "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
+      assert render(view) =~
+               "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
     end
 
     @tag role: :admin
@@ -530,7 +548,11 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       repository = "some-repo"
 
@@ -555,7 +577,11 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       {:ok, view, _html} =
         live(
@@ -571,7 +597,12 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
+
       insert(:project_repo, %{project_id: project.id, project: nil})
 
       {:ok, view, _html} =
@@ -588,7 +619,12 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
+
       insert(:project_repo, %{project_id: project.id, project: nil})
 
       {:ok, view, _html} =
@@ -606,7 +642,11 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: "111111",
+        app_name: "test-github"
+      )
 
       insert(:project_repo, %{
         project_id: project.id,

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -402,10 +402,10 @@ defmodule LightningWeb.ProjectLiveTest do
             %Tesla.Env{status: 404}
 
           "https://api.github.com/app/installations/wrong-cert/access_tokens" ->
-            %Tesla.Env{status: 201}
+            %Tesla.Env{status: 200}
 
           "https://api.github.com/app/installations/some-id/access_tokens" ->
-            %Tesla.Env{status: 200, body: %{"token" => "some-token"}}
+            %Tesla.Env{status: 201, body: %{"token" => "some-token"}}
 
           "https://api.github.com/installation/repositories" ->
             %Tesla.Env{
@@ -439,7 +439,7 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       {:ok, _view, html} =
         live(
@@ -456,7 +456,7 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       insert(:project_repo, %{
         project: project,
@@ -480,7 +480,7 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       insert(:project_repo, %{
         project: project,
@@ -496,7 +496,7 @@ defmodule LightningWeb.ProjectLiveTest do
           ~p"/projects/#{project.id}/settings#vcs"
         )
 
-      assert render(view) =~ "Invalid installation ID"
+      assert render(view) =~ "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
     end
 
     @tag role: :admin
@@ -505,7 +505,7 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       insert(:project_repo, %{
         project: project,
@@ -521,7 +521,7 @@ defmodule LightningWeb.ProjectLiveTest do
           ~p"/projects/#{project.id}/settings#vcs"
         )
 
-      assert render(view) =~ "Invalid Github PEM KEY"
+      assert render(view) =~ "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
     end
 
     @tag role: :admin
@@ -530,7 +530,7 @@ defmodule LightningWeb.ProjectLiveTest do
       project: project,
       user: user
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       repository = "some-repo"
 
@@ -555,7 +555,7 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       {:ok, view, _html} =
         live(
@@ -571,7 +571,7 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
       insert(:project_repo, %{project_id: project.id, project: nil})
 
       {:ok, view, _html} =
@@ -588,7 +588,7 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
       insert(:project_repo, %{project_id: project.id, project: nil})
 
       {:ok, view, _html} =
@@ -606,7 +606,7 @@ defmodule LightningWeb.ProjectLiveTest do
       conn: conn,
       project: project
     } do
-      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111")
+      put_temporary_env(:lightning, :github_app, cert: @cert, app_id: "111111", app_name: "test-github")
 
       insert(:project_repo, %{
         project_id: project.id,


### PR DESCRIPTION
## Notes for the reviewer
Introduces further fixes for the github sync feature
-  Better error flashes when github cert or app id is wrong, try unsetting these when testing 
- Handle github http statuses according to how they send them back
- Update tests to reflect new featurs

## Related issue

Fixes #1024

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
