### PR TITLE
Crash and wrong error message when setting up version control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to
 - Creating a new user without a password fails and there is no user feedback
   [#731](https://github.com/OpenFn/Lightning/issues/731)
 
+- Crash when setting up version control
+  [#1112](https://github.com/OpenFn/Lightning/issues/1112)
+
 ## [v0.9.2] - 2023-09-20
 
 ### Added

--- a/lib/lightning/version_control/github_client.ex
+++ b/lib/lightning/version_control/github_client.ex
@@ -67,7 +67,7 @@ defmodule Lightning.VersionControl.GithubClient do
           ]}
        ])}
     else
-      %{status: 404, body: body} ->
+      %{status: 404, body: body} = resp ->
         error =
           GithubError.installation_not_found(
             "Github Installation APP ID is misconfigured",
@@ -75,9 +75,11 @@ defmodule Lightning.VersionControl.GithubClient do
           )
 
         Sentry.capture_exception(error)
+        Logger.error(inspect(resp, label: "Unexpected Github Response: "))
         {:error, error}
 
-      _unused_status ->
+      resp ->
+        Logger.error(inspect(resp, label: "Unexpected Github Response: "))
         error = GithubError.invalid_pem("Github Cert is misconfigured")
         Sentry.capture_exception(error)
         {:error, error}

--- a/lib/lightning/version_control/github_client.ex
+++ b/lib/lightning/version_control/github_client.ex
@@ -67,7 +67,7 @@ defmodule Lightning.VersionControl.GithubClient do
           ]}
        ])}
     else
-      %{status: 404, body: body} = resp ->
+      %{status: 404, body: body} ->
         error =
           GithubError.installation_not_found(
             "Github Installation APP ID is misconfigured",
@@ -75,13 +75,14 @@ defmodule Lightning.VersionControl.GithubClient do
           )
 
         Sentry.capture_exception(error)
-        Logger.error(inspect(resp, label: "Unexpected Github Response: "))
+        Logger.error(inspect(body, label: "Unexpected Github Response: "))
         {:error, error}
 
-      resp ->
-        Logger.error(inspect(resp, label: "Unexpected Github Response: "))
+      %{status: 401, body: body} ->
+        Logger.error(inspect(body, label: "Unexpected Github Response: "))
         error = GithubError.invalid_pem("Github Cert is misconfigured")
         Sentry.capture_exception(error)
+
         {:error, error}
     end
   end

--- a/lib/lightning/version_control/github_client.ex
+++ b/lib/lightning/version_control/github_client.ex
@@ -71,6 +71,8 @@ defmodule Lightning.VersionControl.GithubClient do
            ])}
 
         {:ok, %{status: 404, body: body}} ->
+          Logger.error("Unexpected Github Response: #{inspect(body)}")
+
           error =
             GithubError.installation_not_found(
               "Github Installation APP ID is misconfigured",
@@ -78,11 +80,11 @@ defmodule Lightning.VersionControl.GithubClient do
             )
 
           Sentry.capture_exception(error)
-          Logger.error(inspect(body, label: "Unexpected Github Response: "))
+
           {:error, error}
 
         {:ok, %{status: 401, body: body}} ->
