### PR TITLE
key-bindings for save/retry getting overriden when user focuses on the job editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   [a6e4ada](https://github.com/OpenFn/Lightning/commit/a6e4adafd558269cfd690e7c4fdd8f9fe66c5f62)
 - Fixing attempt/run language for "skipped" tooltip on inspector.
   [fd7dd0c](https://github.com/OpenFn/Lightning/commit/fd7dd0ca8128dfba2902e5aa6a2259e2073f0f10)
+- Fixed key-bindings for save/retry getting overrided when user focuses on the monaco job editor
+  [#1596](https://github.com/OpenFn/Lightning/issues/1596)
 
 ## [2.0.0-rc1] - 2023-01-05
 

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,0 +1,15 @@
+// this has been added here because we still can't find a better place for it
+// it's being used in both the hooks and the job editor
+export function retryOrCreateWorkOrder(buttonElement) {
+  if (buttonElement.getAttribute('type') == 'submit') {
+    const formId = buttonElement.getAttribute('form');
+    const form = document.getElementById(formId);
+    form.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+  } else {
+    buttonElement.dispatchEvent(
+      new Event('click', { bubbles: true, cancelable: true })
+    );
+  }
+}

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,6 +1,6 @@
 // this has been added here because we still can't find a better place for it
 // it's being used in both the hooks and the job editor
-export function retryOrCreateWorkOrder(buttonElement) {
+export function initiateSaveAndRun(buttonElement) {
   if (buttonElement.getAttribute('type') == 'submit') {
     const formId = buttonElement.getAttribute('form');
     const form = document.getElementById(formId);

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -4,7 +4,7 @@ import type { EditorProps as MonacoProps } from '@monaco-editor/react/lib/types'
 
 import { fetchDTSListing, fetchFile } from '@openfn/describe-package';
 import createCompletionProvider from './magic-completion';
-import { retryOrCreateWorkOrder } from '../common';
+import { initiateSaveAndRun } from '../common';
 
 // static imports for core lib
 import dts_es5 from './lib/es5.min.dts';
@@ -182,8 +182,8 @@ export default function Editor({
         // https://microsoft.github.io/monaco-editor/typedoc/enums/KeyCode.html
         monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
         function () {
-          const action_button = document.getElementById('save-and-run')!;
-          retryOrCreateWorkOrder(action_button);
+          const actionButton = document.getElementById('save-and-run')!;
+          initiateSaveAndRun(actionButton);
         }
       );
 
@@ -192,10 +192,10 @@ export default function Editor({
         // https://microsoft.github.io/monaco-editor/typedoc/enums/KeyCode.html
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
         function () {
-          const action_button = document.getElementById(
+          const actionButton = document.getElementById(
             'create-new-work-order'
           )!;
-          retryOrCreateWorkOrder(action_button);
+          initiateSaveAndRun(actionButton);
         }
       );
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -4,6 +4,7 @@ import type { EditorProps as MonacoProps } from '@monaco-editor/react/lib/types'
 
 import { fetchDTSListing, fetchFile } from '@openfn/describe-package';
 import createCompletionProvider from './magic-completion';
+import { retryOrCreateWorkOrder } from '../common';
 
 // static imports for core lib
 import dts_es5 from './lib/es5.min.dts';
@@ -21,7 +22,7 @@ type EditorProps = {
 
 const spinner = (
   <svg
-    className="animate-spin h-5 w-5 inline-block"
+    className="inline-block h-5 w-5 animate-spin"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
@@ -43,7 +44,7 @@ const spinner = (
 );
 
 const loadingIndicator = (
-  <div className="inline-block bg-vs-dark p-2">
+  <div className="bg-vs-dark inline-block p-2">
     <span className="mr-2">Loading</span>
     {spinner}
   </div>
@@ -181,10 +182,20 @@ export default function Editor({
         // https://microsoft.github.io/monaco-editor/typedoc/enums/KeyCode.html
         monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
         function () {
-          const manual_run_form = document.getElementById('manual_run_form')!;
-          manual_run_form.dispatchEvent(
-            new Event('submit', { bubbles: true, cancelable: true })
-          );
+          const action_button = document.getElementById('save-and-run')!;
+          retryOrCreateWorkOrder(action_button);
+        }
+      );
+
+      editor.addCommand(
+        // https://microsoft.github.io/monaco-editor/typedoc/classes/KeyMod.html
+        // https://microsoft.github.io/monaco-editor/typedoc/enums/KeyCode.html
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+        function () {
+          const action_button = document.getElementById(
+            'create-new-work-order'
+          )!;
+          retryOrCreateWorkOrder(action_button);
         }
       );
 
@@ -307,7 +318,7 @@ export default function Editor({
 
   return (
     <>
-      <div className="text-xs text-white text-right h-0 z-10 overflow-visible relative">
+      <div className="relative z-10 h-0 overflow-visible text-right text-xs text-white">
         {loading && loadingIndicator}
       </div>
       <Monaco

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -4,7 +4,7 @@ import { PhoenixHook } from './PhoenixHook';
 import LogLineHighlight from './LogLineHighlight';
 import ElapsedIndicator from './ElapsedIndicator';
 import TabSelector from './TabSelector';
-import { retryOrCreateWorkOrder } from '../common';
+import { initiateSaveAndRun } from '../common';
 
 export { LogLineHighlight, ElapsedIndicator, TabSelector };
 
@@ -187,7 +187,7 @@ function createKeyCombinationHook(
  * @param el - The HTML element to which the action will be applied.
  */
 function clickAction(e: KeyboardEvent, el: HTMLElement) {
-  retryOrCreateWorkOrder(el);
+  initiateSaveAndRun(el);
 }
 
 /**

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -4,6 +4,7 @@ import { PhoenixHook } from './PhoenixHook';
 import LogLineHighlight from './LogLineHighlight';
 import ElapsedIndicator from './ElapsedIndicator';
 import TabSelector from './TabSelector';
+import { retryOrCreateWorkOrder } from '../common';
 
 export { LogLineHighlight, ElapsedIndicator, TabSelector };
 
@@ -186,15 +187,7 @@ function createKeyCombinationHook(
  * @param el - The HTML element to which the action will be applied.
  */
 function clickAction(e: KeyboardEvent, el: HTMLElement) {
-  if (el.getAttribute('type') == 'submit') {
-    const formId = el.getAttribute('form');
-    const form = document.getElementById(formId);
-    form.dispatchEvent(
-      new Event('submit', { bubbles: true, cancelable: true })
-    );
-  } else {
-    el.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
-  }
+  retryOrCreateWorkOrder(el);
 }
 
 /**


### PR DESCRIPTION
## Notes for the reviewer

- added commands in the monaco editor
- introduced a `common.js` for storing common functions.


## Related issue

Fixes #1596

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
