### PR TITLE
Bring credential delete in line with new GDPR interpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ and this project adheres to
 - Add favicons [#1079](https://github.com/OpenFn/Lightning/issues/1079)
 - Validate job name in placeholder job node
   [#1021](https://github.com/OpenFn/Lightning/issues/1021)
+- Bring credential delete in line with new GDPR interpretation
+  [#802](https://github.com/OpenFn/Lightning/issues/802)
 
 ### Changed
 
 ### Fixed
+
+- Cannot delete some credentials via web UI
+  [#1072](https://github.com/OpenFn/Lightning/issues/1072)
 
 ## [v0.8.3] - 2023-09-05
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -95,6 +95,8 @@ conditional_cron =
     do:
       base_oban_cron ++
         [
+          {"0 2 * * *", Lightning.Credentials,
+           args: %{"type" => "purge_deleted"}},
           {"0 2 * * *", Lightning.Accounts, args: %{"type" => "purge_deleted"}},
           {"0 2 * * *", Lightning.Projects, args: %{"type" => "purge_deleted"}}
         ],

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -116,15 +116,17 @@ defmodule Lightning.Accounts.UserNotifier do
   def send_credential_deletion_notification_email(user) do
     deliver(user.email, "Credential Deletion", """
 
-
     Hi #{user.first_name},
 
-    Your credential has been scheduled for deletion. It will be permanently deleted in #{permanent_deletion_grace()}.
+    We wanted to inform you that one of your credentials has been scheduled for deletion.
 
-    Note that if your credential is associated to some ongoing activities in some projects, it won't be deleted until that activity expires.
+    Here's what this means for you:
 
-    If you don't want this to happen, please contact #{admin()} as soon as possible.
+    - The credential will be disconnected from all projects it's currently associated with.
+    - Any jobs that were using this credential will lose their connection to it, and might not function as intended.
+    - Your credential will be permanently deleted in #{permanent_deletion_grace()}.
 
+    The good news is that you can cancel this deletion anytime before the scheduled date. If you believe this is a mistake or you'd like to discuss this further, please contact #{admin()} as soon as possible.
     """)
   end
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -102,31 +102,32 @@ defmodule Lightning.Accounts.UserNotifier do
 
     Hi #{user.first_name},
 
-    Your Lightning account has been scheduled for deletion. From now on your account is disabled and you are no longer able to access it.
+    Your Lightning account has been scheduled for deletion. It has been disabled and you will no longer be able to login.
 
-    It will be permanently deleted in #{permanent_deletion_grace()}. This will delete all of your credentials and remove you from all projects you are participating.
+    It will be permanently deleted in #{permanent_deletion_grace()}. This will delete all of your credentials and remove you from all projects.
 
-    Note that if you have some ongoing activities in some projects, your account won't be deleted until that activity expires.
+    Note that if you have auditable events associated with projects, your account won't be permanently deleted until that audit activity expires.
 
-    If you don't want this to happen, please contact #{admin()} as soon as possible.
-
+    If you have any questions or don't want your account deleted, please contact #{admin()} as soon as possible.
     """)
   end
 
-  def send_credential_deletion_notification_email(user) do
+  def send_credential_deletion_notification_email(user, credential) do
     deliver(user.email, "Credential Deletion", """
 
     Hi #{user.first_name},
 
-    We wanted to inform you that one of your credentials has been scheduled for deletion.
+    Your "#{credential.name}" has been scheduled for deletion.
 
     Here's what this means for you:
 
-    - The credential will be disconnected from all projects it's currently associated with.
-    - Any jobs that were using this credential will lose their connection to it, and might not function as intended.
-    - Your credential will be permanently deleted in #{permanent_deletion_grace()}.
+    - The credential has been disconnected from all projects. Nobody can use it.
+    - Any jobs that were using this credential are now set to run without any credential. (If they require authentication, they may no longer function properly.)
+    - After #{permanent_deletion_grace()} your credentials secrets will be scrubbed. The record itself may be kept until all related audit trail activity has expired.
 
-    The good news is that you can cancel this deletion anytime before the scheduled date. If you believe this is a mistake or you'd like to discuss this further, please contact #{admin()} as soon as possible.
+    You can cancel this deletion anytime before the scheduled date.
+
+    If you have any questions or don't want your credential deleted, please contact #{admin()} as soon as possible.
     """)
   end
 
@@ -159,7 +160,6 @@ defmodule Lightning.Accounts.UserNotifier do
     #{url}
 
     If you didn't request this change, please ignore this.
-
     """)
   end
 
@@ -176,7 +176,6 @@ defmodule Lightning.Accounts.UserNotifier do
     Please visit your inbox (#{new_email}) to activate your account
 
     If you didn't request this change, please ignore this.
-
     """)
   end
 
@@ -207,7 +206,6 @@ defmodule Lightning.Accounts.UserNotifier do
     - #{failed_workorders} work orders that failed, crashed or timed out
     Click the link below to view this in the history page:
     #{build_digest_url(workflow, start_date, end_date)}
-
     """
   end
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -206,6 +206,7 @@ defmodule Lightning.Accounts.UserNotifier do
     - #{failed_workorders} work orders that failed, crashed or timed out
     Click the link below to view this in the history page:
     #{build_digest_url(workflow, start_date, end_date)}
+
     """
   end
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -113,6 +113,21 @@ defmodule Lightning.Accounts.UserNotifier do
     """)
   end
 
+  def send_credential_deletion_notification_email(user) do
+    deliver(user.email, "Credential Deletion", """
+
+
+    Hi #{user.first_name},
+
+    Your credential has been scheduled for deletion. It will be permanently deleted in #{permanent_deletion_grace()}.
+
+    Note that if your credential is associated to some ongoing activities in some projects, it won't be deleted until that activity expires.
+
+    If you don't want this to happen, please contact #{admin()} as soon as possible.
+
+    """)
+  end
+
   @doc """
   Deliver instructions to reset a user password.
   """

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -220,6 +220,40 @@ defmodule Lightning.Credentials do
   end
 
   @doc """
+  Checks if a given `Credential` has any associated `Run` activity.
+
+  ## Parameters
+
+    - `_credential`: A `Credential` struct. Only the `id` field is used by the function.
+
+  ## Returns
+
+    - `true` if there's at least one `Run` associated with the given `Credential`.
+    - `false` otherwise.
+
+  ## Examples
+
+      iex> has_activity_in_projects?(%Credential{id: some_id})
+      true
+
+      iex> has_activity_in_projects?(%Credential{id: another_id})
+      false
+
+  ## Notes
+
+  This function leverages the association between `Run` and `Credential` to determine
+  if any runs exist for a given credential. It's a fast check that does not load
+  any records into memory, but simply checks for their existence.
+
+  """
+  def has_activity_in_projects?(%Credential{id: id} = _credential) do
+    from(run in Lightning.Invocation.Run,
+      where: run.credential_id == ^id
+    )
+    |> Repo.exists?()
+  end
+
+  @doc """
   Returns an `%Ecto.Changeset{}` for tracking credential changes.
 
   ## Examples

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -343,7 +343,7 @@ defmodule Lightning.Credentials do
     credential
     |> Repo.preload(:user)
     |> Map.get(:user)
-    |> UserNotifier.send_credential_deletion_notification_email()
+    |> UserNotifier.send_credential_deletion_notification_email(credential)
   end
 
   @doc """

--- a/lib/lightning/credentials/credential.ex
+++ b/lib/lightning/credentials/credential.ex
@@ -17,11 +17,13 @@ defmodule Lightning.Credentials.Credential do
   @foreign_key_type :binary_id
   schema "credentials" do
     field :name, :string
-
     field :body, Lightning.Encrypted.Map
     field :production, :boolean, default: false
     field :schema, :string
+    field :scheduled_deletion, :utc_datetime
+
     belongs_to :user, User
+
     has_many :project_credentials, ProjectCredential
     has_many :projects, through: [:project_credentials, :project]
 
@@ -31,7 +33,14 @@ defmodule Lightning.Credentials.Credential do
   @doc false
   def changeset(credential, attrs) do
     credential
-    |> cast(attrs, [:name, :body, :production, :user_id, :schema])
+    |> cast(attrs, [
+      :name,
+      :body,
+      :production,
+      :user_id,
+      :schema,
+      :scheduled_deletion
+    ])
     |> cast_assoc(:project_credentials)
     |> validate_required([:name, :body, :user_id])
     |> assoc_constraint(:user)

--- a/lib/lightning_web/live/components/credential_deletion_modal.ex
+++ b/lib/lightning_web/live/components/credential_deletion_modal.ex
@@ -9,24 +9,15 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
 
   @impl true
   def update(
-        %{credential: credential, current_user: current_user} = assigns,
+        %{credential: credential} = assigns,
         socket
       ) do
-    can_delete_credential =
-      Lightning.Policies.Users
-      |> Lightning.Policies.Permissions.can?(
-        :delete_credential,
-        current_user,
-        credential
-      )
-
     {:ok,
      socket
      |> assign(
        delete_now?: !is_nil(credential.scheduled_deletion),
        has_activity_in_projects?:
-         Credentials.has_activity_in_projects?(credential),
-       can_delete_credential: can_delete_credential
+         Credentials.has_activity_in_projects?(credential)
      )
      |> assign(assigns)}
   end
@@ -36,11 +27,6 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
     credential = Credentials.get_credential!(id)
 
     cond do
-      not socket.assigns.can_delete_credential ->
-        {:noreply,
-         put_flash(socket, :error, "You can't perform this action")
-         |> push_patch(to: ~p"/credentials")}
-
       not socket.assigns.delete_now? ->
         case Credentials.schedule_credential_deletion(credential) do
           {:ok, %Credential{}} ->

--- a/lib/lightning_web/live/components/credential_deletion_modal.ex
+++ b/lib/lightning_web/live/components/credential_deletion_modal.ex
@@ -69,11 +69,19 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
     <div id={"credential-#{@id}"}>
       <PetalComponents.Modal.modal
         max_width="sm"
-        title="Delete credential"
+        title="Credential marked for deletion"
         close_modal_target={@myself}
       >
         <p>
-          This credential can't be deleted for now. It is involved in projects that has ongoing activities.
+          This credential has been used in workflow attempts that
+          are still monitored in at least one project's audit trail. The
+          credential will be made unavailable for future use immediately and
+          after a cooling-off period all secrets will be permanently scrubbed,
+          but the record itself will not be removed until related workflow
+          attempts have been purged.
+        </p>
+        <p class="py-2">
+          Contact your instance administrator for more details.
         </p>
         <div class="flex justify-end">
           <PetalComponents.Button.button
@@ -95,15 +103,23 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
         close_modal_target={@myself}
       >
         <p>
-          Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?
+          Deleting this credential will immediately remove it from all jobs and
+          projects. If you later restore it, you will need to re-share it with
+          projects and re-associate it with jobs. Are you sure you'd like to
+          delete the credential?
         </p>
 
         <%= if @has_activity_in_projects? do %>
           <div class="hidden sm:block" aria-hidden="true">
             <div class="py-2"></div>
           </div>
-          <p>
-            *Note that this credential still has activity related to active projects. We may not be able to delete it entirely from the app until those activities are expired.
+          <p class="italic text-slate-500">
+            *This credential has been used in workflow attempts that
+            are still monitored in at least one project's audit trail. The
+            credential will be made unavailable for future use immediately and
+            after a cooling-off period all secrets will be permanently scrubbed,
+            but the record itself will not be removed until related workflow
+            attempts have been purged.
           </p>
         <% end %>
         <div class="hidden sm:block" aria-hidden="true">

--- a/lib/lightning_web/live/components/credential_deletion_modal.ex
+++ b/lib/lightning_web/live/components/credential_deletion_modal.ex
@@ -80,7 +80,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
   @impl true
   def render(%{delete_now?: true, has_activity_in_projects?: true} = assigns) do
     ~H"""
-    <div id={"user-#{@id}"}>
+    <div id={"credential-#{@id}"}>
       <PetalComponents.Modal.modal
         max_width="sm"
         title="Delete credential"
@@ -102,7 +102,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
 
   def render(assigns) do
     ~H"""
-    <div id={"user-#{@id}"}>
+    <div id={"credential-#{@id}"}>
       <PetalComponents.Modal.modal
         max_width="sm"
         title="Delete credential"

--- a/lib/lightning_web/live/components/credential_deletion_modal.ex
+++ b/lib/lightning_web/live/components/credential_deletion_modal.ex
@@ -83,7 +83,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
     <div id={"user-#{@id}"}>
       <PetalComponents.Modal.modal
         max_width="sm"
-        title="Delete user"
+        title="Delete credential"
         close_modal_target={@myself}
       >
         <p>
@@ -105,7 +105,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
     <div id={"user-#{@id}"}>
       <PetalComponents.Modal.modal
         max_width="sm"
-        title="Delete user"
+        title="Delete credential"
         close_modal_target={@myself}
       >
         <p>

--- a/lib/lightning_web/live/components/credential_deletion_modal.ex
+++ b/lib/lightning_web/live/components/credential_deletion_modal.ex
@@ -1,0 +1,165 @@
+defmodule LightningWeb.Components.CredentialDeletionModal do
+  @moduledoc false
+  alias Lightning.Credentials
+  use LightningWeb, :component
+
+  use Phoenix.LiveComponent
+
+  alias Lightning.Accounts
+  alias Lightning.Accounts.User
+
+  @impl true
+  def update(%{credential: credential} = assigns, socket) do
+    {:ok,
+     socket
+     |> assign(
+       delete_now?: !is_nil(credential.scheduled_deletion),
+       has_activity_in_projects?:
+         Credentials.has_activity_in_projects?(credential)
+     )
+     |> assign(assigns)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    credential = Credentials.get_credential!(id)
+
+    can_delete_credential =
+      Lightning.Policies.Users
+      |> Lightning.Policies.Permissions.can?(
+        :delete_credential,
+        socket.assigns.current_user,
+        credential
+      )
+
+    has_activity_in_projects = Credentials.has_activity_in_projects?(credential)
+
+    cond do
+      not can_delete_credential ->
+        {:noreply,
+         put_flash(socket, :error, "You can't perform this action")
+         |> push_patch(to: ~p"/credentials")}
+
+      has_activity_in_projects ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           "Cannot delete a credential that has activities in projects"
+         )}
+
+      true ->
+        Credentials.delete_credential(credential)
+        |> case do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Credential deleted successfully")
+             |> push_patch(to: ~p"/credentials")}
+
+          {:error, _changeset} ->
+            {:noreply, socket |> put_flash(:error, "Can't delete credential")}
+        end
+    end
+  end
+
+  @impl true
+  def handle_event("close_modal", _, socket) do
+    {:noreply, push_redirect(socket, to: ~p"/credentials")}
+  end
+
+  @impl true
+  def render(%{delete_now?: true, has_activity_in_projects?: true} = assigns) do
+    ~H"""
+    <div id={"user-#{@id}"}>
+      <PetalComponents.Modal.modal
+        max_width="sm"
+        title="Delete user"
+        close_modal_target={@myself}
+      >
+        <p>
+          This credential can't be deleted for now. It is involved in projects that has ongoing activities.
+        </p>
+        <div class="flex justify-end">
+          <PetalComponents.Button.button
+            label="Ok, understood"
+            phx-click={PetalComponents.Modal.hide_modal(@myself)}
+          />
+        </div>
+      </PetalComponents.Modal.modal>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id={"user-#{@id}"}>
+      <PetalComponents.Modal.modal
+        max_width="sm"
+        title="Delete user"
+        close_modal_target={@myself}
+      >
+        <.form
+          :let={f}
+          for={@scheduled_deletion_changeset}
+          phx-change="validate"
+          phx-submit="delete"
+          phx-target={@myself}
+          id="scheduled_deletion_form"
+        >
+          <span>
+            This user's account and credential data will be deleted. Please make sure none of these credentials are used in production workflows.
+          </span>
+
+          <%= if @has_activity_in_projects? do %>
+            <div class="hidden sm:block" aria-hidden="true">
+              <div class="py-2"></div>
+            </div>
+            <p>
+              *Note that this user still has activity related to active projects. We may not be able to delete them entirely from the app until those projects are deleted.
+            </p>
+          <% end %>
+          <div class="hidden sm:block" aria-hidden="true">
+            <div class="py-2"></div>
+          </div>
+          <div class="grid grid-cols-12 gap-12">
+            <div class="col-span-8">
+              <%= label(f, :scheduled_deletion_email, "User email",
+                class: "block text-sm font-medium text-secondary-700"
+              ) %>
+              <%= text_input(f, :scheduled_deletion_email,
+                class: "block w-full rounded-md",
+                phx_debounce: "blur"
+              ) %>
+              <%= error_tag(f, :scheduled_deletion_email,
+                class:
+                  "mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
+              ) %>
+            </div>
+          </div>
+
+          <%= hidden_input(f, :id) %>
+
+          <div class="hidden sm:block" aria-hidden="true">
+            <div class="py-5"></div>
+          </div>
+          <div class="flex justify-end">
+            <PetalComponents.Button.button
+              label="Cancel"
+              phx-click={PetalComponents.Modal.hide_modal(@myself)}
+            /> &nbsp;
+            <LightningWeb.Components.Common.button
+              type="submit"
+              color="red"
+              phx-disable-with="Deleting..."
+              disabled={!@scheduled_deletion_changeset.valid?}
+            >
+              Delete account
+            </LightningWeb.Components.Common.button>
+          </div>
+        </.form>
+      </PetalComponents.Modal.modal>
+    </div>
+    """
+  end
+end

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -31,9 +31,25 @@ defmodule LightningWeb.CredentialLive.Index do
   end
 
   defp apply_action(socket, :delete, %{"id" => id}) do
-    socket
-    |> assign(:page_title, "Credentials")
-    |> assign(:credential, Credentials.get_credential!(id))
+    credential = Credentials.get_credential!(id)
+
+    can_delete_credential =
+      Lightning.Policies.Users
+      |> Lightning.Policies.Permissions.can?(
+        :delete_credential,
+        socket.assigns.current_user,
+        credential
+      )
+
+    if can_delete_credential do
+      socket
+      |> assign(:page_title, "Credentials")
+      |> assign(:credential, credential)
+    else
+      socket
+      |> put_flash(:error, "You can't perform this action")
+      |> push_patch(to: ~p"/credentials")
+    end
   end
 
   @impl true

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -17,7 +17,6 @@
       <.live_component
         module={LightningWeb.Components.CredentialDeletionModal}
         id={@credential.id}
-        current_user={@current_user}
         credential={@credential}
         return_to={~p"/credentials"}
       />

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -45,19 +45,48 @@
             </span>
             |
             <span>
-              <%= link("Delete",
-                to: "#",
-                phx_click: "delete",
-                phx_value_id: credential.id,
-                data: [
-                  confirm:
-                    "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?"
-                ]
-              ) %>
+              <.link navigate={~p"/credentials/#{credential.id}/delete"}>
+                Delete
+              </.link>
             </span>
           </.td>
         </.tr>
       <% end %>
     </.table>
+    <PetalComponents.Modal.modal
+      :if={@live_action == :delete}
+      max_width="sm"
+      title="Delete user"
+    >
+      <%= if @has_activity_in_projects do %>
+        <p>
+          This credential can't be deleted for now. It is involved in projects that has ongoing activities.
+        </p>
+        <div class="flex justify-end">
+          <PetalComponents.Button.button
+            label="Ok, understood"
+            phx-click={PetalComponents.Modal.hide_modal()}
+          />
+        </div>
+      <% else %>
+        <p>
+          Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?
+        </p>
+        <div class="flex justify-end">
+          <PetalComponents.Button.button
+            label="Cancel"
+            phx-click={PetalComponents.Modal.hide_modal()}
+          /> &nbsp;
+          <LightningWeb.Components.Common.button
+            phx-click="delete"
+            phx-value-id={@credential.id}
+            color="red"
+            phx-disable-with="Deleting..."
+          >
+            Delete credential
+          </LightningWeb.Components.Common.button>
+        </div>
+      <% end %>
+    </PetalComponents.Modal.modal>
   </LayoutComponents.centered>
 </LayoutComponents.page_content>

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -13,6 +13,15 @@
     </LayoutComponents.header>
   </:header>
   <LayoutComponents.centered>
+    <%= if @live_action == :delete do %>
+      <.live_component
+        module={LightningWeb.Components.CredentialDeletionModal}
+        id={@credential.id}
+        current_user={@current_user}
+        credential={@credential}
+        return_to={~p"/credentials"}
+      />
+    <% end %>
     <.table id="credentials">
       <.tr>
         <.th>Name</.th>
@@ -43,50 +52,10 @@
                 Edit
               </.link>
             </span>
-            |
-            <span>
-              <.link navigate={~p"/credentials/#{credential.id}/delete"}>
-                Delete
-              </.link>
-            </span>
+            | <.delete_action socket={@socket} credential={credential} />
           </.td>
         </.tr>
       <% end %>
     </.table>
-    <PetalComponents.Modal.modal
-      :if={@live_action == :delete}
-      max_width="sm"
-      title="Delete user"
-    >
-      <%= if @has_activity_in_projects do %>
-        <p>
-          This credential can't be deleted for now. It is involved in projects that has ongoing activities.
-        </p>
-        <div class="flex justify-end">
-          <PetalComponents.Button.button
-            label="Ok, understood"
-            phx-click={PetalComponents.Modal.hide_modal()}
-          />
-        </div>
-      <% else %>
-        <p>
-          Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you'd like to delete the credential?
-        </p>
-        <div class="flex justify-end">
-          <PetalComponents.Button.button
-            label="Cancel"
-            phx-click={PetalComponents.Modal.hide_modal()}
-          /> &nbsp;
-          <LightningWeb.Components.Common.button
-            phx-click="delete"
-            phx-value-id={@credential.id}
-            color="red"
-            phx-disable-with="Deleting..."
-          >
-            Delete credential
-          </LightningWeb.Components.Common.button>
-        </div>
-      <% end %>
-    </PetalComponents.Modal.modal>
   </LayoutComponents.centered>
 </LayoutComponents.page_content>

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -32,9 +32,15 @@
 
       <%= for credential <- @credentials do %>
         <.tr id={"credential-#{credential.id}"}>
-          <.td><%= credential.name %></.td>
-          <.td><%= credential.project_names %></.td>
-          <.td><%= credential.schema %></.td>
+          <.td class={if credential.scheduled_deletion, do: "line-through"}>
+            <%= credential.name %>
+          </.td>
+          <.td>
+            <%= credential.project_names %>
+          </.td>
+          <.td class={if credential.scheduled_deletion, do: "line-through"}>
+            <%= credential.schema %>
+          </.td>
           <.td>
             <%= if credential.production do %>
               <div class="flex">
@@ -44,14 +50,17 @@
             <% end %>
           </.td>
           <.td>
-            <span>
-              <.link navigate={
-                Routes.credential_edit_path(@socket, :edit, credential)
-              }>
-                Edit
-              </.link>
-            </span>
-            | <.delete_action socket={@socket} credential={credential} />
+            <%= if !credential.scheduled_deletion do %>
+              <span>
+                <.link navigate={
+                  Routes.credential_edit_path(@socket, :edit, credential)
+                }>
+                  Edit
+                </.link>
+              </span>
+              |
+            <% end %>
+            <.delete_action socket={@socket} credential={credential} />
           </.td>
         </.tr>
       <% end %>

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -148,6 +148,7 @@ defmodule LightningWeb.Router do
       end
 
       live "/credentials", CredentialLive.Index, :index
+      live "/credentials/:id/delete", CredentialLive.Index, :delete
       live "/credentials/new", CredentialLive.Edit, :new
       live "/credentials/:id", CredentialLive.Edit, :edit
 

--- a/priv/repo/migrations/20230907114940_add_scheduled_deletion_field_to_credentials.exs
+++ b/priv/repo/migrations/20230907114940_add_scheduled_deletion_field_to_credentials.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddScheduledDeletionFieldToCredentials do
+  use Ecto.Migration
+
+  def change do
+    alter table(:credentials) do
+      add(:scheduled_deletion, :utc_datetime)
+    end
+  end
+end

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -7,6 +7,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
   alias Lightning.DigestEmailWorker
   alias Lightning.Accounts.{UserNotifier, User}
   alias Lightning.Projects.Project
+  alias Lightning.Credentials.Credential
 
   describe "Notification emails" do
     test "notify_project_deletion/2" do
@@ -99,10 +100,13 @@ defmodule Lightning.Accounts.UserNotifierTest do
       )
     end
 
