### PR TITLE
1254 remove work orders fk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ bearing with us as we move towards our first stable Lightning release.)
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 - Remove foreign key from `attempts` in preparation for partitioning
   `work_orders` [#1254](https://github.com/OpenFn/Lightning/issues/1254)
+- Remove `Workflows.delete_workflow`. It is no longer in use and would
+  require modification to not leave orphaned attempts given the removal
+  of the foreign key from `attempts`.
+  [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ bearing with us as we move towards our first stable Lightning release.)
   [#1223](https://github.com/OpenFn/Lightning/issues/1223)
 - Partition `log_lines` table based on `attempt_id`
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
+- Remove foreign key from `attempts` in preparation for partitioning
+  `work_orders` [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 
 ### Changed
 

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -87,22 +87,6 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
-  Deletes a workflow.
-
-  ## Examples
-
-      iex> delete_workflow(workflow)
-      {:ok, %Workflow{}}
-
-      iex> delete_workflow(workflow)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_workflow(%Workflow{} = workflow) do
-    Repo.delete(workflow)
-  end
-
-  @doc """
   Returns an `%Ecto.Changeset{}` for tracking workflow changes.
 
   ## Examples

--- a/priv/repo/migrations/20231107061550_drop_fk_attempts_workorders.exs
+++ b/priv/repo/migrations/20231107061550_drop_fk_attempts_workorders.exs
@@ -1,0 +1,20 @@
+defmodule Lightning.Repo.Migrations.DropFkAttemptsWorkorders do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE attempts                                                                            
+    DROP CONSTRAINT attempts_work_order_id_fkey                                                     
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE public.attempts                                                                     
+    ADD CONSTRAINT attempts_work_order_id_fkey                                                      
+    FOREIGN KEY (work_order_id)                                                                     
+    REFERENCES public.work_orders(id)                                                               
+    ON DELETE CASCADE                                                                               
+    """)
+  end
+end

--- a/priv/repo/migrations/20231107061550_drop_fk_attempts_workorders.exs
+++ b/priv/repo/migrations/20231107061550_drop_fk_attempts_workorders.exs
@@ -10,10 +10,10 @@ defmodule Lightning.Repo.Migrations.DropFkAttemptsWorkorders do
 
   def down do
     execute("""
-    ALTER TABLE public.attempts                                                                     
+    ALTER TABLE attempts                                                                     
     ADD CONSTRAINT attempts_work_order_id_fkey                                                      
     FOREIGN KEY (work_order_id)                                                                     
-    REFERENCES public.work_orders(id)                                                               
+    REFERENCES work_orders(id)                                                               
     ON DELETE CASCADE                                                                               
     """)
   end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -66,27 +66,6 @@ defmodule Lightning.WorkflowsTest do
       assert workflow.name == "some-updated-name"
     end
 
-    test "delete_workflow/1 deletes the workflow" do
-      workflow = insert(:workflow)
-
-      job_1 = insert(:job, name: "job 1", workflow: workflow)
-      job_2 = insert(:job, name: "job 2", workflow: workflow)
-
-      assert {:ok, %Workflows.Workflow{}} = Workflows.delete_workflow(workflow)
-
-      assert_raise Ecto.NoResultsError, fn ->
-        Workflows.get_workflow!(workflow.id)
-      end
-
-      assert_raise Ecto.NoResultsError, fn ->
-        Jobs.get_job!(job_1.id)
-      end
-
-      assert_raise Ecto.NoResultsError, fn ->
-        Jobs.get_job!(job_2.id)
-      end
-    end
-
     test "change_workflow/1 returns a workflow changeset" do
       workflow = insert(:workflow)
       assert %Ecto.Changeset{} = Workflows.change_workflow(workflow)


### PR DESCRIPTION
## Notes for the reviewer

Removes FK blocking partitioning of `work_orders` and removes an unused method that can only correctly function if the FK is in place.

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
