### PR TITLE
Close node panel via escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Add "esc" key binding to close job inspector modal
+  [#1069](https://github.com/OpenFn/Lightning/issues/1069)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -167,7 +167,11 @@ defmodule LightningWeb.WorkflowLive.Components do
             <%= @title %>
           </div>
           <div class="flex-none">
-            <.link patch={@cancel_url} class="justify-center hover:text-gray-500">
+            <.link
+              phx-hook="ClosePanelViaEscape"
+              patch={@cancel_url}
+              class="justify-center hover:text-gray-500"
+            >
               <Heroicons.x_mark solid class="h-4 w-4 inline-block" />
             </.link>
           </div>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -153,7 +153,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           id="workflow-form"
           for={@workflow_form}
           phx-submit="save"
-          phx-hook="SubmitViaCtrlS"
+          phx-hook="SaveViaCtrlS"
           phx-change="validate"
         >
           <.single_inputs_for

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -80,7 +80,7 @@ defmodule LightningWeb.WorkflowLive.JobView do
           </div>
           <div class="basis-1/3 flex justify-end">
             <div class="flex w-14 items-center justify-center">
-              <.link patch={@close_url}>
+              <.link patch={@close_url} phx-hook="ClosePanelViaEscape">
                 <Heroicons.x_mark class="w-6 h-6 text-gray-500 hover:text-gray-700 hover:cursor-pointer" />
               </.link>
             </div>

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -26,7 +26,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
     <.form
       for={@form}
       id={@form.id}
-      phx-hook="SubmitViaCtrlEnter"
+      phx-hook="SaveAndRunViaCtrlEnter"
       phx-change="manual_run_change"
       phx-submit="manual_run_submit"
       class="h-full flex flex-col gap-4"


### PR DESCRIPTION
## Notes for the reviewer

This PR addresses the need for a more modular approach to key combination hooks. I have refactored the original `createKeyCombinationHook` function a little bit to accommodate different actions based on the key combination. In addition, I have added two reusable action functions, `submitAction` and `closeAction`, which respectively dispatch a submit event and simulate a click event on the given element.

Changes:

- [x] Refactored createKeyCombinationHook to accept an action parameter.
- [x] Added submitAction function to dispatch a submit event.
- [x] Added closeAction function to simulate a click event.
- [x] Introduced new hook ClosePanelViaEscape to handle the Escape key.
- [x] Extracted repetitive key-checking logic into separate functions.

## Related issue

Fixes #1069 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
