### PR TITLE
restore TabSelector behaviour from before #1566 to close #1589

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to
 
 ### Changed
 
-- Set ws-worker to at least v0.3.2
+- Bumped worker to address occasional git install issue
+  `"@openfn/ws-worker": "^0.3.2"`
 
 ### Fixed
 
@@ -20,6 +21,8 @@ and this project adheres to
   GoogleSheetsComponent [#1578](https://github.com/OpenFn/Lightning/issues/1578)
 - Extend export script to include new JS expression edge type
   [#1540](https://github.com/OpenFn/Lightning/issues/1540)
+- Fix regression for attempt viewer log line highlighting
+  [#1589](https://github.com/OpenFn/Lightning/issues/1589)
 
 ## [v0.12.1] - 2023-12-21
 

--- a/assets/js/hooks/TabSelector.ts
+++ b/assets/js/hooks/TabSelector.ts
@@ -46,13 +46,7 @@ export default {
 
     window.addEventListener('hashchange', this._onHashChange);
 
-    // console.log({ getHash: this.getHash(), defaultHash: this.defaultHash });
-    const panel = document.querySelector(`[data-panel-hash=${this.getHash()}]`);
-    if (panel) {
-      this.hashChanged(this.getHash());
-    } else {
-      this.hashChanged(this.defaultHash);
-    }
+    this.hashChanged(this.getHash() || this.defaultHash);
   },
   hashChanged(nextHash: string) {
     let activePanel: HTMLElement | null = null;


### PR DESCRIPTION
## Notes for the reviewer

This restores the TabSelector behaviour from before [this commit](https://github.com/OpenFn/Lightning/commit/afcdc409718d843b98e1dd4c60e30df39e91f387#diff-ab2038829f13be727c2f8f9dbb8507b687a5931dd1560c6739c60b02e5f0d834).

I'll re-open that issue and ask @midigofrank to confirm that he's still getting what he needs to sort out #1566 .

## Related issue

Fixes #1589 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
