### PR TITLE
Accept condition_expression in Provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   [#1602](https://github.com/OpenFn/Lightning/issues/1602)
 - Removed unused runlive code
   [#1625](https://github.com/OpenFn/Lightning/issues/1625)
+- Edge condition expressions not correctly being handled during provisioning
+  [#openfn/kit#560](https://github.com/OpenFn/kit/pull/560)
 
 ## [v2.0.0-rc3] 2024-01-12
 

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -152,6 +152,7 @@ defmodule Lightning.Projects.Provisioner do
       :source_job_id,
       :source_trigger_id,
       :enabled,
+      :condition_expression,
       :condition_type,
       :condition_label,
       :target_job_id,

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -56,9 +56,10 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
   def as_json(%Edge{} = edge) do
     Ecto.embedded_dump(edge, :json)
-    |> Map.take(
-      ~w(id enabled source_job_id source_trigger_id condition_type condition_label condition_expression target_job_id)a
-    )
+    |> Map.take(~w(
+      id enabled source_job_id source_trigger_id
+      condition_type condition_label condition_expression target_job_id
+    )a)
     |> drop_keys_with_nil_value()
   end
 


### PR DESCRIPTION
This adds `condition_expression` to the Provisioner changeset.

## Notes for the reviewer

There will be more details on how to test this on the related issue.

## Related issue

Fixes [#openfn/kit#560](https://github.com/OpenFn/kit/pull/560)

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
