### PR TITLE
Update the broadcast events for attempts and runs on History page

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^4.3.7"
       },
       "devDependencies": {
-        "@openfn/ws-worker": "^0.1.6",
+        "@openfn/ws-worker": "^0.1.8",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
@@ -704,13 +704,13 @@
       }
     },
     "node_modules/@openfn/compiler": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@openfn/compiler/-/compiler-0.0.37.tgz",
-      "integrity": "sha512-SduX9eBwKdwAIqrdBGvYGxmCMY/1vvxI1LgOhckEhGMdYIuTLxg/OgWbi+ODCURt6UdXmjBL+q8nulDGUrWP0w==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@openfn/compiler/-/compiler-0.0.38.tgz",
+      "integrity": "sha512-DYfTvRzmsA2EsqogN7Wt+IESRmEuhFQ9Ddz5Wb3WuFCie0Q/D9WWjtH+tAU1OYZqJyh77zsjtiRR66h29EGrgA==",
       "dev": true,
       "dependencies": {
         "@openfn/describe-package": "0.0.18",
-        "@openfn/logger": "0.0.18",
+        "@openfn/logger": "0.0.19",
         "acorn": "^8.8.0",
         "ast-types": "^0.14.2",
         "recast": "^0.21.5"
@@ -766,15 +766,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.4.tgz",
-      "integrity": "sha512-BJEIVN+EQ/IKs52oSywF5TJ6BReJWJh6HZuQsnX7HVLxfQcam98oznYguryHdNM5NPAHpeFGEV9uoisSLlEAjA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.5.tgz",
+      "integrity": "sha512-/wfPNEQV2a9VpoCvusjQxQzlgZTN/n14jjsCtY6S6pMUPyVkPGUiTNb/Jm61b8T60B1nXGR1Ar/QR/KxIiKkTQ==",
       "dev": true,
       "dependencies": {
-        "@openfn/compiler": "0.0.37",
+        "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
-        "@openfn/logger": "0.0.18",
-        "@openfn/runtime": "0.0.32",
+        "@openfn/logger": "0.0.19",
+        "@openfn/runtime": "0.0.33",
         "workerpool": "^6.5.1"
       }
     },
@@ -785,9 +785,9 @@
       "dev": true
     },
     "node_modules/@openfn/logger": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@openfn/logger/-/logger-0.0.18.tgz",
-      "integrity": "sha512-WeGzwihvpmRXp8F2ojoErJF8CLlQb2SFUigowEajZDLcixvaWU3XsYC5QkfEDP5BeJ1eJ7+piR1hb8UYeupVQA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@openfn/logger/-/logger-0.0.19.tgz",
+      "integrity": "sha512-3NWUjl7n6f2aQhlJEMFKe47BggmD40xgyBpXofwHsRpx81fA9tms09oU+XPAfZuARbOvZNO0eMskPoERmlJhaA==",
       "dev": true,
       "dependencies": {
         "@inquirer/confirm": "2.0.6",
@@ -800,26 +800,26 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.0.32.tgz",
-      "integrity": "sha512-mF0iuAH530gTHqmGQsw2X5PjDVwO4VlkqnA8eelwjNU+UM2EviUxORKqnZE92NEkcY/L5BNBglogna9t3qzlNQ==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.0.33.tgz",
+      "integrity": "sha512-+fBpgcpz/gD0JJdIV9ZxYy6HRLMhf/M6M9tNmPBAuwd/JPmweicLJgxCYW7vKkm0Fz1n7JmMrBz7HIIleX3cGg==",
       "dev": true,
       "dependencies": {
-        "@openfn/logger": "0.0.18",
+        "@openfn/logger": "0.0.19",
         "fast-safe-stringify": "^2.1.1",
         "semver": "^7.5.4"
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.1.6.tgz",
-      "integrity": "sha512-4kN7Tpcvv1CeuW2/pZnzGhwmBRwRCwmeba1NJqFiw0iUWtLGqNaFjsohM1a9I/JMyKt3sxH+Au4kg854yDRfdw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.1.8.tgz",
+      "integrity": "sha512-k8XgXkaPQTdHQkuOeuKgncGFW+HpwsaPjURKqXs5CzPna8HAtZjn71Ie6HM+4J7mk+xgPfjPNDuuCql7svVwUQ==",
       "dev": true,
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.1.4",
-        "@openfn/logger": "0.0.18",
-        "@openfn/runtime": "0.0.32",
+        "@openfn/engine-multi": "0.1.5",
+        "@openfn/logger": "0.0.19",
+        "@openfn/runtime": "0.0.33",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",
@@ -7159,13 +7159,13 @@
       }
     },
     "@openfn/compiler": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@openfn/compiler/-/compiler-0.0.37.tgz",
-      "integrity": "sha512-SduX9eBwKdwAIqrdBGvYGxmCMY/1vvxI1LgOhckEhGMdYIuTLxg/OgWbi+ODCURt6UdXmjBL+q8nulDGUrWP0w==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@openfn/compiler/-/compiler-0.0.38.tgz",
+      "integrity": "sha512-DYfTvRzmsA2EsqogN7Wt+IESRmEuhFQ9Ddz5Wb3WuFCie0Q/D9WWjtH+tAU1OYZqJyh77zsjtiRR66h29EGrgA==",
       "dev": true,
       "requires": {
         "@openfn/describe-package": "0.0.18",
-        "@openfn/logger": "0.0.18",
+        "@openfn/logger": "0.0.19",
         "acorn": "^8.8.0",
         "ast-types": "^0.14.2",
         "recast": "^0.21.5"
@@ -7205,15 +7205,15 @@
       }
     },
     "@openfn/engine-multi": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.4.tgz",
