### PR TITLE
fix: StartRun handler throws an exception when the attempt doesn't exist

### DIFF
--- a/test/lightning/attempts_test.exs
+++ b/test/lightning/attempts_test.exs
@@ -169,10 +169,23 @@ defmodule Lightning.AttemptsTest do
           "attempt_id" => attempt.id,
           "job_id" => Ecto.UUID.generate(),
           "input_dataclip_id" => dataclip.id,
-          "run_id" => _run_id = Ecto.UUID.generate()
+          "run_id" => Ecto.UUID.generate()
         })
 
       assert {:job_id, {"does not exist", []}} in changeset.errors
+      refute {:attempt_id, {"does not exist", []}} in changeset.errors
+
+      # both attempt_id and job_id doesn't exist
+      {:error, changeset} =
+        Attempts.start_run(%{
+          "attempt_id" => Ecto.UUID.generate(),
+          "job_id" => Ecto.UUID.generate(),
+          "input_dataclip_id" => dataclip.id,
+          "run_id" => Ecto.UUID.generate()
+        })
+
+      assert {:job_id, {"does not exist", []}} in changeset.errors
+      assert {:attempt_id, {"does not exist", []}} in changeset.errors
 
       Lightning.WorkOrders.subscribe(workflow.project_id)
 


### PR DESCRIPTION
## Notes for the reviewer
Was able to reproduce this by a non existent attempt


## Related issue

Fixes #1390 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
