### PR TITLE
Derive dataclip from attempt in inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
   [#1217](https://github.com/OpenFn/Lightning/issues/1217)
 - Fix Credential Creation Page UI
   [#1064](https://github.com/OpenFn/Lightning/issues/1064)
+- Populate dataclip in job inspector via URL parameter
+  [#1551](https://github.com/OpenFn/Lightning/issues/1551)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ and this project adheres to
   [#1217](https://github.com/OpenFn/Lightning/issues/1217)
 - Fix Credential Creation Page UI
   [#1064](https://github.com/OpenFn/Lightning/issues/1064)
-- Populate dataclip in job inspector via URL parameter
-  [#1551](https://github.com/OpenFn/Lightning/issues/1551)
 
 ### Changed
 
+- Derive dataclip in inspector from the attempt & step
+  [#1551](https://github.com/OpenFn/Lightning/issues/1551)
 - Updated CLI to 0.4.10 (fixes logging)
 - Changed UserBackupToken model to use UTC timestamps (6563cb77)
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -79,6 +79,22 @@ defmodule Lightning.Invocation do
     Repo.one(query)
   end
 
+  @spec get_input_dataclip_for_attempted_job(
+          attempt_id :: Ecto.UUID.t(),
+          job_id :: Ecto.UUID.t()
+        ) ::
+          Dataclip.t() | nil
+  def get_input_dataclip_for_attempted_job(attempt_id, job_id) do
+    query =
+      from d in Query.dataclip_with_body(),
+        join: r in Lightning.Invocation.Run,
+        on: r.input_dataclip_id == d.id and r.job_id == ^job_id,
+        join: a in assoc(r, :attempts),
+        on: a.id == ^attempt_id
+
+    Repo.one(query)
+  end
+
   @doc """
   Gets a single dataclip.
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -79,12 +79,12 @@ defmodule Lightning.Invocation do
     Repo.one(query)
   end
 
-  @spec get_input_dataclip_for_attempted_job(
+  @spec get_dataclip_for_attempt_and_job(
           attempt_id :: Ecto.UUID.t(),
           job_id :: Ecto.UUID.t()
         ) ::
           Dataclip.t() | nil
-  def get_input_dataclip_for_attempted_job(attempt_id, job_id) do
+  def get_dataclip_for_attempt_and_job(attempt_id, job_id) do
     query =
       from d in Query.dataclip_with_body(),
         join: r in Lightning.Invocation.Run,

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -793,7 +793,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   defp get_selected_dataclip(attempt_id, job_id) do
-    Invocation.get_input_dataclip_for_attempted_job(attempt_id, job_id) ||
+    Invocation.get_dataclip_for_attempt_and_job(attempt_id, job_id) ||
       Invocation.get_dataclip_for_attempt(attempt_id)
   end
 


### PR DESCRIPTION
## Notes for the reviewer
- uses the `attempt` and `job` parameters to fetch the dataclip for the attempt run


## Related issue

Fixes #1551 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
