### PR TITLE
Fix Duplicate ID For GoogleSheetsComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix RuntimeError: found duplicate ID "google-sheets-inner-form" for
+  GoogleSheetsComponent [#1578](https://github.com/OpenFn/Lightning/issues/1578)
+
 ## [v0.12.0] - 2023-12-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix RuntimeError: found duplicate ID "google-sheets-inner-form" for
+  GoogleSheetsComponent [#1578](https://github.com/OpenFn/Lightning/issues/1578)
+
 ## [v0.12.1] - 2023-12-21
 
 ### Added
@@ -27,8 +30,6 @@ and this project adheres to
 
 - History page crashes if job is removed from workflow after it's been run
   [#1568](https://github.com/OpenFn/Lightning/issues/1568)
-- Fix RuntimeError: found duplicate ID "google-sheets-inner-form" for
-  GoogleSheetsComponent [#1578](https://github.com/OpenFn/Lightning/issues/1578)
 
 ## [v0.12.0] - 2023-12-15
 

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -329,6 +329,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
         >
           <.form_component
             :let={{fieldset, _valid?}}
+            id={@credential.id || "new"}
             form={f}
             type={@type}
             update_body={@update_body}
@@ -409,6 +410,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
 
   attr :type, :string, required: true
   attr :form, :map, required: true
+  attr :id, :string, required: false
   attr :update_body, :any, required: false
   attr :phx_target, :any, default: nil
   slot :inner_block
@@ -418,7 +420,12 @@ defmodule LightningWeb.CredentialLive.FormComponent do
   """
   def form_component(%{type: "googlesheets"} = assigns) do
     ~H"""
-    <GoogleSheetsComponent.fieldset :let={l} form={@form} update_body={@update_body}>
+    <GoogleSheetsComponent.fieldset
+      :let={l}
+      id={@id}
+      form={@form}
+      update_body={@update_body}
+    >
       <%= render_slot(@inner_block, l) %>
     </GoogleSheetsComponent.fieldset>
     """

--- a/lib/lightning_web/live/credential_live/google_sheets_component.ex
+++ b/lib/lightning_web/live/credential_live/google_sheets_component.ex
@@ -31,6 +31,7 @@ defmodule LightningWeb.CredentialLive.GoogleSheetsComponent do
   import LightningWeb.OauthCredentialHelper
 
   attr :form, :map, required: true
+  attr :id, :string, required: true
   attr :update_body, :any, required: true
   slot :inner_block
 

--- a/lib/lightning_web/live/credential_live/google_sheets_component.ex
+++ b/lib/lightning_web/live/credential_live/google_sheets_component.ex
@@ -62,7 +62,7 @@ defmodule LightningWeb.CredentialLive.GoogleSheetsComponent do
            form: @form,
            token_body_changeset: @token_body_changeset,
            update_body: @update_body,
-           id: "google-sheets-inner-form"
+           id: "google-sheets-inner-form-#{@id}"
          ],
          {__ENV__.module, __ENV__.function, __ENV__.file, __ENV__.line}
        ), @valid?}

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -902,16 +902,17 @@ defmodule LightningWeb.CredentialLiveTest do
 
       expires_at = DateTime.to_unix(DateTime.utc_now()) + 3600
 
-      credential = credential_fixture(
-        user_id: user.id,
-        schema: "googlesheets",
-        body: %{
-          access_token: "ya29.a0AVvZ...",
-          refresh_token: "1//03vpp6Li...",
-          expires_at: expires_at,
-          scope: "scope1 scope2"
-        }
-      )
+      credential =
+        credential_fixture(
+          user_id: user.id,
+          schema: "googlesheets",
+          body: %{
+            access_token: "ya29.a0AVvZ...",
+            refresh_token: "1//03vpp6Li...",
+            expires_at: expires_at,
+            scope: "scope1 scope2"
+          }
+        )
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -831,12 +831,12 @@ defmodule LightningWeb.CredentialLiveTest do
 
       # Click on the 'Authorize with Google button
       index_live
-      |> element("#google-sheets-inner-form #authorize-button")
+      |> element("#google-sheets-inner-form-new #authorize-button")
       |> render_click()
 
       # Once authorizing the button isn't available
       refute index_live
-             |> has_element?("#google-sheets-inner-form #authorize-button")
+             |> has_element?("#google-sheets-inner-form-new #authorize-button")
 
       # `handle_info/2` in LightingWeb.CredentialLive.Edit forwards the data
       # as a `send_update/3` call to the GoogleSheets component
@@ -902,7 +902,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       expires_at = DateTime.to_unix(DateTime.utc_now()) + 3600
 
-      credential_fixture(
+      credential = credential_fixture(
         user_id: user.id,
         schema: "googlesheets",
         body: %{
@@ -918,7 +918,7 @@ defmodule LightningWeb.CredentialLiveTest do
       assert_receive {:phoenix, :send_update, _}
 
       # Wait for the userinfo endpoint to be called
-      assert wait_for_assigns(edit_live, :userinfo),
+      assert wait_for_assigns(edit_live, :userinfo, credential.id),
              ":userinfo has not been set yet."
 
       edit_live |> render()
@@ -935,16 +935,17 @@ defmodule LightningWeb.CredentialLiveTest do
 
       expires_at = DateTime.to_unix(DateTime.utc_now()) + 3600
 
-      credential_fixture(
-        user_id: user.id,
-        schema: "googlesheets",
-        body: %{
-          access_token: "ya29.a0AVvZ...",
-          refresh_token: "",
-          expires_at: expires_at,
-          scope: "scope1 scope2"
-        }
-      )
+      credential =
+        credential_fixture(
+          user_id: user.id,
+          schema: "googlesheets",
+          body: %{
+            access_token: "ya29.a0AVvZ...",
+            refresh_token: "",
+            expires_at: expires_at,
+            scope: "scope1 scope2"
+          }
+        )
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
@@ -952,7 +953,7 @@ defmodule LightningWeb.CredentialLiveTest do
       assert_receive {:plug_conn, :sent}
 
       edit_live
-      |> element("#google-sheets-inner-form")
+      |> element("#google-sheets-inner-form-#{credential.id}")
       |> render()
 
       assert edit_live |> has_element?("p", "The token is missing it's")
@@ -975,16 +976,17 @@ defmodule LightningWeb.CredentialLiveTest do
 
       expires_at = DateTime.to_unix(DateTime.utc_now()) - 50
 
-      credential_fixture(
-        user_id: user.id,
-        schema: "googlesheets",
-        body: %{
-          access_token: "ya29.a0AVvZ...",
-          refresh_token: "1//03vpp6Li...",
-          expires_at: expires_at,
-          scope: "scope1 scope2"
-        }
-      )
+      credential =
+        credential_fixture(
+          user_id: user.id,
+          schema: "googlesheets",
+          body: %{
+            access_token: "ya29.a0AVvZ...",
+            refresh_token: "1//03vpp6Li...",
+            expires_at: expires_at,
+            scope: "scope1 scope2"
+          }
+        )
 
       expect_token(
         bypass,
@@ -1001,7 +1003,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :userinfo),
+      assert wait_for_assigns(edit_live, :userinfo, credential.id),
              ":userinfo has not been set yet."
 
       edit_live |> render()
@@ -1031,20 +1033,21 @@ defmodule LightningWeb.CredentialLiveTest do
 
       expires_at = DateTime.to_unix(DateTime.utc_now()) + 3600
 
-      credential_fixture(
-        user_id: user.id,
-        schema: "googlesheets",
-        body: %{
-          access_token: "ya29.a0AVvZ...",
-          refresh_token: "1//03vpp6Li...",
-          expires_at: expires_at,
-          scope: "scope1 scope2"
-        }
-      )
+      credential =
+        credential_fixture(
+          user_id: user.id,
+          schema: "googlesheets",
+          body: %{
+            access_token: "ya29.a0AVvZ...",
+            refresh_token: "1//03vpp6Li...",
+            expires_at: expires_at,
+            scope: "scope1 scope2"
+          }
+        )
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :error)
+      assert wait_for_assigns(edit_live, :error, credential.id)
 
       edit_live |> render()
 
@@ -1062,7 +1065,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       edit_live |> element("a", "try again.") |> render_click()
 
-      assert wait_for_assigns(edit_live, :userinfo)
+      assert wait_for_assigns(edit_live, :userinfo, credential.id)
 
       assert edit_live |> has_element?("span", "Test User")
     end
@@ -1089,20 +1092,21 @@ defmodule LightningWeb.CredentialLiveTest do
 
       expires_at = DateTime.to_unix(DateTime.utc_now()) - 50
 
-      credential_fixture(
-        user_id: user.id,
-        schema: "googlesheets",
-        body: %{
-          access_token: "ya29.a0AVvZ...",
-          refresh_token: "1//03vpp6Li...",
-          expires_at: expires_at,
-          scope: "scope1 scope2"
-        }
-      )
+      credential =
+        credential_fixture(
+          user_id: user.id,
+          schema: "googlesheets",
+          body: %{
+            access_token: "ya29.a0AVvZ...",
+            refresh_token: "1//03vpp6Li...",
+            expires_at: expires_at,
+            scope: "scope1 scope2"
+          }
+        )
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :error)
+      assert wait_for_assigns(edit_live, :error, credential.id)
 
       edit_live |> render()
 
@@ -1127,16 +1131,19 @@ defmodule LightningWeb.CredentialLiveTest do
       refute index_live |> has_element?("#credential-type-picker")
 
       assert index_live
-             |> has_element?("#google-sheets-inner-form", "No Client Configured")
+             |> has_element?(
+               "#google-sheets-inner-form-new",
+               "No Client Configured"
+             )
     end
   end
 
-  defp wait_for_assigns(live, key) do
+  defp wait_for_assigns(live, key, id \\ "new") do
     Enum.reduce_while(1..10, nil, fn n, _ ->
       {_mod, assigns} =
         Lightning.LiveViewHelpers.get_component_assigns_by(
           live,
-          id: "google-sheets-inner-form"
+          id: "google-sheets-inner-form-#{id}"
         )
 
       if val = assigns[key] do
@@ -1150,7 +1157,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
   defp get_authorize_url(live) do
     live
-    |> element("#google-sheets-inner-form")
+    |> element("#google-sheets-inner-form-new")
     |> render()
     |> Floki.parse_fragment!()
     |> Floki.find("a[phx-click=authorize_click]")


### PR DESCRIPTION
## Notes for the reviewer

- ### Identified Issue
The GoogleSheetsComponent.fieldset was initially instantiated with a fixed id: `google-sheets-inner-form`. This caused a runtime error in LiveView when multiple Google Sheets credentials were used, due to duplicate component ids.

- ### Proposed Fix
In this PR, I propose appending the credential uuid to the component id, resulting in `google-sheets-inner-form-#{@id}`. This approach ensures a unique, dynamic id for each Google Sheets credential, preventing the LiveView crash and resolving the issue.

- ### Additional Concern
I've identified a broader issue related to how we render modal components in pages listing resources (e.g., credentials, webhook authentication methods). Currently, live components are used within loops, leading to inefficiencies and a cluttered DOM. All modals for listed resources are loaded into the DOM, regardless of whether they are needed. This approach is suboptimal and should be reevaluated. I suggest that modals only be loaded into the DOM when necessary and fully removed upon closure, rather than being hidden via CSS. An issue has been opened [here](https://github.com/OpenFn/Lightning/issues/1588) to address this problem.

## Related issue

Fixes #1578 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
