### PR TITLE
Dim disabled triggers and edges on the canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Dimmed/greyed out triggers and edges on the canvas when they are disabled
+  [#1464](https://github.com/OpenFn/Lightning/issues/1464)
 - Async loading on the history page to improve UX on long DB queries
   [#1279](https://github.com/OpenFn/Lightning/issues/1279)
 

--- a/assets/js/workflow-diagram/edges/Edge.tsx
+++ b/assets/js/workflow-diagram/edges/Edge.tsx
@@ -21,7 +21,7 @@ const CustomEdge: FC<EdgeProps> = props => {
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
               background: 'white',
               pointerEvents: 'all',
-              ...labelStyles(selected),
+              ...labelStyles(selected, stepEdgeProps.data),
             }}
             className="nodrag nopan cursor-pointer"
           >

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -108,15 +108,13 @@ export const animate = (
       if (elapsed > duration) {
         // we are moving the nodes to their destination
         // this needs to happen to avoid glitches
-        const finalNodes = transitions.map(({ node, to }) =>
-          styleItem({
-            ...node,
-            position: {
-              x: to.x,
-              y: to.y,
-            },
-          })
-        );
+        const finalNodes = transitions.map(({ node, to }) => ({
+          ...node,
+          position: {
+            x: to.x,
+            y: to.y,
+          },
+        }));
 
         setModel({ edges: to.edges, nodes: finalNodes });
 

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -18,17 +18,7 @@ const calculateLayout = async (
   flow: ReactFlowInstance,
   duration: number | false = 500
 ): Promise<Positions> => {
-  // TODO: there's gotta be a better way to style w/o relying on updates/clicks
-  let { nodes, edges } = model;
-
-  nodes = nodes.map(n => styleItem(n));
-  edges = edges.map(e => {
-    const source = nodes.find(x => x.id == e.source);
-    if (source.type == 'trigger') {
-      e.data.enabled = source?.data.enabled;
-    }
-    return styleItem(e);
-  });
+  const { nodes, edges } = model;
 
   const hierarchy = stratify<Node>()
     .id(d => d.id)

--- a/assets/js/workflow-diagram/styles.ts
+++ b/assets/js/workflow-diagram/styles.ts
@@ -9,21 +9,32 @@ import { Flow } from './types';
 // import { isPlaceholder } from './util/placeholder';
 
 export const EDGE_COLOR = '#b1b1b7';
+export const EDGE_COLOR_DISABLED = '#E1E1E1';
 export const EDGE_COLOR_SELECTED = '#4f46e5';
+export const EDGE_COLOR_SELECTED_DISABLED = '#bdbaf3';
 
 export const ERROR_COLOR = '#ef4444';
 
-export const labelStyles = (selected?: boolean) => {
-  const primaryColor = selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
+export const labelStyles = (selected?: boolean, data) => {
+  const { enabled } = data;
+
+  const primaryColor = (selected?: boolean, enabled?: boolean) => {
+    if (enabled) return selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
+    return selected ? EDGE_COLOR_SELECTED_DISABLED : EDGE_COLOR_DISABLED;
+  };
+
+  const backgroundColor = enabled ? 'white' : '#F6F6F6';
+
   return {
     width: '32px',
     height: '32px',
-    border: `solid 2px ${primaryColor}`,
+    border: `solid 2px ${primaryColor(selected, enabled)}`,
     borderRadius: 16,
     fontSize: 18,
     textAlign: 'center' as const,
     fontWeight: 700,
-    color: primaryColor,
+    color: primaryColor(selected, enabled),
+    backgroundColor,
   };
 };
 
@@ -36,6 +47,14 @@ export const styleItem = (item: Flow.Edge | Flow.Node) => {
 };
 
 export const styleNode = (node: Flow.Node) => {
+  const { data } = node;
+
+  if (data?.enabled == false) {
+    node.style = {
+      opacity: 0.5,
+    };
+  }
+
   return node;
 };
 
@@ -48,6 +67,12 @@ export const styleEdge = (edge: Flow.Edge) => {
   if (edge.data?.placeholder) {
     edge.style.strokeDasharray = '4, 4';
     edge.style.strokeWidth = '1.5px';
+  }
+
+  if (!edge.data?.enabled) {
+    edge.style.strokeDasharray = '4, 4';
+    edge.style.strokeWidth = '1.5px';
+    edge.style.opacity = 0.5;
   }
 
   if (edge.markerEnd) {

--- a/assets/js/workflow-diagram/styles.ts
+++ b/assets/js/workflow-diagram/styles.ts
@@ -109,3 +109,15 @@ export const nodeLabelStyles = (selected: boolean) => {
     justifyContent: 'center',
   };
 };
+
+export const sortOrderForSvg = (a: object, b: object) => {
+  if (a.data.enabled > b.data.enabled) {
+    return 1;
+  }
+
+  if (a.data.enabled < b.data.enabled) {
+    return -1;
+  }
+
+  return a.selected - b.selected;
+};

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -13,11 +13,13 @@ export namespace Lightning {
 
   export interface CronTrigger extends Node {
     type: 'cron';
+    enabled: boolean;
     cron_expression: string;
   }
 
   export interface WebhookTrigger extends Node {
     has_auth_method: boolean;
+    enabled: boolean;
     type: 'webhook';
     webhook_url: string;
   }
@@ -31,11 +33,13 @@ export namespace Lightning {
 
   export interface Edge {
     id: string;
+    has_auth_method: boolean;
     source_job_id?: string;
     source_trigger_id?: string;
     target_job_id?: string;
     name: string;
     condition?: string;
+    edge?: boolean;
     error_path?: boolean;
     errors: any;
   }

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -1,5 +1,5 @@
 import { Lightning, Flow, Positions } from '../types';
-import { styleEdge } from '../styles';
+import { sortOrderForSvg, styleEdge, styleItem, styleNode } from '../styles';
 
 function getEdgeLabel(condition: string) {
   if (condition) {
@@ -55,10 +55,13 @@ const fromWorkflow = (
         model.data.allowPlaceholder = allowPlaceholder;
 
         if (type === 'trigger') {
+          console.log('trigger model', item);
           model.data.trigger = {
             type: (node as Lightning.TriggerNode).type,
+            enabled: (node as Lightning.TriggerNode).enabled,
           };
         }
+        styleNode(model);
       } else {
         const edge = item as Lightning.Edge;
         model.source = edge.source_trigger_id || edge.source_job_id;
@@ -71,6 +74,15 @@ const fromWorkflow = (
           height: 32,
         };
         model.data = { condition: edge.condition, enabled: edge.enabled };
+
+        // Note: we don't allow the user to disable the edge that goes from a
+        // trigger to a job, but we want to show it as if it were disabled when
+        // the source trigger is disabled. This code does that.
+        const source = nodes.find(x => x.id == model.source);
+        if (source.type == 'trigger') {
+          model.data.enabled = source?.data.enabled;
+        }
+
         styleEdge(model);
       }
 
@@ -83,16 +95,19 @@ const fromWorkflow = (
       if (selectedId == n.id) {
         n.selected = true;
       }
-      return n;
+      return styleNode(n);
     }),
   ] as Flow.Node[];
-  const edges = [...placeholders.edges] as Flow.Edge[];
+
+  const edges = [...placeholders.edges.map(e => styleEdge(e))] as Flow.Edge[];
 
   process(workflow.jobs, nodes, 'job');
   process(workflow.triggers, nodes, 'trigger');
   process(workflow.edges, edges, 'edge');
 
-  return { nodes, edges };
+  const sortedEdges = edges.sort(sortOrderForSvg);
+
+  return { nodes, edges: sortedEdges };
 };
 
 export default fromWorkflow;

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -70,7 +70,7 @@ const fromWorkflow = (
           width: 32,
           height: 32,
         };
-        model.data = { condition: edge.condition };
+        model.data = { condition: edge.condition, enabled: edge.enabled };
         styleEdge(model);
       }
 

--- a/assets/js/workflow-diagram/util/update-selection.ts
+++ b/assets/js/workflow-diagram/util/update-selection.ts
@@ -1,4 +1,4 @@
-import { styleItem } from '../styles';
+import { sortOrderForSvg, styleItem } from '../styles';
 import { Flow } from '../types';
 
 /**
@@ -21,27 +21,17 @@ export default (model: Flow.Model, newSelection?: string) => {
   // we have no way of knowing whether the selection is a node or id
   // so we have to do both
   function updateItem(item: Flow.Edge | Flow.Node) {
-    if (item.selected && item.id !== newSelection) {
-      return styleItem({
-        ...item,
-        selected: false,
-      });
-    }
-    if (item.id === newSelection) {
-      return styleItem({
-        ...item,
-        selected: true,
-      });
-    }
+    return styleItem({
+      ...item,
+      selected: item.id === newSelection,
+    });
     return item;
   }
 
   // Must put selected edge LAST to ensure it stays on top.
   const sortedModel = {
     ...updatedModel,
-    edges: updatedModel.edges.sort((x, y) => {
-      return x.selected - y.selected;
-    }),
+    edges: updatedModel.edges.sort(sortOrderForSvg),
   };
 
   return sortedModel;

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -503,7 +503,7 @@ defmodule LightningWeb.WorkflowLive.Components do
         disabled={true}
       />
       <div class="max-w-xl text-sm text-gray-500 mt-2">
-        <p>Jobs connected to a trigger are always run.</p>
+        <p>This path will be active if its trigger is enabled.</p>
       </div>
     <% else %>
       <Form.select_field

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -255,7 +255,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             field={:edges}
             id={@selected_edge.id}
           >
-            <.panel id={"edge-pane-#{@selected_edge.id}"} cancel_url="?" title="Edge">
+            <.panel id={"edge-pane-#{@selected_edge.id}"} cancel_url="?" title="Path">
               <div class="w-auto h-full" id={"edge-pane-#{@workflow.id}"}>
                 <!-- Show only the currently selected one -->
                 <.edge_form

--- a/lib/lightning_web/live/workflow_live/workflow_params.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_params.ex
@@ -95,7 +95,8 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParams do
             :id,
             :type,
             :cron_expression,
-            :has_auth_method
+            :has_auth_method,
+            :enabled
           ]),
         edges:
           changeset


### PR DESCRIPTION
## Notes on style

Right now we open a different modal for the trigger and the first trigger-to-job edge. In the future, since enable/disable for that combo will only live on the trigger itself, it may make sense to show that trigger/edge combination in a single box with an enabled/disabled toggle.

Right now, I've opted to show the edge between the trigger and the first job as `disabled` if the trigger itself is disabled because the edge could never be reached with a disabled trigger. In other words, if you disabled the trigger, you'll see both the trigger and its only edge get dimmed.

## Notes on implementation

This isn't quite ready... I'm picking up two strange behaviours here:

1. When you click away from an edge onto the canvas (deselect _all_) it doesn't get unstyled.
2. When you change _another_ edge's enabled/disabled property, the disabled trigger-edge-combo looses its disabled style.

Broadly, I had a way harder time than I'd expect applying conditional styles based on trigger and edge data. Looks like there are a number of different places where styles are built and then sometimes overwritten. Maybe a refactor, just of the styling, with an objective to allow data-based styling (applying styles based on actual lightning props) via a single interface is needed. I see the beginnings of this approach were introduced with the `styleItem(...)` implementation. It's possible that I'm misunderstanding how to use that, since changes there didn't do the trick in all settings, but I'm hoping that a review of this PR will either help steer me in the right direction, or provide motivation for a new implementation here.

## Related issue

Fixes #1464

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
