### PR TITLE
Disable selecting workorders that have wiped dataclips in the history page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   [#1212](https://github.com/OpenFn/Lightning/issues/1212)
 - Show appropriate message when a wiped dataclip is viewed
   [#1211](https://github.com/OpenFn/Lightning/issues/1211)
+- Disable selecting work orders having wiped dataclips in the history page
+  [#1210](https://github.com/OpenFn/Lightning/issues/1210)
 
 ### Changed
 

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -102,10 +102,15 @@ export const Tooltip = {
     let placement = this.el.dataset.placement
       ? this.el.dataset.placement
       : 'top';
+    let allowHTML = this.el.dataset.allowHtml
+      ? this.el.dataset.allowHtml
+      : 'false';
     this._tippyInstance = tippy(this.el, {
       content: content,
       placement: placement,
       animation: false,
+      allowHTML: allowHTML === 'true',
+      interactive: true,
     });
   },
   destroyed() {

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -385,12 +385,8 @@ defmodule Lightning.Invocation do
     )
   end
 
-  def search_workorders_having_dataclips_query(
-        %Project{} = project,
-        %SearchParams{} = params
-      ) do
-    project
-    |> search_workorders_query(params)
+  def exclude_wiped_dataclips(work_order_query) do
+    work_order_query
     |> join(:inner, [workorder: wo], assoc(wo, :dataclip), as: :dataclip)
     |> where([dataclip: d], is_nil(d.wiped_at))
   end

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -385,6 +385,16 @@ defmodule Lightning.Invocation do
     )
   end
 
+  def search_workorders_having_dataclips_query(
+        %Project{} = project,
+        %SearchParams{} = params
+      ) do
+    project
+    |> search_workorders_query(params)
+    |> join(:inner, [workorder: wo], assoc(wo, :dataclip), as: :dataclip)
+    |> where([dataclip: d], is_nil(d.wiped_at))
+  end
+
   defp base_query(project_id) do
     from(
       workorder in WorkOrder,
@@ -393,7 +403,7 @@ defmodule Lightning.Invocation do
       as: :workflow,
       where: workflow.project_id == ^project_id,
       select: workorder,
-      preload: [workflow: workflow, attempts: [steps: :job]],
+      preload: [workflow: workflow, attempts: [steps: :job], dataclip: []],
       order_by: [desc_nulls_first: workorder.last_activity],
       distinct: true
     )

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -53,7 +53,13 @@ defmodule LightningWeb.RunLive.Index do
   def mount(
         params,
         _session,
-        %{assigns: %{current_user: current_user, project: project}} = socket
+        %{
+          assigns: %{
+            current_user: current_user,
+            project: project,
+            project_user: project_user
+          }
+        } = socket
       ) do
     WorkOrders.subscribe(project.id)
 
@@ -67,6 +73,14 @@ defmodule LightningWeb.RunLive.Index do
         :rerun_job,
         current_user,
         project
+      )
+
+    can_edit_data_retention =
+      ProjectUsers
+      |> Permissions.can?(
+        :edit_data_retention,
+        current_user,
+        project_user
       )
 
     statuses = [
@@ -100,6 +114,7 @@ defmodule LightningWeb.RunLive.Index do
        work_orders: [],
        selected_work_orders: [],
        can_rerun_job: can_rerun_job,
+       can_edit_data_retention: can_edit_data_retention,
        pagination_path: &pagination_path(socket, project, &1),
        filters: params["filters"]
      )}
@@ -220,7 +235,7 @@ defmodule LightningWeb.RunLive.Index do
     %{work_order: work_order} =
       Lightning.Repo.preload(
         attempt,
-        [work_order: [:workflow, attempts: [steps: :job]]],
+        [work_order: [:workflow, :dataclip, attempts: [steps: :job]]],
         force: true
       )
 
@@ -257,7 +272,9 @@ defmodule LightningWeb.RunLive.Index do
         socket
       ) do
     work_order =
