### PR TITLE
Ensure demo log lines are inserted in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ and this project adheres to
 ### Changed
 
 - Updated CLI to 0.4.10 (fixes logging)
+- Changed UserBackupToken model to use UTC timestamps (6563cb77)
 
 ### Fixed
 
 - Adjusted z-index for Monaco Editor's sibling element to resolve layout
   conflict [#1329](https://github.com/OpenFn/Lightning/issues/1329)
+- Demo script sets up example Runs with their log lines in a consistant order.
+  [#1487](https://github.com/OpenFn/Lightning/issues/1487)
 
 ## [v0.11.0] - 2023-12-06
 

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -257,8 +257,7 @@ defmodule Lightning.Accounts do
     Enum.map_reduce(backup_codes, false, fn backup, valid? ->
       if Plug.Crypto.secure_compare(backup.code, user_code) and
            is_nil(backup.used_at) do
-        {Ecto.Changeset.change(backup, %{used_at: NaiveDateTime.utc_now()}),
-         true}
+        {Ecto.Changeset.change(backup, %{used_at: DateTime.utc_now()}), true}
       else
         {backup, valid?}
       end

--- a/lib/lightning/accounts/user_backup_code.ex
+++ b/lib/lightning/accounts/user_backup_code.ex
@@ -18,7 +18,7 @@ defmodule Lightning.Accounts.UserBackupCode do
       redact: true,
       autogenerate: {__MODULE__, :generate_backup_code, []}
 
-    field :used_at, :naive_datetime_usec
+    field :used_at, :utc_datetime_usec
     belongs_to :user, Lightning.Accounts.User
 
     timestamps()

--- a/lib/lightning/attempts.ex
+++ b/lib/lightning/attempts.ex
@@ -205,13 +205,13 @@ defmodule Lightning.Attempts do
 
   The Run is created with and marked as started at the current time.
   """
-  @spec start_run(%{required(binary()) => Ecto.UUID.t()}) ::
+  @spec start_run(map()) ::
           {:ok, Lightning.Invocation.Run.t()} | {:error, Ecto.Changeset.t()}
   def start_run(params) do
     Handlers.StartRun.call(params)
   end
 
-  @spec complete_run(%{required(binary()) => binary()}) ::
+  @spec complete_run(map()) ::
           {:ok, Lightning.Invocation.Run.t()} | {:error, Ecto.Changeset.t()}
   def complete_run(params) do
     Handlers.CompleteRun.call(params)

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -541,5 +541,7 @@ defmodule Lightning.Invocation do
   """
   @spec assemble_logs_for_run(Run.t()) :: binary()
   def assemble_logs_for_run(%Run{} = run),
-    do: logs_for_run(run) |> Enum.map_join("\n", fn log -> log.message end)
+    do:
+      logs_for_run(run)
+      |> Enum.map_join("\n", fn log -> log.message end)
 end

--- a/lib/lightning/invocation/run.ex
+++ b/lib/lightning/invocation/run.ex
@@ -72,7 +72,7 @@ defmodule Lightning.Invocation.Run do
       exit_reason: exit_reason,
       error_type: error_type
     })
-    |> validate_required([:finished_at, :output_dataclip_id, :exit_reason])
+    |> validate_required([:finished_at, :exit_reason])
   end
 
   @doc false

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -2,22 +2,39 @@ defmodule Lightning.SetupUtils do
   @moduledoc """
   SetupUtils encapsulates logic for setting up initial data for various sites.
   """
+  defmodule Ticker do
+    use Agent
 
-  alias Lightning.{
-    Projects,
-    Accounts,
-    Jobs,
-    Workflows,
-    Repo,
-    Credentials,
-    WorkOrders,
-    VersionControl
-  }
+    def start_link(%DateTime{} = start_time) do
+      Agent.start_link(fn -> start_time end)
+    end
 
-  alias Lightning.Invocation.Run
-  alias Ecto.Multi
+    def next(ticker) do
+      Agent.get_and_update(ticker, fn time ->
+        increment = :rand.uniform(4) + 1
+        next = DateTime.add(time, increment, :millisecond)
+        {next, next}
+      end)
+    end
+
+    def stop(pid) do
+      Agent.stop(pid)
+    end
+  end
+
+  alias Lightning.Attempts
+  alias Lightning.Accounts
+  alias Lightning.Credentials
+  alias Lightning.Jobs
+  alias Lightning.Projects
+  alias Lightning.VersionControl
+  alias Lightning.WorkOrders
+  alias Lightning.Workflows
+
+  alias Lightning.Repo
 
   import Ecto.Query
+  import Ecto.Changeset
 
   @spec setup_demo(nil | maybe_improper_list | map) :: %{
           jobs: [...],
@@ -30,10 +47,8 @@ defmodule Lightning.SetupUtils do
   Creates initial data and returns the created records.
   """
   def setup_demo(opts \\ [create_super: false]) do
-    users = create_users(opts)
-
     %{super_user: super_user, admin: admin, editor: editor, viewer: viewer} =
-      users
+      create_users(opts)
 
     %{
       project: openhie_project,
@@ -90,7 +105,7 @@ defmodule Lightning.SetupUtils do
     end)
   end
 
-  defp create_dhis2_credential(project, user_id) do
+  defp create_dhis2_credential(%Accounts.User{id: user_id}) do
     {:ok, credential} =
       Credentials.create_credential(%{
         body: %{
@@ -100,10 +115,7 @@ defmodule Lightning.SetupUtils do
         },
         name: "DHIS2 play",
         user_id: user_id,
-        schema: "dhis2",
-        project_credentials: [
-          %{project_id: project.id}
-        ]
+        schema: "dhis2"
       })
 
     credential
@@ -172,6 +184,12 @@ defmodule Lightning.SetupUtils do
         project_id: project.id
       })
 
+    {:ok, source_trigger} =
+      Workflows.build_trigger(%{
+        type: :webhook,
+        workflow_id: workflow.id
+      })
+
     {:ok, job_1} =
       Jobs.create_job(%{
         name: "Job 1 - Check if age is over 18 months",
@@ -185,22 +203,7 @@ defmodule Lightning.SetupUtils do
           });
         """,
         adaptor: "@openfn/language-common@latest",
-        # enabled: true,
         workflow_id: workflow.id
-      })
-
-    {:ok, source_trigger} =
-      Workflows.build_trigger(%{
-        type: :webhook,
-        workflow_id: workflow.id
-      })
-
-    {:ok, _job_1_edge} =
-      Workflows.create_edge(%{
-        workflow_id: workflow.id,
-        source_trigger: source_trigger,
-        target_job: job_1,
-        enabled: true
       })
 
     {:ok, job_2} =
