### PR TITLE
workaround for weird line spacing on inspector

### DIFF
--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -125,7 +125,10 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
             </Common.tab_bar>
 
             <div class="min-h-0 grow flex overflow-auto">
-              <Common.panel_content for_hash="log" class="grow overflow-auto rounded-md shadow-sm bg-slate-700 border-slate-300">
+              <Common.panel_content
+                for_hash="log"
+                class="grow overflow-auto rounded-md shadow-sm bg-slate-700 border-slate-300"
+              >
                 <Viewers.log_viewer
                   id={"attempt-log-#{attempt.id}"}
                   class="overflow-auto"

--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -125,10 +125,10 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
             </Common.tab_bar>
 
             <div class="min-h-0 grow flex overflow-auto">
-              <Common.panel_content for_hash="log" class="grow overflow-auto">
+              <Common.panel_content for_hash="log" class="grow overflow-auto rounded-md shadow-sm bg-slate-700 border-slate-300">
                 <Viewers.log_viewer
                   id={"attempt-log-#{attempt.id}"}
-                  class="overflow-auto h-full"
+                  class="overflow-auto"
                   highlight_id={@selected_run_id}
                   stream={@streams.log_lines}
                 />


### PR DESCRIPTION
## Notes for the reviewer

This might not be the prettiest implementation, but by keeping the background and edges of the parent div the same as the expanding div below, we seem to get the desired output on the inspector.

## Related issue

Fixes an issue where log lines would get spaced out in a really strange way. See image:

<img width="735" alt="image" src="https://github.com/OpenFn/Lightning/assets/8732845/ac7bd56f-557d-4536-bf82-bfb4a2dec9cf">

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
