### PR TITLE
Bump Log Line resolution

### DIFF
--- a/lib/lightning/ecto_types.ex
+++ b/lib/lightning/ecto_types.ex
@@ -6,26 +6,50 @@ defmodule Lightning.UnixDateTime do
   second or microsecond precision. This module allows millisecond precision
   integers to be used as DateTime values without losing precision.
 
+  Microsecond timestamps can also be parsed, but currently they are expected
+  to be provided as strings. This is because Javascript can't represent
+  microsecond timestamps as an integer and BigInt can't be represented
+  as a JSON value.
+
   All functions fallback on the default Ecto types conversion functions.
   """
   use Ecto.Type
   def type, do: :utc_datetime_usec
 
   @doc """
-  Cast a millisecond Unix timestamp to a DateTime.
+  Cast a Unix timestamp to a DateTime.
+
+  Accepts integers and strings, and will attempt to parse the string as an
+  integer. If the integer is 13 digits long, it will be parsed as a millisecond
+  timestamp, and as a microsecond timestamp if it is 16 digits long.
   """
-  def cast(u) when is_integer(u) do
-    DateTime.from_unix(u, :millisecond)
+  def cast(u) do
+    cond do
+      is_integer(u) ->
+        DateTime.from_unix(u, :millisecond)
+
+      byte_size(u) == 13 ->
+        String.to_integer(u)
+        |> DateTime.from_unix(:millisecond)
+
+      byte_size(u) == 16 ->
+        String.to_integer(u)
+        |> DateTime.from_unix(:microsecond)
+
+      is_struct(u, DateTime) ->
+        {:ok, u}
+
+      true ->
+        :error
+    end
     |> case do
       {:ok, dt} ->
-        {:ok, dt |> DateTime.add(0, :microsecond)}
+        Ecto.Type.cast(:utc_datetime_usec, dt)
 
       e ->
         e
     end
   end
-
-  def cast(u), do: Ecto.Type.cast(:utc_datetime_usec, u)
 
   def load(u) do
     Ecto.Type.load(:utc_datetime_usec, u)
@@ -53,9 +77,6 @@ defmodule Lightning.LogMessage do
   use Ecto.Type
   def type, do: :string
 
-  @doc """
-  Cast a millisecond Unix timestamp to a DateTime.
-  """
   def cast(d) when is_binary(d), do: Ecto.Type.cast(:string, d)
 
   def cast(d) when is_map(d) or is_list(d) do

--- a/lib/lightning/ecto_types.ex
+++ b/lib/lightning/ecto_types.ex
@@ -28,6 +28,9 @@ defmodule Lightning.UnixDateTime do
       is_integer(u) ->
         DateTime.from_unix(u, :millisecond)
 
+      is_struct(u, DateTime) ->
+        {:ok, u}
+
       byte_size(u) == 13 ->
         String.to_integer(u)
         |> DateTime.from_unix(:millisecond)
@@ -35,9 +38,6 @@ defmodule Lightning.UnixDateTime do
       byte_size(u) == 16 ->
         String.to_integer(u)
         |> DateTime.from_unix(:microsecond)
-
-      is_struct(u, DateTime) ->
-        {:ok, u}
 
       true ->
         :error

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -24,7 +24,7 @@ defmodule Lightning.Invocation.LogLine do
     field :source, :string
 
     field :level, Ecto.Enum,
-      values: [:info, :warn, :error, :debug],
+      values: [:success, :always, :info, :warn, :error, :debug],
       default: :info
 
     field :message, LogMessage, default: ""

--- a/priv/repo/migrations/20231107133932_increase_log_line_timestamp_resolution.exs
+++ b/priv/repo/migrations/20231107133932_increase_log_line_timestamp_resolution.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.IncreaseLogLineTimestampResolution do
+  use Ecto.Migration
+
+  def change do
+    alter table(:log_lines) do
+      modify :timestamp, :utc_datetime_usec
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer

This increases the LogLine `:timestamp` resolution to support usec.

In addition, the `:success` and `:always` log level types were added; and the `UnixDateTime` Ecto type can now handle usec and ms timestamps when sent as strings.


## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