-      "integrity": "sha512-BJEIVN+EQ/IKs52oSywF5TJ6BReJWJh6HZuQsnX7HVLxfQcam98oznYguryHdNM5NPAHpeFGEV9uoisSLlEAjA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.5.tgz",
+      "integrity": "sha512-/wfPNEQV2a9VpoCvusjQxQzlgZTN/n14jjsCtY6S6pMUPyVkPGUiTNb/Jm61b8T60B1nXGR1Ar/QR/KxIiKkTQ==",
       "dev": true,
       "requires": {
-        "@openfn/compiler": "0.0.37",
+        "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
-        "@openfn/logger": "0.0.18",
-        "@openfn/runtime": "0.0.32",
+        "@openfn/logger": "0.0.19",
+        "@openfn/runtime": "0.0.33",
         "workerpool": "^6.5.1"
       }
     },
@@ -7224,9 +7224,9 @@
       "dev": true
     },
     "@openfn/logger": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@openfn/logger/-/logger-0.0.18.tgz",
-      "integrity": "sha512-WeGzwihvpmRXp8F2ojoErJF8CLlQb2SFUigowEajZDLcixvaWU3XsYC5QkfEDP5BeJ1eJ7+piR1hb8UYeupVQA==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@openfn/logger/-/logger-0.0.19.tgz",
+      "integrity": "sha512-3NWUjl7n6f2aQhlJEMFKe47BggmD40xgyBpXofwHsRpx81fA9tms09oU+XPAfZuARbOvZNO0eMskPoERmlJhaA==",
       "dev": true,
       "requires": {
         "@inquirer/confirm": "2.0.6",
@@ -7236,26 +7236,26 @@
       }
     },
     "@openfn/runtime": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.0.32.tgz",
-      "integrity": "sha512-mF0iuAH530gTHqmGQsw2X5PjDVwO4VlkqnA8eelwjNU+UM2EviUxORKqnZE92NEkcY/L5BNBglogna9t3qzlNQ==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.0.33.tgz",
+      "integrity": "sha512-+fBpgcpz/gD0JJdIV9ZxYy6HRLMhf/M6M9tNmPBAuwd/JPmweicLJgxCYW7vKkm0Fz1n7JmMrBz7HIIleX3cGg==",
       "dev": true,
       "requires": {
-        "@openfn/logger": "0.0.18",
+        "@openfn/logger": "0.0.19",
         "fast-safe-stringify": "^2.1.1",
         "semver": "^7.5.4"
       }
     },
     "@openfn/ws-worker": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.1.6.tgz",
-      "integrity": "sha512-4kN7Tpcvv1CeuW2/pZnzGhwmBRwRCwmeba1NJqFiw0iUWtLGqNaFjsohM1a9I/JMyKt3sxH+Au4kg854yDRfdw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.1.8.tgz",
+      "integrity": "sha512-k8XgXkaPQTdHQkuOeuKgncGFW+HpwsaPjURKqXs5CzPna8HAtZjn71Ie6HM+4J7mk+xgPfjPNDuuCql7svVwUQ==",
       "dev": true,
       "requires": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.1.4",
-        "@openfn/logger": "0.0.18",
-        "@openfn/runtime": "0.0.32",
+        "@openfn/engine-multi": "0.1.5",
+        "@openfn/logger": "0.0.19",
+        "@openfn/runtime": "0.0.33",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,7 +35,7 @@
     "zustand": "^4.3.7"
   },
   "devDependencies": {
-    "@openfn/ws-worker": "^0.1.6",
+    "@openfn/ws-worker": "^0.1.8",
     "@types/marked": "^4.0.8",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/lib/lightning/attempts.ex
+++ b/lib/lightning/attempts.ex
@@ -115,8 +115,6 @@ defmodule Lightning.Attempts do
     |> Repo.transaction()
     |> case do
       {:ok, %{attempts: {1, [attempt]}}} ->
-        # TODO: Broadcast here ? Below doesn't seem to update the live view
-        Events.attempt_updated(attempt)
         {:ok, attempt}
 
       {:error, changeset} ->
@@ -136,6 +134,7 @@ defmodule Lightning.Attempts do
     |> Ecto.Multi.run(:post, fn _, %{attempts: {_, attempts}} ->
       Enum.each(attempts, fn attempt ->
         {:ok, _} = Lightning.WorkOrders.update_state(attempt)
+
         Events.attempt_updated(attempt)
       end)
 

--- a/lib/lightning/attempts.ex
+++ b/lib/lightning/attempts.ex
@@ -188,7 +188,7 @@ defmodule Lightning.Attempts do
     Handlers.CompleteRun.call(params)
   end
 
-  defdelegate subscribe(attempt), to: Lightning.Attempts.Events
+  defdelegate subscribe(attempt), to: Events
 
   def get_project_id_for_attempt(attempt) do
     Ecto.assoc(attempt, [:work_order, :workflow, :project])

--- a/lib/lightning/attempts/attempt.ex
+++ b/lib/lightning/attempts/attempt.ex
@@ -56,7 +56,10 @@ defmodule Lightning.Attempt do
     has_one :workflow, through: [:work_order, :workflow]
 
     has_many :log_lines, LogLine
-    many_to_many :runs, Run, join_through: AttemptRun
+
+    many_to_many :runs, Run,
+      join_through: AttemptRun,
+      preload_order: [asc: :finished_at]
 
     field :state, Ecto.Enum,
       values:

--- a/lib/lightning/attempts/attempt.ex
+++ b/lib/lightning/attempts/attempt.ex
@@ -59,7 +59,7 @@ defmodule Lightning.Attempt do
 
     many_to_many :runs, Run,
       join_through: AttemptRun,
-      preload_order: [asc: :finished_at]
+      preload_order: [asc: :started_at]
 
     field :state, Ecto.Enum,
       values:

--- a/lib/lightning/attempts/handlers.ex
+++ b/lib/lightning/attempts/handlers.ex
@@ -5,7 +5,8 @@ defmodule Lightning.Attempts.Handlers do
 
   alias Lightning.Attempt
   alias Lightning.AttemptRun
-  alias Lightning.Attempts.Events
+  alias Lightning.Attempts
+  alias Lightning.WorkOrders
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Run
   alias Lightning.Repo
@@ -45,7 +46,10 @@ defmodule Lightning.Attempts.Handlers do
     def call(params) do
       with {:ok, attrs} <- new(params) |> apply_action(:validate),
            {:ok, run} <- insert(attrs) do
-        Events.run_started(attrs.attempt_id, run)
+        attempt = Attempts.get(attrs.attempt_id, include: [:workflow])
+        WorkOrders.Events.attempt_updated(attempt.workflow.project_id, attempt)
+        Attempts.Events.run_started(attrs.attempt_id, run)
+
         {:ok, run}
       end
     end

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -327,6 +327,7 @@ defmodule Lightning.Invocation do
         %SearchParams{} = search_params
       ) do
     base_query(project_id)
+    |> filter_by_workorder_id(search_params.workorder_id)
     |> filter_by_workflow_id(search_params.workflow_id)
     |> filter_by_statuses(search_params.status)
     |> filter_by_wo_date_after(search_params.wo_date_after)
@@ -351,6 +352,13 @@ defmodule Lightning.Invocation do
       order_by: [desc_nulls_first: workorder.last_activity],
       distinct: true
     )
