### PR TITLE
Adapt dashboard to v2 and add pending wo link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@ and this project adheres to
 - Throw an error when Lightning.MetadataService.get_adaptor_path/1 returns an
   adaptor path that is nil
   [#1601](https://github.com/OpenFn/Lightning/issues/1601)
-
 - Fix failure due to creating work order from a newly created job
   [#1572](https://github.com/OpenFn/Lightning/issues/1572)
+- Fixes on the dashboard and links
+  [#1610](https://github.com/OpenFn/Lightning/issues/1610) and
+  [#1608](https://github.com/OpenFn/Lightning/issues/1608)
 
 ## [2.0.0-rc2] - 2023-01-08
 

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -121,14 +121,13 @@ defmodule Lightning.DashboardStats do
     |> filter_days_ago(30)
     |> Repo.all()
     |> Enum.group_by(fn state ->
-      if state in [:success, :pending, :running] do
-        state
-      else
-        :failed
+      cond do
+        state in [:pending, :running] -> :pending
+        state == :success -> :success
+        true -> :failed
       end
     end)
-    |> Enum.into(%{success: 0, failed: 0, pending: 0, running: 0}, fn {state,
-                                                                       list} ->
+    |> Enum.into(%{success: 0, failed: 0, pending: 0}, fn {state, list} ->
       {state, length(list)}
     end)
   end
@@ -145,13 +144,11 @@ defmodule Lightning.DashboardStats do
     |> Enum.group_by(fn state ->
       cond do
         state == :success -> :success
-        state in [:available, :claimed] -> :pending
-        state == :started -> :running
+        state in [:available, :claimed, :started] -> :pending
         true -> :failed
       end
     end)
-    |> Enum.into(%{success: 0, failed: 0, pending: 0, running: 0}, fn {state,
-                                                                       list} ->
+    |> Enum.into(%{success: 0, failed: 0, pending: 0}, fn {state, list} ->
       {state, length(list)}
     end)
   end
@@ -172,8 +169,7 @@ defmodule Lightning.DashboardStats do
         true -> :failed
       end
     end)
-    |> Enum.into(%{success: 0, failed: 0, pending: 0, running: 0}, fn {state,
-                                                                       list} ->
+    |> Enum.into(%{success: 0, failed: 0, pending: 0}, fn {state, list} ->
       {state, length(list)}
     end)
   end
@@ -189,10 +185,10 @@ defmodule Lightning.DashboardStats do
            pending: acc_pending,
            total: acc_total
          } ->
-        %{success: success, failed: failed, pending: pending, running: running} =
+        %{success: success, failed: failed, pending: pending} =
           Map.get(stats, grouped_entity_count)
 
-        total = success + failed + pending + running
+        total = success + failed + pending
 
         %{
           success: acc_success + success,

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -15,7 +15,7 @@ defmodule Lightning.DashboardStats do
               grouped_attempts_count: %{},
               grouped_workorders_count: %{},
               runs_count: 0,
-              runs_success_percentage: 0.0,
+              runs_success_rate: 0.0,
               workorders_count: 0,
               workflow: %Workflow{}
   end
@@ -46,7 +46,7 @@ defmodule Lightning.DashboardStats do
 
     grouped_attempts_count = count_attempts(workflow)
 
-    {runs_count, runs_success_percentage} =
+    {runs_count, runs_success_rate} =
       workflow |> count_runs() |> runs_stats()
 
     last_workorder = get_last_workorder(workflow)
@@ -59,7 +59,7 @@ defmodule Lightning.DashboardStats do
       grouped_attempts_count: grouped_attempts_count,
       grouped_workorders_count: grouped_workorders_count,
       runs_count: runs_count,
-      runs_success_percentage: round(runs_success_percentage * 100) / 100,
+      runs_success_rate: round(runs_success_rate * 100) / 100,
       workorders_count: workorders_count
     }
   end

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -1,6 +1,7 @@
 defmodule Lightning.DashboardStats do
   @moduledoc false
 
+  alias Lightning.Attempt
   alias Lightning.Invocation.Run
   alias Lightning.Repo
   alias Lightning.Workflows.Workflow
@@ -11,7 +12,7 @@ defmodule Lightning.DashboardStats do
     defstruct last_workorder: %{state: nil, updated_at: nil},
               last_failed_workorder: %{state: nil, updated_at: nil},
               failed_workorders_count: 0,
-              grouped_runs_count: %{},
+              grouped_attempts_count: %{},
               grouped_workorders_count: %{},
               runs_count: 0,
               runs_success_percentage: 0.0,
@@ -22,14 +23,15 @@ defmodule Lightning.DashboardStats do
   defmodule ProjectMetrics do
     defstruct work_order_metrics: %{
                 total: 0,
+                pending: 0,
                 failed: 0,
-                failure_percentage: 0.0
+                failed_percentage: 0.0
               },
-              run_metrics: %{
+              attempt_metrics: %{
                 total: 0,
                 pending: 0,
                 success: 0,
-                success_percentage: 0.0
+                success_rate: 0.0
               }
   end
 
@@ -37,21 +39,15 @@ defmodule Lightning.DashboardStats do
     %{failed: failed_wo_count} =
       grouped_workorders_count = count_workorders(workflow)
 
-    %{success: success_runs_count} =
-      grouped_runs_count = count_runs(workflow)
-
-    runs_count =
-      grouped_runs_count
-      |> Enum.map(fn {_key, count} -> count end)
-      |> Enum.sum()
-
     workorders_count =
       grouped_workorders_count
       |> Enum.map(fn {_key, count} -> count end)
       |> Enum.sum()
 
-    runs_success_percentage =
-      if runs_count == 0, do: 0, else: success_runs_count * 100 / runs_count
+    grouped_attempts_count = count_attempts(workflow)
+
+    {runs_count, runs_success_percentage} =
+      workflow |> count_runs() |> runs_stats()
 
     last_workorder = get_last_workorder(workflow)
 
@@ -60,7 +56,7 @@ defmodule Lightning.DashboardStats do
       last_workorder: last_workorder,
       last_failed_workorder: get_last_failed_workorder(workflow, last_workorder),
       failed_workorders_count: failed_wo_count,
-      grouped_runs_count: grouped_runs_count,
+      grouped_attempts_count: grouped_attempts_count,
       grouped_workorders_count: grouped_workorders_count,
       runs_count: runs_count,
       runs_success_percentage: round(runs_success_percentage * 100) / 100,
@@ -70,9 +66,26 @@ defmodule Lightning.DashboardStats do
 
   def aggregate_project_metrics(workflows_stats) do
     %ProjectMetrics{
-      work_order_metrics: aggregate_work_order_metrics(workflows_stats),
-      run_metrics: aggregate_run_metrics(workflows_stats)
+      work_order_metrics:
+        aggregate_metrics(workflows_stats, :grouped_workorders_count),
+      attempt_metrics:
+        aggregate_metrics(workflows_stats, :grouped_attempts_count)
     }
+  end
+
+  defp runs_stats(%{
+         success: success_count,
+         failed: failed_count,
+         pending: pending_count
+       }) do
+    runs_count = success_count + failed_count + pending_count
+
+    if runs_count == 0 do
+      {0, 0.0}
+    else
+      success_rate = success_count * 100 / (success_count + failed_count)
+      {runs_count, success_rate}
+    end
   end
 
   defp get_last_failed_workorder(workflow, %{state: :success}) do
@@ -108,18 +121,37 @@ defmodule Lightning.DashboardStats do
     |> filter_days_ago(30)
     |> Repo.all()
     |> Enum.group_by(fn state ->
-      cond do
-        state == :success ->
-          :success
-
-        state in [:pending, :running] ->
-          :unfinished
-
-        true ->
-          :failed
+      if state in [:success, :pending, :running] do
+        state
+      else
+        :failed
       end
     end)
-    |> Enum.into(%{success: 0, failed: 0, unfinished: 0}, fn {state, list} ->
+    |> Enum.into(%{success: 0, failed: 0, pending: 0, running: 0}, fn {state,
+                                                                       list} ->
+      {state, length(list)}
+    end)
+  end
+
+  defp count_attempts(%Workflow{id: workflow_id}) do
+    from(a in Attempt,
+      join: wo in assoc(a, :work_order),
+      join: wf in assoc(wo, :workflow),
+      where: wf.id == ^workflow_id,
+      select: a.state
+    )
+    |> filter_days_ago(30)
+    |> Repo.all()
+    |> Enum.group_by(fn state ->
+      cond do
+        state == :success -> :success
+        state in [:available, :claimed] -> :pending
+        state == :started -> :running
+        true -> :failed
+      end
+    end)
+    |> Enum.into(%{success: 0, failed: 0, pending: 0, running: 0}, fn {state,
+                                                                       list} ->
       {state, length(list)}
     end)
   end
@@ -140,72 +172,44 @@ defmodule Lightning.DashboardStats do
         true -> :failed
       end
     end)
-    |> Enum.into(%{success: 0, failed: 0, pending: 0}, fn {state, list} ->
+    |> Enum.into(%{success: 0, failed: 0, pending: 0, running: 0}, fn {state,
+                                                                       list} ->
       {state, length(list)}
     end)
   end
 
-  defp aggregate_work_order_metrics(workflows) do
-    Enum.reduce(workflows, %{total: 0, failed: 0}, fn %{
-                                                        grouped_workorders_count:
-                                                          %{
-                                                            success: success,
-                                                            failed: failed,
-                                                            unfinished:
-                                                              unfinished
-                                                          }
-                                                      },
-                                                      %{
-                                                        total: acc_total,
-                                                        failed: acc_failed
-                                                      } ->
-      total = success + failed + unfinished
+  defp aggregate_metrics(workflows, grouped_entity_count) do
+    Enum.reduce(
+      workflows,
+      %{success: 0, failed: 0, pending: 0, total: 0},
+      fn stats,
+         %{
+           success: acc_success,
+           failed: acc_failed,
+           pending: acc_pending,
+           total: acc_total
+         } ->
+        %{success: success, failed: failed, pending: pending, running: running} =
+          Map.get(stats, grouped_entity_count)
 
-      %{
-        total: acc_total + total,
-        failed: acc_failed + failed
-      }
-    end)
-    |> then(fn %{total: total, failed: failed} = map ->
-      failure_rate = if total > 0, do: failed / total * 100, else: 0.0
+        total = success + failed + pending + running
 
-      Map.put(map, :failure_percentage, round(failure_rate * 100) / 100)
-    end)
-  end
-
-  defp aggregate_run_metrics(workflows) do
-    Enum.reduce(workflows, %{success: 0, failed: 0, pending: 0}, fn %{
-                                                                      grouped_runs_count:
-                                                                        %{
-                                                                          success:
-                                                                            success,
-                                                                          failed:
-                                                                            failed,
-                                                                          pending:
-                                                                            pending
-                                                                        }
-                                                                    },
-                                                                    %{
-                                                                      success:
-                                                                        acc_success,
-                                                                      failed:
-                                                                        acc_failed,
-                                                                      pending:
-                                                                        acc_pending
-                                                                    } ->
-      %{
-        success: acc_success + success,
-        failed: acc_failed + failed,
-        pending: acc_pending + pending
-      }
-    end)
-    |> then(fn %{success: success, failed: failed, pending: pending} = map ->
+        %{
+          success: acc_success + success,
+          failed: acc_failed + failed,
+          pending: acc_pending + pending,
+          total: acc_total + total
+        }
+      end
+    )
+    |> then(fn %{success: success, failed: failed, total: total} = map ->
       completed = success + failed
-      success_rate = if success > 0, do: success * 100 / completed, else: 0.0
+      failed_percent = if completed > 0, do: failed * 100 / total, else: 0.0
+      success_rate = if completed > 0, do: success * 100 / completed, else: 0.0
 
       Map.merge(map, %{
-        success_percentage: round(success_rate * 100) / 100,
-        total: completed + pending
+        success_rate: round(success_rate * 100) / 100,
+        failed_percentage: round(failed_percent * 100) / 100
       })
     end)
   end

--- a/lib/lightning_web/live/attempt_live/components.ex
+++ b/lib/lightning_web/live/attempt_live/components.ex
@@ -70,10 +70,10 @@ defmodule LightningWeb.AttemptLive.Components do
     [text, classes] =
       case state do
         # only workorder states...
-        :pending -> ["Pending", "bg-gray-200 text-gray-800"]
+        :pending -> ["Enqueued", "bg-gray-200 text-gray-800"]
         :running -> ["Running", "bg-blue-200 text-blue-800"]
         # attempt & workorder states...
-        :available -> ["Pending", "bg-gray-200 text-gray-800"]
+        :available -> ["Enqueued", "bg-gray-200 text-gray-800"]
         :claimed -> ["Starting", "bg-blue-200 text-blue-800"]
         :started -> ["Running", "bg-blue-200 text-blue-800"]
         :success -> ["Success", "bg-green-200 text-green-800"]

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -70,7 +70,7 @@ defmodule LightningWeb.RunLive.Index do
       )
 
     statuses = [
-      %{id: :pending, label: "Pending"},
+      %{id: :pending, label: "Enqueued"},
       %{id: :running, label: "Running"},
       %{id: :success, label: "Success"},
       %{id: :failed, label: "Failed"},

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -237,7 +237,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     assigns =
       assigns
       |> assign(
-        filters:
+        failed_filters:
           SearchParams.to_uri_params(%{
             "date_after" => Timex.now() |> Timex.shift(months: -1),
             "date_before" => DateTime.utc_now(),
@@ -247,6 +247,12 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
             "cancelled" => "true",
             "lost" => "true",
             "exception" => "true"
+          }),
+        pending_filters:
+          SearchParams.to_uri_params(%{
+            "date_after" => Timex.now() |> Timex.shift(months: -1),
+            "date_before" => DateTime.utc_now(),
+            "pending" => "true"
           })
       )
 
@@ -254,6 +260,14 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     <div class="grid gap-12 md:grid-cols-2 lg:grid-cols-4">
       <.metric_card title="Work Orders">
         <:value><%= @metrics.work_order_metrics.total %></:value>
+        <:suffix>
+          <.link
+            navigate={~p"/projects/#{@project}/runs?#{%{filters: @pending_filters}}"}
+            class="text-indigo-700 hover:underline"
+          >
+            (<%= @metrics.work_order_metrics.pending %> pending)
+          </.link>
+        </:suffix>
       </.metric_card>
       <.metric_card title="Runs">
         <:value><%= @metrics.attempt_metrics.total %></:value>
@@ -274,7 +288,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
         </:suffix>
         <:link>
           <.link
-            navigate={~p"/projects/#{@project}/runs?#{%{filters: @filters}}"}
+            navigate={~p"/projects/#{@project}/runs?#{%{filters: @failed_filters}}"}
             class="text-indigo-700 hover:underline"
           >
             View all

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -255,22 +255,22 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
       <.metric_card title="Work Orders">
         <:value><%= @metrics.work_order_metrics.total %></:value>
       </.metric_card>
-      <.metric_card title="Runs">
-        <:value><%= @metrics.run_metrics.total %></:value>
+      <.metric_card title="Attempts">
+        <:value><%= @metrics.attempt_metrics.total %></:value>
         <:suffix>
-          (<%= @metrics.run_metrics.pending %> pending)
+          (<%= @metrics.attempt_metrics.pending %> pending)
         </:suffix>
       </.metric_card>
-      <.metric_card title="Successful Runs">
-        <:value><%= @metrics.run_metrics.success %></:value>
+      <.metric_card title="Successful Attempts">
+        <:value><%= @metrics.attempt_metrics.success %></:value>
         <:suffix>
-          (<%= @metrics.run_metrics.success_percentage %>%)
+          (<%= @metrics.attempt_metrics.success_rate %>%)
         </:suffix>
       </.metric_card>
       <.metric_card title="Work Orders in failed state">
         <:value><%= @metrics.work_order_metrics.failed %></:value>
         <:suffix>
-          (<%= @metrics.work_order_metrics.failure_percentage %>%)
+          (<%= @metrics.work_order_metrics.failed_percentage %>%)
         </:suffix>
         <:link>
           <.link

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -95,7 +95,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
             <div class="text-gray-500 text-xs">
               (<%= workflow.runs_count %> runs,
               <span>
-                <%= workflow.runs_success_percentage %>% success
+                <%= workflow.runs_success_rate %>% success
               </span>
               )
             </div>

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -239,7 +239,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
       |> assign(
         failed_filters:
           SearchParams.to_uri_params(%{
-            "date_after" => Timex.now() |> Timex.shift(months: -1),
+            "wo_date_after" => Timex.now() |> Timex.shift(months: -1),
             "failed" => "true",
             "crashed" => "true",
             "killed" => "true",
@@ -249,8 +249,9 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           }),
         pending_filters:
           SearchParams.to_uri_params(%{
-            "date_after" => Timex.now() |> Timex.shift(months: -1),
-            "pending" => "true"
+            "wo_date_after" => Timex.now() |> Timex.shift(months: -1),
+            "pending" => "true",
+            "running" => "true"
           })
       )
 

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -93,7 +93,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
               </.link>
             </div>
             <div class="text-gray-500 text-xs">
-              (<%= workflow.runs_count %> runs,
+              (<%= workflow.runs_count %> steps,
               <span>
                 <%= workflow.runs_success_rate %>% success
               </span>
@@ -255,13 +255,13 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
       <.metric_card title="Work Orders">
         <:value><%= @metrics.work_order_metrics.total %></:value>
       </.metric_card>
-      <.metric_card title="Attempts">
+      <.metric_card title="Runs">
         <:value><%= @metrics.attempt_metrics.total %></:value>
         <:suffix>
           (<%= @metrics.attempt_metrics.pending %> pending)
         </:suffix>
       </.metric_card>
-      <.metric_card title="Successful Attempts">
+      <.metric_card title="Successful Runs">
         <:value><%= @metrics.attempt_metrics.success %></:value>
         <:suffix>
           (<%= @metrics.attempt_metrics.success_rate %>%)

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -240,7 +240,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
         failed_filters:
           SearchParams.to_uri_params(%{
             "date_after" => Timex.now() |> Timex.shift(months: -1),
-            "date_before" => DateTime.utc_now(),
             "failed" => "true",
             "crashed" => "true",
             "killed" => "true",
@@ -251,7 +250,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
         pending_filters:
           SearchParams.to_uri_params(%{
             "date_after" => Timex.now() |> Timex.shift(months: -1),
-            "date_before" => DateTime.utc_now(),
             "pending" => "true"
           })
       )

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -54,15 +54,13 @@ defmodule Lightning.DashboardStatsTest do
 
       assert %{
                failed: 1,
-               pending: 2,
-               running: 1,
+               pending: 3,
                success: 1
              } = grouped_attempts_count
 
       assert %{
                failed: 1,
-               pending: 1,
-               running: 2,
+               pending: 3,
                success: 1
              } = grouped_workorders_count
     end
@@ -90,15 +88,13 @@ defmodule Lightning.DashboardStatsTest do
 
       assert %{
                failed: 1,
-               pending: 2,
-               running: 1,
+               pending: 3,
                success: 1
              } = grouped_attempts_count
 
       assert %{
                failed: 1,
-               pending: 1,
-               running: 2,
+               pending: 3,
                success: 1
              } = grouped_workorders_count
     end
@@ -112,20 +108,21 @@ defmodule Lightning.DashboardStatsTest do
       workflow_stats1 = DashboardStats.get_workflow_stats(workflow1)
       workflow_stats2 = DashboardStats.get_workflow_stats(workflow2)
 
-      success_percentage = round(2 * 100 * 100 / 4) / 100
+      success_rate = round(2 * 100 * 100 / 4) / 100
+      failed_percent = round(2 * 100 * 100 / 10) / 100
 
       assert %ProjectMetrics{
                attempt_metrics: %{
                  failed: 2,
-                 pending: 4,
+                 pending: 6,
                  success: 2,
-                 success_percentage: ^success_percentage,
+                 success_rate: ^success_rate,
                  total: 10
                },
                work_order_metrics: %{
                  failed: 2,
-                 pending: 2,
-                 failed_percent: 20.0,
+                 pending: 6,
+                 failed_percentage: ^failed_percent,
                  total: 10
                }
              } =

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -28,7 +28,7 @@ defmodule Lightning.DashboardStatsTest do
                last_workorder: %{state: nil, updated_at: nil},
                last_failed_workorder: %{state: nil, updated_at: nil},
                runs_count: 0,
-               runs_success_percentage: 0.0,
+               runs_success_rate: 0.0,
                workorders_count: 0
              } = DashboardStats.get_workflow_stats(workflow)
     end
@@ -37,7 +37,7 @@ defmodule Lightning.DashboardStatsTest do
       %{id: workflow_id} =
         workflow = complex_workflow_with_runs(last_workorder_failed: true)
 
-      runs_success_percentage =
+      runs_success_rate =
         round(5 / 7 * 100 * 100) / 100
 
       assert %WorkflowStats{
@@ -48,7 +48,7 @@ defmodule Lightning.DashboardStatsTest do
                grouped_attempts_count: grouped_attempts_count,
                grouped_workorders_count: grouped_workorders_count,
                runs_count: 8,
-               runs_success_percentage: ^runs_success_percentage,
+               runs_success_rate: ^runs_success_rate,
                workorders_count: 5
              } = DashboardStats.get_workflow_stats(workflow)
 
@@ -71,7 +71,7 @@ defmodule Lightning.DashboardStatsTest do
       %{id: workflow_id} =
         workflow = complex_workflow_with_runs(last_workorder_failed: false)
 
-      runs_success_percentage = round(5 / 7 * 100 * 100) / 100
+      runs_success_rate = round(5 / 7 * 100 * 100) / 100
 
       assert %WorkflowStats{
                workflow: %{id: ^workflow_id},
@@ -81,7 +81,7 @@ defmodule Lightning.DashboardStatsTest do
                grouped_attempts_count: grouped_attempts_count,
                grouped_workorders_count: grouped_workorders_count,
                runs_count: 8,
-               runs_success_percentage: ^runs_success_percentage,
+               runs_success_rate: ^runs_success_rate,
                workorders_count: 5
              } = DashboardStats.get_workflow_stats(workflow)
 

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -37,29 +37,32 @@ defmodule Lightning.DashboardStatsTest do
       %{id: workflow_id} =
         workflow = complex_workflow_with_runs(last_workorder_failed: true)
 
-      runs_success_percentage = 5 / 8 * 100
+      runs_success_percentage =
+        round(5 / 7 * 100 * 100) / 100
 
       assert %WorkflowStats{
                workflow: %{id: ^workflow_id},
                last_workorder: last_workorder,
                last_failed_workorder: last_workorder,
                failed_workorders_count: 1,
-               grouped_runs_count: grouped_runs_count,
+               grouped_attempts_count: grouped_attempts_count,
                grouped_workorders_count: grouped_workorders_count,
                runs_count: 8,
                runs_success_percentage: ^runs_success_percentage,
-               workorders_count: 4
+               workorders_count: 5
              } = DashboardStats.get_workflow_stats(workflow)
 
       assert %{
-               failed: 2,
-               pending: 1,
-               success: 5
-             } = grouped_runs_count
+               failed: 1,
+               pending: 2,
+               running: 1,
+               success: 1
+             } = grouped_attempts_count
 
       assert %{
                failed: 1,
-               unfinished: 2,
+               pending: 1,
+               running: 2,
                success: 1
              } = grouped_workorders_count
     end
@@ -68,32 +71,34 @@ defmodule Lightning.DashboardStatsTest do
       %{id: workflow_id} =
         workflow = complex_workflow_with_runs(last_workorder_failed: false)
 
-      runs_success_percentage = 5 / 8 * 100
+      runs_success_percentage = round(5 / 7 * 100 * 100) / 100
 
       assert %WorkflowStats{
                workflow: %{id: ^workflow_id},
                last_workorder: last_workorder,
                last_failed_workorder: failed_last_workorder,
                failed_workorders_count: 1,
-               grouped_runs_count: grouped_runs_count,
+               grouped_attempts_count: grouped_attempts_count,
                grouped_workorders_count: grouped_workorders_count,
                runs_count: 8,
                runs_success_percentage: ^runs_success_percentage,
-               workorders_count: 4
+               workorders_count: 5
              } = DashboardStats.get_workflow_stats(workflow)
 
       assert last_workorder != failed_last_workorder
       assert last_workorder.state == :success
 
       assert %{
-               failed: 2,
-               pending: 1,
-               success: 5
-             } = grouped_runs_count
+               failed: 1,
+               pending: 2,
+               running: 1,
+               success: 1
+             } = grouped_attempts_count
 
       assert %{
                failed: 1,
-               unfinished: 2,
+               pending: 1,
+               running: 2,
                success: 1
              } = grouped_workorders_count
     end
@@ -107,20 +112,21 @@ defmodule Lightning.DashboardStatsTest do
       workflow_stats1 = DashboardStats.get_workflow_stats(workflow1)
       workflow_stats2 = DashboardStats.get_workflow_stats(workflow2)
 
-      success_percentage = round(10 / 14 * 100 * 100) / 100
+      success_percentage = round(2 * 100 * 100 / 4) / 100
 
       assert %ProjectMetrics{
-               run_metrics: %{
-                 pending: 2,
-                 success: 10,
+               attempt_metrics: %{
+                 failed: 2,
+                 pending: 4,
+                 success: 2,
                  success_percentage: ^success_percentage,
-                 total: 16,
-                 failed: 4
+                 total: 10
                },
                work_order_metrics: %{
                  failed: 2,
-                 failure_percentage: 25.0,
-                 total: 8
+                 pending: 2,
+                 failed_percent: 20.0,
+                 total: 10
                }
              } =
                DashboardStats.aggregate_project_metrics([

--- a/test/lightning_web/live/attempt_live/show_test.exs
+++ b/test/lightning_web/live/attempt_live/show_test.exs
@@ -49,8 +49,8 @@ defmodule LightningWeb.AttemptLive.ShowTest do
 
       assert view
              |> element("#attempt-detail-#{attempt_id}")
-             |> render_async() =~ "Pending",
-             "has pending state"
+             |> render_async() =~ "Enqueued",
+             "has enqueued state"
 
       assert view |> log_is_empty?(attempt)
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -283,7 +283,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       render_async(run_viewer)
 
       assert run_viewer
-             |> element("li:nth-child(5) dd", "Pending")
+             |> element("li:nth-child(5) dd", "Enqueued")
              |> has_element?()
     end
 

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -70,20 +70,20 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       assert Regex.match?(~r{<h1.*Dashboard.*</h1>}s, html)
 
       # Metrics
-      # 8 total workorders
-      # 16 total runs (2 pending, 4 failed)
-      # 10 successful runs out of 14 (71.43%)
-      # 2 work orders failed (25.0%)
-      assert Regex.match?(~r/Work Orders.*?<div>\s*8/s, html)
-      assert Regex.match?(~r/Runs.*?<div>\s*16.*">\s*\(2 pending\)/s, html)
+      # 10 total workorders
+      # 10 total attempts (4 pending)
+      # 2 successful attempts out of 4 completed
+      # 2 work orders failed out of 10
+      assert Regex.match?(~r/Work Orders.*?<div>\s*10/s, html)
+      assert Regex.match?(~r/Attempts.*?<div>\s*10.*">\s*\(4 pending\)/s, html)
 
       assert Regex.match?(
-               ~r/Successful Runs.*<div>\s*10.*">\s*\(71.43%\)/s,
+               ~r/Successful Attempts.*<div>\s*2.*">\s*\(50.0%\)/s,
                html
              )
 
       assert Regex.match?(
-               ~r/Work Orders in failed state.*<div>\s*2.*">\s*\(25.0%\)/s,
+               ~r/Work Orders in failed state.*<div>\s*2.*">\s*\(20.0%\)/s,
                html
              )
 
@@ -191,8 +191,11 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
                failed_runs_count
              )
 
-      # 5 successful runs out of 8 (62.5%)
-      assert Regex.match?(~r/(8 runs.*62.5% success)/s, html)
+      # ,
+      assert Regex.match?(
+               ~r/(8 runs.*#{round(5 / 7 * 100 * 100) / 100}% success)/s,
+               html
+             )
 
       # Last workflow with placeholders
       assert Regex.match?(

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -69,20 +69,30 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
 
       assert Regex.match?(~r{<h1.*Dashboard.*</h1>}s, html)
 
+      File.write("text.html", html)
       # Metrics
       # 10 total workorders
       # 10 total attempts (4 pending)
       # 2 successful attempts out of 4 completed
       # 2 work orders failed out of 10
-      assert Regex.match?(~r/Work Orders.*?<div>\s*10/s, html)
-      assert Regex.match?(~r/Runs.*?<div>\s*10.*">\s*\(4 pending\)/s, html)
+      assert Regex.match?(~r/Work Orders.*?<div>\s*10.*\(6 pending\)/s, html)
+
+      pending_and_date_filter =
+        Timex.now()
+        |> Timex.shift(months: -1)
+        |> Date.to_string()
+        |> then(fn date ->
+          "filters[date_after]=&amp;filters[date_before]=&amp;filters[id]=true&amp;filters[log]=true&amp;filters[pending]=true&amp;filters[wo_date_after]=#{date}"
+        end)
 
       assert html
              |> has_runs_link_pattern?(
                project,
-               "filters[pending]=true",
-               "(4 pending)"
+               pending_and_date_filter,
+               "6 pending"
              )
+
+      assert Regex.match?(~r/Runs.*?<div>\s*10.*">\s*\(6 pending\)/s, html)
 
       assert Regex.match?(
                ~r/Successful Runs.*<div>\s*2.*">\s*\(50.0%\)/s,

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -77,6 +77,13 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       assert Regex.match?(~r/Work Orders.*?<div>\s*10/s, html)
       assert Regex.match?(~r/Runs.*?<div>\s*10.*">\s*\(4 pending\)/s, html)
 
+      assert html
+             |> has_runs_link_pattern?(
+               project,
+               "filters[pending]=true",
+               "(4 pending)"
+             )
+
       assert Regex.match?(
                ~r/Successful Runs.*<div>\s*2.*">\s*\(50.0%\)/s,
                html
@@ -85,6 +92,22 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       assert Regex.match?(
                ~r/Work Orders in failed state.*<div>\s*2.*">\s*\(20.0%\)/s,
                html
+             )
+
+      failed_filter_pattern =
+        "filters[cancelled]=true.*filters[crashed]=true.*filters[exception]=true.*filters[failed]=true.*filters[killed]=true.*filters[lost]=true"
+
+      assert html
+             |> has_runs_link_pattern?(
+               project,
+               failed_filter_pattern,
+               "View all"
+             )
+
+      refute html
+             |> has_runs_link_pattern?(
+               project,
+               "(filters[running]=true|filters[success]=true)"
              )
 
       # Header
@@ -121,34 +144,6 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
              )
 
       # Work orders links
-      failed_filter_pattern =
-        "filters[cancelled]=true.*filters[crashed]=true.*filters[exception]=true.*filters[failed]=true.*filters[killed]=true.*filters[lost]=true"
-
-      assert html
-             |> has_runs_link_pattern?(
-               project,
-               failed_filter_pattern,
-               "View all"
-             )
-
-      refute html
-             |> has_runs_link_pattern?(
-               project,
-               "filters[pending]=true"
-             )
-
-      refute html
-             |> has_runs_link_pattern?(
-               project,
-               "filters[running]=true"
-             )
-
-      refute html
-             |> has_runs_link_pattern?(
-               project,
-               "filters[success]=true"
-             )
-
       workorders_count = "4"
 
       # work order date filter without status filter
@@ -176,6 +171,8 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
 
       # Failed runs links
       failed_runs_count = "1"
+
+      File.write("text.html", html)
 
       assert html
              |> has_runs_link_pattern?(

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -75,10 +75,10 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       # 2 successful attempts out of 4 completed
       # 2 work orders failed out of 10
       assert Regex.match?(~r/Work Orders.*?<div>\s*10/s, html)
-      assert Regex.match?(~r/Attempts.*?<div>\s*10.*">\s*\(4 pending\)/s, html)
+      assert Regex.match?(~r/Runs.*?<div>\s*10.*">\s*\(4 pending\)/s, html)
 
       assert Regex.match?(
-               ~r/Successful Attempts.*<div>\s*2.*">\s*\(50.0%\)/s,
+               ~r/Successful Runs.*<div>\s*2.*">\s*\(50.0%\)/s,
                html
              )
 
@@ -193,7 +193,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
 
       # ,
       assert Regex.match?(
-               ~r/(8 runs.*#{round(5 / 7 * 100 * 100) / 100}% success)/s,
+               ~r/(8 steps.*#{round(5 / 7 * 100 * 100) / 100}% success)/s,
                html
              )
 

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -82,7 +82,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
         |> Timex.shift(months: -1)
         |> Date.to_string()
         |> then(fn date ->
-          "filters[date_after]=&amp;filters[date_before]=&amp;filters[id]=true&amp;filters[log]=true&amp;filters[pending]=true&amp;filters[wo_date_after]=#{date}"
+          "filters[date_after]=&amp;filters[date_before]=&amp;filters[id]=true&amp;filters[log]=true&amp;filters[pending]=true&amp;filters[running]=true&amp;filters[wo_date_after]=#{date}"
         end)
 
       assert html
@@ -117,7 +117,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       refute html
              |> has_runs_link_pattern?(
                project,
-               "(filters[running]=true|filters[success]=true)"
+               "filters[success]=true"
              )
 
       # Header

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -69,7 +69,6 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
 
       assert Regex.match?(~r{<h1.*Dashboard.*</h1>}s, html)
 
-      File.write("text.html", html)
       # Metrics
       # 10 total workorders
       # 10 total attempts (4 pending)
@@ -182,8 +181,6 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       # Failed runs links
       failed_runs_count = "1"
 
-      File.write("text.html", html)
-
       assert html
              |> has_runs_link_pattern?(
                project,
@@ -198,7 +195,6 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
                failed_runs_count
              )
 
-      # ,
       assert Regex.match?(
                ~r/(8 steps.*#{round(5 / 7 * 100 * 100) / 100}% success)/s,
                html

--- a/test/support/fixtures/workflows_fixtures.ex
+++ b/test/support/fixtures/workflows_fixtures.ex
@@ -57,14 +57,45 @@ defmodule Lightning.WorkflowsFixtures do
       workflow: workflow,
       trigger: trigger,
       dataclip: build(:dataclip),
-      state: :pending
+      state: :pending,
+      attempts: [
+        %{
+          state: :available,
+          dataclip: build(:dataclip),
+          starting_trigger: trigger,
+          runs: []
+        }
+      ]
     )
 
     insert(:workorder,
       workflow: workflow,
       trigger: trigger,
       dataclip: build(:dataclip),
-      state: :running
+      state: :running,
+      attempts: [
+        %{
+          state: :claimed,
+          dataclip: build(:dataclip),
+          starting_trigger: trigger,
+          runs: []
+        }
+      ]
+    )
+
+    insert(:workorder,
+      workflow: workflow,
+      trigger: trigger,
+      dataclip: build(:dataclip),
+      state: :running,
+      attempts: [
+        %{
+          state: :started,
+          dataclip: build(:dataclip),
+          starting_trigger: trigger,
+          runs: []
+        }
+      ]
     )
 
     attempts_success = [


### PR DESCRIPTION
## Notes for the reviewer

- Uses v2 runs (attempts) on project metric badges
- Differentiate the two kinds of runs v1 and v2 on the UI (keeping Run for Attempts and renaming runs to steps).
- Adds project work orders pending link

## Related issue

Fixes #1610 #1608 

## Review checklist

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
