### PR TITLE
fix #1664

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to
 
 ### Changed
 
+- Display `http_request` dataclips to the user as they will be provided to the
+  worker as "input" state to avoid confusion while writing jobs.
+  [1664](https://github.com/OpenFn/Lightning/issues/1664)
+
 ### Fixed
 
 - Fix Run via Docker  

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -47,21 +47,8 @@ defmodule Lightning.Invocation do
   end
 
   def list_dataclips_for_job(%Lightning.Workflows.Job{id: job_id}) do
-    from(s in Step,
-      join: d in assoc(s, :input_dataclip),
-      where: s.job_id == ^job_id,
-      select: %Dataclip{
-        id: d.id,
-        body: d.body,
-        type: d.type,
-        project_id: d.project_id,
-        inserted_at: d.inserted_at,
-        updated_at: d.updated_at
-      },
-      distinct: [desc: d.inserted_at],
-      order_by: [desc: d.inserted_at],
-      limit: 3
-    )
+    Query.last_n_for_job(job_id, 5)
+    |> Query.select_as_input()
     |> Repo.all()
   end
 

--- a/lib/lightning_web/live/attempt_live/streaming.ex
+++ b/lib/lightning_web/live/attempt_live/streaming.ex
@@ -45,9 +45,8 @@ defmodule LightningWeb.AttemptLive.Streaming do
   def get_dataclip_lines(step, field) do
     import Ecto.Query
 
-    from(d in Ecto.assoc(step, field),
-      select: [:id, :type, :body]
-    )
+    from(d in Ecto.assoc(step, field))
+    |> Lightning.Invocation.Query.select_as_input()
     |> Repo.one()
     |> case do
       nil ->

--- a/test/lightning_web/live/attempt_live/show_test.exs
+++ b/test/lightning_web/live/attempt_live/show_test.exs
@@ -105,7 +105,8 @@ defmodule LightningWeb.AttemptLive.ShowTest do
              |> element("#step-input-#{step.id}")
              |> render_async()
              |> Floki.parse_fragment!()
-             |> Floki.text() =~ ~s({  "x": 1})
+             |> Floki.text() =~
+               ~s({  \"data\": {    \"x\": 1  },  \"request\": {    \"headers\": {      \"content-type\": \"multipart/mixed; boundary=plug_conn_test\"    })
 
       assert view |> output_is_empty?(step)
 


### PR DESCRIPTION
This gets the job done, fixes #1664 , and DRYs up a bunch of `dataclip` query code, but still introduces duplication on the fragment.

@stuartc , I'd like to _NOT_ duplicate the fragment [here](https://github.com/OpenFn/Lightning/blob/1664/lib/lightning/invocation/query.ex#L85-L94) but don't know how to get it to work. Tried macros and dynamic but broke my brain. Help? (Or say, "not that big a deal" and we merge 😄 .)

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
