### PR TITLE
give project editors and viewers view only access to project settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Added
 
 ### Changed
+- Give project editors and viewers read only access to project settings instead
+  [#1477](https://github.com/OpenFn/Lightning/issues/1477)
 
 ### Fixed
 

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -511,13 +511,13 @@
                 <button
                   id="toggle-mfa-switch"
                   type="button"
-                  class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"}
+                  class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !can_edit_project(assigns), do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
                   role="switch"
                   phx-click="toggle-mfa"
                   aria-checked={@project.requires_mfa}
                   aria-labelledby="require-mfa-label"
                   aria-describedby="require-mfa-description"
-                  {if !can_edit_project(assigns), do: [disabled: true, title: "You don't have permissions to perform this action"], else: []}
+                  {if !can_edit_project(assigns), do: ["phx-hook": "Tooltip", "data-placement": "bottom", "aria-label": "You do not have permission to perform this action"], else: []}
                 >
                   <span
                     aria-hidden="true"

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1267,10 +1267,12 @@ defmodule LightningWeb.ProjectLiveTest do
 
         assert html =~ "Project settings"
 
-        refute has_element?(view, "#toggle-mfa-switch:enabled")
-        assert has_element?(view, "#toggle-mfa-switch:disabled")
+        toggle_button = element(view, "#toggle-mfa-switch")
 
-        assert render_click(view, "toggle-mfa") =~
+        assert render(toggle_button) =~
+                 "You do not have permission to perform this action"
+
+        assert render_click(toggle_button) =~
                  "You are not authorized to perform this action."
       end)
     end


### PR DESCRIPTION
## Notes for the reviewer

- Instead of hiding the whole tab, this PR enables view only access
- I've tried using the `:disabled` state on the button but it was preventing the tooltip from showing. Therefore, I've just added the `cursor-not-allowed` class


## Related issue

Fixes #1477

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
