### PR TITLE
Export includes additional condition fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 - Fix RuntimeError: found duplicate ID "google-sheets-inner-form" for
   GoogleSheetsComponent [#1578](https://github.com/OpenFn/Lightning/issues/1578)
+- Extend export script to include new JS expression edge type
+  [#1540](https://github.com/OpenFn/Lightning/issues/1540)
 
 ## [v0.12.1] - 2023-12-21
 
@@ -45,8 +47,6 @@ and this project adheres to
   [#1515](https://github.com/OpenFn/Lightning/issues/1515)
 - Allow Javascript expressions as conditions for edges
   [#1498](https://github.com/OpenFn/Lightning/issues/1498)
-- Extend export script to include new JS expression edge type
-  [#1540](https://github.com/OpenFn/Lightning/issues/1540)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to
   [#1515](https://github.com/OpenFn/Lightning/issues/1515)
 - Allow Javascript expressions as conditions for edges
   [#1498](https://github.com/OpenFn/Lightning/issues/1498)
+- Extend export script to include new JS expression edge type
+  [#1540](https://github.com/OpenFn/Lightning/issues/1540)
 
 ### Changed
 


### PR DESCRIPTION
## Notes for the reviewer

Include the fields `condition_label` and `condition_expression` on exported file. 

Validation steps:
1. Edit a workflow job selecting the condition "Matches a JS expression"
2. Set the condition label and expression
3. Save
4. Go to settings and export the project
5. The downloaded file should contain the fields added fields, besides `condition_type`.

## Related issue

Solves #1540 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
