### PR TITLE
Shim implementation of ImpactTracker notification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,3 +168,11 @@ PURGE_DELETED_AFTER_DAYS=7
 # The maximum age of an Attempt that will be considered when measuring
 # Attempt performance.
 # METRICS_ATTEMPT_PERFORMANCE_AGE_SECONDS=120
+
+# To enable the reporting of anonymised metrics to the OpenFn Impact tracker, set
+# IMPACT_TRACKING_ENABLED to `true`.
+IMPACT_TRACKING_ENABLED=false
+
+# By default, impact tracking metrics will be reported to https://impact.openfn.org. Use the
+# below if you wish to change that.
+# IMPACT_TRACKER_HOST=https://impact.openfn.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Shim code to interact with the Impact Tracking service
+  [#1671](https://github.com/OpenFn/Lightning/issues/1671)
+
 ### Changed
 
 ### Fixed
@@ -34,7 +37,7 @@ and this project adheres to
 
 ### Fixed
 
-- Fix Run via Docker  
+- Fix Run via Docker
   [#1653](https://github.com/OpenFn/Lightning/issues/1653)
 - Fix remaining warnings, enable "warnings as errors"
   [#1642](https://github.com/OpenFn/Lightning/issues/1642)

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,8 @@ config :tesla, Lightning.VersionControl.GithubClient, adapter: Tesla.Mock
 
 config :tesla, Mix.Tasks.Lightning.InstallAdaptorIcons, adapter: Tesla.Mock
 
+config :tesla, Lightning.ImpactTracking.Client, adapter: Tesla.Mock
+
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used

--- a/lib/lightning/impact_tracking/client.ex
+++ b/lib/lightning/impact_tracking/client.ex
@@ -1,0 +1,16 @@
+defmodule Lightning.ImpactTracking.Client do
+  @moduledoc """
+  Client for Impact Tracker service
+
+
+  """
+  use Tesla, only: [:post], docs: false
+
+  def submit_metrics(metrics, host) do
+    build_client(host) |> post("/api/metrics", metrics)
+  end
+
+  defp build_client(host) do
+    Tesla.client([{Tesla.Middleware.BaseUrl, host}, Tesla.Middleware.JSON])
+  end
+end

--- a/lib/lightning/impact_tracking/worker.ex
+++ b/lib/lightning/impact_tracking/worker.ex
@@ -1,0 +1,24 @@
+defmodule Lightning.ImpactTracking.Worker do
+  @moduledoc """
+  Ensures repeated submissions of anonymised metrics to the Impact Tracker
+  service
+
+
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 1
+
+  alias Lightning.ImpactTracking.Client
+
+  @impl Oban.Worker
+  def perform(_opts) do
+    if Application.get_env(:lightning, :impact_tracking)[:enabled] do
+      host = Application.get_env(:lightning, :impact_tracking)[:host]
+
+      Client.submit_metrics(%{}, host)
+    end
+
+    :ok
+  end
+end

--- a/test/lightning/impact_tracking/client_test.exs
+++ b/test/lightning/impact_tracking/client_test.exs
@@ -1,0 +1,32 @@
+defmodule Lightning.ImpactTracking.ClientTest do
+  use ExUnit.Case, async: false
+
+  import Tesla.Mock
+
+  alias Lightning.ImpactTracking.Client
+
+  @host "https://foo.bar"
+
+  describe ".submit_metrics" do
+    test "sends supplied metrics to impact tracker" do
+      url = "#{@host}/api/metrics"
+      serialised_metrics = Jason.encode!(%{some: :metrics})
+
+      mock(fn
+        %{
+          method: :post,
+          url: ^url,
+          body: ^serialised_metrics,
+          headers: [{"content-type", "application/json"}]
+        } ->
+          %Tesla.Env{status: 200, body: %{status: "great"}}
+
+        _ ->
+          flunk("Unrecognised call")
+      end)
+
+      assert {:ok, %Tesla.Env{status: 200, body: %{status: "great"}}} =
+               Client.submit_metrics(%{some: :metrics}, @host)
+    end
+  end
+end

--- a/test/lightning/impact_tracking/worker_test.exs
+++ b/test/lightning/impact_tracking/worker_test.exs
@@ -1,0 +1,60 @@
+defmodule Lightning.ImpactTracking.WorkerTest do
+  use ExUnit.Case, async: false
+
+  alias Lightning.ImpactTracking.{Client, Worker}
+
+  import Mock
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+
+  @host "https://foo.bar"
+
+  describe "tracking is enabled" do
+    setup do
+      put_temporary_env(:lightning, :impact_tracking,
+        enabled: true,
+        host: @host
+      )
+    end
+
+    test "sends an empty JSON object to the impact tracker" do
+      with_mock Client,
+        submit_metrics: fn _metrics, _host -> true end do
+        Worker.perform(%{})
+
+        assert_called(Client.submit_metrics(%{}, @host))
+      end
+    end
+
+    test "indicates that processing succeeded" do
+      with_mock Client,
+        submit_metrics: fn _metrics, _host -> true end do
+        assert :ok = Worker.perform(%{})
+      end
+    end
+  end
+
+  describe "tracking is disabled" do
+    setup do
+      put_temporary_env(:lightning, :impact_tracking,
+        enabled: false,
+        host: "https://foo.bar"
+      )
+    end
+
+    test "does not submit metrics if tracking is not enabled" do
+      with_mock Client,
+        submit_metrics: fn _metrics, _host -> true end do
+        Worker.perform(%{})
+
+        assert_not_called(Client.submit_metrics(:_, :_))
+      end
+    end
+
+    test "indicates that processing succeeded" do
+      with_mock Client,
+        submit_metrics: fn _metrics, _host -> true end do
+        assert :ok = Worker.perform(%{})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer
This is a placeholder for code that will send anonymised metrics to the ImpactTracker service. For now, all it does is send an empty object to validate that all the plumbing is connected correctly.


## Related issue

Fixes #1671 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
