### PR TITLE
Fixes on Sync to Github scenarios

### DIFF
--- a/lib/lightning_web/live/credential_live/type_picker.ex
+++ b/lib/lightning_web/live/credential_live/type_picker.ex
@@ -86,4 +86,8 @@ defmodule LightningWeb.CredentialLive.TypePicker do
     send(self(), {:credential_type_changed, type})
     {:noreply, socket}
   end
+
+  def handle_event("type_changed", %{"_target" => ["type", "selected"]}, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -364,7 +364,8 @@ defmodule LightningWeb.ProjectLive.Settings do
 
     {:noreply,
      socket
-     |> assign(show_github_setup: true, show_sync_button: false)}
+     |> assign(show_github_setup: true, show_sync_button: false)
+     |> push_patch(to: ~p"/projects/#{project_id}/settings#vcs")}
   end
 
   def handle_event("save_repo", params, socket) do

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -178,7 +178,7 @@ defmodule LightningWeb.ProjectLive.Settings do
         assigns.can_edit_project_description
 
   @impl true
-  def handle_params(params, url, socket) do
+  def handle_params(params, _url, socket) do
     {:noreply, socket |> apply_action(socket.assigns.live_action, params)}
   end
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -368,9 +368,11 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event("save_repo", params, socket) do
-    {:ok, _connection} =
+    %{project: project} = socket.assigns
+
+    {:ok, %{github_installation_id: github_installation_id}} =
       VersionControl.add_github_repo_and_branch(
-        socket.assigns.project.id,
+        project.id,
         params["repo"],
         params["branch"]
       )
@@ -383,7 +385,7 @@ defmodule LightningWeb.ProjectLive.Settings do
        project_repo_connection: %{
          "branch" => params["branch"],
          "repo" => params["repo"],
-         "github_installation_id" => params["github_installation_id"]
+         "github_installation_id" => github_installation_id
        }
      )}
   end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -573,7 +573,7 @@
               <div :if={!@show_github_setup} class="bg-white p-4 rounded-md">
                 <h6 class="font-medium text-black">Sync to Github</h6>
                 <small class="block my-1 text-xs text-gray-600">
-                  Configure a sync from this lightning project to a
+                  Configure a two-way sync between this lightning project and a
                   GitHub repo. See
                   <.link
                     href="https://docs.openfn.org/documentation/portability"

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -573,7 +573,7 @@
               <div :if={!@show_github_setup} class="bg-white p-4 rounded-md">
                 <h6 class="font-medium text-black">Sync to Github</h6>
                 <small class="block my-1 text-xs text-gray-600">
-                  Configure a two-way sync between this lightning project and a
+                  Configure a sync from this lightning project to a
                   GitHub repo. See
                   <.link
                     href="https://docs.openfn.org/documentation/portability"


### PR DESCRIPTION
## Notes for the reviewer

Fixes on Sync to Github scenarios:
- show the github application id after `Connect Branch`
- avoid showing empty select boxes after delete connection (instead shows the Install Github again)

Validation steps:
1. Set the env vars 
```
GITHUB_APP_ID=379244 
GITHUB_APP_NAME=openfn-dev and 
GITHUB_CERT=<<<<paste here the base64 cert>>>
```
2. Reset demo
3. Login with super user
4. Select openhie project
5. Go to Settings -> Sync to Github
6. Install the GitHub configuring the branch demo-openhie
7. Select the given options and press `Connect Branch` (see the Github application not empty)
8. Click on link on the bottom to remove the connection (see the Install Github button)

PS: The options on the select box doesn't depend on the selected repo on Install (but on the github app setup).

## Related issue

Refs #1046

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
