### PR TITLE
New credential doesn't appear in inspector until refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 - Updated CLI to 0.4.10 (fixes logging)
 
 ### Fixed
+- New credential doesn't appear in inspector until refresh
+  [#1531](https://github.com/OpenFn/Lightning/issues/1531)
 - Metadata not refreshing when credential is updated
   [#791](https://github.com/OpenFn/Lightning/issues/791)
 - Adjusted z-index for Monaco Editor's sibling element to resolve layout

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -1,5 +1,6 @@
 defmodule LightningWeb.WorkflowLive.JobView do
   use LightningWeb, :component
+  alias Lightning.Credentials
   alias LightningWeb.WorkflowLive.EditorPane
 
   import LightningWeb.WorkflowLive.Components
@@ -73,7 +74,9 @@ defmodule LightningWeb.WorkflowLive.JobView do
         <div class="flex h-14 place-content-stretch">
           <div class="basis-1/3 flex items-center gap-4 pl-4">
             <.adaptor_block adaptor={@job.adaptor} />
-            <.credential_block credential={@job.credential} />
+            <.credential_block credential={
+              fetch_credential(@form[:project_credential_id].value)
+            } />
           </div>
           <div class="basis-1/3 font-semibold flex items-center justify-center">
             <%= @job.name %>
@@ -144,7 +147,10 @@ defmodule LightningWeb.WorkflowLive.JobView do
 
   defp credential_block(assigns) do
     ~H"""
-    <div class="flex items-center gap-2 whitespace-nowrap">
+    <div
+      id="modal-header-credential-block"
+      class="flex items-center gap-2 whitespace-nowrap"
+    >
       <%= if @credential do %>
         <Heroicons.lock_closed class="w-6 h-6 text-gray-500" />
 
@@ -196,5 +202,10 @@ defmodule LightningWeb.WorkflowLive.JobView do
       </div>
     </div>
     """
+  end
+
+  defp fetch_credential(project_credential_id) do
+    project_credential_id &&
+      Credentials.get_credential_by_project_credential(project_credential_id)
   end
 end


### PR DESCRIPTION
## Notes for the reviewer

Uses the `form` `project_credential_id` value to get the selected credential.

## Related issue

Fixes #1531
Depends on https://github.com/OpenFn/Lightning/pull/1493

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
