### PR TITLE
1684 impact tracking persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Persist impact tracking configuration and reports
+  [#1684](https://github.com/OpenFn/Lightning/issues/1684)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/impact_tracking/client.ex
+++ b/lib/lightning/impact_tracking/client.ex
@@ -6,8 +6,17 @@ defmodule Lightning.ImpactTracking.Client do
   """
   use Tesla, only: [:post], docs: false
 
+  alias Lightning.ImpactTracking.ResponseProcessor
+
   def submit_metrics(metrics, host) do
-    build_client(host) |> post("/api/metrics", metrics)
+    build_client(host)
+    |> post("/api/metrics", metrics)
+    |> elem(1)
+    |> ResponseProcessor.successful?()
+    |> then(fn
+      true -> :ok
+      false -> :error
+    end)
   end
 
   defp build_client(host) do

--- a/lib/lightning/impact_tracking/configuration.ex
+++ b/lib/lightning/impact_tracking/configuration.ex
@@ -1,0 +1,14 @@
+defmodule Lightning.ImpactTracking.Configuration do
+  @moduledoc """
+  Persistence of Impact Tracker submission configuration
+
+  """
+  use Ecto.Schema
+
+  @primary_key false
+  schema "impact_tracking_configurations" do
+    field :instance_id, Ecto.UUID, autogenerate: true
+
+    timestamps()
+  end
+end

--- a/lib/lightning/impact_tracking/report.ex
+++ b/lib/lightning/impact_tracking/report.ex
@@ -1,0 +1,16 @@
+defmodule Lightning.ImpactTracking.Report do
+  @moduledoc """
+  Report submitted to ImpactTracker
+
+  """
+  use Ecto.Schema
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "impact_tracking_reports" do
+    field :data, :map
+    field :submitted, :boolean
+    field :submitted_at, :utc_datetime_usec
+
+    timestamps()
+  end
+end

--- a/lib/lightning/impact_tracking/response_processor.ex
+++ b/lib/lightning/impact_tracking/response_processor.ex
@@ -1,0 +1,9 @@
+defmodule Lightning.ImpactTracking.ResponseProcessor do
+  @moduledoc """
+  Utility module to abstract deaing with some of the Tesla plumbing
+
+  """
+  def successful?(%Tesla.Env{status: status}) do
+    status >= 200 && status < 300
+  end
+end

--- a/lib/lightning/impact_tracking/worker.ex
+++ b/lib/lightning/impact_tracking/worker.ex
@@ -10,15 +10,37 @@ defmodule Lightning.ImpactTracking.Worker do
     max_attempts: 1
 
   alias Lightning.ImpactTracking.Client
+  alias Lightning.ImpactTracking.Configuration
+  alias Lightning.ImpactTracking.Report
+  alias Lightning.Repo
 
   @impl Oban.Worker
   def perform(_opts) do
     if Application.get_env(:lightning, :impact_tracking)[:enabled] do
+      find_configuration()
+
       host = Application.get_env(:lightning, :impact_tracking)[:host]
 
-      Client.submit_metrics(%{}, host)
+      metrics = %{}
+
+      Client.submit_metrics(metrics, host) |> create_report(metrics)
     end
 
     :ok
+  end
+
+  defp find_configuration do
+    with nil <- Repo.one(Configuration) do
+      Repo.insert!(%Configuration{})
+    end
+  end
+
+  defp create_report(:ok, metrics) do
+    %Report{data: metrics, submitted: true, submitted_at: DateTime.utc_now()}
+    |> Repo.insert()
+  end
+
+  defp create_report(:error, metrics) do
+    %Report{data: metrics} |> Repo.insert()
   end
 end

--- a/priv/repo/migrations/20240130105440_create_impact_tracking_configurations.exs
+++ b/priv/repo/migrations/20240130105440_create_impact_tracking_configurations.exs
@@ -1,0 +1,11 @@
+defmodule Lightning.Repo.Migrations.CreateImpactTrackingConfigurations do
+  use Ecto.Migration
+
+  def change do
+    create table(:impact_tracking_configurations, primary_key: false) do
+      add :instance_id, :uuid, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20240131084721_create_impact_tracking_reports_table.exs
+++ b/priv/repo/migrations/20240131084721_create_impact_tracking_reports_table.exs
@@ -1,0 +1,14 @@
+defmodule Lightning.Repo.Migrations.CreateImpactTrackingReportsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:impact_tracking_reports, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :data, :map, null: false
+      add :submitted, :boolean, default: false
+      add :submitted_at, :utc_datetime_usec, null: true
+
+      timestamps()
+    end
+  end
+end

--- a/test/lightning/impact_tracking/client_test.exs
+++ b/test/lightning/impact_tracking/client_test.exs
@@ -6,12 +6,20 @@ defmodule Lightning.ImpactTracking.ClientTest do
   alias Lightning.ImpactTracking.Client
 
   @host "https://foo.bar"
+  @url "#{@host}/api/metrics"
+  @metrics %{some: :metrics}
 
   describe ".submit_metrics" do
-    test "sends supplied metrics to impact tracker" do
-      url = "#{@host}/api/metrics"
-      serialised_metrics = Jason.encode!(%{some: :metrics})
+    setup do
+      %{
+        metrics: @metrics,
+        serialised_metrics: @metrics |> Jason.encode!(),
+        url: @url
+      }
+    end
 
+    test "indicates successful submission of metrics",
+         %{metrics: metrics, serialised_metrics: serialised_metrics, url: url} do
       mock(fn
         %{
           method: :post,
@@ -25,8 +33,25 @@ defmodule Lightning.ImpactTracking.ClientTest do
           flunk("Unrecognised call")
       end)
 
-      assert {:ok, %Tesla.Env{status: 200, body: %{status: "great"}}} =
-               Client.submit_metrics(%{some: :metrics}, @host)
+      assert Client.submit_metrics(metrics, @host) == :ok
+    end
+
+    test "indicates unsuccessful submission of metrics",
+         %{metrics: metrics, serialised_metrics: serialised_metrics, url: url} do
+      mock(fn
+        %{
+          method: :post,
+          url: ^url,
+          body: ^serialised_metrics,
+          headers: [{"content-type", "application/json"}]
+        } ->
+          %Tesla.Env{status: 500, body: %{}}
+
+        _ ->
+          flunk("Unrecognised call")
+      end)
+
+      assert Client.submit_metrics(metrics, @host) == :error
     end
   end
 end

--- a/test/lightning/impact_tracking/response_processor_test.exs
+++ b/test/lightning/impact_tracking/response_processor_test.exs
@@ -1,0 +1,25 @@
+defmodule Lightning.ImpactTracking.ResponseProcessorTest do
+  use ExUnit.Case
+
+  alias Lightning.ImpactTracking.ResponseProcessor
+
+  test "returns false with a status outside the 2xx range" do
+    env = %Tesla.Env{status: 199}
+
+    refute(ResponseProcessor.successful?(env))
+
+    env = %Tesla.Env{status: 300}
+
+    refute(ResponseProcessor.successful?(env))
+  end
+
+  test "returns true within the 2xx range" do
+    env = %Tesla.Env{status: 200}
+
+    assert(ResponseProcessor.successful?(env))
+
+    env = %Tesla.Env{status: 299}
+
+    assert(ResponseProcessor.successful?(env))
+  end
+end


### PR DESCRIPTION
## Notes for the reviewer

This PR includes two changes each in a separate commit to make it easier to follow:
- Implements configuration for impact tracking
- Stores the impact tracking metrics in the DB (follow-up work will allow reports that failed to be submitted to be retried)

There is also a commit for some test cleanup.


## Related issue

Fixes #1684 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