@@ -213,8 +216,15 @@ defmodule Lightning.SetupUtils do
           });
         """,
         adaptor: "@openfn/language-common@latest",
-        # enabled: true,
         workflow_id: workflow.id
+      })
+
+    {:ok, _job_1_edge} =
+      Workflows.create_edge(%{
+        workflow_id: workflow.id,
+        source_trigger: source_trigger,
+        target_job: job_1,
+        enabled: true
       })
 
     Workflows.create_edge(%{
@@ -225,12 +235,12 @@ defmodule Lightning.SetupUtils do
       enabled: true
     })
 
-    user_id = List.first(project_users).user_id
+    user = get_most_privileged_user!(project)
 
-    dhis2_credential = create_dhis2_credential(project, user_id)
+    dhis2_credential = create_dhis2_credential(user)
 
     {:ok, job_3} =
-      Jobs.create_job(%{
+      Workflows.Job.changeset(%Workflows.Job{}, %{
         name: "Job 3 - Upload to DHIS2",
         body: """
           create('trackedEntityInstances', {
@@ -249,11 +259,13 @@ defmodule Lightning.SetupUtils do
           });
         """,
         adaptor: "@openfn/language-dhis2@latest",
-        # enabled: true,
-        workflow_id: workflow.id,
-        project_credential_id:
-          List.first(dhis2_credential.project_credentials).id
+        workflow_id: workflow.id
       })
+      |> put_assoc(:project_credential, %{
+        project: project,
+        credential: dhis2_credential
+      })
+      |> Repo.insert()
 
     Workflows.create_edge(%{
       workflow_id: workflow.id,
@@ -298,8 +310,6 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Writing output to /tmp/output-1686850600-169521-1drewz.json
           [CLI] ✔ Done in 304ms! ✨
           """),
