### PR TITLE
Hide inspector rerun button when the selected step has a wiped dataclip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   [#1211](https://github.com/OpenFn/Lightning/issues/1211)
 - Disable selecting work orders having wiped dataclips in the history page
   [#1210](https://github.com/OpenFn/Lightning/issues/1210)
+- Hide rerun button in inspector when the selected step has a wiped dataclip
+  [#1639](https://github.com/OpenFn/Lightning/issues/1639)
 
 ### Changed
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1291,6 +1291,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
             socket.assigns.selected_job.id
           )
 
+        Attempts.subscribe(%Lightning.Attempt{id: attempt_id})
+
         socket |> assign(follow_attempt_id: attempt_id, step: step)
 
       _ ->

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -139,7 +139,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       ]}
                       disabled={
                         @save_and_run_disabled ||
-                          processing(@follow_attempt_id, @step)
+                          processing(@follow_attempt_id, @step) ||
+                          selected_dataclip_wiped?(
+                            @manual_run_form,
+                            @selectable_dataclips
+                          )
                       }
                     >
                       <%= if processing(@follow_attempt_id, @step) do %>
@@ -431,12 +435,21 @@ defmodule LightningWeb.WorkflowLive.Edit do
     step_dataclip_id = step && step.input_dataclip_id
 
     selected_dataclip =
-      Enum.find(selectable_dataclips, fn d ->
-        d.id == form[:dataclip_id].value
+      Enum.find(selectable_dataclips, fn dataclip ->
+        dataclip.id == form[:dataclip_id].value
       end)
 
     selected_dataclip && selected_dataclip.id == step_dataclip_id &&
       is_nil(selected_dataclip.wiped_at)
+  end
+
+  defp selected_dataclip_wiped?(form, selectable_dataclips) do
+    selected_dataclip =
+      Enum.find(selectable_dataclips, fn dataclip ->
+        dataclip.id == form[:dataclip_id].value
+      end)
+
+    selected_dataclip && !is_nil(selected_dataclip.wiped_at)
   end
 
   defp processing(attempt_id, step), do: attempt_id && !step

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -125,13 +125,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     <.button
                       id="save-and-run"
                       phx-hook="DefaultRunViaCtrlEnter"
-                      {if retry_from_here(@step, @manual_run_form, @selectable_dataclips), do:
+                      {if step_retryable?(@step, @manual_run_form, @selectable_dataclips), do:
                         [type: "button", "phx-click": "rerun", "phx-value-attempt_id": @follow_attempt_id, "phx-value-step_id": @step.id],
                       else:
                           [type: "submit", form: @manual_run_form.id]}
                       class={[
                         "relative inline-flex items-center",
-                        retry_from_here(
+                        step_retryable?(
                           @step,
                           @manual_run_form,
                           @selectable_dataclips
@@ -152,7 +152,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                           class="w-4 h-4 animate-spin mr-1"
                         /> Processing
                       <% else %>
-                        <%= if retry_from_here(@step, @manual_run_form, @selectable_dataclips) do %>
+                        <%= if step_retryable?(@step, @manual_run_form, @selectable_dataclips) do %>
                           <.icon name="hero-arrow-path-mini" class="w-4 h-4 mr-1" />
                           Rerun from here
                         <% else %>
@@ -163,7 +163,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     </.button>
                     <div
                       :if={
-                        retry_from_here(
+                        step_retryable?(
                           @step,
                           @manual_run_form,
                           @selectable_dataclips
@@ -431,7 +431,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     """
   end
 
-  defp retry_from_here(step, form, selectable_dataclips) do
+  defp step_retryable?(step, form, selectable_dataclips) do
     step_dataclip_id = step && step.input_dataclip_id
 
     selected_dataclip =

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -858,8 +858,8 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         step: %{id: ^step_id}
       }
 
-      # wait for 5 milliseconds to give liveview some time to process the event
-      Process.sleep(5)
+      # make sure that the event is processed by liveview
+      render(view)
 
       # dataclip body is nolonger present
       html = view |> element("#manual-job-#{job_1.id}") |> render()


### PR DESCRIPTION
## Notes for the reviewer

- Every time an `attempt` is followed in the `inspector`, we subscribe to the `Attempt Events`. This is there to help update the dataclip body copy if a user follows an attempt before it was started / while running. Since most users Inspect failed / completed steps, the live view will mostly subscribe to events that may never arrive.
- ~~In the test, I have a `Process.sleep(5)` to give an allowance for liveview to process an event.~~ Replaced with `render(view)` 


## Related issue

Fixes #1639 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
