### PR TITLE
Scrub log lines using multiple credentials samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 - Limit entries count on term work orders search
   [#1461](https://github.com/OpenFn/Lightning/issues/1461)
+- Scrub log lines using multiple credentials samples
+  [#1461](https://github.com/OpenFn/Lightning/issues/1519)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to
 - Limit entries count on term work orders search
   [#1461](https://github.com/OpenFn/Lightning/issues/1461)
 - Scrub log lines using multiple credentials samples
-  [#1461](https://github.com/OpenFn/Lightning/issues/1519)
+  [#1519](https://github.com/OpenFn/Lightning/issues/1519)
 - Remove custom telemetry plumbing.
   [1259](https://github.com/OpenFn/Lightning/issues/1259)
 

--- a/lib/lightning/attempts.ex
+++ b/lib/lightning/attempts.ex
@@ -23,6 +23,7 @@ defmodule Lightning.Attempts do
   alias Lightning.Attempt
   alias Lightning.Attempts.Events
   alias Lightning.Attempts.Handlers
+  alias Lightning.Invocation.LogLine
 
   alias Lightning.Repo
 
@@ -173,12 +174,9 @@ defmodule Lightning.Attempts do
     end)
   end
 
-  def append_attempt_log(attempt, params) do
-    alias Lightning.Invocation.LogLine
-    import Ecto.Changeset
-
-    LogLine.new(attempt, params)
-    |> validate_change(:run_id, fn _, run_id ->
+  def append_attempt_log(attempt, params, scrubber \\ nil) do
+    LogLine.new(attempt, params, scrubber)
+    |> Ecto.Changeset.validate_change(:run_id, fn _, run_id ->
       if is_nil(run_id) do
         []
       else

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -438,6 +438,23 @@ defmodule Lightning.Credentials do
     end
   end
 
+  def basic_auth_for(%Credential{body: body}) when is_map(body) do
+    usernames =
+      body
+      |> Map.take(["username", "email"])
+      |> Map.values()
+
+    password = Map.get(body, "password", "")
+
+    usernames
+    |> Enum.zip(List.duplicate(password, length(usernames)))
+    |> Enum.map(fn {username, password} ->
+      Base.encode64("#{username}:#{password}")
+    end)
+  end
+
+  def basic_auth_for(_credential), do: []
+
   @doc """
   Given a credential and a user, returns a list of invalid projects—i.e., those
   that the credential is shared with but that the user does not have access to.

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -472,10 +472,8 @@ defmodule Lightning.Credentials do
   end
 
   # TODO: this doesn't need to be Google specific. It should work for any standard OAuth2 credential.
-  @spec maybe_refresh_token(nil | Lightning.Credentials.Credential.t()) ::
-          {:error, :invalid_config}
-          | {:ok, Lightning.Credentials.Credential.t()}
-          | {:ok, nil}
+  @spec maybe_refresh_token(Lightning.Credentials.Credential.t()) ::
+          {:error, any()} | {:ok, Lightning.Credentials.Credential.t()}
   def maybe_refresh_token(%Credential{schema: "googlesheets"} = credential) do
     token_body = Google.TokenBody.new(credential.body)
 
@@ -494,7 +492,6 @@ defmodule Lightning.Credentials do
   end
 
   def maybe_refresh_token(%Credential{} = credential), do: {:ok, credential}
-  def maybe_refresh_token(nil), do: {:ok, nil}
 
   defp still_fresh(
          %{expires_at: expires_at},

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -13,8 +13,6 @@ defmodule Lightning.Invocation.LogLine do
   use Ecto.Schema
   import Ecto.Changeset
 
-  import Lightning.Security, only: [redact_password: 2]
-
   alias Lightning.Attempt
   alias Lightning.Invocation.Run
   alias Lightning.LogMessage
@@ -50,7 +48,6 @@ defmodule Lightning.Invocation.LogLine do
   def new(%Attempt{} = attempt, attrs \\ %{}) do
     %__MODULE__{id: Ecto.UUID.generate()}
     |> cast(attrs, [:message, :timestamp, :run_id, :attempt_id, :level, :source])
-    |> redact_password(:message)
     |> put_assoc(:attempt, attempt)
     |> validate()
   end
@@ -59,7 +56,6 @@ defmodule Lightning.Invocation.LogLine do
   def changeset(log_line, attrs) do
     log_line
     |> cast(attrs, [:message, :timestamp, :run_id, :attempt_id, :level, :source])
-    |> redact_password(:message)
     |> validate()
   end
 

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -17,6 +17,7 @@ defmodule Lightning.Invocation.LogLine do
   alias Lightning.Invocation.Run
   alias Lightning.LogMessage
   alias Lightning.UnixDateTime
+  alias Lightning.Scrubber
 
   @type t :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
@@ -45,21 +46,14 @@ defmodule Lightning.Invocation.LogLine do
     field :timestamp, UnixDateTime
   end
 
-  def new(%Attempt{} = attempt, attrs \\ %{}) do
+  def new(%Attempt{} = attempt, attrs \\ %{}, scrubber) do
     %__MODULE__{id: Ecto.UUID.generate()}
     |> cast(attrs, [:message, :timestamp, :run_id, :attempt_id, :level, :source])
     |> put_assoc(:attempt, attempt)
-    |> validate()
+    |> validate(scrubber)
   end
 
-  @doc false
-  def changeset(log_line, attrs) do
-    log_line
-    |> cast(attrs, [:message, :timestamp, :run_id, :attempt_id, :level, :source])
-    |> validate()
-  end
-
-  def validate(changeset) do
+  def validate(changeset, scrubber \\ nil) do
     changeset
     |> validate_required([:message, :timestamp])
     |> validate_length(:source, max: 8)
@@ -73,5 +67,15 @@ defmodule Lightning.Invocation.LogLine do
         []
       end
     end)
+    |> maybe_scrub(scrubber)
   end
+
+  defp maybe_scrub(%Ecto.Changeset{valid?: true} = changeset, scrubber)
+       when scrubber != nil do
+    {:ok, message} = fetch_change(changeset, :message)
+    scrubbed = Scrubber.scrub(scrubber, message)
+    put_change(changeset, :message, scrubbed)
+  end
+
+  defp maybe_scrub(changeset, _scrubber), do: changeset
 end

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -34,9 +34,7 @@ defmodule Lightning.Scrubber do
     end
 
     @spec scrub(state :: t(), data :: String.t()) :: String.t()
-    def scrub(nil, _state), do: nil
-
-    def scrub(string, {samples}) when is_binary(string) do
+    def scrub({samples}, string) when is_binary(string) do
       samples
       |> Enum.reduce(string, fn x, acc ->
         String.replace(acc, x, "***", global: true)
@@ -85,11 +83,11 @@ defmodule Lightning.Scrubber do
 
   def scrub(agent, lines) when is_list(lines) do
     state = Agent.get(agent, & &1)
-    lines |> Enum.map(fn line -> State.scrub(line, state) end)
+    lines |> Enum.map(fn line -> State.scrub(state, line) end)
   end
 
   def scrub(agent, data) do
-    agent |> Agent.get(&State.scrub(data, &1))
+    agent |> Agent.get(&State.scrub(&1, data))
   end
 
   @doc """

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -24,7 +24,7 @@ defmodule Lightning.Scrubber do
       {samples}
     end
 
-    @spec add_samples(state :: t(), samples()) :: [String.t()]
+    @spec add_samples(state :: t(), samples()) :: t()
     def add_samples({samples}, new_samples), do: {samples ++ new_samples}
 
     @spec scrub(state :: t(), data :: String.t()) :: String.t()

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -25,7 +25,9 @@ defmodule Lightning.Scrubber do
     end
 
     @spec add_samples(state :: t(), samples()) :: t()
-    def add_samples({samples}, new_samples), do: {samples ++ new_samples}
+    def add_samples({samples}, new_samples) do
+      {samples ++ new_samples}
+    end
 
     @spec scrub(state :: t(), data :: String.t()) :: String.t()
     def scrub(nil, _state), do: nil

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -113,6 +113,10 @@ defmodule Lightning.Scrubber do
         |> Base.encode64()
       end)
       |> Enum.concat(basic_auth)
+      |> Enum.concat(
+        stringified_samples
+        |> Enum.map(fn x -> Base.encode64(x) end)
+      )
 
     Enum.concat([stringified_samples, base64_secrets])
     |> Enum.sort_by(&String.length/1, :desc)

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -33,7 +33,9 @@ defmodule Lightning.Scrubber do
       |> then(fn samples -> {samples} end)
     end
 
-    @spec scrub(state :: t(), data :: String.t()) :: String.t()
+    @spec scrub(state :: t(), data :: String.t() | nil) :: String.t()
+    def scrub(_state, nil), do: nil
+
     def scrub({samples}, string) when is_binary(string) do
       samples
       |> Enum.reduce(string, fn x, acc ->

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -39,7 +39,7 @@ defmodule Lightning.Scrubber do
 
     def scrub(data, state) when is_map(data) do
       Map.new(data, fn {k, v} ->
-        {scrub(k, state), scrub(v, state)}
+        {k, scrub(v, state)}
       end)
     end
 

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -185,9 +185,8 @@ defmodule LightningWeb.AttemptChannel do
 
   def handle_in("attempt:log", payload, socket) do
     %{attempt: attempt, scrubber: scrubber} = socket.assigns
-    payload = Map.update(payload, "message", nil, &maybe_scrub(scrubber, &1))
 
-    Attempts.append_attempt_log(attempt, payload)
+    Attempts.append_attempt_log(attempt, payload, scrubber)
     |> case do
       {:error, changeset} ->
         {:reply, {:error, LightningWeb.ChangesetJSON.error(changeset)}, socket}
@@ -220,10 +219,6 @@ defmodule LightningWeb.AttemptChannel do
       end
     )
   end
-
-  defp maybe_scrub(_scrubber, nil), do: nil
-  defp maybe_scrub(nil, message), do: message
-  defp maybe_scrub(scrubber, message), do: Scrubber.scrub(scrubber, message)
 
   defp update_scrubber(nil, samples, basic_auth) do
     Scrubber.start_link(

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -182,9 +182,9 @@ defmodule LightningWeb.AttemptChannel do
     end
   end
 
-  def handle_in("attempt:log", %{"message" => message} = payload, socket) do
+  def handle_in("attempt:log", payload, socket) do
     %{attempt: attempt, scrubber: scrubber} = socket.assigns
-    payload = Map.put(payload, "message", maybe_scrub(scrubber, message))
+    payload = Map.update(payload, "message", nil, &maybe_scrub(scrubber, &1))
 
     Attempts.append_attempt_log(attempt, payload)
     |> case do
@@ -220,6 +220,7 @@ defmodule LightningWeb.AttemptChannel do
     )
   end
 
+  defp maybe_scrub(_scrubber, nil), do: nil
   defp maybe_scrub(nil, message), do: message
   defp maybe_scrub(scrubber, message), do: Scrubber.scrub(scrubber, message)
 

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -92,7 +92,8 @@ defmodule LightningWeb.AttemptChannel do
     with credential <- Attempts.get_credential(attempt, id) || :not_found,
          {:ok, credential} <- Credentials.maybe_refresh_token(credential),
          samples <- Credentials.sensitive_values_for(credential),
-         {:ok, scrubber} <- update_scrubber(scrubber, samples) do
+         basic_auth <- Credentials.basic_auth_for(credential),
+         {:ok, scrubber} <- update_scrubber(scrubber, samples, basic_auth) do
       socket = assign(socket, scrubber: scrubber)
 
       {:reply, {:ok, credential.body}, socket}
@@ -224,10 +225,15 @@ defmodule LightningWeb.AttemptChannel do
   defp maybe_scrub(nil, message), do: message
   defp maybe_scrub(scrubber, message), do: Scrubber.scrub(scrubber, message)
 
-  defp update_scrubber(nil, samples), do: Scrubber.start_link(samples: samples)
+  defp update_scrubber(nil, samples, basic_auth) do
+    Scrubber.start_link(
+      samples: samples,
+      basic_auth: basic_auth
+    )
+  end
 
-  defp update_scrubber(scrubber, samples) do
-    :ok = Scrubber.add_samples(scrubber, samples)
+  defp update_scrubber(scrubber, samples, basic_auth) do
+    :ok = Scrubber.add_samples(scrubber, samples, basic_auth)
     {:ok, scrubber}
   end
 end

--- a/test/lightning/attempts_test.exs
+++ b/test/lightning/attempts_test.exs
@@ -440,7 +440,7 @@ defmodule Lightning.AttemptsTest do
     end
   end
 
-  describe "append_attempt_log/1" do
+  describe "append_attempt_log/3" do
     test "adds a log line to an attempt" do
       dataclip = insert(:dataclip)
       %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -771,12 +771,12 @@ defmodule Lightning.InvocationTest do
           "run_id" => Ecto.UUID.generate()
         })
 
-      Lightning.Invocation.LogLine.new(attempt, %{
+      insert(:log_line,
+        attempt: attempt,
         run: run,
-        message: "Sadio Mane is playing in Senegal and Al Nasr",
+        message: "Sadio Mane is playing in Senegal",
         timestamp: Timex.now()
-      })
-      |> Repo.insert!()
+      )
 
       assert Lightning.Invocation.search_workorders(
                project,

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -816,6 +816,8 @@ defmodule Lightning.InvocationTest do
                ).entries
     end
 
+    # to be replaced by paginator unit tests
+    @tag :skip
     test "filters workorders sets timeout" do
       project = insert(:project)
       workflow = insert(:workflow, project: project)
@@ -832,7 +834,7 @@ defmodule Lightning.InvocationTest do
           %{
             page: 1,
             page_size: 10,
-            options: [timeout: 20]
+            options: [timeout: 30]
           }
         )
       rescue

--- a/test/lightning/scrubber_test.exs
+++ b/test/lightning/scrubber_test.exs
@@ -29,14 +29,22 @@ defmodule Lightning.ScrubberTest do
     end
 
     test "replaces key and value secrets in a map with ***" do
-      secrets = ["password", "immasecret"]
+      secrets = ["password", "immasecret", "username", "quux"]
       scrubber = start_supervised!({Lightning.Scrubber, samples: secrets})
 
       scrubbed =
         scrubber
-        |> Scrubber.scrub([%{"password" => "immasecret"}])
+        |> Scrubber.scrub([
+          %{
+            "password" => "immasecret",
+            "username" => "quux",
+            "fieldA" => "valueA"
+          }
+        ])
 
-      assert scrubbed == [%{"***" => "***"}]
+      assert scrubbed == [
+               %{"password" => "***", "username" => "***", "fieldA" => "valueA"}
+             ]
     end
 
     test "doesn't replace booleans with ***" do

--- a/test/lightning/scrubber_test.exs
+++ b/test/lightning/scrubber_test.exs
@@ -28,6 +28,17 @@ defmodule Lightning.ScrubberTest do
       assert scrubbed == ["Successfully logged in as *** using ***"]
     end
 
+    test "replaces key and value secrets in a map with ***" do
+      secrets = ["password", "immasecret"]
+      scrubber = start_supervised!({Lightning.Scrubber, samples: secrets})
+
+      scrubbed =
+        scrubber
+        |> Scrubber.scrub([%{"password" => "immasecret"}])
+
+      assert scrubbed == [%{"***" => "***"}]
+    end
+
     test "doesn't replace booleans with ***" do
       secrets = ["ip_addr", "db_name", "my_user", "my_password", 5432, false]
       scrubber = start_supervised!({Lightning.Scrubber, samples: secrets})

--- a/test/lightning/scrubber_test.exs
+++ b/test/lightning/scrubber_test.exs
@@ -100,12 +100,15 @@ defmodule Lightning.ScrubberTest do
                "NTQzMjpzZWNyZXRwYXNzd29yZA==",
                "YTpzZWNyZXRwYXNzd29yZA==",
                "c2VjcmV0cGFzc3dvcmQ6YQ==",
+               "c2VjcmV0cGFzc3dvcmQ=",
                "secretpassword",
                "NTQzMjo1NDMy",
                "YTo1NDMy",
                "NTQzMjph",
+               "NTQzMg==",
                "5432",
                "YTph",
+               "YQ==",
                "a"
              ]
     end

--- a/test/lightning/scrubber_test.exs
+++ b/test/lightning/scrubber_test.exs
@@ -28,7 +28,7 @@ defmodule Lightning.ScrubberTest do
       assert scrubbed == ["Successfully logged in as *** using ***"]
     end
 
-    test "replaces key and value secrets in a map with ***" do
+    test "replaces only value secrets in a map with ***" do
       secrets = ["password", "immasecret", "username", "quux"]
       scrubber = start_supervised!({Lightning.Scrubber, samples: secrets})
 

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -246,7 +246,6 @@ defmodule LightningWeb.EndToEndTest do
           {"JOB", "quux is on the safelist"},
           {"JOB", "but *** should be scrubbed"},
           {"JOB", "along with its encoded form ***"},
-          {"JOB", "and our best effort 'basic auth' encoding ***"},
           {"R/T", "Expression complete!"}
         ])
 
