### PR TITLE
fix #1674

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   [#1653](https://github.com/OpenFn/Lightning/issues/1653)
 - Fix remaining warnings, enable "warnings as errors"
   [#1642](https://github.com/OpenFn/Lightning/issues/1642)
+- Fix workflow dashboard bug when viewed for newly created workflows with only
+  unfinished run steps. [#1674](https://github.com/OpenFn/Lightning/issues/1674)
 
 ## [v2.0.0-rc5] - 2024-01-22
 

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -90,7 +90,7 @@ defmodule Lightning.DashboardStats do
        }) do
     step_count = success_count + failed_count + pending_count
 
-    if step_count == 0 do
+    if success_count == 0 do
       {0, 0.0}
     else
       success_rate = success_count * 100 / (success_count + failed_count)


### PR DESCRIPTION
This fixes #1674 by handling cases where the dashboard is viewed _before_ there are any successful steps. We needed to prevent a divide-by-zero error that was occurring when `step_count` was > 0 but (`success_count` + `fail_count`) was equal to zero!

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
