### PR TITLE
Fix premature 'this run failed' message before run completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Output incorrectly shows "this run failed" when the run hasn't yet finished
+  [#1048](https://github.com/OpenFn/Lightning/issues/1048)
+
 ## [v0.8.2] - 2023-08-31
 
 ### Added

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -194,6 +194,17 @@ defmodule LightningWeb.RunLive.Components do
       </div>
       <div id="output_section" style="display: none;" class="@container">
         <%= cond  do %>
+          <% is_nil(@run.exit_code) -> %>
+            <.dataclip_view
+              dataclip={nil}
+              no_dataclip_message={
+                %{
+                  label: "This run has not yet finished.",
+                  description:
+                    "There is no output. See the logs for more information"
+                }
+              }
+            />
           <% @run.exit_code > 0 -> %>
             <.dataclip_view
               dataclip={nil}

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -24,7 +24,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
                  insert(:run, exit_code: nil, output_dataclip_id: nil)
                  |> Lightning.Repo.preload(:log_lines)
              ) =~
-               "This run failed"
+               "This run has not yet finished."
 
       assert render_component(&LightningWeb.RunLive.Components.run_viewer/1,
                run:

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -18,6 +18,14 @@ defmodule LightningWeb.RunLive.ComponentsTest do
              ) =~
                "This run failed"
 
+      assert render_component(
+               &LightningWeb.RunLive.Components.run_viewer/1,
+               run:
+                 insert(:run, exit_code: nil, output_dataclip_id: nil)
+                 |> Lightning.Repo.preload(:log_lines)
+             ) =~
+               "This run failed"
+
       assert render_component(&LightningWeb.RunLive.Components.run_viewer/1,
                run:
                  insert(:run, exit_code: 0, output_dataclip_id: nil)


### PR DESCRIPTION
## Notes for the reviewer

- **Root Cause:** The issue originated from a comparison between `nil` and `0` in the condition `@run.exit_code > 0` [here](https://github.com/OpenFn/Lightning/blob/68ec1384bcee4613512fb809ef75f833d15811a0/lib/lightning_web/live/run_live/components.ex#L197). In Elixir, the expression `nil > 0` evaluates to `true`, leading to the incorrect display message.

- **Resolution:** Introduced a new condition to check if `@run.exit_code` is nil before evaluating its value. This ensures that the message "This run has not yet finished." is displayed appropriately when the run is ongoing.

## Related issue

Fixes #1048 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
