### PR TITLE
hack, temporarily fixes #1054 until next gen yaml exporter is created

### DIFF
--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -175,7 +175,9 @@ defmodule Lightning.ExportUtils do
 
   def build_yaml_tree(workflows, project) do
     workflows_map =
-      Enum.reduce(workflows, %{}, fn workflow, acc ->
+      workflows
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.reduce(%{}, fn workflow, acc ->
         ytree = build_workflow_yaml_tree(workflow)
         Map.put(acc, hyphenate(workflow.name), ytree)
       end)
@@ -191,9 +193,20 @@ defmodule Lightning.ExportUtils do
   end
 
   defp build_workflow_yaml_tree(workflow) do
-    jobs = Enum.map(workflow.jobs, fn j -> job_to_treenode(j) end)
-    triggers = Enum.map(workflow.triggers, fn t -> trigger_to_treenode(t) end)
-    edges = Enum.map(workflow.edges, fn e -> edge_to_treenode(e, triggers) end)
+    jobs =
+      workflow.jobs
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(fn j -> job_to_treenode(j) end)
+
+    triggers =
+      workflow.triggers
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(fn t -> trigger_to_treenode(t) end)
+
+    edges =
+      workflow.edges
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(fn e -> edge_to_treenode(e, triggers) end)
 
     flow_map = %{jobs: jobs, edges: edges, triggers: triggers}
 

--- a/lib/lightning/jobs/job.ex
+++ b/lib/lightning/jobs/job.ex
@@ -62,6 +62,8 @@ defmodule Lightning.Jobs.Job do
       job
       |> cast(attrs, [
         :id,
+        # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+        :inserted_at,
         :name,
         :body,
         :enabled,

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -448,6 +448,8 @@ defmodule Lightning.SetupUtils do
     {:ok, fhir_standard_data} =
       Jobs.create_job(%{
         name: "Transform data to FHIR standard",
+        # Note: we can drop inserted_at once there's a reliable way to         sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 0),
         body: """
         fn(state => state);
         """,
@@ -467,6 +469,8 @@ defmodule Lightning.SetupUtils do
     {:ok, send_to_openhim} =
       Jobs.create_job(%{
         name: "Send to OpenHIM to route to SHR",
+        # Note: we can drop inserted_at once there's a reliable way to         sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 1),
         body: """
         fn(state => state);
         """,
@@ -486,6 +490,8 @@ defmodule Lightning.SetupUtils do
     {:ok, notify_upload_successful} =
       Jobs.create_job(%{
         name: "Notify CHW upload successful",
+        # Note: we can drop inserted_at once there's a reliable way to         sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 2),
         body: """
         fn(state => state);
         """,
@@ -505,6 +511,8 @@ defmodule Lightning.SetupUtils do
     {:ok, notify_upload_failed} =
       Jobs.create_job(%{
         name: "Notify CHW upload failed",
+        # Note: we can drop inserted_at once there's a reliable way to         sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 3),
         body: """
         fn(state => state);
         """,
@@ -634,6 +642,8 @@ defmodule Lightning.SetupUtils do
     {:ok, get_dhis2_data} =
       Jobs.create_job(%{
         name: "Get DHIS2 data",
+        # Note: we can drop inserted_at once there's a reliable way to         sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 0),
         body: """
         get('trackedEntityInstances/PQfMcpmXeFE');
         """,
@@ -662,6 +672,8 @@ defmodule Lightning.SetupUtils do
     {:ok, upload_to_google_sheet} =
       Jobs.create_job(%{
         name: "Upload to Google Sheet",
+        # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 1),
         body: """
         fn(state => state);
         """,

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -11,14 +11,34 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
   def as_json(%Project{} = project) do
     Ecto.embedded_dump(project, :json)
-    |> Map.put("workflows", Enum.map(project.workflows, &as_json/1))
+    |> Map.put(
+      "workflows",
+      project.workflows
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(&as_json/1)
+    )
   end
 
   def as_json(%Workflow{} = workflow) do
     Ecto.embedded_dump(workflow, :json)
-    |> Map.put("jobs", Enum.map(workflow.jobs, &as_json/1))
-    |> Map.put("triggers", Enum.map(workflow.triggers, &as_json/1))
-    |> Map.put("edges", Enum.map(workflow.edges, &as_json/1))
+    |> Map.put(
+      "jobs",
+      workflow.jobs
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(&as_json/1)
+    )
+    |> Map.put(
+      "triggers",
+      workflow.triggers
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(&as_json/1)
+    )
+    |> Map.put(
+      "edges",
+      workflow.edges
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(&as_json/1)
+    )
   end
 
   def as_json(%Job{} = job) do

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -543,6 +543,8 @@ defmodule Lightning.ProjectsTest do
     workflow_1_job =
       insert(:job,
         name: "webhook job",
+        # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 0),
         project: project,
         workflow: workflow_1,
         project_credential: %{credential: credential, project: project},
@@ -563,6 +565,8 @@ defmodule Lightning.ProjectsTest do
       target_job:
         insert(:job,
           name: "on fail",
+          # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+          inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 1),
           workflow: workflow_1,
           body: "console.log('on fail')\nfn(state => state)"
         )
@@ -575,6 +579,8 @@ defmodule Lightning.ProjectsTest do
       target_job:
         insert(:job,
           name: "on success",
+          # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+          inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 2),
           workflow: workflow_1
         )
     )
@@ -582,6 +588,8 @@ defmodule Lightning.ProjectsTest do
     workflow_2_job =
       insert(:job,
         name: "some cronjob",
+        # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+        inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 3),
         workflow: workflow_2
       )
 
@@ -604,6 +612,8 @@ defmodule Lightning.ProjectsTest do
       target_job:
         insert(:job,
           name: "on cron failure",
+          # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+          inserted_at: NaiveDateTime.utc_now() |> Timex.shift(seconds: 4),
           workflow: workflow_2
         )
     )


### PR DESCRIPTION
## Notes for the reviewer

This is a temporary fix. The order of the jobs coming back from the DB was only flaking this test (and creating random diffs on the github sync) because we're ordering on `inserted_at`. Normally, this wouldn't present a problem but for the demo projects and the test project, all jobs have exactly the same `inserted_at` timestamp because our precision is `:seconds`.

Rather than dialing up the precision, or sorting on something that might change when a name changes (alpha-sort on job name?) I'd like to politely "make this go away" by setting the inserted_at for our demo projects and in the tests.

Note that this does _not_ fix the random `inserted_at` sort when a user deploys to a Lightning instance from scratch, but in the OpenFn world that's an edge case right now and I imagine that before that happens very much we'll have a new, better way of sorting YAML.

If you @stuartc , are super against this, then I think the backup would be to say to users: "Every time you pull a project from Lightning your project.yaml and your projectState.json will have their jobs alphabetically sorted, regardless of what your YAML looked like before. If you deploy a YAML to Lightning that isn't alphabetically sorted, you'll get back a sorted projectState.json, but if you then pull down changes from Lightning to your repo you'll notice a phantom diff, where we sort your YAML for you."

## Related issue

Fixes #1054

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
