### PR TITLE
Adjust stacking order of sibling elements within Job Editor container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Fixed
 
+- Adjusted z-index for Monaco Editor's sibling element to resolve layout
+  conflict [#1329](https://github.com/OpenFn/Lightning/issues/1329)
+
 ## [v0.11.0] - 2023-12-06
 
 ### Added
@@ -85,8 +88,6 @@ and this project adheres to
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 - Fix for missing data in 'created' audit trail events for webhook auth methods
   [#1500](https://github.com/OpenFn/Lightning/issues/1500)
-- Adjusted z-index for Monaco Editor's sibling element to resolve layout conflict
-  [#1329](https://github.com/OpenFn/Lightning/issues/1329)
 
 ## [v0.10.4] - 2023-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 - Fix for missing data in 'created' audit trail events for webhook auth methods
   [#1500](https://github.com/OpenFn/Lightning/issues/1500)
+- Adjusted z-index for Monaco Editor's sibling element to resolve layout conflict
+  [#1329](https://github.com/OpenFn/Lightning/issues/1329)
 
 ## [v0.10.4] - 2023-11-30
 

--- a/assets/js/job-editor/JobEditor.tsx
+++ b/assets/js/job-editor/JobEditor.tsx
@@ -180,7 +180,7 @@ export default ({
         </div>
         <div
           className={`${
-            showPanel ? 'flex flex-col flex-1 overflow-auto' : ''
+            showPanel ? 'flex flex-1 flex-col z-10 overflow-auto' : ''
           } bg-white`}
         >
           <div


### PR DESCRIPTION
## Notes for the reviewer
 Adjust z-index for Monaco Editor's sibling element.


## Related issue
Stacking order of elements in the Monaco Editor's container was causing layout problems.

Fixes #1329 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
