### PR TITLE
Update CLI Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 
 ### Changed
 
+- Updated CLI to 0.4.10 (fixes logging)
+
 ### Fixed
 
 - Adjusted z-index for Monaco Editor's sibling element to resolve layout

--- a/lib/mix/tasks/install_runtime.ex
+++ b/lib/mix/tasks/install_runtime.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Lightning.InstallRuntime do
 
   def packages() do
     ~W(
-      @openfn/cli@0.0.35
+      @openfn/cli@0.4.10
       @openfn/language-common@latest
     )
   end


### PR DESCRIPTION
Lightning is using a very very old CLI version from the halcyon days of April 2023. Nostalgic.

So far as I know the only thing the CLI is used for is the metadata service for Salesforce and dhis2.

I've bumped the version to improve the log output:

![image](https://github.com/OpenFn/Lightning/assets/7052509/97059f38-932c-4680-b6ba-d92a78eceb8c)
