### PR TITLE
Avoid error component when js expression is selected

### DIFF
--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -303,7 +303,6 @@ defmodule LightningWeb.Components.NewInputs do
         ]}
         {@rest}
       />
-
       <div :if={Enum.any?(@errors)} class="error-space h-6">
         <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
@@ -338,7 +337,7 @@ defmodule LightningWeb.Components.NewInputs do
     ~H"""
     <p
       data-tag="error_message"
-      class="mt-3 inline-flex items-center gap-x-1.5 text-xs text-danger-600 phx-no-feedback:hidden"
+      class="mt-3 inline-flex items-center gap-x-1.5 text-xs text-danger-600"
     >
       <.icon name="hero-exclamation-circle" class="h-4 w-4" />
       <%= render_slot(@inner_block) %>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -538,7 +538,7 @@ defmodule LightningWeb.WorkflowLive.Components do
         </div>
       <% end %>
       <%= if Phoenix.HTML.Form.input_value(@form, :source_trigger_id) do %>
-        <div class="max-w-xl text-sm text-gray-500 mt-2">
+        <div class="max-w-xl text-sm text-gray-500 mt-3">
           <p>This path will be active if its trigger is enabled.</p>
         </div>
       <% else %>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -886,7 +886,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
-  # Returns the index of the edge that is being edited on Path form
+  # Returns the inputs that have being edited on the form
   defp get_params_opts_for(workflow_attribute, params) do
     params
     |> Map.get(workflow_attribute, %{})
@@ -941,6 +941,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             |> Enum.with_index()
             |> Enum.map(fn
               {%{errors: errors} = edge, index} when index == edge_edit_index ->
+                # ignore errors for inputs that have not been edited
                 %{edge | errors: Keyword.take(errors, edge_edit_inputs)}
 
               {edge, _index} ->

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -894,7 +894,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     |> then(fn
       [{index, %{"condition_type" => "js_expression"} = map}] ->
         inputs_edited = Map.keys(map)
-        [edge_edited_input: {String.to_integer(index), inputs_edited}]
+        [edge_edited_inputs: {String.to_integer(index), inputs_edited}]
 
       _other ->
         []
@@ -934,7 +934,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       |> then(fn
         %Ecto.Changeset{changes: %{edges: edges} = changes} = changeset ->
           {edge_edit_index, edge_edit_inputs} =
-            Keyword.get(opts, :edge_edited_input, {nil, []})
+            Keyword.get(opts, :edge_edited_inputs, {nil, []})
 
           cleared_edges =
             edges


### PR DESCRIPTION
## Notes for the reviewer

The error component is rendered before the user starts filling the data since the changeset is initialized with required errors after selecting the condition `Matches a Javascript Expression`:
```
errors: [
          condition_label: {"can't be blank", [validation: :required]},
          condition_expression: {"can't be blank", [validation: :required]}
        ]
```
The fix changes the UI when editing an edge from this:
![Screenshot from 2023-12-14 18-07-01](https://github.com/OpenFn/Lightning/assets/44991200/f49d3fcb-0ffe-483a-8376-02e18aa21f60)
to this:
![Screenshot from 2023-12-14 18-04-35](https://github.com/OpenFn/Lightning/assets/44991200/ae612d13-4d2e-4461-aa96-baea74527523)


## Related issue

Closes #1498

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
