### PR TITLE
Esc Keybinding To Blur Job / Dataclip Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to
   [#1435](https://github.com/OpenFn/Lightning/issues/1435)
 - Validate schema field with any of expected values
   [#1502](https://github.com/OpenFn/Lightning/issues/1502)
+- Enhance UX to prevent modal closure when Monaco/Dataclip editor is focused
+  [#1510](https://github.com/OpenFn/Lightning/pull/1510)
 
 ### Fixed
 
@@ -47,6 +49,7 @@ and this project adheres to
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 - Fix for missing data in 'created' audit trail events for webhook auth methods
   [#1500](https://github.com/OpenFn/Lightning/issues/1500)
+
 
 ## [v0.10.4] - 2023-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ and this project adheres to
 - Fix for missing data in 'created' audit trail events for webhook auth methods
   [#1500](https://github.com/OpenFn/Lightning/issues/1500)
 
-
 ## [v0.10.4] - 2023-11-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 - Limit entries count on term work orders search
   [#1461](https://github.com/OpenFn/Lightning/issues/1461)
+- Enhance UX to prevent modal closure when Monaco/Dataclip editor is focused
+  [#1510](https://github.com/OpenFn/Lightning/pull/1510)
 
 ### Fixed
 
@@ -35,8 +37,6 @@ and this project adheres to
   [#1435](https://github.com/OpenFn/Lightning/issues/1435)
 - Validate schema field with any of expected values
   [#1502](https://github.com/OpenFn/Lightning/issues/1502)
-- Enhance UX to prevent modal closure when Monaco/Dataclip editor is focused
-  [#1510](https://github.com/OpenFn/Lightning/pull/1510)
 
 ### Fixed
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -167,7 +167,6 @@ export default function Editor({
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: typeof Monaco) => {
       setMonaco(monaco);
-      
 
       editor.addCommand(
         monaco.KeyCode.Escape,
@@ -176,7 +175,6 @@ export default function Editor({
         },
         '!suggestWidgetVisible'
       );
-      
 
       editor.addCommand(
         // https://microsoft.github.io/monaco-editor/typedoc/classes/KeyMod.html

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -167,9 +167,11 @@ export default function Editor({
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: typeof Monaco) => {
       setMonaco(monaco);
+
       editor.addCommand(monaco.KeyCode.Escape, function () {
         document.activeElement.blur();
       });
+
       editor.addCommand(
         // https://microsoft.github.io/monaco-editor/typedoc/classes/KeyMod.html
         // https://microsoft.github.io/monaco-editor/typedoc/enums/KeyCode.html

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -167,10 +167,16 @@ export default function Editor({
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: typeof Monaco) => {
       setMonaco(monaco);
+      
 
-      editor.addCommand(monaco.KeyCode.Escape, function () {
-        document.activeElement.blur();
-      });
+      editor.addCommand(
+        monaco.KeyCode.Escape,
+        () => {
+          document.activeElement.blur();
+        },
+        '!suggestWidgetVisible'
+      );
+      
 
       editor.addCommand(
         // https://microsoft.github.io/monaco-editor/typedoc/classes/KeyMod.html

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -167,7 +167,9 @@ export default function Editor({
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: typeof Monaco) => {
       setMonaco(monaco);
-
+      editor.addCommand(monaco.KeyCode.Escape, function () {
+        document.activeElement.blur();
+      });
       editor.addCommand(
         // https://microsoft.github.io/monaco-editor/typedoc/classes/KeyMod.html
         // https://microsoft.github.io/monaco-editor/typedoc/enums/KeyCode.html

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -131,19 +131,16 @@ export const collapsiblePanel = {
   },
 } as PhoenixHook;
 
-
-export const dataClipEditor = {
+export const BlurDataclipEditor = {
   mounted() {
     this.el.addEventListener('keydown', event => {
-      if (event.key === "Escape") {
+      if (event.key === 'Escape') {
         document.activeElement.blur();
-        event.stopImmediatePropagation()
+        event.stopImmediatePropagation();
       }
     });
-  }
+  },
 } as PhoenixHook;
-
-
 
 /**
  * Factory function to create a hook for listening to specific key combinations.

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -131,6 +131,20 @@ export const collapsiblePanel = {
   },
 } as PhoenixHook;
 
+
+export const dataClipEditor = {
+  mounted() {
+    this.el.addEventListener('keydown', event => {
+      if (event.key === "Escape") {
+        document.activeElement.blur();
+        event.stopImmediatePropagation()
+      }
+    });
+  }
+} as PhoenixHook;
+
+
+
 /**
  * Factory function to create a hook for listening to specific key combinations.
  *

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -80,7 +80,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
           disabled={@disabled}
           class="h-full pb-2"
           phx-debounce="300"
-          phx-hook="dataClipEditor"
+          phx-hook="BlurDataclipEditor"
         />
       </div>
     </.form>

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -80,6 +80,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
           disabled={@disabled}
           class="h-full pb-2"
           phx-debounce="300"
+          phx-hook="dataClipEditor"
         />
       </div>
     </.form>


### PR DESCRIPTION
## Notes for the reviewer
- Implement defocus on first ESC press in Monaco/Dataclip editor
- Enable modal closure on second ESC press


## Related issue
This fix addresses the issue users accidentally closed the entire modal when trying to dismiss a tooltip in Monaco/Dataclip editor

Fixes #1367 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
