### PR TITLE
Rerun jobs from the job inspector modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to
 
 ### Added
 
-- Close the loop between History and Inspector
+- Link to the job inspctor for a selected run from the history interface
+  [#1524](https://github.com/OpenFn/Lightning/issues/1524)
+- Reprocess an existing workorder from the job inspector by default (instead of
+  always creating a new workorder)
   [#1524](https://github.com/OpenFn/Lightning/issues/1524)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ and this project adheres to
 
 ### Changed
 
+- Updated naming to prepare for v2 release
+  [#1248](https://github.com/OpenFn/Lightning/issues/1248); the major change is
+  that each time a work order (the typical unit of business value for an
+  organization, e.g. "execute workflow ABC for patient 123") is executed, it is
+  called a "run". Previously, it was called an "attempt". The hierarchy is now:
+
+  ```
+  Build-Time: Projects > Workflows > Steps
+  Run-Time: Work Orders > Runs > Steps
+  ```
+
+  Note the name changes here are reflected in the UI, but not all tables/models
+  will be changed until [1571](https://github.com/OpenFn/Lightning/issues/1571)
+  is delivered.
+
 ### Fixed
 
 ## [v0.12.2] - 2023-12-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Close the loop between History and Inspector
+  [#1524](https://github.com/OpenFn/Lightning/issues/1524)
+
 ### Changed
 
 ### Fixed

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -241,8 +241,6 @@ export const SaveAndRunViaCtrlEnter = createKeyCombinationHook(
   submitAction
 );
 
-// export const RetryOrCreateNewWorkOrder = 
-
 /**
  * Hook to trigger a close action on the job panel when the Escape key is pressed.
  */

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -180,6 +180,16 @@ function createKeyCombinationHook(
 }
 
 /**
+ * Function to dispatch a click event on the provided element.
+ *
+ * @param e - The keyboard event triggering the action.
+ * @param el - The HTML element to which the action will be applied.
+ */
+function clickAction(e: KeyboardEvent, el: HTMLElement) {
+  el.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
+}
+
+/**
  * Function to dispatch a submit event on the provided element.
  *
  * @param e - The keyboard event triggering the action.
@@ -203,6 +213,8 @@ const isCtrlOrMetaS = (e: KeyboardEvent) =>
   (e.ctrlKey || e.metaKey) && e.key === 's';
 const isCtrlOrMetaEnter = (e: KeyboardEvent) =>
   (e.ctrlKey || e.metaKey) && e.key === 'Enter';
+const isCtrlOrMetaShiftEnter = (e: KeyboardEvent) =>
+  (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'Enter';
 const isEscape = (e: KeyboardEvent) => e.key === 'Escape';
 
 /**
@@ -216,8 +228,16 @@ export const SaveViaCtrlS = createKeyCombinationHook(
 /**
  * Hook to trigger a save and run action on the job panel when the Ctrl (or Cmd on Mac) + Enter key combination is pressed.
  */
-export const SaveAndRunViaCtrlEnter = createKeyCombinationHook(
+export const RetryViaCtrlShiftEnter = createKeyCombinationHook(
   isCtrlOrMetaEnter,
+  clickAction
+);
+
+/**
+ * Hook to trigger a retry action on the job panel when the Ctrl (or Cmd on Mac) + Shift + Enter key combination is pressed.
+ */
+export const SaveAndRunViaCtrlEnter = createKeyCombinationHook(
+  isCtrlOrMetaShiftEnter,
   submitAction
 );
 

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -186,7 +186,15 @@ function createKeyCombinationHook(
  * @param el - The HTML element to which the action will be applied.
  */
 function clickAction(e: KeyboardEvent, el: HTMLElement) {
-  el.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
+  if (el.getAttribute('type') == 'submit') {
+    const formId = el.getAttribute('form');
+    const form = document.getElementById(formId);
+    form.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+  } else {
+    el.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
+  }
 }
 
 /**
@@ -212,17 +220,11 @@ function closeAction(e: KeyboardEvent, el: HTMLElement) {
 const isCtrlOrMetaS = (e: KeyboardEvent) =>
   (e.ctrlKey || e.metaKey) && e.key === 's';
 
-const isCtrlOrMetaEnter = (e: KeyboardEvent) => {
-  const test = (e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'Enter';
-  console.log('cntrl-enter', test);
-  return test;
-};
+const isCtrlOrMetaEnter = (e: KeyboardEvent) =>
+  (e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'Enter';
 
-const isCtrlOrMetaShiftEnter = (e: KeyboardEvent) => {
-  const test = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'Enter';
-  console.log('cntrl-shift-enter', test);
-  return test;
-};
+const isCtrlOrMetaShiftEnter = (e: KeyboardEvent) =>
+  (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'Enter';
 
 const isEscape = (e: KeyboardEvent) => e.key === 'Escape';
 
@@ -245,14 +247,6 @@ export const DefaultRunViaCtrlEnter = createKeyCombinationHook(
 export const AltRunViaCtrlShiftEnter = createKeyCombinationHook(
   isCtrlOrMetaShiftEnter,
   clickAction
-);
-
-/**
- * Hook to trigger a retry action on the job panel when the Ctrl (or Cmd on Mac) + Shift + Enter key combination is pressed.
- */
-export const SaveAndRunViaCtrlEnter = createKeyCombinationHook(
-  isCtrlOrMetaShiftEnter,
-  submitAction
 );
 
 /**

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -241,6 +241,8 @@ export const SaveAndRunViaCtrlEnter = createKeyCombinationHook(
   submitAction
 );
 
+// export const RetryOrCreateNewWorkOrder = 
+
 /**
  * Hook to trigger a close action on the job panel when the Escape key is pressed.
  */

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -211,10 +211,19 @@ function closeAction(e: KeyboardEvent, el: HTMLElement) {
 
 const isCtrlOrMetaS = (e: KeyboardEvent) =>
   (e.ctrlKey || e.metaKey) && e.key === 's';
-const isCtrlOrMetaEnter = (e: KeyboardEvent) =>
-  (e.ctrlKey || e.metaKey) && e.key === 'Enter';
-const isCtrlOrMetaShiftEnter = (e: KeyboardEvent) =>
-  (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'Enter';
+
+const isCtrlOrMetaEnter = (e: KeyboardEvent) => {
+  const test = (e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'Enter';
+  console.log('cntrl-enter', test);
+  return test;
+};
+
+const isCtrlOrMetaShiftEnter = (e: KeyboardEvent) => {
+  const test = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'Enter';
+  console.log('cntrl-shift-enter', test);
+  return test;
+};
+
 const isEscape = (e: KeyboardEvent) => e.key === 'Escape';
 
 /**
@@ -228,8 +237,13 @@ export const SaveViaCtrlS = createKeyCombinationHook(
 /**
  * Hook to trigger a save and run action on the job panel when the Ctrl (or Cmd on Mac) + Enter key combination is pressed.
  */
-export const RetryViaCtrlShiftEnter = createKeyCombinationHook(
+export const DefaultRunViaCtrlEnter = createKeyCombinationHook(
   isCtrlOrMetaEnter,
+  clickAction
+);
+
+export const AltRunViaCtrlShiftEnter = createKeyCombinationHook(
+  isCtrlOrMetaShiftEnter,
   clickAction
 );
 

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -109,7 +109,7 @@ export default {
     });
 
     this.handleEvent<{ href: string; patch: boolean }>('navigate', e => {
-      const id = new URL(e.href).searchParams.get('s');
+      const id = new URL(window.location.href).searchParams.get('s');
 
       if (e.patch && this.component) this.component.render(id);
     });

--- a/lib/lightning/digest_email_worker.ex
+++ b/lib/lightning/digest_email_worker.ex
@@ -90,7 +90,7 @@ defmodule Lightning.DigestEmailWorker do
   end
 
   @doc """
-  Get a map of counts for successful, rerun and failed Workorders for a given workflow in a given timeframe.
+  Get a map of counts for successful, rerun and failed Work Orders for a given workflow in a given timeframe.
   """
   def get_digest_data(workflow, start_date, end_date) do
     project = Projects.get_project!(workflow.project_id)

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -95,6 +95,21 @@ defmodule Lightning.Invocation do
     Repo.one(query)
   end
 
+  @spec get_run_for_attempt_and_job(
+          attempt_id :: Ecto.UUID.t(),
+          job_id :: Ecto.UUID.t()
+        ) ::
+          Lightning.Invocation.Run.t() | nil
+  def get_run_for_attempt_and_job(attempt_id, job_id) do
+    query =
+      from r in Lightning.Invocation.Run,
+        join: a in assoc(r, :attempts),
+        on: a.id == ^attempt_id,
+        where: r.job_id == ^job_id
+
+    Repo.one(query)
+  end
+
   @doc """
   Gets a single dataclip.
 

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -2,9 +2,9 @@ defmodule Lightning.WorkOrders do
   @moduledoc """
   Context for creating WorkOrders.
 
-  ## Workorders
+  ## Work Orders
 
-  Workorders represent the entrypoint for a unit of work in Lightning.
+  Work Orders represent the entrypoint for a unit of work in Lightning.
   They allow you to track the status of a webhook or cron trigger.
 
   For example if a user makes a request to a webhook endpoint, a Work Order

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -17,7 +17,7 @@ defmodule LightningWeb.Components.NewInputs do
   """
   attr :id, :string, default: ""
   attr :type, :string, default: "button", values: ["button", "submit"]
-  attr :class, :string, default: nil
+  attr :class, :any, default: nil
   attr :rest, :global, include: ~w(disabled form name value)
   attr :tooltip, :any, default: nil
 

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -39,7 +39,7 @@ defmodule LightningWeb.Components.NewInputs do
           "focus:ring-2 focus:ring-offset-2 focus:ring-primary-500",
           "bg-primary-600 hover:bg-primary-700",
           "disabled:bg-primary-300",
-          "phx-submit-loading:opacity-75 ",
+          "phx-submit-loading:opacity-75",
           @class
         ]}
         {@rest}

--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -44,7 +44,9 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
                 <:label>Run</:label>
                 <:value>
                   <.link
-                    navigate={~p"/projects/#{@project}/attempts/#{attempt}"}
+                    navigate={
+                      ~p"/projects/#{@project}/attempts/#{attempt}?r=#{@selected_run_id}"
+                    }
                     class="hover:underline hover:text-primary-900 whitespace-nowrap text-ellipsis"
                   >
                     <span class="whitespace-nowrap text-ellipsis">

--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -45,7 +45,7 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
                 <:value>
                   <.link
                     navigate={
-                      ~p"/projects/#{@project}/attempts/#{attempt}?r=#{@selected_run_id}"
+                      ~p"/projects/#{@project}/attempts/#{attempt}?r=#{@selected_run_id || ""}"
                     }
                     class="hover:underline hover:text-primary-900 whitespace-nowrap text-ellipsis"
                   >

--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -41,7 +41,7 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
                 </:value>
               </.list_item>
               <.list_item>
-                <:label>Attempt</:label>
+                <:label>Run</:label>
                 <:value>
                   <.link
                     navigate={~p"/projects/#{@project}/attempts/#{attempt}"}
@@ -74,6 +74,9 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
             >
               <.step_item
                 run={run}
+                is_clone={
+                  DateTime.compare(run.inserted_at, attempt.inserted_at) == :lt
+                }
                 phx-click="select_run"
                 phx-value-id={run.id}
                 selected={run.id == @selected_run_id}

--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -55,7 +55,18 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
                 </:value>
               </.list_item>
               <.list_item>
-                <:label>Elapsed</:label>
+                <:label>Started</:label>
+                <:value>
+                  <%= if attempt.started_at,
+                    do:
+                      Timex.Format.DateTime.Formatters.Relative.format!(
+                        attempt.started_at,
+                        "{relative}"
+                      ) %>
+                </:value>
+              </.list_item>
+              <.list_item>
+                <:label>Duration</:label>
                 <:value>
                   <.elapsed_indicator attempt={attempt} />
                 </:value>

--- a/lib/lightning_web/live/attempt_live/components.ex
+++ b/lib/lightning_web/live/attempt_live/components.ex
@@ -191,11 +191,17 @@ defmodule LightningWeb.AttemptLive.Components do
   end
 
   attr :run, Lightning.Invocation.Run, required: true
+  attr :show_inspector_link, :boolean, default: false
+  attr :attempt_id, :string
+  attr :project_id, :string
   attr :selected, :boolean, default: false
   attr :class, :string, default: ""
   attr :rest, :global
 
   def step_item(assigns) do
+    # TODO - add dataclip and workorder
+    # <> "?i=DATACLIP_ID&m=expand&wo=WORKORDER_ID"
+
     ~H"""
     <div
       class={[
@@ -215,6 +221,18 @@ defmodule LightningWeb.AttemptLive.Components do
         <div>
           <p class="text-sm text-gray-900">
             <%= @run.job.name %>
+            <%= if @show_inspector_link do %>
+              <.link navigate={
+                ~p"/projects/#{@project_id}/w/#{@run.job.workflow_id}"
+                  <> "?a=#{@attempt_id}&m=expand&s=#{@run.job_id}"
+              }>
+                <.icon
+                  title="Inspect Step"
+                  name="hero-document-magnifying-glass-mini"
+                  class="h-4 w-4 mb-2 hover:text-primary-400"
+                />
+              </.link>
+            <% end %>
           </p>
         </div>
         <div class="whitespace-nowrap text-right text-sm text-gray-500">

--- a/lib/lightning_web/live/attempt_live/components.ex
+++ b/lib/lightning_web/live/attempt_live/components.ex
@@ -191,6 +191,7 @@ defmodule LightningWeb.AttemptLive.Components do
   end
 
   attr :run, Lightning.Invocation.Run, required: true
+  attr :is_clone, :boolean, default: false
   attr :show_inspector_link, :boolean, default: false
   attr :attempt_id, :string
   attr :project_id, :string
@@ -217,7 +218,28 @@ defmodule LightningWeb.AttemptLive.Components do
       <div class="flex items-center">
         <.run_state_circle run={@run} />
       </div>
-      <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5 pr-1.5">
+      <div class={[
+        "flex min-w-0 flex-1 justify-between space-x-4 pt-1.5 pr-1.5",
+        if(@is_clone, do: "opacity-50")
+      ]}>
+        <%= if @is_clone do %>
+          <div class="flex">
+            <span
+              class="cursor-pointer"
+              id={"clone_" <> @run.id}
+              aria-label="This step was originally executed in a previous attempt.
+                    It was skipped in this attempt; the original output has been
+                    used as the starting point for downstream jobs."
+              phx-hook="Tooltip"
+              data-placement="bottom"
+            >
+              <Heroicons.paper_clip
+                mini
+                class="mr-1 mt-1 h-3 w-3 flex-shrink-0 text-gray-500"
+              />
+            </span>
+          </div>
+        <% end %>
         <div>
           <p class="text-sm text-gray-900">
             <%= @run.job.name %>

--- a/lib/lightning_web/live/attempt_live/show.ex
+++ b/lib/lightning_web/live/attempt_live/show.ex
@@ -91,15 +91,14 @@ defmodule LightningWeb.AttemptLive.Show do
                   <:value>
                     <%= if attempt.finished_at,
                       do:
-                        Timex.format!(
+                        Timex.Format.DateTime.Formatters.Relative.format!(
                           attempt.finished_at,
-                          "%d/%b/%y, %H:%M:%S",
-                          :strftime
+                          "{relative}"
                         ) %>
                   </:value>
                 </.list_item>
                 <.list_item>
-                  <:label>Elapsed</:label>
+                  <:label>Duration</:label>
                   <:value>
                     <.elapsed_indicator attempt={attempt} />
                   </:value>

--- a/lib/lightning_web/live/attempt_live/show.ex
+++ b/lib/lightning_web/live/attempt_live/show.ex
@@ -20,7 +20,12 @@ defmodule LightningWeb.AttemptLive.Show do
     <LayoutComponents.page_content>
       <:header>
         <LayoutComponents.header current_user={@current_user}>
-          <:title><%= @page_title %></:title>
+          <:title>
+            <%= @page_title %>
+            <span class="pl-2 font-light">
+              <%= display_short_uuid(@id) %>
+            </span>
+          </:title>
         </LayoutComponents.header>
       </:header>
 
@@ -30,7 +35,7 @@ defmodule LightningWeb.AttemptLive.Show do
             <.loading_filler />
           </:loading>
           <:failed :let={_reason}>
-            there was an error loading the attemptanization
+            there was an error loading the run
           </:failed>
 
           <div class="flex gap-6 @5xl/main:flex-row flex-col">
@@ -39,6 +44,20 @@ defmodule LightningWeb.AttemptLive.Show do
                 id={"attempt-detail-#{attempt.id}"}
                 class="flex-1 @5xl/main:flex-none"
               >
+                <.list_item>
+                  <:label>Workflow</:label>
+                  <:value>
+                    <.link
+                      navigate={~p"/projects/#{@project}/w/#{@workflow.id}"}
+                      class="hover:underline hover:text-primary-900 whitespace-nowrap text-ellipsis"
+                    >
+                      <span class="whitespace-nowrap text-ellipsis">
+                        <%= display_short_uuid(@workflow.id) %>
+                      </span>
+                      <.icon name="hero-arrow-up-right" class="h-2 w-2 float-right" />
+                    </.link>
+                  </:value>
+                </.list_item>
                 <.list_item>
                   <:label>Work Order</:label>
                   <:value>
@@ -56,11 +75,27 @@ defmodule LightningWeb.AttemptLive.Show do
                   </:value>
                 </.list_item>
                 <.list_item>
-                  <:label>Attempt</:label>
+                  <:label>Started</:label>
                   <:value>
-                    <span class="whitespace-nowrap text-ellipsis pr-2">
-                      <%= display_short_uuid(attempt.id) %>
-                    </span>
+                    <%= if attempt.started_at,
+                      do:
+                        Timex.format!(
+                          attempt.started_at,
+                          "%d/%b/%y, %H:%M:%S",
+                          :strftime
+                        ) %>
+                  </:value>
+                </.list_item>
+                <.list_item>
+                  <:label>Finished</:label>
+                  <:value>
+                    <%= if attempt.finished_at,
+                      do:
+                        Timex.format!(
+                          attempt.finished_at,
+                          "%d/%b/%y, %H:%M:%S",
+                          :strftime
+                        ) %>
                   </:value>
                 </.list_item>
                 <.list_item>
@@ -84,6 +119,9 @@ defmodule LightningWeb.AttemptLive.Show do
                 <.link patch={"?r=#{run.id}"} id={"select-run-#{run.id}"}>
                   <.step_item
                     run={run}
+                    is_clone={
+                      DateTime.compare(run.inserted_at, attempt.inserted_at) == :lt
+                    }
                     selected={run.id == @selected_run_id}
                     show_inspector_link={true}
                     attempt_id={attempt.id}
@@ -105,6 +143,7 @@ defmodule LightningWeb.AttemptLive.Show do
                   orientation="horizontal"
                   hash="input"
                   disabled={@no_run_selected?}
+                  disabled_msg="A valid step must be selected to view its input"
                 >
                   <.icon
                     name="hero-arrow-down-on-square"
@@ -116,6 +155,7 @@ defmodule LightningWeb.AttemptLive.Show do
                   orientation="horizontal"
                   hash="output"
                   disabled={@no_run_selected?}
+                  disabled_msg="A valid step (with a readable output) must be selected to view its output"
                 >
                   <.icon
                     name="hero-arrow-up-on-square"
@@ -172,7 +212,8 @@ defmodule LightningWeb.AttemptLive.Show do
      socket
      |> assign(
        active_menu_item: :runs,
-       page_title: "Attempt",
+       page_title: "Run",
+       id: id,
        selected_run_id: nil,
        runs: []
      )

--- a/lib/lightning_web/live/attempt_live/show.ex
+++ b/lib/lightning_web/live/attempt_live/show.ex
@@ -82,7 +82,13 @@ defmodule LightningWeb.AttemptLive.Show do
                 class="flex-1"
               >
                 <.link patch={"?r=#{run.id}"} id={"select-run-#{run.id}"}>
-                  <.step_item run={run} selected={run.id == @selected_run_id} />
+                  <.step_item
+                    run={run}
+                    selected={run.id == @selected_run_id}
+                    show_inspector_link={true}
+                    attempt_id={attempt.id}
+                    project_id={@project}
+                  />
                 </.link>
               </.step_list>
             </div>

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -368,6 +368,7 @@ defmodule LightningWeb.Components.Common do
   attr :hash, :string, required: true
   attr :orientation, :string, required: true, values: ["horizontal", "vertical"]
   attr :disabled, :boolean, default: false
+  attr :disabled_msg, :string, default: "Unavailable"
   slot :inner_block, required: true
 
   def tab_item(assigns) do
@@ -407,6 +408,9 @@ defmodule LightningWeb.Components.Common do
     <%= if @disabled do %>
       <span
         id={"tab-item-#{@hash}"}
+        aria-label={@disabled_msg}
+        phx-hook="Tooltip"
+        data-placement="bottom"
         class={[@base_classes, @orientation_classes, @disabled_classes]}
         data-disabled
         data-hash={@hash}

--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -84,7 +84,7 @@ defmodule LightningWeb.CredentialLive.TypePicker do
   @impl true
   def handle_event(
         "type_changed",
-        %{"_target" => _target, "type" => %{"selected" => type}},
+        %{"type" => %{"selected" => type}},
         socket
       ) do
     send(self(), {:credential_type_changed, type})

--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -82,7 +82,11 @@ defmodule LightningWeb.CredentialLive.TypePicker do
   end
 
   @impl true
-  def handle_event("type_changed", %{"type" => %{"selected" => type}}, socket) do
+  def handle_event(
+        "type_changed",
+        %{"_target" => _target, "type" => %{"selected" => type}},
+        socket
+      ) do
     send(self(), {:credential_type_changed, type})
     {:noreply, socket}
   end

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -103,7 +103,7 @@ defmodule LightningWeb.RunLive.Components do
                 </span>
               </div>
             <% end %>
-            <div class="flex gap-1">
+            <div class="flex gap-3">
               <%= if @can_rerun_job && @run.exit_reason do %>
                 <span
                   id={@run.id}
@@ -116,6 +116,19 @@ defmodule LightningWeb.RunLive.Components do
                   rerun
                 </span>
               <% end %>
+              <.link
+                class="inline-flex items-center gap-x-0.5 text-indigo-400 hover:text-indigo-500 cursor-pointer"
+                navigate={
+                ~p"/projects/#{@project_id}/w/#{@run.job.workflow_id}"
+                  <> "?a=#{@attempt.id}&m=expand&s=#{@run.job_id}"
+              }
+              >
+                <.icon
+                  title="Inspect Step"
+                  name="hero-document-magnifying-glass-mini"
+                  class="h-4 w-4"
+                /> inspect
+              </.link>
             </div>
           </div>
         </div>

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -90,8 +90,8 @@ defmodule LightningWeb.RunLive.Components do
                 <span
                   class="cursor-pointer"
                   id={"clone_" <> @attempt.id <> "_" <> @run.id}
-                  aria-label="This run was originally executed in a previous attempt.
-                    It was skipped in this attempt; the original output has been
+                  aria-label="This step was originally executed in a previous run.
+                    It was skipped in this run; the original output has been
                     used as the starting point for downstream jobs."
                   phx-hook="Tooltip"
                   data-placement="right"
@@ -103,7 +103,7 @@ defmodule LightningWeb.RunLive.Components do
                 </span>
               </div>
             <% end %>
-            <div class="flex gap-1 text-xs">
+            <div class="flex gap-1 text-xs leading-5">
               <%= if @can_rerun_job && @run.exit_reason do %>
                 <span
                   id={@run.id}

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -103,7 +103,7 @@ defmodule LightningWeb.RunLive.Components do
                 </span>
               </div>
             <% end %>
-            <div class="flex gap-3">
+            <div class="flex gap-1 text-xs">
               <%= if @can_rerun_job && @run.exit_reason do %>
                 <span
                   id={@run.id}
@@ -114,20 +114,16 @@ defmodule LightningWeb.RunLive.Components do
                   title="Rerun workflow from here"
                 >
                   rerun
-                </span>
+                </span>/
               <% end %>
               <.link
-                class="inline-flex items-center gap-x-0.5 text-indigo-400 hover:text-indigo-500 cursor-pointer"
+                class="text-indigo-400 hover:underline hover:underline-offset-2 hover:text-indigo-500 cursor-pointer"
                 navigate={
                 ~p"/projects/#{@project_id}/w/#{@run.job.workflow_id}"
                   <> "?a=#{@attempt.id}&m=expand&s=#{@run.job_id}"
               }
               >
-                <.icon
-                  title="Inspect Step"
-                  name="hero-document-magnifying-glass-mini"
-                  class="h-4 w-4"
-                /> inspect
+                inspect
               </.link>
             </div>
           </div>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -679,7 +679,7 @@
                     class="px-4 py-3.5 text-sm font-normal text-left rtl:text-right text-gray-500"
                   >
                     <div>
-                      <p class="text-sm text-gray-500 mb-1">Run</p>
+                      <p class="text-sm text-gray-500 mb-1">Step</p>
                       <span class="text-gray-700 mt-2 font-medium">
                         STARTED AT
                       </span>
@@ -691,7 +691,7 @@
                     class="px-4 py-3.5 text-sm font-normal text-left rtl:text-right text-gray-500"
                   >
                     <div>
-                      <p class="text-sm text-gray-500 mb-1">Run</p>
+                      <p class="text-sm text-gray-500 mb-1">Step</p>
                       <span class="text-gray-700 mt-2 font-medium">
                         FINISHED AT
                       </span>

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -230,6 +230,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
             <div>
               <div class="flex gap-1 items-center bg-gray-200 pl-28 text-xs py-2">
                 <div>
+                  Run
                   <.link navigate={
                     ~p"/projects/#{@project.id}/attempts/#{attempt.id}"
                   }>
@@ -243,6 +244,25 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
                       <%= display_short_uuid(attempt.id) %>
                     </span>
                   </.link>
+                  <%= if Enum.count(@attempts) > 1 do %>
+                    (<%= index %>/<%= Enum.count(@attempts) %><%= if index !=
+                                                                       Enum.count(
+                                                                         @attempts
+                                                                       ),
+                                                                     do: ")" %>
+                    <%= if index == Enum.count(@attempts) do %>
+                      <span>
+                        &bull; <a
+                          id={"toggle_attempts_for_#{@work_order.id}"}
+                          href="#"
+                          class="text-indigo-400"
+                          phx-click="toggle_attempts"
+                          phx-target={@myself}
+                        >
+                        <%= if @show_prev_attempts, do: "hide", else: "show" %> previous</a>)
+                      </span>
+                    <% end %>
+                  <% end %>
                   <%= case attempt.state do %>
                     <% :available -> %>
                       enqueued @ <.timestamp timestamp={attempt.inserted_at} />
@@ -255,21 +275,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
                       <.timestamp timestamp={attempt.finished_at} />
                   <% end %>
                 </div>
-                <p class="text-gray-800">
-                  <%= if Enum.count(@attempts) > 1 do %>
-                    - attempt <%= index %> of <%= Enum.count(@attempts) %>
-                    <a
-                      :if={index == Enum.count(@attempts)}
-                      id={"toggle_attempts_for_#{@work_order.id}"}
-                      href="#"
-                      class="text-blue-600"
-                      phx-click="toggle_attempts"
-                      phx-target={@myself}
-                    >
-                      <%= if @show_prev_attempts, do: "hide", else: "show" %> previous
-                    </a>
-                  <% end %>
-                </p>
               </div>
             </div>
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -109,7 +109,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   <.save_is_blocked_error :if={
                     editor_is_empty(@workflow_form, @selected_job)
                   }>
-                    The job can't be blank
+                    The step can't be blank
                   </.save_is_blocked_error>
 
                   <.icon
@@ -337,9 +337,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         class="focus:ring-red-500 bg-red-600 hover:bg-red-700 disabled:bg-red-300"
                         disabled={!@can_edit_job or has_child_edges or is_first_job}
                         tooltip={deletion_tooltip_message(@has_multiple_jobs)}
-                        data-confirm="Are you sure you want to delete this Job?"
+                        data-confirm="Are you sure you want to delete this step?"
                       >
-                        Delete Job
+                        Delete Step
                       </.button>
                     </label>
                   </div>
@@ -427,9 +427,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   defp deletion_tooltip_message(has_multiple_jobs) do
     if has_multiple_jobs do
-      "You can't delete a job that has downstream jobs flowing from it."
+      "You can't delete a step that other downstream steps depend on."
     else
-      "You can't delete the only job in a workflow."
+      "You can't delete the only step in a workflow."
     end
   end
 
@@ -454,7 +454,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     </.link>
 
     <.save_is_blocked_error :if={@is_empty}>
-      The job can't be blank
+      The step can't be blank
     </.save_is_blocked_error>
     """
   end
@@ -690,12 +690,12 @@ defmodule LightningWeb.WorkflowLive.Edit do
       :has_child_edges ->
         {:noreply,
          socket
-         |> put_flash(:error, "Delete all descendant jobs first.")}
+         |> put_flash(:error, "Delete all descendant steps first.")}
 
       :is_first_job ->
         {:noreply,
          socket
-         |> put_flash(:error, "You can't delete the first job of a workflow.")}
+         |> put_flash(:error, "You can't delete the first step of a workflow.")}
     end
   end
 
@@ -1064,7 +1064,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     |> Map.get(workflow_attribute, %{})
     |> Map.to_list()
     |> then(fn
-      [{index, %{"condition_type" => "js_expression"} = map}] ->
+      [{index, %{"condition_type" => "js_expression"} = _map}] ->
         [
           edge_edit_index: String.to_integer(index)
         ]

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1048,21 +1048,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
-  defp get_params_opts_for(workflow_attribute, params) do
-    params
-    |> Map.get(workflow_attribute, %{})
-    |> Map.to_list()
-    |> then(fn
-      [{index, %{"condition_type" => "js_expression"} = _map}] ->
-        [
-          edge_edit_index: String.to_integer(index)
-        ]
-
-      _other ->
-        []
-    end)
-  end
-
   defp webhook_url(trigger) do
     trigger
     |> case do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -116,6 +116,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   <div class="inline-flex rounded-md shadow-sm">
                     <%= if @run && @run.input_dataclip_id == @manual_run_form[:dataclip_id].value do %>
                       <.button
+                        id="retry-attempt"
+                        phx-hook="RetryViaCtrlShiftEnter"
                         phx-click="rerun"
                         phx-value-attempt_id={@follow_attempt_id}
                         phx-value-run_id={@run.id}

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -117,7 +117,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     <%!-- TODO: pass RUN id in here --%>
                     <%!-- TODO: logic -> only allow retry if selected_dataclip == run.input_dataclip --%>
                     <%= if @follow_attempt_id do %>
-                      <.button
+                      <%!-- <.button
                         phx-click="rerun"
                         phx-value-attempt_id={@follow_attempt_id}
                         phx-value-run_id={@run.id}
@@ -130,7 +130,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       >
                         <.icon name="hero-arrow-path-mini" class="w-4 h-4" />
                         Retry from here
-                      </.button>
+                      </.button> --%>
                       <div class="relative -ml-px block">
                         <.button
                           type="button"

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -114,74 +114,82 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     class="w-5 h-5 place-self-center text-gray-300"
                   />
                   <div class="inline-flex rounded-md shadow-sm">
-                    <.button
-                      type="submit"
-                      class="relative inline-flex
-                      items-center rounded-l-md rounded-r-none
-                      px-3 py-2 text-sm font-semibold
-                      text-gray-900
-                      hover:bg-gray-50 focus:z-10"
-                      form={@manual_run_form.id}
-                      disabled={@save_and_run_disabled}
-                    >
-                      Create new work order
-                    </.button>
-
-                    <div class="relative -ml-px block">
+                    <%!-- TODO: pass RUN id in here --%>
+                    <%!-- TODO: logic -> only allow retry if selected_dataclip == run.input_dataclip --%>
+                    <%= if @follow_attempt_id do %>
                       <.button
-                        type="button"
-                        class="relative inline-flex items-center rounded-r-md rounded-l-none text-white pr-1 pl-1"
-                        id="option-menu-button"
-                        aria-expanded="true"
-                        aria-haspopup="true"
-                        phx-click={show_dropdown("new_attempt_menu")}
+                        phx-click="rerun"
+                        phx-value-attempt_id={@follow_attempt_id}
+                        phx-value-run_id={@run.id}
+                        class="relative inline-flex gap-x-1.5
+                          items-center rounded-l-md rounded-r-none
+                          px-3 py-2 text-sm font-semibold
+                          text-gray-900
+                          hover:bg-gray-50 focus:z-10"
+                        disabled={@save_and_run_disabled}
                       >
-                        <span class="sr-only">Open options</span>
-                        <svg
-                          class="h-5 w-5"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                          aria-hidden="true"
-                        >
-                          <path
-                            fill-rule="evenodd"
-                            d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                            clip-rule="evenodd"
-                          />
-                        </svg>
+                        <.icon name="hero-arrow-path-mini" class="w-4 h-4" />
+                        Retry from here
                       </.button>
-                      <div
-                        phx-click-away={hide_dropdown("new_attempt_menu")}
-                        id="new_attempt_menu"
-                        class="hidden absolute right-0 bottom-9 z-10 mb-2 w-80
-                          origin-bottom-right rounded-md bg-white shadow-lg focus:outline-none ring-1 ring-black ring-opacity-5"
-                        role="menu"
-                        aria-orientation="vertical"
-                        aria-labelledby="option-menu-button"
-                        tabindex="-1"
-                      >
-                        <div class="py-1" role="none">
-                          <a
-                            href="#"
-                            class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900"
-                            role="menuitem"
-                            tabindex="-1"
-                            id="option-menu-item-0"
+                      <div class="relative -ml-px block">
+                        <.button
+                          type="button"
+                          class="relative inline-flex items-center rounded-r-md rounded-l-none text-white pr-1 pl-1"
+                          id="option-menu-button"
+                          aria-expanded="true"
+                          aria-haspopup="true"
+                          phx-click={show_dropdown("new_attempt_menu")}
+                        >
+                          <span class="sr-only">Open options</span>
+                          <svg
+                            class="h-5 w-5"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            aria-hidden="true"
                           >
-                            Create new attempt for this work order
-                          </a>
-                          <a
-                            href="#"
-                            class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900"
-                            role="menuitem"
-                            tabindex="-1"
-                            id="option-menu-item-1"
+                            <path
+                              fill-rule="evenodd"
+                              d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                              clip-rule="evenodd"
+                            />
+                          </svg>
+                        </.button>
+                        <div
+                          role="menu"
+                          aria-orientation="vertical"
+                          aria-labelledby="option-menu-button"
+                          tabindex="-1"
+                        >
+                          <button
+                            phx-click-away={hide_dropdown("new_attempt_menu")}
+                            id="new_attempt_menu"
+                            type="submit"
+                            class={[
+                              "hidden absolute right-0 bottom-9 z-10 mb-2 w-56",
+                              "inline-flex justify-center py-2 px-4 border border-gray-50",
+                              "bg-white hover:bg-gray-100 text-gray-700 hover:text-gray-900",
+                              "shadow-md text-sm font-medium rounded-md focus:outline-none",
+                              "gap-x-1.5 items-center"
+                            ]}
+                            form={@manual_run_form.id}
+                            disabled={@save_and_run_disabled}
                           >
-                            Create new work order
-                          </a>
+                            <.icon name="hero-play-solid" class="w-4 h-4" />
+                            Create New Work Order
+                          </button>
                         </div>
                       </div>
-                    </div>
+                    <% else %>
+                      <.button
+                        type="submit"
+                        class="inline-flex items-center gap-x-1.5"
+                        form={@manual_run_form.id}
+                        disabled={@save_and_run_disabled}
+                      >
+                        <.icon name="hero-play-solid" class="w-4 h-4" />
+                        Create New Work Order
+                      </.button>
+                    <% end %>
                   </div>
                   <.with_changes_indicator changeset={@changeset}>
                     <Form.submit_button
@@ -741,6 +749,33 @@ defmodule LightningWeb.WorkflowLive.Edit do
     {:noreply, socket |> assign_manual_run_form(changeset)}
   end
 
+  @doc """
+  The retry_from_run event is for creating a new attempt for an existing work
+  order, just like clicking "rerun from here" on the history page.
+  """
+  @impl true
+  def handle_event(
+        "rerun",
+        %{"attempt_id" => attempt_id, "run_id" => run_id},
+        socket
+      ) do
+    if socket.assigns.can_rerun_job do
+      WorkOrders.retry(attempt_id, run_id,
+        created_by: socket.assigns.current_user
+      )
+
+      {:noreply, socket}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "You are not authorized to perform this action.")}
+    end
+  end
+
+  @doc """
+  The manual_run_submit event is for create a new work order from a dataclip and
+  a job.
+  """
   def handle_event("manual_run_submit", %{"manual" => params}, socket) do
     %{
       project: project,
@@ -752,23 +787,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
       can_run_job: can_run_job
     } = socket.assigns
 
-    IO.inspect(socket.assigns, label: "what do we have here?")
-
-    # TODO - get attempt.id (optional, from URL is fine)
-    # assigns.follow_attempt_id DONE!
-
-    # TODO - get attempt_run.run.input_dataclip_id (optional)
-
-    # TODO - get dataclip_id (optional, from URL is fine)
-    # assigns.selected_dataclip_id (FRANK?)
-
     socket = socket |> apply_params(workflow_params)
 
     if can_run_job && can_edit_job do
       Helpers.save_and_run(
         socket.assigns.changeset,
-        # TODO - either create a new work order or create a new attempt for an
-        # existing work order
         WorkOrders.Manual.new(
           params,
           workflow: workflow,

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -123,7 +123,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       <.icon name="hero-play-solid" class="w-4 h-4" /> Save & Run
                     </.button>
                   </div>
-
                   <.with_changes_indicator changeset={@changeset}>
                     <Form.submit_button
                       class=""
@@ -693,11 +692,15 @@ defmodule LightningWeb.WorkflowLive.Edit do
       can_run_job: can_run_job
     } = socket.assigns
 
+    IO.inspect(socket.assigns, label: "what do we have here?")
+
     socket = socket |> apply_params(workflow_params)
 
     if can_run_job && can_edit_job do
       Helpers.save_and_run(
         socket.assigns.changeset,
+        # TODO - either create a new work order or create a new attempt for an
+        # existing work order
         WorkOrders.Manual.new(
           params,
           workflow: workflow,

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -113,15 +113,75 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     name="hero-lock-closed"
                     class="w-5 h-5 place-self-center text-gray-300"
                   />
-                  <div>
+                  <div class="inline-flex rounded-md shadow-sm">
                     <.button
                       type="submit"
-                      class="inline-flex items-center gap-x-1.5"
+                      class="relative inline-flex
+                      items-center rounded-l-md rounded-r-none
+                      px-3 py-2 text-sm font-semibold
+                      text-gray-900
+                      hover:bg-gray-50 focus:z-10"
                       form={@manual_run_form.id}
                       disabled={@save_and_run_disabled}
                     >
-                      <.icon name="hero-play-solid" class="w-4 h-4" /> Save & Run
+                      Create new work order
                     </.button>
+
+                    <div class="relative -ml-px block">
+                      <.button
+                        type="button"
+                        class="relative inline-flex items-center rounded-r-md rounded-l-none text-white pr-1 pl-1"
+                        id="option-menu-button"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        phx-click={show_dropdown("new_attempt_menu")}
+                      >
+                        <span class="sr-only">Open options</span>
+                        <svg
+                          class="h-5 w-5"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            fill-rule="evenodd"
+                            d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                            clip-rule="evenodd"
+                          />
+                        </svg>
+                      </.button>
+                      <div
+                        phx-click-away={hide_dropdown("new_attempt_menu")}
+                        id="new_attempt_menu"
+                        class="hidden absolute right-0 bottom-9 z-10 mb-2 w-80
+                          origin-bottom-right rounded-md bg-white shadow-lg focus:outline-none ring-1 ring-black ring-opacity-5"
+                        role="menu"
+                        aria-orientation="vertical"
+                        aria-labelledby="option-menu-button"
+                        tabindex="-1"
+                      >
+                        <div class="py-1" role="none">
+                          <a
+                            href="#"
+                            class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900"
+                            role="menuitem"
+                            tabindex="-1"
+                            id="option-menu-item-0"
+                          >
+                            Create new attempt for this work order
+                          </a>
+                          <a
+                            href="#"
+                            class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900"
+                            role="menuitem"
+                            tabindex="-1"
+                            id="option-menu-item-1"
+                          >
+                            Create new work order
+                          </a>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                   <.with_changes_indicator changeset={@changeset}>
                     <Form.submit_button

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -137,7 +137,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       <%= if @run && @run.input_dataclip_id == @manual_run_form[:dataclip_id].value do %>
                         <.button
                           id="retry-attempt"
-                          phx-hook="RetryViaCtrlShiftEnter"
+                          phx-hook="RetryOrCreateNewWorkOrder"
+                          data-action-type="primary"
                           phx-click="rerun"
                           phx-value-attempt_id={@follow_attempt_id}
                           phx-value-run_id={@run.id}
@@ -184,6 +185,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
                             <button
                               phx-click-away={hide_dropdown("new_attempt_menu")}
                               id="new_attempt_menu"
+                              phx-hook="RetryOrCreateNewWorkOrder"
+                              data-action-type="secondary"
                               type="submit"
                               class={[
                                 "hidden absolute right-0 bottom-9 z-10 mb-2 w-56",
@@ -202,6 +205,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         </div>
                       <% else %>
                         <.button
+                          id="save-and-run"
+                          phx-hook="RetryOrCreateNewWorkOrder"
+                          data-action-type="primary"
                           type="submit"
                           class="inline-flex items-center gap-x-1.5"
                           form={@manual_run_form.id}
@@ -884,7 +890,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
   def handle_info(
         %RunCompleted{run: run},
         socket
-      ) do
+      )
+      when run.job_id === socket.assigns.selected_job.id do
     dataclip = Invocation.get_dataclip_details!(run.input_dataclip_id)
 
     selectable_dataclips =

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -123,15 +123,17 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     phx-hook="RunViaKeyBinding"
                   >
                     <.button
-                      id="create-or-retry-workorder"
+                      id="save-and-run"
                       {if retry_from_here(@run, @manual_run_form), do:
                         [type: "button", "phx-click": "rerun", "phx-value-attempt_id": @follow_attempt_id, "phx-value-run_id": @run.id],
                       else:
                           [type: "submit", form: @manual_run_form.id]}
-                      class={"relative inline-flex gap-x-1.5 items-center rounded-l-md
-                        rounded-r-#{if retry_from_here(@run, @manual_run_form), do: 'none', else: 'md'}
-                        px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50 focus:z-10
-                        focus:outline-none outline-none focus:ring-none focus:ring-offset-none"}
+                      class={[
+                        "relative inline-flex gap-x-1.5 items-center",
+                        retry_from_here(@run, @manual_run_form) && "rounded-r-none",
+                        "px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50 focus:z-10",
+                        "focus:outline-none outline-none focus:ring-none focus:ring-offset-none"
+                      ]}
                       disabled={
                         @save_and_run_disabled ||
                           processing(@follow_attempt_id, @run)

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -694,6 +694,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     IO.inspect(socket.assigns, label: "what do we have here?")
 
+    # TODO - get attempt.id (optional, from URL is fine)
+    # assigns.follow_attempt_id DONE!
+
+    # TODO - get attempt_run.run.input_dataclip_id (optional)
+
+    # TODO - get dataclip_id (optional, from URL is fine)
+    # assigns.selected_dataclip_id (FRANK?)
+
     socket = socket |> apply_params(workflow_params)
 
     if can_run_job && can_edit_job do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -117,107 +117,92 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     name="hero-lock-closed"
                     class="w-5 h-5 place-self-center text-gray-300"
                   />
-                  <div class="inline-flex rounded-md shadow-sm">
-                    <%= if @follow_attempt_id && !@run do %>
-                      <.button
-                        id="processing"
-                        disabled="true"
-                        class="relative inline-flex gap-x-1.5
-                          items-center
-                          px-3 py-2 text-sm font-semibold
-                          text-gray-900
-                          hover:bg-gray-50 focus:z-10"
-                      >
+                  <div
+                    id="run-buttons"
+                    class="inline-flex rounded-md shadow-sm"
+                    phx-hook="RunViaKeyBinding"
+                  >
+                    <.button
+                      id="create-or-retry-workorder"
+                      {if retry_from_here(@run, @manual_run_form), do:
+                        [type: "button", "phx-click": "rerun", "phx-value-attempt_id": @follow_attempt_id, "phx-value-run_id": @run.id],
+                      else:
+                          [type: "submit", form: @manual_run_form.id]}
+                      class={"relative inline-flex gap-x-1.5 items-center rounded-l-md
+                        rounded-r-#{if retry_from_here(@run, @manual_run_form), do: 'none', else: 'md'}
+                        px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50 focus:z-10
+                        focus:outline-none outline-none focus:ring-none focus:ring-offset-none"}
+                      disabled={
+                        @save_and_run_disabled ||
+                          processing(@follow_attempt_id, @run)
+                      }
+                    >
+                      <%= if processing(@follow_attempt_id, @run) do %>
                         <.icon
                           name="hero-arrow-path-mini"
                           class="w-4 h-4 animate-spin"
-                        /> Running
-                      </.button>
-                    <% else %>
-                      <%= if @run && @run.input_dataclip_id == @manual_run_form[:dataclip_id].value do %>
-                        <.button
-                          id="retry-attempt"
-                          phx-hook="RetryOrCreateNewWorkOrder"
-                          data-action-type="primary"
-                          phx-click="rerun"
-                          phx-value-attempt_id={@follow_attempt_id}
-                          phx-value-run_id={@run.id}
-                          class="relative inline-flex gap-x-1.5
-                          items-center rounded-l-md rounded-r-none
-                          px-3 py-2 text-sm font-semibold
-                          text-gray-900
-                          hover:bg-gray-50 focus:z-10"
-                          disabled={@save_and_run_disabled}
-                        >
+                        /> Processing
+                      <% else %>
+                        <%= if retry_from_here(@run, @manual_run_form) do %>
                           <.icon name="hero-arrow-path-mini" class="w-4 h-4" />
                           Retry from here
-                        </.button>
-                        <div class="relative -ml-px block">
-                          <.button
-                            type="button"
-                            class="relative inline-flex items-center rounded-r-md rounded-l-none text-white pr-1 pl-1"
-                            id="option-menu-button"
-                            aria-expanded="true"
-                            aria-haspopup="true"
-                            disabled={@save_and_run_disabled}
-                            phx-click={show_dropdown("new_attempt_menu")}
-                          >
-                            <span class="sr-only">Open options</span>
-                            <svg
-                              class="h-5 w-5"
-                              viewBox="0 0 20 20"
-                              fill="currentColor"
-                              aria-hidden="true"
-                            >
-                              <path
-                                fill-rule="evenodd"
-                                d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                                clip-rule="evenodd"
-                              />
-                            </svg>
-                          </.button>
-                          <div
-                            role="menu"
-                            aria-orientation="vertical"
-                            aria-labelledby="option-menu-button"
-                            tabindex="-1"
-                          >
-                            <button
-                              phx-click-away={hide_dropdown("new_attempt_menu")}
-                              id="new_attempt_menu"
-                              phx-hook="RetryOrCreateNewWorkOrder"
-                              data-action-type="secondary"
-                              type="submit"
-                              class={[
-                                "hidden absolute right-0 bottom-9 z-10 mb-2 w-56",
-                                "inline-flex justify-center py-2 px-4 border border-gray-50",
-                                "bg-white hover:bg-gray-100 text-gray-700 hover:text-gray-900",
-                                "shadow-md text-sm font-medium rounded-md focus:outline-none",
-                                "gap-x-1.5 items-center"
-                              ]}
-                              form={@manual_run_form.id}
-                              disabled={@save_and_run_disabled}
-                            >
-                              <.icon name="hero-play-solid" class="w-4 h-4" />
-                              Create New Work Order
-                            </button>
-                          </div>
-                        </div>
-                      <% else %>
-                        <.button
-                          id="save-and-run"
-                          phx-hook="RetryOrCreateNewWorkOrder"
-                          data-action-type="primary"
+                        <% else %>
+                          <.icon name="hero-play-solid" class="w-4 h-4" />
+                          New work order
+                        <% end %>
+                      <% end %>
+                    </.button>
+                    <div
+                      :if={retry_from_here(@run, @manual_run_form)}
+                      class="relative -ml-px block"
+                    >
+                      <.button
+                        type="button"
+                        class="relative inline-flex items-center rounded-r-md rounded-l-none text-white pr-1 pl-1
+                          focus:outline-none outline-none focus:ring-none focus:ring-offset-none"
+                        id="option-menu-button"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        disabled={@save_and_run_disabled}
+                        phx-click={show_dropdown("create-new-work-order")}
+                      >
+                        <span class="sr-only">Open options</span>
+                        <svg
+                          class="h-5 w-5"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            fill-rule="evenodd"
+                            d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                            clip-rule="evenodd"
+                          />
+                        </svg>
+                      </.button>
+                      <div
+                        role="menu"
+                        aria-orientation="vertical"
+                        aria-labelledby="option-menu-button"
+                        tabindex="-1"
+                      >
+                        <button
+                          phx-click-away={hide_dropdown("create-new-work-order")}
+                          id="create-new-work-order"
                           type="submit"
-                          class="inline-flex items-center gap-x-1.5"
+                          class="hidden absolute right-0 bottom-9 z-10 mb-2 w-60
+                            inline-flex justify-center py-2 px-2 border border-gray-50
+                            bg-white hover:bg-gray-100 text-gray-700 hover:text-gray-900
+                            shadow-md text-sm font-medium rounded-md focus:outline-none
+                            gap-x-1.5 items-center outline-none focus:ring-none focus:ring-offset-none"
                           form={@manual_run_form.id}
                           disabled={@save_and_run_disabled}
                         >
                           <.icon name="hero-play-solid" class="w-4 h-4" />
-                          Create New Work Order
-                        </.button>
-                      <% end %>
-                    <% end %>
+                          New work order
+                        </button>
+                      </div>
+                    </div>
                   </div>
                   <.with_changes_indicator changeset={@changeset}>
                     <Form.submit_button
@@ -424,6 +409,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
     </LayoutComponents.page_content>
     """
   end
+
+  defp retry_from_here(run, form),
+    do: run && run.input_dataclip_id == form[:dataclip_id].value
+
+  defp processing(attempt_id, run), do: attempt_id && !run
 
   defp deletion_tooltip_message(has_multiple_jobs) do
     if has_multiple_jobs do
@@ -1049,7 +1039,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
         WorkflowParams.apply_form_params(socket.assigns.workflow_params, params)
 
       socket
-      |> apply_params(next_params, get_params_opts_for("edges", params))
+      |> apply_params(next_params)
       |> mark_validated()
       |> push_patches_applied(initial_params)
     else
@@ -1058,7 +1048,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
-  # Returns the inputs that have being edited on the form
   defp get_params_opts_for(workflow_attribute, params) do
     params
     |> Map.get(workflow_attribute, %{})
@@ -1095,7 +1084,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     |> apply_params(socket.assigns.workflow_params)
   end
 
-  defp apply_params(socket, params, opts \\ []) do
+  defp apply_params(socket, params) do
     # Build a new changeset from the new params
     changeset =
       socket.assigns.workflow
@@ -1104,36 +1093,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
         |> set_default_adaptors()
         |> Map.put("project_id", socket.assigns.project.id)
       )
-      |> then(fn
-        %Ecto.Changeset{changes: %{edges: edges} = changes} = changeset ->
-          edge_edit_index = Keyword.get(opts, :edge_edit_index, nil)
-
-          cleared_edges =
-            edges
-            |> Enum.with_index()
-            |> Enum.map(fn
-              {%{errors: errors, changes: changes} = edge, index}
-              when index == edge_edit_index ->
-                errors_fields_taken =
-                  if Map.has_key?(changes, :condition_expression),
-                    do: [:condition_label],
-                    else: []
-
-                # ignore errors for inputs that have not been edited
-                %{edge | errors: Keyword.take(errors, errors_fields_taken)}
-
-              {edge, _index} ->
-                edge
-            end)
-
-          %{
-            changeset
-            | changes: Map.put(changes, :edges, cleared_edges)
-          }
-
-        changeset ->
-          changeset
-      end)
 
     has_multiple_jobs =
       length(Ecto.Changeset.get_field(changeset, :jobs)) > 1

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -117,22 +117,17 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     name="hero-lock-closed"
                     class="w-5 h-5 place-self-center text-gray-300"
                   />
-                  <div
-                    id="run-buttons"
-                    class="inline-flex rounded-md shadow-sm"
-                    phx-hook="RunViaKeyBinding"
-                  >
+                  <div id="run-buttons" class="inline-flex rounded-md shadow-sm">
                     <.button
                       id="save-and-run"
+                      phx-hook="DefaultRunViaCtrlEnter"
                       {if retry_from_here(@run, @manual_run_form), do:
                         [type: "button", "phx-click": "rerun", "phx-value-attempt_id": @follow_attempt_id, "phx-value-run_id": @run.id],
                       else:
                           [type: "submit", form: @manual_run_form.id]}
                       class={[
-                        "relative inline-flex gap-x-1.5 items-center",
-                        retry_from_here(@run, @manual_run_form) && "rounded-r-none",
-                        "px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50 focus:z-10",
-                        "focus:outline-none outline-none focus:ring-none focus:ring-offset-none"
+                        "relative inline-flex items-center",
+                        retry_from_here(@run, @manual_run_form) && "rounded-r-none"
                       ]}
                       disabled={
                         @save_and_run_disabled ||
@@ -146,7 +141,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         /> Processing
                       <% else %>
                         <%= if retry_from_here(@run, @manual_run_form) do %>
-                          <.icon name="hero-arrow-path-mini" class="w-4 h-4" />
+                          <.icon name="hero-arrow-path-mini" class="w-4 h-4 mr-1" />
                           Rerun from here
                         <% else %>
                           <.icon name="hero-play-solid" class="w-4 h-4" />
@@ -160,8 +155,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     >
                       <.button
                         type="button"
-                        class="relative inline-flex items-center rounded-r-md rounded-l-none text-white pr-1 pl-1
-                          focus:outline-none outline-none focus:ring-none focus:ring-offset-none"
+                        class="rounded-l-none pr-1 pl-1 focus:ring-inset"
                         id="option-menu-button"
                         aria-expanded="true"
                         aria-haspopup="true"
@@ -190,13 +184,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       >
                         <button
                           phx-click-away={hide_dropdown("create-new-work-order")}
+                          phx-hook="AltRunViaCtrlShiftEnter"
                           id="create-new-work-order"
                           type="submit"
-                          class="hidden absolute right-0 bottom-9 z-10 mb-2 w-60
-                            inline-flex justify-center py-2 px-2 border border-gray-50
-                            bg-white hover:bg-gray-100 text-gray-700 hover:text-gray-900
-                            shadow-md text-sm font-medium rounded-md focus:outline-none
-                            gap-x-1.5 items-center outline-none focus:ring-none focus:ring-offset-none"
+                          class={[
+                            "hidden absolute right-0 bottom-9 z-10 mb-2 w-max",
+                            "rounded-md bg-white px-4 py-2 text-sm font-semibold",
+                            "text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                          ]}
                           form={@manual_run_form.id}
                           disabled={@save_and_run_disabled}
                         >

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -147,10 +147,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       <% else %>
                         <%= if retry_from_here(@run, @manual_run_form) do %>
                           <.icon name="hero-arrow-path-mini" class="w-4 h-4" />
-                          Retry from here
+                          Rerun from here
                         <% else %>
                           <.icon name="hero-play-solid" class="w-4 h-4" />
-                          New work order
+                          Create New Work Order
                         <% end %>
                       <% end %>
                     </.button>
@@ -201,7 +201,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                           disabled={@save_and_run_disabled}
                         >
                           <.icon name="hero-play-solid" class="w-4 h-4" />
-                          New work order
+                          Create New Work Order
                         </button>
                       </div>
                     </div>

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -24,7 +24,6 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
     <.form
       for={@form}
       id={@form.id}
-      phx-hook="SubmitViaCtrlEnter"
       phx-change="manual_run_change"
       phx-submit="manual_run_submit"
       class="h-full flex flex-col gap-4"

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -24,7 +24,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
     <.form
       for={@form}
       id={@form.id}
-      phx-hook="SaveAndRunViaCtrlEnter"
+      phx-hook="SubmitViaCtrlEnter"
       phx-change="manual_run_change"
       phx-submit="manual_run_submit"
       class="h-full flex flex-col gap-4"

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -35,7 +35,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
             type="select"
             field={@form[:dataclip_id]}
             options={@dataclips |> Enum.map(&{&1.id, &1.id})}
-            prompt="Create a new dataclip"
+            prompt="Create a new input"
             disabled={@disabled}
           />
         </div>
@@ -44,7 +44,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
       <div class="flex-0">
         <div class="flex flex-row">
           <div class="basis-1/2 font-semibold text-secondary-700 text-xs xl:text-base">
-            Dataclip Type
+            Type
           </div>
           <div class="basis-1/2 text-right">
             <Common.dataclip_type_pill type={
@@ -54,7 +54,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
         </div>
         <div class="flex flex-row mt-4">
           <div class="basis-1/2 font-semibold text-secondary-700 text-xs xl:text-base ">
-            State Assembly
+            Initial State
           </div>
           <div class="text-right text-xs xl:text-sm">
             <%= if(not is_nil(@selected_dataclip) and @selected_dataclip.type == :http_request) do %>

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -227,7 +227,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
            |> Floki.find(~s{span[id="clone_#{attempt2.id}_#{first_run.id}"]})
            |> Enum.any?()
 
-    assert html =~ "This run was originally executed in a previous attempt"
+    assert html =~ "This step was originally executed in a previous run"
 
     html =
       render_component(&Components.run_list_item/1,
@@ -242,7 +242,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
            |> Floki.find(~s{span[id="clone_#{attempt2.id}_#{first_run.id}"]})
            |> Enum.any?()
 
-    refute html =~ "This run was originally executed in a previous attempt"
+    refute html =~ "This step was originally executed in a previous run"
   end
 
   test "no rerun button is displayed when user can't rerun a job" do

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -242,12 +242,12 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       view |> change_editor_text("some body")
 
       refute view |> render() =~
-               "The job can&#39;t be blank"
+               "The step can&#39;t be blank"
 
       view |> change_editor_text("")
 
       assert view |> render() =~
-               "The job can&#39;t be blank"
+               "The step can&#39;t be blank"
     end
 
     test "allows editing job name", %{
@@ -359,7 +359,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       # Test that the delete event doesn't work even if the button is disabled.
       assert view |> force_event(:delete_node, job_1) =~
-               "Delete all descendant jobs first."
+               "Delete all descendant steps first."
 
       view |> select_node(job_2)
       assert_patched(view, ~p"/projects/#{project}/w/#{workflow}?s=#{job_2}")
@@ -403,7 +403,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert view |> delete_job_button_is_disabled?(job)
 
       assert view |> force_event(:delete_node, job) =~
-               "You can&#39;t delete the only job in a workflow."
+               "You can&#39;t delete the only step in a workflow."
     end
 
     @tag role: :editor
@@ -433,10 +433,10 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert view |> delete_job_button_is_disabled?(job_a)
 
       assert html =~
-               "You can&#39;t delete a job that has downstream jobs flowing from it."
+               "You can&#39;t delete a step that other downstream steps depend on"
 
       assert view |> force_event(:delete_node, job_a) =~
-               "Delete all descendant jobs first"
+               "Delete all descendant steps first"
 
       {:ok, view, html} =
         live(conn, ~p"/projects/#{project}/w/#{workflow}?s=#{job_b}")
@@ -444,10 +444,10 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert view |> delete_job_button_is_disabled?(job_b)
 
       assert html =~
-               "You can&#39;t delete a job that has downstream jobs flowing from it."
+               "You can&#39;t delete a step that other downstream steps depend on"
 
       assert view |> force_event(:delete_node, job_a) =~
-               "Delete all descendant jobs first"
+               "Delete all descendant steps first"
     end
 
     @tag role: :viewer

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -173,7 +173,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       assert view
              |> element(
                ~s{#manual-job-#{job.id} form select[name='manual[dataclip_id]'] option},
-               "Create a new dataclip"
+               "Create a new input"
              )
              |> has_element?()
 
@@ -187,7 +187,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       end
     end
 
-    test "can create a new dataclip", %{
+    test "can create a new input dataclip", %{
       conn: conn,
       project: p,
       workflow: w

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -282,7 +282,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       render_async(run_viewer)
 
       assert run_viewer
-             |> element("li:nth-child(4) dd", "Pending")
+             |> element("li:nth-child(5) dd", "Pending")
              |> has_element?()
     end
 
@@ -342,9 +342,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       assert render(element) =~ "selected"
 
       refute view
-             |> element(
-               ~s{button[type='submit'][form='manual_run_form'][disabled]}
-             )
+             |> element("save-and-run", ~c"Create New Work Order")
              |> has_element?()
     end
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -532,7 +532,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         )
 
       # user gets option to rerun
-      assert has_element?(view, "button", "Retry from here")
+      assert has_element?(view, "button", "Rerun from here")
       assert has_element?(view, "button", "Create New Work Order")
 
       # if we choose a different dataclip, the retry button disappears
@@ -540,7 +540,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       |> form("#manual_run_form", manual: %{dataclip_id: hd(dataclips).id})
       |> render_change()
 
-      refute has_element?(view, "button", "Retry from here")
+      refute has_element?(view, "button", "Rerun from here")
       assert has_element?(view, "button", "Create New Work Order")
 
       # if we choose the run input dataclip, the retry button becomes available
@@ -550,10 +550,10 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       |> form("#manual_run_form", manual: %{dataclip_id: run.input_dataclip_id})
       |> render_change()
 
-      assert has_element?(view, "button", "Retry from here")
+      assert has_element?(view, "button", "Rerun from here")
       assert has_element?(view, "button", "Create New Work Order")
 
-      view |> element("button", "Retry from here") |> render_click()
+      view |> element("button", "Rerun from here") |> render_click()
 
       all_attempts =
         Lightning.Repo.preload(workorder, [:attempts], force: true).attempts


### PR DESCRIPTION
## Notes for the reviewer

Still pending:
 
- [x] Make the `control-enter` behaviour bind to the main button action.
- [x] Make a new `control-shift-enter` behaviour bind to the secondary action if there is a secondary action.

@taylordowns2000 I have been able to add the binding for `control-shift-enter` as a `rerun` action, however, I haven't been able to swap them, such that `ctrl+enter` can trigger either depending on which primary button is available

## Related issue

Fixes #1524 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
