### PR TITLE
OpenFn logo in navbar now clickable (redirects to openfn.org)

### DIFF
--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -170,11 +170,13 @@ defmodule LightningWeb.LayoutComponents do
         <div class="flex items-center justify-between h-16">
           <div class="flex items-center">
             <div class="flex-shrink-0">
-              <img
-                class="h-8 w-8"
-                src={Routes.static_path(@conn, "/images/square-logo.png")}
-                alt="OpenFn"
-              />
+              <a href="https://openfn.org/">
+                  <img
+                    class="h-8 w-8"
+                    src={Routes.static_path(@conn, "/images/square-logo.png")}
+                    alt="OpenFn"
+                  />
+                </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Notes for the reviewer
- This my contribution as mentioned on X (Twitter). I don't fully understand everything so I only touched the necessary
- This is my very first time manipulating Elixir, so I hope I didn't mess some things up :)
- I'm a junior dev. so I kept it as simple as possible

## Related issue
OpenFn's logo was just a static image

Fixes #
Wrapped OpenFn's logo in html link tag, with href attribute value set to openfn.org

## Review checklist

- [ ] I have performed a **self-review** of my code