### PR TITLE
Partition log_lines

### DIFF
--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -18,9 +18,10 @@ defmodule Lightning.Invocation.LogLine do
           attempt: Attempt.t() | Ecto.Association.NotLoaded.t() | nil
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
+  @primary_key false
   @foreign_key_type :binary_id
   schema "log_lines" do
+    field :id, :binary_id, autogenerate: true, primary_key: true
     field :source, :string
 
     field :level, Ecto.Enum,
@@ -32,7 +33,7 @@ defmodule Lightning.Invocation.LogLine do
     belongs_to :run, Run
     belongs_to :attempt, Attempt
 
-    field :timestamp, UnixDateTime
+    field :timestamp, UnixDateTime, primary_key: true
   end
 
   def new(%Attempt{} = attempt, attrs \\ %{}) do

--- a/lib/lightning/maintenance/admin_tools.ex
+++ b/lib/lightning/maintenance/admin_tools.ex
@@ -1,0 +1,21 @@
+defmodule Lightning.AdminTools do
+  def generate_iso_weeks(start_date, end_date) do
+    Date.range(start_date, end_date)
+    |> Enum.with_index()
+    |> Enum.filter(fn {_date, i} ->
+      rem(i, 7) == 0
+    end)
+    |> Enum.map(fn {date, _i} ->
+      weeknum = Timex.format!(date, "{Wiso}")
+      year = Timex.format!(date, "{WYYYY}")
+      monday = Timex.parse!("#{year}-#{weeknum}", "{YYYY}-{Wiso}")
+
+      {
+        year,
+        weeknum,
+        monday |> Date.to_string(),
+        monday |> Timex.shift(weeks: 1) |> Date.to_string()
+      }
+    end)
+  end
+end

--- a/priv/repo/migrations/20231106102231_partition_log_lines_by_week.exs
+++ b/priv/repo/migrations/20231106102231_partition_log_lines_by_week.exs
@@ -1,0 +1,153 @@
+defmodule Lightning.Repo.Migrations.PartitionLogLinesByWeek do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE log_lines
+    RENAME TO log_lines_monolith
+    """)
+
+    execute("""
+    ALTER TABLE log_lines_monolith
+    RENAME CONSTRAINT log_lines_pkey TO log_lines_monolith_pkey
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_attempt_id_index
+    RENAME TO log_lines_monolith_attempt_id_index
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_run_id_index
+    RENAME TO log_lines_monolith_run_id_index
+    """)
+
+    execute("""
+    ALTER TABLE log_lines_monolith
+    RENAME CONSTRAINT log_lines_attempt_id_fkey TO log_lines_monolith_attempt_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE log_lines_monolith
+    RENAME CONSTRAINT log_lines_run_id_fkey TO log_lines_monolith_run_id_fkey
+    """)
+
+    execute("""
+    CREATE TABLE public.log_lines (
+    id uuid NOT NULL,
+    message text NOT NULL,
+    run_id uuid,
+    "timestamp" timestamp(0) without time zone NOT NULL,
+    attempt_id uuid,
+    level character varying(255),
+    source character varying(255),
+    CONSTRAINT log_lines_pkey PRIMARY KEY (id, timestamp)
+    ) PARTITION BY range(timestamp)
+    """)
+
+    Lightning.AdminTools.generate_iso_weeks(~D[2023-01-02], ~D[2024-01-29])
+    |> Enum.each(fn {year, wnum, from, to} ->
+      execute("""
+      CREATE TABLE log_lines_#{year}_#{wnum}
+        PARTITION OF log_lines
+          FOR VALUES FROM ('#{from}') TO ('#{to}')
+      """)
+    end)
+
+    execute("""
+    CREATE TABLE log_lines_default
+    PARTITION OF log_lines
+    DEFAULT
+    """)
+
+    execute("""
+    INSERT INTO log_lines
+    SELECT *
+    FROM log_lines_monolith
+    """)
+
+    execute("""
+    CREATE INDEX log_lines_attempt_id_index
+    ON public.log_lines
+    USING btree (attempt_id)
+    """)
+
+    execute("""
+    CREATE INDEX log_lines_run_id_index
+    ON public.log_lines
+    USING btree (run_id)
+    """)
+
+    execute("""
+    ALTER TABLE public.log_lines
+    ADD CONSTRAINT log_lines_attempt_id_fkey
+    FOREIGN KEY (attempt_id)
+    REFERENCES public.attempts(id)
+    ON DELETE CASCADE
+    """)
+
+    execute("""
+    ALTER TABLE public.log_lines
+    ADD CONSTRAINT log_lines_run_id_fkey
+    FOREIGN KEY (run_id)
+    REFERENCES public.runs(id)
+    ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    Lightning.AdminTools.generate_iso_weeks(~D[2023-01-02], ~D[2024-01-29])
+    |> Enum.each(fn {year, wnum, _from, _to} ->
+      execute("""
+      ALTER TABLE IF EXISTS log_lines
+      DETACH PARTITION log_lines_#{year}_#{wnum}
+      """)
+
+      execute("""
+      DROP TABLE IF EXISTS log_lines_#{year}_#{wnum}
+      """)
+    end)
+
+    execute("""
+    ALTER TABLE IF EXISTS log_lines DETACH PARTITION log_lines_default
+    """)
+
+    execute("""
+    DROP TABLE IF EXISTS log_lines_default
+    """)
+
+    execute("""
+    DROP TABLE IF EXISTS public.log_lines
+    """)
+
+    execute("""
+    ALTER TABLE IF EXISTS log_lines_monolith
+    RENAME TO log_lines
+    """)
+
+    execute("""
+    ALTER TABLE log_lines
+    RENAME CONSTRAINT log_lines_monolith_pkey TO log_lines_pkey
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_monolith_attempt_id_index
+    RENAME TO log_lines_attempt_id_index
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_monolith_run_id_index
+    RENAME TO log_lines_run_id_index
+    """)
+
+    execute("""
+    ALTER TABLE log_lines
+    RENAME CONSTRAINT log_lines_monolith_attempt_id_fkey TO log_lines_attempt_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE log_lines
+    RENAME CONSTRAINT log_lines_monolith_run_id_fkey TO log_lines_run_id_fkey
+    """)
+  end
+end

--- a/test/lightning/maintenance/admin_tools_test.exs
+++ b/test/lightning/maintenance/admin_tools_test.exs
@@ -1,0 +1,21 @@
+defmodule Lightning.AdminToolstest do
+  use ExUnit.Case, async: true
+
+  alias Lightning.AdminTools
+
+  describe "generate_iso_weeks" do
+    test "returns a list of weeks between two given dates" do
+      expected_weeks = [
+        {"2023", "40", "2023-10-02", "2023-10-09"},
+        {"2023", "41", "2023-10-09", "2023-10-16"},
+        {"2023", "42", "2023-10-16", "2023-10-23"},
+        {"2023", "43", "2023-10-23", "2023-10-30"},
+        {"2023", "44", "2023-10-30", "2023-11-06"}
+      ]
+
+      weeks = AdminTools.generate_iso_weeks(~D[2023-10-02], ~D[2023-10-30])
+
+      assert weeks == expected_weeks
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer

Creates a partitioned version of the `log_lines` table. I have deliberately not added the maintenance code from platform as I thought I would hold off on that until we have some clarity on how we would like to proceed. This PR should at least create some space for experimentation.

This change leaves behind the `log_lines_monolith` table - my intent is to keep the `*_monolith` tables until the migration has successfully taken place on prod and then generate a new migration to clean them all up.

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
