### PR TITLE
Ignore validate on settings without input

### DIFF
--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -198,6 +198,11 @@ defmodule LightningWeb.ProjectLive.Settings do
     {:noreply, assign(socket, :project_changeset, changeset)}
   end
 
+  # validate without input can be ignored
+  def handle_event("validate", _params, socket) do
+    {:noreply, socket}
+  end
+
   def handle_event("save", %{"project" => project_params}, socket) do
     if can_edit_project(socket.assigns) do
       save_project(socket, project_params)


### PR DESCRIPTION
## Notes for the reviewer

A `FunctionClauseError` happens on `LightningWeb.ProjectLive.Settings.handle_event/3` with the args:
```
arg0	"validate"
arg1	%{"_target" => ["project", "name"]}
arg2	some socket
```

However the `"validate"` event comes from a `phx-change` i.e from a form and when there is no data from the form to be validated it can be ignored.

PS: Tried to find some navigation error and could find only on the [deletion](https://github.com/OpenFn/Lightning/issues/808#issuecomment-1824618562) of a project.

## Related issue

Fixes #1375 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
