### PR TITLE
Separate merge for condition rename refactor

### DIFF
--- a/assets/dev-server/src/App.tsx
+++ b/assets/dev-server/src/App.tsx
@@ -24,7 +24,7 @@ const Form = ({ nodeId, store, onChange }) => {
     {item.adaptor && <p>{`adaptor: ${item.adaptor}`}</p>}
     {item.type && <p>{`type: ${item.type}`}</p>}
     {item.target_job_id ?
-     <p>{`condition: ${item.condition}`}</p>
+     <p>{`condition_type: ${item.condition_type}`}</p>
      : <p>{`expression: ${item.cronExpression || item.expression}`}</p>}
   </>);
 }

--- a/assets/js/workflow-diagram/styles.ts
+++ b/assets/js/workflow-diagram/styles.ts
@@ -16,7 +16,7 @@ export const EDGE_COLOR_SELECTED_DISABLED = '#bdbaf3';
 export const ERROR_COLOR = '#ef4444';
 
 export const labelStyles = (selected?: boolean, data) => {
-  const { condition, enabled } = data;
+  const { condition_type, enabled } = data;
 
   const primaryColor = (selected?: boolean, enabled?: boolean) => {
     if (enabled) return selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
@@ -25,7 +25,7 @@ export const labelStyles = (selected?: boolean, data) => {
 
   const backgroundColor = enabled ? 'white' : '#F6F6F6';
 
-  if (condition === 'js_expression') {
+  if (condition_type === 'js_expression') {
     return {
       padding: '0 4px',
       height: '32px',

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -42,7 +42,7 @@ export namespace Lightning {
     edge?: boolean;
     error_path?: boolean;
     errors: any;
-    js_expression_label?: string;
+    condition_label?: string;
   }
 
   export type Workflow = {

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -38,7 +38,7 @@ export namespace Lightning {
     source_trigger_id?: string;
     target_job_id?: string;
     name: string;
-    condition?: string;
+    condition_type?: string;
     edge?: boolean;
     error_path?: boolean;
     errors: any;

--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -38,7 +38,7 @@ export const create = (parentNode: Flow.Node) => {
       type: 'step',
       source: parentNode.id,
       target: targetId,
-      data: { condition: 'on_job_success', placeholder: true },
+      data: { condition_type: 'on_job_success', placeholder: true },
     })
   );
 

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -4,7 +4,7 @@ import { sortOrderForSvg, styleEdge, styleItem, styleNode } from '../styles';
 function getEdgeLabel(edge: Lightning.Edge) {
   let label = '( )';
 
-  switch (edge.condition) {
+  switch (edge.condition_type) {
     case 'on_job_success':
       label = '✓';
       break;
@@ -85,7 +85,7 @@ const fromWorkflow = (
           width: 32,
           height: 32,
         };
-        model.data = { condition: edge.condition, enabled: edge.enabled };
+        model.data = { condition_type: edge.condition_type, enabled: edge.enabled };
 
         // Note: we don't allow the user to disable the edge that goes from a
         // trigger to a job, but we want to show it as if it were disabled when

--- a/assets/js/workflow-diagram/util/from-workflow.ts
+++ b/assets/js/workflow-diagram/util/from-workflow.ts
@@ -15,7 +15,7 @@ function getEdgeLabel(edge: Lightning.Edge) {
       label = '∞';
       break;
     case 'js_expression':
-      const condition_label = edge.js_expression_label;
+      const condition_label = edge.condition_label;
 
       if (condition_label) {
         if (condition_label.length > 16) {

--- a/assets/js/workflow-diagram/util/to-workflow.ts
+++ b/assets/js/workflow-diagram/util/to-workflow.ts
@@ -44,8 +44,8 @@ const model = (model: Flow.Model) => {
       wfEdge.source_job_id = edge.source;
     }
 
-    if (edge.data?.condition) {
-      wfEdge.condition = edge.data.condition;
+    if (edge.data?.condition_type) {
+      wfEdge.condition_type = edge.data.condition_type;
     }
 
     workflow.edges.push(wfEdge as Lightning.Edge);

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -59,7 +59,7 @@ const createNewWorkflow = () => {
       id: crypto.randomUUID(),
       source_trigger_id: triggers[0].id,
       target_job_id: jobs[0].id,
-      condition: 'always',
+      condition_type: 'always',
     },
   ];
   return { triggers, jobs, edges };

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -53,7 +53,7 @@ defmodule Lightning.ExportUtils do
       name: "#{trigger_name}->#{target_name}",
       source_trigger: find_trigger_name(edge, triggers),
       target_job: target_name,
-      condition: edge.condition |> Atom.to_string(),
+      condition_type: edge.condition_type |> Atom.to_string(),
       enabled: edge.enabled,
       node_type: :edge
     }
@@ -68,7 +68,7 @@ defmodule Lightning.ExportUtils do
       name: "#{source_job}->#{target_job}",
       source_job: source_job,
       target_job: target_job,
-      condition: edge.condition |> Atom.to_string(),
+      condition_type: edge.condition_type |> Atom.to_string(),
       node_type: :edge,
       enabled: edge.enabled
     }
@@ -86,7 +86,13 @@ defmodule Lightning.ExportUtils do
       workflow: [:name, :jobs, :triggers, :edges],
       job: [:name, :adaptor, :credential, :globals, :body],
       trigger: [:type, :cron_expression, :enabled],
-      edge: [:source_trigger, :source_job, :target_job, :condition, :enabled]
+      edge: [
+        :source_trigger,
+        :source_job,
+        :target_job,
+        :condition_type,
+        :enabled
+      ]
     }
 
     map

--- a/lib/lightning/jobs.ex
+++ b/lib/lightning/jobs.ex
@@ -84,7 +84,7 @@ defmodule Lightning.Jobs do
 
   def get_downstream_jobs_for(job_id, edge_condition) do
     downstream_query(job_id)
-    |> where([_, e], e.condition == ^edge_condition)
+    |> where([_, e], e.condition_type == ^edge_condition)
     |> Repo.all()
   end
 

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -149,7 +149,7 @@ defmodule Lightning.Projects.Provisioner do
       :source_trigger_id,
       :enabled,
       :condition_type,
-      :js_expression_label,
+      :condition_label,
       :target_job_id,
       :delete
     ])

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -148,7 +148,7 @@ defmodule Lightning.Projects.Provisioner do
       :source_job_id,
       :source_trigger_id,
       :enabled,
-      :condition,
+      :condition_type,
       :js_expression_label,
       :target_job_id,
       :delete

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -230,7 +230,7 @@ defmodule Lightning.SetupUtils do
     Workflows.create_edge(%{
       workflow_id: workflow.id,
       source_job: job_1,
-      condition: :on_job_success,
+      condition_type: :on_job_success,
       target_job_id: job_2.id,
       enabled: true
     })
@@ -270,7 +270,7 @@ defmodule Lightning.SetupUtils do
     Workflows.create_edge(%{
       workflow_id: workflow.id,
       source_job: job_2,
-      condition: :on_job_success,
+      condition_type: :on_job_success,
       target_job_id: job_3.id,
       enabled: true
     })
@@ -469,7 +469,7 @@ defmodule Lightning.SetupUtils do
     {:ok, _openhie_root_edge} =
       Workflows.create_edge(%{
         workflow_id: openhie_workflow.id,
-        condition: :always,
+        condition_type: :always,
         source_trigger: openhie_trigger,
         target_job: fhir_standard_data,
         enabled: true
@@ -517,7 +517,7 @@ defmodule Lightning.SetupUtils do
     {:ok, _send_to_openhim_edge} =
       Workflows.create_edge(%{
         workflow_id: openhie_workflow.id,
-        condition: :on_job_success,
+        condition_type: :on_job_success,
         target_job_id: send_to_openhim.id,
         source_job_id: fhir_standard_data.id,
         enabled: true
@@ -526,7 +526,7 @@ defmodule Lightning.SetupUtils do
     {:ok, _success_upload} =
       Workflows.create_edge(%{
         workflow_id: openhie_workflow.id,
-        condition: :on_job_success,
+        condition_type: :on_job_success,
         target_job_id: notify_upload_successful.id,
         source_job_id: send_to_openhim.id,
         enabled: true
@@ -535,7 +535,7 @@ defmodule Lightning.SetupUtils do
     {:ok, _failed_upload} =
       Workflows.create_edge(%{
         workflow_id: openhie_workflow.id,
-        condition: :on_job_failure,
+        condition_type: :on_job_failure,
         target_job_id: notify_upload_failed.id,
         source_job_id: send_to_openhim.id,
         enabled: true
@@ -697,7 +697,7 @@ defmodule Lightning.SetupUtils do
     {:ok, _root_edge} =
       Workflows.create_edge(%{
         workflow_id: dhis2_workflow.id,
-        condition: :always,
+        condition_type: :always,
         source_trigger: dhis_trigger,
         target_job: get_dhis2_data,
         enabled: true
@@ -719,7 +719,7 @@ defmodule Lightning.SetupUtils do
     {:ok, _success_upload} =
       Workflows.create_edge(%{
         workflow_id: dhis2_workflow.id,
-        condition: :on_job_success,
+        condition_type: :on_job_success,
         target_job_id: upload_to_google_sheet.id,
         source_job_id: get_dhis2_data.id,
         enabled: true

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -40,7 +40,7 @@ defmodule Lightning.Workflows.Edge do
     belongs_to :target_job, Job
 
     field :condition_type, Ecto.Enum, values: @conditions
-    field :js_expression_body, :string
+    field :condition_expression, :string
     field :condition_label, :string
 
     field :enabled, :boolean, default: true
@@ -66,7 +66,7 @@ defmodule Lightning.Workflows.Edge do
       :enabled,
       :target_job_id,
       :condition_label,
-      :js_expression_body
+      :condition_expression
     ])
     |> validate()
   end
@@ -103,37 +103,37 @@ defmodule Lightning.Workflows.Edge do
   defp validate_js_condition(changeset) do
     if :js_expression == get_field(changeset, :condition_type) do
       changeset
-      |> validate_required([:condition_label, :js_expression_body])
-      |> validate_js_expression_body()
+      |> validate_required([:condition_label, :condition_expression])
+      |> validate_condition_expression()
     else
       changeset
     end
   end
 
-  defp validate_js_expression_body(%{valid?: false} = changeset), do: changeset
+  defp validate_condition_expression(%{valid?: false} = changeset), do: changeset
 
-  defp validate_js_expression_body(changeset) do
-    js_code = get_field(changeset, :js_expression_body)
+  defp validate_condition_expression(changeset) do
+    js_code = get_field(changeset, :condition_expression)
 
     cond do
       String.match?(js_code, ~r/(import|require)(\(|\{| )/) ->
         add_error(
           changeset,
-          :js_expression_body,
+          :condition_expression,
           "must not contain import or require statements"
         )
 
       String.match?(js_code, ~r/(;|{)/) ->
         add_error(
           changeset,
-          :js_expression_body,
+          :condition_expression,
           "must not contain a statement"
         )
 
       true ->
         changeset
         |> validate_length(:condition_label, max: 255)
-        |> validate_length(:js_expression_body, max: 255)
+        |> validate_length(:condition_expression, max: 255)
     end
   end
 

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -21,7 +21,7 @@ defmodule Lightning.Workflows.Edge do
   @type t() :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: Ecto.UUID.t() | nil,
-          condition: edge_condition(),
+          condition_type: edge_condition(),
           enabled: boolean(),
           workflow: nil | Workflow.t() | Ecto.Association.NotLoaded.t(),
           source_job: nil | Job.t() | Ecto.Association.NotLoaded.t(),
@@ -39,7 +39,7 @@ defmodule Lightning.Workflows.Edge do
     belongs_to :source_trigger, Trigger
     belongs_to :target_job, Job
 
-    field :condition, Ecto.Enum, values: @conditions
+    field :condition_type, Ecto.Enum, values: @conditions
     field :js_expression_body, :string
     field :js_expression_label, :string
 
@@ -62,7 +62,7 @@ defmodule Lightning.Workflows.Edge do
       :workflow_id,
       :source_job_id,
       :source_trigger_id,
-      :condition,
+      :condition_type,
       :enabled,
       :target_job_id,
       :js_expression_label,
@@ -77,7 +77,7 @@ defmodule Lightning.Workflows.Edge do
     |> assoc_constraint(:source_trigger)
     |> assoc_constraint(:source_job)
     |> assoc_constraint(:target_job)
-    |> validate_required([:condition])
+    |> validate_required([:condition_type])
     |> validate_node_in_same_workflow()
     |> foreign_key_constraint(:workflow_id)
     |> validate_exclusive(
@@ -92,7 +92,7 @@ defmodule Lightning.Workflows.Edge do
   defp validate_source_condition(changeset) do
     if nil != get_field(changeset, :source_trigger_id) do
       changeset
-      |> validate_inclusion(:condition, [:always, :js_expression],
+      |> validate_inclusion(:condition_type, [:always, :js_expression],
         message: "must be :always or :js_expression when source is a trigger"
       )
     else
@@ -101,7 +101,7 @@ defmodule Lightning.Workflows.Edge do
   end
 
   defp validate_js_condition(changeset) do
-    if :js_expression == get_field(changeset, :condition) do
+    if :js_expression == get_field(changeset, :condition_type) do
       changeset
       |> validate_required([:js_expression_label, :js_expression_body])
       |> validate_js_expression_body()

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -41,7 +41,7 @@ defmodule Lightning.Workflows.Edge do
 
     field :condition_type, Ecto.Enum, values: @conditions
     field :js_expression_body, :string
-    field :js_expression_label, :string
+    field :condition_label, :string
 
     field :enabled, :boolean, default: true
 
@@ -65,7 +65,7 @@ defmodule Lightning.Workflows.Edge do
       :condition_type,
       :enabled,
       :target_job_id,
-      :js_expression_label,
+      :condition_label,
       :js_expression_body
     ])
     |> validate()
@@ -103,7 +103,7 @@ defmodule Lightning.Workflows.Edge do
   defp validate_js_condition(changeset) do
     if :js_expression == get_field(changeset, :condition_type) do
       changeset
-      |> validate_required([:js_expression_label, :js_expression_body])
+      |> validate_required([:condition_label, :js_expression_body])
       |> validate_js_expression_body()
     else
       changeset
@@ -132,7 +132,7 @@ defmodule Lightning.Workflows.Edge do
 
       true ->
         changeset
-        |> validate_length(:js_expression_label, max: 255)
+        |> validate_length(:condition_label, max: 255)
         |> validate_length(:js_expression_body, max: 255)
     end
   end

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -113,17 +113,17 @@ defmodule Lightning.Workflows.Edge do
   defp validate_condition_expression(%{valid?: false} = changeset), do: changeset
 
   defp validate_condition_expression(changeset) do
-    js_code = get_field(changeset, :condition_expression)
+    js_expr = get_field(changeset, :condition_expression)
 
     cond do
-      String.match?(js_code, ~r/(import|require)(\(|\{| )/) ->
+      String.match?(js_expr, ~r/(import|require)(\(|\{| )/) ->
         add_error(
           changeset,
           :condition_expression,
           "must not contain import or require statements"
         )
 
-      String.match?(js_code, ~r/(;|{)/) ->
+      String.match?(js_expr, ~r/(;|{)/) ->
         add_error(
           changeset,
           :condition_expression,

--- a/lib/lightning_web/channels/attempt_json.ex
+++ b/lib/lightning_web/channels/attempt_json.ex
@@ -38,13 +38,13 @@ defmodule LightningWeb.AttemptJson do
   def render(
         %Edge{
           condition_type: condition_type,
-          js_expression_body: js_expression_body
+          condition_expression: condition_expression
         } =
           edge
       ) do
     condition =
       if condition_type == :js_expression do
-        js_expression_body
+        condition_expression
       else
         condition_type
       end

--- a/lib/lightning_web/channels/attempt_json.ex
+++ b/lib/lightning_web/channels/attempt_json.ex
@@ -36,14 +36,17 @@ defmodule LightningWeb.AttemptJson do
   end
 
   def render(
-        %Edge{condition: condition, js_expression_body: js_expression_body} =
+        %Edge{
+          condition_type: condition_type,
+          js_expression_body: js_expression_body
+        } =
           edge
       ) do
     condition =
-      if condition == :js_expression do
+      if condition_type == :js_expression do
         js_expression_body
       else
-        condition
+        condition_type
       end
 
     %{

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -53,7 +53,9 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
   def as_json(%Edge{} = edge) do
     Ecto.embedded_dump(edge, :json)
-    |> Map.take(~w(id source_job_id source_trigger_id condition target_job_id)a)
+    |> Map.take(
+      ~w(id source_job_id source_trigger_id condition_type target_job_id)a
+    )
     |> drop_keys_with_nil_value()
   end
 

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -529,7 +529,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             </p>
             <.input
               type="textarea"
-              field={@form[:js_expression_body]}
+              field={@form[:condition_expression]}
               class="h-24"
               phx-debounce="300"
               maxlength="255"

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -492,18 +492,22 @@ defmodule LightningWeb.WorkflowLive.Components do
       )
       |> assign(
         :edge_condition,
-        Map.get(form.params, "condition", Atom.to_string(form.data.condition))
+        Map.get(
+          form.params,
+          "condition_type",
+          Atom.to_string(form.data.condition_type)
+        )
       )
 
     ~H"""
     <% Phoenix.HTML.Form.hidden_inputs_for(@form) %>
-    <.old_error field={@form[:condition]} />
+    <.old_error field={@form[:condition_type]} />
     <div class="grid grid-flow-row gap-4 auto-rows-max">
       <div>
         <.input
           type="select"
           label="Condition"
-          field={@form[:condition]}
+          field={@form[:condition_type]}
           options={@edge_options}
           disabled={@disabled}
         />

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -517,7 +517,7 @@ defmodule LightningWeb.WorkflowLive.Components do
           <.input
             type="text"
             label="Condition Label"
-            field={@form[:js_expression_label]}
+            field={@form[:condition_label]}
             maxlength="255"
           />
         </div>

--- a/lib/lightning_web/live/workflow_live/workflow_params.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_params.ex
@@ -108,7 +108,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParams do
             :source_trigger_id,
             :source_job_id,
             :enabled,
-            :condition,
+            :condition_type,
             :js_expression_label,
             :target_job_id
           ])

--- a/lib/lightning_web/live/workflow_live/workflow_params.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_params.ex
@@ -109,7 +109,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParams do
             :source_job_id,
             :enabled,
             :condition_type,
-            :js_expression_label,
+            :condition_label,
             :target_job_id
           ])
       }

--- a/priv/repo/migrations/20231211090740_add_js_expression.exs
+++ b/priv/repo/migrations/20231211090740_add_js_expression.exs
@@ -3,7 +3,7 @@ defmodule Lightning.Repo.Migrations.AddJsExpression do
 
   def change do
     alter table(:workflow_edges) do
-      add :js_expression_body, :string
+      add :condition_expression, :string
       add :condition_label, :string
     end
 

--- a/priv/repo/migrations/20231211090740_add_js_expression.exs
+++ b/priv/repo/migrations/20231211090740_add_js_expression.exs
@@ -6,5 +6,7 @@ defmodule Lightning.Repo.Migrations.AddJsExpression do
       add :js_expression_body, :string
       add :js_expression_label, :string
     end
+
+    rename table(:workflow_edges), :condition, to: :condition_type
   end
 end

--- a/priv/repo/migrations/20231211090740_add_js_expression.exs
+++ b/priv/repo/migrations/20231211090740_add_js_expression.exs
@@ -4,7 +4,7 @@ defmodule Lightning.Repo.Migrations.AddJsExpression do
   def change do
     alter table(:workflow_edges) do
       add :js_expression_body, :string
-      add :js_expression_label, :string
+      add :condition_label, :string
     end
 
     rename table(:workflow_edges), :condition, to: :condition_type

--- a/test/fixtures/canonical_project.yaml
+++ b/test/fixtures/canonical_project.yaml
@@ -37,17 +37,17 @@ workflows:
       webhook->webhook-job:
         source_trigger: webhook
         target_job: webhook-job
-        condition: always
+        condition_type: always
         enabled: true
       webhook-job->on-fail:
         source_job: webhook-job
         target_job: on-fail
-        condition: on_job_failure
+        condition_type: on_job_failure
         enabled: true
       webhook-job->on-success:
         source_job: webhook-job
         target_job: on-success
-        condition: on_job_success
+        condition_type: on_job_success
         enabled: true
   workflow-2:
     name: workflow 2
@@ -75,10 +75,10 @@ workflows:
       cron->some-cronjob:
         source_trigger: cron
         target_job: some-cronjob
-        condition: always
+        condition_type: always
         enabled: true
       some-cronjob->on-cron-failure:
         source_job: some-cronjob
         target_job: on-cron-failure
-        condition: on_job_success
+        condition_type: on_job_success
         enabled: true 

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -112,7 +112,7 @@ defmodule Lightning.JobsTest do
         source_job_id: job.id,
         workflow: job.workflow,
         target_job_id: other_job.id,
-        condition: :on_job_failure
+        condition_type: :on_job_failure
       })
 
       assert Jobs.get_downstream_jobs_for(job) == [

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -223,7 +223,7 @@ defmodule Lightning.Projects.ProvisionerTest do
           body
           |> add_entity_to_workflow(workflow_id, "edges", %{
             "id" => other_edge_id,
-            "condition" => "on_job_success"
+            "condition_type" => "on_job_success"
           })
         )
 
@@ -363,7 +363,7 @@ defmodule Lightning.Projects.ProvisionerTest do
             %{
               "id" => job_edge_id,
               "source_job_id" => first_job_id,
-              "condition" => "on_job_success",
+              "condition_type" => "on_job_success",
               "target_job_id" => second_job_id
             }
           ]

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -584,13 +584,13 @@ defmodule Lightning.ProjectsTest do
       workflow: workflow_1,
       source_trigger: build(:trigger, workflow: workflow_1),
       target_job: workflow_1_job,
-      condition: :always
+      condition_type: :always
     )
 
     insert(:edge,
       workflow: workflow_1,
       source_job: workflow_1_job,
-      condition: :on_job_failure,
+      condition_type: :on_job_failure,
       target_job:
         insert(:job,
           name: "on fail",
@@ -604,7 +604,7 @@ defmodule Lightning.ProjectsTest do
     insert(:edge,
       workflow: workflow_1,
       source_job: workflow_1_job,
-      condition: :on_job_success,
+      condition_type: :on_job_success,
       target_job:
         insert(:job,
           name: "on success",
@@ -631,13 +631,13 @@ defmodule Lightning.ProjectsTest do
           cron_expression: "0 23 * * *"
         ),
       target_job: workflow_2_job,
-      condition: :always
+      condition_type: :always
     )
 
     insert(:edge,
       workflow: workflow_2,
       source_job: workflow_2_job,
-      condition: :on_job_success,
+      condition_type: :on_job_success,
       target_job:
         insert(:job,
           name: "on cron failure",

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -77,30 +77,30 @@ defmodule Lightning.SetupUtilsTest do
              end)
 
       assert Enum.find(loaded_flow.edges, fn e ->
-               e.condition == :always &&
+               e.condition_type == :always &&
                  e.target_job_id == fhir_standard_data.id
              end)
 
       assert Enum.find(loaded_flow.edges, fn e ->
-               e.condition == :on_job_success &&
+               e.condition_type == :on_job_success &&
                  e.source_job_id == fhir_standard_data.id &&
                  e.target_job_id == send_to_openhim.id
              end)
 
       assert Enum.find(loaded_flow.edges, fn e ->
-               e.condition == :on_job_success &&
+               e.condition_type == :on_job_success &&
                  e.source_job_id == fhir_standard_data.id &&
                  e.target_job_id == send_to_openhim.id
              end)
 
       assert Enum.find(loaded_flow.edges, fn e ->
-               e.condition == :on_job_success &&
+               e.condition_type == :on_job_success &&
                  e.target_job_id == notify_upload_successful.id &&
                  e.source_job_id == send_to_openhim.id
              end)
 
       assert Enum.find(loaded_flow.edges, fn e ->
-               e.condition == :on_job_failure &&
+               e.condition_type == :on_job_failure &&
                  e.target_job_id == notify_upload_failed.id &&
                  e.source_job_id == send_to_openhim.id
              end)
@@ -110,12 +110,12 @@ defmodule Lightning.SetupUtilsTest do
         |> Repo.preload([:edges, :triggers])
 
       assert Enum.find(loaded_dhis_flow.edges, fn e ->
-               e.condition == :always &&
+               e.condition_type == :always &&
                  e.target_job_id == get_dhis2_data.id
              end)
 
       assert Enum.find(loaded_dhis_flow.edges, fn e ->
-               e.condition == :on_job_success &&
+               e.condition_type == :on_job_success &&
                  e.source_job_id == get_dhis2_data.id &&
                  e.target_job_id == upload_to_google_sheet.id
              end)

--- a/test/lightning/workflows/edge_test.exs
+++ b/test/lightning/workflows/edge_test.exs
@@ -215,7 +215,7 @@ defmodule Lightning.Workflows.EdgeTest do
         )
 
       assert changeset.errors == [
-               js_expression_label: {"can't be blank", [validation: :required]},
+               condition_label: {"can't be blank", [validation: :required]},
                js_expression_body: {"can't be blank", [validation: :required]}
              ]
     end
@@ -231,7 +231,7 @@ defmodule Lightning.Workflows.EdgeTest do
           },
           %{
             condition_type: :js_expression,
-            js_expression_label: String.duplicate("a", 256),
+            condition_label: String.duplicate("a", 256),
             js_expression_body: String.duplicate("a", 256)
           }
         )
@@ -246,7 +246,7 @@ defmodule Lightning.Workflows.EdgeTest do
                    {:type, :string}
                  ]
                },
-               js_expression_label:
+               condition_label:
                  {"should be at most %{count} character(s)",
                   [count: 255, validation: :length, kind: :max, type: :string]}
              ]
@@ -262,7 +262,7 @@ defmodule Lightning.Workflows.EdgeTest do
 
       js_attrs = %{
         condition_type: :js_expression,
-        js_expression_label: "Some JS Expression"
+        condition_label: "Some JS Expression"
       }
 
       changeset =
@@ -316,7 +316,7 @@ defmodule Lightning.Workflows.EdgeTest do
 
       js_attrs = %{
         condition_type: :js_expression,
-        js_expression_label: "Some JS Expression"
+        condition_label: "Some JS Expression"
       }
 
       changeset =

--- a/test/lightning/workflows/edge_test.exs
+++ b/test/lightning/workflows/edge_test.exs
@@ -216,7 +216,7 @@ defmodule Lightning.Workflows.EdgeTest do
 
       assert changeset.errors == [
                condition_label: {"can't be blank", [validation: :required]},
-               js_expression_body: {"can't be blank", [validation: :required]}
+               condition_expression: {"can't be blank", [validation: :required]}
              ]
     end
 
@@ -232,12 +232,12 @@ defmodule Lightning.Workflows.EdgeTest do
           %{
             condition_type: :js_expression,
             condition_label: String.duplicate("a", 256),
-            js_expression_body: String.duplicate("a", 256)
+            condition_expression: String.duplicate("a", 256)
           }
         )
 
       assert changeset.errors == [
-               js_expression_body: {
+               condition_expression: {
                  "should be at most %{count} character(s)",
                  [
                    {:count, 255},
@@ -270,13 +270,13 @@ defmodule Lightning.Workflows.EdgeTest do
           edge,
           Map.put(
             js_attrs,
-            :js_expression_body,
+            :condition_expression,
             "state.data.foo == 'bar';"
           )
         )
 
       assert changeset.errors == [
-               js_expression_body: {"must not contain a statement", []}
+               condition_expression: {"must not contain a statement", []}
              ]
 
       changeset =
@@ -284,13 +284,13 @@ defmodule Lightning.Workflows.EdgeTest do
           edge,
           Map.put(
             js_attrs,
-            :js_expression_body,
+            :condition_expression,
             "{ state.data.foo == 'bar' }"
           )
         )
 
       assert changeset.errors == [
-               js_expression_body: {"must not contain a statement", []}
+               condition_expression: {"must not contain a statement", []}
              ]
 
       changeset =
@@ -298,7 +298,7 @@ defmodule Lightning.Workflows.EdgeTest do
           edge,
           Map.put(
             js_attrs,
-            :js_expression_body,
+            :condition_expression,
             "state.data.foo == 'bar' || state.data.bar == 'foo'"
           )
         )
@@ -324,13 +324,13 @@ defmodule Lightning.Workflows.EdgeTest do
           edge,
           Map.put(
             js_attrs,
-            :js_expression_body,
+            :condition_expression,
             "{ var fs = require('fs'); }"
           )
         )
 
       assert changeset.errors == [
-               js_expression_body:
+               condition_expression:
                  {"must not contain import or require statements", []}
              ]
 
@@ -339,13 +339,13 @@ defmodule Lightning.Workflows.EdgeTest do
           edge,
           Map.put(
             js_attrs,
-            :js_expression_body,
+            :condition_expression,
             "{ var fs = import('fs'); }"
           )
         )
 
       assert changeset.errors == [
-               js_expression_body:
+               condition_expression:
                  {"must not contain import or require statements", []}
              ]
     end

--- a/test/lightning/workflows/edge_test.exs
+++ b/test/lightning/workflows/edge_test.exs
@@ -8,7 +8,7 @@ defmodule Lightning.Workflows.EdgeTest do
       changeset =
         Edge.changeset(%Edge{}, %{
           workflow_id: Ecto.UUID.generate(),
-          condition: :on_job_success
+          condition_type: :on_job_success
         })
 
       assert changeset.valid?
@@ -20,7 +20,7 @@ defmodule Lightning.Workflows.EdgeTest do
       refute changeset.valid?
 
       assert changeset.errors == [
-               condition: {"can't be blank", [validation: :required]}
+               condition_type: {"can't be blank", [validation: :required]}
              ]
     end
 
@@ -29,12 +29,12 @@ defmodule Lightning.Workflows.EdgeTest do
         Edge.changeset(%Edge{}, %{
           workflow_id: Ecto.UUID.generate(),
           source_trigger_id: Ecto.UUID.generate(),
-          condition: "on_job_success"
+          condition_type: "on_job_success"
         })
 
       refute changeset.valid?
 
-      assert {:condition,
+      assert {:condition_type,
               {"must be :always or :js_expression when source is a trigger",
                [validation: :inclusion, enum: [:always, :js_expression]]}} in changeset.errors
     end
@@ -74,7 +74,7 @@ defmodule Lightning.Workflows.EdgeTest do
         Edge.changeset(%Edge{}, %{
           workflow_id: Ecto.UUID.generate(),
           source_job_id: job_id,
-          condition: :on_job_success,
+          condition_type: :on_job_success,
           target_job_id: job_id
         })
 
@@ -89,7 +89,7 @@ defmodule Lightning.Workflows.EdgeTest do
         Edge.changeset(%Edge{}, %{
           workflow_id: Ecto.UUID.generate(),
           source_job_id: job_id,
-          condition: :on_job_success,
+          condition_type: :on_job_success,
           target_job_id: Ecto.UUID.generate()
         })
 
@@ -103,7 +103,7 @@ defmodule Lightning.Workflows.EdgeTest do
       changeset =
         Edge.changeset(%Edge{}, %{
           workflow_id: workflow.id,
-          condition: :on_job_success,
+          condition_type: :on_job_success,
           source_job_id: job.id
         })
 
@@ -123,7 +123,7 @@ defmodule Lightning.Workflows.EdgeTest do
       changeset =
         Edge.changeset(%Edge{}, %{
           workflow_id: workflow.id,
-          condition: :on_job_success,
+          condition_type: :on_job_success,
           target_job_id: job.id
         })
 
@@ -153,7 +153,7 @@ defmodule Lightning.Workflows.EdgeTest do
       changeset =
         Edge.changeset(%Edge{}, %{
           workflow_id: workflow.id,
-          condition: :always,
+          condition_type: :always,
           source_trigger_id: trigger.id
         })
 
@@ -176,7 +176,7 @@ defmodule Lightning.Workflows.EdgeTest do
         Edge.changeset(%Edge{}, %{
           workflow_id: Ecto.UUID.generate(),
           target_job_id: Ecto.UUID.generate(),
-          condition: :on_job_success
+          condition_type: :on_job_success
         })
 
       assert changeset.valid?
@@ -192,7 +192,7 @@ defmodule Lightning.Workflows.EdgeTest do
           workflow_id: Ecto.UUID.generate(),
           source_trigger_id: Ecto.UUID.generate(),
           target_job_id: Ecto.UUID.generate(),
-          condition: :always
+          condition_type: :always
         })
 
       assert changeset.valid?
@@ -211,7 +211,7 @@ defmodule Lightning.Workflows.EdgeTest do
             source_job_id: Ecto.UUID.generate(),
             enabled: true
           },
-          %{condition: :js_expression}
+          %{condition_type: :js_expression}
         )
 
       assert changeset.errors == [
@@ -230,7 +230,7 @@ defmodule Lightning.Workflows.EdgeTest do
             enabled: true
           },
           %{
-            condition: :js_expression,
+            condition_type: :js_expression,
             js_expression_label: String.duplicate("a", 256),
             js_expression_body: String.duplicate("a", 256)
           }
@@ -261,7 +261,7 @@ defmodule Lightning.Workflows.EdgeTest do
       }
 
       js_attrs = %{
-        condition: :js_expression,
+        condition_type: :js_expression,
         js_expression_label: "Some JS Expression"
       }
 
@@ -315,7 +315,7 @@ defmodule Lightning.Workflows.EdgeTest do
       }
 
       js_attrs = %{
-        condition: :js_expression,
+        condition_type: :js_expression,
         js_expression_label: "Some JS Expression"
       }
 

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -131,7 +131,7 @@ defmodule Lightning.WorkflowsTest do
         edges: [
           %{
             source_trigger_id: trigger_id,
-            condition: :always,
+            condition_type: :always,
             target_job_id: job_id
           }
         ]
@@ -161,7 +161,7 @@ defmodule Lightning.WorkflowsTest do
           %{
             source_trigger_id: trigger_id,
             target_job_id: job_id,
-            condition: :always
+            condition_type: :always
           }
         ]
       }
@@ -178,7 +178,7 @@ defmodule Lightning.WorkflowsTest do
             id: edge.id,
             source_trigger_id: trigger_id,
             target_job_id: job_id,
-            condition: :always
+            condition_type: :always
           }
         ]
       }
@@ -272,7 +272,7 @@ defmodule Lightning.WorkflowsTest do
       insert(:edge,
         workflow: w1,
         source_job: w1_job,
-        condition: :on_job_failure,
+        condition_type: :on_job_failure,
         target_job:
           insert(:job,
             name: "on fail",
@@ -284,7 +284,7 @@ defmodule Lightning.WorkflowsTest do
       insert(:edge,
         workflow: w1,
         source_job: w1_job,
-        condition: :on_job_success,
+        condition_type: :on_job_success,
         target_job:
           insert(:job,
             name: "on success",
@@ -304,7 +304,7 @@ defmodule Lightning.WorkflowsTest do
       insert(:edge,
         workflow: w2,
         source_job: w2_job,
-        condition: :on_job_failure,
+        condition_type: :on_job_failure,
         target_job:
           insert(:job,
             name: "on fail",

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -166,7 +166,6 @@ defmodule LightningWeb.AttemptChannelTest do
               :id,
               :source_trigger_id,
               :source_job_id,
-              :condition,
               :enabled,
               :target_job_id
             ])
@@ -794,7 +793,7 @@ defmodule LightningWeb.AttemptChannelTest do
       |> with_trigger(trigger)
       |> with_job(job)
       |> with_edge({trigger, job}, %{
-        condition: :js_expression,
+        condition_type: :js_expression,
         js_expression_body: "state.a == 33"
       })
       |> insert()

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -794,7 +794,7 @@ defmodule LightningWeb.AttemptChannelTest do
       |> with_job(job)
       |> with_edge({trigger, job}, %{
         condition_type: :js_expression,
-        js_expression_body: "state.a == 33"
+        condition_expression: "state.a == 33"
       })
       |> insert()
 

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -376,7 +376,7 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
             %{
               "id" => job_edge_id,
               "source_job_id" => first_job_id,
-              "condition" => "on_job_success",
+              "condition_type" => "on_job_success",
               "target_job_id" => second_job_id
             }
           ]

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -156,7 +156,7 @@ defmodule LightningWeb.EndToEndTest do
         target_job_id: expression1_job.id,
         condition_type: :js_expression,
         condition_label: "less_than_1000",
-        js_expression_body: "state.x < 1000"
+        condition_expression: "state.x < 1000"
       })
 
       webhook_body = %{"fieldOne" => 123, "fieldTwo" => "some string"}

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -155,7 +155,7 @@ defmodule LightningWeb.EndToEndTest do
         workflow: workflow,
         target_job_id: expression1_job.id,
         condition_type: :js_expression,
-        js_expression_label: "less_than_1000",
+        condition_label: "less_than_1000",
         js_expression_body: "state.x < 1000"
       })
 

--- a/test/lightning_web/end_to_end_test.exs
+++ b/test/lightning_web/end_to_end_test.exs
@@ -122,7 +122,7 @@ defmodule LightningWeb.EndToEndTest do
         workflow: workflow,
         source_job_id: first_job.id,
         target_job_id: flow_job.id,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
       catch_job =
@@ -138,7 +138,7 @@ defmodule LightningWeb.EndToEndTest do
         source_job_id: flow_job.id,
         workflow: workflow,
         target_job_id: catch_job.id,
-        condition: :on_job_failure
+        condition_type: :on_job_failure
       })
 
       expression1_job =
@@ -154,7 +154,7 @@ defmodule LightningWeb.EndToEndTest do
         source_job_id: catch_job.id,
         workflow: workflow,
         target_job_id: expression1_job.id,
-        condition: :js_expression,
+        condition_type: :js_expression,
         js_expression_label: "less_than_1000",
         js_expression_body: "state.x < 1000"
       })

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -772,7 +772,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         workflow: workflow,
         source_trigger: trigger,
         target_job: job,
-        condition: :always,
+        condition_type: :always,
         enabled: true
       )
 
@@ -858,7 +858,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         workflow: workflow,
         source_trigger: trigger,
         target_job: job,
-        condition: :always,
+        condition_type: :always,
         enabled: true
       )
 

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -961,7 +961,7 @@ defmodule LightningWeb.RunWorkOrderTest do
         workflow: workflow,
         source_trigger: trigger,
         target_job: job,
-        condition: :always,
+        condition_type: :always,
         enabled: true
       )
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -310,7 +310,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         view
         |> form("#workflow-form", %{
           "workflow" => %{
-            "edges" => %{"1" => %{"condition" => "js_expression"}}
+            "edges" => %{"1" => %{"condition_type" => "js_expression"}}
           }
         })
         |> render_change()
@@ -340,7 +340,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert Map.delete(Repo.reload!(edge_on_edit), :updated_at) ==
                Map.delete(
                  Map.merge(edge_on_edit, %{
-                   condition: :js_expression,
+                   condition_type: :js_expression,
                    js_expression_label: "My JS Expression",
                    js_expression_body: "state.data.field === 33"
                  }),
@@ -465,7 +465,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       view |> select_node(workflow.edges |> Enum.at(0))
 
-      assert view |> input_is_disabled?("[name='workflow[edges][0][condition]']")
+      assert view
+             |> input_is_disabled?("[name='workflow[edges][0][condition_type]']")
 
       assert view |> save_is_disabled?()
       job_1 = workflow.jobs |> Enum.at(0)

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -325,7 +325,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         "workflow" => %{
           "edges" => %{
             "1" => %{
-              "js_expression_label" => "My JS Expression",
+              "condition_label" => "My JS Expression",
               "js_expression_body" => "state.data.field === 33"
             }
           }
@@ -341,7 +341,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
                Map.delete(
                  Map.merge(edge_on_edit, %{
                    condition_type: :js_expression,
-                   js_expression_label: "My JS Expression",
+                   condition_label: "My JS Expression",
                    js_expression_body: "state.data.field === 33"
                  }),
                  :updated_at

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -326,7 +326,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           "edges" => %{
             "1" => %{
               "condition_label" => "My JS Expression",
-              "js_expression_body" => "state.data.field === 33"
+              "condition_expression" => "state.data.field === 33"
             }
           }
         }
@@ -342,7 +342,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
                  Map.merge(edge_on_edit, %{
                    condition_type: :js_expression,
                    condition_label: "My JS Expression",
-                   js_expression_body: "state.data.field === 33"
+                   condition_expression: "state.data.field === 33"
                  }),
                  :updated_at
                )

--- a/test/lightning_web/live/workflow_live/workflow_params_test.exs
+++ b/test/lightning_web/live/workflow_live/workflow_params_test.exs
@@ -60,7 +60,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "condition" => "on_job_failure",
                    "enabled" => true,
                    "errors" => %{
-                     "condition" => [
+                     "condition_type" => [
                        "The condition must be 'Always' or 'JS expression' when the source is trigger."
                      ]
                    },
@@ -82,7 +82,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                "errors" => %{
                  "edges" => [
                    %{
-                     "condition" => [
+                     "condition_type" => [
                        "The condition must be 'Always' or 'JS expression' when the source is trigger."
                      ]
                    },

--- a/test/lightning_web/live/workflow_live/workflow_params_test.exs
+++ b/test/lightning_web/live/workflow_live/workflow_params_test.exs
@@ -23,14 +23,14 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
         %{
           "id" => Ecto.UUID.generate(),
           "source_trigger_id" => trigger_1_id,
-          "condition" => "on_job_failure",
+          "condition_type" => "on_job_failure",
           "target_job_id" => job_1_id,
           "enabled" => true
         },
         %{
           "id" => Ecto.UUID.generate(),
           "source_job_id" => job_1_id,
-          "condition" => "on_job_success",
+          "condition_type" => "on_job_success",
           "target_job_id" => job_2_id,
           "enabled" => true
         }
@@ -57,7 +57,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
       assert %{
                "edges" => [
                  %{
-                   "condition" => "on_job_failure",
+                   "condition_type" => "on_job_failure",
                    "enabled" => true,
                    "errors" => %{
                      "condition_type" => [
@@ -70,7 +70,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "target_job_id" => ^job_1_id
                  },
                  %{
-                   "condition" => "on_job_success",
+                   "condition_type" => "on_job_success",
                    "enabled" => true,
                    "errors" => %{},
                    "id" => _,
@@ -160,7 +160,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
       assert %{
                "edges" => [
                  %{
-                   "condition" => "on_job_failure",
+                   "condition_type" => "on_job_failure",
                    "enabled" => true,
                    "errors" => %{},
                    "id" => _,
@@ -169,7 +169,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "target_job_id" => ^job_1_id
                  },
                  %{
-                   "condition" => "on_job_success",
+                   "condition_type" => "on_job_success",
                    "enabled" => true,
                    "errors" => %{},
                    "id" => _,

--- a/test/support/fixtures/jobs_fixtures.ex
+++ b/test/support/fixtures/jobs_fixtures.ex
@@ -109,7 +109,7 @@ defmodule Lightning.JobsFixtures do
         workflow: attrs[:workflow],
         source_trigger: t,
         target_job: job,
-        condition: :always,
+        condition_type: :always,
         enabled: true
       )
 
@@ -164,7 +164,7 @@ defmodule Lightning.JobsFixtures do
         workflow: workflow,
         source_job: job_a,
         target_job: job_b,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
     job_c = insert(:job, %{name: "job_c", workflow: workflow})
@@ -174,7 +174,7 @@ defmodule Lightning.JobsFixtures do
         workflow: workflow,
         source_job: job_b,
         target_job: job_c,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
     job_d = insert(:job, %{name: "job_d", workflow: workflow})
@@ -184,7 +184,7 @@ defmodule Lightning.JobsFixtures do
         workflow: workflow,
         source_job: job_c,
         target_job: job_d,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
     job_e = insert(:job, %{name: "job_e", workflow: workflow})
@@ -194,7 +194,7 @@ defmodule Lightning.JobsFixtures do
         workflow: workflow,
         source_job: job_a,
         target_job: job_e,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
     job_f = insert(:job, %{name: "job_f", workflow: workflow})
@@ -204,7 +204,7 @@ defmodule Lightning.JobsFixtures do
         workflow: workflow,
         source_job: job_e,
         target_job: job_f,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
     job_g = insert(:job, %{workflow: workflow, name: "job_g"})
@@ -214,7 +214,7 @@ defmodule Lightning.JobsFixtures do
         workflow: workflow,
         source_job: job_f,
         target_job: job_g,
-        condition: :on_job_success
+        condition_type: :on_job_success
       })
 
     %{

--- a/test/support/workflow_live_helpers.ex
+++ b/test/support/workflow_live_helpers.ex
@@ -216,7 +216,7 @@ defmodule Lightning.WorkflowLive.Helpers do
           %{
             "id" => Ecto.UUID.generate(),
             "source_trigger_id" => trigger_id,
-            "condition" => :always,
+            "condition_type" => :always,
             "target_job_id" => job_id
           }
         ],
@@ -358,9 +358,9 @@ defmodule Lightning.WorkflowLive.Helpers do
       build(:workflow, project: project)
       |> with_job(job_1)
       |> with_trigger(trigger)
-      |> with_edge({trigger, job_1}, %{condition: :always})
+      |> with_edge({trigger, job_1}, %{condition_type: :always})
       |> with_job(job_2)
-      |> with_edge({job_1, job_2}, %{condition: :on_job_success})
+      |> with_edge({job_1, job_2}, %{condition_type: :on_job_success})
       |> insert()
 
     %{workflow: workflow |> Lightning.Repo.preload([:jobs, :triggers, :edges])}


### PR DESCRIPTION
## Notes for the reviewer

Following the best practice that allows proper debugging of refactoring side effects, this PR complements [`1498-edge-js-expression`](https://github.com/OpenFn/Lightning/pull/1547) by renaming `condition` to `condition_type` and `js_expression_body` to `condition_expression`

## Related issue

Refs #1498 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
