### PR TITLE
Use config port for test env

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^4.3.7"
       },
       "devDependencies": {
-        "@openfn/ws-worker": "^0.2.9",
+        "@openfn/ws-worker": "^0.2.11",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
@@ -491,15 +491,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.2.0.tgz",
-      "integrity": "sha512-yqWKz5Q5GroXQyIcxr2OTwSaOKbsnNkZHgre9udbdVln9JSpBbJ9Zc9bFSiGz1RW9Yyu6mBMMP0PYWnE458tgA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.2.2.tgz",
+      "integrity": "sha512-emIXMbzqbLFiViXbb2slQsTk6NkI8RVUYipXI0MP+xRJcWjNDJQ30MU97OFygZwsthDzjK7dyEBgKyzxwWlIUA==",
       "dev": true,
       "dependencies": {
         "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.2.0",
+        "@openfn/runtime": "0.2.1",
         "workerpool": "^6.5.1"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.2.0.tgz",
-      "integrity": "sha512-43nWRXT4mW90ElglIK2dZ07LmGPAI+RKihpU68y9NpSiQ8kE0HF5n4799Flz7uYtFPCJ8CImm7++ITfOGAokKg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.2.1.tgz",
+      "integrity": "sha512-wH5Fcaj91ShxHo4i7xgpl9lvdB/TAMvl6qJM/IAaPpDh+6KcED+2a4DxOz7khlcVe6+wDV1XOLtR4JZgAYuaJA==",
       "dev": true,
       "dependencies": {
         "@openfn/logger": "0.0.19",
@@ -536,15 +536,15 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.9.tgz",
-      "integrity": "sha512-UKxr5mRQ5H4I3aUKhNn7LdDIbCUDT2wAYe5ubYT+AbWwBsaPF/tU1AwYcVqYBlXxAp5t8e2EYUO8ale4KorS4g==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.11.tgz",
+      "integrity": "sha512-/eass8mmDK2dcuu/a6IvIpExek/0765OpxbltdmbgK484dc6iIQ1wuWnuvfo1u9o42l2sqasJKhG0Tah4pc8pQ==",
       "dev": true,
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.2.0",
+        "@openfn/engine-multi": "0.2.2",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.2.0",
+        "@openfn/runtime": "0.2.1",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "engines": {
         "node": ">=6"

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,7 +35,7 @@
     "zustand": "^4.3.7"
   },
   "devDependencies": {
-    "@openfn/ws-worker": "^0.2.9",
+    "@openfn/ws-worker": "^0.2.11",
     "@types/marked": "^4.0.8",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -183,15 +183,22 @@ url_scheme = System.get_env("URL_SCHEME", "https")
 
 # The webserver port will always prefer and environment variable _when_
 # given, otherwise it uses the existing config and lastly defaults to 4000.
+
 port =
-  (System.get_env("PORT") ||
-     Application.get_env(:lightning, LightningWeb.Endpoint)
-     |> Keyword.get(:http, port: nil)
-     |> Keyword.get(:port) ||
-     4000)
-  |> case do
-    p when is_binary(p) -> String.to_integer(p)
-    p when is_integer(p) -> p
+  case config_env() do
+    :test ->
+      Application.get_env(:lightning, LightningWeb.Endpoint)[:url][:port]
+
+    _dev_prod ->
+      (System.get_env("PORT") ||
+         Application.get_env(:lightning, LightningWeb.Endpoint)
+         |> Keyword.get(:http, port: nil)
+         |> Keyword.get(:port) ||
+         4000)
+      |> case do
+        p when is_binary(p) -> String.to_integer(p)
+        p when is_integer(p) -> p
+      end
   end
 
 # Use the `PRIMARY_ENCRYPTION_KEY` env variable if available, else fall back

--- a/lib/lightning/attempts.ex
+++ b/lib/lightning/attempts.ex
@@ -140,13 +140,11 @@ defmodule Lightning.Attempts do
       |> join(:inner, [a], s in fragment(~s("subset")), on: a.id == s.id)
       |> select([a, _], a)
 
-    update_attempts(update_query, changeset)
-    |> Repo.transaction()
-    |> case do
+    case update_attempts(update_query, changeset) do
       {:ok, %{attempts: {1, [attempt]}}} ->
         {:ok, attempt}
 
-      {:error, changeset} ->
+      {:error, _op, changeset, _changes} ->
         {:error, changeset}
     end
   end
@@ -163,11 +161,15 @@ defmodule Lightning.Attempts do
     |> Ecto.Multi.run(:post, fn _, %{attempts: {_, attempts}} ->
       Enum.each(attempts, fn attempt ->
         {:ok, _} = Lightning.WorkOrders.update_state(attempt)
-
-        Events.attempt_updated(attempt)
       end)
 
       {:ok, nil}
+    end)
+    |> Repo.transaction()
+    |> tap(fn result ->
+      with {:ok, %{attempts: {_n, attempts}}} <- result do
+        Enum.each(attempts, &Events.attempt_updated/1)
+      end
     end)
   end
 

--- a/lib/lightning/attempts/queue.ex
+++ b/lib/lightning/attempts/queue.ex
@@ -37,16 +37,14 @@ defmodule Lightning.Attempts.Queue do
       |> where([a, x], a.id == x.id)
       |> select([a, _], a)
 
-    Attempts.update_attempts(query,
-      set: [state: :claimed, claimed_at: DateTime.utc_now()]
-    )
-    |> Repo.transaction()
-    |> case do
+    case Attempts.update_attempts(query,
+           set: [state: :claimed, claimed_at: DateTime.utc_now()]
+         ) do
       {:ok, %{attempts: {_, attempts}}} ->
         {:ok, attempts}
 
-      {:error, _} = e ->
-        e
+      {:error, _op, changeset, _changes} ->
+        {:error, changeset}
     end
   end
 

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -147,15 +147,13 @@ defmodule LightningWeb.EndToEndTest do
 
       assert %{"work_order_id" => wo_id} = json_response(conn, 200)
 
-      assert %{attempts: [attempt]} =
+      assert %{attempts: [%{id: attempt_id} = attempt]} =
                WorkOrders.get(wo_id, include: [:attempts])
 
       assert %{runs: []} = Attempts.get(attempt.id, include: [:runs])
 
       # wait to complete
       Events.subscribe(attempt)
-
-      attempt_id = attempt.id
 
       assert_receive %Events.AttemptUpdated{
                        attempt: %{id: ^attempt_id, state: :success}


### PR DESCRIPTION
## Notes for the reviewer

For test env, instead of using the PORT env var, it uses the config (port 4002).

## Related issue

If there is a Lightning instance running it gives an `eaddrinuse` on 4000 when running the tests.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
