### PR TITLE
Render error when workflow diagram node is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Render error when workflow diagram node is invalid
+  [#956](https://github.com/OpenFn/Lightning/issues/956)
+
 ### Changed
 
 ### Fixed

--- a/assets/js/workflow-diagram/nodes/Job.tsx
+++ b/assets/js/workflow-diagram/nodes/Job.tsx
@@ -26,6 +26,7 @@ const JobNode = ({
       sourcePosition={sourcePosition}
       allowSource
       toolbar={toolbar}
+      errors={props.data?.errors}
     />
   );
 };

--- a/assets/js/workflow-diagram/styles.ts
+++ b/assets/js/workflow-diagram/styles.ts
@@ -11,6 +11,8 @@ import { Flow } from './types';
 export const EDGE_COLOR = '#b1b1b7';
 export const EDGE_COLOR_SELECTED = '#4f46e5';
 
+export const ERROR_COLOR = '#ef4444';
+
 export const labelStyles = (selected?: boolean) => {
   const primaryColor = selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
   return {
@@ -56,7 +58,7 @@ export const styleEdge = (edge: Flow.Edge) => {
   return edge;
 };
 
-export const nodeIconStyles = (selected?: boolean) => {
+export const nodeIconStyles = (selected?: boolean, hasErrors?: boolean) => {
   const size = 100;
   const primaryColor = selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
   return {
@@ -65,7 +67,7 @@ export const nodeIconStyles = (selected?: boolean) => {
     anchorx: size / 2,
     strokeWidth: 2,
     style: {
-      stroke: primaryColor,
+      stroke: hasErrors ? ERROR_COLOR : primaryColor,
       fill: 'white',
     },
   };

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -291,7 +291,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   defp save_is_blocked_error(assigns) do
     ~H"""
-    <span class="flex items-center font-medium text-sm text-red-600 mr-4 gap-x-1.5">
+    <span class="flex items-center font-medium text-sm text-red-600 ml-1 mr-4 gap-x-1.5">
       <.icon name="hero-exclamation-circle" class="h-5 w-5" />
       <%= render_slot(@inner_block) %>
     </span>


### PR DESCRIPTION
## Notes for the reviewer

This PR introduces improved error handling when workflow diagram nodes are in invalid state.

- [x] Introduced a `hasErrors` utility function to detect the presence of errors in an object.
- [x] Enhanced the `ErrorMessage` component to conditionally display based on error presence.
- [x] Updated the `Label` component to visually indicate error presence.

## Related issue

Fixes #956 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
