### PR TITLE
Fix failure due to creating work order from a newly created job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix failure due to creating work order from a newly created job
+  [#1572](https://github.com/OpenFn/Lightning/issues/1572)
+
 ## [2.0.0-rc2] - 2023-01-08
 
 ### Added

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -817,7 +817,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
   def handle_event("manual_run_submit", %{"manual" => params}, socket) do
     %{
       project: project,
-      workflow: workflow,
       selected_job: selected_job,
       current_user: current_user,
       workflow_params: workflow_params,
@@ -830,13 +829,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
     if can_run_job && can_edit_job do
       Helpers.save_and_run(
         socket.assigns.changeset,
-        WorkOrders.Manual.new(
-          params,
-          workflow: workflow,
-          project: project,
-          job: selected_job,
-          created_by: current_user
-        )
+        params,
+        project: project,
+        selected_job: selected_job,
+        created_by: current_user
       )
     else
       {:error, :unauthorized}

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -529,6 +529,20 @@ defmodule LightningWeb.WorkflowLive.Edit do
               :rerun_job,
               current_user,
               project_user
+            ),
+          can_create_webhook_auth_method:
+            Permissions.can?(
+              ProjectUsers,
+              :create_webhook_auth_method,
+              current_user,
+              project_user
+            ),
+          can_edit_webhook_auth_method:
+            Permissions.can?(
+              ProjectUsers,
+              :edit_webhook_auth_method,
+              current_user,
+              project_user
             )
         )
 

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -11,7 +11,10 @@ defmodule LightningWeb.WorkflowLive.Helpers do
 
   @spec save_and_run(
           Ecto.Changeset.t(Workflows.Workflow.t()),
-          Ecto.Changeset.t(WorkOrders.Manual.t())
+          map(),
+          selected_job: map(),
+          created_by: map(),
+          project: map()
         ) ::
           {:ok,
            %{
@@ -20,21 +23,28 @@ defmodule LightningWeb.WorkflowLive.Helpers do
            }}
           | {:error, Ecto.Changeset.t(Workflows.Workflow.t())}
           | {:error, Ecto.Changeset.t(WorkOrders.Manual.t())}
-  def save_and_run(workflow_changeset, manual_workorder_changeset) do
+  def save_and_run(workflow_changeset, params, opts) do
     Lightning.Repo.transact(fn ->
       with {:ok, workflow} <- save_workflow(workflow_changeset),
-           {:ok, manual} <-
-             Ecto.Changeset.apply_action(manual_workorder_changeset, :validate),
+           {:ok, manual} <- build_manual_workorder(params, workflow, opts),
            {:ok, workorder} <- WorkOrders.create_for(manual) do
         {:ok, %{workorder: workorder, workflow: workflow}}
       end
     end)
   end
 
-  @spec save_workflow(Ecto.Changeset.t(Workflows.Workflow.t())) ::
-          {:ok, Workflows.Workflow.t()}
-          | {:error, Ecto.Changeset.t(Workflows.Workflow.t())}
-  def save_workflow(changeset) do
+  defp build_manual_workorder(params, workflow, opts) do
+    {selected_job, opts} = Keyword.pop!(opts, :selected_job)
+
+    opts =
+      Keyword.merge(opts, job: Repo.reload(selected_job), workflow: workflow)
+
+    params
+    |> WorkOrders.Manual.new(opts)
+    |> Ecto.Changeset.apply_action(:validate)
+  end
+
+  defp save_workflow(changeset) do
     Repo.insert_or_update(changeset)
   end
 end

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -205,7 +205,7 @@ defmodule LightningWeb.WorkflowLive.JobView do
   end
 
   defp fetch_credential(project_credential_id) do
-    project_credential_id &&
+    project_credential_id && byte_size(project_credential_id) > 0 &&
       Credentials.get_credential_by_project_credential(project_credential_id)
   end
 end

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -8,6 +8,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
   import Ecto.Query
 
   alias Lightning.Invocation
+  alias Lightning.Workflows.Workflow
 
   setup :register_and_log_in_user
   setup :create_project_for_current_user
@@ -344,6 +345,57 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       refute view
              |> element("save-and-run", ~c"Create New Work Order")
              |> has_element?()
+    end
+
+    test "creating a work order from a newly created job should save the workflow first",
+         %{
+           conn: conn,
+           project: project
+         } do
+      workflow =
+        insert(:workflow, project: project)
+        |> Lightning.Repo.preload([:jobs, :work_orders])
+
+      new_job_name = "new job"
+
+      assert workflow.jobs |> Enum.count() === 0
+
+      assert workflow.jobs |> Enum.find(fn job -> job.name === new_job_name end) ===
+               nil
+
+      assert workflow.work_orders |> Enum.count() === 0
+
+      %{"value" => %{"id" => job_id}} =
+        job_patch = add_job_patch(new_job_name)
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project}/w/#{workflow}")
+
+      # add a job to it but don't save
+      view |> push_patches_to_view([job_patch])
+
+      view |> select_node(%{id: job_id})
+
+      view |> click_edit(%{id: job_id})
+
+      view |> change_editor_text("some body")
+
+      view
+      |> form("#manual_run_form", %{
+        manual: %{body: Jason.encode!(%{})}
+      })
+      |> render_submit()
+
+      workflow =
+        Lightning.Repo.get!(Workflow, workflow.id)
+        |> Lightning.Repo.preload([:jobs, :work_orders])
+
+      assert workflow.jobs |> Enum.count() === 1
+
+      assert workflow.jobs
+             |> Enum.find(fn job -> job.name === new_job_name end)
+             |> Map.get(:name) === new_job_name
+
+      assert workflow.work_orders |> Enum.count() === 1
     end
 
     test "selects the input dataclip for the attempt run if an attempt is followed",


### PR DESCRIPTION
## Notes for the reviewer

This PR fixes the issue related to the app crashing when we attempt to run a new added job node in the workflow diagram.

It also adds a liveview tests for the fixed bug in this PR [here](https://github.com/OpenFn/Lightning/pull/1598).

## Related issue

Fixes #1572 
Re #1596 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
