### PR TITLE
Add warning re: default PromEx implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   [#1189] (https://github.com/OpenFn/Lightning/issues/1189)
 - Add plumbing to support the use of PromEx
   [1199](https://github.com/OpenFn/Lightning/issues/1199)
+- Add warning text to PromEx config
+  [1222] (https://github.com/OpenFn/Lightning/issues/1222)
 
 ### Changed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -309,6 +309,9 @@ config :sentry,
   enable_source_code_context: true,
   root_source_code_path: File.cwd!()
 
+# WARNING: By default, PromEx exposes the metrics for Prometheus on an
+# unprotected endpoint. This functionality is not considered ready
+# for production use.
 config :lightning, Lightning.PromEx,
   disabled: System.get_env("PROMEX_ENABLED") != "true",
   manual_metrics_start_delay: :no_delay,


### PR DESCRIPTION
## Notes for the reviewer

Warning text until I can setup authenticated Prometheus scraping

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
