### PR TITLE
dont duplicate http_request dataclips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to
 ### Fixed
 
 - Fixed bug that was duplicating inbound http_requests, resulting in unnecessary
-  data storage [#1695](https://github.com/OpenFn/Lightning/issues/1695)
+  data storage  
+  [#1695](https://github.com/OpenFn/Lightning/issues/1695)
 
 ## [v2.0.0-rc8] - 2024-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed bug that was duplicating inbound http_requests, resulting in unnecessary
+  data storage [#1695](https://github.com/OpenFn/Lightning/issues/1695)
+
 ## [v2.0.0-rc8] - 2024-01-30
 
 ### Added

--- a/lib/lightning/workflows/scheduler.ex
+++ b/lib/lightning/workflows/scheduler.ex
@@ -12,7 +12,6 @@ defmodule Lightning.Workflows.Scheduler do
     unique: [period: 59]
 
   alias Lightning.Invocation
-  alias Lightning.Invocation.Dataclip
   alias Lightning.Repo
   alias Lightning.Workflows
   alias Lightning.Workflows.Edge
@@ -52,17 +51,12 @@ defmodule Lightning.Workflows.Scheduler do
         # default_state_for_job(id)
         # %{id: uuid, type: :global, body: %{arbitrary: true}}
 
-        dataclip =
-          %{
+        WorkOrders.create_for(trigger,
+          dataclip: %{
             type: :global,
             body: %{},
             project_id: job.workflow.project_id
-          }
-          |> Dataclip.new()
-          |> Repo.insert!()
-
-        WorkOrders.create_for(trigger,
-          dataclip: dataclip,
+          },
           workflow: job.workflow
         )
 

--- a/test/integration/end_to_end_test.exs
+++ b/test/integration/end_to_end_test.exs
@@ -82,6 +82,9 @@ defmodule LightningWeb.EndToEndTest do
              |> Enum.all?(fn {_x, count} -> count == 2 end)
 
       assert %{state: :success} = WorkOrders.get(wo_id)
+
+      # There was an initial http_request dataclip and 7 run_result dataclips
+      assert Repo.all(Lightning.Invocation.Dataclip) |> Enum.count() == 8
     end
 
     @tag :integration

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -45,6 +45,7 @@ defmodule Lightning.WorkOrdersTest do
       [run] = workorder.runs
 
       assert run.starting_trigger.id == trigger.id
+      assert run.dataclip_id == dataclip.id
 
       workorder_id = workorder.id
 


### PR DESCRIPTION
This fixes #1695 , a bug that resulted in `http_request` dataclips getting duplicated because of how we `put_assoc` down through a fairly complex changeset for a new workorder.

```
  @spec build_for(Trigger.t() | Job.t(), map()) ::
          Ecto.Changeset.t(WorkOrder.t())
  def build_for(%Trigger{} = trigger, attrs) do
    %WorkOrder{}
    |> change()
    |> put_assoc(:workflow, attrs[:workflow])
    |> put_assoc(:trigger, trigger)
    |> put_assoc(:dataclip, attrs[:dataclip])
    |> put_assoc(:runs, [
      Run.for(trigger, %{dataclip: attrs[:dataclip]})
    ])
    |> validate_required_assoc(:workflow)
    |> validate_required_assoc(:trigger)
    |> validate_required_assoc(:dataclip)
    |> assoc_constraint(:trigger)
    |> assoc_constraint(:workflow)
  end
```

This code, if given an existing dataclip, will associate the work order and the run with that dataclip. If it's given the attributes for a dataclip, however, it will build 2 new dataclips and stick 'em both in the DB.

This popped up while I was reviewing the zero-persistence pipeline code — one of the 2 dataclips was being scrubbed properly!

@stuartc , there's probably a much more elegant way to do this, and I have no idea how it will impact performance on that endpoint, but I figure we should start by stopping the duplication and then enhance from there. Please feel free to make whatever changes you'd like directly and merge to `main` when you're happy.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
