### PR TITLE
Check/enforce search field type

### DIFF
--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -491,10 +491,6 @@ defmodule Lightning.Invocation do
           ^dynamic or
             ilike(type(log_line.message, :string), ^"%#{search_term}%")
         )
-
-      _other, dynamic ->
-        # Not a valid search field
-        dynamic
     end)
   end
 
@@ -512,9 +508,6 @@ defmodule Lightning.Invocation do
 
       :id, query ->
         safe_join_runs(query)
-
-      _other, query ->
-        query
     end)
   end
 


### PR DESCRIPTION
## Notes for the reviewer

Implementation looks great just enforces the known field types by preventing silent error on non matching search field types.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
