### PR TITLE
Fixed refresh token handling in OAuth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to
   [#1145](https://github.com/OpenFn/Lightning/issues/1145)
 - Fix for adding ellipses on credential info on job editor heading
   [#1428](https://github.com/OpenFn/Lightning/issues/1428)
+- Enable user to reauthorize and obtain a new refresh token.
+  [#1495](https://github.com/OpenFn/Lightning/issues/1495)
+
 
 ## [v0.10.3] - 2023-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to
 - Fix for adding ellipses on credential info on job editor heading
   [#1428](https://github.com/OpenFn/Lightning/issues/1428)
 - Enable user to reauthorize and obtain a new refresh token.
-  [#1495](https://github.com/OpenFn/Lightning/issues/1495)
+  [#1496](https://github.com/OpenFn/Lightning/issues/1496)
 
 
 ## [v0.10.3] - 2023-11-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to
 - Fix for adding ellipses on credential info on job editor heading
   [#1428](https://github.com/OpenFn/Lightning/issues/1428)
 - Enable user to reauthorize and obtain a new refresh token.
-  [#1496](https://github.com/OpenFn/Lightning/issues/1496)
+  [#1495](https://github.com/OpenFn/Lightning/issues/1495)
 
 
 ## [v0.10.3] - 2023-11-28

--- a/lib/lightning/auth_providers/google.ex
+++ b/lib/lightning/auth_providers/google.ex
@@ -85,7 +85,8 @@ defmodule Lightning.AuthProviders.Google do
     OAuth2.Client.authorize_url!(client,
       scope: scope,
       state: state,
-      access_type: "offline"
+      access_type: "offline",
+      prompt: "consent"
     )
   end
 


### PR DESCRIPTION
## Notes for the reviewer
This will prompt the user to authorize the application again and will always return a refresh_token.


## Related issue
The refresh_token is only provided on the first authorization from the user. Subsequent authorizationswill not return the refresh_token.
Fixes #1495 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