-    test "send_credential_deletion_notification_email/1" do
-      UserNotifier.send_credential_deletion_notification_email(%User{
-        email: "real@email.com"
-      })
+    test "send_credential_deletion_notification_email/2" do
+      UserNotifier.send_credential_deletion_notification_email(
+        %User{
+          email: "real@email.com"
+        },
+        %Credential{name: "Test"}
+      )
 
       assert_email_sent(
         subject: "Credential Deletion",

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -99,6 +99,17 @@ defmodule Lightning.Accounts.UserNotifierTest do
       )
     end
 
+    test "send_credential_deletion_notification_email/1" do
+      UserNotifier.send_credential_deletion_notification_email(%User{
+        email: "real@email.com"
+      })
+
+      assert_email_sent(
+        subject: "Credential Deletion",
+        to: "real@email.com"
+      )
+    end
+
     test "build_digest_url/3" do
       workflow = Lightning.WorkflowsFixtures.workflow_fixture(name: "Workflow A")
       start_date = Timex.now()

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -6,7 +6,7 @@ defmodule Lightning.CredentialsTest do
   alias Lightning.Credentials
   alias Lightning.Credentials.{Credential, Audit}
   import Lightning.BypassHelpers
-  # import Lightning.Factories
+  import Lightning.Factories
 
   import Lightning.{
     JobsFixtures,
@@ -267,6 +267,25 @@ defmodule Lightning.CredentialsTest do
                user_id_3
              ) ==
                [project_id]
