### PR TITLE
editor: remove redundant overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   project.yaml export [#1050](https://github.com/OpenFn/Lightning/issues/1050)
 - Allows the demo script to set a project id during creation to help with cli
   deploy/pull/Github integration testing.
+- Fixed an issue where the monaco suggestion tooltip was offset from the main
+  editor
 
 ## [v0.7.3] - 2023-08-15
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -80,7 +80,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           <div
             :if={@selected_job && @selection_mode == "expand"}
             class="fixed left-0 top-0 right-0 bottom-0 m-8 hidden inset-0
-            bg-white fixed inset-0 z-10 overflow-y-auto rounded-lg shadow-xl"
+            bg-white fixed inset-0 z-49 overflow-y-auto rounded-lg shadow-xl"
             phx-mounted={fade_in()}
             phx-remove={fade_out()}
           >

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -79,7 +79,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
         <div class="flex-none" id="job-editor-pane">
           <div
             :if={@selected_job && @selection_mode == "expand"}
-            class="fixed left-0 top-0 right-0 bottom-0 m-8 hidden inset-0 z-50
+            class="fixed left-0 top-0 right-0 bottom-0 m-8 hidden inset-0
             bg-white fixed inset-0 z-10 overflow-y-auto rounded-lg shadow-xl"
             phx-mounted={fade_in()}
             phx-remove={fade_out()}


### PR DESCRIPTION
I have no idea why this works.

Something about the DOM structure was meaning that the editor's suggestion box was getting offset weirdly.

While trying to work out the offending style, I happened to notice that the editor redundant declares z-index twice. Being a good citizen (I hope) I removed the `z-50` class as it wasn't really applying.

And suddenly it all started working. 

It turns out that any other `z-` class is fine - it's just the presence `z-50` that breaks it.

It just so happens that the top modal also uses z-50. Both the tooltip and the modal use `fixed` position.

I think there's something funny going on in the DOM layout that's trigging the offset - like it's trying to arrange these two fixed elements together in the same layer, causing the offset.

Wierd.

## Repro steps

Here's how to repro on main:

* Create or open a `dhis2@latest` job
* Paste this code:
```
create("programs", {
    
});
````
* Place the cursor inside the object (anywhere in the second line) and press ctrl+space
* A tooltip should appear, floating to the right of the editor window

Against this branch the same test should render the tooltip next to the cursor.

## Related issue

Fixes #1030

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