-        started_at: DateTime.utc_now() |> DateTime.add(-45, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(-40, :second),
         input_dataclip_id:
           create_dataclip(%{
             body: %{
@@ -311,21 +321,18 @@ defmodule Lightning.SetupUtils do
             project_id: project.id,
             type: :run_result
           }).id,
-        output_dataclip_id:
-          create_dataclip(%{
-            body: %{
-              data: %{
-                age_in_months: 19,
-                name: "Genevieve Wimplemews"
-              },
-              names: [
-                "Genevieve",
-                "Wimplemews"
-              ]
+        output_dataclip:
+          %{
+            data: %{
+              age_in_months: 19,
+              name: "Genevieve Wimplemews"
             },
-            project_id: project.id,
-            type: :run_result
-          }).id
+            names: [
+              "Genevieve",
+              "Wimplemews"
+            ]
+          }
+          |> Jason.encode!()
       },
       %{
         job_id: job_3.id,
@@ -370,60 +377,42 @@ defmodule Lightning.SetupUtils do
           """),
         started_at: DateTime.utc_now() |> DateTime.add(-35, :second),
         finished_at: DateTime.utc_now() |> DateTime.add(-30, :second),
-        input_dataclip_id:
-          create_dataclip(%{
-            body: %{
-              data: %{
+        output_dataclip:
+          %{
+            data: %{
+              httpStatus: "OK",
+              httpStatusCode: 200,
+              message: "Import was successful.",
+              response: %{
+                importSummaries: [
+                  %{
+                    href:
+                      "https://play.dhis2.org/dev/api/trackedEntityInstances/iqJrb85GmJb",
+                    reference: "iqJrb85GmJb",
+                    responseType: "ImportSummary",
+                    status: "SUCCESS"
+                  }
+                ],
+                imported: 1,
+                responseType: "ImportSummaries",
+                status: "SUCCESS",
+                total: 1,
+                updated: 0
+              },
+              status: "OK"
+            },
+            names: [
+              "Genevieve",
+              "Wimplemews"
+            ],
+            references: [
+              %{
                 age_in_months: 19,
                 name: "Genevieve Wimplemews"
-              },
-              names: [
-                "Genevieve",
-                "Wimplemews"
-              ]
-            },
-            project_id: project.id,
-            type: :run_result
-          }).id,
-        output_dataclip_id:
-          create_dataclip(%{
-            body: %{
-              data: %{
-                httpStatus: "OK",
-                httpStatusCode: 200,
-                message: "Import was successful.",
-                response: %{
-                  importSummaries: [
-                    %{
-                      href:
-                        "https://play.dhis2.org/dev/api/trackedEntityInstances/iqJrb85GmJb",
-                      reference: "iqJrb85GmJb",
-                      responseType: "ImportSummary",
-                      status: "SUCCESS"
-                    }
-                  ],
-                  imported: 1,
-                  responseType: "ImportSummaries",
-                  status: "SUCCESS",
-                  total: 1,
-                  updated: 0
-                },
-                status: "OK"
-              },
-              names: [
-                "Genevieve",
-                "Wimplemews"
-              ],
-              references: [
-                %{
-                  age_in_months: 19,
-                  name: "Genevieve Wimplemews"
-                }
-              ]
-            },
-            project_id: project.id,
-            type: :run_result
-          }).id
+              }
+            ]
+          }
+          |> Jason.encode!()
       }
     ]
 
@@ -474,7 +463,6 @@ defmodule Lightning.SetupUtils do
         fn(state => state);
         """,
         adaptor: "@openfn/language-http@latest",
-        # enabled: true,
         workflow_id: openhie_workflow.id
       })
 
@@ -500,15 +488,6 @@ defmodule Lightning.SetupUtils do
         workflow_id: openhie_workflow.id
       })
 
-    {:ok, _send_to_openhim_edge} =
-      Workflows.create_edge(%{
-        workflow_id: openhie_workflow.id,
-        condition: :on_job_success,
-        target_job_id: send_to_openhim.id,
-        source_job_id: fhir_standard_data.id,
-        enabled: true
-      })
-
     {:ok, notify_upload_successful} =
       Jobs.create_job(%{
         name: "Notify CHW upload successful",
@@ -522,15 +501,6 @@ defmodule Lightning.SetupUtils do
         workflow_id: openhie_workflow.id
       })
 
