### PR TITLE
fix permissions on webhook auth methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed permissions issue that allowed viewer/editor to modify webhook auth
+  methods. These permissions only belong to project owners and admins
+  [#1692](https://github.com/OpenFn/Lightning/issues/1692)
 - Fixed bug that was duplicating inbound http_requests, resulting in unnecessary
-  data storage  
-  [#1695](https://github.com/OpenFn/Lightning/issues/1695)
+  data storage [#1695](https://github.com/OpenFn/Lightning/issues/1695)
 
 ## [v2.0.0-rc8] - 2024-01-30
 

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -23,9 +23,8 @@ defmodule Lightning.Policies.ProjectUsers do
           | :edit_failure_alerts
           | :edit_project_description
           | :provision_project
-          | :create_webhook_auth_method
           | :create_project_credential
-          | :edit_webhook_auth_method
+          | :write_webhook_auth_method
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -74,6 +73,12 @@ defmodule Lightning.Policies.ProjectUsers do
 
   def authorize(action, %User{}, %ProjectUser{} = project_user)
       when action in [
+             :write_webhook_auth_method
+           ],
+      do: project_user.role in [:owner, :admin]
+
+  def authorize(action, %User{}, %ProjectUser{} = project_user)
+      when action in [
              :create_workflow,
              :edit_job,
              :create_job,
@@ -81,9 +86,8 @@ defmodule Lightning.Policies.ProjectUsers do
              :run_job,
              :rerun_job,
              :provision_project,
-             :create_webhook_auth_method,
              :create_project_credential,
-             :edit_webhook_auth_method
+             :write_webhook_auth_method
            ],
       do: project_user.role in [:owner, :admin, :editor]
 end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -62,10 +62,10 @@ defmodule LightningWeb.ProjectLive.Settings do
         project_user.user_id == current_user.id
       end)
 
-    can_create_webhook_auth_method =
+    can_write_webhook_auth_method =
       Permissions.can?(
         ProjectUsers,
-        :create_webhook_auth_method,
+        :write_webhook_auth_method,
         current_user,
         project_user
       )
@@ -74,14 +74,6 @@ defmodule LightningWeb.ProjectLive.Settings do
       Permissions.can?(
         ProjectUsers,
         :create_project_credential,
-        current_user,
-        project_user
-      )
-
-    can_edit_webhook_auth_method =
-      Permissions.can?(
-        ProjectUsers,
-        :edit_webhook_auth_method,
         current_user,
         project_user
       )
@@ -105,9 +97,8 @@ defmodule LightningWeb.ProjectLive.Settings do
        can_delete_project: can_delete_project,
        can_edit_project_name: can_edit_project_name,
        can_edit_project_description: can_edit_project_description,
-       can_create_webhook_auth_method: can_create_webhook_auth_method,
+       can_write_webhook_auth_method: can_write_webhook_auth_method,
        can_create_project_credential: can_create_project_credential,
-       can_edit_webhook_auth_method: can_edit_webhook_auth_method,
        show_github_setup: show_github_setup,
        show_repo_setup: show_repo_setup,
        show_sync_button: show_sync_button,

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -301,12 +301,12 @@
                 type="button"
                 phx-click={show_modal("new_auth_method_modal")}
                 class="rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50"
-                {if !@can_create_webhook_auth_method, do: [disabled: "disabled"], else: []}
+                {if !@can_write_webhook_auth_method, do: [disabled: "disabled"], else: []}
               >
                 Add an auth method
               </button>
               <.live_component
-                :if={@can_create_webhook_auth_method}
+                :if={@can_write_webhook_auth_method}
                 module={
                   LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent
                 }
@@ -367,7 +367,7 @@
               </span>
             </:linked_triggers>
             <:action :let={auth_method}>
-              <%= if @can_edit_webhook_auth_method do %>
+              <%= if @can_write_webhook_auth_method do %>
                 <a
                   id={"edit_auth_method_link_#{auth_method.id}"}
                   href="#"
@@ -403,30 +403,40 @@
               <% end %>
             </:action>
             <:action :let={auth_method}>
-              <a
-                id={"delete_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="text-red-600 hover:text-red-800"
-                phx-click={show_modal("delete_auth_#{auth_method.id}_modal")}
-              >
-                Delete
-              </a>
-              <div class="text-left">
-                <.live_component
-                  module={
-                    LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent
-                  }
-                  id={"delete_auth_#{auth_method.id}_modal"}
-                  action={:delete}
-                  project={@project}
-                  webhook_auth_method={auth_method}
-                  current_user={@current_user}
-                  return_to={
-                    ~p"/projects/#{@project.id}/settings#webhook_security"
-                  }
-                  trigger={nil}
-                />
-              </div>
+              <%= if @can_write_webhook_auth_method do %>
+                <a
+                  id={"delete_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="text-red-600 hover:text-red-800"
+                  phx-click={show_modal("delete_auth_#{auth_method.id}_modal")}
+                >
+                  Delete
+                </a>
+                <div class="text-left">
+                  <.live_component
+                    module={
+                      LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent
+                    }
+                    id={"delete_auth_#{auth_method.id}_modal"}
+                    action={:delete}
+                    project={@project}
+                    webhook_auth_method={auth_method}
+                    current_user={@current_user}
+                    return_to={
+                      ~p"/projects/#{@project.id}/settings#webhook_security"
+                    }
+                    trigger={nil}
+                  />
+                </div>
+              <% else %>
+                <a
+                  id={"edit_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="ml-1 cursor-not-allowed text-indigo-300"
+                >
+                  Delete
+                </a>
+              <% end %>
             </:action>
           </LightningWeb.WorkflowLive.Components.webhook_auth_methods_table>
         </LightningWeb.Components.Common.panel_content>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -158,6 +158,7 @@ defmodule LightningWeb.WorkflowLive.Components do
   attr :form, :map, required: true
   attr :cancel_url, :string, required: true
   attr :disabled, :boolean, required: true
+  attr :can_write_webhook_auth_method, :boolean, required: true
   attr :webhook_url, :string, required: true
   attr :on_change, :any, required: true
   attr :selected_trigger, Trigger, required: true
@@ -286,7 +287,11 @@ defmodule LightningWeb.WorkflowLive.Components do
                 <div>
                   <.link
                     href="#"
-                    class="text-primary-700 underline hover:text-primary-800"
+                    class={[
+                      "text-primary-700 underline hover:text-primary-800",
+                      !@can_write_webhook_auth_method &&
+                        "text-gray-500 cursor-not-allowed"
+                    ]}
                     phx-click={show_modal("webhooks_auth_method_modal")}
                   >
                     Manage authentication
@@ -308,6 +313,7 @@ defmodule LightningWeb.WorkflowLive.Components do
       form={@form}
       field={:enabled}
       label="Disable this trigger"
+      disabled={@disabled}
       checked_value={false}
       unchecked_value={true}
       value={@trigger_enabled}
@@ -424,6 +430,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             <Form.check_box
               form={@form}
               field={:enabled}
+              disabled={@disabled}
               label="Disable this path"
               checked_value={false}
               unchecked_value={true}

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -249,7 +249,7 @@ defmodule LightningWeb.WorkflowLive.Components do
                     href="#"
                     class={[
                       "text-indigo-400 underline not-italic inline-flex items-center",
-                      if(@action == :new or @disabled,
+                      if(@action == :new or !@can_write_webhook_auth_method,
                         do: "text-gray-500 cursor-not-allowed",
                         else: ""
                       )

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -361,6 +361,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   form={tf}
                   on_change={&send_form_changed/1}
                   disabled={!@can_edit_job}
+                  can_write_webhook_auth_method={@can_write_webhook_auth_method}
                   webhook_url={webhook_url(@selected_trigger)}
                   selected_trigger={@selected_trigger}
                   action={@live_action}
@@ -395,7 +396,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
         <.live_component
           :if={
-            @live_action == :edit && @can_create_webhook_auth_method &&
+            @live_action == :edit && @can_write_webhook_auth_method &&
               @selected_trigger
           }
           module={LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent}
@@ -536,17 +537,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
               current_user,
               project_user
             ),
-          can_create_webhook_auth_method:
+          can_write_webhook_auth_method:
             Permissions.can?(
               ProjectUsers,
-              :create_webhook_auth_method,
-              current_user,
-              project_user
-            ),
-          can_edit_webhook_auth_method:
-            Permissions.can?(
-              ProjectUsers,
-              :edit_webhook_auth_method,
+              :write_webhook_auth_method,
               current_user,
               project_user
             )
@@ -564,17 +558,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     socket
     |> assign(
-      can_create_webhook_auth_method:
+      can_write_webhook_auth_method:
         Permissions.can?(
           ProjectUsers,
-          :create_webhook_auth_method,
-          current_user,
-          project_user
-        ),
-      can_edit_webhook_auth_method:
-        Permissions.can?(
-          ProjectUsers,
-          :edit_webhook_auth_method,
+          :write_webhook_auth_method,
           current_user,
           project_user
         ),

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -335,7 +335,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
 
   def render(assigns) do
     ~H"""
-    <div id="create_edit_webhook_auth_method">
+    <div id="write_webhook_auth_method">
       <%!-- <%= if @webhook_auth_method.auth_type do %> --%>
       <.form
         :let={f}

--- a/test/lightning/policies/project_user_permissions_test.exs
+++ b/test/lightning/policies/project_user_permissions_test.exs
@@ -112,10 +112,10 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_workflow
         delete_workflow
         edit_job
+        provision_project
         edit_project_description
         edit_project_name
-        provision_project
-        create_webhook_auth_method
+        write_webhook_auth_method
         create_project_credential
         rerun_job
         run_job
@@ -134,9 +134,8 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_workflow
         delete_workflow
         edit_job
-        provision_project
-        create_webhook_auth_method
         create_project_credential
+        provision_project
         rerun_job
         run_job
       )a |> (&assert_can(ProjectUsers, &1, editor, project)).()
@@ -150,6 +149,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
       ~w(
           edit_project_description
           edit_project_name
+          write_webhook_auth_method
         )a |> (&refute_can(ProjectUsers, &1, editor, project)).()
     end
   end
@@ -168,7 +168,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
           edit_project_description
           edit_project_name
           provision_project
-          create_webhook_auth_method
+          write_webhook_auth_method
           create_project_credential
           rerun_job
           run_job
@@ -190,7 +190,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         edit_project_description
         edit_project_name
         provision_project
-        create_webhook_auth_method
+        write_webhook_auth_method
         create_project_credential
         rerun_job
         run_job

--- a/test/lightning_web/live/workflow_live/trigger_test.exs
+++ b/test/lightning_web/live/workflow_live/trigger_test.exs
@@ -1,6 +1,10 @@
 defmodule LightningWeb.WorkflowLive.TriggerTest do
   use LightningWeb.ConnCase, async: true
 
+  alias Lightning.Name
+  alias Lightning.Repo
+  alias Lightning.Workflows.WebhookAuthMethod
+
   import Phoenix.LiveViewTest
   import Lightning.Factories
 
@@ -11,39 +15,18 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
     workflow = insert(:workflow, project: project)
     trigger = insert(:trigger, type: :webhook, workflow: workflow)
 
-    %{conn: admin_conn, user: admin_user} =
-      register_and_log_in_user(%{conn: build_conn()})
-
-    insert(:project_user,
-      role: :admin,
-      project: project,
-      user: admin_user
-    )
-
     [
       workflow: workflow,
-      trigger: trigger,
-      admin_conn: admin_conn,
-      admin_user: admin_user
+      trigger: trigger
     ]
   end
 
-  test "authorized users can see link to add authentication method", %{
-    conn: conn,
+  test "owner/admin can see link to add auth method, editor/viewer can't", %{
     project: project,
     workflow: workflow,
     trigger: trigger
   } do
-    for project_user <-
-          Enum.map([:admin, :owner], fn role ->
-            insert(:project_user,
-              role: role,
-              project: project,
-              user: build(:user)
-            )
-          end) do
-      conn = log_in_user(conn, project_user.user)
-
+    for conn <- project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -54,16 +37,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       assert view |> element("#webhooks_auth_method_modal") |> has_element?()
     end
 
-    for project_user <-
-          Enum.map([:editor, :viewer], fn role ->
-            insert(:project_user,
-              role: role,
-              project: project,
-              user: build(:user)
-            )
-          end) do
-      conn = log_in_user(conn, project_user.user)
-
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -78,171 +52,192 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
     end
   end
 
-  test "user can see existing trigger authentication methods", %{
-    conn: conn,
+  test "all users can see existing trigger authentication methods", %{
     project: project,
     workflow: workflow,
     trigger: trigger
   } do
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin, :editor, :viewer]) do
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    auth_method =
-      insert(:webhook_auth_method,
-        project: project,
-        auth_type: :basic,
-        triggers: [trigger]
-      )
+      auth_method =
+        insert(:webhook_auth_method,
+          project: project,
+          auth_type: :basic,
+          triggers: [trigger]
+        )
 
-    refute html =~ auth_method.name
+      refute html =~ auth_method.name
 
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert html =~ auth_method.name
+      assert html =~ auth_method.name
+    end
   end
 
-  test "admin can successfully create a basic authentication method, editor cant",
+  test "owner/admin can successfully create a basic authentication method, editor/viewer can't",
        %{
-         conn: conn,
-         admin_conn: admin_conn,
          project: project,
          workflow: workflow,
          trigger: trigger
        } do
     modal_id = "webhooks_auth_method_modal"
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("##{modal_id}") |> has_element?()
+      refute view |> element("##{modal_id}") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("##{modal_id}") |> has_element?()
+      assert view |> element("##{modal_id}") |> has_element?()
 
-    html =
+      html =
+        view
+        |> form("#choose_auth_type_form_#{modal_id}",
+          webhook_auth_method: %{auth_type: "basic"}
+        )
+        |> render_submit()
+
+      assert html =~ "Create auth method"
+
+      auth_method_name = Name.generate()
+
+      refute render(view) =~ auth_method_name
+
       view
-      |> form("#choose_auth_type_form_#{modal_id}",
-        webhook_auth_method: %{auth_type: "basic"}
+      |> form("#form_#{modal_id}_new_webhook_auth_method",
+        webhook_auth_method: %{
+          name: auth_method_name,
+          username: "testusername",
+          password: "testpassword123"
+        }
       )
       |> render_submit()
 
-    assert html =~ "Create auth method"
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    auth_method_name = "funnyauthmethodname"
+      assert flash["info"] == "Webhook auth method created successfully"
 
-    refute render(view) =~ auth_method_name
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    view
-    |> form("#form_#{modal_id}_new_webhook_auth_method",
-      webhook_auth_method: %{
-        name: auth_method_name,
-        username: "testusername",
-        password: "testpassword123"
-      }
-    )
-    |> render_submit()
+      assert html =~ auth_method_name
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      assert %Postgrex.Result{num_rows: 1} =
+               Ecto.Adapters.SQL.query!(
+                 Repo,
+                 "delete from trigger_webhook_auth_methods"
+               )
 
-    assert flash["info"] == "Webhook auth method created successfully"
-
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
-
-    assert html =~ auth_method_name
+      Repo.get_by(WebhookAuthMethod, name: auth_method_name)
+      |> Repo.delete()
+    end
   end
 
-  test "admin can successfully create an API authentication method, user can't",
+  test "admin can successfully create an API authentication method, editor/viewer can't",
        %{
-         conn: conn,
-         admin_conn: admin_conn,
          project: project,
          workflow: workflow,
          trigger: trigger
        } do
     modal_id = "webhooks_auth_method_modal"
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("##{modal_id}") |> has_element?()
+      refute view |> element("##{modal_id}") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("##{modal_id}") |> has_element?()
+      assert view |> element("##{modal_id}") |> has_element?()
 
-    html =
-      view
-      |> form("#choose_auth_type_form_#{modal_id}",
-        webhook_auth_method: %{auth_type: "api"}
-      )
-      |> render_submit()
+      html =
+        view
+        |> form("#choose_auth_type_form_#{modal_id}",
+          webhook_auth_method: %{auth_type: "api"}
+        )
+        |> render_submit()
 
-    assert html =~ "Create auth method"
-    assert html =~ "API Key"
-    refute html =~ "password"
+      assert html =~ "Create auth method"
+      assert html =~ "API Key"
+      refute html =~ "password"
 
-    auth_method_name = "funnyapiauthmethodname"
+      auth_method_name = Name.generate()
 
-    refute render(view) =~ auth_method_name
+      refute render(view) =~ auth_method_name
 
-    assert view
-           |> form("#form_#{modal_id}_new_webhook_auth_method",
-             webhook_auth_method: %{
-               name: auth_method_name
-             }
-           )
-           |> render_submit()
+      assert view
+             |> form("#form_#{modal_id}_new_webhook_auth_method",
+               webhook_auth_method: %{
+                 name: auth_method_name
+               }
+             )
+             |> render_submit()
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert flash["info"] == "Webhook auth method created successfully"
+      assert flash["info"] == "Webhook auth method created successfully"
 
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert html =~ auth_method_name
+      assert html =~ auth_method_name
+
+      assert %Postgrex.Result{num_rows: 1} =
+               Ecto.Adapters.SQL.query!(
+                 Repo,
+                 "delete from trigger_webhook_auth_methods"
+               )
+
+      Repo.get_by(WebhookAuthMethod, name: auth_method_name)
+      |> Repo.delete()
+    end
   end
 
   test "admin can successfully update an authentication method, editor cant", %{
-    conn: conn,
-    admin_conn: admin_conn,
     project: project,
     workflow: workflow,
     trigger: trigger
@@ -256,67 +251,68 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
 
     modal_id = "webhooks_auth_method_modal"
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("##{modal_id}") |> has_element?()
+      refute view |> element("##{modal_id}") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("##{modal_id}") |> has_element?()
+      assert view |> element("##{modal_id}") |> has_element?()
 
-    html =
-      view
-      |> element("#edit_auth_method_link_#{auth_method.id}")
-      |> render_click()
+      html =
+        view
+        |> element("#edit_auth_method_link_#{auth_method.id}")
+        |> render_click()
 
-    assert html =~ "Edit webhook auth method"
+      assert html =~ "Edit webhook auth method"
 
-    new_auth_method_name = "funnyapiauthmethodname"
+      new_auth_method_name = Name.generate()
 
-    assert view
-           |> form("#form_#{modal_id}_#{auth_method.id}")
-           |> render_submit(%{
-             webhook_auth_method: %{
-               name: new_auth_method_name,
-               username: "newusername",
-               password: "newpassword123"
-             }
-           })
+      assert view
+             |> form("#form_#{modal_id}_#{auth_method.id}")
+             |> render_submit(%{
+               webhook_auth_method: %{
+                 name: new_auth_method_name,
+                 username: "newusername",
+                 password: "newpassword123"
+               }
+             })
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert flash["info"] == "Webhook auth method updated successfully"
+      assert flash["info"] == "Webhook auth method updated successfully"
 
-    updated_auth_method =
-      Lightning.Repo.get(Lightning.Workflows.WebhookAuthMethod, auth_method.id)
+      updated_auth_method = Repo.get(WebhookAuthMethod, auth_method.id)
 
-    refute updated_auth_method.name == auth_method.name
-    assert updated_auth_method.name == new_auth_method_name
+      refute updated_auth_method.name == auth_method.name
+      assert updated_auth_method.name == new_auth_method_name
 
-    # only auth method name is updated
-    refute auth_method.username == "username"
-    assert auth_method.username == updated_auth_method.username
+      # only auth method name is updated
+      refute auth_method.username == "username"
+      assert auth_method.username == updated_auth_method.username
 
-    refute auth_method.password == "newpassword123"
-    assert auth_method.password == updated_auth_method.password
+      refute auth_method.password == "newpassword123"
+      assert auth_method.password == updated_auth_method.password
+    end
   end
 
-  test "admin can successfully remove an authentication method from a trigger, user can't",
+  test "owner/admin can remove an auth method from a trigger, editor/viewer can't",
        %{
-         conn: conn,
-         admin_conn: admin_conn,
          project: project,
          workflow: workflow,
          trigger: trigger
@@ -328,39 +324,57 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
         triggers: [trigger]
       )
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("#webhooks_auth_method_modal") |> has_element?()
+      refute view |> element("#webhooks_auth_method_modal") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("#webhooks_auth_method_modal") |> has_element?()
+      assert view |> element("#webhooks_auth_method_modal") |> has_element?()
 
-    view
-    |> element("#select_#{auth_method.id}")
-    |> render_click()
+      view
+      |> element("#select_#{auth_method.id}")
+      |> render_click()
 
-    view |> element("#update_trigger_auth_methods_button") |> render_click()
+      view |> element("#update_trigger_auth_methods_button") |> render_click()
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert flash["info"] == "Trigger webhook auth methods updated successfully"
+      assert flash["info"] == "Trigger webhook auth methods updated successfully"
 
-    updated_trigger =
-      Lightning.Repo.preload(trigger, [:webhook_auth_methods], force: true)
+      updated_trigger =
+        Repo.preload(trigger, [:webhook_auth_methods], force: true)
 
-    assert updated_trigger.webhook_auth_methods == []
+      assert updated_trigger.webhook_auth_methods == []
+
+      # Then we add it back for the next test role! ============================
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
+
+      view
+      |> element("#select_#{auth_method.id}")
+      |> render_click()
+
+      view |> element("#update_trigger_auth_methods_button") |> render_click()
+      # ========================================================================
+    end
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -161,4 +161,20 @@ defmodule LightningWeb.ConnCase do
     |> Phoenix.ConnTest.init_test_session(%{})
     |> Plug.Conn.put_session(:user_token, token)
   end
+
+  @doc """
+  """
+  def project_user_conns(project, roles) do
+    Enum.map(roles, fn role ->
+      project_user =
+        Lightning.Factories.insert(:project_user,
+          role: role,
+          project: project,
+          user: Lightning.Factories.build(:user)
+        )
+
+      Phoenix.ConnTest.build_conn()
+      |> log_in_user(project_user.user)
+    end)
+  end
 end


### PR DESCRIPTION
- This fixes #1692 , ensuring that only owners and admins can edit webhook auth methods for a project.
- It _also_ collapses "create_webhook_blah" and "edit_webhook_blah" and _adds_ _deletion_ prevention by using `write_webhook_auth_methods`.

On this ⬆️ , I'd _really_ when possible I'd really like to collapse down our permissions. For instance, the only two permissions we should have on workflows are `write` and `read` - if you can create one, you can edit one, and you can delete one. In some cases, I bet we'll separate delete out, but in many cases it will be much cleaner to simply use `write_workflows`.

A second thing here, I'd like to remove `edit_job` and replace it with `create_workflows`. Especially as we've now got a big workflow changeset (soon JSON!?) it makes sense to have `write_workflow` and have that control whether you can create/edit/delete triggers, paths, and steps. This will come in later PRs.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
