### PR TITLE
Add storing webhook request headers in Dataclips for use in jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Store webhook request headers in Dataclips for use in jobs.
+  [#1638](https://github.com/OpenFn/Lightning/issues/1638)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/invocation/dataclip.ex
+++ b/lib/lightning/invocation/dataclip.ex
@@ -30,6 +30,7 @@ defmodule Lightning.Invocation.Dataclip do
           id: Ecto.UUID.t() | nil,
           project_id: Ecto.UUID.t() | nil,
           body: %{} | nil,
+          request: %{} | nil,
           source_step: Step.t() | Ecto.Association.NotLoaded.t() | nil
         }
 
@@ -40,6 +41,7 @@ defmodule Lightning.Invocation.Dataclip do
   @foreign_key_type :binary_id
   schema "dataclips" do
     field :body, :map, load_in_query: false
+    field :request, :map, load_in_query: false
     field :type, Ecto.Enum, values: @source_types
     belongs_to :project, Project
 
@@ -105,8 +107,18 @@ defmodule Lightning.Invocation.Dataclip do
     end
   end
 
+  defp validate_request(changeset) do
+    if fetch_field!(changeset, :type) != :http_request and
+         not is_nil(fetch_field!(changeset, :request)) do
+      add_error(changeset, :request, "cannot be set for this type")
+    else
+      changeset
+    end
+  end
+
   defp validate(changeset) do
     changeset
+    |> validate_request()
     |> validate_by_type()
   end
 

--- a/lib/lightning_web/channels/attempt_channel.ex
+++ b/lib/lightning_web/channels/attempt_channel.ex
@@ -131,12 +131,7 @@ defmodule LightningWeb.AttemptChannel do
   of those HTTP requests to the worker to use as initial state.
   """
   def handle_in("fetch:dataclip", _, socket) do
-    {type, raw_body} = Attempts.get_dataclip_for_worker(socket.assigns.attempt)
-
-    body =
-      if type == :http_request,
-        do: "{\"data\": " <> raw_body <> "}",
-        else: raw_body
+    body = Attempts.get_input(socket.assigns.attempt)
 
     {:reply, {:ok, {:binary, body}}, socket}
   end

--- a/lib/lightning_web/controllers/webhooks_controller.ex
+++ b/lib/lightning_web/controllers/webhooks_controller.ex
@@ -18,6 +18,7 @@ defmodule LightningWeb.WebhooksController do
             workflow: trigger.workflow,
             dataclip: %{
               body: conn.body_params,
+              request: build_request(conn),
               type: :http_request,
               project_id: trigger.workflow.project_id
             }
@@ -32,5 +33,9 @@ defmodule LightningWeb.WebhooksController do
             "Unable to process request, trigger is disabled. Enable it on OpenFn to allow requests to this endpoint."
         })
     end
+  end
+
+  defp build_request(%Plug.Conn{} = conn) do
+    %{headers: conn.req_headers |> Enum.into(%{})}
   end
 end

--- a/priv/repo/migrations/20240122132725_add_request_json_to_dataclips.exs
+++ b/priv/repo/migrations/20240122132725_add_request_json_to_dataclips.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddRequestJsonToDataclips do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataclips) do
+      add :request, :map
+    end
+  end
+end

--- a/test/lightning/invocation/dataclip_test.exs
+++ b/test/lightning/invocation/dataclip_test.exs
@@ -1,0 +1,39 @@
+defmodule Lightning.Invocation.DataclipTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Invocation.Dataclip
+
+  import Lightning.Factories
+
+  describe "http_request" do
+    test "can provide a request map" do
+      {:ok, dataclip} =
+        params_with_assocs(:dataclip, request: %{"url" => "https://example.com"})
+        |> Dataclip.new()
+        |> Repo.insert()
+
+      dataclip = dataclip |> Repo.reload()
+      assert dataclip.request == nil, "Does not load request in query by default"
+
+      request =
+        Dataclip
+        |> select([d], d.request)
+        |> where([d], d.id == ^dataclip.id)
+        |> Repo.one()
+
+      assert request == %{"url" => "https://example.com"}
+    end
+
+    test "only http_request dataclips can have a request" do
+      changeset =
+        params_with_assocs(:dataclip,
+          request: %{"url" => "https://example.com"},
+          type: :step_result
+        )
+        |> Dataclip.new()
+
+      refute changeset.valid?
+      assert {:request, {"cannot be set for this type", []}} in changeset.errors
+    end
+  end
+end

--- a/test/lightning_web/channels/attempt_channel_test.exs
+++ b/test/lightning_web/channels/attempt_channel_test.exs
@@ -189,7 +189,10 @@ defmodule LightningWeb.AttemptChannelTest do
     } do
       ref = push(socket, "fetch:dataclip", %{})
 
-      assert_reply ref, :ok, {:binary, ~s<{\"data\": {\"foo\": \"bar\"}}>}
+      assert_reply ref,
+                   :ok,
+                   {:binary,
+                    ~s<{"data": {"foo": "bar"}, "request": {"headers": {"content-type": "application/json"}}}>}
 
       Ecto.Changeset.change(dataclip, type: :step_result)
       |> Repo.update()
@@ -658,7 +661,7 @@ defmodule LightningWeb.AttemptChannelTest do
       attempt_state = Map.get(context, :attempt_state, :available)
 
       project = insert(:project)
-      dataclip = insert(:dataclip, body: %{"foo" => "bar"}, project: project)
+      dataclip = insert(:http_request_dataclip, project: project)
 
       %{triggers: [trigger]} =
         workflow = insert(:simple_workflow, project: project)
@@ -842,11 +845,7 @@ defmodule LightningWeb.AttemptChannelTest do
     project = insert(:project, project_users: [%{user: user}])
 
     dataclip =
-      insert(:dataclip,
-        type: :http_request,
-        body: %{"foo" => "bar"},
-        project: project
-      )
+      insert(:http_request_dataclip, project: project)
 
     trigger = build(:trigger, type: :webhook, enabled: true)
 

--- a/test/lightning_web/controllers/webhooks_controller_test.exs
+++ b/test/lightning_web/controllers/webhooks_controller_test.exs
@@ -29,6 +29,9 @@ defmodule LightningWeb.WebhooksControllerTest do
 
       assert Attempts.get_dataclip_body(attempt) == ~s({"foo": "bar"})
 
+      assert Attempts.get_dataclip_request(attempt) ==
+               ~s({"headers": {"content-type": "multipart/mixed; boundary=plug_conn_test"}})
+
       %{attempts: [attempt]} = work_order
       assert attempt.starting_trigger_id == trigger.id
     end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -67,6 +67,15 @@ defmodule Lightning.Factories do
     }
   end
 
+  def http_request_dataclip_factory do
+    %Lightning.Invocation.Dataclip{
+      project: build(:project),
+      body: %{"foo" => "bar"},
+      request: %{"headers" => %{"content-type" => "application/json"}},
+      type: :http_request
+    }
+  end
+
   def step_factory do
     %Lightning.Invocation.Step{
       id: fn -> Ecto.UUID.generate() end,


### PR DESCRIPTION
## Notes for the reviewer

- Migration to add a `request` jsonb column to `dataclips`.
- `Attempts.get_dataclip_body` renamed to `get_input`. 
- `get_input` moves all serialisation to Postgres.
- Input returns `{data: <body>, request: <request>}`.

## Related issue

Fixes #1638 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
