### PR TITLE
Conform all Diagram selections to the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to
   [#1550](https://github.com/OpenFn/Lightning/issues/1550)
 - Not able to create a new Job when clicking the Check icon on the placeholder
   [#1537](https://github.com/OpenFn/Lightning/issues/1537)
+- Improve selection logic on WorkflowDiagram
+  [#1220](https://github.com/OpenFn/Lightning/issues/1220)
 
 ## [v0.11.0] - 2023-12-06
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -45,6 +45,13 @@
 }
 
 .phx-click-loading {
+  &:not([phx-hook='WorkflowEditor']) {
+    opacity: 0.5;
+    transition: opacity 1s ease-out;
+  }
+}
+
+[phx-hook='WorkflowEditor'].phx-click-loading ~ form#workflow-form {
   opacity: 0.5;
   transition: opacity 1s ease-out;
 }

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -49,6 +49,10 @@ const PlaceholderJobNode = ({ id, selected }: NodeProps<NodeData>) => {
   });
 
   const handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    if (evt.code === 'Escape') {
+      handleCancel();
+      return;
+    }
     if (evt.target.value.trim() === '') {
       setValidationResult({
         isValid: false,
@@ -58,9 +62,6 @@ const PlaceholderJobNode = ({ id, selected }: NodeProps<NodeData>) => {
     }
     if (evt.code === 'Enter') {
       validationResult.isValid && handleCommit();
-    }
-    if (evt.code === 'Escape') {
-      handleCancel();
     }
   };
 
@@ -93,26 +94,24 @@ const PlaceholderJobNode = ({ id, selected }: NodeProps<NodeData>) => {
 
   // TODO what if a name hasn't been entered?
   const handleCommit = useCallback(
-    (evt: SyntheticEvent | null) => {
-      evt?.stopPropagation();
-
+    (evt?: SyntheticEvent) => {
       if (textRef.current) {
         dispatch(textRef.current, 'commit-placeholder', {
           id,
           name: textRef.current.value,
         });
       }
+      evt?.stopPropagation();
     },
     [textRef]
   );
 
   const handleCancel = useCallback(
-    (evt: SyntheticEvent | null) => {
-      evt?.stopPropagation();
-
+    (evt?: SyntheticEvent) => {
       if (textRef.current) {
         dispatch(textRef.current, 'cancel-placeholder', { id });
       }
+      evt?.stopPropagation();
     },
     [textRef]
   );

--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -48,7 +48,7 @@ export const create = (parentNode: Flow.Node) => {
 export default (
   ref: HTMLElement | null,
   store: StoreApi<WorkflowState>,
-  requestSelectionChange: (id?: string) => void // TODO more like changeSelection
+  requestSelectionChange: (id: string | null) => void // TODO more like changeSelection
 ) => {
   // TODO in new-workflow, we need to take a placeholder as a prop
   const [placeholders, setPlaceholders] = useState<Flow.Model>({
@@ -82,9 +82,8 @@ export default (
     [addToStore, placeholders]
   );
 
-  const cancel = useCallback((evt: CustomEvent<any>) => {
+  const cancel = useCallback((_evt?: CustomEvent<any>) => {
     setPlaceholders({ nodes: [], edges: [] });
-    requestSelectionChange(undefined);
   }, []);
 
   useEffect(() => {
@@ -101,5 +100,5 @@ export default (
     }
   }, [commit, cancel, ref]);
 
-  return { placeholders, add };
+  return { placeholders, add, cancel };
 };

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -21,7 +21,7 @@ const fromWorkflow = (
   workflow: Lightning.Workflow,
   positions: Positions,
   placeholders: Flow.Model = { nodes: [], edges: [] },
-  selectedId?: string
+  selectedId: string | null
 ): Flow.Model => {
   const allowPlaceholder = placeholders.nodes.length === 0;
 

--- a/assets/js/workflow-diagram/util/update-selection.ts
+++ b/assets/js/workflow-diagram/util/update-selection.ts
@@ -12,7 +12,7 @@ import { Flow } from '../types';
  *
  * TODO: as an optimisation, consider exiting early once we've updated both selected items
  */
-export default (model: Flow.Model, newSelection?: string) => {
+export default (model: Flow.Model, newSelection: string | null) => {
   const updatedModel = {
     nodes: model.nodes.map(updateItem) as Flow.Node[],
     edges: model.edges.map(updateItem) as Flow.Edge[],

--- a/assets/js/workflow-editor/component.tsx
+++ b/assets/js/workflow-editor/component.tsx
@@ -9,7 +9,7 @@ type Store = ReturnType<typeof createWorkflowStore>;
 export function mount(
   el: HTMLElement,
   workflowStore: Store,
-  onSelectionChange: (id?: string) => void
+  onSelectionChange: (id: string | null) => void
 ) {
   const componentRoot = createRoot(el);
 
@@ -20,7 +20,7 @@ export function mount(
     componentRoot.render(
       <WorkflowDiagram
         ref={el}
-        selection={selection}
+        selection={selection || null}
         store={workflowStore}
         onSelectionChange={onSelectionChange}
       />

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -23,7 +23,7 @@ type WorkflowEditorEntrypoint = PhoenixHook<
     ): Lightning.TriggerNode | Lightning.JobNode | Lightning.Edge | undefined;
     handleWorkflowParams(payload: { workflow_params: WorkflowProps }): void;
     maybeMountComponent(): void;
-    onSelectionChange(id?: string): void;
+    onSelectionChange(id?: string | null): void;
     pendingChanges: PendingAction[];
     processPendingChanges(): void;
     pushPendingChange(
@@ -78,12 +78,9 @@ export default {
     this.handleEvent<{ to: string; kind: string }>(
       'page-loading-stop',
       ({ to, kind }) => {
-        console.log('page-loading-stop', { to, kind });
         if (kind === 'initial') setHasLoaded(new URL(to));
       }
     );
-
-    console.debug('WorkflowEditor hook mounted');
 
     this._pendingWorker = Promise.resolve();
     this._isMounting = false;
@@ -114,7 +111,7 @@ export default {
     this.handleEvent<{ href: string; patch: boolean }>('navigate', e => {
       const id = new URL(e.href).searchParams.get('s');
 
-      if (id && e.patch && this.component) this.component.render(id);
+      if (e.patch && this.component) this.component.render(id);
     });
 
     // Get the initial data from the server
@@ -136,7 +133,7 @@ export default {
       }
     }
   },
-  onSelectionChange(id?: string) {
+  onSelectionChange(id?: string | null) {
     (async () => {
       console.debug('onSelectionChange', id);
 


### PR DESCRIPTION
## Notes for the reviewer

In order to reproduce this _before_ these changes by clicking "+" on a Job node, and cancelling the placeholder (clicking "X"); the very next Node you click won't respond to being selected.

This is a set of fixes which changes selection behaviour in the WorkflowDiagram.

- The currently selected id is now derived only from the URL.
- The switching appears immediately because we pull the selection off the URL from the `navigate` event (i.e. before the liveview has to reply).
- This change appears to reduce render calls and fixes what looks like the node being selected twice.
- I've changed the logic for cancelling a placeholder, if you hit Esc, it cancels it.

Other changes include a CSS change that moves the opacity animation when LiveView is processing a click event (specifically when switching Nodes) to apply the animation only to the form and not the entire diagram.

## Related issue

Fixes #1220 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