+    end
+  end
+
+  describe "has_activity_in_projects?/1" do
+    setup do
+      {:ok, credential: insert(:credential)}
+    end
+
+    test "returns true when there's at least one associated run", %{
+      credential: credential
+    } do
+      insert(:run, credential: credential)
+      assert Credentials.has_activity_in_projects?(credential)
+    end
+
+    test "returns false when there's no associated run", %{
+      credential: credential
+    } do
+      refute Credentials.has_activity_in_projects?(credential)
     end
   end
 

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -7,6 +7,7 @@ defmodule Lightning.CredentialsTest do
   alias Lightning.Credentials.{Credential, Audit}
   import Lightning.BypassHelpers
   import Lightning.Factories
+  import Swoosh.TestAssertions
 
   import Lightning.{
     JobsFixtures,
@@ -234,6 +235,90 @@ defmodule Lightning.CredentialsTest do
       assert job.project_credential_id == nil
     end
 
+    test "schedule_credential_deletion/1 schedules a deletion date according to the :purge_deleted_after_days env" do
+      days = Application.get_env(:lightning, :purge_deleted_after_days)
+
+      user = insert(:user)
+      project = build(:project) |> with_project_user(user, :owner) |> insert()
+
+      credential =
+        insert(:credential,
+          name: "My Credential",
+          body: %{foo: :bar},
+          user: user
+        )
+
+      project_credential =
+        insert(:project_credential, credential: credential, project: project)
+
+      job = insert(:job, project_credential: project_credential)
+
+      # Ensure associations are existent before deletion
+      initial_project_credentials =
+        Repo.all(assoc(credential, :project_credentials))
+
+      assert not Enum.empty?(initial_project_credentials)
+
+      initial_job = Repo.reload!(job)
+      assert initial_job.project_credential_id == project_credential.id
+
+      refute_email_sent()
+
+      assert credential.scheduled_deletion == nil
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {:ok, updated_credential} =
+        Credentials.schedule_credential_deletion(credential)
+
+      # Ensure scheduled_deletion is updated as expected
+      assert updated_credential.scheduled_deletion != nil
+
+      assert Timex.diff(updated_credential.scheduled_deletion, now, :days) ==
+               days
+
+      # Verify project_credential association removal
+      retrieved_project_credentials =
+        Repo.all(assoc(updated_credential, :project_credentials))
+
+      assert Enum.empty?(retrieved_project_credentials)
+
+      # Verify job's credential_id is set to nil
+      retrieved_job = Repo.reload!(job)
+      assert is_nil(retrieved_job.project_credential_id)
+
+      assert_email_sent(
+        subject: "Credential Deletion",
+        to: user.email
+      )
+    end
+
+    test "cancel_scheduled_deletion/1 sets scheduled_deletion to nil for a given credential" do
+      # Set up a credential with a scheduled_deletion date
+      # 1 hour from now, truncated to seconds
+      scheduled_date =
+        DateTime.utc_now() |> DateTime.add(3600) |> DateTime.truncate(:second)
+
+      credential =
+        insert(:credential,
+          user: insert(:user),
+          name: "My Credential",
+          body: %{foo: :bar},
+          scheduled_deletion: scheduled_date
+        )
+
+      # Ensure the initial setup is correct
+      assert DateTime.truncate(credential.scheduled_deletion, :second) ==
+               scheduled_date
+
+      # Call the function to cancel the scheduled deletion
+      {:ok, updated_credential} =
+        Credentials.cancel_scheduled_deletion(credential.id)
+
+      # Verify the scheduled_deletion field is set to nil
+      assert is_nil(updated_credential.scheduled_deletion)
+    end
+
     test "change_credential/1 returns a credential changeset" do
       user = user_fixture()
       credential = credential_fixture(user_id: user.id)
@@ -381,6 +466,88 @@ defmodule Lightning.CredentialsTest do
 
       assert is_integer(new_expiry)
       assert new_expiry > DateTime.to_unix(DateTime.utc_now()) + 10 * 60
+    end
+  end
+
+  describe "perform/1 with type purge_deleted" do
+    setup do
+      active_credential =
+        insert(:credential,
+          name: "Active Credential",
+          body: %{foo: :bar},
+          user: insert(:user)
+        )
+
+      scheduled_credential =
+        insert(:credential,
+          name: "Scheduled Credential",
+          body: %{foo: :bar},
+          user: insert(:user),
+          scheduled_deletion: DateTime.utc_now()
+        )
+
+      {
+        :ok,
+        active_credential: active_credential,
+        scheduled_credential: scheduled_credential
+      }
+    end
+
+    defp mock_activity(credential) do
+      insert(:run, credential: credential)
+    end
+
+    test "doesn't delete credentials that are not scheduled for deletion", %{
+      active_credential: credential
+    } do
+      Credentials.perform(%Oban.Job{args: %{"type" => "purge_deleted"}})
+      assert Repo.get(Credential, credential.id)
+    end
+
+    test "sets bodies of credentials scheduled for deletion to nil", %{
+      scheduled_credential: credential
+    } do
+      mock_activity(credential)
+      Credentials.perform(%Oban.Job{args: %{"type" => "purge_deleted"}})
+      updated_credential = Repo.get(Credential, credential.id)
+      assert updated_credential.body == %{}
+    end
+
+    test "doesn't set bodies of other credentials to nil", %{
+      active_credential: credential
+    } do
+      Credentials.perform(%Oban.Job{args: %{"type" => "purge_deleted"}})
+      updated_credential = Repo.get(Credential, credential.id)
+      assert updated_credential.body != nil
+    end
+
+    test "doesn't delete credentials with activity in projects", %{
+      scheduled_credential: credential
+    } do
+      mock_activity(credential)
+      Credentials.perform(%Oban.Job{args: %{"type" => "purge_deleted"}})
+      assert Repo.get(Credential, credential.id)
+    end
+
+    test "deletes other credentials scheduled for deletion", %{
+      scheduled_credential: credential
+    } do
+      # This mock might be unnecessary if you want to show the credential does NOT have activity, just remove it if that's the case.
+      mock_activity(credential)
+
+      # A second scheduled credential without activity
+      scheduled_credential_2 =
+        insert(:credential,
+          name: "Another Scheduled Credential",
+          body: %{baz: :qux},
+          user: insert(:user),
+          scheduled_deletion: DateTime.utc_now()
+        )
+
+      Credentials.perform(%Oban.Job{args: %{"type" => "purge_deleted"}})
+
+      assert is_nil(Repo.get(Credential, scheduled_credential_2.id))
+      assert Repo.get(Credential, credential.id)
     end
   end
 end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -29,7 +29,7 @@ defmodule LightningWeb.EndToEndTest do
           assert unquote(string) =~ ~r/(?=.*compiler)(?=.*0.0.29)/
 
         :adaptor ->
-          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.0.2)/
+          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.0.3)/
       end
     end
   end

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -94,7 +94,9 @@ defmodule LightningWeb.CredentialLiveTest do
       assert html =~ "Delete credential"
 
       assert html =~
