### PR TITLE
Ensure that the whole edge when selected is highlighted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to
   gracefully
 - [#1283](https://github.com/OpenFn/Lightning/issues/1283) Selected dataclip
   gets lost when starting a manual workorder from the inspector interface
+- Ensure that the whole edge when selected is highlighted
+  [#1160](https://github.com/OpenFn/Lightning/issues/1160)
 
 ## [v0.9.3] - 2023-09-27
 

--- a/assets/js/workflow-diagram/edges/Edge.tsx
+++ b/assets/js/workflow-diagram/edges/Edge.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { StepEdge, EdgeProps, EdgeLabelRenderer } from 'reactflow';
+import { BezierEdge, EdgeProps, EdgeLabelRenderer } from 'reactflow';
 import { labelStyles } from '../styles';
 
 const CustomEdge: FC<EdgeProps> = props => {
@@ -12,7 +12,7 @@ const CustomEdge: FC<EdgeProps> = props => {
   const labelY = (sourceY + targetY) / 2;
   return (
     <>
-      <StepEdge {...stepEdgeProps} />
+      <BezierEdge {...stepEdgeProps} />
       {label && (
         <EdgeLabelRenderer>
           <div

--- a/assets/js/workflow-diagram/edges/Edge.tsx
+++ b/assets/js/workflow-diagram/edges/Edge.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { BezierEdge, EdgeProps, EdgeLabelRenderer } from 'reactflow';
+import { SmoothStepEdge, EdgeProps, EdgeLabelRenderer } from 'reactflow';
 import { labelStyles } from '../styles';
 
 const CustomEdge: FC<EdgeProps> = props => {
@@ -12,7 +12,7 @@ const CustomEdge: FC<EdgeProps> = props => {
   const labelY = (sourceY + targetY) / 2;
   return (
     <>
-      <BezierEdge {...stepEdgeProps} />
+      <SmoothStepEdge {...stepEdgeProps} />
       {label && (
         <EdgeLabelRenderer>
           <div

--- a/assets/js/workflow-diagram/styles.ts
+++ b/assets/js/workflow-diagram/styles.ts
@@ -41,6 +41,7 @@ export const styleNode = (node: Flow.Node) => {
 
 export const styleEdge = (edge: Flow.Edge) => {
   edge.style = {
+    strokeWidth: '2',
     stroke: edge.selected ? EDGE_COLOR_SELECTED : EDGE_COLOR,
   };
 
@@ -52,6 +53,7 @@ export const styleEdge = (edge: Flow.Edge) => {
   if (edge.markerEnd) {
     edge.markerEnd = {
       ...edge.markerEnd,
+      width: 15,
       color: edge.selected ? EDGE_COLOR_SELECTED : EDGE_COLOR,
     };
   }

--- a/assets/js/workflow-diagram/util/update-selection.ts
+++ b/assets/js/workflow-diagram/util/update-selection.ts
@@ -36,5 +36,13 @@ export default (model: Flow.Model, newSelection?: string) => {
     return item;
   }
 
-  return updatedModel;
+  // Must put selected edge LAST to ensure it stays on top.
+  const sortedModel = {
+    ...updatedModel,
+    edges: updatedModel.edges.sort((x, y) => {
+      return x.selected - y.selected;
+    }),
+  };
+
+  return sortedModel;
 };


### PR DESCRIPTION
## Notes for the reviewer

- Uses Bezier type edge
<img width="934" alt="Screenshot 2023-11-10 at 16 28 22" src="https://github.com/OpenFn/Lightning/assets/39288959/e99abbda-1082-4911-a1c7-53ee36f1fced">



## Related issue

Fixes #1160 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
