### PR TITLE
Fix flaky attempt run view

### DIFF
--- a/test/lightning_web/live/attempt_live/show_test.exs
+++ b/test/lightning_web/live/attempt_live/show_test.exs
@@ -78,9 +78,11 @@ defmodule LightningWeb.AttemptLive.ShowTest do
 
       Lightning.Attempts.start_attempt(attempt)
 
+      render_async(view)
+
       assert view
              |> element("#attempt-detail-#{attempt_id}")
-             |> render_async() =~ "Running",
+             |> render() =~ "Running",
              "has running state"
 
       refute view
@@ -110,9 +112,11 @@ defmodule LightningWeb.AttemptLive.ShowTest do
       view |> select_run(attempt, job_a.name)
 
       # Check that the input dataclip is rendered
+      render_async(view)
+
       assert view
              |> element("#run-input-#{run.id}")
-             |> render_async()
+             |> render()
              |> Floki.parse_fragment!()
              |> Floki.text() =~ ~s({  "x": 1})
 


### PR DESCRIPTION
## Notes for the reviewer

"Awaits" on the view async state instead on the element to render the change.

## Related issue

https://app.circleci.com/pipelines/github/OpenFn/Lightning/5568/workflows/53dbe327-fcf9-4970-8107-9dc4809b2422/jobs/29065

```
  1) test handle_async/3 lifecycle of an attempt (LightningWeb.AttemptLive.ShowTest)
     test/lightning_web/live/attempt_live/show_test.exs:43
     Assertion with =~ failed
     code:  assert view
            |> element("#run-input-#{run.id}")
            |> render_async()
            |> Floki.parse_fragment!()
            |> Floki.text() =~ ~s"{  \"x\": 1}"
     left:  "\n    Nothing yet...\n  "
     right: "{  \"x\": 1}"
     stacktrace:
       test/lightning_web/live/attempt_live/show_test.exs:113: (test)
```

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