-               "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you&#39;d like to delete the credential?"
+               "Deleting this credential will immediately remove it from all jobs"
+
+      refute html =~ "credential has been used in workflow attempts"
 
       assert index_live
              |> element("button", "Delete credential")
@@ -125,8 +127,8 @@ defmodule LightningWeb.CredentialLiveTest do
 
       assert html =~ "Delete credential"
 
-      assert html =~
-               "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you&#39;d like to delete the credential?"
+      assert html =~ "Deleting this credential will immediately"
+      assert html =~ "*This credential has been used in workflow attempts"
 
       assert index_live
              |> element("button", "Delete credential")
@@ -183,7 +185,9 @@ defmodule LightningWeb.CredentialLiveTest do
         live(conn, ~p"/credentials/#{credential.id}/delete")
 
       assert html =~
-               "Deleting this credential will remove it from all projects and jobs, even if it is currently in use. Are you sure you&#39;d like to delete the credential?"
+               "Deleting this credential will immediately remove it from all jobs"
+
+      refute html =~ "credential has been used in workflow attempts"
 
       assert index_live
              |> element("button", "Delete credential")
@@ -208,8 +212,8 @@ defmodule LightningWeb.CredentialLiveTest do
       {:ok, index_live, html} =
         live(conn, ~p"/credentials/#{credential.id}/delete")
 
