### PR TITLE
Validate schema field expecting multiple formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 - Use dynamic Endpoint config only on prod
   [#1494](https://github.com/OpenFn/Lightning/pull/1494)
+- Validate schema field with any of expected values
+  [#1502](https://github.com/OpenFn/Lightning/pull/1502)  
 
 ### Fixed
 

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -162,6 +162,25 @@ defmodule Lightning.Credentials do
     end
   end
 
+  @doc """
+  Creates a credential schema from credential json schema.
+  """
+  @spec get_schema(String.t()) :: Credentials.Schema.t()
+  # false positive, it's safe file path (path from config)
+  # sobelow_skip ["Traversal.FileModule"]
+  def get_schema(schema_name) do
+    {:ok, schemas_path} = Application.fetch_env(:lightning, :schemas_path)
+
+    File.read("#{schemas_path}/#{schema_name}.json")
+    |> case do
+      {:ok, raw_json} ->
+        Credentials.Schema.new(raw_json, schema_name)
+
+      {:error, reason} ->
+        raise "Error reading credential schema. Got: #{reason |> inspect()}"
+    end
+  end
+
   defp derive_events(
          multi,
          %Ecto.Changeset{data: %Credential{}} = changeset

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -43,9 +43,9 @@ defmodule Lightning.Credentials.Schema do
     |> new(name)
   end
 
-  @spec validate(changeset :: Ecto.Changeset.t(), schema :: __MODULE__.t()) ::
+  @spec validate(changeset :: Ecto.Changeset.t(), schema :: t()) ::
           Ecto.Changeset.t()
-  def validate(changeset, %__MODULE__{} = schema) do
+  def validate(changeset, schema) do
     validation =
       Validator.validate(
         schema.root,
@@ -78,9 +78,8 @@ defmodule Lightning.Credentials.Schema do
 
   defp error_to_changeset(
          %{
-           path: path,
            error: %Validator.Error.AnyOf{invalid: alternatives}
-         },
+         } = error_map,
          changeset
        ) do
     formats =
@@ -88,10 +87,9 @@ defmodule Lightning.Credentials.Schema do
         format
       end)
 
-    error_to_changeset(
-      %{path: path, error: %{any_of: MapSet.new(formats)}},
-      changeset
-    )
+    error_map
+    |> Map.put(:error, %{any_of: formats})
+    |> error_to_changeset(changeset)
   end
 
   defp error_to_changeset(%{path: path, error: error}, changeset) do

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -8,7 +8,9 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
 
   def fieldset(%{form: form} = assigns) do
     changeset = form.source
-    schema = changeset |> Ecto.Changeset.get_field(:schema) |> get_schema()
+
+    schema =
+      changeset |> Ecto.Changeset.get_field(:schema) |> Credentials.get_schema()
 
     schema_changeset =
       create_schema_changeset(
@@ -63,21 +65,6 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
       </div>
     </fieldset>
     """
-  end
-
-  # false positive, it's a file from config
-  # sobelow_skip ["Traversal.FileModule"]
-  defp get_schema(schema_name) do
-    {:ok, schemas_path} = Application.fetch_env(:lightning, :schemas_path)
-
-    File.read("#{schemas_path}/#{schema_name}.json")
-    |> case do
-      {:ok, raw_json} ->
-        Credentials.Schema.new(raw_json, schema_name)
-
-      {:error, reason} ->
-        raise "Error reading credential schema. Got: #{reason |> inspect()}"
-    end
   end
 
   defp create_schema_changeset(schema, params) do

--- a/test/fixtures/schemas/postgresql.json
+++ b/test/fixtures/schemas/postgresql.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "host": {
+      "title": "Host",
+      "type": "string",
+      "description": "Postgres instance host URL or IP address",
+      "minLength": 1,
+      "anyOf": [
+        {
+          "format": "uri"
+        },
+        {
+          "format": "ipv4"
+        }
+      ],
+      "examples": [
+        "https://some-host.compute-1.amazonaws.com",
+        "201.220.61.246"
+      ]
+    },
+    "port": {
+      "title": "Port",
+      "type": "integer",
+      "default": 5432,
+      "description": "Database instance port",
+      "minLength": 1,
+      "examples": [
+        5432
+      ]
+    },
+    "database": {
+      "title": "Database",
+      "type": "string",
+      "description": "The database name",
+      "minLength": 1,
+      "examples": [
+        "demo-db"
+      ]
+    },
+    "user": {
+      "title": "User",
+      "type": "string",
+      "description": "User name",
+      "minLength": 1,
+      "examples": [
+        "admin"
+      ]
+    },
+    "password": {
+      "title": "Password",
+      "type": "string",
+      "description": "Password",
+      "writeOnly": true,
+      "minLength": 1,
+      "examples": [
+        "@super(!)Secretpass"
+      ]
+    },
+    "ssl": {
+      "title": "Use SSL",
+      "type": "boolean",
+      "examples": [
+        true
+      ]
+    },
+    "allowSelfSignedCert": {
+      "title": "Allow self-signed certificate",
+      "type": "boolean",
+      "examples": [
+        true
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "host",
+    "port",
+    "database"
+  ]
+}

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -1,6 +1,7 @@
 defmodule Lightning.Credentials.SchemaTest do
   use Lightning.DataCase, async: true
 
+  alias Lightning.Credentials
   alias Lightning.Credentials.Schema
   alias Lightning.Credentials.SchemaDocument
 
@@ -21,12 +22,12 @@ defmodule Lightning.Credentials.SchemaTest do
           },
           "hostUrl": {
             "type": "string",
-            "description": "The password used to log in",
+            "description": "The host URL",
             "format": "uri"
           },
           "number": {
             "type": "integer",
-            "description": "A number to log in"
+            "description": "Any other number field"
           }
         },
         "type": "object",
@@ -69,7 +70,7 @@ defmodule Lightning.Credentials.SchemaTest do
 
   describe "validate/2" do
     test "returns a changeset with 2 expected formats" do
-      schema = Schema.new(postgres_schema_json(), "postgres")
+      schema = Credentials.get_schema("postgresql")
 
       changeset =
         Ecto.Changeset.put_change(
@@ -84,6 +85,41 @@ defmodule Lightning.Credentials.SchemaTest do
                errors,
                &(&1 == {:host, {"expected to be a URI or an IPv4 address", []}})
              )
+    end
+
+    test "returns a changeset with 1 expected format and 2 allowed types" do
+      schema = Credentials.get_schema("http")
+
+      changeset =
+        Ecto.Changeset.put_change(
+          %Ecto.Changeset{data: %{}, types: schema.types},
+          :baseUrl,
+          "not a uri"
+        )
+
+      assert %Ecto.Changeset{errors: errors} = Schema.validate(changeset, schema)
+
+      assert Enum.any?(
+               errors,
+               &(&1 == {:baseUrl, {"expected to be a URI", []}})
+             )
+    end
+
+    test "returns a changeset with no expected format and 2 allowed types" do
+      schema = Credentials.get_schema("dhis2")
+
+      changeset =
+        Ecto.Changeset.put_change(
+          %Ecto.Changeset{data: %{}, types: schema.types},
+          :apiVersion,
+          "v2"
+        )
+
+      assert %Ecto.Changeset{errors: errors} = Schema.validate(changeset, schema)
+
+      refute Enum.find(errors, fn {field, {_message, _list}} ->
+               field == "apiVersion"
+             end)
     end
   end
 
@@ -131,92 +167,5 @@ defmodule Lightning.Credentials.SchemaTest do
 
       assert changeset.valid?
     end
-  end
-
-  defp postgres_schema_json do
-    """
-    {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "properties": {
-        "host": {
-          "title": "Host",
-          "type": "string",
-          "description": "Postgres instance host URL or IP address",
-          "minLength": 1,
-          "anyOf": [
-            {
-              "format": "uri"
-            },
-            {
-              "format": "ipv4"
-            }
-          ],
-          "examples": [
-            "https://some-host.compute-1.amazonaws.com",
-            "201.220.61.246"
-          ]
-        },
-        "port": {
-          "title": "Port",
-          "type": "integer",
-          "default": 5432,
-          "description": "Database instance port",
-          "minLength": 1,
-          "examples": [
-            5432
-          ]
-        },
-        "database": {
-          "title": "Database",
-          "type": "string",
-          "description": "The database name",
-          "minLength": 1,
-          "examples": [
-            "demo-db"
-          ]
-        },
-        "user": {
-          "title": "User",
-          "type": "string",
-          "description": "User name",
-          "minLength": 1,
-          "examples": [
-            "admin"
-          ]
-        },
-        "password": {
-          "title": "Password",
-          "type": "string",
-          "description": "Password",
-          "writeOnly": true,
-          "minLength": 1,
-          "examples": [
-            "@super(!)Secretpass"
-          ]
-        },
-        "ssl": {
-          "title": "Use SSL",
-          "type": "boolean",
-          "examples": [
-            true
-          ]
-        },
-        "allowSelfSignedCert": {
-          "title": "Allow self-signed certificate",
-          "type": "boolean",
-          "examples": [
-            true
-          ]
-        }
-      },
-      "type": "object",
-      "additionalProperties": true,
-      "required": [
-        "host",
-        "port",
-        "database"
-      ]
-    }
-    """
   end
 end

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -68,7 +68,7 @@ defmodule Lightning.Credentials.SchemaTest do
   end
 
   describe "validate/2" do
-    test "returns a changeset with error text" do
+    test "returns a changeset with 2 expected formats" do
       schema = Schema.new(postgres_schema_json(), "postgres")
 
       changeset =
@@ -82,7 +82,7 @@ defmodule Lightning.Credentials.SchemaTest do
 
       assert Enum.any?(
                errors,
-               &(&1 == {:host, {"expected to be an IPv4 address or a URI", []}})
+               &(&1 == {:host, {"expected to be a URI or an IPv4 address", []}})
              )
     end
   end


### PR DESCRIPTION
## Notes for the reviewer

Adds a validation for schema fields that support multiple formats.

Postgres schema has a host field that expects/allows an `uri` or a `ipv4`.

## Related issue

Fixes #1502

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
