### PR TITLE
1431 GitHub links displaying as buttons on settings page

### DIFF
--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -677,15 +677,16 @@
                         <small>
                           Need to change the repository or branch?
                         </small>
-                        <.button phx-click="reinstall_app">
+                        <button class="text-[#5046E4]" phx-click="reinstall_app">
                           Re-configure your Github permissions (admin access required)
-                        </.button>
+                        </button>
                       </div>
                       <div>
                         <small>
                           No longer need to sync your project?
                         </small>
-                        <.button
+                        <button
+                        class="text-[#FF0101]"
                           phx-click={
                             LightningWeb.Components.Modal.show_modal(
                               "delete_connection_modal"
@@ -694,7 +695,7 @@
                           phx-value-id={@project.id}
                         >
                           Remove github connection
-                        </.button>
+                        </button>
                       </div>
                     </div>
                   </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -676,26 +676,29 @@
                       <div>
                         <small>
                           Need to change the repository or branch?
+                          <button
+                            class="text-primary-600"
+                            phx-click="reinstall_app"
+                          >
+                            Re-configure your Github permissions (admin access required)
+                          </button>
                         </small>
-                        <button class="text-[#5046E4]" phx-click="reinstall_app">
-                          Re-configure your Github permissions (admin access required)
-                        </button>
                       </div>
                       <div>
                         <small>
                           No longer need to sync your project?
+                          <button
+                            class="text-red-500"
+                            phx-click={
+                              LightningWeb.Components.Modal.show_modal(
+                                "delete_connection_modal"
+                              )
+                            }
+                            phx-value-id={@project.id}
+                          >
+                            Remove github connection
+                          </button>
                         </small>
-                        <button
-                          class="text-[#FF0101]"
-                          phx-click={
-                            LightningWeb.Components.Modal.show_modal(
-                              "delete_connection_modal"
-                            )
-                          }
-                          phx-value-id={@project.id}
-                        >
-                          Remove github connection
-                        </button>
                       </div>
                     </div>
                   </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -686,7 +686,7 @@
                           No longer need to sync your project?
                         </small>
                         <button
-                        class="text-[#FF0101]"
+                          class="text-[#FF0101]"
                           phx-click={
                             LightningWeb.Components.Modal.show_modal(
                               "delete_connection_modal"


### PR DESCRIPTION
## Notes for the reviewer
Links now display correctly (like in the  design).

## Related issue
Github links displaying as buttons on settings page

Fixes #1431 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
