### PR TITLE
Optimize workorders query by status

### DIFF
--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -5,6 +5,7 @@ defmodule Lightning.Invocation do
 
   import Ecto.Query, warn: false
   import Lightning.Helpers, only: [coerce_json_field: 2]
+
   alias Lightning.WorkOrder
   alias Lightning.WorkOrders.SearchParams
   alias Lightning.Repo
@@ -335,12 +336,19 @@ defmodule Lightning.Invocation do
 
   def search_workorders_query(
         %Project{id: project_id},
-        %SearchParams{} = search_params
+        %SearchParams{status: status_list} = search_params
       ) do
+    status_filter =
+      if SearchParams.all_statuses_set?(search_params) do
+        []
+      else
+        status_list
+      end
+
     base_query(project_id)
     |> filter_by_workorder_id(search_params.workorder_id)
     |> filter_by_workflow_id(search_params.workflow_id)
-    |> filter_by_statuses(search_params.status)
+    |> filter_by_statuses(status_filter)
     |> filter_by_wo_date_after(search_params.wo_date_after)
     |> filter_by_wo_date_before(search_params.wo_date_before)
     |> filter_by_date_after(search_params.date_after)


### PR DESCRIPTION
## Notes for the reviewer

Ignores filter by `status` when all status are selected on SearchParams.

## Related issue

Refs #1279 

## Review checklist

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
