### PR TITLE
Allow attempt to be marked as failed before started

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^4.3.7"
       },
       "devDependencies": {
-        "@openfn/ws-worker": "^0.2.3",
+        "@openfn/ws-worker": "^0.2.5",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
@@ -491,15 +491,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.8.tgz",
-      "integrity": "sha512-G74HdcUCLdS7xvnGwbVrKQHMKYrlenR66ObFs/htGM2ztSFj+o/6Nsqf4xwZhre/Ofd4jLMnfs79pQ63F9AllA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.1.9.tgz",
+      "integrity": "sha512-74DWFsiqIQd2GXbSz0BbntoGpPpjbk6RJe7yoonIGhhUcS+IyEtmyC2gFQnEasraB8hi/54RzMPN/99aPv11DQ==",
       "dev": true,
       "dependencies": {
         "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.1.1",
+        "@openfn/runtime": "0.1.2",
         "workerpool": "^6.5.1"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.1.1.tgz",
-      "integrity": "sha512-C9ksA0UGXvEesZI6SkMydv4eMGKca3HiUsTlGH0cN/EEHa+0xIHaugsIjSlt3WfqMRzhGF5q6JVmAxUoFQA6rQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.1.2.tgz",
+      "integrity": "sha512-/mhVRulWbBSAo6XvL55cxhKaIoV5/G5L+FKS1NZxP11c4AlMMYrF954+OEgRKKW+ot7gmy1DUr+hk+Ek9VS8YA==",
       "dev": true,
       "dependencies": {
         "@openfn/logger": "0.0.19",
@@ -536,15 +536,15 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.3.tgz",
-      "integrity": "sha512-XfmjVlMFcUCpOCxCTgA0a4xrS04bwKDp5kKfh+/FHlc8kZrk/YwfF+yj2D0Wp2M9ysnSIgroLeoyRNyJkXZ8tw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.5.tgz",
+      "integrity": "sha512-x/as4NcePbAvNeH1KukpNo1d0t3n84YmY1nVKAw6NmIvF1HB97ADBJi8Rrx9DdqjYUXNJO+kOoXrbVHpfrHrNg==",
       "dev": true,
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.1.8",
+        "@openfn/engine-multi": "0.1.9",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.1.1",
+        "@openfn/runtime": "0.1.2",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",

--- a/test/lightning/attempts_test.exs
+++ b/test/lightning/attempts_test.exs
@@ -289,7 +289,9 @@ defmodule Lightning.AttemptsTest do
       {:error, changeset} =
         Attempts.complete_attempt(attempt, {"success", nil, nil})
 
-      assert {:state, {"cannot complete attempt that has not been started", []}} in changeset.errors
+      assert {:state,
+              {"cannot mark attempt success that has not been claimed by a worker",
+               []}} in changeset.errors
 
       {:ok, attempt} =
         Repo.update(attempt |> Ecto.Changeset.change(state: :claimed))

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -3,11 +3,7 @@ defmodule Lightning.WorkflowsTest do
 
   import Lightning.Factories
 
-  alias Lightning.{
-    Workflows,
-    Jobs
-  }
-
+  alias Lightning.Workflows
   alias Lightning.Workflows.Trigger
 
   describe "workflows" do

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -555,10 +555,19 @@ defmodule LightningWeb.AttemptChannelTest do
           "error_message" => nil
         })
 
+      assert_reply ref, :ok, nil
+
+      ref =
+        push(socket, "attempt:complete", %{
+          "reason" => "failed",
+          "error_type" => nil,
+          "error_message" => nil
+        })
+
       assert_reply ref, :error, errors
 
       assert errors == %{
-               state: ["cannot complete attempt that has not been started"]
+               state: ["already in completed state"]
              }
     end
 


### PR DESCRIPTION
## Notes for the reviewer

The worker can fail before starting an attempt, this drops the requirement that an attempt must be started before being marked as failed.

## Related issue

Fixes #1379 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
