### PR TITLE
Preload and keep the attempts workorder and project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
   [#1487](https://github.com/OpenFn/Lightning/issues/1487)
 - Initial credential creation `changes` show `after` as `null` rather a value
   [#1118](https://github.com/OpenFn/Lightning/issues/1118)
+- AttemptViewer flashing/rerendering when Jobs are running
+  [#1550](https://github.com/OpenFn/Lightning/issues/1550)
 
 ## [v0.11.0] - 2023-12-06
 
@@ -102,7 +104,6 @@ and this project adheres to
   [#1254](https://github.com/OpenFn/Lightning/issues/1254)
 - Fix for missing data in 'created' audit trail events for webhook auth methods
   [#1500](https://github.com/OpenFn/Lightning/issues/1500)
-
 
 ## [v0.10.4] - 2023-11-30
 

--- a/lib/lightning_web/live/attempt_live/show.ex
+++ b/lib/lightning_web/live/attempt_live/show.ex
@@ -1,12 +1,13 @@
 defmodule LightningWeb.AttemptLive.Show do
   use LightningWeb, :live_view
 
-  alias Lightning.Attempts
   alias Phoenix.LiveView.AsyncResult
 
   import LightningWeb.AttemptLive.Components
   alias LightningWeb.Components.Viewers
   alias LightningWeb.AttemptLive.Streaming
+
+  use Streaming, chunk_size: 100
 
   on_mount {LightningWeb.Hooks, :project_scope}
 
@@ -159,8 +160,6 @@ defmodule LightningWeb.AttemptLive.Show do
     """
   end
 
-  use Streaming, chunk_size: 100
-
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     {:ok,
@@ -178,7 +177,7 @@ defmodule LightningWeb.AttemptLive.Show do
      |> assign(:output_dataclip, false)
      |> assign(:attempt, AsyncResult.loading())
      |> assign(:log_lines, AsyncResult.loading())
-     |> start_async(:attempt, fn -> Attempts.get(id, include: [runs: :job]) end)}
+     |> get_attempt_async(id)}
   end
 
   def handle_runs_change(socket) do


### PR DESCRIPTION
When manually running a job, the output pane would flash (white-out/rerender).

This was caused by the URLs not having the required preloads (`...workflow.project` in this case).

What was happening is that we _were_ preloading correctly, however when the attempt is updated a new version of it (without preloads) replaces it and the LiveView crashes.

It settles down when the Attempt is complete and it no longer updated.

I moved the `start_async` into the shared macro, and when the Attempt is loaded I pull the workflow and project off the attempt record and keep it separately, so when the Attempt is updated we still have the project etc in state. 

## Notes for the reviewer

Run a job manually, you should see any 'flashing' or the manual run component disappearing and reappearing quickly.

## Related issue

Fixes #1550

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
