### PR TITLE
Use dynamic Endpoint config only on prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
 - Increased History search timeout to 30s
   [#1461](https://github.com/OpenFn/Lightning/issues/1461)
 
+- Use dynamic Endpoint config only on prod
+  [#1494](https://github.com/OpenFn/Lightning/pull/1494)
+  
 ### Fixed
 
 - Tooltip text clears later than the background

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to
 
 - Increased History search timeout to 30s
   [#1461](https://github.com/OpenFn/Lightning/issues/1461)
-
 - Use dynamic Endpoint config only on prod
   [#1494](https://github.com/OpenFn/Lightning/pull/1494)
   

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,6 +16,7 @@ config :lightning, Lightning.Repo,
 # watchers to your application. For example, we use it
 # with esbuild to bundle .js and .css sources.
 config :lightning, LightningWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -235,43 +235,13 @@ if config_env() == :prod do
       """
 
   host = System.get_env("URL_HOST") || "example.com"
+  port = String.to_integer(System.get_env("PORT") || "4000")
 
-  # The webserver port will always prefer and environment variable _when_
-  # given, otherwise it uses the existing config and lastly defaults to 4000.
-  port =
-    (System.get_env("PORT") ||
-       Application.get_env(:lightning, LightningWeb.Endpoint)
-       |> Keyword.get(:http, port: nil)
-       |> Keyword.get(:port) ||
-       4000)
-    |> case do
-      p when is_binary(p) -> String.to_integer(p)
-      p when is_integer(p) -> p
-    end
-
-  # Binding to loopback ipv4 address prevents access from other machines.
-  # http: [ip: {0, 0, 0, 0}, port: 4000],
-  # Set `http.ip` to {127, 0, 0, 1} to block access from other machines.
-  # Note that this may interfere with Docker networking.
-  # Enable IPv6 and bind on all interfaces.
-  # Set it to {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-  # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
-  # for details about using IPv6 vs IPv4 and loopback vs public addresses.
   listen_address =
-    (System.get_env("LISTEN_ADDRESS") ||
-       Application.get_env(:lightning, LightningWeb.Endpoint)
-       |> Keyword.get(:http, ip: nil)
-       |> Keyword.get(:ip) || {127, 0, 0, 1})
-    |> case do
-      p when is_binary(p) ->
-        p
-        |> String.split(".")
-        |> Enum.map(&String.to_integer/1)
-        |> List.to_tuple()
-
-      p when is_tuple(p) ->
-        p
-    end
+    System.get_env("LISTEN_ADDRESS", "127.0.0.1")
+    |> String.split(".")
+    |> Enum.map(&String.to_integer/1)
+    |> List.to_tuple()
 
   origins =
     case System.get_env("ORIGINS") do

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,7 +31,6 @@ config :lightning, Lightning.Vault,
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :lightning, LightningWeb.Endpoint,
-  url: [host: "localhost", port: 4002],
   http: [port: 4002],
   secret_key_base:
     "/8zedVJLxvmGGFoRExE3e870g7CGZZQ1Vq11A5MbQGPKOpK57MahVsPW6Wkkv61n",

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -289,7 +289,6 @@ defmodule LightningWeb.EndToEndTest do
         name: E2ETestRuntimeManager,
         start: true,
         worker_secret: Lightning.Config.worker_secret(),
-        ws_url: "ws://localhost:4002/worker",
         port: Enum.random(2223..3333)
       )
 

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -283,20 +283,13 @@ defmodule LightningWeb.EndToEndTest do
   end
 
   defp start_runtime_manager(_context) do
-    ws_url =
-      struct!(
-        URI,
-        LightningWeb.Endpoint.config(:url) ++ [scheme: "ws", path: "/worker"]
-      )
-      |> URI.to_string()
-
     opts =
       Application.get_env(:lightning, RuntimeManager)
       |> Keyword.merge(
         name: E2ETestRuntimeManager,
         start: true,
         worker_secret: Lightning.Config.worker_secret(),
-        ws_url: ws_url,
+        ws_url: "ws://localhost:4002/worker",
         port: Enum.random(2223..3333)
       )
 


### PR DESCRIPTION
## Notes for the reviewer

Talked to @stuartc and in order to make websockets to listen on 4002 while keeping a lean port configuration for runtime the `Endpoint` config was changed so that:

- the port is set the 4002 on `config/test.exs` since Phoenix demands a port there (mandatory)
- runtime only defines the http port only for prod (other environments depend on compilation so keep static, not dynamic/runtime)

## Related issue

Websockets doesn't listen on 4002 when `.env` is on the root.
Closes #1435

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
