### PR TITLE
1277 remove exit code

### DIFF
--- a/lib/lightning/attempt_service.ex
+++ b/lib/lightning/attempt_service.ex
@@ -253,7 +253,6 @@ defmodule Lightning.AttemptService do
               :job_id,
               :started_at,
               :finished_at,
-              :exit_code,
               :input_dataclip_id,
               :output_dataclip_id
             ]
@@ -302,7 +301,6 @@ defmodule Lightning.AttemptService do
                 :job_id,
                 :started_at,
                 :finished_at,
-                :exit_code,
                 :input_dataclip_id,
                 :output_dataclip_id
               ]

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -25,7 +25,6 @@ defmodule Lightning.Invocation.Run do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "runs" do
-    field :exit_code, :integer
     field :exit_reason, :string
     field :finished_at, :utc_datetime_usec
     field :started_at, :utc_datetime_usec
@@ -79,7 +78,6 @@ defmodule Lightning.Invocation.Run do
     run
     |> cast(attrs, [
       :id,
-      :exit_code,
       :exit_reason,
       :started_at,
       :finished_at,

--- a/lib/lightning/runtime/child_process.ex
+++ b/lib/lightning/runtime/child_process.ex
@@ -48,7 +48,6 @@ defmodule Lightning.Runtime.ChildProcess do
         {msg,
          Result.new(
            exit_reason: msg,
-           exit_code: res.status,
            log: String.split(res.out <> res.err, "\n"),
            final_state_path: runspec.final_state_path
          )}

--- a/lib/lightning/runtime/result.ex
+++ b/lib/lightning/runtime/result.ex
@@ -5,12 +5,11 @@ defmodule Lightning.Runtime.Result do
   """
   @type t :: %__MODULE__{
           exit_reason: atom(),
-          exit_code: integer(),
           log: list(String.t()),
           final_state_path: String.t()
         }
 
-  defstruct [:exit_reason, :exit_code, :log, :final_state_path]
+  defstruct [:exit_reason, :log, :final_state_path]
 
   def new(fields \\ []) do
     struct!(__MODULE__, fields)

--- a/lib/lightning_web/controllers/api/run_json.ex
+++ b/lib/lightning_web/controllers/api/run_json.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.API.RunJSON do
   alias LightningWeb.Router.Helpers, as: Routes
   import LightningWeb.API.Helpers
 
-  @fields ~w(exit_code started_at finished_at log)a
+  @fields ~w(started_at finished_at log)a
 
   def render("index.json", %{page: page, conn: conn}) do
     %{

--- a/priv/repo/migrations/20231108155138_drop_exit_code.exs
+++ b/priv/repo/migrations/20231108155138_drop_exit_code.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.DropExitCode do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      remove :exit_code
+    end
+  end
+end

--- a/test/lightning/attempt_service_test.exs
+++ b/test/lightning/attempt_service_test.exs
@@ -91,7 +91,7 @@ defmodule Lightning.AttemptServiceTest do
         Enum.map([jobs.a, jobs.b, jobs.c, jobs.e, jobs.f], fn j ->
           %{
             job_id: j.id,
-            input_dataclip_id: dataclip.id,
+            input_dataclip_id: dataclip.id
           }
         end) ++
           [%{job_id: jobs.d.id, input_dataclip_id: dataclip.id}]
@@ -164,7 +164,7 @@ defmodule Lightning.AttemptServiceTest do
         Enum.map([jobs.a, jobs.b, jobs.c, jobs.e, jobs.f], fn j ->
           %{
             job_id: j.id,
-            input_dataclip_id: dataclip.id,
+            input_dataclip_id: dataclip.id
           }
         end) ++
           [%{job_id: jobs.d.id, input_dataclip_id: dataclip.id}]
@@ -343,7 +343,7 @@ defmodule Lightning.AttemptServiceTest do
         Enum.map([jobs.a, jobs.b, jobs.c, jobs.e, jobs.f], fn j ->
           %{
             job_id: j.id,
-            input_dataclip_id: dataclip2.id,
+            input_dataclip_id: dataclip2.id
           }
         end)
 

--- a/test/lightning/attempt_service_test.exs
+++ b/test/lightning/attempt_service_test.exs
@@ -92,10 +92,9 @@ defmodule Lightning.AttemptServiceTest do
           %{
             job_id: j.id,
             input_dataclip_id: dataclip.id,
-            exit_code: 0
           }
         end) ++
-          [%{job_id: jobs.d.id, exit_code: 1, input_dataclip_id: dataclip.id}]
+          [%{job_id: jobs.d.id, input_dataclip_id: dataclip.id}]
 
       attempt =
         insert(:attempt,
@@ -109,7 +108,7 @@ defmodule Lightning.AttemptServiceTest do
         from(r in Run,
           join: a in assoc(r, :attempts),
           where: a.id == ^attempt.id,
-          where: r.exit_code == 1
+          where: r.exit_reason != :success
         )
         |> Repo.one()
 
@@ -166,10 +165,9 @@ defmodule Lightning.AttemptServiceTest do
           %{
             job_id: j.id,
             input_dataclip_id: dataclip.id,
-            exit_code: 0
           }
         end) ++
-          [%{job_id: jobs.d.id, exit_code: 1, input_dataclip_id: dataclip.id}]
+          [%{job_id: jobs.d.id, input_dataclip_id: dataclip.id}]
 
       attempt =
         Lightning.Attempt.new(%{
@@ -184,7 +182,7 @@ defmodule Lightning.AttemptServiceTest do
         from(r in Run,
           join: a in assoc(r, :attempts),
           where: a.id == ^attempt.id,
-          where: r.exit_code == 1
+          where: r.exit_reason == :failed
         )
         |> Repo.one()
 
@@ -260,7 +258,6 @@ defmodule Lightning.AttemptServiceTest do
               %{
                 job_id: j.id,
                 input_dataclip_id: dataclip.id,
-                exit_code: 0,
                 started_at: Timex.shift(now, microseconds: time),
                 finished_at: Timex.shift(now, microseconds: time + 5)
               }
@@ -325,7 +322,7 @@ defmodule Lightning.AttemptServiceTest do
                 %{
                   job_id: j.id,
                   input_dataclip_id: dataclip.id,
-                  exit_code: 0
+                  exit_reason: "success"
                 }
               end
             )
@@ -347,7 +344,6 @@ defmodule Lightning.AttemptServiceTest do
           %{
             job_id: j.id,
             input_dataclip_id: dataclip2.id,
-            exit_code: 0
           }
         end)
 
@@ -378,7 +374,7 @@ defmodule Lightning.AttemptServiceTest do
           run: %{
             job_id: jobs.d.id,
             input_dataclip_id: dataclip2.id,
-            exit_code: 0
+            exit_reason: "success"
           }
         })
         |> Repo.insert!()

--- a/test/lightning/crash_test.exs
+++ b/test/lightning/crash_test.exs
@@ -82,7 +82,6 @@
 #       result = Pipeline.Runner.start(run)
 
 #       assert result.exit_reason == :killed
-#       assert result.exit_code == nil
 
 #       assert File.read!(result.final_state_path) == ""
 

--- a/test/lightning/factories_test.exs
+++ b/test/lightning/factories_test.exs
@@ -45,7 +45,6 @@ defmodule Lightning.FactoriesTest do
                      job: job,
                      started_at: Factories.build(:timestamp),
                      finished_at: nil,
-                     exit_code: nil,
                      input_dataclip: dataclip
                    }
                  ]

--- a/test/lightning/invocation/run_test.exs
+++ b/test/lightning/invocation/run_test.exs
@@ -9,7 +9,6 @@ defmodule Lightning.Invocation.RunTest do
     test "returns a new Run changeset based off another" do
       run =
         Lightning.InvocationFixtures.run_fixture(
-          exit_code: 1,
           started_at: DateTime.utc_now(),
           finished_at: DateTime.utc_now(),
           log_lines: [%{body: "log"}, %{body: "line"}]

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -130,7 +130,7 @@ defmodule Lightning.InvocationTest do
   describe "runs" do
     @invalid_attrs %{job_id: nil}
     @valid_attrs %{
-      exit_code: 42,
+      exit_reason: "success",
       finished_at: ~U[2022-02-02 11:49:00.000000Z],
       log: [],
       started_at: ~U[2022-02-02 11:49:00.000000Z]
@@ -191,7 +191,6 @@ defmodule Lightning.InvocationTest do
                  })
                )
 
-      assert run.exit_code == 42
       assert run |> Invocation.logs_for_run() == []
       assert run.finished_at == ~U[2022-02-02 11:49:00.000000Z]
       assert run.started_at == ~U[2022-02-02 11:49:00.000000Z]

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -130,7 +130,8 @@ defmodule Lightning.InvocationTest do
   describe "runs" do
     @invalid_attrs %{job_id: nil}
     @valid_attrs %{
-      exit_reason: "success",
+      # Note that we faithfully persist any string the worker sends back.
+      exit_reason: "something very strange",
       finished_at: ~U[2022-02-02 11:49:00.000000Z],
       log: [],
       started_at: ~U[2022-02-02 11:49:00.000000Z]
@@ -191,6 +192,7 @@ defmodule Lightning.InvocationTest do
                  })
                )
 
+      assert run.exit_reason == "something very strange"
       assert run |> Invocation.logs_for_run() == []
       assert run.finished_at == ~U[2022-02-02 11:49:00.000000Z]
       assert run.started_at == ~U[2022-02-02 11:49:00.000000Z]

--- a/test/lightning/runtime/child_process_test.exs
+++ b/test/lightning/runtime/child_process_test.exs
@@ -18,8 +18,6 @@ defmodule Lightning.Runtime.ChildProcessTest do
                env: %{"PATH" => "./priv/openfn/bin:#{System.get_env("PATH")}"}
              )
 
-    # NOTE: we don't appear to get an exit code
-    # assert result.exit_code == 134
     assert result.exit_reason == :error
 
     assert String.contains?(Enum.join(result.log, "\n"), "heap out of memory")

--- a/test/lightning_web/controllers/api/run_controller_test.exs
+++ b/test/lightning_web/controllers/api/run_controller_test.exs
@@ -110,7 +110,6 @@ defmodule LightningWeb.API.RunControllerTest do
 
       assert %{
                "attributes" => %{
-                 "exit_code" => nil,
                  "finished_at" => nil
                },
                "id" => ^run_id,

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -129,7 +129,6 @@ defmodule LightningWeb.EndToEndTest do
 
       # Run 1 should succeed and use the appropriate packages
       assert run_1.finished_at != nil
-      assert run_1.exit_code == 0
 
       assert Invocation.assemble_logs_for_run(run_1) =~ "Done in"
 
@@ -152,7 +151,7 @@ defmodule LightningWeb.EndToEndTest do
 
       # #  Run 2 should fail but not expose a secret
       assert run_2.finished_at != nil
-      assert run_2.exit_code == 1
+      assert run_2.exit_reason == :failed
 
       log = Invocation.assemble_logs_for_run(run_2)
       assert log =~ ~S[{"password":"***","username":"quux"}]
@@ -160,7 +159,7 @@ defmodule LightningWeb.EndToEndTest do
 
       #  Run 3 should succeed and log "6"
       assert run_3.finished_at != nil
-      assert run_3.exit_code == 0
+
       log = Invocation.assemble_logs_for_run(run_3)
       assert log =~ "[JOB] ℹ 6"
     end)

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -20,7 +20,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
       assert render_component(
                &LightningWeb.RunLive.Components.run_viewer/1,
                run:
-                 insert(:run, exit_code: nil, output_dataclip_id: nil)
+                 insert(:run, output_dataclip_id: nil)
                  |> Lightning.Repo.preload(:log_lines)
              ) =~
                "This run has not yet finished."

--- a/test/support/fixtures/invocation_fixtures.ex
+++ b/test/support/fixtures/invocation_fixtures.ex
@@ -96,7 +96,7 @@ defmodule Lightning.InvocationFixtures do
         dataclip_fixture(project_id: attrs[:project_id]).id
       end)
       |> Enum.into(%{
-        exit_code: nil,
+        exit_reason: nil,
         finished_at: nil,
         log: [],
         event_id: nil,


### PR DESCRIPTION
## Notes for the reviewer

Removes `:exit_code` completely from the app.

Remaining test errors are the same as without `exit_code`:
- credential_live_test
- accounts_test
- setup_utils_test

## Related issue

Fixes #1277

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
