### PR TITLE
Handle nil in LogMessage ecto type

### DIFF
--- a/lib/lightning/ecto_types.ex
+++ b/lib/lightning/ecto_types.ex
@@ -94,7 +94,7 @@ defmodule Lightning.LogMessage do
      |> IO.iodata_to_binary()}
   end
 
-  def cast(d) when is_map(d) or is_list(d) do
+  def cast(d) when is_map(d) or is_list(d) or is_nil(d) do
     Jason.encode(d)
   end
 

--- a/test/lightning/ecto_types_test.exs
+++ b/test/lightning/ecto_types_test.exs
@@ -1,0 +1,40 @@
+defmodule Lightning.EctoTypesTest do
+  use ExUnit.Case
+
+  alias Lightning.LogMessage
+  alias Lightning.UnixDateTime
+
+  describe "LogMessage" do
+    test "can be cast from a string" do
+      assert {:ok, "Hello, world!"} = LogMessage.cast("Hello, world!")
+    end
+
+    test "can be cast from a list" do
+      assert {:ok, ~s<Hello, world! {"foo":"bar"} null>} =
+               LogMessage.cast(["Hello, world!", %{"foo" => "bar"}, nil])
+    end
+
+    test "can be cast from a map" do
+      assert {:ok, ~s<{"baz":null,"foo":"bar"}>} =
+               LogMessage.cast(%{"foo" => "bar", "baz" => nil})
+    end
+  end
+
+  describe "UnixDateTime" do
+    test "can be cast from a string" do
+      timestamp = "1699867499906674"
+
+      assert {:ok, ~U[2023-11-13 09:24:59.906674Z]} =
+               UnixDateTime.cast(timestamp)
+
+      timestamp = "1699867499906"
+
+      assert {:ok, ~U[2023-11-13 09:24:59.906000Z]} =
+               UnixDateTime.cast(timestamp)
+    end
+
+    test "raises an error when the string is invalid" do
+      assert UnixDateTime.cast("invalid timestamp") == :error
+    end
+  end
+end


### PR DESCRIPTION
The worker sends a variety of message structures, all of which are coerced into a string.
This adds handling of `null|nil`.

Fixes #1362

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
