### PR TITLE
Partition log_lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,13 @@ and this project adheres to
 - Add plumbing to support the use of PromEx
   [#1199](https://github.com/OpenFn/Lightning/issues/1199)
 - Add warning text to PromEx config 
-  [#1222] (https://github.com/OpenFn/Lightning/issues/1222)
+  [#1222](https://github.com/OpenFn/Lightning/issues/1222)
 - Track and filter on webhook controller state in :telemetry metrics
   [#1192](https://github.com/OpenFn/Lightning/issues/1192)
 - Secure PromEx metrics endpoint by default
   [#1223](https://github.com/OpenFn/Lightning/issues/1223)
+- Partition `log_lines` table based on `attempt_id`
+  [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 
 ### Changed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -295,7 +295,11 @@ if config_env() == :test do
   # When running tests, set the number of database connections to the number
   # of cores available.
   config :lightning, Lightning.Repo,
-    pool_size: :erlang.system_info(:schedulers_online) + 4
+    pool_size: :erlang.system_info(:schedulers_online) + 8
+
+  config :ex_unit,
+    assert_receive_timeout:
+      System.get_env("ASSERT_RECEIVE_TIMEOUT", "500") |> String.to_integer()
 end
 
 release =

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,5 @@
 import Config
 
-config :ex_unit, :assert_receive_timeout, 500
-
 # Only in tests, remove the complexity from the password hashing algorithm
 config :bcrypt_elixir, :log_rounds, 1
 

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -27,9 +27,10 @@ defmodule Lightning.Invocation.LogLine do
           attempt: Attempt.t() | Ecto.Association.NotLoaded.t() | nil
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
+  @primary_key false
   @foreign_key_type :binary_id
   schema "log_lines" do
+    field :id, Ecto.UUID
     field :source, :string
 
     field :level, Ecto.Enum,

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -36,7 +36,7 @@ defmodule Lightning.Invocation.Run do
 
     belongs_to :previous, __MODULE__
 
-    has_many :log_lines, LogLine
+    has_many :log_lines, LogLine, preload_order: [asc: :timestamp]
 
     many_to_many :attempts, Attempt, join_through: AttemptRun
 

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -81,8 +81,12 @@ defmodule Lightning.SetupUtils do
   defp to_log_lines(log) do
     log
     |> String.split("\n")
-    |> Enum.map(fn log ->
-      %{message: log, timestamp: DateTime.utc_now()}
+    |> Enum.with_index()
+    |> Enum.map(fn {log, index} ->
+      %{
+        message: log,
+        timestamp: DateTime.utc_now() |> DateTime.add(index, :millisecond)
+      }
     end)
   end
 
@@ -936,7 +940,10 @@ defmodule Lightning.SetupUtils do
           Enum.map(run_params, fn params ->
             log_lines =
               Enum.map(params.log_lines, fn line ->
-                Map.merge(line, %{attempt_id: attempt.id})
+                Map.merge(line, %{
+                  id: Ecto.UUID.generate(),
+                  attempt_id: attempt.id
+                })
               end)
 
             params

--- a/priv/repo/migrations/20231106102231_partition_log_lines_by_week.exs
+++ b/priv/repo/migrations/20231106102231_partition_log_lines_by_week.exs
@@ -1,0 +1,158 @@
+defmodule Lightning.Repo.Migrations.PartitionLogLinesByWeek do
+  use Ecto.Migration
+
+  @num_partitions 100
+
+  def up do
+    execute("""
+    ALTER TABLE log_lines
+    RENAME TO log_lines_monolith
+    """)
+
+    execute("""
+    ALTER TABLE log_lines_monolith
+    RENAME CONSTRAINT log_lines_pkey TO log_lines_monolith_pkey
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_attempt_id_index
+    RENAME TO log_lines_monolith_attempt_id_index
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_run_id_index
+    RENAME TO log_lines_monolith_run_id_index
+    """)
+
+    execute("""
+    ALTER TABLE log_lines_monolith
+    RENAME CONSTRAINT log_lines_attempt_id_fkey TO log_lines_monolith_attempt_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE log_lines_monolith
+    RENAME CONSTRAINT log_lines_run_id_fkey TO log_lines_monolith_run_id_fkey
+    """)
+
+    execute("""
+    CREATE TABLE public.log_lines (
+    id uuid NOT NULL,
+    message text NOT NULL,
+    run_id uuid,
+    "timestamp" timestamp(6) without time zone NOT NULL,
+    attempt_id uuid,
+    level character varying(255),
+    source character varying(255)
+    ) PARTITION BY HASH(attempt_id)
+    """)
+
+    manage_partitions(@num_partitions, &create_partition/2)
+
+    execute("""
+    INSERT INTO log_lines
+    SELECT *
+    FROM log_lines_monolith
+    """)
+
+    execute("""
+    CREATE INDEX log_lines_id_index
+    ON public.log_lines
+    USING hash (id)
+    """)
+
+    execute("""
+    CREATE INDEX log_lines_attempt_id_index
+    ON public.log_lines
+    USING hash (attempt_id)
+    """)
+
+    execute("""
+    CREATE INDEX log_lines_run_id_index
+    ON public.log_lines
+    USING hash (run_id)
+    """)
+
+    execute("""
+    CREATE INDEX log_lines_timestamp_index
+    ON public.log_lines (timestamp ASC)
+    """)
+
+    execute("""
+    ALTER TABLE public.log_lines
+    ADD CONSTRAINT log_lines_attempt_id_fkey
+    FOREIGN KEY (attempt_id)
+    REFERENCES public.attempts(id)
+    ON DELETE CASCADE
+    """)
+
+    execute("""
+    ALTER TABLE public.log_lines
+    ADD CONSTRAINT log_lines_run_id_fkey
+    FOREIGN KEY (run_id)
+    REFERENCES public.runs(id)
+    ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    manage_partitions(@num_partitions, &drop_partition/2)
+
+    execute("""
+    DROP TABLE IF EXISTS public.log_lines
+    """)
+
+    execute("""
+    ALTER TABLE IF EXISTS log_lines_monolith
+    RENAME TO log_lines
+    """)
+
+    execute("""
+    ALTER TABLE log_lines
+    RENAME CONSTRAINT log_lines_monolith_pkey TO log_lines_pkey
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_monolith_attempt_id_index
+    RENAME TO log_lines_attempt_id_index
+    """)
+
+    execute("""
+    ALTER INDEX log_lines_monolith_run_id_index
+    RENAME TO log_lines_run_id_index
+    """)
+
+    execute("""
+    ALTER TABLE log_lines
+    RENAME CONSTRAINT log_lines_monolith_attempt_id_fkey TO log_lines_attempt_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE log_lines
+    RENAME CONSTRAINT log_lines_monolith_run_id_fkey TO log_lines_run_id_fkey
+    """)
+  end
+
+  defp manage_partitions(num_partitions, manage_function) do
+    1..num_partitions
+    |> Enum.each(&manage_function.(num_partitions, &1))
+  end
+
+  defp create_partition(num_partitions, part_num) do
+    execute("""
+    CREATE TABLE log_lines_#{part_num}
+    PARTITION OF log_lines
+    FOR VALUES WITH (MODULUS #{num_partitions}, REMAINDER #{part_num - 1})
+    """)
+  end
+
+  defp drop_partition(_num_partitions, part_num) do
+    execute("""
+    ALTER TABLE IF EXISTS log_lines
+    DETACH PARTITION log_lines_#{part_num}
+    """)
+
+    execute("""
+    DROP TABLE IF EXISTS log_lines_#{part_num}
+    """)
+  end
+end

--- a/priv/repo/migrations/20231110102231_partition_log_lines_by_week.exs
+++ b/priv/repo/migrations/20231110102231_partition_log_lines_by_week.exs
@@ -35,14 +35,14 @@ defmodule Lightning.Repo.Migrations.PartitionLogLinesByWeek do
     """)
 
     execute("""
-    CREATE TABLE public.log_lines (
-    id uuid NOT NULL,
-    message text NOT NULL,
-    run_id uuid,
-    "timestamp" timestamp(6) without time zone NOT NULL,
-    attempt_id uuid,
-    level character varying(255),
-    source character varying(255)
+    CREATE TABLE log_lines (
+      id uuid NOT NULL,
+      message text NOT NULL,
+      run_id uuid,
+      "timestamp" timestamp(6) without time zone NOT NULL,
+      attempt_id uuid,
+      level character varying(255),
+      source character varying(255)
     ) PARTITION BY HASH(attempt_id)
     """)
 
@@ -56,40 +56,40 @@ defmodule Lightning.Repo.Migrations.PartitionLogLinesByWeek do
 
     execute("""
     CREATE INDEX log_lines_id_index
-    ON public.log_lines
+    ON log_lines
     USING hash (id)
     """)
 
     execute("""
     CREATE INDEX log_lines_attempt_id_index
-    ON public.log_lines
+    ON log_lines
     USING hash (attempt_id)
     """)
 
     execute("""
     CREATE INDEX log_lines_run_id_index
-    ON public.log_lines
+    ON log_lines
     USING hash (run_id)
     """)
 
     execute("""
     CREATE INDEX log_lines_timestamp_index
-    ON public.log_lines (timestamp ASC)
+    ON log_lines (timestamp ASC)
     """)
 
     execute("""
-    ALTER TABLE public.log_lines
+    ALTER TABLE log_lines
     ADD CONSTRAINT log_lines_attempt_id_fkey
     FOREIGN KEY (attempt_id)
-    REFERENCES public.attempts(id)
+    REFERENCES attempts(id)
     ON DELETE CASCADE
     """)
 
     execute("""
-    ALTER TABLE public.log_lines
+    ALTER TABLE log_lines
     ADD CONSTRAINT log_lines_run_id_fkey
     FOREIGN KEY (run_id)
-    REFERENCES public.runs(id)
+    REFERENCES runs(id)
     ON DELETE CASCADE
     """)
   end
@@ -98,7 +98,7 @@ defmodule Lightning.Repo.Migrations.PartitionLogLinesByWeek do
     manage_partitions(@num_partitions, &drop_partition/2)
 
     execute("""
-    DROP TABLE IF EXISTS public.log_lines
+    DROP TABLE IF EXISTS log_lines
     """)
 
     execute("""

--- a/test/lightning/attempts_test.exs
+++ b/test/lightning/attempts_test.exs
@@ -405,7 +405,9 @@ defmodule Lightning.AttemptsTest do
           timestamp: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
         })
 
-      log_line = log_line |> Repo.reload!() |> Repo.preload(:run)
+      log_line =
+        Repo.get_by(Invocation.LogLine, id: log_line.id)
+        |> Repo.preload(:run)
 
       assert log_line.run.id == run.id
     end

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -708,12 +708,11 @@ defmodule Lightning.InvocationTest do
           "run_id" => Ecto.UUID.generate()
         })
 
-      %Lightning.Invocation.LogLine{
-        attempt: attempt,
+      Lightning.Invocation.LogLine.new(attempt, %{
         run: run,
         message: "Sadio Mane is playing in Senegal and Al Nasr",
         timestamp: Timex.now()
-      }
+      })
       |> Repo.insert!()
 
       assert Lightning.Invocation.search_workorders(
@@ -759,11 +758,7 @@ defmodule Lightning.InvocationTest do
     test "logs_for_run/1 returns an array of the logs for a given run" do
       run =
         insert(:run,
-          log_lines: [
-            %{message: "Hello", timestamp: build(:timestamp)},
-            %{message: "I am a", timestamp: build(:timestamp)},
-            %{message: "log", timestamp: build(:timestamp)}
-          ]
+          log_lines: ["Hello", "I am a", "log"] |> Enum.map(&build_log_map/1)
         )
 
       log_lines = Invocation.logs_for_run(run)
@@ -780,11 +775,7 @@ defmodule Lightning.InvocationTest do
     test "assemble_logs_for_run/1 returns a string representation of the logs for a run" do
       run =
         insert(:run,
-          log_lines: [
-            %{message: "Hello", timestamp: build(:timestamp)},
-            %{message: "I am a", timestamp: build(:timestamp)},
-            %{message: "log", timestamp: build(:timestamp)}
-          ]
+          log_lines: ["Hello", "I am a", "log"] |> Enum.map(&build_log_map/1)
         )
 
       log_string = Invocation.assemble_logs_for_run(run)
@@ -794,6 +785,10 @@ defmodule Lightning.InvocationTest do
 
     test "assemble_logs_for_run/1 returns nil when given a nil run" do
       assert Invocation.assemble_logs_for_run(nil) == nil
+    end
+
+    defp build_log_map(message) do
+      %{id: Ecto.UUID.generate(), message: message, timestamp: build(:timestamp)}
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,13 +11,10 @@ Mimic.copy(Lightning.FailureEmail)
 Mimic.copy(Lightning.WorkOrderService)
 Mimic.copy(Mix.Tasks.Lightning.InstallSchemas)
 
-assert_receive_timeout =
-  System.get_env("ASSERT_RECEIVE_TIMEOUT", "100") |> String.to_integer()
-
-ExUnit.configure(
-  formatters: [JUnitFormatter, ExUnit.CLIFormatter],
-  assert_receive_timeout: assert_receive_timeout
-)
+# Other ExUnit configuration can be found in `config/runtime.exs`,
+# for example to change the `assert_receive` timeout, configure it using the
+# `ASSERT_RECEIVE_TIMEOUT` environment variable.
+ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Lightning.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,7 +11,13 @@ Mimic.copy(Lightning.FailureEmail)
 Mimic.copy(Lightning.WorkOrderService)
 Mimic.copy(Mix.Tasks.Lightning.InstallSchemas)
 
-ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
+assert_receive_timeout =
+  System.get_env("ASSERT_RECEIVE_TIMEOUT", "100") |> String.to_integer()
+
+ExUnit.configure(
+  formatters: [JUnitFormatter, ExUnit.CLIFormatter],
+  assert_receive_timeout: assert_receive_timeout
+)
 
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Lightning.Repo, :manual)


### PR DESCRIPTION
## Notes for the reviewer

Partitions the `log_lines` table by hash of the `attempt_id` plus some test fixes to deal with the removal of the PK on `id`.

On my branch there are currently 2 failing tests  that appear unrelated and I see that there is a feature branch addressing them - so I have left them for now. I have also looked at the other failing checks and they appear to be unrelated to the code changes in this branch.

I am not sure if this change warrants mention in the CHANGELOG?



## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
