### PR TITLE
new worker

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "zustand": "^4.3.7"
       },
       "devDependencies": {
-        "@openfn/ws-worker": "^0.2.9",
+        "@openfn/ws-worker": "^0.2.11",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
@@ -491,15 +491,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.2.0.tgz",
-      "integrity": "sha512-yqWKz5Q5GroXQyIcxr2OTwSaOKbsnNkZHgre9udbdVln9JSpBbJ9Zc9bFSiGz1RW9Yyu6mBMMP0PYWnE458tgA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-0.2.2.tgz",
+      "integrity": "sha512-emIXMbzqbLFiViXbb2slQsTk6NkI8RVUYipXI0MP+xRJcWjNDJQ30MU97OFygZwsthDzjK7dyEBgKyzxwWlIUA==",
       "dev": true,
       "dependencies": {
         "@openfn/compiler": "0.0.38",
         "@openfn/language-common": "2.0.0-rc3",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.2.0",
+        "@openfn/runtime": "0.2.1",
         "workerpool": "^6.5.1"
       }
     },
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.2.0.tgz",
-      "integrity": "sha512-43nWRXT4mW90ElglIK2dZ07LmGPAI+RKihpU68y9NpSiQ8kE0HF5n4799Flz7uYtFPCJ8CImm7++ITfOGAokKg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-0.2.1.tgz",
+      "integrity": "sha512-wH5Fcaj91ShxHo4i7xgpl9lvdB/TAMvl6qJM/IAaPpDh+6KcED+2a4DxOz7khlcVe6+wDV1XOLtR4JZgAYuaJA==",
       "dev": true,
       "dependencies": {
         "@openfn/logger": "0.0.19",
@@ -536,15 +536,15 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.9.tgz",
-      "integrity": "sha512-UKxr5mRQ5H4I3aUKhNn7LdDIbCUDT2wAYe5ubYT+AbWwBsaPF/tU1AwYcVqYBlXxAp5t8e2EYUO8ale4KorS4g==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-0.2.11.tgz",
+      "integrity": "sha512-/eass8mmDK2dcuu/a6IvIpExek/0765OpxbltdmbgK484dc6iIQ1wuWnuvfo1u9o42l2sqasJKhG0Tah4pc8pQ==",
       "dev": true,
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "0.2.0",
+        "@openfn/engine-multi": "0.2.2",
         "@openfn/logger": "0.0.19",
-        "@openfn/runtime": "0.2.0",
+        "@openfn/runtime": "0.2.1",
         "@types/koa-logger": "^3.1.2",
         "@types/ws": "^8.5.6",
         "fast-safe-stringify": "^2.1.1",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "engines": {
         "node": ">=6"

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,7 +35,7 @@
     "zustand": "^4.3.7"
   },
   "devDependencies": {
-    "@openfn/ws-worker": "^0.2.9",
+    "@openfn/ws-worker": "^0.2.11",
     "@types/marked": "^4.0.8",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -48,7 +48,7 @@ defmodule LightningWeb.EndToEndTest do
       # wait to complete
       Events.subscribe(attempt)
 
-      Enum.any?(1..100, fn _i ->
+      Enum.any?(1..150, fn _i ->
         receive do
           %Events.AttemptUpdated{attempt: %{state: state}}
           when state in Attempt.final_states() ->


### PR DESCRIPTION
Raising the `Enum.any?(1..100, ...` to `Enum.any?(1..150, ...` gets the e2e tests to pass for the new version of the `ws-worker@v0.2.11`.

The question is (a) how does that relate to a standard timeout or `Process.sleep` and (b) is this OK for me to bump?