### PR TITLE
Use checkbox on boolean credential fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Use checkbox on boolean credential fields
+  [#1430](https://github.com/OpenFn/Lightning/issues/1430)
+
 ## [v0.10.5] - 2023-12-03
 
 ### Added
@@ -22,11 +25,11 @@ and this project adheres to
 
 - Only add history page filters when needed for simpler multi-select status
   interface and shorter page URLs
-  [#1331](https://github.com/OpenFn/Lightning/pull/1331)
+  [#1331](https://github.com/OpenFn/Lightning/issues/1331)
 - Use dynamic Endpoint config only on prod
-  [#1494](https://github.com/OpenFn/Lightning/pull/1494)
+  [#1435](https://github.com/OpenFn/Lightning/issues/1435)
 - Validate schema field with any of expected values
-  [#1502](https://github.com/OpenFn/Lightning/pull/1502)
+  [#1502](https://github.com/OpenFn/Lightning/issues/1502)
 
 ### Fixed
 

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -87,7 +87,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         %{"type" => "string", "writeOnly" => true} -> :password_input
         %{"type" => "string"} -> :text_input
         %{"type" => "integer"} -> :text_input
-        %{"type" => "boolean"} -> :text_input
+        %{"type" => "boolean"} -> :checkbox
         %{"anyOf" => [%{"type" => "string"}, %{"type" => "null"}]} -> :text_input
       end
 
@@ -103,33 +103,44 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         type: type
       )
 
-    ~H"""
-    <LightningWeb.Components.Form.label_field
-      form={@form}
-      field={@field}
-      title={@title}
-    />
-    <span :if={@required} class="text-sm text-secondary-700 text-right">
-      Required
-    </span>
-    <div class="col-span-2">
-      <%= apply(Phoenix.HTML.Form, @type, [
-        @form,
-        @field,
-        [
-          value: @value || "",
-          class: ~w(mt-1 focus:ring-primary-500 focus:border-primary-500 block
-               w-full shadow-sm sm:text-sm border-secondary-300 rounded-md)
-        ]
-      ]) %>
-      <span
-        :for={error <- @errors}
-        phx-feedback_for={Phoenix.HTML.Form.input_id(@form, @field)}
-        class="block w-full text-sm text-secondary-700"
-      >
-        <%= LightningWeb.Components.NewInputs.translate_error(error) %>
+    if type == :checkbox do
+      ~H"""
+      <LightningWeb.Components.Form.check_box
+        form={@form}
+        field={@field}
+        label={@title}
+        value={@value}
+      />
+      """
+    else
+      ~H"""
+      <LightningWeb.Components.Form.label_field
+        form={@form}
+        field={@field}
+        title={@title}
+      />
+      <span :if={@required} class="text-sm text-secondary-700 text-right">
+        Required
       </span>
-    </div>
-    """
+      <div class="col-span-2">
+        <%= apply(Phoenix.HTML.Form, @type, [
+          @form,
+          @field,
+          [
+            value: @value || "",
+            class: ~w(mt-1 focus:ring-primary-500 focus:border-primary-500 block
+                 w-full shadow-sm sm:text-sm border-secondary-300 rounded-md)
+          ]
+        ]) %>
+        <span
+          :for={error <- @errors}
+          phx-feedback_for={Phoenix.HTML.Form.input_id(@form, @field)}
+          class="block w-full text-sm text-secondary-700"
+        >
+          <%= LightningWeb.Components.NewInputs.translate_error(error) %>
+        </span>
+      </div>
+      """
+    end
   end
 end


### PR DESCRIPTION
## Notes for the reviewer

Changes the input for boolean credential fields to use a checkbox. This change affects both a new credential as well as the settings credentials editor.

## Validation steps

1. Select or create a workflow 
2. Click on a job and create a new PostgreSQL credential.
3. Fill all the fields and check "Use SSL"
4. Save
5. On main menu, go to Settings->Credentials
6. Click on edit the credential
7. See that "Use SSL" is checked and now uncheck it and check the "Allow self-signed certificate"
8. Save
9. Click on edit again and find that only "Allow self-signed certificate" is checked

## Related issue

Fixes #1430 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
