### PR TITLE
Expand workorder row when workorder_id is specified in the filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
   [#1064](https://github.com/OpenFn/Lightning/issues/1064)
 - Custom metric to track Attempt queue delay
   [#1556](https://github.com/OpenFn/Lightning/issues/1556)
+- Expand workorder row when a `workorder_id` is specified in the filter
+  [#1515](https://github.com/OpenFn/Lightning/issues/1515)
 
 ### Changed
 

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -24,6 +24,10 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
     {:ok, socket |> assign(assigns) |> set_work_order_details(work_order)}
   end
 
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
   defp set_work_order_details(socket, work_order) do
     last_run = List.last(List.first(work_order.attempts).runs)
 


### PR DESCRIPTION
## Notes for the reviewer

- This PR uses the `workorder_id` filter param to control the logic.
- After the `workorders` `async` task is complete, it dispatches a `send_update` to the `WorkOrderOrderComponent` using the `workorder_id` from the `filters_changeset`


## Related issue

Fixes #1515 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
