### PR TITLE
Add ellipsis when adaptor name is longer than the container allows 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Add ellipsis when adaptor name is longer than the container allows
+  [#1095](https://github.com/OpenFn/Lightning/issues/1095)
+
 ### Changed
 
 - Prevent deletion of first job of a workflow

--- a/assets/js/workflow-diagram/nodes/Node.tsx
+++ b/assets/js/workflow-diagram/nodes/Node.tsx
@@ -137,7 +137,16 @@ const Node = ({
               }}
             >
               {typeof icon === 'string' ? (
-                <div className="font-bold">{icon}</div>
+                <div
+                  className="font-bold"
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {icon}
+                </div>
               ) : (
                 icon
               )}


### PR DESCRIPTION
## Notes for the reviewer

## Related issue

Fixes #1095 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
