### PR TITLE
Fix history page crashing when last run is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to
   [#1537](https://github.com/OpenFn/Lightning/issues/1537)
 - Improve selection logic on WorkflowDiagram
   [#1220](https://github.com/OpenFn/Lightning/issues/1220)
+- History page crashes if job is removed from workflow after it's been run
+  [#1568](https://github.com/OpenFn/Lightning/issues/1568)
 
 ## [v0.11.0] - 2023-12-06
 

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -34,13 +34,14 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
     work_order_inserted_at = Calendar.strftime(work_order.inserted_at, "%c %Z")
     workflow_name = work_order.workflow.name || "Untitled"
 
-    assign_details(
-      socket,
-      work_order,
-      last_run,
-      last_run_finished_at,
-      work_order_inserted_at,
-      workflow_name
+    socket
+    |> assign(
+      work_order: work_order,
+      attempts: work_order.attempts,
+      last_run: last_run,
+      last_run_finished_at: last_run_finished_at,
+      work_order_inserted_at: work_order_inserted_at,
+      workflow_name: workflow_name
     )
   end
 
@@ -61,25 +62,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
       _ ->
         nil
     end
-  end
-
-  defp assign_details(
-         socket,
-         work_order,
-         last_run,
-         last_run_finished_at,
-         work_order_inserted_at,
-         workflow_name
-       ) do
-    socket
-    |> assign(
-      work_order: work_order,
-      attempts: work_order.attempts,
-      last_run: last_run,
-      last_run_finished_at: last_run_finished_at,
-      work_order_inserted_at: work_order_inserted_at,
-      workflow_name: workflow_name
-    )
   end
 
   @impl true
@@ -156,22 +138,24 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
                 {if @entry_selected, do: [checked: "checked"], else: []}
               />
             </form>
-            <button
-              id={"toggle_details_for_#{@work_order.id}"}
-              class="w-auto rounded-full p-3 hover:bg-gray-100"
-              phx-click="toggle_details"
-              phx-target={@myself}
-            >
-              <%= if get_last_run(@work_order) do %>
+            <%= if @work_order.attempts !== [] do %>
+              <button
+                id={"toggle_details_for_#{@work_order.id}"}
+                class="w-auto rounded-full p-3 hover:bg-gray-100"
+                phx-click="toggle_details"
+                phx-target={@myself}
+              >
                 <%= if @show_details do %>
                   <Heroicons.chevron_up outline class="h-4 w-4 rounded-lg" />
                 <% else %>
                   <Heroicons.chevron_down outline class="h-4 w-4 rounded-lg" />
                 <% end %>
-              <% else %>
+              </button>
+            <% else %>
+              <span class="w-auto p-3">
                 <Heroicons.minus outline class="h-4 w-4 rounded-lg" />
-              <% end %>
-            </button>
+              </span>
+            <% end %>
 
             <div class="ml-3 py-2">
               <h1 class={"text-sm mb-1 #{unless @show_details, do: "truncate"}"}>

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -74,6 +74,17 @@ defmodule LightningWeb.RunWorkOrderTest do
                id: work_order.id,
                work_order: work_order
              ) =~ work_order.dataclip_id
+
+      Lightning.Repo.delete!(job)
+
+      work_order =
+        Lightning.Repo.reload!(work_order)
+        |> Lightning.Repo.preload([:attempts, :workflow])
+
+      assert render_component(LightningWeb.RunLive.WorkOrderComponent,
+               id: work_order.id,
+               work_order: work_order
+             ) =~ work_order.dataclip_id
     end
 
     test "lists all workorders", %{

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -84,7 +84,7 @@ defmodule LightningWeb.RunWorkOrderTest do
   end
 
   defp format_timestamp(timestamp) do
-    Timex.format!(timestamp, "%d/%b/%y, %H:%M:%S", :strftime)
+    Timex.format!(timestamp, "%d/%b/%y, %H:%M", :strftime)
   end
 
   defp assert_work_order_runs(work_order, expected_count) do

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -39,6 +39,54 @@ defmodule LightningWeb.RunWorkOrderTest do
     {work_order, dataclip}
   end
 
+  defp setup_work_order_with_multiple_attempts(
+         workflow,
+         trigger,
+         job,
+         dataclip,
+         attempts_params
+       ) do
+    work_order =
+      insert(:workorder,
+        workflow: workflow,
+        trigger: trigger,
+        dataclip: dataclip,
+        last_activity: DateTime.utc_now()
+      )
+
+    attempts =
+      Enum.map(attempts_params, fn params ->
+        insert_attempt_with_run(work_order, trigger, dataclip, job, params)
+      end)
+
+    {work_order, attempts}
+  end
+
+  defp insert_attempt_with_run(work_order, trigger, dataclip, job, opts) do
+    state = opts[:state]
+    timestamp = opts[:state_timestamp]
+
+    insert(:attempt,
+      work_order: work_order,
+      starting_trigger: trigger,
+      dataclip: dataclip,
+      state: state,
+      "#{state}_at": timestamp,
+      runs: [
+        build(:run,
+          job: job,
+          started_at: build(:timestamp),
+          finished_at: build(:timestamp),
+          input_dataclip: dataclip
+        )
+      ]
+    )
+  end
+
+  defp format_timestamp(timestamp) do
+    Timex.format!(timestamp, "%d/%b/%y, %H:%M:%S", :strftime)
+  end
+
   defp assert_work_order_runs(work_order, expected_count) do
     assert length(work_order.attempts) === expected_count
 
@@ -153,6 +201,44 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       assert rendered =~ work_order.dataclip_id
       refute rendered =~ "toggle_details_for_#{work_order.id}"
+    end
+
+    test "toggle details of a work order shows attempt state and timestamp", %{
+      conn: conn,
+      project: project
+    } do
+      workflow = insert(:workflow, project: project, name: "my workflow")
+      trigger = insert(:trigger, type: :webhook, workflow: workflow)
+      job = insert(:job, workflow: workflow)
+      dataclip = insert(:dataclip)
+
+      attempts_params = [
+        %{state: :claimed, state_timestamp: build(:timestamp)},
+        %{state: :started, state_timestamp: build(:timestamp)}
+      ]
+
+      {work_order, [attempt_1, attempt_2]} =
+        setup_work_order_with_multiple_attempts(
+          workflow,
+          trigger,
+          job,
+          dataclip,
+          attempts_params
+        )
+
+      claimed_at = format_timestamp(attempt_1.claimed_at)
+      started_at = format_timestamp(attempt_2.started_at)
+
+      {:ok, view, _html} =
+        live_async(conn, Routes.project_run_index_path(conn, :index, project.id))
+
+      rendered =
+        view |> element("#toggle_details_for_#{work_order.id}") |> render_click()
+
+      assert rendered =~ attempt_1.id
+      assert rendered =~ attempt_2.id
+      assert rendered =~ "claimed @ \n  \n      #{claimed_at}"
+      assert rendered =~ "claimed @ \n  \n      #{started_at}"
     end
 
     test "lists all workorders", %{

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -100,6 +100,37 @@ defmodule LightningWeb.RunWorkOrderTest do
       assert rendered =~ "toggle_details_for_#{work_order.id}"
     end
 
+    test "WorkOrderComponent renders runs when details are toggled", %{
+      project: project
+    } do
+      %{jobs: [job]} = insert(:simple_workflow, project: project)
+      {work_order, _dataclip} = setup_work_order(project, job)
+
+      assert_work_order_runs(work_order, 1)
+
+      rendered =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: work_order,
+          show_details: true,
+          project: project,
+          can_rerun_job: true
+        )
+
+      assert rendered =~ work_order.dataclip_id
+      assert rendered =~ "toggle_details_for_#{work_order.id}"
+
+      work_order.attempts
+      |> Enum.each(fn attempt ->
+        assert rendered =~ "attempt_#{attempt.id}"
+      end)
+
+      hd(work_order.attempts).runs
+      |> Enum.each(fn run ->
+        assert rendered =~ "run-#{run.id}"
+      end)
+    end
+
     test "WorkOrderComponent remains stable when associated jobs are deleted", %{
       project: project
     } do


### PR DESCRIPTION
## Notes for the reviewer

This PR introduces a fix to the history page that is crashing when a workorder has no runs (runs deleted thru deletion of jobs). To reproduce the bug it is fixing, do the following:

1. Run the last job of a workflow
2. Then delete that job and save
3. Go to history page and see it crashing

The fix improves this line of code `last_run = List.last(List.first(work_order.attempts).runs)` and makes sure it doesn't blow when attempts are `nil`.

## Related issue

Re #1568 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
