### PR TITLE
Claims immediate attempts first

### DIFF
--- a/lib/lightning/attempts/attempt.ex
+++ b/lib/lightning/attempts/attempt.ex
@@ -55,6 +55,10 @@ defmodule Lightning.Attempt do
     field :started_at, :utc_datetime_usec
     field :finished_at, :utc_datetime_usec
 
+    field :priority, Ecto.Enum,
+      values: [immediate: 0, normal: 1],
+      default: :normal
+
     timestamps type: :utc_datetime_usec, updated_at: false
   end
 
@@ -87,7 +91,7 @@ defmodule Lightning.Attempt do
   @doc false
   def changeset(attempt, attrs) do
     attempt
-    |> cast(attrs, [:reason_id, :work_order_id])
+    |> cast(attrs, [:reason_id, :work_order_id, :priority])
     |> cast_assoc(:runs, required: false)
     |> validate_required([:reason_id, :work_order_id])
     |> assoc_constraint(:work_order)

--- a/lib/lightning/attempts/queue.ex
+++ b/lib/lightning/attempts/queue.ex
@@ -18,7 +18,7 @@ defmodule Lightning.Attempts.Queue do
       |> select([:id])
       |> where([j], j.state == :available)
       |> limit(^demand)
-      |> order_by(asc: :inserted_at)
+      |> order_by([:priority, :inserted_at])
       |> lock("FOR UPDATE SKIP LOCKED")
 
     # The Postgres planner may choose to generate a plan that executes a nested

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -211,7 +211,7 @@ defmodule Lightning.WorkOrders do
         end)
       end)
 
-    Attempt.new()
+    Attempt.new(%{priority: :immediate})
     |> put_assoc(:created_by, attrs[:created_by])
     |> put_assoc(:work_order, attempt.work_order)
     |> put_change(:dataclip_id, run.input_dataclip_id)

--- a/priv/repo/migrations/20231030180230_add_attempt_priority.exs
+++ b/priv/repo/migrations/20231030180230_add_attempt_priority.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddAttemptPriority do
+  use Ecto.Migration
+
+  def change do
+    alter table(:attempts) do
+      add :priority, :integer, null: false
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer

On a claim from the attempts queue, it returns attempts with higher priority (`immediate`) before regular ones, expect when more than 1 is demanded and the amount immediate remaining ones is less than the demand. 

## Related issue

Resolves #1238 

## Review checklist

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