+  end
+
+  defp filter_by_workorder_id(query, nil), do: query
+
+  defp filter_by_workorder_id(query, workorder_id)
+       when is_binary(workorder_id) do
+    from([workorder: workorder] in query, where: workorder.id == ^workorder_id)
   end
 
   defp filter_by_workflow_id(query, nil), do: query

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -348,7 +348,7 @@ defmodule Lightning.Invocation do
       as: :workflow,
       where: workflow.project_id == ^project_id,
       select: workorder,
-      preload: [workflow: workflow, attempts: [:runs]],
+      preload: [workflow: workflow, attempts: [runs: :job]],
       order_by: [desc_nulls_first: workorder.last_activity],
       distinct: true
     )

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -52,32 +52,32 @@ defmodule Lightning.WorkOrders do
   import Ecto.Query
   import Lightning.Validators
 
-  @pubsub Lightning.PubSub
-
   @type work_order_option ::
           {:workflow, Workflow.t()}
           | {:dataclip, Dataclip.t()}
           | {:created_by, User.t()}
 
-  # @doc """
-  # Create a new Workorder.
-  #
-  # **For a webhook**
-  #     create(trigger, workflow: workflow, dataclip: dataclip)
-  #
-  # **For a user**
-  #     create(job, workflow: workflow, dataclip: dataclip, user: user)
-  # """
+  @doc """
+  Create a new Workorder.
+
+  **For a webhook**
+      create_for(trigger, workflow: workflow, dataclip: dataclip)
+
+  **For a user**
+      create_for(job, workflow: workflow, dataclip: dataclip, user: user)
+  """
   @spec create_for(Trigger.t() | Job.t(), [work_order_option()]) ::
           {:ok, WorkOrder.t()} | {:error, Ecto.Changeset.t(WorkOrder.t())}
   def create_for(%Trigger{} = trigger, opts) do
     build_for(trigger, opts |> Map.new())
     |> Repo.insert()
+    |> maybe_broadcast_workorder_creation()
   end
 
   def create_for(%Job{} = job, opts) do
     build_for(job, opts |> Map.new())
     |> Repo.insert()
+    |> maybe_broadcast_workorder_creation()
   end
 
   def create_for(%Manual{} = manual) do
@@ -90,13 +90,28 @@ defmodule Lightning.WorkOrders do
         created_by: manual.created_by
       })
     end)
-    |> Multi.run(:broadcast, fn _repo, %{workorder: %{attempts: [attempt]}} ->
-      {:ok, Events.attempt_created(manual.project.id, attempt)}
+    |> Multi.run(:broadcast, fn _repo,
+                                %{workorder: %{attempts: [attempt]} = workorder} ->
+      Events.work_order_created(manual.project.id, workorder)
+      Events.attempt_created(manual.project.id, attempt)
+      {:ok, nil}
     end)
     |> Repo.transaction()
     |> case do
       {:ok, %{workorder: workorder}} ->
         {:ok, workorder}
+    end
+  end
+
+  defp maybe_broadcast_workorder_creation(result) do
+    case result do
+      {:ok, workorder} ->
+        workflow = workorder |> Repo.preload(:workflow) |> Map.get(:workflow)
+        Events.work_order_created(workflow.project_id, workorder)
+        {:ok, workorder}
+
+      other ->
+        other
     end
   end
 
@@ -224,7 +239,15 @@ defmodule Lightning.WorkOrders do
     |> validate_required_assoc(:work_order)
     |> validate_required_assoc(:created_by)
     |> Attempts.enqueue()
-    |> maybe_broadcast()
+    |> then(fn
+      {:ok, attempt} ->
+        workflow = attempt |> Repo.preload(:workflow) |> Map.get(:workflow)
+        Events.attempt_created(workflow.project_id, attempt)
+        {:ok, attempt}
+
+      other ->
+        other
+    end)
   end
 
   def retry(%Attempt{id: attempt_id}, %Run{id: run_id}, opts) do
@@ -335,7 +358,11 @@ defmodule Lightning.WorkOrders do
       update: [set: [state: s.state, last_activity: ^DateTime.utc_now()]]
     )
     |> Repo.update_all([])
