### PR TITLE
for #271, set up audit_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Modified audit trail to handle lots of different kind of audit events
+  [#271](https://github.com/OpenFn/Lightning/issues/271)/[#44](https://github.com/OpenFn/Lightning/issues/44)
+
 ### Fixed
 
 ## [v0.9.0] - 2023-09-15

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -7,10 +7,18 @@ defmodule Lightning.Auditing do
   alias Lightning.Repo
 
   def list_all(params \\ %{}) do
-    from(a in Lightning.Credentials.Audit,
-      # preload: [:actor_id],
-      order_by: [desc: a.inserted_at]
-    )
-    |> Repo.paginate(params)
+      from(a in Lightning.Credentials.Audit,
+        order_by: [desc: a.inserted_at]
+      )
+      |> Repo.paginate(params)
+      |> try_to_get_actors()
+  end
+
+  defp try_to_get_actors(page) do
+    page
+    |> Map.put(:entries, Enum.map(page.entries, fn entry ->
+      entry
+      |> Map.put(:actor, Repo.get(Lightning.Accounts.User, entry.actor_id))
+    end))
   end
 end

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -8,20 +8,11 @@ defmodule Lightning.Auditing do
 
   def list_all(params \\ %{}) do
     from(a in Lightning.Credentials.Audit,
+      left_join: u in Lightning.Accounts.User,
+      on: [id: a.actor_id],
+      select_merge: %{actor: u},
       order_by: [desc: a.inserted_at]
     )
     |> Repo.paginate(params)
-    |> try_to_get_actors()
-  end
-
-  defp try_to_get_actors(page) do
-    page
-    |> Map.put(
-      :entries,
-      Enum.map(page.entries, fn entry ->
-        entry
-        |> Map.put(:actor, Repo.get(Lightning.Accounts.User, entry.actor_id))
-      end)
-    )
   end
 end

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -7,18 +7,21 @@ defmodule Lightning.Auditing do
   alias Lightning.Repo
 
   def list_all(params \\ %{}) do
-      from(a in Lightning.Credentials.Audit,
-        order_by: [desc: a.inserted_at]
-      )
-      |> Repo.paginate(params)
-      |> try_to_get_actors()
+    from(a in Lightning.Credentials.Audit,
+      order_by: [desc: a.inserted_at]
+    )
+    |> Repo.paginate(params)
+    |> try_to_get_actors()
   end
 
   defp try_to_get_actors(page) do
     page
-    |> Map.put(:entries, Enum.map(page.entries, fn entry ->
-      entry
-      |> Map.put(:actor, Repo.get(Lightning.Accounts.User, entry.actor_id))
-    end))
+    |> Map.put(
+      :entries,
+      Enum.map(page.entries, fn entry ->
+        entry
+        |> Map.put(:actor, Repo.get(Lightning.Accounts.User, entry.actor_id))
+      end)
+    )
   end
 end

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -8,7 +8,7 @@ defmodule Lightning.Auditing do
 
   def list_all(params \\ %{}) do
     from(a in Lightning.Credentials.Audit,
-      preload: [:actor],
+      # preload: [:actor_id],
       order_by: [desc: a.inserted_at]
     )
     |> Repo.paginate(params)

--- a/lib/lightning/auditing/model.ex
+++ b/lib/lightning/auditing/model.ex
@@ -128,7 +128,8 @@ defmodule Lightning.Auditing.Model do
     audit_changeset(schema, item_type, event, item_id, actor_id, changes)
   end
 
-  def event(schema, item_type, event, item_id, actor_id, changes) when is_map(changes) do
+  def event(schema, item_type, event, item_id, actor_id, changes)
+      when is_map(changes) do
     audit_changeset(schema, item_type, event, item_id, actor_id, changes)
   end
 

--- a/lib/lightning/auditing/model.ex
+++ b/lib/lightning/auditing/model.ex
@@ -28,7 +28,7 @@ defmodule Lightning.Auditing.Model do
 
     event_signature =
       quote do
-        def event(item_type, event, item_id, actor_id, changes \\ %{})
+        def event(event, item_id, actor_id, changes \\ %{})
       end
 
     event_log_functions =
@@ -39,7 +39,7 @@ defmodule Lightning.Auditing.Model do
           # def event(item_type, "foo_event", item_id, actor_id, changes) do
           #   Lightning.Audit.event(item_type, schema, "foo_event", item_id, actor_id, changes)
           # end
-          def event(item_type, unquote(event_name), item_id, actor_id, changes) do
+          def event(unquote(event_name), item_id, actor_id, changes) do
             unquote(__MODULE__).event(
               unquote(schema),
               unquote(item),

--- a/lib/lightning/auditing/model.ex
+++ b/lib/lightning/auditing/model.ex
@@ -27,7 +27,7 @@ defmodule Lightning.Auditing.Model do
 
     event_signature =
       quote do
-        def event(event, row_id, actor_id, metadata \\ %{})
+        def event(item_type, event, item_id, actor_id, changes \\ %{})
       end
 
     event_log_functions =
@@ -35,16 +35,17 @@ defmodule Lightning.Auditing.Model do
         quote do
           # Output:
           #
-          # def event("foo_event", row_id, actor_id, metadata) do
-          #   Lightning.Audit.event(schema, "foo_event", row_id, actor_id, metadata)
+          # def event(item_type, "foo_event", item_id, actor_id, changes) do
+          #   Lightning.Audit.event(item_type, schema, "foo_event", item_id, actor_id, changes)
           # end
-          def event(unquote(event_name), row_id, actor_id, metadata) do
+          def event(item_type, unquote(event_name), item_id, actor_id, changes) do
             unquote(__MODULE__).event(
               unquote(schema),
+              item_type,
               unquote(event_name),
-              row_id,
+              item_id,
               actor_id,
-              metadata
+              changes
             )
           end
         end
@@ -78,16 +79,17 @@ defmodule Lightning.Auditing.Model do
   end
 
   @doc """
-  Creates a `schema` changeset for the `event` identified by `row_id` and caused
+  Creates a `schema` changeset for the `event` identified by `item_id` and caused
   by `actor_id`.
 
-  The given `metadata` can be either `nil`, `Ecto.Changeset`, struct or map.
+  The given `changes` can be either `nil`, `Ecto.Changeset`, struct or map.
 
-  It returns `:no_changes` in case of an `Ecto.Changeset` metadata that changed nothing
+  It returns `:no_changes` in case of an `Ecto.Changeset` changes that changed nothing
   or an `Ecto.Changeset` with the event ready to be inserted.
   """
   @spec event(
           module(),
+          String.t(),
           String.t(),
           Ecto.UUID.t(),
           Ecto.UUID.t(),
@@ -95,17 +97,18 @@ defmodule Lightning.Auditing.Model do
         ) ::
           :no_changes | Ecto.Changeset.t()
 
-  def event(schema, event, row_id, actor_id, metadata \\ %{})
+  def event(schema, item_type, event, item_id, actor_id, changes \\ %{})
 
-  def event(_, _, _, _, %Ecto.Changeset{changes: changes} = _changeset)
+  def event(_, _, _, _, _, %Ecto.Changeset{changes: changes} = _changeset)
       when map_size(changes) == 0 do
     :no_changes
   end
 
   def event(
         schema,
+        item_type,
         event,
-        row_id,
+        item_id,
         actor_id,
         %Ecto.Changeset{data: %subject_schema{} = data, changes: changes}
       ) do
@@ -117,26 +120,27 @@ defmodule Lightning.Auditing.Model do
       |> MapSet.intersection(change_keys)
       |> MapSet.to_list()
 
-    metadata = %{
+    changes = %{
       before: Map.take(data, field_keys),
       after: Map.take(changes, field_keys)
     }
 
-    audit_changeset(schema, event, row_id, actor_id, metadata)
+    audit_changeset(schema, item_type, event, item_id, actor_id, changes)
   end
 
-  def event(schema, event, row_id, actor_id, metadata) when is_map(metadata) do
-    audit_changeset(schema, event, row_id, actor_id, metadata)
+  def event(schema, item_type, event, item_id, actor_id, changes) when is_map(changes) do
+    audit_changeset(schema, item_type, event, item_id, actor_id, changes)
   end
 
-  defp audit_changeset(schema, event, row_id, actor_id, metadata) do
+  defp audit_changeset(schema, item_type, event, item_id, actor_id, changes) do
     schema
     |> struct()
     |> schema.changeset(%{
+      item_type: item_type,
       event: event,
-      row_id: row_id,
+      item_id: item_id,
       actor_id: actor_id,
-      metadata: metadata
+      changes: changes
     })
   end
 end

--- a/lib/lightning/auditing/model.ex
+++ b/lib/lightning/auditing/model.ex
@@ -6,6 +6,7 @@ defmodule Lightning.Auditing.Model do
 
   # coveralls-ignore-start
   defmacro __using__(opts) do
+    model = Keyword.fetch!(opts, :model)
     repo = Keyword.fetch!(opts, :repo)
     schema = Keyword.fetch!(opts, :schema)
     events = Keyword.fetch!(opts, :events)
@@ -41,7 +42,7 @@ defmodule Lightning.Auditing.Model do
           def event(item_type, unquote(event_name), item_id, actor_id, changes) do
             unquote(__MODULE__).event(
               unquote(schema),
-              item_type,
+              unquote(model) |> to_string(),
               unquote(event_name),
               item_id,
               actor_id,

--- a/lib/lightning/auditing/model.ex
+++ b/lib/lightning/auditing/model.ex
@@ -6,9 +6,9 @@ defmodule Lightning.Auditing.Model do
 
   # coveralls-ignore-start
   defmacro __using__(opts) do
-    model = Keyword.fetch!(opts, :model)
     repo = Keyword.fetch!(opts, :repo)
     schema = Keyword.fetch!(opts, :schema)
+    item = Keyword.fetch!(opts, :item)
     events = Keyword.fetch!(opts, :events)
 
     if Enum.empty?(events),
@@ -42,7 +42,7 @@ defmodule Lightning.Auditing.Model do
           def event(item_type, unquote(event_name), item_id, actor_id, changes) do
             unquote(__MODULE__).event(
               unquote(schema),
-              unquote(model) |> to_string(),
+              unquote(item),
               unquote(event_name),
               item_id,
               actor_id,

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -181,7 +181,13 @@ defmodule Lightning.Credentials do
         |> Multi.insert(
           :audit,
           fn %{credential: credential} ->
-            Audit.event("Credential", "updated", credential.id, credential.user_id, changeset)
+            Audit.event(
+              "Credential",
+              "updated",
+              credential.id,
+              credential.user_id,
+              changeset
+            )
           end
         )
         |> Multi.append(project_credentials_multi)
@@ -200,12 +206,17 @@ defmodule Lightning.Credentials do
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
         "Credential"
-        |> Audit.event("removed_from_project", credential.id, credential.user_id, %{
-          before: %{
-            project_id: Ecto.Changeset.get_field(changeset, :project_id)
-          },
-          after: %{project_id: nil}
-        })
+        |> Audit.event(
+          "removed_from_project",
+          credential.id,
+          credential.user_id,
+          %{
+            before: %{
+              project_id: Ecto.Changeset.get_field(changeset, :project_id)
+            },
+            after: %{project_id: nil}
+          }
+        )
       end
     )
   end

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -122,7 +122,7 @@ defmodule Lightning.Credentials do
       Credential.changeset(%Credential{}, attrs |> coerce_json_field("body"))
     )
     |> Multi.insert(:audit, fn %{credential: credential} ->
-      Audit.event("created", credential.id, credential.user_id)
+      Audit.event("credential", "created", credential.id, credential.user_id)
     end)
     |> Repo.transaction()
     |> case do
@@ -181,7 +181,7 @@ defmodule Lightning.Credentials do
         |> Multi.insert(
           :audit,
           fn %{credential: credential} ->
-            Audit.event("updated", credential.id, credential.user_id, changeset)
+            Audit.event("credential", "updated", credential.id, credential.user_id, changeset)
           end
         )
         |> Multi.append(project_credentials_multi)
@@ -255,7 +255,7 @@ defmodule Lightning.Credentials do
     Multi.new()
     |> Multi.delete(:credential, credential)
     |> Multi.insert(:audit, fn _ ->
-      Audit.event("deleted", credential.id, credential.user_id)
+      Audit.event("credential", "deleted", credential.id, credential.user_id)
     end)
     |> Repo.transaction()
   end

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -122,7 +122,7 @@ defmodule Lightning.Credentials do
       Credential.changeset(%Credential{}, attrs |> coerce_json_field("body"))
     )
     |> Multi.insert(:audit, fn %{credential: credential} ->
-      Audit.event("credential", "created", credential.id, credential.user_id)
+      Audit.event("Credential", "created", credential.id, credential.user_id)
     end)
     |> Repo.transaction()
     |> case do
@@ -181,7 +181,7 @@ defmodule Lightning.Credentials do
         |> Multi.insert(
           :audit,
           fn %{credential: credential} ->
-            Audit.event("credential", "updated", credential.id, credential.user_id, changeset)
+            Audit.event("Credential", "updated", credential.id, credential.user_id, changeset)
           end
         )
         |> Multi.append(project_credentials_multi)
@@ -199,8 +199,8 @@ defmodule Lightning.Credentials do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
-        "removed_from_project"
-        |> Audit.event(credential.id, credential.user_id, %{
+        "Credential"
+        |> Audit.event("removed_from_project", credential.id, credential.user_id, %{
           before: %{
             project_id: Ecto.Changeset.get_field(changeset, :project_id)
           },
@@ -221,8 +221,8 @@ defmodule Lightning.Credentials do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
-        "added_to_project"
-        |> Audit.event(credential.id, credential.user_id, %{
+        "Credential"
+        |> Audit.event("added_to_project", credential.id, credential.user_id, %{
           before: %{project_id: nil},
           after: %{
             project_id: Ecto.Changeset.get_field(changeset, :project_id)
@@ -255,7 +255,7 @@ defmodule Lightning.Credentials do
     Multi.new()
     |> Multi.delete(:credential, credential)
     |> Multi.insert(:audit, fn _ ->
-      Audit.event("credential", "deleted", credential.id, credential.user_id)
+      Audit.event("Credential", "deleted", credential.id, credential.user_id)
     end)
     |> Repo.transaction()
   end

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -122,7 +122,7 @@ defmodule Lightning.Credentials do
       Credential.changeset(%Credential{}, attrs |> coerce_json_field("body"))
     )
     |> Multi.insert(:audit, fn %{credential: credential} ->
-      Audit.event("Credential", "created", credential.id, credential.user_id)
+      Audit.event("created", credential.id, credential.user_id)
     end)
     |> Repo.transaction()
     |> case do
@@ -182,7 +182,6 @@ defmodule Lightning.Credentials do
           :audit,
           fn %{credential: credential} ->
             Audit.event(
-              "Credential",
               "updated",
               credential.id,
               credential.user_id,
@@ -205,8 +204,7 @@ defmodule Lightning.Credentials do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
-        "Credential"
-        |> Audit.event(
+        Audit.event(
           "removed_from_project",
           credential.id,
           credential.user_id,
@@ -232,8 +230,7 @@ defmodule Lightning.Credentials do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
-        "Credential"
-        |> Audit.event("added_to_project", credential.id, credential.user_id, %{
+        Audit.event("added_to_project", credential.id, credential.user_id, %{
           before: %{project_id: nil},
           after: %{
             project_id: Ecto.Changeset.get_field(changeset, :project_id)
@@ -266,7 +263,7 @@ defmodule Lightning.Credentials do
     Multi.new()
     |> Multi.delete(:credential, credential)
     |> Multi.insert(:audit, fn _ ->
-      Audit.event("Credential", "deleted", credential.id, credential.user_id)
+      Audit.event("deleted", credential.id, credential.user_id)
     end)
     |> Repo.transaction()
   end

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -13,7 +13,7 @@ defmodule Lightning.Credentials.Audit do
       "deleted"
     ]
 
-  defmodule Metadata do
+  defmodule Changes do
     @moduledoc false
 
     use Ecto.Schema
@@ -26,8 +26,8 @@ defmodule Lightning.Credentials.Audit do
     end
 
     @doc false
-    def changeset(metadata, attrs \\ %{}) do
-      metadata
+    def changeset(changes, attrs \\ %{}) do
+      changes
       |> cast(attrs, [:before, :after])
       |> update_change(:before, &encrypt_body/1)
       |> update_change(:after, &encrypt_body/1)
@@ -53,11 +53,12 @@ defmodule Lightning.Credentials.Audit do
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
-  schema "credentials_audit" do
+  schema "audit_events" do
     field :event, :string
-    field :row_id, Ecto.UUID
-    embeds_one :metadata, Metadata
-    belongs_to :actor, User
+    field :item_type, :string
+    field :item_id, Ecto.UUID
+    embeds_one :changes, Changes
+    field :actor_id, Ecto.UUID
 
     timestamps(updated_at: false)
   end
@@ -65,8 +66,8 @@ defmodule Lightning.Credentials.Audit do
   @doc false
   def changeset(%__MODULE__{} = audit, attrs) do
     audit
-    |> cast(attrs, [:event, :row_id, :actor_id])
-    |> cast_embed(:metadata)
+    |> cast(attrs, [:event, :item_id, :actor_id, :item_type])
+    |> cast_embed(:changes)
     |> validate_required([:event, :actor_id])
   end
 end

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -3,20 +3,9 @@ defmodule Lightning.Credentials.Audit do
   Model for storing changes to Credentials
   """
   use Lightning.Auditing.Model,
-    # TODO: Decide if we want to provide a way to later Repo.get automatically
-    model: Lightning.Credentials.Credential,
-    # So... by defining an actual Elixir model here we can later fetch the item
-    # in question, despite the polymorphic `item_id` column:
-    #
-    #   audit.item_type
-    #   |> String.to_existing_atom()
-    #   |> Repo.get(audit.item_id)
-    #
-    # Do we want this? Or should we simply pass in a human readable? I imagine
-    # the the auditor will eventually want to "get" (Repo.get?) the record that
-    # has been modified and for this they'll need to know the precise model.
     repo: Lightning.Repo,
     schema: __MODULE__,
+    item: "credential",
     events: [
       "created",
       "updated",

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -50,8 +50,6 @@ defmodule Lightning.Credentials.Audit do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lightning.Accounts.User
-
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "audit_events" do

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -60,6 +60,7 @@ defmodule Lightning.Credentials.Audit do
     field :item_id, Ecto.UUID
     embeds_one :changes, Changes
     field :actor_id, Ecto.UUID
+    field :actor, :map, virtual: true
 
     timestamps(updated_at: false)
   end

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -3,6 +3,18 @@ defmodule Lightning.Credentials.Audit do
   Model for storing changes to Credentials
   """
   use Lightning.Auditing.Model,
+    # TODO: Decide if we want to provide a way to later Repo.get automatically
+    model: Lightning.Credentials.Credential,
+    # So... by defining an actual Elixir model here we can later fetch the item
+    # in question, despite the polymorphic `item_id` column:
+    #
+    #   audit.item_type
+    #   |> String.to_existing_atom()
+    #   |> Repo.get(audit.item_id)
+    #
+    # Do we want this? Or should we simply pass in a human readable? I imagine
+    # the the auditor will eventually want to "get" (Repo.get?) the record that
+    # has been modified and for this they'll need to know the precise model.
     repo: Lightning.Repo,
     schema: __MODULE__,
     events: [

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -8,7 +8,7 @@
     <.table>
       <.tr>
         <.th>Occurred</.th>
-        <.th class="text-center">Event</.th>
+        <.th>Event</.th>
         <.th>Actor</.th>
         <.th>Subject</.th>
       </.tr>
@@ -17,10 +17,23 @@
           <.td>
             <%= audit.inserted_at |> Calendar.strftime("%c %Z") %>
           </.td>
-          <.td class="text-center">
+          <.td>
             <.badge color="success" label={audit.event} />
           </.td>
-          <.td><%= audit.actor_id %></.td>
+          <.td>
+            <div class="flex flex-col overflow-hidden">
+              <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
+                <%= if audit.actor,
+                  do: audit.actor.first_name <> " " <> audit.actor.last_name,
+                  else: "(User deleted)" %>
+              </div>
+              <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">
+                <%= if audit.actor,
+                  do: audit.actor.email,
+                  else: display_short_uuid(audit.actor_id) %>
+              </div>
+            </div>
+          </.td>
           <.td>
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -24,7 +24,7 @@
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
                 <%= if audit.actor,
-                  do: audit.actor.first_name <> " " <> audit.actor.last_name,
+                  do: "#{audit.actor.first_name} #{audit.actor.last_name}",
                   else: "(User deleted)" %>
               </div>
               <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -37,7 +37,7 @@
           <.td>
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
-                <%= audit.item_type %>
+                <%= audit.item_type |> String.split(".") |> Enum.at(-1) %>
               </div>
               <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">
                 <%= display_short_uuid(audit.item_id) %>

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -21,23 +21,23 @@
           <.td class="text-center">
             <.badge color="success" label={audit.event} />
           </.td>
-          <.td><%= audit.actor.email %></.td>
+          <.td><%= audit.actor_id %></.td>
           <.td>
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
                 Credential
               </div>
               <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">
-                <%= display_short_uuid(audit.row_id) %>
+                <%= display_short_uuid(audit.item_id) %>
               </div>
             </div>
           </.td>
         </.tr>
 
         <.tr>
-          <%= if audit.metadata.after do %>
+          <%= if audit.changes.after do %>
             <.td colspan="4" class="font-mono text-xs break-all">
-              <.diff metadata={audit.metadata} />
+              <.diff metadata={audit.changes} />
             </.td>
           <% else %>
             <.td colspan="4" class="font-mono text-xs">

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -12,7 +12,6 @@
         <.th>Actor</.th>
         <.th>Subject</.th>
       </.tr>
-
       <%= for audit <- @page.entries do %>
         <.tr id={"audit-#{audit.id}"} class="border-dotted border-gray-100">
           <.td>
@@ -25,7 +24,7 @@
           <.td>
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
-                Credential
+                <%= audit.item_type %>
               </div>
               <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">
                 <%= display_short_uuid(audit.item_id) %>
@@ -33,7 +32,6 @@
             </div>
           </.td>
         </.tr>
-
         <.tr>
           <%= if audit.changes.after do %>
             <.td colspan="4" class="font-mono text-xs break-all">

--- a/priv/repo/migrations/20230916052400_change_credentials_audit_to_audit_events.exs
+++ b/priv/repo/migrations/20230916052400_change_credentials_audit_to_audit_events.exs
@@ -1,0 +1,41 @@
+defmodule Lightning.Repo.Migrations.ChangeCredentialsAuditToAuditEvents do
+  use Ecto.Migration
+
+  def up do
+    rename_index(from: "credentials_audit_pkey", to: "audit_events_pkey")
+    rename_index(from: "credentials_audit_row_id_index", to: "audit_events_item_id_index")
+    drop constraint("credentials_audit", "credentials_audit_actor_id_fkey")
+
+    rename table("credentials_audit"), :row_id, to: :item_id
+    rename table("credentials_audit"), :metadata, to: :changes
+    create index("credentials_audit", [:actor_id])
+
+    rename table(:credentials_audit), to: table(:audit_events)
+
+    alter table("audit_events") do
+      add :item_type, :string, default: "credential"
+    end
+  end
+
+  defp rename_constraint(table, from: from, to: to) do
+    execute(
+      """
+      ALTER TABLE #{table} RENAME CONSTRAINT "#{from}" TO "#{to}";
+      """,
+      """
+      ALTER TABLE #{table} RENAME CONSTRAINT "#{to}" TO "#{from}";
+      """
+    )
+  end
+
+  defp rename_index(from: from, to: to) do
+    execute(
+      """
+      ALTER INDEX #{from} RENAME TO #{to};
+      """,
+      """
+      ALTER INDEX #{to} RENAME TO #{from};
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20230916055521_remove_defauilt_item_type_for_audit_events.exs
+++ b/priv/repo/migrations/20230916055521_remove_defauilt_item_type_for_audit_events.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.RemoveDefauiltItemTypeForAuditEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_events) do
+      modify(:item_type, :string, default: nil, null: false)
+    end
+  end
+end

--- a/test/lightning/auditing_test.exs
+++ b/test/lightning/auditing_test.exs
@@ -10,7 +10,7 @@ defmodule Lightning.AuditingTest do
 
       %{entries: [entry]} = Auditing.list_all()
 
-      assert entry.row_id == credential_id
+      assert entry.item_id == credential_id
     end
   end
 end

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -12,11 +12,11 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("created", credential.id, user.id)
+        Audit.event("credential", "created", credential.id, user.id)
         |> Audit.save()
 
-      assert audit.row_id == credential.id
-      assert %{before: nil, after: nil} = audit.metadata
+      assert audit.item_id == credential.id
+      assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "created"
       assert audit.actor_id == user.id
     end
@@ -30,20 +30,36 @@ defmodule Lightning.Credentials.AuditTest do
         Credential.changeset(credential, %{body: %{"my-secret" => "value"}})
 
       {:ok, audit} =
-        Audit.event("updated", credential.id, user.id, changeset)
+        Audit.event("credential", "updated", credential.id, user.id, changeset)
         |> Audit.save()
 
-      assert audit.row_id == credential.id
+      assert audit.item_id == credential.id
 
       # Check that the body attribute is encrypted in audit records too.
       # We can only test the beginning of the encrypted string as the
       # algorithm include randomness or padding of some sort.
       # %{}
-      assert audit.metadata.before.body =~ "AQpBRVMuR0NNLlYx"
+      assert audit.changes.before.body =~ "AQpBRVMuR0NNLlYx"
       # %{"my-secret" => "value}
-      assert audit.metadata.after.body =~ "AQpBRVMuR0NNLlYx"
+      assert audit.changes.after.body =~ "AQpBRVMuR0NNLlYx"
 
       assert audit.event == "updated"
+      assert audit.actor_id == user.id
+    end
+
+    test "generates 'deleted' audit trail entries" do
+      user = user_fixture()
+
+      credential =
+        credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
+
+      {:ok, audit} =
+        Audit.event("credential", "deleted", credential.id, user.id)
+        |> Audit.save()
+
+      assert audit.item_id == credential.id
+      assert %{before: nil, after: nil} = audit.changes
+      assert audit.event == "deleted"
       assert audit.actor_id == user.id
     end
   end

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -12,7 +12,7 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("credential", "created", credential.id, user.id)
+        Audit.event("Credential", "created", credential.id, user.id)
         |> Audit.save()
 
       assert audit.item_id == credential.id
@@ -30,7 +30,7 @@ defmodule Lightning.Credentials.AuditTest do
         Credential.changeset(credential, %{body: %{"my-secret" => "value"}})
 
       {:ok, audit} =
-        Audit.event("credential", "updated", credential.id, user.id, changeset)
+        Audit.event("Credential", "updated", credential.id, user.id, changeset)
         |> Audit.save()
 
       assert audit.item_id == credential.id
@@ -54,7 +54,7 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("credential", "deleted", credential.id, user.id)
+        Audit.event("Credential", "deleted", credential.id, user.id)
         |> Audit.save()
 
       assert audit.item_id == credential.id

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -12,7 +12,7 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("Credential", "created", credential.id, user.id)
+        Audit.event("created", credential.id, user.id)
         |> Audit.save()
 
       assert audit.item_type == "credential"
@@ -31,7 +31,7 @@ defmodule Lightning.Credentials.AuditTest do
         Credential.changeset(credential, %{body: %{"my-secret" => "value"}})
 
       {:ok, audit} =
-        Audit.event("Credential", "updated", credential.id, user.id, changeset)
+        Audit.event("updated", credential.id, user.id, changeset)
         |> Audit.save()
 
       assert audit.item_type == "credential"
@@ -56,12 +56,17 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("Credential", "deleted", credential.id, user.id)
+        Audit.event("deleted", credential.id, user.id)
         |> Audit.save()
 
       assert audit.item_type == "credential"
       assert audit.item_id == credential.id
-      assert %{before: nil, after: nil} = audit.changes
+
+      assert audit.changes == %Lightning.Credentials.Audit.Changes{
+               before: nil,
+               after: nil
+             }
+
       assert audit.event == "deleted"
       assert audit.actor_id == user.id
     end

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -15,7 +15,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "created", credential.id, user.id)
         |> Audit.save()
 
-      assert audit.item_type == "Elixir.Lightning.Credentials.Credential"
+      assert audit.item_type == "credential"
       assert audit.item_id == credential.id
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "created"
@@ -34,7 +34,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "updated", credential.id, user.id, changeset)
         |> Audit.save()
 
-      assert audit.item_type == "Elixir.Lightning.Credentials.Credential"
+      assert audit.item_type == "credential"
       assert audit.item_id == credential.id
 
       # Check that the body attribute is encrypted in audit records too.
@@ -59,7 +59,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "deleted", credential.id, user.id)
         |> Audit.save()
 
-      assert audit.item_type == "Elixir.Lightning.Credentials.Credential"
+      assert audit.item_type == "credential"
       assert audit.item_id == credential.id
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "deleted"

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -15,7 +15,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "created", credential.id, user.id)
         |> Audit.save()
 
-      assert audit.item_type == "Credential"
+      assert audit.item_type == "Elixir.Lightning.Credentials.Credential"
       assert audit.item_id == credential.id
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "created"
@@ -34,7 +34,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "updated", credential.id, user.id, changeset)
         |> Audit.save()
 
-      assert audit.item_type == "Credential"
+      assert audit.item_type == "Elixir.Lightning.Credentials.Credential"
       assert audit.item_id == credential.id
 
       # Check that the body attribute is encrypted in audit records too.
@@ -59,7 +59,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "deleted", credential.id, user.id)
         |> Audit.save()
 
-      assert audit.item_type == "Credential"
+      assert audit.item_type == "Elixir.Lightning.Credentials.Credential"
       assert audit.item_id == credential.id
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "deleted"

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -15,6 +15,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "created", credential.id, user.id)
         |> Audit.save()
 
+      assert audit.item_type == "Credential"
       assert audit.item_id == credential.id
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "created"
@@ -33,6 +34,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "updated", credential.id, user.id, changeset)
         |> Audit.save()
 
+      assert audit.item_type == "Credential"
       assert audit.item_id == credential.id
 
       # Check that the body attribute is encrypted in audit records too.
@@ -57,6 +59,7 @@ defmodule Lightning.Credentials.AuditTest do
         Audit.event("Credential", "deleted", credential.id, user.id)
         |> Audit.save()
 
+      assert audit.item_type == "Credential"
       assert audit.item_id == credential.id
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "deleted"

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -87,7 +87,7 @@ defmodule Lightning.CredentialsTest do
       assert credential.name == "some name"
 
       assert from(a in Audit,
-               where: a.row_id == ^credential.id and a.event == "created"
+               where: a.item_id == ^credential.id and a.event == "created"
              )
              |> Repo.one!(),
              "Has exactly one 'created' event"
@@ -138,8 +138,8 @@ defmodule Lightning.CredentialsTest do
 
       audit_events =
         from(a in Audit,
-          where: a.row_id == ^credential.id,
-          select: {a.event, type(a.metadata, :map)}
+          where: a.item_id == ^credential.id,
+          select: {a.event, type(a.changes, :map)}
         )
         |> Repo.all()
 
@@ -204,16 +204,16 @@ defmodule Lightning.CredentialsTest do
                })
 
       assert audit.event == "deleted"
-      assert audit.row_id == credential_id
+      assert audit.item_id == credential_id
 
       # previous  audit records are not deleted
       # a new audit (event: deleted) is added
       assert from(a in Lightning.Credentials.Audit,
-               where: a.row_id == ^credential.id
+               where: a.item_id == ^credential.id
              )
              |> Repo.all()
              |> Enum.all?(fn a ->
-               a.row_id == credential.id &&
+               a.item_id == credential.id &&
                  a.event in ["created", "updated", "deleted", "added_to_project"]
              end)
 

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -2,6 +2,7 @@ defmodule LightningWeb.AuditLiveTest do
   use LightningWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
+  import Lightning.CredentialsFixtures
 
   describe "Index as a regular user" do
     setup :register_and_log_in_user
@@ -15,13 +16,42 @@ defmodule LightningWeb.AuditLiveTest do
   end
 
   describe "Index as a superuser" do
-    setup [:register_and_log_in_superuser]
+    setup :register_and_log_in_superuser
+    setup :create_project_for_current_user
 
-    test "lists all audit entries", %{conn: conn} do
+    test "lists all audit entries", %{conn: conn, user: user} do
+      # Generate an audit event on creation.
+      credential =
+        credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
+
+      # Add another audit event, but this time for a user that doesn't exist to
+      # simulate an event from a user that has since been deleted.
+      deleted_user_id = "655993ca-4828-496c-8ff9-e742b175e462"
+
+      {:ok, _audit} =
+        Lightning.Credentials.Audit.event(
+          "deleted",
+          credential.id,
+          deleted_user_id
+        )
+        |> Lightning.Credentials.Audit.save()
+
       {:ok, _index_live, html} =
         live(conn, Routes.audit_index_path(conn, :index))
 
       assert html =~ "Audit"
+      # Assert that the table works for users that still exist.
+      assert html =~ user.first_name
+      assert html =~ user.email
+      assert html =~ LightningWeb.LiveHelpers.display_short_uuid(credential.id)
+      assert html =~ "created"
+      assert html =~ "No changes"
+      refute html =~ "nil"
+
+      # Assert that the table works for users that have been deleted.
+      assert html =~ "created"
+      assert html =~ "(User deleted)"
+      assert html =~ LightningWeb.LiveHelpers.display_short_uuid(deleted_user_id)
     end
   end
 end


### PR DESCRIPTION
**First, remember that audit trails are weird.** There is no longer a foreign key on `actor_id` (because actors can get deleted and we sometimes want audit trails to live on) or `item_id` (because it's polymorphic).

This fixes #271 and fixes #44 so we can start wiring up many more audit events, but there is a big open question in my mind:

**How do we want to store `item_type` in the `audit_events` table?** Right now, I'm storing it as the whole string version of a model in Lightning (e.g., "Elixir.Lightning.Credentials.Credential") so that we could (in the future) make it possible for auditors to access the items in question using some automatic `Repo.get` interface. Imagine something weird like this:

```ex
audit.item_type
|> String.to_existing_atom()
|> Repo.get(audit.item_id)
```

We don't do that right now, so we almost might as well simply write "Credential" in the DB for `item_type` but I wanted to consider the benefits and drawbacks of storing the whole official model name.

**Note that there is also a pretty weird `try_to_get_actors` (almost a "maybe preload") without a proper ecto relationship** thing going on [here](https://github.com/OpenFn/Lightning/pull/1119/files#diff-09d9a2ead0f010271c4bf0ba7ddd893d56882ef968f7c7008013cb6713a7ecc3R14) that I'm not proud of, but I still think it's useful to display actor info on the audit trail screen.

In the end, no matter which way we go with the two funky bits above, it's probably better to get this _in_ so that we can add the other audit events as we build out the administrative features and come back to these enhancements later.

<img width="1315" alt="image" src="https://github.com/OpenFn/Lightning/assets/8732845/7d649439-fa91-4013-95c1-c58ce9391199">

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
