### PR TITLE
add hover on copy and add button

### DIFF
--- a/assets/js/adaptor-docs/components/render/Function.tsx
+++ b/assets/js/adaptor-docs/components/render/Function.tsx
@@ -41,7 +41,7 @@ return <span>
 const PreButton = ({ label, onClick, tooltip }: PreButtonFunctionProps) => 
   // TODO give some kind of feedback on click
   <button
-    className="rounded-md bg-slate-300 text-white px-2 py-1 mr-1 text-xs"
+    className="rounded-md bg-slate-300 text-white px-2 py-1 mr-1 text-xs hover:bg-primary-600"
     title={tooltip || ''}
     onClick={onClick}>
     {label}


### PR DESCRIPTION
## Notes for the reviewer

Added a hover effect on copy and add button for adaptors examples

https://github.com/OpenFn/Lightning/assets/6592749/60a65963-0563-4312-afd4-04dee9e4a870

## Related issue

Fixes #1297 

## Review checklist

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
