### PR TITLE
1259 remove custom telemetry plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 - Limit entries count on term work orders search
   [#1461](https://github.com/OpenFn/Lightning/issues/1461)
+- Remove custom telemetry plumbing.
+  [1259](https://github.com/OpenFn/Lightning/issues/1259)
 
 ### Fixed
 

--- a/lib/lightning_web/controllers/webhooks_controller.ex
+++ b/lib/lightning_web/controllers/webhooks_controller.ex
@@ -7,21 +7,8 @@ defmodule LightningWeb.WebhooksController do
   alias Lightning.WorkOrders
 
   @spec create(Plug.Conn.t(), %{path: binary()}) :: Plug.Conn.t()
-  def create(conn, %{"path" => path}) do
-    path = Enum.join(path, "/")
-    start_opts = %{path: path}
-
-    :telemetry.span([:lightning, :workorder, :webhook], start_opts, fn ->
-      {conn, metadata} =
-        OpenTelemetry.Tracer.with_span "lightning.api.webhook", %{
-          attributes: start_opts
-        } do
-          conn = handle_create(conn)
-          {conn, %{status: Plug.Conn.Status.reason_atom(conn.status)}}
-        end
-
-      {conn, start_opts |> Map.merge(metadata)}
-    end)
+  def create(conn, _params) do
+    handle_create(conn)
   end
 
   defp handle_create(conn) do

--- a/lib/lightning_web/controllers/webhooks_controller.ex
+++ b/lib/lightning_web/controllers/webhooks_controller.ex
@@ -8,10 +8,6 @@ defmodule LightningWeb.WebhooksController do
 
   @spec create(Plug.Conn.t(), %{path: binary()}) :: Plug.Conn.t()
   def create(conn, _params) do
-    handle_create(conn)
-  end
-
-  defp handle_create(conn) do
     case conn.assigns.trigger do
       nil ->
         conn |> put_status(:not_found) |> json(%{"error" => "Webhook not found"})

--- a/lib/lightning_web/plugs/webhook_auth.ex
+++ b/lib/lightning_web/plugs/webhook_auth.ex
@@ -59,25 +59,12 @@ defmodule LightningWeb.Plugs.WebhookAuth do
   def call(conn, _opts) do
     case conn.path_info do
       ["i", webhook] ->
-        start_opts = %{path: webhook}
+        trigger =
+          Workflows.get_webhook_trigger(webhook,
+            include: [:workflow, :edges]
+          )
 
-        :telemetry.span([:lightning, :workorder, :webhook], start_opts, fn ->
-          {conn, metadata} =
-            OpenTelemetry.Tracer.with_span "lightning.api.webhook", %{
-              attributes: start_opts
-            } do
-              trigger =
-                Workflows.get_webhook_trigger(webhook,
-                  include: [:workflow, :edges]
-                )
-
-              conn = validate_auth(trigger, conn)
-
-              {conn, %{status: Plug.Conn.Status.reason_atom(conn.status || 202)}}
-            end
-
-          {conn, start_opts |> Map.merge(metadata)}
-        end)
+        validate_auth(trigger, conn)
 
       _ ->
         conn


### PR DESCRIPTION
## Notes for the reviewer
Custom telemetry plumbing was added when we were first experimenting with surfacing metrics via LiveDashboard. Now that we are moving towards Prometheus & Grafana, the reporting is good enough that the custom metric is not currently required.

Once the telemetry was removed, I could remove an unnecessary private method - I did this in a separate commit for the sake of clarity.


## Related issue

Fixes #1259 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
