### PR TITLE
Ensure Unique Job Names Within the Same Workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
 - Add favicons [#1079](https://github.com/OpenFn/Lightning/issues/1079)
 - Validate job name in placeholder job node
   [#1021](https://github.com/OpenFn/Lightning/issues/1021)
+- Make job names unique per workflow
+  [#1053](https://github.com/OpenFn/Lightning/issues/1053)
 
 ### Changed
 

--- a/lib/lightning/jobs/job.ex
+++ b/lib/lightning/jobs/job.ex
@@ -74,6 +74,7 @@ defmodule Lightning.Jobs.Job do
 
     change
     |> validate()
+    |> unique_constraint(:name, name: "jobs_name_workflow_id_index")
   end
 
   def validate(changeset) do

--- a/priv/repo/migrations/20230904133348_add_unique_name_index_to_jobs.exs
+++ b/priv/repo/migrations/20230904133348_add_unique_name_index_to_jobs.exs
@@ -1,0 +1,7 @@
+defmodule Lightning.Repo.Migrations.AddUniqueNameIndexToJobs do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:jobs, [:name, :workflow_id])
+  end
+end

--- a/priv/repo/migrations/20230904133348_add_unique_name_index_to_jobs.exs
+++ b/priv/repo/migrations/20230904133348_add_unique_name_index_to_jobs.exs
@@ -1,7 +1,0 @@
-defmodule Lightning.Repo.Migrations.AddUniqueNameIndexToJobs do
-  use Ecto.Migration
-
-  def change do
-    create unique_index(:jobs, [:name, :workflow_id])
-  end
-end

--- a/priv/repo/migrations/20230906133408_add_unique_name_index_to_jobs.exs
+++ b/priv/repo/migrations/20230906133408_add_unique_name_index_to_jobs.exs
@@ -1,0 +1,15 @@
+defmodule Lightning.Repo.Migrations.AddUniqueNameIndexToJobs do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE UNIQUE INDEX jobs_name_workflow_id_index ON jobs (LOWER(REPLACE(name, '-', ' ')), workflow_id);
+    """
+  end
+
+  def down do
+    execute """
+    DROP INDEX jobs_name_workflow_id_index;
+    """
+  end
+end

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -127,8 +127,8 @@ defmodule Lightning.InvocationTest do
 
     test "list_runs_for_project/2 returns runs ordered by inserted at desc" do
       workflow = workflow_fixture() |> Repo.preload(:project)
-      job_one = job_fixture(workflow_id: workflow.id)
-      job_two = job_fixture(workflow_id: workflow.id)
+      job_one = job_fixture(name: "job 1", workflow_id: workflow.id)
+      job_two = job_fixture(name: "job 2", workflow_id: workflow.id)
 
       first_run =
         run_fixture(job_id: job_one.id)

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -553,6 +553,8 @@ defmodule Lightning.InvocationTest do
       {_workflow, trigger, job1} =
         build_workflow(project: project, name: "chw-help")
 
+      trigger |> Repo
+
       Enum.each(1..10, fn index ->
         create_work_order(project, job1, trigger, now, 10 * index)
       end)

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -387,15 +387,8 @@ defmodule Lightning.InvocationTest do
     test "list_work_orders_for_project/1 returns runs ordered by desc finished_at" do
       project = insert(:project)
 
-      job_one = build(:job)
-      trigger = build(:trigger)
-
-      workflow =
-        build(:workflow, name: "chw-help", project: project)
-        |> with_job(job_one)
-        |> with_trigger(trigger)
-        |> with_edge({trigger, job_one})
-        |> insert()
+      {workflow, _trigger, job_one} =
+        build_workflow(project: project, name: "chw-help")
 
       dataclip = insert(:dataclip)
 

--- a/test/lightning/jobs/job_test.exs
+++ b/test/lightning/jobs/job_test.exs
@@ -1,4 +1,5 @@
 defmodule Lightning.Jobs.JobTest do
+  alias Lightning.WorkflowsFixtures
   use Lightning.DataCase, async: true
 
   alias Lightning.Jobs.Job
@@ -13,6 +14,35 @@ defmodule Lightning.Jobs.JobTest do
   end
 
   describe "changeset/2" do
+    test "raises a constraint error when jobs in the same workflow have the same name" do
+      workflow = WorkflowsFixtures.workflow_fixture()
+
+      job_attrs = %{
+        name: "Test Job",
+        body: ~s[fn(state => state)],
+        workflow_id: workflow.id
+      }
+
+      {:ok, _} =
+        %Job{}
+        |> Job.changeset(job_attrs)
+        |> Repo.insert()
+
+      {:error, changeset} =
+        %Job{}
+        |> Job.changeset(job_attrs)
+        |> Repo.insert()
+
+      refute changeset.valid?
+
+      assert changeset.errors[:name] ==
+               {"has already been taken",
+                [
+                  constraint: :unique,
+                  constraint_name: "jobs_name_workflow_id_index"
+                ]}
+    end
+
     test "name can't be longer than 100 chars" do
       name = random_job_name(101)
       errors = Job.changeset(%Job{}, %{name: name}) |> errors_on()

--- a/test/lightning/jobs/job_test.exs
+++ b/test/lightning/jobs/job_test.exs
@@ -1,8 +1,9 @@
 defmodule Lightning.Jobs.JobTest do
-  alias Lightning.WorkflowsFixtures
   use Lightning.DataCase, async: true
 
   alias Lightning.Jobs.Job
+
+  import Lightning.Factories
 
   defp random_job_name(length) do
     for _ <- 1..length,
@@ -15,7 +16,7 @@ defmodule Lightning.Jobs.JobTest do
 
   describe "changeset/2" do
     test "raises a constraint error when jobs in the same workflow have the same name" do
-      workflow = WorkflowsFixtures.workflow_fixture()
+      workflow = insert(:workflow)
 
       job_attrs = %{
         name: "Test Job",

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -73,11 +73,17 @@ defmodule Lightning.JobsTest do
       workflow_1 = workflow_fixture()
       workflow_2 = workflow_fixture()
 
-      workflow_1_job_1 = job_fixture(workflow_id: workflow_1.id)
-      workflow_1_job_2 = job_fixture(workflow_id: workflow_1.id)
+      workflow_1_job_1 =
+        job_fixture(name: "workflow 1 job 1", workflow_id: workflow_1.id)
 
-      workflow_2_job_1 = job_fixture(workflow_id: workflow_2.id)
-      workflow_2_job_2 = job_fixture(workflow_id: workflow_2.id)
+      workflow_1_job_2 =
+        job_fixture(name: "workflow 1 job 2", workflow_id: workflow_1.id)
+
+      workflow_2_job_1 =
+        job_fixture(name: "workflow 2 job 1", workflow_id: workflow_2.id)
+
+      workflow_2_job_2 =
+        job_fixture(name: "workflow 2 job 2", workflow_id: workflow_2.id)
 
       assert Jobs.get_upstream_jobs_for(workflow_1_job_1) == [
                Jobs.get_job!(workflow_1_job_2.id)
@@ -236,9 +242,9 @@ defmodule Lightning.JobsTest do
 
       {:ok, %Job{} = upstream_job} =
         Jobs.create_job(%{
+          name: "job 1",
           body: "some body",
           enabled: true,
-          name: "some name",
           adaptor: "@openfn/language-common",
           trigger: %{type: "webhook"},
           workflow_id: workflow.id
@@ -246,9 +252,9 @@ defmodule Lightning.JobsTest do
 
       {:ok, %Job{} = job} =
         Jobs.create_job(%{
+          name: "job 2",
           body: "some body",
           enabled: true,
-          name: "some name",
           adaptor: "@openfn/language-common",
           trigger: %{type: "on_job_success", upstream_job_id: upstream_job.id},
           workflow_id: workflow.id
@@ -264,7 +270,7 @@ defmodule Lightning.JobsTest do
         Jobs.create_job(%{
           body: "some body",
           enabled: true,
-          name: "some name",
+          name: "job 1",
           adaptor: "@openfn/language-common",
           trigger: %{type: "webhook"},
           workflow_id: workflow.id
@@ -276,7 +282,7 @@ defmodule Lightning.JobsTest do
         Jobs.create_job(%{
           body: "some body",
           enabled: true,
-          name: "some name",
+          name: "job 2",
           adaptor: "@openfn/language-common",
           trigger: %{type: "on_job_success", upstream_job_id: upstream_job.id},
           workflow_id: workflow.id

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -48,17 +48,13 @@ defmodule Lightning.JobsTest do
     end
 
     test "get_job!/1 returns the job with given id" do
-      job = insert(:job)
+      %{id: job_id} = insert(:job)
 
-      assert Jobs.get_job!(job.id) |> unload_relation(:workflow) ==
-               job |> unload_relation(:workflow)
+      assert %Job{id: ^job_id} = Jobs.get_job!(job_id)
 
       assert_raise Ecto.NoResultsError, fn ->
         Jobs.get_job!(Ecto.UUID.generate())
       end
-
-      assert Jobs.get_job(job.id) |> unload_relation(:workflow) ==
-               job |> unload_relation(:workflow)
 
       assert Jobs.get_job(Ecto.UUID.generate()) == nil
     end

--- a/test/lightning/pipeline_test.exs
+++ b/test/lightning/pipeline_test.exs
@@ -15,11 +15,13 @@ defmodule Lightning.PipelineTest do
     test "starts a run for a given AttemptRun and executes its on_job_failure downstream job" do
       %{job: job, trigger: trigger} =
         workflow_job_fixture(
+          name: "job 1",
           body: ~s[fn(state => { throw new Error("I'm supposed to fail.") })]
         )
 
       %{id: downstream_job_id} =
         job_fixture(
+          name: "job 2",
           trigger: %{type: :on_job_failure, upstream_job_id: job.id},
           body: ~s[fn(state => state)],
           workflow_id: job.workflow_id,

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -33,8 +33,8 @@ defmodule Lightning.ProjectsTest do
     end
 
     test "get_project!/1 returns the project with given id" do
-      project = project_fixture() |> unload_relation(:project_users)
-      assert Projects.get_project!(project.id) == project
+      project = project_fixture()
+      assert Projects.get_project!(project.id) |> to_map() == project |> to_map()
 
       assert_raise Ecto.NoResultsError, fn ->
         Projects.get_project!(Ecto.UUID.generate())

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -63,8 +63,8 @@ defmodule Lightning.WorkflowsTest do
     test "delete_workflow/1 deletes the workflow" do
       workflow = WorkflowsFixtures.workflow_fixture()
 
-      job_1 = JobsFixtures.job_fixture(workflow_id: workflow.id)
-      job_2 = JobsFixtures.job_fixture(workflow_id: workflow.id)
+      job_1 = JobsFixtures.job_fixture(name: "job 1", workflow_id: workflow.id)
+      job_2 = JobsFixtures.job_fixture(name: "job 2", workflow_id: workflow.id)
 
       assert {:ok, %Workflows.Workflow{}} = Workflows.delete_workflow(workflow)
 
@@ -348,8 +348,8 @@ defmodule Lightning.WorkflowsTest do
 
       assert w2.deleted_at == nil
 
-      job_1 = JobsFixtures.job_fixture(workflow_id: w1.id)
-      job_2 = JobsFixtures.job_fixture(workflow_id: w1.id)
+      job_1 = JobsFixtures.job_fixture(name: "job 1", workflow_id: w1.id)
+      job_2 = JobsFixtures.job_fixture(name: "job 2", workflow_id: w1.id)
 
       # mark delete at request of a workflows and disable all associated jobs
       assert {:ok, _workflow} = Workflows.mark_for_deletion(w1)

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -29,7 +29,7 @@ defmodule LightningWeb.EndToEndTest do
           assert unquote(string) =~ ~r/(?=.*compiler)(?=.*0.0.29)/
 
         :adaptor ->
-          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.0.2)/
+          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.0.3)/
       end
     end
   end

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -275,12 +275,14 @@ defmodule LightningWeb.RunWorkOrderTest do
          %{conn: conn, project: project} do
       %{job: job_a, trigger: trigger} =
         workflow_job_fixture(
+          name: "job a",
           project_id: project.id,
           body: ~s[fn(state => { return {...state, extra: "data"} })]
         )
 
       job_b =
         job_fixture(
+          name: "job b",
           trigger: %{type: :on_job_success, upstream_job_id: job_a.id},
           body: ~s[fn(state => state)],
           workflow_id: job_a.workflow_id
@@ -288,6 +290,7 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       job_c =
         job_fixture(
+          name: "job c",
           trigger: %{type: :on_job_success, upstream_job_id: job_b.id},
           body: ~s[fn(state => state)],
           workflow_id: job_a.workflow_id
@@ -463,12 +466,14 @@ defmodule LightningWeb.RunWorkOrderTest do
          %{conn: conn, project: project} do
       %{job: job_a, trigger: trigger} =
         workflow_job_fixture(
+          name: "job a",
           project_id: project.id,
           body: ~s[fn(state => { return {...state, extra: "data"} })]
         )
 
       job_b =
         job_fixture(
+          name: "job b",
           trigger: %{type: :on_job_success, upstream_job_id: job_a.id},
           body: ~s[fn(state => state)],
           workflow_id: job_a.workflow_id
@@ -476,6 +481,7 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       job_c =
         job_fixture(
+          name: "job c",
           trigger: %{type: :on_job_success, upstream_job_id: job_b.id},
           body: ~s[fn(state => state)],
           workflow_id: job_a.workflow_id

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -27,6 +27,7 @@ defmodule Lightning.Factories do
   def job_factory do
     %Lightning.Jobs.Job{
       id: fn -> Ecto.UUID.generate() end,
+      name: sequence(:job_name, &"job-#{&1}"),
       workflow: build(:workflow),
       body: "console.log('hello!');"
     }

--- a/test/support/model_helpers.ex
+++ b/test/support/model_helpers.ex
@@ -4,6 +4,9 @@ defmodule Lightning.ModelHelpers do
   Our factories product models with loaded relations on them but our context
   functions don't preload credentials - this helps make make our factories
   uniform for these specific tests.
+
+  > NOTE: It may be preferable to use `to_map/1` instead of this function.
+  > as it is clearer about what the differences are between the two models.
   """
   def unload_relation(model, field) do
     model
@@ -21,5 +24,18 @@ defmodule Lightning.ModelHelpers do
 
     Ecto.Changeset.change(struct, %{inserted_at: inserted_at})
     |> Lightning.Repo.update!()
+  end
+
+  @doc """
+  Strips an Ecto model of its meta data and returns a map of its fields.
+
+  Useful for comparing models in tests, where loaded relations (or preloads) may
+  be different.
+  """
+  @spec to_map(Ecto.Schema.t()) :: map()
+  def to_map(%{__meta__: _, __struct__: s} = model) do
+    s.__schema__(:fields)
+    |> Enum.map(fn field -> {field, model |> Map.get(field)} end)
+    |> Enum.into(%{})
   end
 end


### PR DESCRIPTION
## Notes for the reviewer

This PR introduces a database constraint and accompanying changeset validations to ensure that job names within a given workflow are unique.

- [x] Added a unique index on the jobs table combining name and workflow_id fields.
- [x] Modified the Job changeset function to incorporate the unique_constraint validation.
- [x] Introduced a unit test to ensure the validity of the new constraint and its proper functioning.

With these changes in place, users will be prevented from inadvertently creating jobs with the same name in a given workflow,

## Related issue

Fixes #1053 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
