### PR TITLE
fix: Selected dataclip gets lost when starting a manual workorder from the inspector interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to
   [#1189](https://github.com/OpenFn/Lightning/issues/1189)
 - Add plumbing to support the use of PromEx
   [#1199](https://github.com/OpenFn/Lightning/issues/1199)
-- Add warning text to PromEx config 
+- Add warning text to PromEx config
   [#1222](https://github.com/OpenFn/Lightning/issues/1222)
 - Track and filter on webhook controller state in :telemetry metrics
   [#1192](https://github.com/OpenFn/Lightning/issues/1192)
@@ -50,13 +50,15 @@ and this project adheres to
   [#1176](https://github.com/OpenFn/Lightning/issues/1176)
 - Update "Delete" to "Delete Job" on Job panel and include javascript deletion
   confirmation [#1105](https://github.com/OpenFn/Lightning/issues/1105)
-- Move "Enabled" property from "Jobs" to "Edges" 
-   [#895](https://github.com/OpenFn/Lightning/issues/895)
+- Move "Enabled" property from "Jobs" to "Edges"
+  [#895](https://github.com/OpenFn/Lightning/issues/895)
 
 ### Fixed
 
 - [#1140](https://github.com/OpenFn/Lightning/issues/1140) Adaptor icons load
   gracefully
+- [#1283](https://github.com/OpenFn/Lightning/issues/1283) Selected dataclip
+  gets lost when starting a manual workorder from the inspector interface
 
 ## [v0.9.3] - 2023-09-27
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -62,6 +62,17 @@ defmodule Lightning.Invocation do
   def get_dataclip_details!(id),
     do: Repo.get!(Query.dataclip_with_body(), id)
 
+  @spec get_dataclip_for_attempt(attempt_id :: Ecto.UUID.t()) ::
+          Dataclip.t() | nil
+  def get_dataclip_for_attempt(attempt_id) do
+    query =
+      from d in Query.dataclip_with_body(),
+        join: a in Lightning.Attempt,
+        on: a.dataclip_id == d.id and a.id == ^attempt_id
+
+    Repo.one(query)
+  end
+
   @doc """
   Gets a single dataclip.
 


### PR DESCRIPTION
## Notes for the reviewer

- Fetches the dataclip from the `attempt` that's being "followed" on the page


## Related issue

Fixes #1283

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
