### PR TITLE
Documentation: Troubleshooting NodeJS dns resolution for localhost

### DIFF
--- a/WORKERS.md
+++ b/WORKERS.md
@@ -88,19 +88,29 @@ This is used by workers to verify Attempt Tokens coming from Lightning.
 
 ### Problems with NodeJS DNS name resolution
 
-NodeJS v17 [changed](https://github.com/nodejs/node/pull/39987) how DNS name resolution is handled. In earlier versions, Node would reorder DNS lookup results so IPv4 addresses came before IPv6 addresses. In v17, Node started returning addresses in the same order provided by the resolver. The net effect is that your workers might fail to connect to Lightning if the native DNS resolver on your system is returning the loopback IPv6 address (`::1`) before the IPv4 address (`127.0.0.1`). In these cases, your worker might report an error similar to the following:
- 
- ```
- CRITICAL ERROR: could not connect to lightning at ws://localhost:4000/worker
- ```
-
-If you experience this, try specifying the IPv4 loopback address explicitly when starting your worker, as shown below.
+NodeJS v17 [changed](https://github.com/nodejs/node/pull/39987) how DNS name
+resolution is handled. In earlier versions, Node would reorder DNS lookup
+results so IPv4 addresses came before IPv6 addresses. In v17, Node started
+returning addresses in the same order provided by the resolver. The net effect
+is that your workers might fail to connect to Lightning if the native DNS
+resolver on your system is returning the loopback IPv6 address (`::1`) before
+the IPv4 address (`127.0.0.1`). In these cases, your worker might report an
+error similar to the following:
 
 ```
-pnpm start:prod -l ws://127.0.0.1:4000/worker
+CRITICAL ERROR: could not connect to lightning at ws://localhost:4000/worker
 ```
 
-If interested, you can directly inspect what Node returns for `localhost` by running the following command:
+If you experience this, it can be helpful to set the `NODE_OPTIONS` environment
+variable as shown below. This will force pre-v17 behavior of returning
+IPv4 addresses first.
+
+```
+NODE_OPTIONS=--dns-result-order=ipv4first
+```
+
+You can directly inspect what IP address Node returns for `localhost` by
+running the following command:
 
 ```
 node -e 'dns.lookup("localhost", console.log)'

--- a/WORKERS.md
+++ b/WORKERS.md
@@ -97,7 +97,7 @@ NodeJS v17 [changed](https://github.com/nodejs/node/pull/39987) how DNS name res
 If you experience this, try specifying the IPv4 loopback address explicitly when starting your worker, as shown below.
 
 ```
-pnpm start:prod -l ws://localhost:4000/worker
+pnpm start:prod -l ws://127.0.0.1:4000/worker
 ```
 
 If interested, you can directly inspect what Node returns for `localhost` by running the following command:

--- a/WORKERS.md
+++ b/WORKERS.md
@@ -83,3 +83,25 @@ _Workers only_
 
 A Base64 encoded public key in PEM format derived from the private key.
 This is used by workers to verify Attempt Tokens coming from Lightning.
+
+## Troubleshooting
+
+### Problems with NodeJS DNS name resolution
+
+NodeJS v17 [changed](https://github.com/nodejs/node/pull/39987) how DNS name resolution is handled. In earlier versions, Node would reorder DNS lookup results so IPv4 addresses came before IPv6 addresses. In v17, Node started returning addresses in the same order provided by the resolver. The net effect is that your workers might fail to connect to Lightning if the native DNS resolver on your system is returning the loopback IPv6 address (`::1`) before the IPv4 address (`127.0.0.1`). In these cases, your worker might report an error similar to the following:
+ 
+ ```
+ CRITICAL ERROR: could not connect to lightning at ws://localhost:4000/worker
+ ```
+
+If you experience this, try specifying the IPv4 loopback address explicitly when starting your worker, as shown below.
+
+```
+pnpm start:prod -l ws://localhost:4000/worker
+```
+
+If interested, you can directly inspect what Node returns for `localhost` by running the following command:
+
+```
+node -e 'dns.lookup("localhost", console.log)'
+```


### PR DESCRIPTION
## Notes for the reviewer
This is a pure documentation PR related to Lightning workers and NodeJS DNS name resolution. I've added a few lines to the bottom of the `WORKERS.md` to help users troubleshoot situations where Workers aren't connecting to Lightning due to NodeJS DNS resolution behavior changes in NodeJS v17. I bumped into this issue a couple days ago and it took a little digging to diagnose and resolve. I hope this PR helps someone else.


## Related issue

No associated issues.

## Review checklist

As this PR is pure documentation, I haven't haven't done any code review or QA. I also haven't modified the CHANGELOG.
