### PR TITLE
fix: error flash message for login is always displayed

### DIFF
--- a/lib/lightning_web/controllers/user_auth.ex
+++ b/lib/lightning_web/controllers/user_auth.ex
@@ -109,7 +109,7 @@ defmodule LightningWeb.UserAuth do
     conn
     |> renew_session()
     |> delete_resp_cookie(@remember_me_cookie)
-    |> redirect(to: "/")
+    |> redirect(to: "/users/log_in")
   end
 
   @doc """
@@ -223,7 +223,7 @@ defmodule LightningWeb.UserAuth do
 
           _ ->
             conn
-            |> put_flash(:error, "You must log in to access this page.")
+            # |> put_flash(:error, "You must log in to access this page.")
             |> maybe_store_return_to()
             |> redirect(to: Routes.user_session_path(conn, :new))
             |> halt()

--- a/test/lightning_web/controllers/user_auth_test.exs
+++ b/test/lightning_web/controllers/user_auth_test.exs
@@ -106,7 +106,7 @@ defmodule LightningWeb.UserAuthTest do
       refute get_session(conn, :user_token)
       refute conn.cookies[@remember_me_cookie]
       assert %{max_age: 0} = conn.resp_cookies[@remember_me_cookie]
-      assert redirected_to(conn) == "/"
+      assert redirected_to(conn) == "/users/log_in"
       refute Accounts.get_user_by_session_token(user_token)
     end
 
@@ -128,7 +128,7 @@ defmodule LightningWeb.UserAuthTest do
       conn = conn |> fetch_cookies() |> UserAuth.log_out_user()
       refute get_session(conn, :user_token)
       assert %{max_age: 0} = conn.resp_cookies[@remember_me_cookie]
-      assert redirected_to(conn) == "/"
+      assert redirected_to(conn) == "/users/log_in"
     end
   end
 
@@ -197,8 +197,8 @@ defmodule LightningWeb.UserAuthTest do
       assert conn.halted
       assert redirected_to(conn) == Routes.user_session_path(conn, :new)
 
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
-               "You must log in to access this page."
+      # flash message disabled
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) |> is_nil()
     end
 
     test "returns a 401 on json requests if user is not authenticated", %{

--- a/test/lightning_web/controllers/user_session_controller_test.exs
+++ b/test/lightning_web/controllers/user_session_controller_test.exs
@@ -253,7 +253,7 @@ defmodule LightningWeb.UserSessionControllerTest do
       conn =
         conn |> log_in_user(user) |> get(Routes.user_session_path(conn, :delete))
 
-      assert redirected_to(conn) == "/"
+      assert redirected_to(conn) == "/users/log_in"
       refute get_session(conn, :user_token)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
@@ -262,7 +262,7 @@ defmodule LightningWeb.UserSessionControllerTest do
 
     test "succeeds even if the user is not logged in", %{conn: conn} do
       conn = get(conn, Routes.user_session_path(conn, :delete))
-      assert redirected_to(conn) == "/"
+      assert redirected_to(conn) == "/users/log_in"
       refute get_session(conn, :user_token)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~


### PR DESCRIPTION
## Notes for the reviewer

- Removes the `put_flash` function from the `UserAuth.require_authenticated_user/2` `plug`


## Related issue

Fixes #1092

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