-    |> then(fn {_, [wo]} -> {:ok, wo} end)
+    |> then(fn {_, [wo]} ->
+      workflow = wo |> Repo.preload(:workflow) |> Map.get(:workflow)
+      Events.work_order_updated(workflow.project_id, wo)
+      {:ok, wo}
+    end)
   end
 
   @doc """
@@ -355,24 +382,4 @@ defmodule Lightning.WorkOrders do
     )
     |> Repo.one()
   end
-
-  def subscribe(project_id) do
-    Events.subscribe(project_id)
-  end
-
-  defp maybe_broadcast({:ok, attempt} = result) do
-    workflow = attempt |> Repo.preload(:workflow) |> Map.get(:workflow)
-
-    Phoenix.PubSub.broadcast(
-      @pubsub,
-      topic(workflow.project_id),
-      {__MODULE__, %Events.AttemptCreated{attempt: attempt}}
-    )
-
-    result
-  end
-
-  defp maybe_broadcast(result), do: result
-
-  defp topic(project_id), do: "project:#{project_id}"
 end

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -387,4 +387,6 @@ defmodule Lightning.WorkOrders do
     )
     |> Repo.one()
   end
+
+  defdelegate subscribe(project_id), to: Events
 end

--- a/lib/lightning/workorders/events.ex
+++ b/lib/lightning/workorders/events.ex
@@ -1,6 +1,16 @@
 defmodule Lightning.WorkOrders.Events do
   @moduledoc false
 
+  defmodule WorkOrderCreated do
+    @moduledoc false
+    defstruct work_order: nil
+  end
+
+  defmodule WorkOrderUpdated do
+    @moduledoc false
+    defstruct work_order: nil
+  end
+
   defmodule AttemptCreated do
     @moduledoc false
     defstruct attempt: nil
@@ -11,10 +21,31 @@ defmodule Lightning.WorkOrders.Events do
     defstruct attempt: nil
   end
 
+  def work_order_created(project_id, work_order) do
+    Lightning.broadcast(
+      topic(project_id),
+      %WorkOrderCreated{work_order: work_order}
+    )
+  end
+
+  def work_order_updated(project_id, work_order) do
+    Lightning.broadcast(
+      topic(project_id),
+      %WorkOrderUpdated{work_order: work_order}
+    )
+  end
+
   def attempt_created(project_id, attempt) do
     Lightning.broadcast(
       topic(project_id),
       %AttemptCreated{attempt: attempt}
+    )
+  end
+
+  def attempt_updated(project_id, attempt) do
+    Lightning.broadcast(
+      topic(project_id),
+      %AttemptUpdated{attempt: attempt}
     )
   end
 

--- a/lib/lightning/workorders/search_params.ex
+++ b/lib/lightning/workorders/search_params.ex
@@ -29,6 +29,7 @@ defmodule Lightning.WorkOrders.SearchParams do
     field(:search_fields, {:array, :string}, default: @search_fields)
     field(:search_term, :string)
     field(:workflow_id, :binary_id)
+    field(:workorder_id, :binary_id)
     field(:date_after, :utc_datetime_usec)
     field(:date_before, :utc_datetime_usec)
     field(:wo_date_after, :utc_datetime_usec)
@@ -38,11 +39,13 @@ defmodule Lightning.WorkOrders.SearchParams do
   def new(params) do
     params = from_uri(params)
 
-    Ecto.Changeset.cast(%__MODULE__{}, params, [
+    %__MODULE__{}
+    |> cast(params, [
       :status,
       :search_fields,
       :search_term,
       :workflow_id,
+      :workorder_id,
       :date_after,
       :date_before,
       :wo_date_after,

--- a/lib/lightning/workorders/workorder.ex
+++ b/lib/lightning/workorders/workorder.ex
@@ -43,7 +43,7 @@ defmodule Lightning.WorkOrder do
     belongs_to :dataclip, Dataclip
 
     belongs_to :reason, InvocationReason
-    has_many :attempts, Attempt
+    has_many :attempts, Attempt, preload_order: [desc: :inserted_at]
     has_many :jobs, through: [:workflow, :jobs]
 
     timestamps(type: :utc_datetime_usec)

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -57,7 +57,7 @@ defmodule LightningWeb.RunLive.Components do
       assign(assigns, is_clone: is_clone, run_item_classes: run_item_classes)
 
     ~H"""
-    <div role="row" class={@run_item_classes}>
+    <div id={"run-#{@run.id}"} role="row" class={@run_item_classes}>
       <div
         role="cell"
         class="col-span-3 py-2 text-sm font-normal text-left rtl:text-right text-gray-500"

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -185,12 +185,10 @@ defmodule LightningWeb.RunLive.Index do
         force: true
       )
 
