### PR TITLE
more e2e tests for secret scrubbing

### DIFF
--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -438,6 +438,14 @@ defmodule Lightning.Credentials do
     end
   end
 
+  def usernames_for(%Credential{body: body}) when is_map(body) do
+    body
+    |> Map.take(["username", "email"])
+    |> Map.values()
+  end
+
+  def usernames_for(_credential), do: []
+
   @doc """
   Given a credential and a user, returns a list of invalid projects—i.e., those
   that the credential is shared with but that the user does not have access to.

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -438,13 +438,22 @@ defmodule Lightning.Credentials do
     end
   end
 
-  def usernames_for(%Credential{body: body}) when is_map(body) do
-    body
-    |> Map.take(["username", "email"])
-    |> Map.values()
+  def basic_auth_for(%Credential{body: body}) when is_map(body) do
+    usernames =
+      body
+      |> Map.take(["username", "email"])
+      |> Map.values()
+
+    password = Map.get(body, "password", "")
+
+    usernames
+    |> Enum.zip(List.duplicate(password, length(usernames)))
+    |> Enum.map(fn {username, password} ->
+      Base.encode64("#{username}:#{password}")
+    end)
   end
 
-  def usernames_for(_credential), do: []
+  def basic_auth_for(_credential), do: []
 
   @doc """
   Given a credential and a user, returns a list of invalid projects—i.e., those

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -72,7 +72,8 @@ defmodule Lightning.Scrubber do
   end
 
   def add_samples(agent, new_samples) do
-    Agent.update(agent, &State.add_samples(&1, new_samples))
+    new_encoded_samples = encode_samples(new_samples)
+    Agent.update(agent, &State.add_samples(&1, new_encoded_samples))
   end
 
   def scrub(agent, lines) when is_list(lines) do

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -285,7 +285,7 @@ defmodule LightningWeb.EndToEndTest do
       console.log(state.x);
       console.log('quux is on the safelist')
       console.log('but immasecret should be scrubbed');
-      console.log('along with its encoded form aW1tYXNlY3JldA==');
+      console.log('along with its encoded form #{Base.encode64("quux:immasecret")}');
       return state;
     });"
   end

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -241,6 +241,11 @@ defmodule LightningWeb.EndToEndTest do
         MapSet.new([
           {"R/T", "Starting operation 1"},
           {"JOB", "#{expected_job_x_value}"},
+          # Check to ensure that an inadvertantly exposed secret from job 2 is
+          # still scrubbed properly in job 3.
+          {"JOB", "quux is on the safelist"},
+          {"JOB", "but *** should be scrubbed"},
+          {"JOB", "along with its encoded form ***"},
           {"R/T", "Expression complete!"}
         ])
 
@@ -278,6 +283,9 @@ defmodule LightningWeb.EndToEndTest do
     "fn(state => {
       state.x = state.x * 3;
       console.log(state.x);
+      console.log('quux is on the safelist')
+      console.log('but immasecret should be scrubbed');
+      console.log('along with its encoded form aW1tYXNlY3JldA==');
       return state;
     });"
   end


### PR DESCRIPTION
## Notes for the reviewer

@jyeshe , i've extended the e2e tests to ensure that secrets are scrubbed in downstream jobs (✅ ), that the safelist is still respected (✅ ) and that the base64 representations of those strings are still scrubbed... ❌ .

I'm hoping that this addition to the e2e test helps clarify the behavior of the scrubber! Please merge into your branch and fix the implementation (if needed) on that side.

Related to #1519 