### PR TITLE
Stop cancel/confirm placeholder job from propagating click events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
   [#1118](https://github.com/OpenFn/Lightning/issues/1118)
 - AttemptViewer flashing/rerendering when Jobs are running
   [#1550](https://github.com/OpenFn/Lightning/issues/1550)
+- Not able to create a new Job when clicking the Check icon on the placeholder
+  [#1537](https://github.com/OpenFn/Lightning/issues/1537)
 
 ## [v0.11.0] - 2023-12-06
 

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -1,4 +1,10 @@
-import React, { memo, useCallback, useRef, useState } from 'react';
+import React, {
+  SyntheticEvent,
+  memo,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
 import {
   CheckCircleIcon,
@@ -86,20 +92,30 @@ const PlaceholderJobNode = ({ id, selected }: NodeProps<NodeData>) => {
   };
 
   // TODO what if a name hasn't been entered?
-  const handleCommit = useCallback(() => {
-    if (textRef.current) {
-      dispatch(textRef.current, 'commit-placeholder', {
-        id,
-        name: textRef.current.value,
-      });
-    }
-  }, [textRef]);
+  const handleCommit = useCallback(
+    (evt: SyntheticEvent | null) => {
+      evt?.stopPropagation();
 
-  const handleCancel = useCallback(() => {
-    if (textRef.current) {
-      dispatch(textRef.current, 'cancel-placeholder', { id });
-    }
-  }, [textRef]);
+      if (textRef.current) {
+        dispatch(textRef.current, 'commit-placeholder', {
+          id,
+          name: textRef.current.value,
+        });
+      }
+    },
+    [textRef]
+  );
+
+  const handleCancel = useCallback(
+    (evt: SyntheticEvent | null) => {
+      evt?.stopPropagation();
+
+      if (textRef.current) {
+        dispatch(textRef.current, 'cancel-placeholder', { id });
+      }
+    },
+    [textRef]
+  );
 
   return (
     <div

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -55,7 +55,6 @@ const fromWorkflow = (
         model.data.allowPlaceholder = allowPlaceholder;
 
         if (type === 'trigger') {
-          console.log('trigger model', item);
           model.data.trigger = {
             type: (node as Lightning.TriggerNode).type,
             enabled: (node as Lightning.TriggerNode).enabled,


### PR DESCRIPTION
## Notes for the reviewer

When clicking cancel or confirm, the click event was being propagated up and calling `handleSelection`, resulting in two `pushHistoryPatch` events being fired within a few usecs.

LiveView fails to render some (if not all) diffs calculated from the workflow state store. In subsequent renders an error would be thrown when those elements need to be changed and aren't on the DOM.

This _may_ be a bug in LiveView, or intended behaviour. But for now, we shouldn't be pushing a new URL twice anyway. I've added a `stopPropagation` to both the commit and cancel buttons on the PlaceholderJob component.

In order to recreate this, when creating a new job node (clicking the + icon below a Job node) after entering the jobs name click the "Check/Tick" icon (don't press enter). Previously this would make other nodes unselectable, the Job edit pane not appear; and errors can be found in the browser console.

## Related issue

Fixes #1537

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
