### PR TITLE
Change AttemptView dataclip assigns to be asyncs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -185,20 +185,14 @@ url_scheme = System.get_env("URL_SCHEME", "https")
 # given, otherwise it uses the existing config and lastly defaults to 4000.
 
 port =
-  case config_env() do
-    :test ->
-      Application.get_env(:lightning, LightningWeb.Endpoint)[:url][:port]
-
-    _dev_prod ->
-      (System.get_env("PORT") ||
-         Application.get_env(:lightning, LightningWeb.Endpoint)
-         |> Keyword.get(:http, port: nil)
-         |> Keyword.get(:port) ||
-         4000)
-      |> case do
-        p when is_binary(p) -> String.to_integer(p)
-        p when is_integer(p) -> p
-      end
+  (System.get_env("PORT") ||
+     Application.get_env(:lightning, LightningWeb.Endpoint)
+     |> Keyword.get(:http, port: nil)
+     |> Keyword.get(:port) ||
+     4000)
+  |> case do
+    p when is_binary(p) -> String.to_integer(p)
+    p when is_integer(p) -> p
   end
 
 # Use the `PRIMARY_ENCRYPTION_KEY` env variable if available, else fall back

--- a/lib/lightning_web/live/attempt_live/show.ex
+++ b/lib/lightning_web/live/attempt_live/show.ex
@@ -180,7 +180,8 @@ defmodule LightningWeb.AttemptLive.Show do
     %{selected_run: selected_run} = socket.assigns
 
     if selected_run && socket.assigns.input_dataclip == false do
-      Task.start(fn ->
+      socket
+      |> assign_async(:input_dataclip, fn ->
         lines =
           from(d in Ecto.assoc(selected_run, :input_dataclip),
             select: d.body
@@ -194,9 +195,9 @@ defmodule LightningWeb.AttemptLive.Show do
           end)
 
         send(live_view_pid, {:input_dataclip, lines})
-      end)
 
-      socket |> assign(:input_dataclip, true)
+        {:ok, %{input_dataclip: selected_run.id}}
+      end)
     else
       socket
     end
@@ -209,13 +210,14 @@ defmodule LightningWeb.AttemptLive.Show do
 
     if selected_run && selected_run.output_dataclip_id &&
          socket.assigns.output_dataclip == false do
-      Task.start(fn ->
+      socket
+      |> assign_async(:output_dataclip, fn ->
         lines = get_output_dataclip_lines(selected_run)
 
         send(live_view_pid, {:output_dataclip, lines})
-      end)
 
-      socket |> assign(:output_dataclip, true)
+        {:ok, %{output_dataclip: selected_run.id}}
+      end)
     else
       socket
     end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -283,13 +283,20 @@ defmodule LightningWeb.EndToEndTest do
   end
 
   defp start_runtime_manager(_context) do
+    ws_url =
+      struct!(
+        URI,
+        LightningWeb.Endpoint.config(:url) ++ [scheme: "ws", path: "/worker"]
+      )
+      |> URI.to_string()
+
     opts =
       Application.get_env(:lightning, RuntimeManager)
       |> Keyword.merge(
         name: E2ETestRuntimeManager,
         start: true,
         worker_secret: Lightning.Config.worker_secret(),
-        ws_url: "ws://localhost:4002/worker",
+        ws_url: ws_url,
         port: Enum.random(2223..3333)
       )
 


### PR DESCRIPTION
## Notes for the reviewer

We have had issues in the new AttemptView tests, where once a run is selected we weren't able to reliably tell if the dataclip has been loaded since it was using `Task` and so `render_async` had no effect on the timing.

I switched the regular tasks to use `assign_async` instead, allowing us to lean on `render_async` in the tests to wait for all async to resolve before continuing.

**Extra**

There is a commit that addresses how the end to end tests get their worker URL, instead of hard coding things the test now gets a URI directly from the Endpoint process.

## Related issue

Fixes #1491

Has a commit that may address #1435 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