-    {:ok, _success_upload} =
-      Workflows.create_edge(%{
-        workflow_id: openhie_workflow.id,
-        condition: :on_job_success,
-        target_job_id: notify_upload_successful.id,
-        source_job_id: send_to_openhim.id,
-        enabled: true
-      })
-
     {:ok, notify_upload_failed} =
       Jobs.create_job(%{
         name: "Notify CHW upload failed",
@@ -542,6 +512,24 @@ defmodule Lightning.SetupUtils do
         adaptor: "@openfn/language-http@latest",
         # enabled: true,
         workflow_id: openhie_workflow.id
+      })
+
+    {:ok, _send_to_openhim_edge} =
+      Workflows.create_edge(%{
+        workflow_id: openhie_workflow.id,
+        condition: :on_job_success,
+        target_job_id: send_to_openhim.id,
+        source_job_id: fhir_standard_data.id,
+        enabled: true
+      })
+
+    {:ok, _success_upload} =
+      Workflows.create_edge(%{
+        workflow_id: openhie_workflow.id,
+        condition: :on_job_success,
+        target_job_id: notify_upload_successful.id,
+        source_job_id: send_to_openhim.id,
+        enabled: true
       })
 
     {:ok, _failed_upload} =
@@ -565,15 +553,6 @@ defmodule Lightning.SetupUtils do
         project_id: openhie_project.id,
         type: :http_request
       })
-
-    output_dataclip_payload = %{
-      body: %{data: http_body, references: []},
-      project_id: openhie_project.id,
-      type: :run_result
-    }
-
-    [output_dataclip_1, output_dataclip_2, output_dataclip_3] =
-      Enum.map(1..3, fn _n -> create_dataclip(output_dataclip_payload) end)
 
     run_params = [
       %{
@@ -599,10 +578,8 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Writing output to /tmp/output-1686840746-126941-i2yb2g.json
           [CLI] ✔ Done in 223ms! ✨
           """),
-        started_at: DateTime.utc_now() |> DateTime.add(1, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(2, :second),
         input_dataclip_id: dataclip.id,
-        output_dataclip_id: output_dataclip_1.id
+        output_dataclip: %{data: http_body, references: []} |> Jason.encode!()
       },
       %{
         job_id: send_to_openhim.id,
@@ -626,10 +603,7 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Writing output to /tmp/output-1686840746-126941-i2yb2g.json
           [CLI] ✔ Done in 223ms! ✨
           """),
-        started_at: DateTime.utc_now() |> DateTime.add(3, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(4, :second),
-        input_dataclip_id: output_dataclip_1.id,
-        output_dataclip_id: output_dataclip_2.id
+        output_dataclip: %{data: http_body, references: []} |> Jason.encode!()
       },
       %{
         job_id: notify_upload_successful.id,
@@ -653,10 +627,7 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Writing output to /tmp/output-1686840747-126941-16ewhef.json
           [CLI] ✔ Done in 209ms! ✨
           """),
-        started_at: DateTime.utc_now() |> DateTime.add(5, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(6, :second),
-        input_dataclip_id: output_dataclip_2.id,
-        output_dataclip_id: output_dataclip_3.id
+        output_dataclip: %{data: http_body, references: []} |> Jason.encode!()
       }
     ]
 
@@ -682,7 +653,7 @@ defmodule Lightning.SetupUtils do
   end
 
   def create_dhis2_project(project_users) do
-    {:ok, dhis2_project} =
+    {:ok, project} =
       Projects.create_project(%{
         name: "dhis2-project",
         project_users: project_users
@@ -691,14 +662,15 @@ defmodule Lightning.SetupUtils do
     {:ok, dhis2_workflow} =
       Workflows.create_workflow(%{
         name: "DHIS2 to Sheets",
-        project_id: dhis2_project.id
+        project_id: project.id
       })
 
-    user_id = List.first(project_users).user_id
-    dhis2_credential = create_dhis2_credential(dhis2_project, user_id)
+    user = get_most_privileged_user!(project)
+
+    dhis2_credential = create_dhis2_credential(user)
 
     {:ok, get_dhis2_data} =
-      Jobs.create_job(%{
+      Workflows.Job.changeset(%Workflows.Job{}, %{
         name: "Get DHIS2 data",
         # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
         inserted_at: NaiveDateTime.utc_now(),
@@ -707,10 +679,13 @@ defmodule Lightning.SetupUtils do
         """,
         adaptor: "@openfn/language-dhis2@latest",
         # enabled: true,
-        workflow_id: dhis2_workflow.id,
-        project_credential_id:
-          List.first(dhis2_credential.project_credentials).id
+        workflow_id: dhis2_workflow.id
       })
