### PR TITLE
Fix broken UI in credential type picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix broken UI in credential type picker
+  [#1064](https://github.com/OpenFn/Lightning/issues/1064)
+
 ## [v0.8.3] - 2023-09-05
 
 ### Added

--- a/lib/lightning_web/live/credential_live/credential_edit_modal.ex
+++ b/lib/lightning_web/live/credential_live/credential_edit_modal.ex
@@ -6,7 +6,7 @@ defmodule LightningWeb.CredentialLive.CredentialEditModal do
 
   @impl true
   def update(%{project: _project} = assigns, socket) do
-    {:ok, socket |> assign(assigns)}
+    {:ok, socket |> assign(assigns) |> assign_new(:modal, fn -> false end)}
   end
 
   @impl true
@@ -29,6 +29,7 @@ defmodule LightningWeb.CredentialLive.CredentialEditModal do
         project={@project}
         on_save={@on_save}
         show_project_credentials={false}
+        modal={@modal}
       >
         <:button>
           <%= render_slot(@cancel) %>

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -30,6 +30,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
         id={"#{@id}-type-picker"}
         on_confirm="type_selected"
         phx_target={@myself}
+        modal={@modal}
       />
       <div :if={@type} class="mt-10 sm:mt-0">
         <div class="lg:grid md:grid-cols-3 md:gap-6">
@@ -296,7 +297,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
      end)}
   end
 
