### PR TITLE
add search by ID on the history page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Dashboard with project and workflow stats
   [#755](https://github.com/OpenFn/Lightning/issues/755)
+- Add search by ID on the history page
+  [#1468](https://github.com/OpenFn/Lightning/issues/1468)
 
 ### Changed
 - Give project editors and viewers read only access to project settings instead

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lightning",
       "license": "LGPLv3",
       "dependencies": {
-        "@heroicons/react": "^2.0.16",
+        "@heroicons/react": "^2.1.1",
         "@monaco-editor/react": "^4.4.5",
         "@openfn/describe-package": "^0.0.16",
         "@tailwindcss/container-queries": "^0.1.1",
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@heroicons/react": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
-      "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==",
       "peerDependencies": {
         "react": ">= 16"
       }

--- a/assets/package.json
+++ b/assets/package.json
@@ -9,7 +9,7 @@
   },
   "license": "LGPLv3",
   "dependencies": {
-    "@heroicons/react": "^2.0.16",
+    "@heroicons/react": "^2.1.1",
     "@monaco-editor/react": "^4.4.5",
     "@openfn/describe-package": "^0.0.16",
     "@tailwindcss/container-queries": "^0.1.1",

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -620,6 +620,9 @@ defmodule Lightning.Invocation do
 
       :id, query ->
         safe_join_runs(query)
+
+      _other, query ->
+        query
     end)
   end
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -474,44 +474,22 @@ defmodule Lightning.Invocation do
       :body, dynamic ->
         dynamic(
           [input_dataclip: dataclip],
-          ^dynamic or
-            fragment(
-              "CAST(? AS TEXT) iLIKE ?",
-              dataclip.body,
-              ^"%#{search_term}%"
-            )
+          ^dynamic or ilike(type(dataclip.body, :string), ^"%#{search_term}%")
         )
 
       :id, dynamic ->
         dynamic(
           [workorder: wo, attempts: att, runs: run],
-          ^dynamic or
-            fragment(
-              "CAST(? AS TEXT) iLIKE ?",
-              wo.id,
-              ^"%#{search_term}%"
-            ) or
-            fragment(
-              "CAST(? AS TEXT) iLIKE ?",
-              att.id,
-              ^"%#{search_term}%"
-            ) or
-            fragment(
-              "CAST(? AS TEXT) iLIKE ?",
-              run.id,
-              ^"%#{search_term}%"
-            )
+          ^dynamic or like(type(wo.id, :string), ^"%#{search_term}%") or
+            like(type(att.id, :string), ^"%#{search_term}%") or
+            like(type(run.id, :string), ^"%#{search_term}%")
         )
 
       :log, dynamic ->
         dynamic(
           [log_lines: log_line],
           ^dynamic or
-            fragment(
-              "CAST(? AS TEXT) iLIKE ?",
-              log_line.message,
-              ^"%#{search_term}%"
-            )
+            ilike(type(log_line.message, :string), ^"%#{search_term}%")
         )
 
       _other, dynamic ->

--- a/lib/lightning/workorders/search_params.ex
+++ b/lib/lightning/workorders/search_params.ex
@@ -11,7 +11,7 @@ defmodule Lightning.WorkOrders.SearchParams do
 
   @statuses ~w(pending running success failed crashed killed cancelled lost exception)
   @statuses_set MapSet.new(@statuses, fn x -> String.to_existing_atom(x) end)
-  @search_fields ~w(body log)
+  @search_fields ~w(id body log)
 
   defmacro status_list() do
     quote do

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -82,9 +82,9 @@ defmodule LightningWeb.RunLive.Index do
     ]
 
     search_fields = [
-      %{id: :id, label: "ID"},
-      %{id: :body, label: "Input"},
-      %{id: :log, label: "Logs"}
+      %{id: :id, icon: "hero-finger-print", label: "Work Order or Run IDs"},
+      %{id: :body, icon: "hero-arrow-down-on-square", label: "Inputs"},
+      %{id: :log, icon: "hero-bars-arrow-down", label: "Run Logs"}
     ]
 
     params = Map.put_new(params, "filters", init_filters())

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -19,6 +19,7 @@ defmodule LightningWeb.RunLive.Index do
 
   @filters_types %{
     search_term: :string,
+    id: :boolean,
     body: :boolean,
     log: :boolean,
     workflow_id: :string,
@@ -81,6 +82,7 @@ defmodule LightningWeb.RunLive.Index do
     ]
 
     search_fields = [
+      %{id: :id, label: "ID"},
       %{id: :body, label: "Input"},
       %{id: :log, label: "Logs"}
     ]

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -82,9 +82,9 @@ defmodule LightningWeb.RunLive.Index do
     ]
 
     search_fields = [
-      %{id: :id, icon: "hero-finger-print", label: "Work Order or Run IDs"},
-      %{id: :body, icon: "hero-arrow-down-on-square", label: "Inputs"},
-      %{id: :log, icon: "hero-bars-arrow-down", label: "Run Logs"}
+      %{id: :id, icon: "hero-finger-print-mini", label: "Include IDs"},
+      %{id: :body, icon: "hero-document-arrow-down", label: "Include inputs"},
+      %{id: :log, icon: "hero-bars-arrow-down-mini", label: "Include run logs"}
     ]
 
     params = Map.put_new(params, "filters", init_filters())

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -507,7 +507,7 @@
                         as={:filters}
                         phx-submit="apply_filters"
                         class="inline"
