### PR TITLE
fix: current_user not available in project_scope hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   [#1145](https://github.com/OpenFn/Lightning/issues/1145)
 - Fix for adding ellipses on credential info on job editor heading
   [#1428](https://github.com/OpenFn/Lightning/issues/1428)
+- Fix for liveview crash when token expires or gets deleted after mount
+  [#1394](https://github.com/OpenFn/Lightning/issues/1394)
 
 ## [v0.10.3] - 2023-11-28
 
@@ -46,7 +48,7 @@ and this project adheres to
 
 - Create new workflow button sizing regression
   [#1405](https://github.com/OpenFn/Lightning/issues/1405)
-- Google credential creation  and automatic closing of oAuth tab  
+- Google credential creation  and automatic closing of oAuth tab
   [#1109](https://github.com/OpenFn/Lightning/issues/1109)
 - Exporting project breaks the navigation of the page
   [#1440](https://github.com/OpenFn/Lightning/issues/1440)

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -15,6 +15,16 @@ defmodule LightningWeb.Hooks do
   this is for liveviews that may or may not have a `project_id` depending on
   usage - like `DashboardLive`.
   """
+  def on_mount(
+        :project_scope,
+        _params,
+        _session,
+        %{assigns: %{current_user: nil}} = socket
+      ) do
+    # redirect if there's no current user
+    {:halt, redirect(socket, to: "/")}
+  end
+
   def on_mount(:project_scope, %{"project_id" => project_id}, _session, socket) do
     %{current_user: current_user} = socket.assigns
 

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -7,6 +7,8 @@ defmodule LightningWeb.Hooks do
   import Phoenix.LiveView
   import Phoenix.Component
 
+  use LightningWeb, :verified_routes
+
   @doc """
   Finds and assigns a project to the socket, if a user doesn't have access
   they are redirected and shown a 'No Access' screen via a `:nav` flash message.
@@ -15,6 +17,7 @@ defmodule LightningWeb.Hooks do
   this is for liveviews that may or may not have a `project_id` depending on
   usage - like `DashboardLive`.
   """
+
   def on_mount(
         :project_scope,
         _params,
@@ -22,7 +25,7 @@ defmodule LightningWeb.Hooks do
         %{assigns: %{current_user: nil}} = socket
       ) do
     # redirect if there's no current user
-    {:halt, redirect(socket, to: "/")}
+    {:halt, redirect(socket, to: ~p"/users/log_in")}
   end
 
   def on_mount(:project_scope, %{"project_id" => project_id}, _session, socket) do
@@ -41,7 +44,7 @@ defmodule LightningWeb.Hooks do
 
     cond do
       can_access_project and project.requires_mfa and !current_user.mfa_enabled ->
-        {:halt, redirect(socket, to: "/mfa_required")}
+        {:halt, redirect(socket, to: ~p"/mfa_required")}
 
       can_access_project ->
         {:cont,

--- a/test/lightning_web/live/hooks_test.exs
+++ b/test/lightning_web/live/hooks_test.exs
@@ -1,0 +1,36 @@
+defmodule LightningWeb.HooksTest do
+  use LightningWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  import Lightning.Factories
+
+  import Ecto.Query
+
+  setup :register_and_log_in_user
+  setup :create_project_for_current_user
+
+  describe "project_scope" do
+    test "redirects to /users/login when current_user assign is missing", %{
+      conn: conn,
+      project: project,
+      user: user
+    } do
+      workflow = insert(:workflow, project: project, name: "One")
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w")
+
+      query =
+        from t in Lightning.Accounts.UserToken, where: t.user_id == ^user.id
+
+      Lightning.Repo.delete_all(query)
+
+      result =
+        view
+        |> element("#workflow-card-#{workflow.id}")
+        |> render_click()
+        |> follow_redirect(conn)
+
+      assert {:error, {:redirect, %{to: "/users/log_in", flash: %{}}}} = result
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer

- ~~Haven't been able to reproduce this locally~~. But as seen in the sentry error log, this happens because the user is not available in the `assigns` yet. This PR redirects to `/users/log_in` if there's no `curent_user`


## Related issue

Fixes #1318

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