-          Logger.error(inspect(body, label: "Unexpected Github Response: "))
+          Logger.error("Unexpected Github Response: #{inspect(body)}")
 
           error =
             GithubError.invalid_certificate(

--- a/lib/lightning/version_control/github_client.ex
+++ b/lib/lightning/version_control/github_client.ex
@@ -83,7 +83,13 @@ defmodule Lightning.VersionControl.GithubClient do
 
         {:ok, %{status: 401, body: body}} ->
           Logger.error(inspect(body, label: "Unexpected Github Response: "))
-          error = GithubError.invalid_pem("Github Cert is misconfigured")
+
+          error =
+            GithubError.invalid_certificate(
+              "Github Certificate is misconfigured",
+              body
+            )
+
           Sentry.capture_exception(error)
 
           {:error, error}

--- a/lib/lightning/version_control/github_error.ex
+++ b/lib/lightning/version_control/github_error.ex
@@ -1,0 +1,37 @@
+defmodule Lightning.VersionControl.GithubError do
+  @moduledoc """
+  Github Error exception
+  """
+  defexception [:code, :message, :meta]
+
+  @impl true
+  def exception(msg) when is_binary(msg) do
+    new(:uknown, msg, %{})
+  end
+
+  @impl true
+  def exception([message: _msg] = opts) do
+    struct(__MODULE__, opts)
+  end
+
+  @impl true
+  def message(error) do
+    error.message
+  end
+
+  def new(code, msg, meta) when is_binary(msg) do
+    %__MODULE__{code: code, message: msg, meta: Map.new(meta)}
+  end
+
+  def installation_not_found(msg, meta \\ %{}) do
+    new(:installation_not_found, msg, meta)
+  end
+
+  def misconfigured(msg, meta \\ %{}) do
+    new(:misconfigured, msg, meta)
+  end
+
+  def invalid_pem(msg, meta \\ %{}) do
+    new(:invalid_pem, msg, meta)
+  end
+end

--- a/lib/lightning/version_control/github_error.ex
+++ b/lib/lightning/version_control/github_error.ex
@@ -4,21 +4,6 @@ defmodule Lightning.VersionControl.GithubError do
   """
   defexception [:code, :message, :meta]
 
-  @impl true
-  def exception(msg) when is_binary(msg) do
-    new(:uknown, msg, %{})
-  end
-
-  @impl true
-  def exception([message: _msg] = opts) do
-    struct(__MODULE__, opts)
-  end
-
-  @impl true
-  def message(error) do
-    error.message
-  end
-
   def new(code, msg, meta) when is_binary(msg) do
     %__MODULE__{code: code, message: msg, meta: Map.new(meta)}
   end
@@ -31,7 +16,7 @@ defmodule Lightning.VersionControl.GithubError do
     new(:misconfigured, msg, meta)
   end
 
-  def invalid_pem(msg, meta \\ %{}) do
-    new(:invalid_pem, msg, meta)
+  def invalid_certificate(msg, meta \\ %{}) do
+    new(:invalid_certificate, msg, meta)
   end
 end

--- a/lib/lightning/version_control/project_repo_connection.ex
+++ b/lib/lightning/version_control/project_repo_connection.ex
@@ -37,5 +37,8 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     project_repo_connection
     |> cast(attrs, @fields ++ @required_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:project_id,
+      message: "project already has a repo connection"
+    )
   end
 end

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -51,7 +51,7 @@ defmodule Lightning.VersionControl do
 
   def add_github_repo_and_branch(project_id, repo, branch) do
     pending_installation =
-      Repo.one(
+      Repo.one!(
         from(prc in ProjectRepoConnection,
           where: prc.project_id == ^project_id
         )

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -36,6 +36,17 @@ defmodule Lightning.VersionControl do
     )
   end
 
+  @spec get_pending_user_installation(Ecto.UUID.t()) ::
+          ProjectRepoConnection.t() | nil
+  def get_pending_user_installation(user_id) do
+    query =
+      from(prc in ProjectRepoConnection,
+        where: prc.user_id == ^user_id and is_nil(prc.github_installation_id)
+      )
+
+    Repo.one(query)
+  end
+
   def add_github_installation_id(user_id, installation_id) do
     pending_installation =
       Repo.one!(

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -38,7 +38,7 @@ defmodule Lightning.VersionControl do
 
   def add_github_installation_id(user_id, installation_id) do
     pending_installation =
-      Repo.one(
+      Repo.one!(
         from(prc in ProjectRepoConnection,
           where: prc.user_id == ^user_id and is_nil(prc.github_installation_id)
         )

--- a/lib/lightning_web/controllers/version_control_controller.ex
+++ b/lib/lightning_web/controllers/version_control_controller.ex
@@ -2,7 +2,6 @@ defmodule LightningWeb.VersionControlController do
   use LightningWeb, :controller
 
   alias Lightning.VersionControl
-  alias Lightning.VersionControl.GithubClient
 
   def index(conn, params) do
     # add installation id to project repo
@@ -14,7 +13,12 @@ defmodule LightningWeb.VersionControlController do
         params["installation_id"]
       )
 
-    GithubClient.send_sentry_error("Github App Configured successfully")
+    Sentry.capture_message("Github configuration successful",
+      level: "info",
+      extra: params,
+      message: "User configured version control successfully",
+      tags: %{type: "github"}
+    )
 
     # get project repo connection and forward to project settings
     redirect(conn,

--- a/lib/lightning_web/controllers/version_control_controller.ex
+++ b/lib/lightning_web/controllers/version_control_controller.ex
@@ -2,6 +2,7 @@ defmodule LightningWeb.VersionControlController do
   use LightningWeb, :controller
 
   alias Lightning.VersionControl
+  alias Lightning.VersionControl.GithubClient
 
   def index(conn, params) do
     # add installation id to project repo
@@ -12,6 +13,8 @@ defmodule LightningWeb.VersionControlController do
         conn.assigns.current_user.id,
         params["installation_id"]
       )
+
+    GithubClient.send_sentry_error("Github App Configured successfully")
 
     # get project repo connection and forward to project settings
     redirect(conn,

--- a/lib/lightning_web/controllers/version_control_controller.ex
+++ b/lib/lightning_web/controllers/version_control_controller.ex
@@ -6,23 +6,27 @@ defmodule LightningWeb.VersionControlController do
   def index(conn, params) do
     # add installation id to project repo
     # {:error, %{reason: "Can't find a pending connection."}}
+    user_id = conn.assigns.current_user.id
+    pending_connection = VersionControl.get_pending_user_installation(user_id)
 
-    {:ok, project_repo_connection} =
-      VersionControl.add_github_installation_id(
-        conn.assigns.current_user.id,
-        params["installation_id"]
+    if params["setup_action"] == "update" and is_nil(pending_connection) do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(
+        200,
+        "Github installation updated successfully; you may close this page or navigate to any OpenFn project which uses this installation: #{params["installation_id"]}"
       )
+    else
+      {:ok, project_repo_connection} =
+        VersionControl.add_github_installation_id(
+          user_id,
+          params["installation_id"]
+        )
 
-    Sentry.capture_message("Github configuration successful",
-      level: "info",
-      extra: params,
-      message: "User configured version control successfully",
-      tags: %{type: "github"}
-    )
-
-    # get project repo connection and forward to project settings
-    redirect(conn,
-      to: ~p"/projects/#{project_repo_connection.project_id}/settings#vcs"
-    )
+      # get project repo connection and forward to project settings
+      redirect(conn,
+        to: ~p"/projects/#{project_repo_connection.project_id}/settings#vcs"
+      )
+    end
   end
 end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -277,7 +277,9 @@ defmodule LightningWeb.ProjectLive.Settings do
           })
 
         {:noreply,
-         redirect(socket, external: "https://github.com/apps/#{app_name}")}
+         redirect(socket,
+           external: "https://github.com/apps/#{app_name}"
+         )}
     end
   end
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -54,7 +54,7 @@ defmodule LightningWeb.ProjectLive.Settings do
      project_repo_connection} =
       repo_settings(socket)
 
-    if show_repo_setup do
+    if show_repo_setup and connected?(socket) do
       collect_project_repo_connections(socket.assigns.project.id)
     end
 
@@ -425,7 +425,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       %{code: :installation_not_found} ->
         "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
 
-      %{code: :invalid_pem} ->
+      %{code: :invalid_certificate} ->
         "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
     end
   end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -347,7 +347,7 @@
         </LightningWeb.Components.Common.panel_content>
         <LightningWeb.Components.Common.panel_content for_hash="vcs">
           <%= if  @github_enabled do %>
-            <div :if={@can_edit_project_name}>
+            <div :if={@can_install_github}>
               <div :if={@show_github_setup} class="bg-white p-4 rounded-md">
                 <h6 class="font-medium text-black">
                   Install Github App to get started

--- a/priv/repo/migrations/20230926034840_add_unique_constraint_to_project_repo_connections.exs
+++ b/priv/repo/migrations/20230926034840_add_unique_constraint_to_project_repo_connections.exs
@@ -1,0 +1,7 @@
+defmodule Lightning.Repo.Migrations.AddUniqueConstraintToProjectRepoConnections do
+  use Ecto.Migration
+
+  def change do
+    create unique_index("project_repo_connections", [:project_id])
+  end
+end

--- a/test/lightning/version_control/github_client_test.exs
+++ b/test/lightning/version_control/github_client_test.exs
@@ -21,7 +21,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
       Tesla.Mock.mock(fn env ->
         case env.url do
           "https://api.github.com/app/installations/some-id/access_tokens" ->
-            %Tesla.Env{status: 400, body: %{}}
+            %Tesla.Env{status: 401, body: %{}}
 
           "https://api.github.com/app/installations/fail-id/access_tokens" ->
             %Tesla.Env{status: 404, body: %{}}
@@ -30,7 +30,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
             %Tesla.Env{status: 404, body: %{}}
 
           "https://api.github.com/repos/some/repo/branches" ->
-            %Tesla.Env{status: 400, body: %{}}
+            %Tesla.Env{status: 401, body: %{}}
         end
       end)
     end
@@ -40,8 +40,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                code: :invalid_pem,
-                message: "Github Cert is misconfigured"
+                code: :invalid_certificate,
+                message: "Github Certificate is misconfigured"
               }} =
                VersionControl.fetch_installation_repos(p_repo.project_id)
     end
@@ -63,8 +63,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                code: :invalid_pem,
-                message: "Github Cert is misconfigured"
+                code: :invalid_certificate,
+                message: "Github Certificate is misconfigured"
               }} =
                VersionControl.fetch_repo_branches(p_repo.project_id, p_repo.repo)
     end
@@ -74,8 +74,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                code: :invalid_pem,
-                message: "Github Cert is misconfigured"
+                code: :invalid_certificate,
+                message: "Github Certificate is misconfigured"
               }} =
                VersionControl.fetch_installation_repos(p_repo.project_id)
     end

--- a/test/lightning/version_control/github_client_test.exs
+++ b/test/lightning/version_control/github_client_test.exs
@@ -21,16 +21,16 @@ defmodule Lightning.VersionControl.GithubClientTest do
       Tesla.Mock.mock(fn env ->
         case env.url do
           "https://api.github.com/app/installations/some-id/access_tokens" ->
-            %Tesla.Env{status: 400}
+            %Tesla.Env{status: 400, body: %{}}
 
           "https://api.github.com/app/installations/fail-id/access_tokens" ->
-            %Tesla.Env{status: 404}
+            %Tesla.Env{status: 404, body: %{}}
 
           "https://api.github.com/installation/repositories" ->
-            %Tesla.Env{status: 404}
+            %Tesla.Env{status: 404, body: %{}}
 
           "https://api.github.com/repos/some/repo/branches" ->
-            %Tesla.Env{status: 400}
+            %Tesla.Env{status: 400, body: %{}}
         end
       end)
     end
@@ -40,8 +40,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                message:
-                  "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
+                code: :invalid_pem,
+                message: "Github Cert is misconfigured"
               }} =
                VersionControl.fetch_installation_repos(p_repo.project_id)
     end
@@ -52,8 +52,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                message:
-                  "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
+                code: :installation_not_found,
+                message: "Github Installation APP ID is misconfigured"
               }} =
                VersionControl.run_sync(p_repo.project_id, "some-user-name")
     end
@@ -63,8 +63,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                message:
-                  "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
+                code: :invalid_pem,
+                message: "Github Cert is misconfigured"
               }} =
                VersionControl.fetch_repo_branches(p_repo.project_id, p_repo.repo)
     end
@@ -74,8 +74,8 @@ defmodule Lightning.VersionControl.GithubClientTest do
 
       assert {:error,
               %{
-                message:
-                  "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"
+                code: :invalid_pem,
+                message: "Github Cert is misconfigured"
               }} =
                VersionControl.fetch_installation_repos(p_repo.project_id)
     end
@@ -104,7 +104,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
             %Tesla.Env{status: 200, body: [%{"name" => "master"}]}
 
           "https://api.github.com/repos/some/repo/dispatches" ->
-            %Tesla.Env{status: 204}
+            %Tesla.Env{status: 204, body: %{}}
         end
       end)
     end

--- a/test/lightning_web/controllers/version_control_controller_test.exs
+++ b/test/lightning_web/controllers/version_control_controller_test.exs
@@ -32,6 +32,32 @@ defmodule LightningWeb.VersionControlControllerTest do
       assert redirected_to(response) ==
                ~p"/projects/#{p_repo.project_id}/settings#vcs"
     end
+
+    test "responds with a text when the setup_action is set to update and there's no pending installation",
+         %{
+           conn: conn,
+           project: project,
+           user: user
+         } do
+      installation_id = "my_id"
+
+      insert(:project_repo_connection, %{
+        github_installation_id: installation_id,
+        branch: nil,
+        repo: nil,
+        user: user,
+        project: project
+      })
+
+      conn =
+        get(
+          conn,
+          ~p"/setup_vcs?installation_id=#{installation_id}&setup_action=update"
+        )
+
+      assert text_response(conn, 200) ==
+               "Github installation updated successfully; you may close this page or navigate to any OpenFn project which uses this installation: #{installation_id}"
+    end
   end
 
   describe "when not logged in" do

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -597,6 +597,27 @@ defmodule LightningWeb.ProjectLiveTest do
     end
 
     @tag role: :admin
+    test "Flashes an error when APP Name is missing during installation", %{
+      conn: conn,
+      project: project
+    } do
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: nil,
+        app_name: nil
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#vcs"
+        )
+
+      assert view |> render_click("install_app", %{}) =~
+               "Sorry, it seems that the GitHub App Name has not been properly configured for this instance of Lighting. Please contact the instance administrator"
+    end
+
+    @tag role: :admin
     test "can reinstall github app", %{
       conn: conn,
       project: project
@@ -616,6 +637,29 @@ defmodule LightningWeb.ProjectLiveTest do
         )
 
       assert view |> render_click("reinstall_app", %{})
+    end
+
+    @tag role: :admin
+    test "Flashes an error when APP Name is missing during reinstallation", %{
+      conn: conn,
+      project: project
+    } do
+      put_temporary_env(:lightning, :github_app,
+        cert: @cert,
+        app_id: nil,
+        app_name: nil
+      )
+
+      insert(:project_repo_connection, %{project_id: project.id, project: nil})
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#vcs"
+        )
+
+      assert view |> render_click("reinstall_app", %{}) =~
+               "Sorry, it seems that the GitHub App Name has not been properly configured for this instance of Lighting. Please contact the instance administrator"
     end
 
     @tag role: :admin

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -399,10 +399,10 @@ defmodule LightningWeb.ProjectLiveTest do
       Tesla.Mock.mock_global(fn env ->
         case env.url do
           "https://api.github.com/app/installations/bad-id/access_tokens" ->
-            %Tesla.Env{status: 404}
+            %Tesla.Env{status: 404, body: %{}}
 
           "https://api.github.com/app/installations/wrong-cert/access_tokens" ->
-            %Tesla.Env{status: 200}
+            %Tesla.Env{status: 401, body: %{}}
 
           "https://api.github.com/app/installations/some-id/access_tokens" ->
             %Tesla.Env{status: 201, body: %{"token" => "some-token"}}
@@ -483,7 +483,6 @@ defmodule LightningWeb.ProjectLiveTest do
     end
 
     @tag role: :admin
-    @tag :skip
     test "Flashes an error when APP ID is wrong", %{
       conn: conn,
       project: project,
@@ -509,12 +508,13 @@ defmodule LightningWeb.ProjectLiveTest do
           ~p"/projects/#{project.id}/settings#vcs"
         )
 
+      Process.sleep(15)
+
       assert render(view) =~
                "Sorry, it seems that the GitHub App ID has not been properly configured for this instance of Lightning. Please contact the instance administrator"
     end
 
     @tag role: :admin
-    @tag :skip
     test "Flashes an error when PEM CERT is corrupt", %{
       conn: conn,
       project: project,
@@ -539,6 +539,8 @@ defmodule LightningWeb.ProjectLiveTest do
           conn,
           ~p"/projects/#{project.id}/settings#vcs"
         )
+
+      Process.sleep(10)
 
       assert render(view) =~
                "Sorry, it seems that the GitHub cert has not been properly configured for this instance of Lightning. Please contact the instance administrator"


### PR DESCRIPTION
## Notes for the reviewer

- [x] Introduces `GithubError` exception for easier tracking
- [x] Adds `unique_constraint` to `project_repo_connections` for each `project`
- [x] Raise when we don't find a `pending` `connection` while trying to update `installation id`
- [x] add entire body of error to the sentry capture so that we are never hiding the errors from future developers!
- [x] Send a text response back to the user whenever they update the app settings on github, e.g. add more `repo` and they get redirected to the app. `Github installation updated successfully; you may close this page or navigate to any OpenFn project which uses this installation: <INSTALLATION_ID>` @NickOpenFn we may need to improve this later
- [x] check to see that we don’t capture an unknown error anywhere. (it’s fine if we do, though Taylor points out that it may be risky! do you REALLY know for sure that we will never get another type of error?)
- [x] Add tests

## Current flow for Github Installation
![github-installation](https://github.com/OpenFn/Lightning/assets/39288959/60dcec1d-1889-4e3d-96ec-bf1397530cd6)

## Related issue

Fixes #1112 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