+      |> put_assoc(:project_credential, %{
+        project: project,
+        credential: dhis2_credential
+      })
+      |> Repo.insert()
 
     {:ok, dhis_trigger} =
       Workflows.build_trigger(%{
@@ -784,26 +759,8 @@ defmodule Lightning.SetupUtils do
             %{}
           ]
         },
-        project_id: dhis2_project.id,
+        project_id: project.id,
         type: :http_request
-      })
-
-    output_dataclip =
-      create_dataclip(%{
-        body: %{
-          data: %{
-            spreadsheetId: "wv5ftwhte",
-            tableRange: "A3:D3",
-            updates: %{
-              updatedCells: 4
-            }
-          },
-          references: [
-            %{}
-          ]
-        },
-        project_id: dhis2_project.id,
-        type: :run_result
       })
 
     # Make it fail for demo purposes
@@ -831,10 +788,21 @@ defmodule Lightning.SetupUtils do
             [CMP] ℹ Added import statement for @openfn/language-dhis2@latest
             [CMP] ℹ Added export * statement for @openfn/language-dhis2@latest
           """),
-        started_at: DateTime.utc_now() |> DateTime.add(1, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(2, :second),
         input_dataclip_id: input_dataclip.id,
-        output_dataclip_id: output_dataclip.id
+        output_dataclip:
+          %{
+            data: %{
+              spreadsheetId: "wv5ftwhte",
+              tableRange: "A3:D3",
+              updates: %{
+                updatedCells: 4
+              }
+            },
+            references: [
+              %{}
+            ]
+          }
+          |> Jason.encode!()
       },
       %{
         job_id: upload_to_google_sheet.id,
@@ -855,10 +823,7 @@ defmodule Lightning.SetupUtils do
           [R/T] ℹ Resolved adaptor @openfn/language-http to version 4.2.8
           [CLI] ✘ Error: 503 Service Unavailable, please try again later
           [CLI] ✘ Took 1.634s.
-          """),
-        started_at: DateTime.utc_now() |> DateTime.add(3, :second),
-        finished_at: DateTime.utc_now() |> DateTime.add(4, :second),
-        input_dataclip_id: output_dataclip.id
+          """)
       }
     ]
 
@@ -871,7 +836,7 @@ defmodule Lightning.SetupUtils do
       )
 
     %{
-      project: dhis2_project,
+      project: project,
       workflow: dhis2_workflow,
       workorders: [failure_dhis2_workorder],
       jobs: [get_dhis2_data, upload_to_google_sheet]
@@ -927,71 +892,120 @@ defmodule Lightning.SetupUtils do
          input_dataclip,
          run_params
        ) do
-    attempt_finished_at =
-      DateTime.utc_now()
-      |> DateTime.add(length(run_params) * 2, :second)
+    workflow |> Repo.preload(:project)
+    {:ok, ticker} = Ticker.start_link(DateTime.utc_now())
 
-    [%{exit_reason: final_run_exit_reason} | _rest] = Enum.reverse(run_params)
+    workorder =
+      Repo.transaction(fn ->
+        workorder =
+          %{attempts: [attempt]} =
+          WorkOrders.build_for(trigger, %{
+            workflow: workflow,
+            dataclip: input_dataclip
+          })
+          |> then(fn changeset ->
+            [attempt] = changeset |> get_change(:attempts)
 
-    Multi.new()
-    |> Multi.insert(
-      :workorder,
-      WorkOrders.build_for(trigger, %{
-        workflow: workflow,
-        dataclip: input_dataclip,
-        last_activity: attempt_finished_at
-      })
-    )
-    |> Multi.update(:attempt, fn %{workorder: %{attempts: [attempt]}} ->
-      runs =
-        Enum.map(run_params, fn params ->
-          log_lines =
-            Enum.map(params.log_lines, fn line ->
-              Map.merge(line, %{
-                id: Ecto.UUID.generate(),
-                attempt_id: attempt.id
-              })
-            end)
+            put_change(changeset, :attempts, [
+              attempt
+              |> change(%{state: :claimed, claimed_at: Ticker.next(ticker)})
+            ])
+          end)
+          |> Repo.insert!()
 
-          params
-          |> Map.merge(%{log_lines: log_lines})
-          |> Run.new()
+        Attempts.start_attempt(attempt)
+
+        run_params
+        |> Enum.reduce(%{}, fn run, previous ->
+          run_id = Ecto.UUID.generate()
+
+          input_dataclip_id =
+            Map.get(
+              run,
+              :input_dataclip_id,
+              Map.get(previous, :output_dataclip_id, input_dataclip.id)
+            )
+
+          Attempts.start_run(%{
+            attempt_id: attempt.id,
+            run_id: run_id,
+            job_id: run.job_id,
+            input_dataclip_id: input_dataclip_id,
+            started_at: Ticker.next(ticker)
+          })
+
+          run.log_lines
+          |> Enum.each(fn line ->
+            Attempts.append_attempt_log(attempt, %{
+              run_id: run_id,
+              message: line.message,
+              timestamp: Ticker.next(ticker)
+            })
+          end)
+
+          complete_run_params =
+            %{
+              attempt_id: attempt.id,
+              project_id: workflow.project_id,
+              run_id: run_id,
+              reason: run.exit_reason,
+              finished_at: Ticker.next(ticker)
+            }
+            |> Map.merge(
+              if run[:output_dataclip] do
+                %{
+                  output_dataclip_id: Ecto.UUID.generate(),
+                  output_dataclip: run.output_dataclip
+                }
+              else
+                %{}
+              end
+            )
+
+          {:ok, run} = Attempts.complete_run(complete_run_params)
+
+          run
         end)
 
-      attempt
-      |> Repo.preload([:runs])
-      |> Ecto.Changeset.change(%{
-        state:
-          if(final_run_exit_reason == "success", do: :success, else: :failed),
-        claimed_at: DateTime.utc_now() |> DateTime.add(1, :second),
-        started_at: DateTime.utc_now() |> DateTime.add(1, :second),
-        finished_at: attempt_finished_at
-      })
-      |> Ecto.Changeset.put_assoc(:runs, runs)
-    end)
-    |> Multi.update(:workorder_status, fn %{
-                                            workorder: workorder,
-                                            attempt: attempt
-                                          } ->
-      Ecto.Changeset.change(workorder, %{
-        state: attempt.state,
-        last_activity: attempt_finished_at
-      })
-    end)
-    |> Repo.transaction()
-    |> case do
-      {:ok, %{workorder: workorder}} ->
-        {:ok, workorder}
+        state =
+          List.last(run_params)
+          |> Map.get(:exit_reason)
+          |> case do
+            "fail" -> "failed"
+            reason -> reason
+          end
 
-      {:error, _operation, failed_value, _changes} ->
-        {:error, failed_value}
-    end
+        {:ok, _} = Attempts.complete_attempt(attempt, %{state: state})
+
+        workorder
+      end)
+
+    Ticker.stop(ticker)
+
+    workorder
   end
 
   defp create_dataclip(params) do
     {:ok, dataclip} = Lightning.Invocation.create_dataclip(params)
 
     dataclip
+  end
+
+  defp get_most_privileged_user!(project) do
+    Ecto.assoc(project, :project_users)
+    |> with_cte("role_ordering",
+      as:
+        fragment(
+          "SELECT * FROM UNNEST(?::varchar[]) WITH ORDINALITY o(role, ord)",
+          ~w[owner admin editor viewer]
+        )
+    )
+    |> join(:inner, [pu], o in "role_ordering", on: pu.role == o.role)
+    |> join(:inner, [pu], u in assoc(pu, :user))
+    |> order_by([pu, o], asc: o.ord)
+    |> select([pu, _o, u], u)
+    |> limit(1)
+    |> Repo.one!()
   end
 
   @doc """

