### PR TITLE
use the internal network port with "web" for the worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     env_file:
       - '.env'
     command:
-      ['pnpm', 'start:prod', '-l', 'ws://web:${LIGHTNING_EXTERNAL_PORT}/worker']
+      ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT}/worker']
     restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
     stop_grace_period: '3s'
     expose:


### PR DESCRIPTION
use the internal network port with "web" for the worker

was setup to external blocking the change of external

here the result:

```
lightning-dev-worker-1  | 
lightning-dev-worker-1  | > @openfn/ws-worker@0.2.11 start:prod /app/packages/ws-worker
lightning-dev-worker-1  | > node dist/start.js "-l" "ws://web:4004/worker"
lightning-dev-worker-1  | 
lightning-dev-worker-1  | [RTE] ⚠ Using default repo directory:  /tmp/openfn/worker/repo
lightning-dev-worker-1  | [RTE] ℹ repoDir set to  /tmp/openfn/worker/repo
lightning-dev-worker-1  | [RTE] ℹ memory limit set to 500mb
lightning-dev-worker-1  | [RTE] ❯ Loading workers from  /app/packages/engine-multi/dist/worker/worker.js
lightning-dev-worker-1  | [SRV] ✔ ws-worker vast-moose-knock listening on 2222
lightning-dev-worker-1  | [SRV] ✔ Connected to Lightning at ws://web:4004/worker
lightning-dev-worker-1  | [SRV] ℹ Starting workloop
``` 