-    send_update(LightningWeb.RunLive.WorkOrderComponent,
-      id: attempt.work_order_id,
-      work_order: attempt.work_order
-    )
-
-    {:noreply, socket}
+    {:noreply,
+     assign(socket,
+       page: update_page_workorder(socket.assigns.page, attempt.work_order)
+     )}
   end
 
   @impl true
@@ -205,12 +203,10 @@ defmodule LightningWeb.RunLive.Index do
         force: true
       )
 
-    send_update(LightningWeb.RunLive.WorkOrderComponent,
-      id: attempt.work_order_id,
-      work_order: attempt.work_order
-    )
-
-    {:noreply, socket}
+    {:noreply,
+     assign(socket,
+       page: update_page_workorder(socket.assigns.page, attempt.work_order)
+     )}
   end
 
   @impl true
@@ -245,12 +241,8 @@ defmodule LightningWeb.RunLive.Index do
         force: true
       )
 
-    send_update(LightningWeb.RunLive.WorkOrderComponent,
-      id: work_order.id,
-      work_order: work_order
-    )
-
-    {:noreply, socket}
+    {:noreply,
+     assign(socket, page: update_page_workorder(socket.assigns.page, work_order))}
   end
 
   @impl true
@@ -428,5 +420,18 @@ defmodule LightningWeb.RunLive.Index do
 
   defp maybe_humanize_date(date) do
     date && Timex.format!(date, "{D}/{M}/{YY}")
+  end
+
+  defp update_page_workorder(page, workorder) do
+    entries =
+      Enum.reduce(page.entries, [], fn entry, acc ->
+        if entry.id == workorder.id do
+          [workorder | acc]
+        else
+          [entry | acc]
+        end
+      end)
+
+    %{page | entries: Enum.reverse(entries)}
   end
 end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -36,7 +36,7 @@ defmodule LightningWeb.RunLive.Index do
 
   @impl true
   def mount(params, _session, socket) do
-    WorkOrders.Events.subscribe(socket.assigns.project.id)
+    WorkOrders.subscribe(socket.assigns.project.id)
 
     workflows =
       Lightning.Workflows.get_workflows_for(socket.assigns.project)

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -178,8 +178,14 @@ defmodule LightningWeb.RunLive.Index do
         %Lightning.WorkOrders.Events.AttemptCreated{attempt: attempt},
         socket
       ) do
+    attempt =
+      Lightning.Repo.preload(attempt,
+        work_order: [:workflow, attempts: [runs: :job]]
+      )
+
     send_update(LightningWeb.RunLive.WorkOrderComponent,
-      id: attempt.work_order_id
+      id: attempt.work_order_id,
+      work_order: attempt.work_order
     )
 
     {:noreply, socket}
@@ -190,8 +196,14 @@ defmodule LightningWeb.RunLive.Index do
         %Lightning.WorkOrders.Events.AttemptUpdated{attempt: attempt},
         socket
       ) do
+    attempt =
+      Lightning.Repo.preload(attempt,
+        work_order: [:workflow, attempts: [runs: :job]]
+      )
+
     send_update(LightningWeb.RunLive.WorkOrderComponent,
-      id: attempt.work_order_id
+      id: attempt.work_order_id,
+      work_order: attempt.work_order
     )
 
     {:noreply, socket}
@@ -224,8 +236,12 @@ defmodule LightningWeb.RunLive.Index do
         %Lightning.WorkOrders.Events.WorkOrderUpdated{work_order: work_order},
         socket
       ) do
+    work_order =
+      Lightning.Repo.preload(work_order, [:workflow, attempts: [runs: :job]])
+
     send_update(LightningWeb.RunLive.WorkOrderComponent,
-      id: work_order.id
+      id: work_order.id,
+      work_order: work_order
     )
 
     {:noreply, socket}

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -179,8 +179,10 @@ defmodule LightningWeb.RunLive.Index do
         socket
       ) do
     attempt =
