### PR TITLE
Make it possible to disable PromEx auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 # uncommented option that means it's either mandatory to set or it's being
 # overwritten in development to make your life easier.
 
-# Set this up to handle Github App configuration 
-# GITHUB_APP_ID=12345 
+# Set this up to handle Github App configuration
+# GITHUB_APP_ID=12345
 # GITHUB_CERT=Base64-encoded-private-key
 
 # Choose an admin email address and configure a mailer. If you don't specify
@@ -152,5 +152,6 @@ PURGE_DELETED_AFTER_DAYS=7
 # PROMEX_GRAFANA_PASSWORD=admin
 # PROMEX_UPLOAD_GRAFANA_DASHBOARDS_ON_START=true
 # PROMEX_DATASOURCE_ID=promex
+# PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=yes
 # PROMEX_METRICS_ENDPOINT_TOKEN=foobar
 # PROMEX_ENDPOINT_SCHEME=http

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,8 @@ bearing with us as we move towards our first stable Lightning release.)
   [#1327](https://github.com/OpenFn/Lightning/issues/1327)
 - Have user create workflow name before moving to the canvas
   [#1103](https://github.com/OpenFn/Lightning/issues/1103)
+- Allow PromEx authorization to be disabled
+  [#1483](https://github.com/OpenFn/Lightning/issues/1483)
 
 ### Changed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -349,6 +349,8 @@ config :lightning, Lightning.PromEx,
   ],
   metrics_server: :disabled,
   datasource_id: System.get_env("PROMEX_DATASOURCE_ID") || "",
+  metrics_endpoint_authorization_required:
+    System.get_env("PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED") != "no",
   metrics_endpoint_token:
     System.get_env("PROMEX_METRICS_ENDPOINT_TOKEN") ||
       :crypto.strong_rand_bytes(100),

--- a/lib/lightning_web/prom_ex_plug_authorization.ex
+++ b/lib/lightning_web/prom_ex_plug_authorization.ex
@@ -9,14 +9,18 @@ defmodule LightningWeb.PromExPlugAuthorization do
   def call(conn, _vars) do
     config = Application.get_env(:lightning, Lightning.PromEx)
 
-    valid_token?(
-      Plug.Conn.get_req_header(conn, "authorization"),
-      config[:metrics_endpoint_token]
-    ) &&
-      valid_scheme?(
-        Atom.to_string(conn.scheme),
-        config[:metrics_endpoint_scheme]
-      )
+    if config[:metrics_endpoint_authorization_required] do
+      valid_token?(
+        Plug.Conn.get_req_header(conn, "authorization"),
+        config[:metrics_endpoint_token]
+      ) &&
+        valid_scheme?(
+          Atom.to_string(conn.scheme),
+          config[:metrics_endpoint_scheme]
+        )
+    else
+      true
+    end
   end
 
   defp valid_token?(["Bearer " <> provided_token], expected_token) do


### PR DESCRIPTION
## Notes for the reviewer

Default to requiring authorization to the PromEx metrics endpoint, but allow it to be disabled for situations where this is not available (e.g. GCP) or not desired.


## Related issue

Fixes #1483 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