@@ -286,8 +285,7 @@ defmodule LightningWeb.EndToEndTest do
       console.log(state.x);
       console.log('quux is on the safelist')
       console.log('but immasecret should be scrubbed');
-      console.log('along with its encoded form #{Base.encode64("immasecret")}')
-      console.log('and our best effort 'basic auth' encoding #{Base.encode64("quux:immasecret")}');
+      console.log('along with its encoded form #{Base.encode64("quux:immasecret")}');
       return state;
     });"
   end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -246,6 +246,7 @@ defmodule LightningWeb.EndToEndTest do
           {"JOB", "quux is on the safelist"},
           {"JOB", "but *** should be scrubbed"},
           {"JOB", "along with its encoded form ***"},
+          {"JOB", "and its basic auth form ***"},
           {"R/T", "Expression complete!"}
         ])
 
@@ -285,7 +286,8 @@ defmodule LightningWeb.EndToEndTest do
       console.log(state.x);
       console.log('quux is on the safelist')
       console.log('but immasecret should be scrubbed');
-      console.log('along with its encoded form #{Base.encode64("quux:immasecret")}');
+      console.log('along with its encoded form #{Base.encode64("immasecret")}');
+      console.log('and its basic auth form #{Base.encode64("quux:immasecret")}');
       return state;
     });"
   end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -246,6 +246,7 @@ defmodule LightningWeb.EndToEndTest do
           {"JOB", "quux is on the safelist"},
           {"JOB", "but *** should be scrubbed"},
           {"JOB", "along with its encoded form ***"},
