### PR TITLE
use 'ramping-arrival-rate' for more realistic RPS measures

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 erlang 26.0.2
 elixir 1.15.4-otp-26
 nodejs 18.17.1
-k6 0.43.1
+k6 0.47.0

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -2,39 +2,21 @@
 
 ## Sample benchmarks
 
-### System specs on a Thinkpad Carbon X1 5th Gen laptop
+### System specs on a 2020 MacBook Pro
 
 ```
-❯ sudo lshw -short
-H/W path           Device          Class          Description
-=============================================================
-                                   system         20HR000HUS (LENOVO_MT_20HR_BU_Think_FM_ThinkPad X1 Carbon 5th)
-/0                                 bus            20HR000HUS
-/0/3                               memory         8GiB System Memory
-/0/3/0                             memory         4GiB Row of chips LPDDR3 Synchronous Unbuffered (Unregistered) 1867 MHz (0.5 ns)
-/0/3/1                             memory         4GiB Row of chips LPDDR3 Synchronous Unbuffered (Unregistered) 1867 MHz (0.5 ns)
-/0/7                               memory         128KiB L1 cache
-/0/8                               memory         512KiB L2 cache
-/0/9                               memory         4MiB L3 cache
-/0/a                               processor      Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz
-/0/b                               memory         128KiB BIOS
-/0/100                             bridge         Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
-...
-/0/100/1c.4/0      /dev/nvme0      storage        SAMSUNG MZVLW256HEHP-000L7
-/0/100/1c.4/0/0    hwmon3          disk           NVMe disk
-/0/100/1c.4/0/2    /dev/ng0n1      disk           NVMe disk
-/0/100/1c.4/0/1    /dev/nvme0n1    disk           256GB NVMe disk
-/0/100/1c.4/0/1/1  /dev/nvme0n1p1  volume         259MiB Windows FAT volume
-
-❯ lsb_release -a
-Description:	Ubuntu 22.04.3 LTS
-Release:	22.04
+Model Name: MacBook Pro
+Model Identifier: MacBookPro17,1
+Model Number: Z11B000E3LL/A
+Chip: Apple M1
+Total Number of Cores: 8 (4 performance and 4 efficiency)
+Memory: 16 GB
 ```
 
 ### Results with 50kb payloads
 
 ```
-❯ k6 run -e PAYLOAD_SIZE=50 benchmarking/script.js
+k6 run -e PAYLOAD_SIZE=10 benchmarking/script.js                         Node 18.17.1 k6 0.43.1 07:40:29
 
           /\      |‾‾| /‾‾/   /‾‾/
      /\  /  \     |  |/  /   /  /
@@ -47,35 +29,34 @@ Release:	22.04
      output: -
 
   scenarios: (100.00%) 1 scenario, 50 max VUs, 2m50s max duration (incl. graceful stop):
-           * default: Up to 50 looping VUs for 2m20s over 3 stages (gracefulRampDown: 30s, gracefulStop: 30s)
+           * webhookRequests: Up to 50.00 iterations/s for 2m20s over 3 stages (maxVUs: 50, gracefulStop: 30s)
 
 
      ✓ status was 200
 
      █ setup
 
-     checks.........................: 100.00% ✓ 5271      ✗ 0
-     data_received..................: 1.5 MB  11 kB/s
-     data_sent......................: 265 MB  1.9 MB/s
-     http_req_blocked...............: avg=11µs     min=1.92µs   med=4.72µs   max=7ms      p(90)=5.93µs   p(95)=7.09µs
-     http_req_connecting............: avg=1.28µs   min=0s       med=0s       max=218.87µs p(90)=0s       p(95)=0s
-   ✗ http_req_duration..............: avg=630.38ms min=44.61ms  med=612.48ms max=1.68s    p(90)=1.05s    p(95)=1.15s
-       { expected_response:true }...: avg=630.38ms min=44.61ms  med=612.48ms max=1.68s    p(90)=1.05s    p(95)=1.15s
-   ✓ http_req_failed................: 0.00%   ✓ 0         ✗ 5271
-     http_req_receiving.............: avg=106.35µs min=21.5µs   med=61.35µs  max=26.63ms  p(90)=76.03µs  p(95)=88.56µs
-     http_req_sending...............: avg=193.3µs  min=53.54µs  med=100.42µs max=20.72ms  p(90)=140.83µs p(95)=210.86µs
-     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s
-     http_req_waiting...............: avg=630.08ms min=44.47ms  med=612.17ms max=1.68s    p(90)=1.05s    p(95)=1.15s
-     http_reqs......................: 5271    37.642872/s
-     iteration_duration.............: avg=632.07ms min=180.16µs med=614.54ms max=1.69s    p(90)=1.05s    p(95)=1.15s
-     iterations.....................: 5271    37.642872/s
-     vus............................: 1       min=1       max=49
-     vus_max........................: 50      min=50      max=50
+     checks.........................: 100.00% ✓ 5765     ✗ 0
+     data_received..................: 1.6 MB  12 kB/s
+     data_sent......................: 59 MB   421 kB/s
+     http_req_blocked...............: avg=16.01µs min=2µs     med=9µs     max=6.84ms   p(90)=12µs    p(95)=13µs
+     http_req_connecting............: avg=4.35µs  min=0s      med=0s      max=2.22ms   p(90)=0s      p(95)=0s
+   ✓ http_req_duration..............: avg=53.62ms min=26.86ms med=49.03ms max=501.62ms p(90)=66.62ms p(95)=84.33ms
+       { expected_response:true }...: avg=53.62ms min=26.86ms med=49.03ms max=501.62ms p(90)=66.62ms p(95)=84.33ms
+   ✓ http_req_failed................: 0.00%   ✓ 0        ✗ 5765
+     http_req_receiving.............: avg=88.57µs min=13µs    med=90µs    max=2.99ms   p(90)=108µs   p(95)=124.8µs
+     http_req_sending...............: avg=97.47µs min=29µs    med=83µs    max=6.86ms   p(90)=139µs   p(95)=162µs
+     http_req_tls_handshaking.......: avg=0s      min=0s      med=0s      max=0s       p(90)=0s      p(95)=0s
+     http_req_waiting...............: avg=53.44ms min=26.68ms med=48.84ms max=501.43ms p(90)=66.43ms p(95)=84.05ms
+     http_reqs......................: 5765    41.15402/s
+     iteration_duration.............: avg=54.34ms min=20.75µs med=49.75ms max=502.26ms p(90)=67.39ms p(95)=84.91ms
+     iterations.....................: 5765    41.15402/s
+     vus............................: 50      min=50     max=50
+     vus_max........................: 50      min=50     max=50
 
 
-running (2m20.0s), 00/50 VUs, 5271 complete and 0 interrupted iterations
-default ✓ [======================================] 00/50 VUs  2m20s
-ERRO[0141] thresholds on metrics 'http_req_duration' have been breached
+running (2m20.1s), 00/50 VUs, 5765 complete and 0 interrupted iterations
+webhookRequests ✓ [======================================] 00/50 VUs  2m20s  01.12 iters/s
 ```
 
 ## Run your own benchmarking tests
