### PR TITLE
3 instances of state to status

### DIFF
--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -74,7 +74,7 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
                 </:value>
               </.list_item>
               <.list_item>
-                <:label>State</:label>
+                <:label>Status</:label>
                 <:value><.state_pill state={attempt.state} /></:value>
               </.list_item>
             </.detail_list>

--- a/lib/lightning_web/live/attempt_live/show.ex
+++ b/lib/lightning_web/live/attempt_live/show.ex
@@ -104,7 +104,7 @@ defmodule LightningWeb.AttemptLive.Show do
                   </:value>
                 </.list_item>
                 <.list_item>
-                  <:label>State</:label>
+                  <:label>Status</:label>
                   <:value><.state_pill state={attempt.state} /></:value>
                 </.list_item>
               </.detail_list>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -22,7 +22,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
       )
 
     ~H"""
-    State: <%= @attempt_state %> Attempt ID: <%= @attempt.id %>
+    Status: <%= @attempt_state %> Attempt ID: <%= @attempt.id %>
     <%= @run && @run.id %>
     <table>
       <tbody id="log_lines" phx-update="stream">


### PR DESCRIPTION
@NickOpenFn , we'd already been calling it "Status" in the history page filter. This amends the run viewer and inspector.