### PR TITLE
Increase test pool size

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -275,12 +275,14 @@ end
 if config_env() == :test do
   # When running tests, set the number of database connections to the number
   # of cores available.
+  schedulers = :erlang.system_info(:schedulers_online)
+
   config :lightning, Lightning.Repo,
-    pool_size: :erlang.system_info(:schedulers_online) + 8
+    pool_size: Enum.max([schedulers + 8, schedulers * 2])
 
   config :ex_unit,
     assert_receive_timeout:
-      System.get_env("ASSERT_RECEIVE_TIMEOUT", "500") |> String.to_integer()
+      System.get_env("ASSERT_RECEIVE_TIMEOUT", "600") |> String.to_integer()
 end
 
 release =


### PR DESCRIPTION
## Notes for the reviewer

- Increase test pool size to avoid flaky "connection not available" error when running `mix test` without `--max-cases=6`.
- Increase ASSERT_RECEIVE_TIMEOUT default from "500" to "600" in order to avoid this flaky:
```
  1) test worker:queue channel returns attempts (LightningWeb.WorkerChannelTest)
     test/lightning_web/channels/worker_channel_test.exs:42
     Assertion failed, no matching message after 500ms
     The following variables were pinned:
       attempt_id = "e4edaaae-9cf0-4f50-8c61-dfe7552da422"
     The process mailbox is empty.
     code: assert_receive %Phoenix.Socket.Reply{
             ref: ^ref,
             status: :ok,
             payload: %{attempts: [%{"id" => ^attempt_id, "token" => token}]}
           }
     stacktrace:
       test/lightning_web/channels/worker_channel_test.exs:65: (test)
```
https://app.circleci.com/pipelines/github/OpenFn/Lightning/5659/workflows/2825846d-a546-4978-8a49-ea00f59a16c6/jobs/29525/parallel-runs/0/steps/0-117 (happened locally as well)

## Related issue

```
1) test responds with 404 when trigger doesn't exist (LightningWeb.Plugs.WebhookAuthTest)
     test/lightning_web/plugs/webhook_auth_test.exs:14
     ** (MatchError) no match of right hand side value: {:error, {%DBConnection.ConnectionError{message: "connection not available and request was dropped from queue after 220ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:\n\n  1. Ensuring your database is available and that you can connect to it\n  2. Tracking down slow queries and making sure they are running fast enough\n  3. Increasing the pool_size (although this increases resource consumption)\n  4. Allowing requests to wait longer by increasing :queue_target and :queue_interval\n\nSee DBConnection.start_link/2 for more information\n", severity: :error, reason: :queue_timeout}, [{DBConnection.Ownership, :ownership_checkout, 2, [file: ~c"lib/db_connection/ownership.ex", line: 105, error_info: %{module: Exception}]}, {Ecto.Adapters.SQL.Sandbox, :checkout, 2, [file: ~c"lib/ecto/adapters/sql/sandbox.ex", line: 500]}, {Ecto.Adapters.SQL.Sandbox, :"-start_owner!/2-fun-0-", 3, [file: ~c"lib/ecto/adapters/sql/sandbox.ex", line: 407]}, {Agent.Server, :init, 1, [file: ~c"lib/agent/server.ex", line: 8]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}
     stacktrace:
       (ecto_sql 3.10.2) lib/ecto/adapters/sql/sandbox.ex:404: Ecto.Adapters.SQL.Sandbox.start_owner!/2
       (lightning 0.10.4) test/support/conn_case.ex:42: LightningWeb.ConnCase.__ex_unit_setup_0/1
       (lightning 0.10.4) test/support/conn_case.ex:1: LightningWeb.ConnCase.__ex_unit__/2
       test/lightning_web/plugs/webhook_auth_test.exs:1: LightningWeb.Plugs.WebhookAuthTest.__ex_unit__/2



  2) test get_trigger_by_webhook/1 returns nil when no matching trigger is found (Lightning.WorkflowsTest)
     test/lightning/workflows_test.exs:228
     ** (MatchError) no match of right hand side value: {:error, {%DBConnection.ConnectionError{message: "connection not available and request was dropped from queue after 233ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:\n\n  1. Ensuring your database is available and that you can connect to it\n  2. Tracking down slow queries and making sure they are running fast enough\n  3. Increasing the pool_size (although this increases resource consumption)\n  4. Allowing requests to wait longer by increasing :queue_target and :queue_interval\n\nSee DBConnection.start_link/2 for more information\n", severity: :error, reason: :queue_timeout}, [{DBConnection.Ownership, :ownership_checkout, 2, [file: ~c"lib/db_connection/ownership.ex", line: 105, error_info: %{module: Exception}]}, {Ecto.Adapters.SQL.Sandbox, :checkout, 2, [file: ~c"lib/ecto/adapters/sql/sandbox.ex", line: 500]}, {Ecto.Adapters.SQL.Sandbox, :"-start_owner!/2-fun-0-", 3, [file: ~c"lib/ecto/adapters/sql/sandbox.ex", line: 407]}, {Agent.Server, :init, 1, [file: ~c"lib/agent/server.ex", line: 8]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}
```

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