-      assert html =~
-               "This credential can&#39;t be deleted for now. It is involved in projects that has ongoing activities."
+      assert html =~ "This credential has been used in workflow attempts"
+      assert html =~ "will be made unavailable for future use immediately"
 
       assert index_live |> element("button", "Ok, understood") |> has_element?()
 

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -223,16 +223,17 @@ defmodule LightningWeb.CredentialLiveTest do
       assert has_element?(index_live, "#credential-#{credential.id}")
     end
 
-    # test "user can only delete their own credential", %{
-    #   conn: conn
-    # } do
-    #   credential = credential_fixture()
+    test "user can only delete their own credential", %{
+      conn: conn
+    } do
+      credential = credential_fixture()
 
-    #   {:ok, index_live, _html} = live(conn, ~p"/credentials/#{credential.id}/delete")
+      {:ok, _index_live, html} =
+        live(conn, ~p"/credentials/#{credential.id}/delete")
+        |> follow_redirect(conn, ~p"/credentials")
 
-    #   assert index_live
-    #          |> with_target("#credential-#{credential.id}") |> render_click("delete", %{"id" => credential.id}) |> (to: ~p"/credentials")
-    # end
+      assert html =~ "You can&#39;t perform this action"
+    end
   end
 
   describe "Clicking new from the list view" do

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -102,14 +102,11 @@ defmodule LightningWeb.CredentialLiveTest do
     } do
       insert(:run, credential: credential)
 
