### PR TITLE
fix workflow params tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Lightning.MixProject do
       {:httpoison, "~> 1.8"},
       {:jason, "~> 1.2"},
       {:joken, "~> 2.6.0"},
-      {:jsonpatch, "~> 1.0.1"},
+      {:jsonpatch, "~> 1.0.2"},
       {:junit_formatter, "~> 3.0", only: [:test]},
       {:libcluster, "~> 3.3"},
       {:mimic, "~> 1.7.2", only: :test},

--- a/test/lightning_web/live/workflow_live/workflow_params_test.exs
+++ b/test/lightning_web/live/workflow_live/workflow_params_test.exs
@@ -220,10 +220,6 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
     } do
       assert WorkflowParams.to_patches(original_params, params) ==
                [
-                 # Remove when https://github.com/corka149/jsonpatch/issues/16
-                 # is fixed and released.
-                 %{op: "add", path: "/project_id", value: nil},
-                 %{op: "add", path: "/name", value: nil},
                  %{op: "remove", path: "/jobs/1"},
                  %{op: "remove", path: "/jobs/0"}
                ]


### PR DESCRIPTION
## Notes for the reviewer
- Removes the `nil` add operations as instructed in the note. 
- Updates the mix file to `1.0.2` for easy visibility. The package was already updated in the `mix.lock`

Here's the diff for the release: https://diff.hex.pm/diff/jsonpatch/1.0.1..1.0.2


## Related issue

Fixes #

## Review checklist

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