-                        id="run-both-search-form"
+                        id="run-all-search-form"
                       >
                         <%= for search_field <- @search_fields do %>
                           <%= Phoenix.HTML.Form.hidden_input(f, search_field.id,
@@ -522,7 +522,7 @@
                               is_checked(@filters_changeset, search_field.id)
                             end), do: "bg-gray-300")}"}
                         >
-                          Both
+                          All
                         </button>
                       </.form>
                       <%= for search_field <- @search_fields do %>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -443,25 +443,23 @@
 
         <div>
           <div class="mt-2">
-            <div class="flex justify-between items-center">
-              <div>
-                <p class="text-xl text-gray-500 font-medium">
-                  <%= if search = get_change(@filters_changeset, :search_term) do %>
-                    <%= @page.total_entries %><%= if @page.total_entries >=
-                                                       @string_search_limit,
-                                                     do: "+" %> work orders with runs matching "<%= search %>"
-                    <%= if @page.total_entries >= @string_search_limit do %>
-                      <span class="text-xs text-gray">
-                        (try more specific filters)
-                      </span>
-                    <% end %>
-                  <% else %>
-                    Work Orders
+            <div class="flex justify-between items-end">
+              <div class="text-md text-gray-500 font-medium truncate w-full">
+                <%= if search = get_change(@filters_changeset, :search_term) do %>
+                  <%= @page.total_entries %><%= if @page.total_entries >=
+                                                     @string_search_limit,
+                                                   do: "+" %> work orders with runs matching "<%= search %>"
+                  <%= if @page.total_entries >= @string_search_limit do %>
+                    <span class="text-xs text-gray">
+                      (try more specific filters)
+                    </span>
                   <% end %>
-                </p>
+                <% else %>
+                  Work Orders
+                <% end %>
               </div>
-              <div>
-                <div class="w-full flex items-center gap-2">
+              <div class="flex w-full justify-end grow">
+                <div class="flex items-end gap-1">
                   <.form
                     :let={f}
                     for={@filters_changeset}
@@ -469,7 +467,7 @@
                     as={:filters}
                     phx-submit="apply_filters"
                   >
-                    <div class="relative rounded-md shadow-sm">
+                    <div class="relative rounded-md shadow-sm flex grow">
                       <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
                         <Heroicons.magnifying_glass class="h-5 w-5 text-gray-400" />
                       </div>
@@ -499,9 +497,10 @@
                       </div>
                     </div>
                   </.form>
-                  <div id="search_button_group" class="hidden">
+                  <div id="search_button_group" class="hidden flex text-right">
                     <div class="inline-flex overflow-hidden bg-white border divide-x rounded-lg dark:bg-gray-900 rtl:flex-row-reverse dark:border-gray-700 dark:divide-gray-700">
-                      <.form
+                      <%!-- TODO: Frank to remove! --%>
+                      <%!-- <.form
                         :let={f}
                         for={@filters_changeset}
                         as={:filters}
@@ -522,9 +521,12 @@
                               is_checked(@filters_changeset, search_field.id)
                             end), do: "bg-gray-300")}"}
                         >
-                          All
+                          <.icon
+                            name="hero-ellipsis-horizontal-circle"
+                            class="h-3 w-3 inline-block align-middle"
+                          />
                         </button>
-                      </.form>
+                      </.form> --%>
                       <%= for search_field <- @search_fields do %>
                         <.form
                           :let={f}