--- a/lib/lightning/workflows/job.ex
+++ b/lib/lightning/workflows/job.ex
@@ -47,7 +47,7 @@ defmodule Lightning.Workflows.Job do
 
     field :delete, :boolean, virtual: true
 
-    timestamps(type: :naive_datetime_usec)
+    timestamps(type: :utc_datetime_usec)
   end
 
   def new(attrs \\ %{}) do
@@ -56,20 +56,17 @@ defmodule Lightning.Workflows.Job do
 
   @doc false
   def changeset(job, attrs) do
-    change =
-      job
-      |> cast(attrs, [
-        :id,
-        # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
-        :inserted_at,
-        :name,
-        :body,
-        :adaptor,
-        :project_credential_id,
-        :workflow_id
-      ])
-
-    change
+    job
+    |> cast(attrs, [
+      :id,
+      # Note: we can drop inserted_at once there's a reliable way to sort yaml for export
+      :inserted_at,
+      :name,
+      :body,
+      :adaptor,
+      :project_credential_id,
+      :workflow_id
+    ])
     |> validate()
     |> unique_constraint(:name, name: "jobs_name_workflow_id_index")
   end

--- a/priv/repo/migrations/20231208075606_naive_to_utc_datetimes.exs
+++ b/priv/repo/migrations/20231208075606_naive_to_utc_datetimes.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.NaiveToUtcDatetimes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_backup_codes) do
+      modify :used_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -799,7 +799,7 @@ defmodule Lightning.AccountsTest do
 
     test "does not update email if token expired", %{user: user, token: token} do
       {1, nil} =
