### PR TITLE
fix: Exporting project breaks the navigation of the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 
 - Create new workflow button sizing regression
   [#1405](https://github.com/OpenFn/Lightning/issues/1405)
+- Exporting project breaks the navigation of the page
+  [#1440](https://github.com/OpenFn/Lightning/issues/1440)
 
 ## [v0.10.2] - 2023-11-21
 

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -146,6 +146,7 @@
               </div>
               <a
                 href={~p"/download/yaml?id=#{@project.id}"}
+                target="_blank"
                 class="bg-primary-600 hover:bg-primary-700 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 "
               >
                 Export project

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -141,10 +141,12 @@ defmodule LightningWeb.ProjectLiveTest do
       assert html =~
                "Export your project as code, to save this version or edit your project locally"
 
-      assert index_live |> element("a", "Export project") |> has_element?()
+      assert index_live
+             |> element(~s{a[target="_blank"]}, "Export project")
+             |> has_element?()
 
       assert index_live
-             |> element("a", "Export project")
+             |> element(~s{a[target="_blank"]}, "Export project")
              |> render_click()
              |> follow_redirect(conn, "/download/yaml?id=#{project.id}")
     end


### PR DESCRIPTION
## Notes for the reviewer

- sets the `target` to `_blank`. This way the liveview connection on the current tab isn't interrupted


## Related issue

Fixes #1440 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
