### PR TITLE
Update UI for managing project users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Tooltip text clears later than the background
   [#1094](https://github.com/OpenFn/Lightning/issues/1094)
+- Temporary fix to superuser UI for managing project users
+  [#1145](https://github.com/OpenFn/Lightning/issues/1145)
 
 ## [v0.10.3] - 2023-11-28
 

--- a/lib/lightning_web/components/core_components.ex
+++ b/lib/lightning_web/components/core_components.ex
@@ -11,6 +11,79 @@ defmodule LightningWeb.CoreComponents do
 
   import LightningWeb.Components.NewInputs
 
+  @doc ~S"""
+  Renders a table with generic styling.
+
+  ## Examples
+
+      <.new_table id="users" rows={@users}>
+        <:col :let={user} label="id"><%= user.id %></:col>
+        <:col :let={user} label="username"><%= user.username %></:col>
+      </.new_table>
+  """
+
+  attr :id, :string, required: true
+  attr :row_click, :any, default: nil
+  attr :rows, :list, required: true
+
+  slot :col, required: true do
+    attr :label, :string
+  end
+
+  slot :action, doc: "the slot for showing user actions in the last table column"
+
+  def new_table(assigns) do
+    ~H"""
+    <div id={@id} class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
+      <table class="mt-11 w-[40rem] sm:w-full">
+        <thead class="text-left text-[0.8125rem] leading-6 text-zinc-500">
+          <tr>
+            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal">
+              <%= col[:label] %>
+            </th>
+            <th class="relative p-0 pb-4">
+              <span class="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700">
+          <tr
+            :for={row <- @rows}
+            id={"#{@id}-#{Phoenix.Param.to_param(row)}"}
+            class="relative group hover:bg-zinc-50"
+          >
+            <td
+              :for={{col, i} <- Enum.with_index(@col)}
+              phx-click={@row_click && @row_click.(row)}
+              class={["p-0", @row_click && "hover:cursor-pointer"]}
+            >
+              <div :if={i == 0}>
+                <span class="absolute h-full w-4 top-0 -left-4 group-hover:bg-zinc-50 sm:rounded-l-xl" />
+                <span class="absolute h-full w-4 top-0 -right-4 group-hover:bg-zinc-50 sm:rounded-r-xl" />
+              </div>
+              <div class="block py-4 pr-6">
+                <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
+                  <%= render_slot(col, row) %>
+                </span>
+              </div>
+            </td>
+            <td :if={@action != []} class="p-0 w-14">
+              <div class="relative whitespace-nowrap py-4 text-right text-sm font-medium">
+                <span
+                  :for={action <- @action}
+                  class="relative ml-4 font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
+                >
+                  <%= render_slot(action, row) %>
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
   @doc """
   Generates tag for inlined form input errors.
   """

--- a/lib/lightning_web/components/core_components.ex
+++ b/lib/lightning_web/components/core_components.ex
@@ -28,6 +28,7 @@ defmodule LightningWeb.CoreComponents do
 
   slot :col, required: true do
     attr :label, :string
+    attr :label_class, :string
   end
 
   slot :action, doc: "the slot for showing user actions in the last table column"
@@ -46,7 +47,9 @@ defmodule LightningWeb.CoreComponents do
               scope="col"
               class="px-3 py-3.5 text-left text-sm font-semibold text-gray-500"
             >
-              <%= col[:label] %>
+              <div class={col[:label_class]}>
+                <%= col[:label] %>
+              </div>
             </th>
             <th
               :if={@action != []}
@@ -64,7 +67,7 @@ defmodule LightningWeb.CoreComponents do
             class=""
           >
             <td
-              :for={{col, i} <- Enum.with_index(@col)}
+              :for={col <- @col}
               phx-click={@row_click && @row_click.(row)}
               class={[
                 "whitespace-nowrap px-3 py-4 text-sm text-gray-500",

--- a/lib/lightning_web/components/core_components.ex
+++ b/lib/lightning_web/components/core_components.ex
@@ -34,38 +34,44 @@ defmodule LightningWeb.CoreComponents do
 
   def new_table(assigns) do
     ~H"""
-    <div id={@id} class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
-      <table class="mt-11 w-[40rem] sm:w-full">
-        <thead class="text-left text-[0.8125rem] leading-6 text-zinc-500">
+    <div
+      id={@id}
+      class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg"
+    >
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead class="">
           <tr>
-            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal">
+            <th
+              :for={col <- @col}
+              scope="col"
+              class="px-3 py-3.5 text-left text-sm font-semibold text-gray-500"
+            >
               <%= col[:label] %>
             </th>
-            <th class="relative p-0 pb-4">
+            <th
+              :if={@action != []}
+              scope="col"
+              class="relative py-3.5 pl-3 pr-4 sm:pr-6"
+            >
               <span class="sr-only">Actions</span>
             </th>
           </tr>
         </thead>
-        <tbody class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700">
+        <tbody class="divide-y divide-gray-200 bg-white">
           <tr
             :for={row <- @rows}
             id={"#{@id}-#{Phoenix.Param.to_param(row)}"}
-            class="relative group hover:bg-zinc-50"
+            class=""
           >
             <td
               :for={{col, i} <- Enum.with_index(@col)}
               phx-click={@row_click && @row_click.(row)}
-              class={["p-0", @row_click && "hover:cursor-pointer"]}
+              class={[
+                "whitespace-nowrap px-3 py-4 text-sm text-gray-500",
+                @row_click && "hover:cursor-pointer"
+              ]}
             >
-              <div :if={i == 0}>
-                <span class="absolute h-full w-4 top-0 -left-4 group-hover:bg-zinc-50 sm:rounded-l-xl" />
-                <span class="absolute h-full w-4 top-0 -right-4 group-hover:bg-zinc-50 sm:rounded-r-xl" />
-              </div>
-              <div class="block py-4 pr-6">
-                <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
-                  <%= render_slot(col, row) %>
-                </span>
-              </div>
+              <%= render_slot(col, row) %>
             </td>
             <td :if={@action != []} class="p-0 w-14">
               <div class="relative whitespace-nowrap py-4 text-right text-sm font-medium">

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -257,6 +257,17 @@ defmodule LightningWeb.Components.NewInputs do
     """
   end
 
+  def input(%{type: "hidden"} = assigns) do
+    ~H"""
+    <input
+      type="hidden"
+      name={@name}
+      id={@id}
+      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+    />
+    """
+  end
+
   # All other inputs text, datetime-local, url etc. are handled here...
   def input(assigns) do
     ~H"""

--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -6,7 +6,7 @@
     phx-target={@myself}
     phx-change="validate"
   >
-    <div class="flex items-end gap-6">
+    <div class="flex items-end gap-2">
       <div class="w-3/6">
         <%= Phoenix.HTML.Form.label(f, :name,
           class: "block text-sm font-medium text-secondary-700 mb-2"
@@ -19,7 +19,7 @@
         ) %>
         <.old_error field={f[:name]} />
       </div>
-      <div class="pl-2">
+      <div class="">
         <%= if (@changeset.valid?) do %>
           Your project will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
       <%= @name %></span>.
@@ -27,6 +27,13 @@
       </div>
     </div>
   </.form>
+  <div class="sm:flex sm:items-center mt-8">
+    <div class="sm:flex-auto">
+      <h1 class="text-base font-semibold leading-6 text-gray-600">
+        Manage project users
+      </h1>
+    </div>
+  </div>
   <.form
     :let={f}
     for={@changeset}
@@ -35,7 +42,7 @@
     phx-submit="save"
   >
     <%= Phoenix.HTML.Form.hidden_input(f, :name) %>
-    <div class="mt-8 flow-root">
+    <div class="mt-2 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
           <.new_table
@@ -51,33 +58,38 @@
           >
             <:col :let={form} label="NAME">
               <%= full_user_name(form.data.user) %>
-              <%= Phoenix.HTML.Form.hidden_input(form, :id) %>
-              <%= Phoenix.HTML.Form.hidden_input(form, :user_id) %>
+              <.input :if={form.data.id} type="hidden" field={form[:id]} />
+              <.input type="hidden" field={form[:user_id]} />
             </:col>
             <:col :let={form} label="EMAIL">
               <%= form.data.user.email %>
             </:col>
-            <:col :let={form} label="NO ACCESS">
-              <%= Phoenix.HTML.Form.radio_button(form, :role, nil,
-                class:
-                  "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-              ) %>
+            <:col :let={form} label="NO ACCESS" label_class="text-center">
+              <div class="text-center">
+                <%= Phoenix.HTML.Form.radio_button(form, :role, nil,
+                  class:
+                    "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                ) %>
+              </div>
             </:col>
             <:col
               :let={form}
               :for={role <- ["owner", "admin", "editor", "viewer"]}
               label={String.upcase(role)}
+              label_class="text-center"
             >
-              <%= Phoenix.HTML.Form.radio_button(form, :role, role,
-                class:
-                  "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-              ) %>
+              <div class="text-center">
+                <%= Phoenix.HTML.Form.radio_button(form, :role, role,
+                  class:
+                    "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                ) %>
+              </div>
             </:col>
           </.new_table>
         </div>
       </div>
     </div>
-    <div class="mt-2">
+    <div class="mt-4">
       <span>
         <.link
           navigate={Routes.project_index_path(@socket, :index)}

--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -7,8 +7,8 @@
     phx-change="validate"
     phx-submit="save"
   >
-    <div class="grid grid-cols-6 gap-6">
-      <div class="col-span-3">
+    <div class="flex items-end gap-6">
+      <div class="w-3/6">
         <%= Phoenix.HTML.Form.label(f, :name,
           class: "block text-sm font-medium text-secondary-700 mb-2"
         ) %>
@@ -19,81 +19,35 @@
           value: Phoenix.HTML.Form.input_value(f, :name)
         ) %>
         <.old_error field={f[:name]} />
-        <br />
-        <div class="inline-block pl-2">
-          <%= if (@changeset.valid?) do %>
-            Your project will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
-          <%= @name %></span>.
-          <% end %>
-        </div>
       </div>
-      <div class="col-span-3">
-        <%= Phoenix.HTML.Form.label(f, :project_users, "Members",
-          class: "block text-sm font-medium text-secondary-700 mb-2"
-        ) %>
-
-        <div class="flex w-full items-center gap-2 pb-3">
-          <div class="grow">
-            <.select
-              phx-hook="AssocListChange"
-              phx-target={@myself}
-              id="member_list"
-            >
-              <option>Select a user</option>
-              <%= Phoenix.HTML.Form.options_for_select(
-                @available_users,
-                @selected_member
-              ) %>
-            </.select>
-          </div>
-          <div class="grow-0 items-right">
-            <.button
-              disabled={@selected_member == ""}
-              phx-target={@myself}
-              phx-value-userid={@selected_member}
-              phx-click="add_new_member"
-            >
-              Add
-            </.button>
-          </div>
-        </div>
-
-        <.inputs_for :let={member_form} field={f[:project_users]}>
-          <%= if member_form[:delete].value != true do %>
-            <div class="flex w-full gap-2 items-center pb-2">
-              <div class="grow">
-                <%= user_name_for_id(@all_users, member_form[:user_id]) %>
-                <.old_error field={member_form[:project_id]} />
-              </div>
-              <div class="grow-0 items-right">
-                <.select_field
-                  form={member_form}
-                  name={:role}
-                  id="role"
-                  values={["owner", "admin", "editor", "viewer"]}
-                />
-              </div>
-              <div class="grow-0 items-right">
-                <.button
-                  phx-target={@myself}
-                  phx-value-index={member_form.index}
-                  phx-click="delete_member"
-                >
-                  Remove
-                </.button>
-              </div>
-            </div>
-          <% end %>
-          <.input type="hidden" field={member_form[:user_id]} />
-          <.input type="hidden" field={member_form[:delete]} />
-        </.inputs_for>
-      </div>
-      <div class="col-span-6">
-        <div class="hidden sm:block" aria-hidden="true">
-          <div class="border-t border-secondary-200"></div>
-        </div>
+      <div class="pl-2">
+        <%= if (@changeset.valid?) do %>
+          Your project will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
+      <%= @name %></span>.
+        <% end %>
       </div>
     </div>
+    <.new_table
+      id="project_users"
+      rows={Phoenix.HTML.Form.inputs_for(f, :project_users)}
+    >
+      <:col :let={form} label="NAME"><%= full_user_name(form.data.user) %></:col>
+      <:col :let={form} label="EMAIL"><%= form.data.user.email %></:col>
+      <:col :let={form} label="NO ACCESS">
+        <%= Phoenix.HTML.Form.radio_button(form, :role, nil,
+          class: "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+        ) %>
+      </:col>
+      <:col
+        :let={form}
+        :for={role <- ["owner", "admin", "editor", "viewer"]}
+        label={String.upcase(role)}
+      >
+        <%= Phoenix.HTML.Form.radio_button(form, :role, role,
+          class: "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+        ) %>
+      </:col>
+    </.new_table>
 
     <div class="mt-2">
       <span>

--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -5,7 +5,6 @@
     id="project-form"
     phx-target={@myself}
     phx-change="validate"
-    phx-submit="save"
   >
     <div class="flex items-end gap-6">
       <div class="w-3/6">
@@ -27,28 +26,57 @@
         <% end %>
       </div>
     </div>
-    <.new_table
-      id="project_users"
-      rows={Phoenix.HTML.Form.inputs_for(f, :project_users)}
-    >
-      <:col :let={form} label="NAME"><%= full_user_name(form.data.user) %></:col>
-      <:col :let={form} label="EMAIL"><%= form.data.user.email %></:col>
-      <:col :let={form} label="NO ACCESS">
-        <%= Phoenix.HTML.Form.radio_button(form, :role, nil,
-          class: "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-        ) %>
-      </:col>
-      <:col
-        :let={form}
-        :for={role <- ["owner", "admin", "editor", "viewer"]}
-        label={String.upcase(role)}
-      >
-        <%= Phoenix.HTML.Form.radio_button(form, :role, role,
-          class: "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-        ) %>
-      </:col>
-    </.new_table>
-
+  </.form>
+  <.form
+    :let={f}
+    for={@changeset}
+    id="project-users-form"
+    phx-target={@myself}
+    phx-submit="save"
+  >
+    <%= Phoenix.HTML.Form.hidden_input(f, :name) %>
+    <div class="mt-8 flow-root">
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+        <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+          <.new_table
+            id="project_users_table"
+            rows={
+              Phoenix.HTML.FormData.to_form(
+                f.source,
+                f,
+                :project_users,
+                f.options
+              )
+            }
+          >
+            <:col :let={form} label="NAME">
+              <%= full_user_name(form.data.user) %>
+              <%= Phoenix.HTML.Form.hidden_input(form, :id) %>
+              <%= Phoenix.HTML.Form.hidden_input(form, :user_id) %>
+            </:col>
+            <:col :let={form} label="EMAIL">
+              <%= form.data.user.email %>
+            </:col>
+            <:col :let={form} label="NO ACCESS">
+              <%= Phoenix.HTML.Form.radio_button(form, :role, nil,
+                class:
+                  "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+              ) %>
+            </:col>
+            <:col
+              :let={form}
+              :for={role <- ["owner", "admin", "editor", "viewer"]}
+              label={String.upcase(role)}
+            >
+              <%= Phoenix.HTML.Form.radio_button(form, :role, role,
+                class:
+                  "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+              ) %>
+            </:col>
+          </.new_table>
+        </div>
+      </div>
+    </div>
     <div class="mt-2">
       <span>
         <.link

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -52,7 +52,7 @@ defmodule LightningWeb.ProjectLive.Index do
     |> assign(
       page_title: "New Project",
       active_menu_item: :projects,
-      project: %Lightning.Projects.Project{},
+      project: %Lightning.Projects.Project{project_users: []},
       users: Lightning.Accounts.list_users()
     )
   end

--- a/test/lightning/digest_email_worker_test.exs
+++ b/test/lightning/digest_email_worker_test.exs
@@ -11,10 +11,10 @@ defmodule Lightning.DigestEmailWorkerTest do
 
   describe "perform/1" do
     test "projects that are scheduled for deletion are not part of the projects for which digest alerts are sent" do
-      user = AccountsFixtures.user_fixture()
+      user = insert(:user)
 
       project =
-        ProjectsFixtures.project_fixture(
+        insert(:project,
           scheduled_deletion: Timex.now(),
           project_users: [
             %{user_id: user.id, digest: :daily}

--- a/test/lightning/invocation/query_test.exs
+++ b/test/lightning/invocation/query_test.exs
@@ -2,20 +2,50 @@ defmodule Lightning.Invocation.QueryTest do
   use Lightning.DataCase, async: true
 
   alias Lightning.Invocation.Query
-  import Lightning.InvocationFixtures
-  import Lightning.JobsFixtures
-  import Lightning.AccountsFixtures
-  import Lightning.ProjectsFixtures
-  import Lightning.WorkflowsFixtures
+
+  import Lightning.Factories
 
   test "runs_for/1 with user" do
-    user = user_fixture()
-    project = project_fixture(project_users: [%{user_id: user.id}])
+    user = insert(:user)
+    project = insert(:project, project_users: [%{user_id: user.id}])
 
-    job = job_fixture(workflow_id: workflow_fixture(project_id: project.id).id)
-    run = run_fixture(job_id: job.id)
-    _other_run = run_fixture()
+    %{triggers: [trigger], jobs: [job]} =
+      workflow = insert(:simple_workflow, project: project)
 
-    assert Query.runs_for(user) |> Repo.all() == [run]
+    %{attempts: [%{runs: [run1]}]} =
+      insert(:workorder,
+        workflow: workflow,
+        dataclip: build(:dataclip, project: project),
+        trigger: trigger,
+        attempts: [
+          build(:attempt,
+            starting_trigger: trigger,
+            dataclip: build(:dataclip, project: project),
+            runs: [build(:run, job: job)]
+          )
+        ]
+      )
+
+    %{triggers: [trigger2], jobs: [job2]} = workflow2 = insert(:simple_workflow)
+
+    %{attempts: [%{runs: [run2]}]} =
+      insert(:workorder,
+        workflow: workflow2,
+        dataclip: build(:dataclip),
+        trigger: trigger2,
+        attempts: [
+          build(:attempt,
+            dataclip: build(:dataclip),
+            starting_trigger: trigger2,
+            runs: [build(:run, job: job2)]
+          )
+        ]
+      )
+
+    refute run1.id == run2.id
+
+    run1_id = run1.id
+
+    assert [%{id: ^run1_id}] = Query.runs_for(user) |> Repo.all()
   end
 end

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -64,7 +64,7 @@ defmodule LightningWeb.ProjectLiveTest do
       |> render_change()
 
       index_live
-      |> form("#project-form")
+      |> form("#project-users-form")
       |> render_submit()
 
       assert_patch(index_live, Routes.project_index_path(conn, :index))
@@ -72,7 +72,8 @@ defmodule LightningWeb.ProjectLiveTest do
     end
 
     test "saves new project", %{conn: conn} do
-      user = user_fixture()
+      # this makes it first in the list
+      user = insert(:user, first_name: "1")
 
       {:ok, index_live, _html} =
         live(conn, Routes.project_index_path(conn, :index))
@@ -91,15 +92,13 @@ defmodule LightningWeb.ProjectLiveTest do
       |> render_change()
 
       index_live
-      |> element("#member_list")
-      |> render_hook("select_item", %{"id" => user.id})
-
-      assert index_live
-             |> element("button", "Add")
-             |> render_click() =~ "editor"
-
-      index_live
-      |> form("#project-form")
+      |> form("#project-users-form",
+        project: %{
+          "project_users" => %{
+            "0" => %{"user_id" => user.id, "role" => "editor"}
+          }
+        }
+      )
       |> render_submit()
 
       assert_patch(index_live, Routes.project_index_path(conn, :index))
@@ -294,26 +293,42 @@ defmodule LightningWeb.ProjectLiveTest do
       refute index_live |> element("project-#{project.id}") |> has_element?()
     end
 
-    test "Edits a project", %{conn: conn} do
-      user = user_fixture()
-      project = project_fixture()
+    test "Edits a project", %{conn: conn, user: superuser} do
+      # the alphabetical order here is important. In the page, the users are ordered alphabeticaly
+      superuser
+      |> Ecto.Changeset.change(%{first_name: "1"})
+      |> Lightning.Repo.update!()
+
+      user1 = insert(:user, first_name: "2")
+      user2 = insert(:user, first_name: "3")
+      project = insert(:project)
 
       {:ok, view, _html} = live(conn, ~p"/settings/projects/#{project.id}")
 
+      # notice the order. We've skipped `0` who's the superadmin. Changing this order will fail the test
       view
-      |> element("#member_list")
-      |> render_hook("select_item", %{"id" => user.id})
-
-      assert view
-             |> element("button", "Add")
-             |> render_click() =~ "editor"
-
-      view
-      |> form("#project-form")
+      |> form("#project-users-form",
+        project: %{
+          "project_users" => %{
+            "1" => %{"user_id" => user1.id, "role" => "editor"},
+            "2" => %{"user_id" => user2.id, "role" => "viewer"}
+          }
+        }
+      )
       |> render_submit()
 
       assert_patch(view, ~p"/settings/projects")
       assert render(view) =~ "Project updated successfully"
+
+      updated_project =
+        Lightning.Repo.preload(project, [:project_users], force: true)
+
+      assert Enum.count(updated_project.project_users) == 2
+
+      for p_user <- updated_project.project_users do
+        assert p_user.user_id in [user1.id, user2.id]
+        refute p_user.user_id == superuser.id
+      end
     end
   end
 
@@ -321,25 +336,25 @@ defmodule LightningWeb.ProjectLiveTest do
     setup :register_and_log_in_user
 
     test "Access project settings page", %{conn: conn, user: user} do
-      another_user = user_fixture()
+      another_user = insert(:user)
 
-      {:ok, project_1} =
-        Lightning.Projects.create_project(%{
+      project_1 =
+        insert(:project,
           name: "project-1",
           project_users: [%{user_id: user.id}]
-        })
+        )
 
-      {:ok, project_2} =
-        Lightning.Projects.create_project(%{
+      project_2 =
+        insert(:project,
           name: "project-2",
           project_users: [%{user_id: user.id}]
-        })
+        )
 
-      {:ok, project_3} =
-        Lightning.Projects.create_project(%{
+      project_3 =
+        insert(:project,
           name: "project-3",
           project_users: [%{user_id: another_user.id}]
-        })
+        )
 
       {:ok, view, _html} = live(conn, ~p"/projects/#{project_1}/w")
 


### PR DESCRIPTION
## Notes for the reviewer

- Introduces a `new_table` component. This is an exact replica of the one generated by `phx.gen.live` in `phoenix 1.7`
- uses [Phoenix.HTML.FormData.html.to_form/4](https://hexdocs.pm/phoenix_html/Phoenix.HTML.FormData.html#to_form/4) to generate the nested  form. I first used [Phoenix.HTML.Form.html.inputs_for/2](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#inputs_for/2) to do this, but then it was emitting  `deprecation` warnings, so I checked how it is implemented. @stuartc this is the hack I was talking of during standup. The lean way to do this is to use [Phoenix.Component.html.inputs_for/1](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#inputs_for/1) but then I couldn't use this given the definition of the `new_table` component.


## Related issue

Fixes #1145 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
