### PR TITLE
Prevent Deletion of First Job of a Workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ and this project adheres to
 
 ### Changed
 
+- Prevent deletion of first job of a workflow
+  [#1097](https://github.com/OpenFn/Lightning/issues/1097)
+
 ### Fixed
 
 - Creating a new user without a password fails and there is no user feedback
   [#731](https://github.com/OpenFn/Lightning/issues/731)
-  
+
 ## [v0.9.2] - 2023-09-20
 
 ### Added

--- a/assets/js/workflow-diagram/nodes/Trigger.tsx
+++ b/assets/js/workflow-diagram/nodes/Trigger.tsx
@@ -18,7 +18,8 @@ const TriggerNode = ({
   sourcePosition = Position.Bottom,
   ...props
 }): JSX.Element => {
-  const toolbar = () => props.data?.allowPlaceholder && <PlusButton />;
+  // Do not remove yet, we might need this snippet of code when implementing issue #1121
+  // const toolbar = () => props.data?.allowPlaceholder && <PlusButton />;
   const { label, sublabel, tooltip, icon } = getTriggerMeta(
     props.data as Lightning.TriggerNode
   );
@@ -32,7 +33,8 @@ const TriggerNode = ({
       icon={icon}
       sourcePosition={sourcePosition}
       interactive={props.data.trigger.type === 'webhook'}
-      toolbar={toolbar}
+      // TODO: put back the toolbar when implementing issue #1121
+      toolbar={false}
     />
   );
 };

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -15,7 +15,7 @@ defmodule LightningWeb.Components.NewInputs do
       <.button phx-click="go" class="ml-2">Send!</.button>
   """
   attr :id, :string, default: "no-id"
-  attr :type, :string, default: nil
+  attr :type, :string, default: "button", values: ["button", "submit"]
   attr :class, :string, default: nil
   attr :rest, :global, include: ~w(disabled form name value)
   attr :tooltip, :any, default: nil

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -168,6 +168,7 @@ defmodule LightningWeb.WorkflowLive.Components do
           </div>
           <div class="flex-none">
             <.link
+              id="close-panel"
               phx-hook="ClosePanelViaEscape"
               patch={@cancel_url}
               class="justify-center hover:text-gray-500"

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -465,7 +465,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
     } = socket.assigns
 
     with true <- can_edit_job || :not_authorized,
-         true <- !has_child_edges?(changeset, id) || :has_child_edges do
+         true <- !has_child_edges?(changeset, id) || :has_child_edges,
+         true <- !is_first_job?(changeset, id) || :is_first_job do
       edges_to_delete =
         Ecto.Changeset.get_assoc(changeset, :edges, :struct)
         |> Enum.filter(&(&1.target_job_id == id))
@@ -493,6 +494,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
         {:noreply,
          socket
          |> put_flash(:error, "Delete all descendant jobs first.")}
+
+      :is_first_job ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "You can't delete the first job of a workflow.")}
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -193,22 +193,15 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   <div class="grow flex justify-end">
                     <label>
                       <.button
+                        id="delete-job-button"
                         phx-click="delete_node"
                         phx-value-id={@selected_job.id}
                         class="focus:ring-red-500 bg-red-600 hover:bg-red-700 disabled:bg-red-300"
                         disabled={!@can_edit_job or has_child_edges or is_first_job}
-                        tooltip="All fields are required"
+                        tooltip="You can't delete the first job of a workflow"
                       >
                         Delete
                       </.button>
-                      <%!-- <Common.button
-                        color="red"
-                        phx-click="delete_node"
-                        phx-value-id={@selected_job.id}
-                        disabled={!@can_edit_job or has_child_edges or is_first_job}
-                      >
-                        Delete
-                      </Common.button> --%>
                     </label>
                   </div>
                 </div>

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -80,7 +80,11 @@ defmodule LightningWeb.WorkflowLive.JobView do
           </div>
           <div class="basis-1/3 flex justify-end">
             <div class="flex w-14 items-center justify-center">
-              <.link patch={@close_url} phx-hook="ClosePanelViaEscape">
+              <.link
+                id={"close-job-edit-view-#{@job.id}"}
+                patch={@close_url}
+                phx-hook="ClosePanelViaEscape"
+              >
                 <Heroicons.x_mark class="w-6 h-6 text-gray-500 hover:text-gray-700 hover:cursor-pointer" />
               </.link>
             </div>


### PR DESCRIPTION
## Notes for the reviewer

This PR introduces a mechanism to prevent the deletion of the first job within a workflow. This is crucial because, at present, our workflow diagram cannot represent a workflow that consists solely of a trigger with no associated job. At a minimum, a workflow should comprise a pair of Trigger and Job. Allowing the deletion of the first job in a workflow subsequently leads to a failure in our app, a scenario we aim to avoid.

### Changes:

- Deactivation of the deletion button for the first job in a workflow, to prevent unintended removal.
- Removal of the plus button on triggers to avoid users adding new job nodes from a trigger.
- Implementation of restrictions to ensure the first job within a workflow cannot be deleted.

## Related issue

Fixes #1097 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