+          {"JOB", "and our best effort 'basic auth' encoding ***"},
           {"R/T", "Expression complete!"}
         ])
 
@@ -285,7 +286,8 @@ defmodule LightningWeb.EndToEndTest do
       console.log(state.x);
       console.log('quux is on the safelist')
       console.log('but immasecret should be scrubbed');
-      console.log('along with its encoded form #{Base.encode64("quux:immasecret")}');
+      console.log('along with its encoded form #{Base.encode64("immasecret")}')
+      console.log('and our best effort 'basic auth' encoding #{Base.encode64("quux:immasecret")}');
       return state;
     });"
   end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -241,6 +241,11 @@ defmodule LightningWeb.EndToEndTest do
         MapSet.new([
           {"R/T", "Starting operation 1"},
           {"JOB", "#{expected_job_x_value}"},
+          # Check to ensure that an inadvertantly exposed secret from job 2 is
+          # still scrubbed properly in job 3.
+          {"JOB", "quux is on the safelist"},
+          {"JOB", "but *** should be scrubbed"},
+          {"JOB", "along with its encoded form ***"},
           {"R/T", "Expression complete!"}
         ])
 
@@ -278,6 +283,9 @@ defmodule LightningWeb.EndToEndTest do
     "fn(state => {
       state.x = state.x * 3;
       console.log(state.x);
+      console.log('quux is on the safelist')
+      console.log('but immasecret should be scrubbed');
+      console.log('along with its encoded form #{Base.encode64("quux:immasecret")}');
       return state;
     });"
   end


### PR DESCRIPTION
## Notes for the reviewer

1. Extends the Scrubber to accept updates to handle multiple credentials.
2. Applies the scrubbing to the log lines.
3. Handles scrubbing on Basic auth method that might be present on logs

## Related issue

Solves #1519 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
