### PR TITLE
Throw an error when `Lightning.MetadataService.get_adaptor_path/1` returns an adaptor path that is `nil`

### DIFF
--- a/lib/lightning/metadata_service.ex
+++ b/lib/lightning/metadata_service.ex
@@ -91,8 +91,8 @@ defmodule Lightning.MetadataService do
 
   defp get_adaptor_path(adaptor) do
     case AdaptorService.install(@adaptor_service, adaptor) do
-      {:error, _} -> {:error, Error.new("no_matching_adaptor")}
-      {:ok, %{path: path}} -> {:ok, path}
+      {:ok, %{path: path}} when is_binary(path) -> {:ok, path}
+      _ -> {:error, Error.new("no_matching_adaptor")}
     end
   end
 


### PR DESCRIPTION
## Notes for the reviewer

For some reasons (that I couldn't reproduce locally), the function `Lightning.MetadataService.get_adaptor_path/1` returns a `{:ok, %{path: path}}` where `path` is `nil`. Even though I couldn't reproduce it, it is sure that we don't need adaptor paths that are nil. We are always expecting adaptor paths to be valid paths (string). This PR ships a tiny fix that asserts that we only return `{:ok, path}` if the path is a valid string. Otherwise we always throw an error of type `{:error, Error.new("no_matching_adaptor")}`. 

## Related issue

Fixes #1601 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
