### PR TITLE
make-janitor-also-clean-up-runs-inside-an-attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ bearing with us as we move towards our first stable Lightning release.)
   [#1160](https://github.com/OpenFn/Lightning/issues/1160)
 - Fix "Reconfigure Github" button in Project Settings
   [#1386](https://github.com/OpenFn/Lightning/issues/1386)
+- Make janitor also clean up runs inside an attempt
+  [#1348](https://github.com/OpenFn/Lightning/issues/1348)
 
 ## [v0.9.3] - 2023-09-27
 

--- a/lib/lightning/janitor.ex
+++ b/lib/lightning/janitor.ex
@@ -16,9 +16,8 @@ defmodule Lightning.Janitor do
     max_attempts: 10,
     unique: [period: 55]
 
-  require Logger
-
   alias Lightning.Repo
+  alias Lightning.Attempts
   alias Lightning.Attempts
 
   @doc """
@@ -39,20 +38,7 @@ defmodule Lightning.Janitor do
     Attempts.Query.lost(now)
     |> Repo.all()
     |> Enum.each(fn att ->
-      error_type =
-        case att.state do
-          :claimed -> "LostAfterClaim"
-          :started -> "LostAfterStart"
-          _other -> "UnknownReason"
-        end
-
-      Logger.warning(fn ->
-        "Detected lost attempt with reason #{error_type}: #{inspect(att)}"
-      end)
-
-      Attempts.complete_attempt(att, {:lost, error_type, nil})
-      # TODO - Implement this in https://github.com/OpenFn/Lightning/issues/1348
-      # Attempts.mark_unfinished_runs_lost(att)
+      Attempts.mark_attempt_lost(att)
     end)
   end
 end

--- a/test/lightning/attempts_test.exs
+++ b/test/lightning/attempts_test.exs
@@ -482,4 +482,45 @@ defmodule Lightning.AttemptsTest do
       assert log_line.message == ~s<{"foo":"bar"}>
     end
   end
+
+  describe "mark_unfinished_runs_lost/1" do
+    @tag :capture_log
+    test "marks unfinished runs as lost" do
+      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+      dataclip = insert(:dataclip)
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip
+        )
+
+      attempt =
+        insert(:attempt,
+          work_order: work_order,
+          starting_trigger: trigger,
+          dataclip: dataclip
+        )
+
+      finished_run =
+        insert(:run,
+          attempts: [attempt],
+          finished_at: DateTime.utc_now(),
+          exit_reason: "success"
+        )
+
+      unfinished_run = insert(:run, attempts: [attempt])
+
+      Attempts.mark_attempt_lost(attempt)
+
+      reloaded_finished_run = Repo.get(Invocation.Run, finished_run.id)
+      reloaded_unfinished_run = Repo.get(Invocation.Run, unfinished_run.id)
+
+      assert reloaded_finished_run.exit_reason == "success"
+      assert reloaded_unfinished_run.exit_reason == "lost"
+
+      assert reloaded_unfinished_run.finished_at != nil
+    end
+  end
 end

--- a/test/lightning/janitor_test.exs
+++ b/test/lightning/janitor_test.exs
@@ -1,0 +1,51 @@
+defmodule Lightning.JanitorTest do
+  use ExUnit.Case, async: false
+  alias Lightning.Janitor
+  alias Lightning.Invocation
+  import Lightning.Factories
+  alias Lightning.Repo
+  alias Lightning.Attempt
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Lightning.Repo)
+  end
+
+  describe "find_and_update_lost/0" do
+    @tag :capture_log
+    test "updates lost attempts and their runs" do
+      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+      dataclip = insert(:dataclip)
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip
+        )
+
+      lost_attempt =
+        insert(:attempt,
+          work_order: work_order,
+          starting_trigger: trigger,
+          dataclip: dataclip,
+          state: :started,
+          claimed_at: DateTime.utc_now() |> DateTime.add(-3600)
+        )
+
+      unfinished_run =
+        insert(:run,
+          attempts: [lost_attempt],
+          finished_at: nil,
+          exit_reason: nil
+        )
+
+      Janitor.find_and_update_lost()
+
+      reloaded_attempt = Repo.get(Attempt, lost_attempt.id)
+      reloaded_run = Repo.get(Invocation.Run, unfinished_run.id)
+
+      assert reloaded_attempt.state == :lost
+      assert reloaded_run.exit_reason == "lost"
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer
I've added a function mark_unfinished_runs_lost in the Lightning.Attempts module. This function is designed to check all runs associated with a 'lost' attempt and mark any unfinished ones as lost too


## Related issue

Fixes #1348 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
