### PR TITLE
use Application.compile_env in endpoint module

### DIFF
--- a/lib/lightning_web/endpoint.ex
+++ b/lib/lightning_web/endpoint.ex
@@ -57,9 +57,7 @@ defmodule LightningWeb.Endpoint do
     parsers: [
       :urlencoded,
       :multipart,
-      # Increase to 10MB max request size only for JSON parser
-      {:json,
-       length: Application.get_env(:lightning, :max_dataclip_size, 10_000_000)}
+      {:json, length: Application.compile_env(:lightning, :max_dataclip_size)}
     ],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()


### PR DESCRIPTION
This PR does two things:
1. it uses Application.compile_env rather than Application.get_env in the endpoint module
2. it removes the default value, as we already set that in `runtime.exs:160` - felt weird to set it twice.

## Review checklist

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
