### PR TITLE
Make condition label non mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 - Do not persist the active tab setting on the job editor
   [#1504](https://github.com/OpenFn/Lightning/issues/1504)
+- Make condition label non mandatory 
+  [#1648](https://github.com/OpenFn/Lightning/issues/1648)
 
 ### Fixed
 

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -103,7 +103,7 @@ defmodule Lightning.Workflows.Edge do
   defp validate_js_condition(changeset) do
     if :js_expression == get_field(changeset, :condition_type) do
       changeset
-      |> validate_required([:condition_label, :condition_expression])
+      |> validate_required([:condition_expression])
       |> validate_condition_expression()
     else
       changeset

--- a/test/lightning/workflows/edge_test.exs
+++ b/test/lightning/workflows/edge_test.exs
@@ -215,7 +215,6 @@ defmodule Lightning.Workflows.EdgeTest do
         )
 
       assert changeset.errors == [
-               condition_label: {"can't be blank", [validation: :required]},
                condition_expression: {"can't be blank", [validation: :required]}
              ]
     end


### PR DESCRIPTION
## Notes for the reviewer

Make JS condition label not mandatory anymore.

Should see only the expression as required:
![Screenshot from 2024-01-19 11-37-06](https://github.com/OpenFn/Lightning/assets/44991200/361adc88-5184-4a11-8810-903283b7cdb3)

## Related issue

Fixes #1648 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