@@ -552,8 +554,15 @@
                                 fn other_field ->
                                   is_checked(@filters_changeset, other_field.id)
                                 end), do: "bg-gray-300")}"}
+                            id={"search-button-#{search_field.label}"}
+                            aria-label={search_field.label}
+                            phx-hook="Tooltip"
+                            data-placement="top"
                           >
-                            <%= search_field.label %>
+                            <.icon
+                              name={search_field.icon}
+                              class={"h-4 w-4 inline-block align-middle #{is_checked(@filters_changeset, search_field.id) && "text-indigo-700"}"}
+                            />
                           </button>
                         </.form>
                       <% end %>
@@ -561,7 +570,7 @@
                     <button
                       type="submit"
                       form="run-search-form"
-                      class="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                      class="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 truncate"
                     >
                       Search
                     </button>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -498,75 +498,29 @@
                     </div>
                   </.form>
                   <div id="search_button_group" class="hidden flex text-right">
-                    <div class="inline-flex overflow-hidden bg-white border divide-x rounded-lg dark:bg-gray-900 rtl:flex-row-reverse dark:border-gray-700 dark:divide-gray-700">
-                      <%!-- TODO: Frank to remove! --%>
-                      <%!-- <.form
-                        :let={f}
-                        for={@filters_changeset}
-                        as={:filters}
-                        phx-submit="apply_filters"
-                        class="inline"
-                        id="run-all-search-form"
-                      >
-                        <%= for search_field <- @search_fields do %>
-                          <%= Phoenix.HTML.Form.hidden_input(f, search_field.id,
-                            value: true
+                    <.form
+                      :let={f}
+                      for={@filters_changeset}
+                      as={:filters}
+                      phx-change="apply_filters"
+                      class="isolate inline-flex rounded-md shadow-sm"
+                      id="run-toggle-form"
+                    >
+                      <%= for {search_field, index} <- Enum.with_index(@search_fields) do %>
+                        <span class={"#{if(index == 0, do: "rounded-l-md", else: "-ml-px")} #{if(index == 2, do: "rounded-r-md")} relative inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 #{if(is_checked(@filters_changeset, search_field.id), do: "bg-gray-300", else: "bg-white")}"}>
+                          <%= Phoenix.HTML.Form.checkbox(f, search_field.id,
+                            class: "absolute invisible",
+                            style: "left: -9999px"
                           ) %>
-                        <% end %>
-                        <button
-                          type="submit"
-                          class={"px-3 py-2 text-sm text-gray-800
-                            dark:hover:bg-gray-800 dark:text-gray-300
-                            hover:bg-gray-100 #{if(Enum.all?(@search_fields, fn search_field ->
-                              is_checked(@filters_changeset, search_field.id)
-                            end), do: "bg-gray-300")}"}
-                        >
-                          <.icon
-                            name="hero-ellipsis-horizontal-circle"
-                            class="h-3 w-3 inline-block align-middle"
-                          />
-                        </button>
-                      </.form> --%>
-                      <%= for search_field <- @search_fields do %>
-                        <.form
-                          :let={f}
-                          for={@filters_changeset}
-                          as={:filters}
-                          phx-submit="apply_filters"
-                          class="inline"
-                          id={"run-#{search_field.id}-search-form"}
-                        >
-                          <%= for other_field <- @search_fields -- [search_field] do %>
-                            <%= Phoenix.HTML.Form.hidden_input(f, other_field.id,
-                              value: false
-                            ) %>
-                          <% end %>
-                          <%= Phoenix.HTML.Form.hidden_input(f, search_field.id,
-                            value: true
-                          ) %>
-                          <button
-                            type="submit"
-                            class={"px-3 py-2 text-sm text-gray-800
-                              dark:hover:bg-gray-800 dark:text-gray-300
-                              hover:bg-gray-100 #{if(
-                                is_checked(@filters_changeset, search_field.id)
-                                  && !Enum.all?(@search_fields -- [search_field],
-                                fn other_field ->
-                                  is_checked(@filters_changeset, other_field.id)
-                                end), do: "bg-gray-300")}"}
-                            id={"search-button-#{search_field.label}"}
-                            aria-label={search_field.label}
-                            phx-hook="Tooltip"
-                            data-placement="top"
-                          >
+                          <%= Phoenix.HTML.Form.label f, search_field.id, id: "search-button-#{search_field.label}", role: "button", phx_hook: "Tooltip", data: [placement: "top"], aria_label: search_field.label do %>
                             <.icon
                               name={search_field.icon}
                               class={"h-4 w-4 inline-block align-middle #{is_checked(@filters_changeset, search_field.id) && "text-indigo-700"}"}
                             />
