### PR TITLE
Close Placeholder Node When Another Node Or Edge Is Clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
   [#1064](https://github.com/OpenFn/Lightning/issues/1064)
 - Custom metric to track Attempt queue delay
   [#1556](https://github.com/OpenFn/Lightning/issues/1556)
+- Close Placeholder Job Node When Another Node / Edge Is Clicked
+  [#1220](https://github.com/OpenFn/Lightning/issues/1220)
 
 ### Changed
 

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -182,6 +182,7 @@ const PlaceholderJobNode = ({ id, selected }: NodeProps<NodeData>) => {
             onClick={handleCancel}
           />
           <input
+            id="placeholder-input"
             type="text"
             ref={textRef}
             autoFocus

--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -84,7 +84,6 @@ export default (
 
   const cancel = useCallback((evt: CustomEvent<any>) => {
     setPlaceholders({ nodes: [], edges: [] });
-    requestSelectionChange(undefined);
   }, []);
 
   useEffect(() => {
@@ -101,5 +100,5 @@ export default (
     }
   }, [commit, cancel, ref]);
 
-  return { placeholders, add };
+  return { placeholders, add, cancel };
 };

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -141,32 +141,41 @@ export default {
       console.debug('onSelectionChange', id);
 
       await this.hasLoaded;
-      const currentUrl = new URL(window.location.href);
-      const nextUrl = new URL(currentUrl);
 
-      const idExists = this.getItem(id);
-      if (!idExists) {
-        nextUrl.searchParams.delete('s');
-        nextUrl.searchParams.delete('m');
-        nextUrl.searchParams.set('placeholder', 'true');
+      if (id?.startsWith('cancel-placeholder')) {
+        const nodeId = id.split('/')[1];
+        const url = new URL(window.location.href);
+        url.searchParams.delete('placeholder');
+        url.searchParams.set('s', nodeId);
+        this.liveSocket.pushHistoryPatch(url.toString(), 'push', this.el);
       } else {
-        nextUrl.searchParams.delete('placeholder');
-        if (!id) {
-          console.debug('Unselecting');
+        const currentUrl = new URL(window.location.href);
+        const nextUrl = new URL(currentUrl);
 
+        const idExists = this.getItem(id);
+        if (!idExists) {
           nextUrl.searchParams.delete('s');
           nextUrl.searchParams.delete('m');
+          nextUrl.searchParams.set('placeholder', 'true');
         } else {
-          console.debug('Selecting', id);
+          nextUrl.searchParams.delete('placeholder');
+          if (!id) {
+            console.debug('Unselecting');
 
-          nextUrl.searchParams.set('s', id);
+            nextUrl.searchParams.delete('s');
+            nextUrl.searchParams.delete('m');
+          } else {
+            console.debug('Selecting', id);
+
+            nextUrl.searchParams.set('s', id);
+          }
         }
-      }
 
-      if (
-        currentUrl.searchParams.toString() !== nextUrl.searchParams.toString()
-      ) {
-        this.liveSocket.pushHistoryPatch(nextUrl.toString(), 'push', this.el);
+        if (
+          currentUrl.searchParams.toString() !== nextUrl.searchParams.toString()
+        ) {
+          this.liveSocket.pushHistoryPatch(nextUrl.toString(), 'push', this.el);
+        }
       }
     })();
   },

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -34,12 +34,6 @@ type WorkflowEditorEntrypoint = PhoenixHook<
     observer: MutationObserver | null;
     setupObserver(): void;
     hasLoaded: Promise<URL>;
-    updateUrlParameter(
-      url: URL,
-      param: string,
-      value: string | null,
-      remove: boolean
-    ): void;
     handleCancelPlaceholder(id: string): void;
     handleUrlChange(id: string | undefined): void;
   },
@@ -144,23 +138,11 @@ export default {
       }
     }
   },
-  updateUrlParameter(
-    url: URL,
-    param: string,
-    value: string | null,
-    remove: boolean
-  ): void {
-    if (remove) {
-      url.searchParams.delete(param);
-    } else {
-      url.searchParams.set(param, value as string);
-    }
-  },
   handleCancelPlaceholder(id: string): void {
     const nodeId = id.split('/')[1];
     const url = new URL(window.location.href);
-    this.updateUrlParameter(url, 'placeholder', null, true);
-    this.updateUrlParameter(url, 's', nodeId, false);
+    url.searchParams.delete('placeholder');
+    url.searchParams.set('s', nodeId);
     this.liveSocket.pushHistoryPatch(url.toString(), 'push', this.el);
   },
   handleUrlChange(id: string | undefined): void {
@@ -169,18 +151,18 @@ export default {
 
     const idExists = this.getItem(id);
     if (!idExists) {
-      this.updateUrlParameter(nextUrl, 's', null, true);
-      this.updateUrlParameter(nextUrl, 'm', null, true);
-      this.updateUrlParameter(nextUrl, 'placeholder', 'true', false);
+      nextUrl.searchParams.delete('s');
+      nextUrl.searchParams.delete('m');
+      nextUrl.searchParams.set('placeholder', 'true');
     } else {
-      this.updateUrlParameter(nextUrl, 'placeholder', null, true);
+      nextUrl.searchParams.delete('placeholder');
       if (!id) {
         console.debug('Unselecting');
-        this.updateUrlParameter(nextUrl, 's', null, true);
-        this.updateUrlParameter(nextUrl, 'm', null, true);
+        nextUrl.searchParams.delete('s');
+        nextUrl.searchParams.delete('m');
       } else {
         console.debug('Selecting', id);
-        this.updateUrlParameter(nextUrl, 's', id, false);
+        nextUrl.searchParams.set('s', id)
       }
     }
 


### PR DESCRIPTION
## Notes for the reviewer

This PR refactors the `onSelectionChange` function in `workflow-editor/index.ts` to support the possibility of changing selection after event of type `cancel-placeholder`. The approach is when firing the event `cancel-placeholder` we send the value `cancel-placeholder-${id}` where the `id` is the `id` of the node or edge that was previously selected. That way, in our `onSelectionChange` function we can conditionnaly handle that case by doing something like this:

```
onSelectionChange(id?: string) {
    (async () => {
      console.debug('onSelectionChange', id);

      await this.hasLoaded;

      if (id?.startsWith('cancel-placeholder')) {
        this.handleCancelPlaceholder(id);
      } else {
        this.handleUrlChange(id);
      }
    })();
  }
```

## Related issue

Fixes #1220 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