-      {:ok, index_live, _html} = live(conn, ~p"/credentials")
+      {:ok, _index_live, html} =
+        live(conn, ~p"/credentials/#{credential.id}/delete")
 
-      assert index_live
-             |> element("#credential-#{credential.id} a", "Delete")
-             |> render_click() =~
-               "Cannot delete a credential that has activities in projects"
-
-      assert has_element?(index_live, "#credential-#{credential.id}")
+      assert html =~
+               "This credential can&#39;t be deleted for now. It is involved in projects that has ongoing activities."
     end
 
     test "user can only delete their own credential", %{

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -223,17 +223,16 @@ defmodule LightningWeb.CredentialLiveTest do
       assert has_element?(index_live, "#credential-#{credential.id}")
     end
 
-    test "user can only delete their own credential", %{
-      conn: conn
-    } do
-      credential = credential_fixture()
+    # test "user can only delete their own credential", %{
+    #   conn: conn
+    # } do
+    #   credential = credential_fixture()
 
-      {:ok, index_live, _html} = live(conn, ~p"/credentials")
+    #   {:ok, index_live, _html} = live(conn, ~p"/credentials/#{credential.id}/delete")
 
-      assert index_live
-             |> render_click("delete", %{"id" => credential.id}) =~
-               "You can&#39;t perform this action"
-    end
+    #   assert index_live
+    #          |> with_target("#credential-#{credential.id}") |> render_click("delete", %{"id" => credential.id}) |> (to: ~p"/credentials")
+    # end
   end
 
   describe "Clicking new from the list view" do

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -5,6 +5,7 @@ defmodule LightningWeb.CredentialLiveTest do
   import LightningWeb.CredentialLiveHelpers
 
   import Lightning.CredentialsFixtures
+  import Lightning.Factories
 
   alias Lightning.CredentialsFixtures
   alias Lightning.Credentials
@@ -93,6 +94,22 @@ defmodule LightningWeb.CredentialLiveTest do
              |> render_click() =~ "Credential deleted"
 
       refute has_element?(index_live, "#credential-#{credential.id}")
+    end
+
+    test "cannot delete credential that has activity in projects", %{
+      conn: conn,
+      credential: credential
+    } do
+      insert(:run, credential: credential)
+
+      {:ok, index_live, _html} = live(conn, ~p"/credentials")
+
+      assert index_live
+             |> element("#credential-#{credential.id} a", "Delete")
+             |> render_click() =~
+               "Cannot delete a credential that has activities in projects"
+
+      assert has_element?(index_live, "#credential-#{credential.id}")
     end
 
     test "user can only delete their own credential", %{


### PR DESCRIPTION
## Notes for the reviewer

This PR enhances our credential deletion process, making it more robust and aligning it with GDPR requirements while improving user experience.

Key Changes:

- Before attempting deletion, we now verify if a credential is associated with any runs within a project. This ensures we only delete credentials that aren't vital for ongoing or historical processes.
- For credentials scheduled for deletion, we cleanse sensitive data by setting the body field to an empty map, ensuring compliance without complete data loss even when the credential can't be purged from the system due to activity in projects.
- When a credential's scheduled for deletion, all associated entities (like project_credentials) are disassociated, ensuring data integrity and coherence.
- Users have the flexibility to cancel the deletion of a credential within a predefined grace period, providing a safety net against unintended deletions.
- Integrated a credential deletion modal, replacing the native JS confirmation box, the modal offers a more intuitive user experience. This modal, provides clear confirmation before deleting a credential. It also offers informative feedback when a credential cannot be deleted due to ongoing project activities, ensuring users understand the reason behind the system's actions.
   
By introducing these changes, we're not only ensuring compliance with data protection regulations but also enhancing user experience.

## Related issue

Fixes #1072 & #802 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
