### PR TITLE
Fix null value in 'created'  for webhook auth methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 - Remove obsolete field `previous_id` from `runs` table.
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
+- Fix for missing data in 'created' audit trail events for webhook auth methods
+  [#1500](https://github.com/OpenFn/Lightning/issues/1500)
 
 ## [v0.10.4] - 2023-11-30
 

--- a/lib/lightning/webhook_auth_methods.ex
+++ b/lib/lightning/webhook_auth_methods.ex
@@ -162,7 +162,12 @@ defmodule Lightning.WebhookAuthMethods do
     Multi.new()
     |> Multi.insert(:auth_method, changeset)
     |> Multi.insert(:audit, fn %{auth_method: auth_method} ->
-      WebhookAuthMethodAudit.event("created", auth_method.id, user.id)
+      WebhookAuthMethodAudit.event("created", auth_method.id, user.id, %{
+        before: %{name: nil},
+        after: %{
+          name: auth_method.name
+        }
+      })
     end)
     |> Repo.transaction()
     |> case do


### PR DESCRIPTION
## Notes for the reviewer
This PR addresses the missing data in 'created' audit trail events for webhook auth methods, ensuring inclusion of 'name'. 


## Related issue
"created" audit trail event for webhook auth method is null

Fixes #1500 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
