### PR TITLE
Fix get_env/3 deprecation warning by using compile_env/3 instead

### DIFF
--- a/lib/lightning_web/endpoint.ex
+++ b/lib/lightning_web/endpoint.ex
@@ -59,7 +59,8 @@ defmodule LightningWeb.Endpoint do
       :multipart,
       # Increase to 10MB max request size only for JSON parser
       {:json,
-       length: Application.get_env(:lightning, :max_dataclip_size, 10_000_000)}
+       length:
+         Application.compile_env(:lightning, :max_dataclip_size, 10_000_000)}
     ],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()


### PR DESCRIPTION
## Notes for the reviewer

This PR changes `Application.get_env/3` to `Application.compile_env/3` to avoid the deprecation warning we see when we launch the server using: `iex -S mix phx.Server`

![image](https://github.com/OpenFn/Lightning/assets/86059666/5a6ed55b-3636-433b-aa57-db279ad4cfc7)

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
