### PR TITLE
Update Delete to Delete Job and Add Confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 
 - Updated vulnerable JS libraries, `postcss` and `semver`
   [#1176](https://github.com/OpenFn/Lightning/issues/1176)
+- Update "Delete" to "Delete Job" on Job panel and include javascript deletion confirmation
+  [#1105](https://github.com/OpenFn/Lightning/issues/1105)
 
 ### Fixed
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -199,7 +199,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         class="focus:ring-red-500 bg-red-600 hover:bg-red-700 disabled:bg-red-300"
                         disabled={!@can_edit_job or has_child_edges or is_first_job}
                         tooltip="You can't delete the first job of a workflow"
-                        data-confirm="Are you sure?"
+                        data-confirm="Are you sure you want to delete this Job?"
                       >
                         Delete Job
                       </.button>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -199,8 +199,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         class="focus:ring-red-500 bg-red-600 hover:bg-red-700 disabled:bg-red-300"
                         disabled={!@can_edit_job or has_child_edges or is_first_job}
                         tooltip="You can't delete the first job of a workflow"
+                        data-confirm="Are you sure?"
                       >
-                        Delete
+                        Delete Job
                       </.button>
                     </label>
                   </div>


### PR DESCRIPTION
## Notes for the reviewer
This PR changes the delete text to **Delete Job** on the button and adds a confirmation to delete

## Related issue

Fixes #1105 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