-  def update(%{projects: projects} = assigns, socket) do
+  def update(%{projects: projects, modal: modal} = assigns, socket) do
     pid = self()
 
     {:ok,
@@ -307,6 +308,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
      )
      |> assign_new(:show_project_credentials, fn -> true end)
      |> assign(
+       modal: modal,
        changeset: Credentials.change_credential(assigns.credential),
        all_projects: projects |> Enum.map(&{&1.name, &1.id}),
        selected_project: "",

--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -18,43 +18,41 @@ defmodule LightningWeb.CredentialLive.TypePicker do
         <div class="mt-5 lg:col-span-3 xl:col-span-2 md:mt-0">
           <div class="shadow sm:rounded-md">
             <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
-              <fieldset>
-                <legend class="contents text-base font-medium text-gray-900">
-                  Types
-                </legend>
-                <p class="text-sm text-gray-500">
-                  These are the different kinds of credentials that can be created.
-                </p>
-                <.form
-                  :let={f}
-                  id="credential-type-picker"
-                  for={%{"selected" => @selected}}
-                  as={:type}
-                  phx-target={@myself}
-                  phx-change="type_changed"
-                  phx-submit="confirm_type"
-                >
-                  <div class="md:columns-3 columns-2">
-                    <div
-                      :for={{name, key} <- @type_options}
-                      class="flex items-center pt-4"
-                    >
-                      <%= radio_button(f, :selected, key,
-                        class:
-                          "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                      ) %>
-                      <LightningWeb.Components.Form.label_field
-                        form={f}
-                        field={:selected}
-                        for={"credential-type-picker_selected_#{key}"}
-                        title={name}
-                        class="ml-3 block text-sm font-medium text-gray-700"
-                        value={key}
-                      />
-                    </div>
+              <span class="contents text-base font-medium text-gray-900">
+                Types
+              </span>
+              <p class="text-sm text-gray-500">
+                These are the different kinds of credentials that can be created.
+              </p>
+              <.form
+                :let={f}
+                id="credential-type-picker"
+                for={%{"selected" => @selected}}
+                as={:type}
+                phx-target={@myself}
+                phx-change="type_changed"
+                phx-submit="confirm_type"
+              >
+                <div class="md:columns-3 columns-2">
+                  <div
+                    :for={{name, key} <- @type_options}
+                    class="flex items-center pt-4"
+                  >
+                    <%= radio_button(f, :selected, key,
+                      class:
+                        "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    ) %>
+                    <LightningWeb.Components.Form.label_field
+                      form={f}
+                      field={:selected}
+                      for={"credential-type-picker_selected_#{key}"}
+                      title={name}
+                      class="ml-3 block text-sm font-medium text-gray-700"
+                      value={key}
+                    />
                   </div>
-                </.form>
-              </fieldset>
+                </div>
+              </.form>
             </div>
             <div class="bg-gray-50 px-4 py-3 text-right sm:px-6">
               <Common.button

--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.CredentialLive.TypePicker do
   alias LightningWeb.Components.Common
 
   @impl true
-  def render(assigns) do
+  def render(%{modal: false} = assigns) do
     ~H"""
     <div class="mt-10 sm:mt-0">
       <div class="lg:grid lg:grid-cols-3 md:gap-6">
@@ -16,7 +16,7 @@ defmodule LightningWeb.CredentialLive.TypePicker do
           </div>
         </div>
         <div class="mt-5 lg:col-span-3 xl:col-span-2 md:mt-0">
-          <div class="shadow sm:rounded-md">
+          <div class="sm:rounded-md">
             <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
               <span class="contents text-base font-medium text-gray-900">
                 Types
@@ -74,6 +74,62 @@ defmodule LightningWeb.CredentialLive.TypePicker do
     """
   end
 
+  def render(%{modal: true} = assigns) do
+    ~H"""
+    <div class="mt-10 sm:mt-0 lg:grid lg:grid-cols-1 md:gap-6">
+      <div class="mt-5 lg:col-span-3 xl:col-span-2 md:mt-0 sm:rounded-md">
+        <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
+          <span class="text-base font-medium text-gray-900">Types</span>
+          <p class="text-sm text-gray-500">
+            These are the different kinds of credentials that can be created.
+          </p>
+          <.form
+            :let={f}
+            id="credential-type-picker"
+            for={%{"selected" => @selected}}
+            as={:type}
+            phx-target={@myself}
+            phx-change="type_changed"
+            phx-submit="confirm_type"
+          >
+            <div class="md:grid md:grid-cols-3 gap-1">
+              <div
+                :for={{name, key} <- @type_options}
+                }
+                class="flex items-center pt-4"
+              >
+                <%= radio_button(f, :selected, key,
+                  class:
+                    "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                ) %>
+                <LightningWeb.Components.Form.label_field
+                  form={f}
+                  field={:selected}
+                  for={"credential-type-picker_selected_#{key}"}
+                  title={name}
+                  class="ml-3 block text-sm font-medium text-gray-700"
+                  value={key}
+                />
+              </div>
+            </div>
+          </.form>
+        </div>
+        <div class="bg-gray-50 px-4 py-3 text-right sm:px-6">
+          <Common.button
+            disabled={!@selected}
+            phx-click={@on_confirm}
+            phx-target={@phx_target || @myself}
+            phx-value-selected={@selected}
+          >
+            <span class="inline-block align-middle">Continue</span>
+            <Heroicons.arrow_long_right class="h-4 w-4 inline-block ml-2" />
+          </Common.button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   @impl true
   def mount(socket) do
     {:ok, schemas_path} = Application.fetch_env(:lightning, :schemas_path)
@@ -116,6 +172,7 @@ defmodule LightningWeb.CredentialLive.TypePicker do
     {:ok,
      socket
      |> assign(%{
+       modal: assigns.modal,
        on_confirm: on_confirm,
        phx_target: assigns[:phx_target] || socket.assigns.myself
      })

--- a/lib/lightning_web/live/job_live/credential_picker.ex
+++ b/lib/lightning_web/live/job_live/credential_picker.ex
@@ -119,7 +119,8 @@ defmodule LightningWeb.JobLive.CredentialPicker do
         project: project,
         projects: [],
         show_project_credentials: false,
-        title: "Create Credential"
+        title: "Create Credential",
+        modal: true
       }
     )
 

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -29,7 +29,7 @@ defmodule LightningWeb.EndToEndTest do
           assert unquote(string) =~ ~r/(?=.*compiler)(?=.*0.0.29)/
 
         :adaptor ->
-          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.0.2)/
+          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.0.3)/
       end
     end
   end


### PR DESCRIPTION
## Notes for the reviewer

**Problem**: Upon reducing the screen size, the UI components inside the CredentialLive.TypePicker was overflowing their parent div.

**Cause**: The root cause was a fieldset element inside the CredentialLive.TypePicker. This fieldset didn't appear to have a direct influence on the visible UI but was impacting the responsiveness of the encapsulated elements.

**Solution**: To address the issue, I removed the fieldset and replaced the legend with a styled span. This seems simpler and better and it solves the problem

## Related issue

Fixes #1064 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