-        Repo.update_all(UserToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+        Repo.update_all(UserToken, set: [inserted_at: ~U[2020-01-01 00:00:00Z]])
 
       assert Accounts.update_user_email(user, token) == :error
       assert Repo.get!(User, user.id).email == user.email
@@ -1027,7 +1027,7 @@ defmodule Lightning.AccountsTest do
 
     test "does not return user for expired token", %{token: token} do
       {1, nil} =
-        Repo.update_all(UserToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+        Repo.update_all(UserToken, set: [inserted_at: ~U[2020-01-01 00:00:00Z]])
 
       refute Accounts.get_user_by_auth_token(token)
     end
@@ -1060,7 +1060,7 @@ defmodule Lightning.AccountsTest do
 
     test "does not return user for expired token", %{token: token} do
       {1, nil} =
-        Repo.update_all(UserToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+        Repo.update_all(UserToken, set: [inserted_at: ~U[2020-01-01 00:00:00Z]])
 
       refute Accounts.get_user_by_session_token(token)
     end
@@ -1147,7 +1147,7 @@ defmodule Lightning.AccountsTest do
 
     test "does not confirm email if token expired", %{user: user, token: token} do
       {1, nil} =
-        Repo.update_all(UserToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+        Repo.update_all(UserToken, set: [inserted_at: ~U[2020-01-01 00:00:00Z]])
 
       assert Accounts.confirm_user(token) == :error
       refute Repo.get!(User, user.id).confirmed_at
@@ -1201,7 +1201,7 @@ defmodule Lightning.AccountsTest do
 
     test "does not return the user if token expired", %{user: user, token: token} do
       {1, nil} =
-        Repo.update_all(UserToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+        Repo.update_all(UserToken, set: [inserted_at: ~U[2020-01-01 00:00:00Z]])
 
       refute Accounts.get_user_by_reset_password_token(token)
       assert Repo.get_by(UserToken, user_id: user.id)


### PR DESCRIPTION
## Notes for the reviewer

![image](https://github.com/OpenFn/Lightning/assets/144796/0819dc93-2c7c-4085-874e-a7b418d9d8fc)

Previously the log lines were interspersed, these changes refactor the SetupUtils in order to ensure log lines are ordered.

A fair amount of the changes involve leveraging our new Attempts and WorkOrders modules, this required us to start a fake PubSub server during the demo scripts execution.

There is another commit here, which changes two model field types to UTC based timestamps - they previously were naive so I migrated them to be inline with the rest of the application.

## Related issue

Fixes #1487 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