-      Lightning.Repo.preload(attempt,
-        work_order: [:workflow, attempts: [runs: :job]]
+      Lightning.Repo.preload(
+        attempt,
+        [work_order: [:workflow, attempts: [runs: :job]]],
+        force: true
       )
 
     send_update(LightningWeb.RunLive.WorkOrderComponent,
@@ -197,8 +199,10 @@ defmodule LightningWeb.RunLive.Index do
         socket
       ) do
     attempt =
-      Lightning.Repo.preload(attempt,
-        work_order: [:workflow, attempts: [runs: :job]]
+      Lightning.Repo.preload(
+        attempt,
+        [work_order: [:workflow, attempts: [runs: :job]]],
+        force: true
       )
 
     send_update(LightningWeb.RunLive.WorkOrderComponent,
@@ -237,7 +241,9 @@ defmodule LightningWeb.RunLive.Index do
         socket
       ) do
     work_order =
-      Lightning.Repo.preload(work_order, [:workflow, attempts: [runs: :job]])
+      Lightning.Repo.preload(work_order, [:workflow, attempts: [runs: :job]],
+        force: true
+      )
 
     send_update(LightningWeb.RunLive.WorkOrderComponent,
       id: work_order.id,

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -711,6 +711,7 @@
                     <.live_component
                       module={LightningWeb.RunLive.WorkOrderComponent}
                       id={wo.id}
+                      work_order={wo}
                       project={@project}
                       can_rerun_job={@can_rerun_job}
                     />

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -6,28 +6,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   use LightningWeb, :live_component
   import LightningWeb.RunLive.Components
 
-  # @impl true
-  # def update_many(assigns_sockets) do
-  #   work_orders =
-  #     Enum.map(assigns_sockets, fn {assigns, _socket} -> assigns.work_order end)
-
-  #   updated_work_orders =
-  #     work_orders
-  #     |> Lightning.Repo.preload([:workflow, attempts: [runs: :job]],
-  #       force: true
-  #     )
-  #     |> Map.new(fn %{id: id} = wo -> {id, wo} end)
-
-  #   Enum.map(assigns_sockets, fn {assigns, socket} ->
-  #     socket =
-  #       assign(socket, assigns)
-  #       |> assign(:work_order, updated_work_orders[assigns.id])
-
-  #     update(socket.assigns, socket)
-  #     |> then(fn {:ok, socket} -> socket end)
-  #   end)
-  # end
-
   @impl true
   def update(
         %{work_order: work_order, project: project, can_rerun_job: can_rerun_job} =

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -2,7 +2,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   @moduledoc """
   Workorder component
   """
-  alias Lightning.Invocation
   use Phoenix.Component
   use LightningWeb, :live_component
   import LightningWeb.RunLive.Components
@@ -84,26 +83,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
     )
 
     {:noreply, assign(socket, :entry_selected, !assigns[:entry_selected])}
-  end
-
-  @impl true
-  def update_many(assigns_sockets) do
-    ids = Enum.map(assigns_sockets, fn {assigns, _socket} -> assigns.id end)
-
-    work_orders =
-      Invocation.get_workorders_by_ids(ids)
-      |> Invocation.with_attempts()
-      |> Lightning.Repo.all()
-      |> Map.new(fn %{id: id} = wo -> {id, wo} end)
-
-    Enum.map(assigns_sockets, fn {assigns, socket} ->
-      socket =
-        assign(socket, assigns)
-        |> assign(:work_order, work_orders[assigns.id])
-
-      update(socket.assigns, socket)
-      |> then(fn {:ok, socket} -> socket end)
-    end)
   end
 
   attr :show_details, :boolean, default: false

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -114,6 +114,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   def render(assigns) do
     ~H"""
     <div
+      id={"workorder-#{@work_order.id}"}
       data-entity="work_order"
       role="rowgroup"
       class={if @entry_selected, do: "bg-gray-50", else: "bg-white"}

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -6,6 +6,28 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   use LightningWeb, :live_component
   import LightningWeb.RunLive.Components
 
+  # @impl true
+  # def update_many(assigns_sockets) do
+  #   work_orders =
+  #     Enum.map(assigns_sockets, fn {assigns, _socket} -> assigns.work_order end)
+
+  #   updated_work_orders =
+  #     work_orders
+  #     |> Lightning.Repo.preload([:workflow, attempts: [runs: :job]],
+  #       force: true
+  #     )
+  #     |> Map.new(fn %{id: id} = wo -> {id, wo} end)
+
+  #   Enum.map(assigns_sockets, fn {assigns, socket} ->
+  #     socket =
+  #       assign(socket, assigns)
+  #       |> assign(:work_order, updated_work_orders[assigns.id])
+
+  #     update(socket.assigns, socket)
+  #     |> then(fn {:ok, socket} -> socket end)
+  #   end)
+  # end
+
   @impl true
   def update(
         %{work_order: work_order, project: project, can_rerun_job: can_rerun_job} =

--- a/test/lightning/attempts_test.exs
+++ b/test/lightning/attempts_test.exs
@@ -174,7 +174,7 @@ defmodule Lightning.AttemptsTest do
 
       assert {:job_id, {"does not exist", []}} in changeset.errors
 
-      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+      Lightning.WorkOrders.subscribe(workflow.project_id)
 
       {:ok, run} =
         Attempts.start_run(%{
@@ -256,7 +256,7 @@ defmodule Lightning.AttemptsTest do
       {:ok, attempt} =
         Repo.update(attempt |> Ecto.Changeset.change(state: :claimed))
 
-      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+      Lightning.WorkOrders.subscribe(workflow.project_id)
 
       {:ok, attempt} = Attempts.start_attempt(attempt)
 
@@ -299,7 +299,7 @@ defmodule Lightning.AttemptsTest do
 
       assert WorkOrders.get(attempt.work_order_id).state == :running
 
-      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+      Lightning.WorkOrders.subscribe(workflow.project_id)
 
       {:ok, attempt} = Attempts.complete_attempt(attempt, "success")
 

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -576,6 +576,34 @@ defmodule Lightning.InvocationTest do
              end)
     end
 
+    test "filters workorders by workorder id" do
+      project = insert(:project)
+
+      workflow = insert(:workflow, project: project, name: "workflow-1")
+
+      workorder_1 = insert(:workorder, workflow: workflow, state: :success)
+
+      workorder_2 = insert(:workorder, workflow: workflow, state: :success)
+
+      page_result =
+        Lightning.Invocation.search_workorders(
+          project,
+          SearchParams.new(%{"workorder_id" => workorder_1.id})
+        )
+
+      assert [entry] = page_result.entries
+      assert entry.id == workorder_1.id
+
+      page_result =
+        Lightning.Invocation.search_workorders(
+          project,
+          SearchParams.new(%{"workorder_id" => workorder_2.id})
+        )
+
+      assert [entry] = page_result.entries
+      assert entry.id == workorder_2.id
+    end
+
     test "filters workorders by last_activity" do
       project = insert(:project)
       _dataclip = insert(:dataclip)

--- a/test/lightning/workorders_test.exs
+++ b/test/lightning/workorders_test.exs
@@ -31,6 +31,7 @@ defmodule Lightning.WorkOrdersTest do
       workflow: workflow,
       trigger: trigger
     } do
+      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
       dataclip = insert(:dataclip)
 
       {:ok, workorder} =
@@ -44,6 +45,12 @@ defmodule Lightning.WorkOrdersTest do
       [attempt] = workorder.attempts
 
       assert attempt.starting_trigger.id == trigger.id
+
+      workorder_id = workorder.id
+
+      assert_received %Lightning.WorkOrders.Events.WorkOrderCreated{
+        work_order: %{id: ^workorder_id}
+      }
     end
 
     @tag trigger_type: :cron
@@ -51,6 +58,8 @@ defmodule Lightning.WorkOrdersTest do
       workflow: workflow,
       trigger: trigger
     } do
+      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+
       dataclip = insert(:dataclip)
 
       {:ok, workorder} =
@@ -64,12 +73,18 @@ defmodule Lightning.WorkOrdersTest do
       [attempt] = workorder.attempts
 
       assert attempt.starting_trigger.id == trigger.id
+
+      workorder_id = workorder.id
+
+      assert_received %Lightning.WorkOrders.Events.WorkOrderCreated{
+        work_order: %{id: ^workorder_id}
+      }
     end
 
     test "creating a manual workorder", %{workflow: workflow, job: job} do
       user = insert(:user)
 
-      Lightning.WorkOrders.subscribe(workflow.project_id)
+      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
 
       assert {:ok, manual} =
                Lightning.WorkOrders.Manual.new(%{"body" => ~s({"foo": "bar"})},
@@ -89,6 +104,12 @@ defmodule Lightning.WorkOrdersTest do
       assert attempt.created_by.id == user.id
 
       assert_received %Lightning.WorkOrders.Events.AttemptCreated{}
+
+      workorder_id = workorder.id
+
+      assert_received %Lightning.WorkOrders.Events.WorkOrderCreated{
+        work_order: %{id: ^workorder_id}
+      }
     end
   end
 

--- a/test/lightning/workorders_test.exs
+++ b/test/lightning/workorders_test.exs
@@ -31,7 +31,7 @@ defmodule Lightning.WorkOrdersTest do
       workflow: workflow,
       trigger: trigger
     } do
-      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+      Lightning.WorkOrders.subscribe(workflow.project_id)
       dataclip = insert(:dataclip)
 
       {:ok, workorder} =
@@ -58,7 +58,7 @@ defmodule Lightning.WorkOrdersTest do
       workflow: workflow,
       trigger: trigger
     } do
-      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+      Lightning.WorkOrders.subscribe(workflow.project_id)
 
       dataclip = insert(:dataclip)
 
@@ -84,7 +84,7 @@ defmodule Lightning.WorkOrdersTest do
     test "creating a manual workorder", %{workflow: workflow, job: job} do
       user = insert(:user)
 
-      Lightning.WorkOrders.Events.subscribe(workflow.project_id)
+      Lightning.WorkOrders.subscribe(workflow.project_id)
 
       assert {:ok, manual} =
                Lightning.WorkOrders.Manual.new(%{"body" => ~s({"foo": "bar"})},

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -939,19 +939,19 @@ defmodule LightningWeb.RunWorkOrderTest do
         insert(:attempt,
           work_order: work_order,
           dataclip: dataclip,
-          starting_trigger: trigger
+          starting_job: job
         )
 
       view |> element("#toggle_details_for_#{work_order.id}") |> render_click()
 
-      refute has_element?(view, "#attempt-#{attempt.id}")
+      refute has_element?(view, "#attempt_#{attempt.id}")
 
       Lightning.WorkOrders.Events.attempt_created(project.id, attempt)
 
-      # wait for liveview to process that event
-      Process.sleep(2)
+      # Force Re-render to ensure the event is included
+      render(view)
 
-      assert has_element?(view, "#attempt-#{attempt.id}")
+      assert has_element?(view, "#attempt_#{attempt.id}")
     end
 
     test "WorkOrders.Events.AttemptUpdated", %{
@@ -1007,8 +1007,8 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       Lightning.WorkOrders.Events.attempt_updated(project.id, attempt)
 
-      # wait for liveview to process that event
-      Process.sleep(2)
+      # Force Re-render to ensure the event is included
+      render(view)
 
       assert has_element?(view, "#run-#{run_1.id}")
       assert has_element?(view, "#run-#{run_2.id}")
@@ -1085,8 +1085,8 @@ defmodule LightningWeb.RunWorkOrderTest do
       Lightning.WorkOrders.Events.work_order_created(project.id, work_order_2)
       Lightning.WorkOrders.Events.work_order_created(project.id, work_order_1)
 
-      # wait for liveview to process the events
-      Process.sleep(2)
+      # Force Re-render to ensure the event is included
+      render(view)
 
       assert has_element?(view, "#workorder-#{work_order_1.id}")
       refute has_element?(view, "#workorder-#{work_order_2.id}")

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -900,6 +900,199 @@ defmodule LightningWeb.RunWorkOrderTest do
     end
   end
 
+  describe "Events" do
+    test "WorkOrders.Events.AttemptCreated", %{
+      conn: conn,
+      project: project
+    } do
+      workflow = insert(:workflow, project: project)
+      trigger = insert(:trigger, type: :webhook, workflow: workflow)
+      job = insert(:job, workflow: workflow)
+
+      dataclip = insert(:dataclip)
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip,
+          attempts: [
+            build(:attempt,
+              dataclip: dataclip,
+              starting_trigger: trigger,
+              runs: [
+                build(:run,
+                  job: job,
+                  exit_reason: "success",
+                  started_at: build(:timestamp),
+                  finished_at: build(:timestamp)
+                )
+              ]
+            )
+          ]
+        )
+
+      {:ok, view, _html} =
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
+
+      attempt =
+        insert(:attempt,
+          work_order: work_order,
+          dataclip: dataclip,
+          starting_trigger: trigger
+        )
+
+      view |> element("#toggle_details_for_#{work_order.id}") |> render_click()
+
+      refute has_element?(view, "#attempt-#{attempt.id}")
+
+      Lightning.WorkOrders.Events.attempt_created(project.id, attempt)
+
+      # wait for liveview to process that event
+      Process.sleep(2)
+
+      assert has_element?(view, "#attempt-#{attempt.id}")
+    end
+
+    test "WorkOrders.Events.AttemptUpdated", %{
+      conn: conn,
+      project: project
+    } do
+      workflow = insert(:workflow, project: project)
+      trigger = insert(:trigger, type: :webhook, workflow: workflow)
+      job_1 = insert(:job, workflow: workflow)
+      job_2 = insert(:job, workflow: workflow)
+
+      dataclip = insert(:dataclip)
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip
+        )
+
+      attempt =
+        insert(:attempt,
+          work_order: work_order,
+          dataclip: dataclip,
+          starting_trigger: trigger
+        )
+
+      run_1 =
+        insert(:run,
+          job: job_1,
+          attempts: [attempt],
+          exit_reason: "success",
+          started_at: build(:timestamp),
+          finished_at: build(:timestamp)
+        )
+
+      {:ok, view, _html} =
+        live(conn, Routes.project_run_index_path(conn, :index, project.id))
+
+      run_2 =
+        insert(:run,
+          job: job_2,
+          attempts: [attempt],
+          exit_reason: "success",
+          started_at: build(:timestamp),
+          finished_at: build(:timestamp)
+        )
+
+      view |> element("#toggle_details_for_#{work_order.id}") |> render_click()
+
+      assert has_element?(view, "#run-#{run_1.id}")
+      refute has_element?(view, "#run-#{run_2.id}")
+
+      Lightning.WorkOrders.Events.attempt_updated(project.id, attempt)
+
+      # wait for liveview to process that event
+      Process.sleep(2)
+
+      assert has_element?(view, "#run-#{run_1.id}")
+      assert has_element?(view, "#run-#{run_2.id}")
+    end
+
+    test "WorkOrders.Events.WorkOrderCreated", %{
+      conn: conn,
+      project: project
+    } do
+      workflow_1 = insert(:workflow, project: project)
+      trigger_1 = insert(:trigger, type: :webhook, workflow: workflow_1)
+      job_1 = insert(:job, workflow: workflow_1)
+      dataclip_1 = insert(:dataclip, project: project)
+
+      workflow_2 = insert(:workflow, project: project)
+      trigger_2 = insert(:trigger, type: :webhook, workflow: workflow_2)
+      job_2 = insert(:job, workflow: workflow_2)
+      dataclip_2 = insert(:dataclip, project: project)
+
+      # filter by workflow
+      {:ok, view, _html} =
+        live(
+          conn,
+          Routes.project_run_index_path(conn, :index, project.id,
+            filters: %{workflow_id: workflow_1.id}
+          )
+        )
+
+      work_order_1 =
+        insert(:workorder,
+          workflow: workflow_1,
+          trigger: trigger_1,
+          dataclip: dataclip_1,
+          attempts: [
+            build(:attempt,
+              dataclip: dataclip_1,
+              starting_trigger: trigger_1,
+              runs: [
+                build(:run,
+                  job: job_1,
+                  exit_reason: "success",
+                  started_at: build(:timestamp),
+                  finished_at: build(:timestamp)
+                )
+              ]
+            )
+          ]
+        )
+
+      work_order_2 =
+        insert(:workorder,
+          workflow: workflow_2,
+          trigger: trigger_2,
+          dataclip: dataclip_2,
+          attempts: [
+            build(:attempt,
+              dataclip: dataclip_2,
+              starting_trigger: trigger_2,
+              runs: [
+                build(:run,
+                  job: job_2,
+                  exit_reason: "success",
+                  started_at: build(:timestamp),
+                  finished_at: build(:timestamp)
+                )
+              ]
+            )
+          ]
+        )
+
+      refute has_element?(view, "#workorder-#{work_order_1.id}")
+      refute has_element?(view, "#workorder-#{work_order_2.id}")
+
+      Lightning.WorkOrders.Events.work_order_created(project.id, work_order_2)
+      Lightning.WorkOrders.Events.work_order_created(project.id, work_order_1)
+
+      # wait for liveview to process the events
+      Process.sleep(2)
+
+      assert has_element?(view, "#workorder-#{work_order_1.id}")
+      refute has_element?(view, "#workorder-#{work_order_2.id}")
+    end
+  end
+
   def search_for(view, term, types) when types == [] do
     search_for(view, term, [:body, :log])
   end


### PR DESCRIPTION
## Notes for the reviewer

- Emits `Lightning.WorkOrders.Events.{WorkOrderCreated, WorkOrderUpdated, AttemptCreated, AttemptUpdated` events when the relevant resource is created or updated.  `Runs` also emit `AttemptUpdated`
- In order to test the broadcast in liveview, ~~I've had to `Process.sleep(2)`~~ to allow the liveview to process that event. @stuartc would like to get your thoughts on this. EDIT: I've found that calling `render(view)` also does the trick


## Related issue

Fixes #1284 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