-                          </button>
-                        </.form>
+                          <% end %>
+                        </span>
                       <% end %>
-                    </div>
+                    </.form>
                     <button
                       type="submit"
                       form="run-search-form"

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -507,24 +507,34 @@
                       id="run-toggle-form"
                     >
                       <%= for {search_field, index} <- Enum.with_index(@search_fields) do %>
-                        <span class={"#{if(index == 0, do: "rounded-l-md", else: "-ml-px")} #{if(index == 2, do: "rounded-r-md")} relative inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 #{if(is_checked(@filters_changeset, search_field.id), do: "bg-gray-300", else: "bg-white")}"}>
-                          <%= Phoenix.HTML.Form.checkbox(f, search_field.id,
-                            class: "absolute invisible",
-                            style: "left: -9999px"
-                          ) %>
-                          <%= Phoenix.HTML.Form.label f, search_field.id, id: "search-button-#{search_field.label}", role: "button", phx_hook: "Tooltip", data: [placement: "top"], aria_label: search_field.label do %>
+                        <%= Phoenix.HTML.Form.checkbox(f, search_field.id,
+                          class: "absolute invisible",
+                          style: "left: -9999px"
+                        ) %>
+                        <%= Phoenix.HTML.Form.label f, search_field.id, id: "search-button-#{search_field.label}",
+                          role: "button", phx_hook: "Tooltip", data: [placement: "top"],
+                          class: "relative inline-flex items-center",
+                          aria_label: search_field.label do %>
+                          <div class={"#{if(index == 0, do: "rounded-l-md", else: "-ml-px")} #{if(index == 2, do: "rounded-r-md")}
+                           ring-1 ring-inset ring-gray-300 px-3 py-2 text-sm
+                           font-semibold text-gray-500 hover:bg-gray-100 focus:z-10
+                           #{if(is_checked(@filters_changeset, search_field.id), do: "bg-gray-200", else: "bg-white")}
+                           "}>
                             <.icon
                               name={search_field.icon}
-                              class={"h-4 w-4 inline-block align-middle #{is_checked(@filters_changeset, search_field.id) && "text-indigo-700"}"}
+                              class={"h-4 w-4 inline-block align-middle #{is_checked(@filters_changeset, search_field.id) && "text-indigo-800"}"}
                             />
-                          <% end %>
-                        </span>
+                          </div>
+                        <% end %>
                       <% end %>
                     </.form>
                     <button
                       type="submit"
                       form="run-search-form"
-                      class="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 truncate"
+                      class="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold
+                      text-white shadow-sm hover:bg-indigo-500 focus-visible:outline
+                      focus-visible:outline-2 focus-visible:outline-offset-2
+                      focus-visible:outline-indigo-600 truncate"
                     >
                       Search
                     </button>

--- a/test/lightning/workorders/search_params_test.exs
+++ b/test/lightning/workorders/search_params_test.exs
@@ -49,6 +49,7 @@ defmodule Lightning.WorkOrders.SearchParamsTest do
                "failed" => true,
                "workflow_id" => "babd29f7-bf15-4a66-af21-51209217ebd4"
              }) == %{
+               "id" => true,
                "log" => true,
                "body" => false,
                "failed" => true,
@@ -66,6 +67,7 @@ defmodule Lightning.WorkOrders.SearchParamsTest do
       assert SearchParams.to_uri_params(%{
                "body" => true,
                "log" => false,
+               "id" => false,
                "crashed" => true,
                "date_after" => now,
                "wo_date_before" => now,
@@ -73,6 +75,7 @@ defmodule Lightning.WorkOrders.SearchParamsTest do
              }) == %{
                "body" => true,
                "log" => false,
+               "id" => false,
                "crashed" => true,
                "wo_date_after" => nil,
                "wo_date_before" => now |> DateTime.to_string(),

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -431,16 +431,22 @@ defmodule LightningWeb.RunWorkOrderTest do
              |> element("input#run-search-form_search_term")
              |> has_element?()
 
-      ## both log and body select
+      ## all id, log and body select
       assert view
              |> element(
-               "input#run-both-search-form_body[type='hidden'][value='true']"
+               "input#run-all-search-form_body[type='hidden'][value='true']"
              )
              |> has_element?()
 
       assert view
              |> element(
-               "input#run-both-search-form_log[type='hidden'][value='true']"
+               "input#run-all-search-form_log[type='hidden'][value='true']"
+             )
+             |> has_element?()
+
+      assert view
+             |> element(
+               "input#run-all-search-form_id[type='hidden'][value='true']"
              )
              |> has_element?()
 
@@ -457,6 +463,12 @@ defmodule LightningWeb.RunWorkOrderTest do
              )
              |> has_element?()
 
+      assert view
+             |> element(
+               "input#run-body-search-form_id[type='hidden'][value='false']"
+             )
+             |> has_element?()
+
       ## individual search for log
       assert view
              |> element(
@@ -466,7 +478,32 @@ defmodule LightningWeb.RunWorkOrderTest do
 
       assert view
              |> element(
+               "input#run-log-search-form_id[type='hidden'][value='false']"
+             )
+             |> has_element?()
+
+      assert view
+             |> element(
                "input#run-log-search-form_log[type='hidden'][value='true']"
+             )
+             |> has_element?()
+
+      ## individual search for id
+      assert view
+             |> element(
+               "input#run-id-search-form_body[type='hidden'][value='false']"
+             )
+             |> has_element?()
+
+      assert view
+             |> element(
+               "input#run-id-search-form_log[type='hidden'][value='false']"
+             )
+             |> has_element?()
+
+      assert view
+             |> element(
+               "input#run-id-search-form_id[type='hidden'][value='true']"
              )
              |> has_element?()
     end

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -431,79 +431,22 @@ defmodule LightningWeb.RunWorkOrderTest do
              |> element("input#run-search-form_search_term")
              |> has_element?()
 
-      ## all id, log and body select
+      ## id, log and body select
       assert view
              |> element(
-               "input#run-all-search-form_body[type='hidden'][value='true']"
+               "input#run-toggle-form_body[type='checkbox'][value='true']"
              )
              |> has_element?()
 
       assert view
              |> element(
-               "input#run-all-search-form_log[type='hidden'][value='true']"
+               "input#run-toggle-form_log[type='checkbox'][value='true']"
              )
              |> has_element?()
 
       assert view
              |> element(
-               "input#run-all-search-form_id[type='hidden'][value='true']"
-             )
-             |> has_element?()
-
-      ## individual search for body
-      assert view
-             |> element(
-               "input#run-body-search-form_body[type='hidden'][value='true']"
-             )
-             |> has_element?()
-
-      assert view
-             |> element(
-               "input#run-body-search-form_log[type='hidden'][value='false']"
-             )
-             |> has_element?()
-
-      assert view
-             |> element(
-               "input#run-body-search-form_id[type='hidden'][value='false']"
-             )
-             |> has_element?()
-
-      ## individual search for log
-      assert view
-             |> element(
-               "input#run-log-search-form_body[type='hidden'][value='false']"
-             )
-             |> has_element?()
-
-      assert view
-             |> element(
-               "input#run-log-search-form_id[type='hidden'][value='false']"
-             )
-             |> has_element?()
-
-      assert view
-             |> element(
-               "input#run-log-search-form_log[type='hidden'][value='true']"
-             )
-             |> has_element?()
-
-      ## individual search for id
-      assert view
-             |> element(
-               "input#run-id-search-form_body[type='hidden'][value='false']"
-             )
-             |> has_element?()
-
-      assert view
-             |> element(
-               "input#run-id-search-form_log[type='hidden'][value='false']"
-             )
-             |> has_element?()
-
-      assert view
-             |> element(
-               "input#run-id-search-form_id[type='hidden'][value='true']"
+               "input#run-toggle-form_id[type='checkbox'][value='true']"
              )
              |> has_element?()
     end

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -157,7 +157,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
         |> Timex.shift(months: -1)
         |> Date.to_string()
         |> then(fn date ->
-          "filters[date_after]=&amp;filters[date_before]=&amp;filters[log]=true&amp;filters[wo_date_after]=#{date}"
+          "filters[date_after]=&amp;filters[date_before]=&amp;filters[id]=true&amp;filters[log]=true&amp;filters[wo_date_after]=#{date}"
         end)
 
       assert html


### PR DESCRIPTION
## Notes for the reviewer

- Builds on top of the existing `search_fields` `query`

### TODO

- [x] Do away with the fragment, use ecto functions `ilike/2, like/2, type/2`
- [x] Use `like/2` instead of `ilike/2` when matching `id` because `ids` are case sensitive

## Related issue

Fixes #1468 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
