### PR TITLE
End to end test with on_job_failure condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
 
       - run: mix local.hex --force
       - run: mix local.rebar --force
+      - run: cd assets && npm install
       - run: MIX_ENV=test mix do deps.get --only test, deps.compile, compile
       - run: MIX_ENV=test mix lightning.install_runtime
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -491,15 +491,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.10.tgz",
-      "integrity": "sha512-LRO1AD8570BRTYUc90VkiQGt/YcuZnhjc8l6VZUEbMkA971O2Hm18gNM19yDo42RMA+TrDzg0/B4MVEbbDeK4g==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.11.tgz",
+      "integrity": "sha512-OSz+QWwIE86a5Y3CUPxLfDg9aShGFfbyUPfTTrX3Btm/h5q8xuzjw7QN6MJh5Xqh1bcMTtRWc3eorxa4/KYfgA==",
       "dev": true,
       "dependencies": {
         "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.1.3",
+        "@openfn/runtime": "0.1.4",
         "workerpool": "^6.5.1"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.1.3.tgz",
-      "integrity": "sha512-cjfv4/Qfa72BGiPcbuVIyQp447GZzJiAMVGzo99JfWgertw+2rXOBMl2xi64T0AskCrOq1PV+zKfOO5ym7jofA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.1.4.tgz",
+      "integrity": "sha512-a5w9B8RvkDUX6zyBn5mZnm523R5RLh5XEtU/9+jqV+ZQIh3fWcL3hf1OWlHBXJ8n66uJdeM/NwiEEq1zNn7BNA==",
       "dev": true,
       "dependencies": {
         "@openfn/logger": "0.0.19",
@@ -536,15 +536,15 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.6.tgz",
-      "integrity": "sha512-8clUlDFnRq1qVvVqXgaF8iUq1MC7ilP7YkkNbY8ZyD1LyO0i2MMtW6YyZfhvkiiPxpyhcbAfuoEid3QLBXy4jA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.7.tgz",
+      "integrity": "sha512-tTCkk3GM2lBHdGG5uYwr4Rw6IzJno6WM3N1Tu355whANYevEn3IAwO1UWGqdY1I7/Cty2f1NtakPIDiYngSs+g==",
       "dev": true,
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.1.10",
+        "@openfn/engine-multi": "0.1.11",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.1.3",
+        "@openfn/runtime": "0.1.4",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^4.3.7"
       },
       "devDependencies": {
-        "@openfn/ws-worker": "^0.2.6",
+        "@openfn/ws-worker": "^0.2.7",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^4.3.7"
       },
       "devDependencies": {
-        "@openfn/ws-worker": "^0.2.5",
+        "@openfn/ws-worker": "^0.2.6",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
@@ -491,15 +491,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.9.tgz",
-      "integrity": "sha512-74DWFsiqIQd2GXbSz0BbntoGpPpjbk6RJe7yoonIGhhUcS+IyEtmyC2gFQnEasraB8hi/54RzMPN/99aPv11DQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.10.tgz",
+      "integrity": "sha512-LRO1AD8570BRTYUc90VkiQGt/YcuZnhjc8l6VZUEbMkA971O2Hm18gNM19yDo42RMA+TrDzg0/B4MVEbbDeK4g==",
       "dev": true,
       "dependencies": {
         "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.1.2",
+        "@openfn/runtime": "0.1.3",
         "workerpool": "^6.5.1"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.1.2.tgz",
-      "integrity": "sha512-/mhVRulWbBSAo6XvL55cxhKaIoV5/G5L+FKS1NZxP11c4AlMMYrF954+OEgRKKW+ot7gmy1DUr+hk+Ek9VS8YA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.1.3.tgz",
+      "integrity": "sha512-cjfv4/Qfa72BGiPcbuVIyQp447GZzJiAMVGzo99JfWgertw+2rXOBMl2xi64T0AskCrOq1PV+zKfOO5ym7jofA==",
       "dev": true,
       "dependencies": {
         "@openfn/logger": "0.0.19",
@@ -536,15 +536,15 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.5.tgz",
-      "integrity": "sha512-x/as4NcePbAvNeH1KukpNo1d0t3n84YmY1nVKAw6NmIvF1HB97ADBJi8Rrx9DdqjYUXNJO+kOoXrbVHpfrHrNg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.6.tgz",
+      "integrity": "sha512-8clUlDFnRq1qVvVqXgaF8iUq1MC7ilP7YkkNbY8ZyD1LyO0i2MMtW6YyZfhvkiiPxpyhcbAfuoEid3QLBXy4jA==",
       "dev": true,
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.1.9",
+        "@openfn/engine-multi": "0.1.10",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.1.2",
+        "@openfn/runtime": "0.1.3",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,7 +35,7 @@
     "zustand": "^4.3.7"
   },
   "devDependencies": {
-    "@openfn/ws-worker": "^0.2.5",
+    "@openfn/ws-worker": "^0.2.6",
     "@types/marked": "^4.0.8",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,7 +35,7 @@
     "zustand": "^4.3.7"
   },
   "devDependencies": {
-    "@openfn/ws-worker": "^0.2.6",
+    "@openfn/ws-worker": "^0.2.7",
     "@types/marked": "^4.0.8",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,7 +34,7 @@ config :lightning, LightningWeb.Endpoint,
   url: [host: "localhost", port: 4002],
   secret_key_base:
     "/8zedVJLxvmGGFoRExE3e870g7CGZZQ1Vq11A5MbQGPKOpK57MahVsPW6Wkkv61n",
-  server: false
+  server: true
 
 # In test we don't send emails.
 config :lightning, Lightning.Mailer, adapter: Swoosh.Adapters.Test

--- a/lib/lightning/invocation/dataclip.ex
+++ b/lib/lightning/invocation/dataclip.ex
@@ -51,8 +51,26 @@ defmodule Lightning.Invocation.Dataclip do
   def new(attrs \\ %{}) do
     change(%__MODULE__{id: Ecto.UUID.generate()}, attrs)
     |> change(attrs)
+    |> redact_password()
     |> validate()
   end
+
+  defp redact_password(
+         %Ecto.Changeset{
+           valid?: true,
+           changes: %{
+             body: %{"configuration" => %{"password" => _password}} = body
+           }
+         } =
+           changeset
+       ) do
+    body =
+      update_in(body, ["configuration", "password"], fn _any -> "***" end)
+
+    put_change(changeset, :body, body)
+  end
+
+  defp redact_password(changeset), do: changeset
 
   @doc false
   def changeset(dataclip, attrs) do

--- a/lib/lightning/invocation/dataclip.ex
+++ b/lib/lightning/invocation/dataclip.ex
@@ -59,13 +59,12 @@ defmodule Lightning.Invocation.Dataclip do
          %Ecto.Changeset{
            valid?: true,
            changes: %{
-             body: %{"configuration" => %{"password" => _password}} = body
+             body: body
            }
          } =
            changeset
        ) do
-    body =
-      update_in(body, ["configuration", "password"], fn _any -> "***" end)
+    body = Map.delete(body, "configuration")
 
     put_change(changeset, :body, body)
   end

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -70,7 +70,7 @@ defmodule Lightning.Invocation.LogLine do
     |> assoc_constraint(:run)
     |> assoc_constraint(:attempt)
     |> validate_change(:message, fn _, message ->
-      if is_nil(message) or message == [nil] do
+      if is_nil(message) do
         [message: "can't be nil"]
       else
         []

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -70,7 +70,7 @@ defmodule Lightning.Invocation.LogLine do
     |> assoc_constraint(:run)
     |> assoc_constraint(:attempt)
     |> validate_change(:message, fn _, message ->
-      if is_nil(message) do
+      if is_nil(message) or message == [nil] do
         [message: "can't be nil"]
       else
         []

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -13,6 +13,8 @@ defmodule Lightning.Invocation.LogLine do
   use Ecto.Schema
   import Ecto.Changeset
 
+  import Lightning.Security, only: [redact_password: 2]
+
   alias Lightning.Attempt
   alias Lightning.Invocation.Run
   alias Lightning.LogMessage
@@ -48,6 +50,7 @@ defmodule Lightning.Invocation.LogLine do
   def new(%Attempt{} = attempt, attrs \\ %{}) do
     %__MODULE__{id: Ecto.UUID.generate()}
     |> cast(attrs, [:message, :timestamp, :run_id, :attempt_id, :level, :source])
+    |> redact_password(:message)
     |> put_assoc(:attempt, attempt)
     |> validate()
   end

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -59,6 +59,7 @@ defmodule Lightning.Invocation.LogLine do
   def changeset(log_line, attrs) do
     log_line
     |> cast(attrs, [:message, :timestamp, :run_id, :attempt_id, :level, :source])
+    |> redact_password(:message)
     |> validate()
   end
 

--- a/lib/lightning/security.ex
+++ b/lib/lightning/security.ex
@@ -25,5 +25,5 @@ defmodule Lightning.Security do
     end
   end
 
-  def redact_password(changeset), do: changeset
+  def redact_password(changeset, _field), do: changeset
 end

--- a/lib/lightning/security.ex
+++ b/lib/lightning/security.ex
@@ -1,0 +1,29 @@
+defmodule Lightning.Security do
+  @moduledoc """
+  Security helpers.
+  """
+  alias Ecto.Changeset
+
+  @doc """
+  Redact a password inside a json on a changeset field.
+  If the field has a valid string value "password":"thesecret" becomes "password":"***".
+  """
+  @spec redact_password(Changeset.t(), atom()) :: Changeset.t()
+  def redact_password(%Changeset{valid?: true} = changeset, field) do
+    with {:ok, str_to_redact} <- Changeset.fetch_change(changeset, field),
+         true <- String.valid?(str_to_redact) do
+      redacted =
+        String.replace(
+          str_to_redact,
+          ~r/\"password\":\"\w+\"/,
+          "\\1\"password\":\"\*\*\*\""
+        )
+
+      Changeset.put_change(changeset, field, redacted)
+    else
+      _any -> changeset
+    end
+  end
+
+  def redact_password(changeset), do: changeset
+end

--- a/lib/lightning/security.ex
+++ b/lib/lightning/security.ex
@@ -11,7 +11,7 @@ defmodule Lightning.Security do
   @spec redact_password(Changeset.t(), atom()) :: Changeset.t()
   def redact_password(%Changeset{valid?: true} = changeset, field) do
     with {:ok, str_to_redact} <- Changeset.fetch_change(changeset, field),
-         true <- String.valid?(str_to_redact) do
+         true <- is_binary(str_to_redact) and String.valid?(str_to_redact) do
       redacted =
         String.replace(
           str_to_redact,

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -187,12 +187,6 @@ defmodule LightningWeb.AttemptChannel do
     end
   end
 
-  def handle_in("attempt:log", %{"message" => message}, socket)
-      when message == nil or message == [nil] do
-    {:reply, {:error, %{errors: %{message: ["This field can't be blank."]}}},
-     socket}
-  end
-
   def handle_in("attempt:log", payload, socket) do
     Attempts.append_attempt_log(socket.assigns.attempt, payload)
     |> case do

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -166,10 +166,15 @@ defmodule LightningWeb.AttemptChannel do
     end
   end
 
-  def handle_in("run:complete", payload, socket) do
+  def handle_in(
+        "run:complete",
+        %{"reason" => reason} = payload,
+        socket
+      ) do
     %{
       "attempt_id" => socket.assigns.attempt.id,
-      "project_id" => socket.assigns.project_id
+      "project_id" => socket.assigns.project_id,
+      "reason" => "#{map_rtm_reason_state(reason)}"
     }
     |> Enum.into(payload)
     |> Attempts.complete_run()
@@ -180,6 +185,12 @@ defmodule LightningWeb.AttemptChannel do
       {:ok, run} ->
         {:reply, {:ok, %{run_id: run.id}}, socket}
     end
+  end
+
+  def handle_in("attempt:log", %{"message" => message}, socket)
+      when message == nil or message == [nil] do
+    {:reply, {:error, %{errors: %{message: ["This field can't be blank."]}}},
+     socket}
   end
 
   def handle_in("attempt:log", payload, socket) do

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -48,14 +48,10 @@ defmodule LightningWeb.AttemptChannel do
 
   @impl true
   def handle_in("fetch:attempt", _, socket) do
-    # IO.write(:stderr, "fetch:attempt #{socket.assigns.attempt.id}\n")
-
     {:reply, {:ok, AttemptJson.render(socket.assigns.attempt)}, socket}
   end
 
   def handle_in("attempt:start", _, socket) do
-    # IO.write(:stderr, "start:attempt #{socket.assigns.attempt.id}\n")
-
     socket.assigns.attempt
     |> Attempts.start_attempt()
     |> case do

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -48,10 +48,14 @@ defmodule LightningWeb.AttemptChannel do
 
   @impl true
   def handle_in("fetch:attempt", _, socket) do
+    # IO.write(:stderr, "fetch:attempt #{socket.assigns.attempt.id}\n")
+
     {:reply, {:ok, AttemptJson.render(socket.assigns.attempt)}, socket}
   end
 
   def handle_in("attempt:start", _, socket) do
+    # IO.write(:stderr, "start:attempt #{socket.assigns.attempt.id}\n")
+
     socket.assigns.attempt
     |> Attempts.start_attempt()
     |> case do

--- a/test/lightning/ecto_types_test.exs
+++ b/test/lightning/ecto_types_test.exs
@@ -12,6 +12,9 @@ defmodule Lightning.EctoTypesTest do
     test "can be cast from a list" do
       assert {:ok, ~s<Hello, world! {"foo":"bar"} null>} =
                LogMessage.cast(["Hello, world!", %{"foo" => "bar"}, nil])
+
+      assert {:ok, ~s<null>} =
+               LogMessage.cast([nil])
     end
 
     test "can be cast from a map" do

--- a/test/lightning/security_test.exs
+++ b/test/lightning/security_test.exs
@@ -24,21 +24,19 @@ defmodule Lightning.SecurityTest do
                |> Security.redact_password(:message)
     end
 
-    test "does not change the field when it is not the password" do
-      message = ~S[{"a":1, "otherfield":"password"}]
+    test "doesn't add change when the changeset is invalid" do
+      message = ~S[{"a":1, "password":"same value"}]
       timestamp = DateTime.utc_now()
 
       assert %Changeset{
                changes: %{
-                 message: ^message,
                  timestamp: ^timestamp
                }
              } =
                %LogLine{id: Ecto.UUID.generate()}
-               |> Changeset.cast(%{message: message, timestamp: timestamp}, [
-                 :message,
-                 :timestamp
-               ])
+               |> Changeset.cast(%{timestamp: timestamp}, [:timestamp])
+               |> Map.put(:valid?, false)
+               |> Changeset.cast(%{message: message}, [:message])
                |> Security.redact_password(:message)
     end
   end

--- a/test/lightning/security_test.exs
+++ b/test/lightning/security_test.exs
@@ -1,0 +1,24 @@
+defmodule Lightning.SecurityTest do
+  use ExUnit.Case
+
+  alias Lightning.Invocation.LogLine
+  alias Lightning.Security
+  alias Ecto.Changeset
+
+  describe "redact_password/1" do
+    test "replaces the password with ***" do
+      id = Ecto.UUID.generate()
+      message = ~S[{"a":1, "password":"secret"}]
+      timestamp = DateTime.utc_now()
+
+      assert ~S[{"a":1, "password":"***"}] ==
+               %LogLine{id: id}
+               |> Changeset.cast(%{message: message, timestamp: timestamp}, [
+                 :message,
+                 :timestamp
+               ])
+               |> Security.redact_password(:message)
+               |> Changeset.get_change(:message)
+    end
+  end
+end

--- a/test/lightning/workorders_test.exs
+++ b/test/lightning/workorders_test.exs
@@ -87,7 +87,13 @@ defmodule Lightning.WorkOrdersTest do
       Lightning.WorkOrders.subscribe(workflow.project_id)
 
       assert {:ok, manual} =
-               Lightning.WorkOrders.Manual.new(%{"body" => ~s({"foo": "bar"})},
+               Lightning.WorkOrders.Manual.new(
+                 %{
+                   "body" =>
+                     Jason.encode!(%{
+                       "configuration" => %{"password" => "secret"}
+                     })
+                 },
                  workflow: workflow,
                  project: workflow.project,
                  job: job,
@@ -99,7 +105,10 @@ defmodule Lightning.WorkOrdersTest do
       assert [attempt] = workorder.attempts
 
       assert workorder.dataclip.type == :saved_input
-      assert workorder.dataclip.body == %{"foo" => "bar"}
+
+      assert workorder.dataclip.body == %{
+               "configuration" => %{"password" => "***"}
+             }
 
       assert attempt.created_by.id == user.id
 

--- a/test/lightning/workorders_test.exs
+++ b/test/lightning/workorders_test.exs
@@ -91,6 +91,7 @@ defmodule Lightning.WorkOrdersTest do
                  %{
                    "body" =>
                      Jason.encode!(%{
+                       "key_left" => "value_left",
                        "configuration" => %{"password" => "secret"}
                      })
                  },
@@ -107,7 +108,7 @@ defmodule Lightning.WorkOrdersTest do
       assert workorder.dataclip.type == :saved_input
 
       assert workorder.dataclip.body == %{
-               "configuration" => %{"password" => "***"}
+               "key_left" => "value_left"
              }
 
       assert attempt.created_by.id == user.id

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -476,7 +476,7 @@ defmodule LightningWeb.AttemptChannelTest do
 
       assert_reply ref, :error, errors
 
-      assert errors == %{errors: %{message: ["This field can't be blank."]}}
+      assert errors == %{message: ["This field can't be blank."]}
     end
 
     test "attempt:log timestamp is handled at microsecond resolution", %{

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -420,7 +420,7 @@ defmodule LightningWeb.AttemptChannelTest do
       %{socket: socket, attempt: attempt, workflow: workflow}
     end
 
-    test "attempt:log message can't be blank", %{
+    test "attempt:log missing message can't be blank", %{
       socket: socket,
       attempt: attempt,
       workflow: workflow
@@ -447,6 +447,36 @@ defmodule LightningWeb.AttemptChannelTest do
       assert_reply ref, :error, errors
 
       assert errors == %{message: ["This field can't be blank."]}
+    end
+
+    test "attempt:log nil message can't be blank", %{
+      socket: socket,
+      attempt: attempt,
+      workflow: workflow
+    } do
+      # { id, job_id, input_dataclip_id }
+      run_id = Ecto.UUID.generate()
+      [job] = workflow.jobs
+
+      ref =
+        push(socket, "run:start", %{
+          "run_id" => run_id,
+          "job_id" => job.id,
+          "input_dataclip_id" => attempt.dataclip_id
+        })
+
+      assert_reply ref, :ok, _
+
+      ref =
+        push(socket, "attempt:log", %{
+          # we expect a 16 character string for microsecond resolution
+          "timestamp" => "1699444653874088",
+          "message" => nil
+        })
+
+      assert_reply ref, :error, errors
+
+      assert errors == %{errors: %{message: ["This field can't be blank."]}}
     end
 
     test "attempt:log timestamp is handled at microsecond resolution", %{

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -297,13 +297,13 @@ defmodule LightningWeb.EndToEndTest do
   defp start_runtime_manager(_context) do
     rtm_args = "node ./node_modules/.bin/worker -- --backoff 0.5/5"
 
-    {:ok, rtm_server} =
-      RuntimeManager.start_link(
-        name: E2ETestRuntimeManager,
-        args: String.split(rtm_args),
-        cd: Path.expand("../../assets", __DIR__),
-        start: true
-      )
+    Application.put_env(:lightning, RuntimeManager,
+      start: true,
+      args: String.split(rtm_args),
+      cd: Path.expand("../../assets", __DIR__)
+    )
+
+    {:ok, rtm_server} = RuntimeManager.start_link(name: E2ETestRuntimeManager)
 
     running =
       Enum.any?(1..20, fn _i ->

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -18,6 +18,38 @@ defmodule LightningWeb.EndToEndTest do
   describe "webhook triggered attempts" do
     setup :register_and_log_in_superuser
 
+    test "complete an attempt on a simple workflow", %{conn: conn} do
+      project = insert(:project)
+
+      %{triggers: [%{id: webhook_trigger_id}]} =
+        insert(:simple_workflow, project: project)
+
+      # Post to webhook
+      conn = post(conn, "/i/#{webhook_trigger_id}", %{"a" => 1})
+
+      assert %{"work_order_id" => wo_id} = json_response(conn, 200)
+
+      assert %{attempts: [%{id: attempt_id}]} =
+               WorkOrders.get(wo_id, include: [:attempts])
+
+      assert %{runs: []} = Attempts.get(attempt_id, include: [:runs])
+
+      assert %{attempts: [%{id: attempt_id}]} =
+               WorkOrders.get(wo_id, include: [:attempts])
+
+      # wait to complete
+      assert Enum.any?(1..100, fn _i ->
+               Process.sleep(50)
+               %{state: state} = Attempts.get(attempt_id)
+               state == :success
+             end)
+
+      assert %{state: :success, attempts: [%{runs: [run]}]} =
+               WorkOrders.get(wo_id, include: [attempts: [:runs]])
+
+      assert run.exit_reason == "success"
+    end
+
     test "the whole thing", %{conn: conn} do
       project = insert(:project)
 

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -41,8 +41,8 @@ defmodule LightningWeb.EndToEndTest do
                WorkOrders.get(wo_id, include: [:attempts])
 
       # wait to complete
-      assert Enum.any?(1..100, fn _i ->
-               Process.sleep(100)
+      assert Enum.any?(1..300, fn _i ->
+               Process.sleep(200)
                %{state: state} = Attempts.get(attempt_id)
                state == :success
              end)
@@ -144,8 +144,8 @@ defmodule LightningWeb.EndToEndTest do
       assert %{runs: []} = Attempts.get(attempt_id, include: [:runs])
 
       # wait to complete
-      assert Enum.any?(1..100, fn _i ->
-               Process.sleep(100)
+      assert Enum.any?(1..300, fn _i ->
+               Process.sleep(200)
                %{state: state} = Attempts.get(attempt_id)
                state == :success
              end)

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -302,7 +302,6 @@ defmodule LightningWeb.EndToEndTest do
 
   defp start_runtime_manager(_context) do
     rtm_args = "node ./node_modules/.bin/worker -- --backoff 0.5/5"
-    # rtm_args = "npm exec @openfn/ws-worker -- --backoff 0.5/5"
 
     Application.put_env(:lightning, RuntimeManager,
       start: true,
@@ -311,12 +310,6 @@ defmodule LightningWeb.EndToEndTest do
     )
 
     {:ok, rtm_server} = RuntimeManager.start_link(name: E2ETestRuntimeManager)
-    # start_supervised(%{
-    #   id: E2ETestRuntimeManager,
-    #   restart: :temporary,
-    #   shutdown: 30_000,
-    #   start: {RuntimeManager, :start_link, [[name: E2ETestRuntimeManager]]}
-    # })
 
     running =
       Enum.any?(1..20, fn _i ->

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -125,7 +125,7 @@ defmodule LightningWeb.EndToEndTest do
         workflow_job_fixture(
           project: project,
           name: "1st-job",
-          adaptor: "@openfn/language-http@latest",
+          adaptor: "@openfn/language-http@5.0",
           body: webhook_expression(),
           project_credential: project_credential
         )
@@ -133,7 +133,7 @@ defmodule LightningWeb.EndToEndTest do
       flow_job =
         insert(:job,
           name: "2nd-job",
-          adaptor: "@openfn/language-http@latest",
+          adaptor: "@openfn/language-http@5.0",
           body: flow_expression(),
           workflow: workflow,
           project_credential: project_credential
@@ -149,7 +149,7 @@ defmodule LightningWeb.EndToEndTest do
       catch_job =
         insert(:job,
           name: "3rd-job",
-          adaptor: "@openfn/language-http@latest",
+          adaptor: "@openfn/language-http@5.0",
           body: catch_expression(),
           workflow: workflow,
           project_credential: project_credential

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -1,173 +1,185 @@
 # This module will be re-introduced in https://github.com/OpenFn/Lightning/issues/1143
 defmodule LightningWeb.EndToEndTest do
-  use LightningWeb.ConnCase, async: true
-  use Oban.Testing, repo: Lightning.Repo
+  use LightningWeb.ConnCase, async: false
 
   import Lightning.JobsFixtures
   import Lightning.Factories
 
+  alias Lightning.Attempts
   alias Lightning.Invocation
+  alias Lightning.Repo
+  alias Lightning.WorkOrders
+  alias Lightning.Runtime.RuntimeManager
 
-  import Ecto.Query
-
-  setup :register_and_log_in_superuser
-
-  defmacrop assert_has_expected_version?(string, dep) do
-    quote do
-      case unquote(dep) do
-        :node ->
-          assert unquote(string) =~ ~r/(?=.*node.js)(?=.*18.17)/
-
-        :cli ->
-          assert unquote(string) =~ ~r/(?=.*cli)(?=.*0.0.35)/
-
-        :runtime ->
-          assert unquote(string) =~ ~r/(?=.*runtime)(?=.*0.0.21)/
-
-        :compiler ->
-          assert unquote(string) =~ ~r/(?=.*compiler)(?=.*0.0.29)/
-
-        :adaptor ->
-          assert unquote(string) =~ ~r/(?=.*language-http)(?=.*5.)/
-      end
-    end
+  setup_all context do
+    start_runtime_manager(context)
   end
 
-  # workflow runs webhook then flow job
-  @tag :skip
-  test "the whole thing", %{conn: conn} do
-    project = insert(:project)
+  describe "webhook triggered attempts" do
+    setup :register_and_log_in_superuser
 
-    project_credential =
-      insert(:project_credential,
-        credential: %{
-          name: "test credential",
-          body: %{"username" => "quux", "password" => "immasecret"}
-        },
-        project: project
-      )
+    test "the whole thing", %{conn: conn} do
+      project = insert(:project)
 
-    %{
-      job: first_job = %{workflow: workflow},
-      trigger: webhook_trigger,
-      edge: _edge
-    } =
-      workflow_job_fixture(
-        project: project,
-        name: "1st-job",
-        adaptor: "@openfn/language-http",
-        body: webhook_expression(),
-        project_credential: project_credential
-      )
-
-    flow_job =
-      insert(:job,
-        name: "2nd-job",
-        adaptor: "@openfn/language-http",
-        body: flow_expression(),
-        workflow: workflow,
-        project_credential: project_credential
-      )
-
-    insert(:edge, %{
-      workflow: workflow,
-      source_job_id: first_job.id,
-      target_job_id: flow_job.id,
-      condition: :on_job_success
-    })
-
-    catch_job =
-      insert(:job,
-        name: "3rd-job",
-        adaptor: "@openfn/language-http",
-        body: catch_expression(),
-        workflow: workflow,
-        project_credential: project_credential
-      )
-
-    insert(:edge, %{
-      source_job_id: flow_job.id,
-      workflow: workflow,
-      target_job_id: catch_job.id,
-      condition: :on_job_failure
-    })
-
-    Oban.Testing.with_testing_mode(:manual, fn ->
-      message = %{"a" => 1}
-
-      conn = post(conn, "/i/#{webhook_trigger.id}", message)
-
-      assert %{"run_id" => run_id, "attempt_id" => attempt_id} =
-               json_response(conn, 200)
-
-      attempt_run =
-        Lightning.Repo.get_by(Lightning.AttemptRun,
-          run_id: run_id,
-          attempt_id: attempt_id
+      project_credential =
+        insert(:project_credential,
+          credential: %{
+            name: "test credential",
+            body: %{"username" => "quux", "password" => "immasecret"}
+          },
+          project: project
         )
 
-      assert_enqueued(
-        worker: Lightning.Pipeline,
-        args: %{attempt_run_id: attempt_run.id}
-      )
+      %{
+        job: first_job = %{workflow: workflow},
+        trigger: webhook_trigger,
+        edge: _edge
+      } =
+        workflow_job_fixture(
+          project: project,
+          name: "1st-job",
+          adaptor: "@openfn/language-http@latest",
+          body: webhook_expression(),
+          project_credential: project_credential
+        )
 
-      from(r in Lightning.Invocation.Run, where: r.id == ^attempt_run.run_id)
-      |> Lightning.Repo.all()
-      |> then(fn [r] ->
-        p =
-          Ecto.assoc(r, [:job, :project])
-          |> Lightning.Repo.one!()
+      flow_job =
+        insert(:job,
+          name: "2nd-job",
+          adaptor: "@openfn/language-http@latest",
+          body: flow_expression(),
+          workflow: workflow,
+          project_credential: project_credential
+        )
 
-        assert p.id == project.id, "run is associated with a different project"
-      end)
+      insert(:edge, %{
+        workflow: workflow,
+        source_job_id: first_job.id,
+        target_job_id: flow_job.id,
+        condition: :on_job_success
+      })
 
-      # All runs should use Oban
-      assert %{success: 3, cancelled: 0, discard: 0, failure: 0, snoozed: 0} ==
-               Oban.drain_queue(Oban, queue: :runs, with_recursion: true)
+      catch_job =
+        insert(:job,
+          name: "3rd-job",
+          adaptor: "@openfn/language-http@latest",
+          body: catch_expression(),
+          workflow: workflow,
+          project_credential: project_credential
+        )
 
-      [run_3, run_2, run_1] = Invocation.list_runs_for_project(project).entries
+      insert(:edge, %{
+        source_job_id: flow_job.id,
+        workflow: workflow,
+        target_job_id: catch_job.id,
+        condition: :on_job_failure
+      })
 
-      # Run 1 should succeed and use the appropriate packages
-      assert run_1.finished_at != nil
+      webhook_body = %{"fieldOne" => 123, "fieldTwo" => "some string"}
 
-      assert Invocation.assemble_logs_for_run(run_1) =~ "Done in"
+      conn = post(conn, "/i/#{webhook_trigger.id}", webhook_body)
 
-      r1_logs =
+      assert %{"work_order_id" => wo_id} = json_response(conn, 200)
+
+      assert %{attempts: [%{id: attempt_id}]} =
+               WorkOrders.get(wo_id, include: [:attempts])
+
+      assert %{runs: []} = Attempts.get(attempt_id, include: [:runs])
+
+      # wait to complete
+      assert Enum.any?(1..100, fn _i ->
+               Process.sleep(50)
+               %{state: state} = Attempts.get(attempt_id)
+               state == :success
+             end)
+
+      # All runs are associated with the same project and attempt and proper job
+      %{runs: runs} = Attempts.get(attempt_id, include: [:runs])
+
+      %{entries: [run_3, run_2, run_1]} =
+        Invocation.list_runs_for_project(project)
+
+      assert MapSet.new(runs, & &1.id) ==
+               MapSet.new([run_1, run_2, run_3], & &1.id)
+
+      # Alls runs have consistent finish_at, exit_reason and dataclips
+      %{claimed_at: claimed_at, finished_at: finished_at} =
+        Attempts.get(attempt_id)
+
+      # Run 1 succeeds with webhook_body as input
+      assert NaiveDateTime.diff(run_1.finished_at, claimed_at, :microsecond) > 0
+      assert NaiveDateTime.diff(run_1.finished_at, finished_at, :microsecond) < 0
+      assert run_1.exit_reason == "success"
+
+      lines =
         Invocation.logs_for_run(run_1)
-        |> Enum.map(fn line -> line.body end)
+        |> Enum.with_index()
+        |> Map.new(fn {line, i} -> {i, line} end)
 
-      # Check that versions are accurate and printed at the top of each run
-      assert Enum.at(r1_logs, 0) == "[CLI] ℹ Versions:"
-      Enum.at(r1_logs, 1) |> assert_has_expected_version?(:node)
-      Enum.at(r1_logs, 2) |> assert_has_expected_version?(:cli)
-      Enum.at(r1_logs, 3) |> assert_has_expected_version?(:runtime)
-      Enum.at(r1_logs, 4) |> assert_has_expected_version?(:compiler)
-      Enum.at(r1_logs, 5) |> assert_has_expected_version?(:adaptor)
+      expected_job_x_value = 123 * 2
+      assert lines[0].source == "R/T"
+      assert lines[0].message == "Starting operation 1"
+      assert lines[1].source == "JOB"
+      assert lines[1].message == "#{expected_job_x_value}"
+      assert lines[2].source == "JOB"
+      assert lines[2].message == "{\"name\":\"ศผ่องรี มมซึฆเ\"}"
+      assert lines[3].source == "R/T"
+      assert lines[3].message =~ "Operation 1 complete in"
+      assert lines[4].source == "R/T"
+      assert lines[4].message == "Expression complete!"
 
-      assert Enum.at(r1_logs, 11) =~ "[JOB] ℹ 2"
-      assert Enum.at(r1_logs, 12) =~ "[JOB] ℹ {\"name\":\"ศผ่องรี มมซึฆเ\"}"
-      assert Enum.at(r1_logs, 13) =~ "[R/T] ✔ Operation 1 complete in"
-      assert Enum.at(r1_logs, 15) =~ "[CLI] ✔ Done in"
+      # input: has only the webhook body
+      assert webhook_body == select_dataclip_body(run_1.input_dataclip_id)
+
+      # output: data unchanged by the job and x is updated
+      assert %{"data" => ^webhook_body, "x" => ^expected_job_x_value} =
+               select_dataclip_body(run_1.output_dataclip_id)
 
       # #  Run 2 should fail but not expose a secret
-      assert run_2.finished_at != nil
-      assert run_2.exit_reason == :failed
+      assert NaiveDateTime.diff(run_2.finished_at, claimed_at, :microsecond) > 0
+      assert NaiveDateTime.diff(run_2.finished_at, finished_at, :microsecond) < 0
+      assert run_2.exit_reason == "failed"
 
       log = Invocation.assemble_logs_for_run(run_2)
+
       assert log =~ ~S[{"password":"***","username":"quux"}]
-      assert log =~ ~S[Error in runtime execution!]
+      assert log =~ ~S"Check state.errors"
+
+      assert select_dataclip_body(run_1.output_dataclip_id) ==
+               select_dataclip_body(run_2.input_dataclip_id)
 
       #  Run 3 should succeed and log "6"
-      assert run_3.finished_at != nil
+      assert NaiveDateTime.diff(run_3.finished_at, claimed_at, :microsecond) > 0
+      assert NaiveDateTime.diff(run_3.finished_at, finished_at, :microsecond) < 0
+      assert run_3.exit_reason == "success"
 
-      log = Invocation.assemble_logs_for_run(run_3)
-      assert log =~ "[JOB] ℹ 6"
-    end)
+      lines =
+        Invocation.logs_for_run(run_3)
+        |> Enum.with_index()
+        |> Map.new(fn {line, i} -> {i, line} end)
+
+      expected_job_x_value = 123 * 6
+
+      assert lines[0].source == "R/T"
+      assert lines[0].message == "Starting operation 1"
+      assert lines[1].source == "JOB"
+      assert lines[1].message == "#{expected_job_x_value}"
+      assert lines[2].source == "R/T"
+      assert lines[2].message =~ "Operation 1 complete in"
+      assert lines[3].source == "R/T"
+      assert lines[3].message == "Expression complete!"
+
+      assert select_dataclip_body(run_2.output_dataclip_id) ==
+               select_dataclip_body(run_3.input_dataclip_id)
+
+      assert %{"data" => ^webhook_body, "x" => ^expected_job_x_value} =
+               select_dataclip_body(run_3.output_dataclip_id)
+    end
   end
 
   defp webhook_expression do
     "fn(state => {
-      state.x = state.data.a * 2;
+      state.x = state.data.fieldOne * 2;
       console.log(state.x);
       console.log({name: 'ศผ่องรี มมซึฆเ'})
       return state;
@@ -178,7 +190,7 @@ defmodule LightningWeb.EndToEndTest do
     "fn(state => {
       console.log(state.configuration);
       throw 'fail!'
-    })"
+    });"
   end
 
   defp catch_expression do
@@ -187,5 +199,38 @@ defmodule LightningWeb.EndToEndTest do
       console.log(state.x);
       return state;
     });"
+  end
+
+  defp start_runtime_manager(_context) do
+    rtm_args = "node ./node_modules/.bin/worker -- --backoff 0.5/5"
+
+    Application.put_env(:lightning, RuntimeManager,
+      start: true,
+      args: String.split(rtm_args),
+      cd: Path.expand("../../assets", __DIR__)
+    )
+
+    {:ok, rtm_server} = RuntimeManager.start_link(name: TestRuntimeManager)
+
+    Enum.any?(1..10, fn _i ->
+      Process.sleep(100)
+      %{runtime_port: port} = :sys.get_state(rtm_server)
+      port != nil
+    end)
+
+    :ok
+  end
+
+  defp select_dataclip_body(uuid) do
+    {:ok, %{rows: [[body]]}} =
+      Ecto.Adapters.SQL.query(
+        Repo,
+        "SELECT BODY FROM DATACLIPS WHERE ID=$1",
+        [
+          Ecto.UUID.dump!(uuid)
+        ]
+      )
+
+    body
   end
 end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -297,15 +297,22 @@ defmodule LightningWeb.EndToEndTest do
       cd: Path.expand("../../assets", __DIR__)
     )
 
-    {:ok, rtm_server} = RuntimeManager.start_link(name: TestRuntimeManager)
+    {:ok, rtm_server} =
+      start_supervised(%{
+        id: E2ETestRuntimeManager,
+        restart: :temporary,
+        shutdown: 30_000,
+        start: {RuntimeManager, :start_link, [[name: E2ETestRuntimeManager]]}
+      })
 
-    Enum.any?(1..10, fn _i ->
-      Process.sleep(100)
-      %{runtime_port: port} = :sys.get_state(rtm_server)
-      port != nil
-    end)
+    running =
+      Enum.any?(1..20, fn _i ->
+        Process.sleep(50)
+        %{runtime_port: port} = :sys.get_state(rtm_server)
+        port != nil
+      end)
 
-    :ok
+    if running, do: :ok, else: :error
   end
 
   defp select_dataclip_body(uuid) do

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -95,7 +95,7 @@ defmodule LightningWeb.EndToEndTest do
         workflow_job_fixture(
           project: project,
           name: "1st-job",
-          adaptor: "@openfn/language-http@5.0.4",
+          adaptor: "@openfn/language-http@lastest",
           body: webhook_expression(),
           project_credential: project_credential
         )
@@ -103,7 +103,7 @@ defmodule LightningWeb.EndToEndTest do
       flow_job =
         insert(:job,
           name: "2nd-job",
-          adaptor: "@openfn/language-http@5.0.4",
+          adaptor: "@openfn/language-http@lastest",
           body: flow_expression(),
           workflow: workflow,
           project_credential: project_credential
@@ -119,7 +119,7 @@ defmodule LightningWeb.EndToEndTest do
       catch_job =
         insert(:job,
           name: "3rd-job",
-          adaptor: "@openfn/language-http@5.0.4",
+          adaptor: "@openfn/language-http@lastest",
           body: catch_expression(),
           workflow: workflow,
           project_credential: project_credential

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -97,6 +97,7 @@ defmodule LightningWeb.EndToEndTest do
       assert runs
              |> Enum.map(&select_dataclip_body(&1.input_dataclip_id)["x"])
              |> Enum.frequencies()
+             |> IO.inspect()
              |> Enum.all?(fn {_x, count} -> count == 2 end)
 
       assert runs
@@ -290,6 +291,7 @@ defmodule LightningWeb.EndToEndTest do
 
   defp start_runtime_manager(_context) do
     rtm_args = "node ./node_modules/.bin/worker -- --backoff 0.5/5"
+    # rtm_args = "npm exec @openfn/ws-worker -- --backoff 0.5/5"
 
     Application.put_env(:lightning, RuntimeManager,
       start: true,
@@ -297,13 +299,13 @@ defmodule LightningWeb.EndToEndTest do
       cd: Path.expand("../../assets", __DIR__)
     )
 
-    {:ok, rtm_server} =
-      start_supervised(%{
-        id: E2ETestRuntimeManager,
-        restart: :temporary,
-        shutdown: 30_000,
-        start: {RuntimeManager, :start_link, [[name: E2ETestRuntimeManager]]}
-      })
+    {:ok, rtm_server} = RuntimeManager.start_link(name: E2ETestRuntimeManager)
+    # start_supervised(%{
+    #   id: E2ETestRuntimeManager,
+    #   restart: :temporary,
+    #   shutdown: 30_000,
+    #   start: {RuntimeManager, :start_link, [[name: E2ETestRuntimeManager]]}
+    # })
 
     running =
       Enum.any?(1..20, fn _i ->

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -95,7 +95,7 @@ defmodule LightningWeb.EndToEndTest do
         workflow_job_fixture(
           project: project,
           name: "1st-job",
-          adaptor: "@openfn/language-http@5.0",
+          adaptor: "@openfn/language-http@5.0.4",
           body: webhook_expression(),
           project_credential: project_credential
         )
@@ -103,7 +103,7 @@ defmodule LightningWeb.EndToEndTest do
       flow_job =
         insert(:job,
           name: "2nd-job",
-          adaptor: "@openfn/language-http@5.0",
+          adaptor: "@openfn/language-http@5.0.4",
           body: flow_expression(),
           workflow: workflow,
           project_credential: project_credential
@@ -119,7 +119,7 @@ defmodule LightningWeb.EndToEndTest do
       catch_job =
         insert(:job,
           name: "3rd-job",
-          adaptor: "@openfn/language-http@5.0",
+          adaptor: "@openfn/language-http@5.0.4",
           body: catch_expression(),
           workflow: workflow,
           project_credential: project_credential

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -297,13 +297,13 @@ defmodule LightningWeb.EndToEndTest do
   defp start_runtime_manager(_context) do
     rtm_args = "node ./node_modules/.bin/worker -- --backoff 0.5/5"
 
-    Application.put_env(:lightning, RuntimeManager,
-      start: true,
-      args: String.split(rtm_args),
-      cd: Path.expand("../../assets", __DIR__)
-    )
-
-    {:ok, rtm_server} = RuntimeManager.start_link(name: E2ETestRuntimeManager)
+    {:ok, rtm_server} =
+      RuntimeManager.start_link(
+        name: E2ETestRuntimeManager,
+        args: String.split(rtm_args),
+        cd: Path.expand("../../assets", __DIR__),
+        start: true
+      )
 
     running =
       Enum.any?(1..20, fn _i ->

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -312,7 +312,18 @@ defmodule Lightning.Factories do
     jobs =
       build_list(7, :job,
         name: fn -> sequence(:name, &"Job-#{&1}") end,
-        body: ~s[fn(state => { return {...state, extra: "data"} })],
+        body: fn ->
+          sequence(
+            :body,
+            &"""
+            fn(state => {
+              state.x = (state.x || state.data.x) * 2;
+              console.log({output: '#{&1}'});
+              return {...state, extra: 'data'};
+            });
+            """
+          )
+        end,
         workflow: nil
       )
 


### PR DESCRIPTION
## Notes for the reviewer

Validates the runs exit_reasons and log lines for a workflow execution involving a `on_job_failure` condition.

Additionally redacts and asserts the password contained in the output dataclip and in the log line.

## Related issue

Fixes #1143 

## Review checklist

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