@@ -86,9 +67,11 @@ Execute the following steps to run a benchmark on Lightning:
    installed locally. If you're using `asdf` you can run `asdf install` in the
    project root.
 
-2. Start up a local Lightning instance with an attached iex session:
+2. Start up a local Lightning instance with an attached iex session. Note that
+   to simulate a production environment, set `RTM=false`. In prod, you'll have
+   your `ws-worker` running on a separate machine:
 
-   `iex -S mix phx.server`
+   `RMT=false iex -S mix phx.server`
 
 3. In the attached iex session, run the following, to have Lightning log
    internal telemetry data:

--- a/benchmarking/script.js
+++ b/benchmarking/script.js
@@ -5,11 +5,20 @@ const webhookURL =
   'http://localhost:4000/i/cae544ab-03dc-4ccc-a09c-fb4edb255d7a';
 
 export const options = {
-  stages: [
-    { duration: '30s', target: 10 },
-    { duration: '1m30s', target: 50 },
-    { duration: '20s', target: 0 },
-  ],
+  discardResponseBodies: true,
+  scenarios: {
+    webhookRequests: {
+      executor: 'ramping-arrival-rate',
+      startRate: 1,
+      timeUnit: '1s',
+      preAllocatedVUs: 50,
+      stages: [
+        { duration: '30s', target: 50 }, // go from 1 to 50 rps in the first 30 seconds
+        { duration: '1m30s', target: 50 }, // hold at 50 rps for 1.5 minutes
+        { duration: '20s', target: 0 }, // ramp down back to 0 rps over the last 30 seconds
+      ],
+    },
+  },
   thresholds: {
     http_req_failed: ['rate<0.0001'], // http errors should be less than 0.01%
     http_req_duration: [


### PR DESCRIPTION
This switches over to a scenario with `ramping-arrival-rate` so we can control the number of requests per second (RPS) rather than allowing system response time to determine iteration time. It's a more realistic measure of external load on the system that "doesn't care" about how long we're taking to respond!

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