-      Lightning.Repo.preload(work_order, [:workflow, attempts: [steps: :job]],
+      Lightning.Repo.preload(
+        work_order,
+        [:workflow, :dataclip, attempts: [steps: :job]],
         force: true
       )
 
@@ -357,7 +374,9 @@ defmodule LightningWeb.RunLive.Index do
 
     work_orders =
       if selection do
-        Enum.map(page.entries, fn entry ->
+        page.entries
+        |> Enum.filter(fn wo -> is_nil(wo.dataclip.wiped_at) end)
+        |> Enum.map(fn entry ->
           %Lightning.WorkOrder{id: entry.id, workflow_id: entry.workflow_id}
         end)
       else
@@ -399,7 +418,7 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_query(filter)
+    |> Invocation.search_workorders_having_dataclips_query(filter)
     |> Lightning.Repo.all()
     |> WorkOrders.retry_many(job_id, created_by: socket.assigns.current_user)
   end
@@ -413,7 +432,7 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_query(filter)
+    |> Invocation.search_workorders_having_dataclips_query(filter)
     |> Lightning.Repo.all()
     |> WorkOrders.retry_many(created_by: socket.assigns.current_user)
   end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -418,7 +418,8 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_having_dataclips_query(filter)
+    |> Invocation.search_workorders_query(filter)
+    |> Invocation.exclude_wiped_dataclips()
     |> Lightning.Repo.all()
     |> WorkOrders.retry_many(job_id, created_by: socket.assigns.current_user)
   end
@@ -432,7 +433,8 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_having_dataclips_query(filter)
+    |> Invocation.search_workorders_query(filter)
+    |> Invocation.exclude_wiped_dataclips()
     |> Lightning.Repo.all()
     |> WorkOrders.retry_many(created_by: socket.assigns.current_user)
   end

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -705,6 +705,7 @@
                         work_order={workorder}
                         project={@project}
                         can_rerun_job={@can_rerun_job}
+                        can_edit_data_retention={@can_edit_data_retention}
                         entry_selected={
                           Enum.any?(@selected_work_orders, fn wo ->
                             wo.id == workorder.id

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -83,15 +83,6 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
      )}
   end
 
-  def handle_event("toggle_selection", %{}, %{assigns: assigns} = socket) do
-    send(
-      self(),
-      {:selection_toggled, {assigns.work_order, !assigns[:entry_selected]}}
-    )
-
-    {:noreply, assign(socket, :entry_selected, !assigns[:entry_selected])}
-  end
-
   attr :show_details, :boolean, default: false
   attr :show_prev_attempts, :boolean, default: false
   attr :entry_selected, :boolean, default: false
@@ -111,33 +102,59 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
           class="col-span-3 py-1 px-4 text-sm font-normal text-left rtl:text-right text-gray-500"
         >
           <div class="flex gap-4 items-center">
-            <form
-              phx-change="toggle_selection"
-              id={"selection-form-#{@work_order.id}"}
-            >
-              <input
-                type="hidden"
-                id={"id_#{@work_order.id}"}
-                name="workorder_id"
-                value={@work_order.id}
-              />
+            <%= if wo_dataclip_available?(@work_order) do %>
+              <form
+                phx-change="toggle_selection"
+                id={"selection-form-#{@work_order.id}"}
+              >
+                <input
+                  type="hidden"
+                  id={"id_#{@work_order.id}"}
+                  name="workorder_id"
+                  value={@work_order.id}
+                />
 
-              <input
-                type="hidden"
-                id={"unselect_#{@work_order.id}"}
-                name="selected"
-                value="false"
-              />
+                <input
+                  type="hidden"
+                  id={"unselect_#{@work_order.id}"}
+                  name="selected"
+                  value="false"
+                />
 
-              <input
-                type="checkbox"
-                id={"select_#{@work_order.id}"}
-                name="selected"
-                class="left-4 top-1/2 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                value="true"
-                {if @entry_selected, do: [checked: "checked"], else: []}
-              />
-            </form>
+                <input
+                  type="checkbox"
+                  id={"select_#{@work_order.id}"}
+                  name="selected"
+                  class="left-4 top-1/2 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                  value="true"
+                  {if @entry_selected, do: [checked: "checked"], else: []}
+                />
+              </form>
+            <% else %>
+              <form id={"selection-form-#{@work_order.id}"}>
+                <span
+                  id={"select_#{@work_order.id}_tooltip"}
+                  class="cursor-pointer"
+                  phx-hook="Tooltip"
+                  data-placement="right"
+                  data-allow-html="true"
+                  aria-label={
+                    rerun_zero_persistence_tooltip_message(
+                      @project.id,
+                      @can_edit_data_retention
+                    )
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    id={"select_#{@work_order.id}"}
+                    name="selected"
+                    class="left-4 top-1/2 h-4 w-4 rounded border-gray-300 bg-gray-100 text-indigo-600 focus:ring-indigo-600"
+                    disabled
+                  />
+                </span>
+              </form>
+            <% end %>
             <%= if @work_order.attempts !== [] do %>
               <button
                 id={"toggle_details_for_#{@work_order.id}"}
@@ -170,18 +187,11 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
                   <%= display_short_uuid(@work_order.id) %>
                 </span>
                 &bull;
-                <.link navigate={
-                  ~p"/projects/#{@work_order.workflow.project_id}/dataclips/#{@work_order.dataclip_id}/show"
-                }>
-                  <span
-                    title={@work_order.dataclip_id}
-                    class="font-normal text-xs whitespace-nowrap text-ellipsis
-                            p-1 rounded-md font-mono text-indigo-400 hover:underline
-                            underline-offset-2 hover:text-indigo-500"
-                  >
-                    <%= display_short_uuid(@work_order.dataclip_id) %>
-                  </span>
-                </.link>
+                <.workorder_dataclip_link
+                  work_order={@work_order}
+                  project={@project}
+                  can_edit_data_retention={@can_edit_data_retention}
+                />
               </span>
             </div>
           </div>
@@ -278,6 +288,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
 
             <.attempt_item
               can_rerun_job={@can_rerun_job}
+              can_edit_data_retention={@can_edit_data_retention}
               attempt={attempt}
               project={@project}
             />
@@ -285,6 +296,58 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
         <% end %>
       <% end %>
     </div>
+    """
+  end
+
+  defp workorder_dataclip_link(assigns) do
+    ~H"""
+    <%= if wo_dataclip_available?(@work_order) do %>
+      <.link
+        id={"view-dataclip-#{@work_order.dataclip_id}"}
+        navigate={
+          ~p"/projects/#{@work_order.workflow.project_id}/dataclips/#{@work_order.dataclip_id}/show"
+        }
+      >
+        <span
+          title={@work_order.dataclip_id}
+          class="font-normal text-xs whitespace-nowrap text-ellipsis
+                p-1 rounded-md font-mono text-indigo-400 hover:underline
+                underline-offset-2 hover:text-indigo-500"
+        >
+          <%= display_short_uuid(@work_order.dataclip_id) %>
+        </span>
+      </.link>
+    <% else %>
+      <span
+        id={"view-dataclip-#{@work_order.dataclip_id}"}
+        title={@work_order.dataclip_id}
+        class="font-normal text-xs whitespace-nowrap text-ellipsis
+              p-1 rounded-md font-mono text-indigo-300 cursor-pointer
+              "
+        phx-hook="Tooltip"
+        data-placement="right"
+        data-allow-html="true"
+        aria-label={
+          wiped_dataclip_tooltip_message(@project.id, @can_edit_data_retention)
+        }
+      >
+        <%= display_short_uuid(@work_order.dataclip_id) %>
+      </span>
+    <% end %>
+    """
+  end
+
+  defp wo_dataclip_available?(work_order) do
+    is_nil(work_order.dataclip.wiped_at)
+  end
+
+  defp wiped_dataclip_tooltip_message(project_id, can_edit_retention) do
+    """
+    <span class="text-center">
+    The input dataclip is unavailable and has not been stored<br>
+    due to the data retention policy set in the project.<br>
+    #{zero_persistence_action_message(project_id, can_edit_retention)}
+    </span>
     """
   end
 end

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -284,7 +284,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
 
     step = List.first(attempt.steps)
 
-    project_id = step.job.workflow.project_id
+    project_id = workflow.project_id
 
     html =
       render_component(&Components.step_list_item/1,

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -375,20 +375,20 @@ defmodule LightningWeb.WorkOrderLiveTest do
       parsed_html = Floki.parse_fragment!(html)
 
       assert parsed_html
-             |> Floki.find(~s{form#select_#{work_order.id}})
+             |> Floki.find(~s{form#selection-form-#{work_order.id}})
              |> Enum.any?(),
              "selection form exists"
 
       refute parsed_html
              |> Floki.find(
-               ~s{form#select_#{work_order.id}[phx-change="toggle_selection"]}
+               ~s{form#selection-form-#{work_order.id}[phx-change="toggle_selection"]}
              )
              |> Enum.any?(),
              "selection form does not have the phx-change attr"
 
       tooltip_html =
         parsed_html
-        |> Floki.find(~s{form#select_#{work_order.id}_tooltip})
+        |> Floki.find(~s{form #select_#{work_order.id}_tooltip})
         |> hd()
         |> Floki.raw_html()
 
@@ -414,20 +414,20 @@ defmodule LightningWeb.WorkOrderLiveTest do
       parsed_html = Floki.parse_fragment!(html)
 
       assert parsed_html
-             |> Floki.find(~s{form#select_#{work_order.id}})
+             |> Floki.find(~s{form#selection-form-#{work_order.id}})
              |> Enum.any?(),
              "selection form exists"
 
       refute parsed_html
              |> Floki.find(
-               ~s{form#select_#{work_order.id}[phx-change="toggle_selection"]}
+               ~s{form#selection-form-#{work_order.id}[phx-change="toggle_selection"]}
              )
              |> Enum.any?(),
              "selection form does not have the phx-change attr"
 
       tooltip_html =
         parsed_html
-        |> Floki.find(~s{form#select_#{work_order.id}_tooltip})
+        |> Floki.find(~s{form #select_#{work_order.id}_tooltip})
         |> hd()
         |> Floki.raw_html()
 
@@ -453,12 +453,12 @@ defmodule LightningWeb.WorkOrderLiveTest do
 
       assert parsed_html
              |> Floki.find(
-               ~s{form#select_#{work_order.id}[phx-change="toggle_selection"]}
+               ~s{form#selection-form-#{work_order.id}[phx-change="toggle_selection"]}
              )
              |> Enum.any?()
 
       refute parsed_html
-             |> Floki.find(~s{form#select_#{work_order.id}_tooltip})
+             |> Floki.find(~s{form #select_#{work_order.id}_tooltip})
              |> Enum.any?(),
              "tooltip does not exist"
     end

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -141,7 +141,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
       rendered =
         render_component(LightningWeb.RunLive.WorkOrderComponent,
           id: work_order.id,
-          work_order: work_order
+          work_order: work_order,
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: true
         )
 
       assert rendered =~ work_order.dataclip_id
@@ -162,7 +165,8 @@ defmodule LightningWeb.WorkOrderLiveTest do
           work_order: work_order,
           show_details: true,
           project: project,
-          can_rerun_job: true
+          can_rerun_job: true,
+          can_edit_data_retention: true
         )
 
       assert rendered =~ work_order.dataclip_id
@@ -189,18 +193,274 @@ defmodule LightningWeb.WorkOrderLiveTest do
 
       work_order =
         Lightning.Repo.reload!(work_order)
-        |> Lightning.Repo.preload([:attempts, :workflow])
+        |> Lightning.Repo.preload([:attempts, :workflow, :dataclip])
 
       assert_work_order_steps(work_order, 0)
 
       rendered =
         render_component(LightningWeb.RunLive.WorkOrderComponent,
           id: work_order.id,
-          work_order: work_order
+          work_order: work_order,
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: true
         )
 
       assert rendered =~ work_order.dataclip_id
       refute rendered =~ "toggle_details_for_#{work_order.id}"
+    end
+
+    test "WorkOrderComponent disables dataclip link if the dataclip has been wiped",
+         %{
+           project: project
+         } do
+      %{triggers: [trigger], jobs: [job | _rest]} =
+        workflow = insert(:simple_workflow, project: project)
+
+      wiped_dataclip = insert(:dataclip, body: nil, wiped_at: DateTime.utc_now())
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: wiped_dataclip,
+          state: :failed
+        )
+        |> with_attempt(
+          state: :failed,
+          dataclip: wiped_dataclip,
+          starting_trigger: trigger,
+          finished_at: build(:timestamp),
+          steps: [
+            build(:step,
+              finished_at: DateTime.utc_now(),
+              job: job,
+              exit_reason: "success",
+              input_dataclip: nil,
+              output_dataclip: nil
+            )
+          ]
+        )
+
+      html =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: work_order,
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: true
+        )
+
+      parsed_html = Floki.parse_fragment!(html)
+
+      refute parsed_html
+             |> Floki.find(~s{a#view-dataclip-#{wiped_dataclip.id}})
+             |> Enum.any?(),
+             "dataclip link not available"
+
+      assert parsed_html
+             |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+             |> Enum.any?()
+
+      dataclip_element =
+        parsed_html
+        |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+        |> hd()
+
+      dataclip_html = Floki.raw_html(dataclip_element)
+
+      assert dataclip_html =~
+               "The input dataclip is unavailable and has not been stored"
+
+      assert dataclip_html =~ "Go to retention settings",
+             "User sees link to go to settings"
+
+      refute dataclip_html =~ "contact one of your account administrators"
+
+      # User cannot edit data retention
+
+      html =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: work_order,
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: false
+        )
+
+      parsed_html = Floki.parse_fragment!(html)
+
+      refute parsed_html
+             |> Floki.find(~s{a#view-dataclip-#{wiped_dataclip.id}})
+             |> Enum.any?(),
+             "dataclip link not available"
+
+      assert parsed_html
+             |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+             |> Enum.any?()
+
+      dataclip_html =
+        parsed_html
+        |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+        |> hd()
+        |> Floki.raw_html()
+
+      assert dataclip_html =~
+               "The input dataclip is unavailable and has not been stored"
+
+      refute dataclip_html =~ "Go to retention settings",
+             "User cannot see link to go to settings"
+
+      assert dataclip_html =~ "contact one of your account administrators"
+
+      # Normal dataclip
+
+      parsed_html =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: %{work_order | dataclip: insert(:dataclip)},
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: false
+        )
+        |> Floki.parse_fragment!()
+
+      assert parsed_html
+             |> Floki.find(~s{a#view-dataclip-#{wiped_dataclip.id}})
+             |> Enum.any?(),
+             "dataclip link available"
+    end
+
+    test "WorkOrderComponent disables the select checkbox if the dataclip has been wiped",
+         %{
+           project: project
+         } do
+      %{triggers: [trigger], jobs: [job | _rest]} =
+        workflow = insert(:simple_workflow, project: project)
+
+      wiped_dataclip = insert(:dataclip, body: nil, wiped_at: DateTime.utc_now())
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: wiped_dataclip,
+          state: :failed
+        )
+        |> with_attempt(
+          state: :failed,
+          dataclip: wiped_dataclip,
+          starting_trigger: trigger,
+          finished_at: build(:timestamp),
+          steps: [
+            build(:step,
+              finished_at: DateTime.utc_now(),
+              job: job,
+              exit_reason: "success",
+              input_dataclip: nil,
+              output_dataclip: nil
+            )
+          ]
+        )
+
+      html =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: work_order,
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: true
+        )
+
+      parsed_html = Floki.parse_fragment!(html)
+
+      assert parsed_html
+             |> Floki.find(~s{form#select_#{work_order.id}})
+             |> Enum.any?(),
+             "selection form exists"
+
+      refute parsed_html
+             |> Floki.find(
+               ~s{form#select_#{work_order.id}[phx-change="toggle_selection"]}
+             )
+             |> Enum.any?(),
+             "selection form does not have the phx-change attr"
+
+      tooltip_html =
+        parsed_html
+        |> Floki.find(~s{form#select_#{work_order.id}_tooltip})
+        |> hd()
+        |> Floki.raw_html()
+
+      assert tooltip_html =~
+               "This work order cannot be rerun since no input data has been stored"
+
+      assert tooltip_html =~ "Go to retention settings",
+             "User sees link to go to settings"
+
+      refute tooltip_html =~ "contact one of your account administrators"
+
+      # User cannot edit data retention
+
+      html =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: work_order,
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: false
+        )
+
+      parsed_html = Floki.parse_fragment!(html)
+
+      assert parsed_html
+             |> Floki.find(~s{form#select_#{work_order.id}})
+             |> Enum.any?(),
+             "selection form exists"
+
+      refute parsed_html
+             |> Floki.find(
+               ~s{form#select_#{work_order.id}[phx-change="toggle_selection"]}
+             )
+             |> Enum.any?(),
+             "selection form does not have the phx-change attr"
+
+      tooltip_html =
+        parsed_html
+        |> Floki.find(~s{form#select_#{work_order.id}_tooltip})
+        |> hd()
+        |> Floki.raw_html()
+
+      assert tooltip_html =~
+               "This work order cannot be rerun since no input data has been stored"
+
+      refute tooltip_html =~ "Go to retention settings",
+             "User cannot see link to go to settings"
+
+      assert tooltip_html =~ "contact one of your account administrators"
+
+      # Normal dataclip
+
+      parsed_html =
+        render_component(LightningWeb.RunLive.WorkOrderComponent,
+          id: work_order.id,
+          work_order: %{work_order | dataclip: insert(:dataclip)},
+          project: project,
+          can_rerun_job: true,
+          can_edit_data_retention: false
+        )
+        |> Floki.parse_fragment!()
+
+      assert parsed_html
+             |> Floki.find(
+               ~s{form#select_#{work_order.id}[phx-change="toggle_selection"]}
+             )
+             |> Enum.any?()
+
+      refute parsed_html
+             |> Floki.find(~s{form#select_#{work_order.id}_tooltip})
+             |> Enum.any?(),
+             "tooltip does not exist"
     end
 
     test "toggle details of a work order shows attempt state and timestamp", %{
@@ -1715,6 +1975,62 @@ defmodule LightningWeb.WorkOrderLiveTest do
       updated_html = render(view)
       refute updated_html =~ "Rerun all 2 matching work orders from start"
       assert updated_html =~ "Rerun 1 selected work order from start"
+    end
+
+    test "workorders with wiped dataclips cannot be selected",
+         %{conn: conn, project: project, work_order: work_order_1} do
+      %{triggers: [trigger], jobs: [job | _rest]} =
+        workflow = insert(:simple_workflow, project: project)
+
+      dataclip = insert(:dataclip, body: nil, wiped_at: DateTime.utc_now())
+
+      work_order_2 =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip,
+          state: :success
+        )
+        |> with_attempt(
+          state: :success,
+          dataclip: dataclip,
+          starting_trigger: trigger,
+          finished_at: build(:timestamp),
+          steps: [
+            build(:step,
+              finished_at: DateTime.utc_now(),
+              job: job,
+              exit_reason: "success",
+              input_dataclip: nil,
+              output_dataclip: nil
+            )
+          ]
+        )
+
+      {:ok, view, _html} =
+        live_async(conn, Routes.project_run_index_path(conn, :index, project.id))
+
+      # Try selecting
+      assert_raise ArgumentError, fn ->
+        view
+        |> form("#selection-form-#{work_order_2.id}")
+        |> render_change(%{selected: true})
+      end
+
+      # Workorder with existing dataclip can be selected
+      assert view
+             |> form("#selection-form-#{work_order_1.id}")
+             |> render_change(%{selected: true}) =~
+               "Rerun 1 selected work order from start"
+
+      # Select All work orders. We have 2 workorders
+      html =
+        render_change(view, "toggle_all_selections", %{all_selections: true})
+
+      refute html =~ "Rerun 2 selected work orders from start"
+
+      assert html =~ "Rerun 1 selected work order from start",
+             "Only one workorder gets selected"
     end
   end
 


### PR DESCRIPTION
## Notes for the reviewer
- Preloads the `:dataclip` on the searched `work orders`
- Checks in the preloaded dataclip has been wiped
- There's an edge case which hasn't been handled. When all the workorders in the page have been disabled, the select all checkbox doesn't select anything.
- ~~The authorization logic has been copied from #1679 . Which ever gets merged first, will mean we get a conflict on the other.~~


## Related issue

Fixes #1210

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
