### PR TITLE
fix mox unexpected errors

### DIFF
--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -33,7 +33,7 @@ defmodule LightningWeb.ChannelCase do
   setup tags do
     # Mox.stub_with(Lightning.Config.Mock, Lightning.Config.Stub)
     # Application.put_env(:lightning, Lightning.Config, Lightning.Config.Mock)
-    # Mox.stub_with(Lightning.Mock, Lightning.Stub)
+    Mox.stub_with(Lightning.Mock, Lightning.Stub)
     # Application.put_env(:lightning, Lightning, Lightning.Mock)
 
     pid =

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -33,8 +33,8 @@ defmodule LightningWeb.ChannelCase do
   setup tags do
     # Mox.stub_with(Lightning.Config.Mock, Lightning.Config.Stub)
     # Application.put_env(:lightning, Lightning.Config, Lightning.Config.Mock)
-    Mox.stub_with(Lightning.Mock, Lightning.Stub)
-    Application.put_env(:lightning, Lightning, Lightning.Mock)
+    # Mox.stub_with(Lightning.Mock, Lightning.Stub)
+    # Application.put_env(:lightning, Lightning, Lightning.Mock)
 
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,


### PR DESCRIPTION
## Notes for the reviewer
From the error logs, it seemed like the Mock is configured to be accessed globally after being used by the `channel tests`.
I've commented the config in `channel_case`, and all tests seem to be passing.


## Related issue

Fixes #

## Review checklist

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
