### PR TITLE
Preserve RTM exit reason for runs

### DIFF
--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -70,8 +70,9 @@ defmodule Lightning.Invocation.LogLine do
     |> assoc_constraint(:run)
     |> assoc_constraint(:attempt)
     |> validate_change(:message, fn _, message ->
-      if is_nil(message) do
-        [message: "can't be nil"]
+      # cast converts [nil] into "null"
+      if message == "null" do
+        [message: "This field can't be blank."]
       else
         []
       end

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -166,15 +166,10 @@ defmodule LightningWeb.AttemptChannel do
     end
   end
 
-  def handle_in(
-        "run:complete",
-        %{"reason" => reason} = payload,
-        socket
-      ) do
+  def handle_in("run:complete", payload, socket) do
     %{
       "attempt_id" => socket.assigns.attempt.id,
-      "project_id" => socket.assigns.project_id,
-      "reason" => "#{map_rtm_reason_state(reason)}"
+      "project_id" => socket.assigns.project_id
     }
     |> Enum.into(payload)
     |> Attempts.complete_run()

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -475,7 +475,7 @@ defmodule LightningWeb.AttemptChannelTest do
       assert errors == %{message: ["This field can't be blank."]}
     end
 
-    test "attempt:log nil message can't be blank", %{
+    test "attempt:log message can't be nil", %{
       socket: socket,
       attempt: attempt,
       workflow: workflow
@@ -498,6 +498,36 @@ defmodule LightningWeb.AttemptChannelTest do
           # we expect a 16 character string for microsecond resolution
           "timestamp" => "1699444653874088",
           "message" => nil
+        })
+
+      assert_reply ref, :error, errors
+
+      assert errors == %{message: ["This field can't be blank."]}
+    end
+
+    test "attempt:log message can't be [nil]", %{
+      socket: socket,
+      attempt: attempt,
+      workflow: workflow
+    } do
+      # { id, job_id, input_dataclip_id }
+      run_id = Ecto.UUID.generate()
+      [job] = workflow.jobs
+
+      ref =
+        push(socket, "run:start", %{
+          "run_id" => run_id,
+          "job_id" => job.id,
+          "input_dataclip_id" => attempt.dataclip_id
+        })
+
+      assert_reply ref, :ok, _
+
+      ref =
+        push(socket, "attempt:log", %{
+          # we expect a 16 character string for microsecond resolution
+          "timestamp" => "1699444653874088",
+          "message" => [nil]
         })
 
       assert_reply ref, :error, errors

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -225,7 +225,7 @@ defmodule LightningWeb.EndToEndTest do
       # #  Run 2 should fail but not expose a secret
       assert NaiveDateTime.diff(run_2.finished_at, claimed_at, :microsecond) > 0
       assert NaiveDateTime.diff(run_2.finished_at, finished_at, :microsecond) < 0
-      assert run_2.exit_reason == "failed"
+      assert run_2.exit_reason == "fail"
 
       log = Invocation.assemble_logs_for_run(run_2)
 


### PR DESCRIPTION
## Notes for the reviewer

Prevents mapping present tense run payload reason into past tense `exit_reason` (not a state).

Plus validations the [nil] message on `run:complete` once sent by RTM.

## Related issue

Fixes #1403 

## Review checklist

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
