### PR TITLE
Investigating Workflow Diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix randomly unresponsive job panel after job deletion
+  [#1113](https://github.com/OpenFn/Lightning/issues/1113)
+
 ## [v0.9.0] - 2023-09-15
 
 ### Added

--- a/assets/js/workflow-diagram/components/PlusButton.tsx
+++ b/assets/js/workflow-diagram/components/PlusButton.tsx
@@ -11,12 +11,12 @@ function PlusButton() {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         fill="currentColor"
-        class="w-4 h-4"
+        className="w-4 h-4"
       >
         <path
-          fill-rule="evenodd"
+          fillRule="evenodd"
           d="M12 5.25a.75.75 0 01.75.75v5.25H18a.75.75 0 010 1.5h-5.25V18a.75.75 0 01-1.5 0v-5.25H6a.75.75 0 010-1.5h5.25V6a.75.75 0 01.75-.75z"
-          clip-rule="evenodd"
+          clipRule="evenodd"
         />
       </svg>
     </button>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -472,11 +472,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
       {:noreply,
        socket
-       |> push_patch(
-         to:
-           ~p"/projects/#{socket.assigns.project}/w/#{socket.assigns.workflow}",
-         replace: true
-       )
        |> apply_params(next_params)
        |> push_patches_applied(initial_params)}
     else

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -286,7 +286,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         ]
       })
 
-      assert_patched(view, ~p"/projects/#{project}/w/#{workflow}")
+      # assert_patched(view, ~p"/projects/#{project}/w/#{workflow}")
     end
 
     @tag role: :viewer

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -285,8 +285,6 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           %{op: "remove", path: "/edges/1"}
         ]
       })
-
-      # assert_patched(view, ~p"/projects/#{project}/w/#{workflow}")
     end
 
     @tag role: :viewer


### PR DESCRIPTION
## Notes for the reviewer

- When we delete a node we are push patching to `~p"/projects/project_id/w/workflow_id"` which ends up sending to the WorkflowDiagram a bad URL string. I am not sure to understand why the URL is not compiled and only the path is sent to the WorkflowDiagram but the fix I propose is to not even push patch.

## Related issue

Fixes #1113

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
