### PR TITLE
Standardize "nothing yet" logs/input/output boxes

### DIFF
--- a/lib/lightning_web.ex
+++ b/lib/lightning_web.ex
@@ -134,6 +134,7 @@ defmodule LightningWeb do
       alias LightningWeb.Router.Helpers, as: Routes
 
       import LightningWeb.Components.Pills
+      import LightningWeb.Components.Loaders
 
       unquote(verified_routes())
     end

--- a/lib/lightning_web/components/loaders.ex
+++ b/lib/lightning_web/components/loaders.ex
@@ -1,0 +1,49 @@
+defmodule LightningWeb.Components.Loaders do
+  @moduledoc """
+  UI component to render a pill to create tags.
+  """
+  use Phoenix.Component
+
+  slot :inner_block, required: true
+
+  def text_ping_loader(assigns) do
+    ~H"""
+    <span class="relative inline-flex">
+      <div class="inline-flex">
+        <%= render_slot(@inner_block) %>
+      </div>
+      <span class="flex absolute h-3 w-3 right-0 -mr-5">
+        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-75">
+        </span>
+        <span class="relative inline-flex rounded-full h-3 w-3 bg-primary-500">
+        </span>
+      </span>
+    </span>
+    """
+  end
+
+  slot :inner_block, required: true
+
+  def button_loader(assigns) do
+    ~H"""
+    <span class="relative inline-flex">
+      <button
+        type="button"
+        class="inline-flex items-center px-4 py-2 font-semibold leading-6
+            text-sm shadow rounded-md bg-white dark:bg-slate-800
+            transition ease-in-out duration-150 cursor-not-allowed ring-1
+            ring-slate-900/10 dark:ring-slate-200/20"
+        disabled=""
+      >
+        <%= render_slot(@inner_block) %>
+      </button>
+      <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
+        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-75">
+        </span>
+        <span class="relative inline-flex rounded-full h-3 w-3 bg-primary-500">
+        </span>
+      </span>
+    </span>
+    """
+  end
+end

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -75,10 +75,12 @@ defmodule LightningWeb.Components.Viewers do
         id={"#{@id}-nothing-yet"}
         class={[
           "hidden only:block m-2 relative block rounded-md",
-          "border-2 border-dashed border-gray-500 p-12 text-center col-span-full"
+          "p-12 text-center col-span-full"
         ]}
       >
-        Nothing yet...
+        <.text_ping_loader>
+          Nothing yet
+        </.text_ping_loader>
       </div>
     </div>
     """
@@ -104,7 +106,7 @@ defmodule LightningWeb.Components.Viewers do
     ~H"""
     <div class={[
       "rounded-md shadow-sm bg-slate-700 border-slate-300",
-      "text-slate-200 text-sm w-full h-full relative",
+      "text-slate-200 text-sm font-mono w-full h-full relative",
       @class
     ]}>
       <.dataclip_type :if={@type} type={@type} id={"#{@id}-type"} />
@@ -132,10 +134,12 @@ defmodule LightningWeb.Components.Viewers do
           id={"#{@id}-nothing-yet"}
           class={[
             "hidden only:block m-2 relative block rounded-md",
-            "border-2 border-dashed border-gray-500 p-12 text-center col-span-full"
+            "p-12 text-center col-span-full"
           ]}
         >
-          Nothing yet...
+          <.text_ping_loader>
+            Nothing yet
+          </.text_ping_loader>
         </div>
       </div>
     </div>

--- a/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
+++ b/lib/lightning_web/live/attempt_live/attempt_viewer_live.ex
@@ -129,7 +129,6 @@ defmodule LightningWeb.AttemptLive.AttemptViewerLive do
               >
                 <Viewers.log_viewer
                   id={"attempt-log-#{attempt.id}"}
-                  class="overflow-auto"
                   highlight_id={@selected_run_id}
                   stream={@streams.log_lines}
                 />

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -225,7 +225,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
         >
           <%!-- Before Editor component has mounted --%>
           <div class="flex place-content-center h-full cursor-wait">
-            <.box_loader />
+            <span class="inline-block top-[50%] relative">
+              <div class="flex items-center justify-center">
+                <.button_loader>
+                  Loading workflow
+                </.button_loader>
+              </div>
+            </span>
           </div>
         </div>
         <%= if @selected_job do %>
@@ -1256,33 +1262,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
   defp mark_validated(socket) do
     socket
     |> assign(changeset: socket.assigns.changeset |> Map.put(:action, :validate))
-  end
-
-  defp box_loader(assigns) do
-    ~H"""
-    <span class="inline-block top-[50%] relative">
-      <div class="flex items-center justify-center">
-        <span class="relative inline-flex">
-          <button
-            type="button"
-            class="inline-flex items-center px-4 py-2 font-semibold leading-6
-            text-sm shadow rounded-md bg-white dark:bg-slate-800
-            transition ease-in-out duration-150 cursor-not-allowed ring-1
-            ring-slate-900/10 dark:ring-slate-200/20"
-            disabled=""
-          >
-            Loading workflow
-          </button>
-          <span class="flex absolute h-3 w-3 top-0 right-0 -mt-1 -mr-1">
-            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-75">
-            </span>
-            <span class="relative inline-flex rounded-full h-3 w-3 bg-primary-500">
-            </span>
-          </span>
-        </span>
-      </div>
-    </span>
-    """
   end
 
   defp with_changes_indicator(assigns) do

--- a/test/lightning_web/live/attempt_live/show_test.exs
+++ b/test/lightning_web/live/attempt_live/show_test.exs
@@ -230,6 +230,6 @@ defmodule LightningWeb.AttemptLive.ShowTest do
     |> Floki.parse_fragment!()
     |> Floki.filter_out("[id$='-type']")
     |> Floki.text() =~
-      ~r/^[\n\s]+Nothing yet\.\.\.[\n\s]+$/
+      ~r/^[\n\s]+Nothing yet[\n\s]+$/
   end
 end


### PR DESCRIPTION
## Notes for the reviewer

@stuartc , standardizing these inputs meant losing the nifty dotted-line-border you had for "Nothing yet". I liked the border a lot, but I'm happier with consistent than with pretty and inconsistent. If you're good with this, I'm good with this.

<img width="699" alt="image" src="https://github.com/OpenFn/Lightning/assets/8732845/6d8e7e99-4686-4fcb-b058-79093d400ae6">

Fixes #1543

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
