### PR TITLE
Prepare for prod migration; update exit_reason with new worker contract

### DIFF
--- a/priv/repo/migrations/20231109123433_modify_runs_exit_reason.exs
+++ b/priv/repo/migrations/20231109123433_modify_runs_exit_reason.exs
@@ -1,0 +1,39 @@
+defmodule Lightning.Repo.Migrations.ModifyRunsExitReason do
+  use Ecto.Migration
+
+  def up do
+    # set exit_reason back to fail before next release for new worker contract
+    execute(
+      fn ->
+        repo().query!(
+          """
+          UPDATE runs
+          SET exit_reason = 'fail'
+          WHERE runs.exit_reason = 'error';
+          """,
+          [],
+          log: :info
+        )
+      end,
+      ""
+    )
+  end
+
+  def down do
+    # set exit_reason back to error
+    execute(
+      fn ->
+        repo().query!(
+          """
+          UPDATE runs
+          SET exit_reason = 'error'
+          WHERE runs.exit_reason = 'fail';
+          """,
+          [],
+          log: :info
+        )
+      end,
+      ""
+    )
+  end
+end


### PR DESCRIPTION
The initial migration from `exit_code` to `exit_reason` mapped `0 : success` and `_other : error`.

We've since changed the contract, so we need to change those `error` exit reasons to `fail`.