### PR TITLE
Permissions update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to
   characters if an empty string secret was provided as a credential field value
   (e.g., {"username": "come-on-in", "password": ""})
   [#1585](https://github.com/OpenFn/Lightning/issues/1585)
+- Fixed permissions issue that allowed viewer/editor to modify webhook auth
+  methods. These permissions only belong to project owners and admins
+  [#1692](https://github.com/OpenFn/Lightning/issues/1692)
 - Fixed bug that was duplicating inbound http_requests, resulting in unnecessary
   data storage [#1695](https://github.com/OpenFn/Lightning/issues/1695)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to
   [#1692](https://github.com/OpenFn/Lightning/issues/1692)
 - Fixed bug that was duplicating inbound http_requests, resulting in unnecessary
   data storage [#1695](https://github.com/OpenFn/Lightning/issues/1695)
+- Fixed permissions issue that allowed editors to set up new Github connections
+  [#1703](https://github.com/OpenFn/Lightning/issues/1703)
+- Fixed permissions issue that allowed viewers to initiate syncs to github
+  [#1704](https://github.com/OpenFn/Lightning/issues/1704)
 
 ## [v2.0.0-rc8] - 2024-01-30
 

--- a/lib/lightning/policies/permissions.ex
+++ b/lib/lightning/policies/permissions.ex
@@ -18,10 +18,10 @@ defmodule Lightning.Policies.Permissions do
 
   Here is an example of how we the `Lightning.Policies.Permissions.can/4` interface to check if the a user can edit a job or not
   ```elixir
-  can_edit_job = Lightning.Policies.ProjectUsers |> Lightning.Policies.Permissions.can?(:edit_job, socket.assigns.current_user, socket.assigns.project)
+  can_edit_workflow = Lightning.Policies.ProjectUsers |> Lightning.Policies.Permissions.can?(:edit_workflow, socket.assigns.current_user, socket.assigns.project)
 
-  if can_edit_job do
-    # allow user to edit the job
+  if can_edit_workflow do
+    # allow user to edit the workflow
   else
     # quick user out
   end

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -10,9 +10,8 @@ defmodule Lightning.Policies.ProjectUsers do
   alias Lightning.Projects.ProjectUser
 
   @type actions ::
-          :run_job
+          :run_workflow
           | :edit_job
-          | :rerun_job
           | :create_job
           | :access_project
           | :delete_project
@@ -91,8 +90,7 @@ defmodule Lightning.Policies.ProjectUsers do
              :edit_job,
              :create_job,
              :delete_workflow,
-             :run_job,
-             :rerun_job,
+             :run_workflow,
              :provision_project,
              :create_project_credential,
              :initiate_github_sync

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -23,10 +23,9 @@ defmodule Lightning.Policies.ProjectUsers do
           | :edit_failure_alerts
           | :edit_project_description
           | :provision_project
-          | :create_webhook_auth_method
           | :create_project_credential
-          | :edit_webhook_auth_method
           | :edit_data_retention
+          | :write_webhook_auth_method
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -79,6 +78,12 @@ defmodule Lightning.Policies.ProjectUsers do
 
   def authorize(action, %User{}, %ProjectUser{} = project_user)
       when action in [
+             :write_webhook_auth_method
+           ],
+      do: project_user.role in [:owner, :admin]
+
+  def authorize(action, %User{}, %ProjectUser{} = project_user)
+      when action in [
              :create_workflow,
              :edit_job,
              :create_job,
@@ -86,9 +91,8 @@ defmodule Lightning.Policies.ProjectUsers do
              :run_job,
              :rerun_job,
              :provision_project,
-             :create_webhook_auth_method,
              :create_project_credential,
-             :edit_webhook_auth_method
+             :write_webhook_auth_method
            ],
       do: project_user.role in [:owner, :admin, :editor]
 end

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -11,8 +11,7 @@ defmodule Lightning.Policies.ProjectUsers do
 
   @type actions ::
           :run_workflow
-          | :edit_job
-          | :create_job
+          | :edit_workflow
           | :access_project
           | :delete_project
           | :delete_workflow
@@ -53,12 +52,11 @@ defmodule Lightning.Policies.ProjectUsers do
   def authorize(:delete_project, %User{} = user, %Project{} = project),
     do: Projects.get_project_user_role(user, project) == :owner
 
-  def authorize(
-        action,
-        %User{id: id} = _user,
-        %ProjectUser{user_id: user_id} = _project
-      )
-      when action in [:edit_digest_alerts, :edit_failure_alerts],
+  def authorize(action, %User{id: id}, %ProjectUser{user_id: user_id})
+      when action in [
+             :edit_digest_alerts,
+             :edit_failure_alerts
+           ],
       do: id == user_id
 
   def authorize(action, %User{} = user, %Project{} = project)
@@ -87,8 +85,7 @@ defmodule Lightning.Policies.ProjectUsers do
   def authorize(action, %User{}, %ProjectUser{} = project_user)
       when action in [
              :create_workflow,
-             :edit_job,
-             :create_job,
+             :edit_workflow,
              :delete_workflow,
              :run_workflow,
              :provision_project,

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -26,6 +26,8 @@ defmodule Lightning.Policies.ProjectUsers do
           | :create_project_credential
           | :edit_data_retention
           | :write_webhook_auth_method
+          | :write_github_connection
+          | :initiate_github_sync
 
   @doc """
   authorize/3 takes an action, a user, and a project. It checks the user's role
@@ -78,7 +80,8 @@ defmodule Lightning.Policies.ProjectUsers do
 
   def authorize(action, %User{}, %ProjectUser{} = project_user)
       when action in [
-             :write_webhook_auth_method
+             :write_webhook_auth_method,
+             :write_github_connection
            ],
       do: project_user.role in [:owner, :admin]
 
@@ -92,7 +95,7 @@ defmodule Lightning.Policies.ProjectUsers do
              :rerun_job,
              :provision_project,
              :create_project_credential,
-             :write_webhook_auth_method
+             :initiate_github_sync
            ],
       do: project_user.role in [:owner, :admin, :editor]
 end

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -91,7 +91,7 @@ defmodule Lightning.VersionControl do
     end
   end
 
-  def run_sync(project_id, user_name) do
+  def initiate_sync(project_id, user_name) do
     with %ProjectRepoConnection{} = repo_connection <-
            Repo.get_by(ProjectRepoConnection, project_id: project_id) do
       GithubClient.fire_repository_dispatch(

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -62,10 +62,10 @@ defmodule LightningWeb.ProjectLive.Settings do
         project_user.user_id == current_user.id
       end)
 
-    can_create_webhook_auth_method =
+    can_write_webhook_auth_method =
       Permissions.can?(
         ProjectUsers,
-        :create_webhook_auth_method,
+        :write_webhook_auth_method,
         current_user,
         project_user
       )
@@ -74,14 +74,6 @@ defmodule LightningWeb.ProjectLive.Settings do
       Permissions.can?(
         ProjectUsers,
         :create_project_credential,
-        current_user,
-        project_user
-      )
-
-    can_edit_webhook_auth_method =
-      Permissions.can?(
-        ProjectUsers,
-        :edit_webhook_auth_method,
         current_user,
         project_user
       )
@@ -106,9 +98,8 @@ defmodule LightningWeb.ProjectLive.Settings do
        can_edit_project_name: can_edit_project_name,
        can_edit_project_description: can_edit_project_description,
        can_edit_data_retention: project_user.role in [:owner, :admin],
-       can_create_webhook_auth_method: can_create_webhook_auth_method,
+       can_write_webhook_auth_method: can_write_webhook_auth_method,
        can_create_project_credential: can_create_project_credential,
-       can_edit_webhook_auth_method: can_edit_webhook_auth_method,
        show_github_setup: show_github_setup,
        show_repo_setup: show_repo_setup,
        show_sync_button: show_sync_button,

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -70,6 +70,22 @@ defmodule LightningWeb.ProjectLive.Settings do
         project_user
       )
 
+    can_write_github_connection =
+      Permissions.can?(
+        ProjectUsers,
+        :write_github_connection,
+        current_user,
+        project_user
+      )
+
+    can_initiate_github_sync =
+      Permissions.can?(
+        ProjectUsers,
+        :initiate_github_sync,
+        current_user,
+        project_user
+      )
+
     can_create_project_credential =
       Permissions.can?(
         ProjectUsers,
@@ -108,16 +124,10 @@ defmodule LightningWeb.ProjectLive.Settings do
        branches: [],
        loading_branches: false,
        github_enabled: VersionControl.github_enabled?(),
-       can_install_github: can_install_github(socket),
+       can_install_github: can_write_github_connection,
+       can_initiate_github_sync: can_initiate_github_sync,
        selected_credential_type: nil
      )}
-  end
-
-  defp can_install_github(socket) do
-    case socket.assigns.project_user.role do
-      :viewer -> false
-      _ -> true
-    end
   end
 
   defp repo_settings(%Project{id: project_id}) do
@@ -393,14 +403,18 @@ defmodule LightningWeb.ProjectLive.Settings do
      )}
   end
 
-  def handle_event("run_sync", params, %{assigns: %{current_user: u}} = socket) do
-    case VersionControl.run_sync(params["id"], u.email) do
-      {:ok, :fired} ->
-        {:noreply, socket |> put_flash(:info, "Sync Initialized")}
+  def handle_event("initiate_sync", params, %{assigns: %{current_user: u}} = socket) do
+    if socket.assigns.can_initiate_github_sync do
+      case VersionControl.initiate_sync(params["id"], u.email) do
+        {:ok, :fired} ->
+          {:noreply, socket |> put_flash(:info, "Sync Initialized")}
 
-      _err ->
-        # we should log or instrument this situation
-        {:noreply, socket |> put_flash(:error, "Sync Error")}
+        _err ->
+          # we should log or instrument this situation
+          {:noreply, socket |> put_flash(:error, "Sync Error")}
+      end
+    else
+      {:noreply, socket |> put_flash(:error, "Viewers Cannot Initiate Sync")}
     end
   end
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -403,7 +403,11 @@ defmodule LightningWeb.ProjectLive.Settings do
      )}
   end
 
-  def handle_event("initiate_sync", params, %{assigns: %{current_user: u}} = socket) do
+  def handle_event(
+        "initiate_sync",
+        params,
+        %{assigns: %{current_user: u}} = socket
+      ) do
     if socket.assigns.can_initiate_github_sync do
       case VersionControl.initiate_sync(params["id"], u.email) do
         {:ok, :fired} ->

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -558,7 +558,7 @@
         </LightningWeb.Components.Common.panel_content>
         <LightningWeb.Components.Common.panel_content for_hash="vcs">
           <%= if  @github_enabled do %>
-            <div :if={@can_install_github}>
+            <div>
               <div :if={@show_github_setup} class="bg-white p-4 rounded-md">
                 <h6 class="font-medium text-black">
                   Install Github App to get started
@@ -574,6 +574,7 @@
                 </div>
                 <button
                   type="button"
+                  disabled={!@can_install_github}
                   phx-click="install_app"
                   phx-value-id={@project.id}
                   class="bg-primary-600 hover:bg-primary-700 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
@@ -632,7 +633,7 @@
                       <Form.select_field
                         :if={@show_repo_setup && !@show_sync_button}
                         form={f}
-                        disabled={@show_sync_button}
+                        disabled={!@can_install_github || @show_sync_button}
                         name={:repo}
                         id="project-repo"
                         phx-change="repo_selected"
@@ -665,7 +666,7 @@
                       <Form.select_field
                         :if={@show_repo_setup && !@show_sync_button}
                         form={f}
-                        disabled={@loading_branches}
+                        disabled={!@can_install_github || @loading_branches}
                         phx-change="branch_selected"
                         name={:branch}
                         id="project-branch"
@@ -695,7 +696,7 @@
                         <Form.select_field
                           :if={@show_repo_setup && !@show_sync_button}
                           form={f}
-                          disabled={@loading_branches}
+                          disabled={!@can_install_github || @loading_branches}
                           phx-change="branch_selected"
                           name={:branch}
                           id="project-branch"
@@ -717,23 +718,29 @@
                         :if={!@show_sync_button}
                         phx-disable-with="Saving"
                         disabled={
-                          !@project_repo_connection["repo"] ||
+                          !@can_install_github ||
+                            !@project_repo_connection["repo"] ||
                             !@project_repo_connection["branch"]
                         }
                       >
                         Connect Branch
                       </Form.submit_button>
-                      <button
+                      <LightningWeb.Components.NewInputs.button
                         :if={@show_sync_button}
+                        disabled={!@can_initiate_github_sync}
                         type="button"
-                        phx-click="run_sync"
+                        tooltip={
+                          !@can_initiate_github_sync &&
+                            "Contact an editor or admin to sync."
+                        }
+                        phx-click="initiate_sync"
                         phx-value-id={@project.id}
                         class="bg-primary-600 hover:bg-primary-700 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
                       >
-                        Sync to Branch
-                      </button>
+                        Initiate Sync to Branch
+                      </LightningWeb.Components.NewInputs.button>
                     </div>
-                    <div>
+                    <div :if={@can_install_github}>
                       <div>
                         <small>
                           Need to change the repository or branch?
@@ -766,14 +773,6 @@
                 </.form>
               </div>
               <DeleteConnectionModal.modal id="delete_connection_modal" />
-            </div>
-            <div :if={!@can_install_github} class="bg-white p-4 rounded-md">
-              <h6 class="font-medium text-black">
-                Sync to Github
-              </h6>
-              <small class="block mt-1 text-xs text-gray-600">
-                Ask an admin to install our github app to start syncing your project
-              </small>
             </div>
           <% else %>
             <div class="bg-white p-4 rounded-md">

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -308,12 +308,12 @@
                 type="button"
                 phx-click={show_modal("new_auth_method_modal")}
                 class="rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50"
-                {if !@can_create_webhook_auth_method, do: [disabled: "disabled"], else: []}
+                {if !@can_write_webhook_auth_method, do: [disabled: "disabled"], else: []}
               >
                 Add an auth method
               </button>
               <.live_component
-                :if={@can_create_webhook_auth_method}
+                :if={@can_write_webhook_auth_method}
                 module={
                   LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent
                 }
@@ -374,7 +374,7 @@
               </span>
             </:linked_triggers>
             <:action :let={auth_method}>
-              <%= if @can_edit_webhook_auth_method do %>
+              <%= if @can_write_webhook_auth_method do %>
                 <a
                   id={"edit_auth_method_link_#{auth_method.id}"}
                   href="#"
@@ -410,30 +410,40 @@
               <% end %>
             </:action>
             <:action :let={auth_method}>
-              <a
-                id={"delete_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="text-red-600 hover:text-red-800"
-                phx-click={show_modal("delete_auth_#{auth_method.id}_modal")}
-              >
-                Delete
-              </a>
-              <div class="text-left">
-                <.live_component
-                  module={
-                    LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent
-                  }
-                  id={"delete_auth_#{auth_method.id}_modal"}
-                  action={:delete}
-                  project={@project}
-                  webhook_auth_method={auth_method}
-                  current_user={@current_user}
-                  return_to={
-                    ~p"/projects/#{@project.id}/settings#webhook_security"
-                  }
-                  trigger={nil}
-                />
-              </div>
+              <%= if @can_write_webhook_auth_method do %>
+                <a
+                  id={"delete_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="text-red-600 hover:text-red-800"
+                  phx-click={show_modal("delete_auth_#{auth_method.id}_modal")}
+                >
+                  Delete
+                </a>
+                <div class="text-left">
+                  <.live_component
+                    module={
+                      LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent
+                    }
+                    id={"delete_auth_#{auth_method.id}_modal"}
+                    action={:delete}
+                    project={@project}
+                    webhook_auth_method={auth_method}
+                    current_user={@current_user}
+                    return_to={
+                      ~p"/projects/#{@project.id}/settings#webhook_security"
+                    }
+                    trigger={nil}
+                  />
+                </div>
+              <% else %>
+                <a
+                  id={"edit_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="ml-1 cursor-not-allowed text-indigo-300"
+                >
+                  Delete
+                </a>
+              <% end %>
             </:action>
           </LightningWeb.WorkflowLive.Components.webhook_auth_methods_table>
         </LightningWeb.Components.Common.panel_content>

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -328,8 +328,8 @@ defmodule LightningWeb.RunLive.Components do
 
   attr :project, :map, required: true
   attr :run, :map, required: true
-  attr :can_rerun_job, :boolean, required: true
   attr :can_edit_data_retention, :boolean, required: true
+  attr :can_run_workflow, :boolean, required: true
 
   def run_item(%{run: run} = assigns) do
     steps = run.steps
@@ -349,7 +349,7 @@ defmodule LightningWeb.RunLive.Components do
     >
       <%= for step <- @step_list do %>
         <.step_list_item
-          can_rerun_job={@can_rerun_job}
+          can_run_workflow={@can_run_workflow}
           project_id={@project.id}
           run={@run}
           can_edit_data_retention={@can_edit_data_retention}
@@ -363,7 +363,7 @@ defmodule LightningWeb.RunLive.Components do
   attr :step, :map, required: true
   attr :run, :map, required: true
   attr :project_id, :string, required: true
-  attr :can_rerun_job, :boolean, required: true
+  attr :can_run_workflow, :boolean, required: true
   attr :can_edit_data_retention, :boolean, required: true
 
   def step_list_item(assigns) do
@@ -415,7 +415,7 @@ defmodule LightningWeb.RunLive.Components do
               </div>
             <% end %>
             <div class="flex gap-1 text-xs leading-5">
-              <%= if @can_rerun_job && @step.exit_reason do %>
+              <%= if @can_run_workflow && @step.exit_reason do %>
                 <.step_rerun_tag {assigns} />/
               <% end %>
               <.link

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -67,10 +67,10 @@ defmodule LightningWeb.RunLive.Index do
       Lightning.Workflows.get_workflows_for(project)
       |> Enum.map(&{&1.name || "Untitled", &1.id})
 
-    can_rerun_job =
+    can_run_workflow =
       ProjectUsers
       |> Permissions.can?(
-        :rerun_job,
+        :run_workflow,
         current_user,
         project
       )
@@ -113,8 +113,8 @@ defmodule LightningWeb.RunLive.Index do
        active_menu_item: :runs,
        work_orders: [],
        selected_work_orders: [],
-       can_rerun_job: can_rerun_job,
        can_edit_data_retention: can_edit_data_retention,
+       can_run_workflow: can_run_workflow,
        pagination_path: &pagination_path(socket, project, &1),
        filters: params["filters"]
      )}
@@ -293,7 +293,7 @@ defmodule LightningWeb.RunLive.Index do
         %{"run_id" => run_id, "step_id" => step_id},
         socket
       ) do
-    if socket.assigns.can_rerun_job do
+    if socket.assigns.can_run_workflow do
       WorkOrders.retry(run_id, step_id, created_by: socket.assigns.current_user)
 
       {:noreply, socket}
@@ -305,7 +305,7 @@ defmodule LightningWeb.RunLive.Index do
   end
 
   def handle_event("bulk-rerun", attrs, socket) do
-    with true <- socket.assigns.can_rerun_job,
+    with true <- socket.assigns.can_run_workflow,
          {:ok, count} <- handle_bulk_rerun(socket, attrs) do
       {:noreply,
        socket

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -704,8 +704,8 @@
                         id={workorder.id}
                         work_order={workorder}
                         project={@project}
-                        can_rerun_job={@can_rerun_job}
                         can_edit_data_retention={@can_edit_data_retention}
+                        can_run_workflow={@can_run_workflow}
                         entry_selected={
                           Enum.any?(@selected_work_orders, fn wo ->
                             wo.id == workorder.id

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -9,14 +9,18 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
 
   @impl true
   def update(
-        %{work_order: work_order, project: project, can_rerun_job: can_rerun_job} =
+        %{
+          work_order: work_order,
+          project: project,
+          can_run_workflow: can_run_workflow
+        } =
           assigns,
         socket
       ) do
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(project: project, can_rerun_job: can_rerun_job)
+     |> assign(project: project, can_run_workflow: can_run_workflow)
      |> set_details(work_order)}
   end
 
@@ -284,8 +288,8 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
             </div>
 
             <.run_item
-              can_rerun_job={@can_rerun_job}
               can_edit_data_retention={@can_edit_data_retention}
+              can_run_workflow={@can_run_workflow}
               run={run}
               project={@project}
             />

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -158,6 +158,7 @@ defmodule LightningWeb.WorkflowLive.Components do
   attr :form, :map, required: true
   attr :cancel_url, :string, required: true
   attr :disabled, :boolean, required: true
+  attr :can_write_webhook_auth_method, :boolean, required: true
   attr :webhook_url, :string, required: true
   attr :on_change, :any, required: true
   attr :selected_trigger, Trigger, required: true
@@ -286,7 +287,11 @@ defmodule LightningWeb.WorkflowLive.Components do
                 <div>
                   <.link
                     href="#"
-                    class="text-primary-700 underline hover:text-primary-800"
+                    class={[
+                      "text-primary-700 underline hover:text-primary-800",
+                      !@can_write_webhook_auth_method &&
+                        "text-gray-500 cursor-not-allowed"
+                    ]}
                     phx-click={show_modal("webhooks_auth_method_modal")}
                   >
                     Manage authentication
@@ -308,6 +313,7 @@ defmodule LightningWeb.WorkflowLive.Components do
       form={@form}
       field={:enabled}
       label="Disable this trigger"
+      disabled={@disabled}
       checked_value={false}
       unchecked_value={true}
       value={@trigger_enabled}
@@ -424,6 +430,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             <Form.check_box
               form={@form}
               field={:enabled}
+              disabled={@disabled}
               label="Disable this path"
               checked_value={false}
               unchecked_value={true}

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -249,7 +249,7 @@ defmodule LightningWeb.WorkflowLive.Components do
                     href="#"
                     class={[
                       "text-indigo-400 underline not-italic inline-flex items-center",
-                      if(@action == :new or @disabled,
+                      if(@action == :new or !@can_write_webhook_auth_method,
                         do: "text-gray-500 cursor-not-allowed",
                         else: ""
                       )

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -54,14 +54,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
           <.with_changes_indicator changeset={@changeset}>
             <div class="flex flex-row gap-2">
               <.icon
-                :if={!@can_edit_job}
+                :if={!@can_edit_workflow}
                 name="hero-lock-closed"
                 class="w-5 h-5 place-self-center text-gray-300"
               />
               <Form.submit_button
                 class=""
                 phx-disable-with="Saving..."
-                disabled={!@can_edit_job or !@changeset.valid?}
+                disabled={!@can_edit_workflow or !@changeset.valid?}
                 form="workflow-form"
               >
                 Save
@@ -119,7 +119,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   </.save_is_blocked_error>
 
                   <.icon
-                    :if={!@can_edit_job}
+                    :if={!@can_edit_workflow}
                     name="hero-lock-closed"
                     class="w-5 h-5 place-self-center text-gray-300"
                   />
@@ -225,7 +225,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     <Form.submit_button
                       class=""
                       phx-disable-with="Saving..."
-                      disabled={!@can_edit_job or !@changeset.valid?}
+                      disabled={!@can_edit_workflow or !@changeset.valid?}
                       form="workflow-form"
                     >
                       Save
@@ -289,7 +289,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 send_form_changed(params)
               end
             }
-            can_create_project_credential={@can_edit_job}
+            can_create_project_credential={@can_edit_workflow}
             return_to={
               ~p"/projects/#{@project.id}/w/#{@workflow.id}?s=#{@selected_job.id}"
             }
@@ -323,7 +323,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
               <!-- Show only the currently selected one -->
               <.job_form
                 on_change={&send_form_changed/1}
-                editable={@can_edit_job}
+                editable={@can_edit_workflow}
                 form={jf}
                 project_user={@project_user}
               />
@@ -343,7 +343,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         phx-click="delete_node"
                         phx-value-id={@selected_job.id}
                         class="focus:ring-red-500 bg-red-600 hover:bg-red-700 disabled:bg-red-300"
-                        disabled={!@can_edit_job or has_child_edges or is_first_job}
+                        disabled={
+                          !@can_edit_workflow or has_child_edges or is_first_job
+                        }
                         tooltip={deletion_tooltip_message(@has_multiple_jobs)}
                         data-confirm="Are you sure you want to delete this step?"
                       >
@@ -380,7 +382,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 <.trigger_form
                   form={tf}
                   on_change={&send_form_changed/1}
-                  disabled={!@can_edit_job}
+                  disabled={!@can_edit_workflow}
                   can_write_webhook_auth_method={@can_write_webhook_auth_method}
                   webhook_url={webhook_url(@selected_trigger)}
                   selected_trigger={@selected_trigger}
@@ -404,7 +406,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 <!-- Show only the currently selected one -->
                 <.edge_form
                   form={ef}
-                  disabled={!@can_edit_job}
+                  disabled={!@can_edit_workflow}
                   cancel_url={
                     ~p"/projects/#{@project.id}/w/#{@workflow.id || "new"}"
                   }
@@ -564,8 +566,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
       :ok ->
         socket
         |> assign(
-          can_edit_job:
-            Permissions.can?(ProjectUsers, :edit_job, current_user, project_user),
+          can_edit_workflow:
+            Permissions.can?(
+              ProjectUsers,
+              :edit_workflow,
+              current_user,
+              project_user
+            ),
           can_run_workflow:
             Permissions.can?(
               ProjectUsers,
@@ -608,8 +615,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
           current_user,
           project_user
         ),
-      can_edit_job:
-        Permissions.can?(ProjectUsers, :edit_job, current_user, project_user),
+      can_edit_workflow:
+        Permissions.can?(
+          ProjectUsers,
+          :edit_workflow,
+          current_user,
+          project_user
+        ),
       can_run_workflow:
         Permissions.can?(ProjectUsers, :run_workflow, current_user, project_user),
       can_rerun_job:
@@ -704,10 +716,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
     %{
       changeset: changeset,
       workflow_params: initial_params,
-      can_edit_job: can_edit_job
+      can_edit_workflow: can_edit_workflow
     } = socket.assigns
 
-    with true <- can_edit_job || :not_authorized,
+    with true <- can_edit_workflow || :not_authorized,
          true <- !has_child_edges?(changeset, id) || :has_child_edges,
          true <- !first_job?(changeset, id) || :is_first_job do
       edges_to_delete =
@@ -753,11 +765,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
     %{
       project: project,
       workflow_params: initial_params,
-      can_edit_job: can_edit_job
+      can_edit_workflow: can_edit_workflow
     } =
       socket.assigns
 
-    if can_edit_job do
+    if can_edit_workflow do
       next_params =
         case params do
           %{"workflow" => params} ->
@@ -882,13 +894,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
       selected_job: selected_job,
       current_user: current_user,
       workflow_params: workflow_params,
-      can_edit_job: can_edit_job,
+      can_edit_workflow: can_edit_workflow,
       can_run_workflow: can_run_workflow
     } = socket.assigns
 
     socket = socket |> apply_params(workflow_params)
 
-    if can_run_workflow && can_edit_job do
+    if can_run_workflow && can_edit_workflow do
       Helpers.save_and_run(
         socket.assigns.changeset,
         params,
@@ -1063,7 +1075,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       %{
         manual_run_form: manual_run_form,
         changeset: changeset,
-        can_edit_job: can_edit_job,
+        can_edit_workflow: can_edit_workflow,
         can_run_workflow: can_run_workflow
       } ->
         form_valid =
@@ -1077,7 +1089,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
         !form_valid or
           !changeset.valid? or
-          !(can_edit_job or can_run_workflow)
+          !(can_edit_workflow or can_run_workflow)
     end
   end
 
@@ -1110,10 +1122,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   defp handle_new_params(socket, params) do
-    %{workflow_params: initial_params, can_edit_job: can_edit_job} =
+    %{workflow_params: initial_params, can_edit_workflow: can_edit_workflow} =
       socket.assigns
 
-    if can_edit_job do
+    if can_edit_workflow do
       next_params =
         WorkflowParams.apply_form_params(socket.assigns.workflow_params, params)
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -381,6 +381,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   form={tf}
                   on_change={&send_form_changed/1}
                   disabled={!@can_edit_job}
+                  can_write_webhook_auth_method={@can_write_webhook_auth_method}
                   webhook_url={webhook_url(@selected_trigger)}
                   selected_trigger={@selected_trigger}
                   action={@live_action}
@@ -415,7 +416,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
         <.live_component
           :if={
-            @live_action == :edit && @can_create_webhook_auth_method &&
+            @live_action == :edit && @can_write_webhook_auth_method &&
               @selected_trigger
           }
           module={LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent}
@@ -574,17 +575,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
               current_user,
               project_user
             ),
-          can_create_webhook_auth_method:
+          can_write_webhook_auth_method:
             Permissions.can?(
               ProjectUsers,
-              :create_webhook_auth_method,
-              current_user,
-              project_user
-            ),
-          can_edit_webhook_auth_method:
-            Permissions.can?(
-              ProjectUsers,
-              :edit_webhook_auth_method,
+              :write_webhook_auth_method,
               current_user,
               project_user
             ),
@@ -609,17 +603,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     socket
     |> assign(
-      can_create_webhook_auth_method:
+      can_write_webhook_auth_method:
         Permissions.can?(
           ProjectUsers,
-          :create_webhook_auth_method,
-          current_user,
-          project_user
-        ),
-      can_edit_webhook_auth_method:
-        Permissions.can?(
-          ProjectUsers,
-          :edit_webhook_auth_method,
+          :write_webhook_auth_method,
           current_user,
           project_user
         ),

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -102,7 +102,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   id={"manual-job-#{@selected_job.id}"}
                   form={@manual_run_form}
                   dataclips={@selectable_dataclips}
-                  disabled={!@can_run_job}
+                  disabled={!@can_run_workflow}
                   project={@project}
                   admin_contacts={@admin_contacts}
                   can_edit_data_retention={@can_edit_data_retention}
@@ -566,12 +566,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
         |> assign(
           can_edit_job:
             Permissions.can?(ProjectUsers, :edit_job, current_user, project_user),
-          can_run_job:
-            Permissions.can?(ProjectUsers, :run_job, current_user, project_user),
-          can_rerun_job:
+          can_run_workflow:
             Permissions.can?(
               ProjectUsers,
-              :rerun_job,
+              :run_workflow,
               current_user,
               project_user
             ),
@@ -612,8 +610,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
         ),
       can_edit_job:
         Permissions.can?(ProjectUsers, :edit_job, current_user, project_user),
-      can_run_job:
-        Permissions.can?(ProjectUsers, :run_job, current_user, project_user),
+      can_run_workflow:
+        Permissions.can?(ProjectUsers, :run_workflow, current_user, project_user),
       can_rerun_job:
         Permissions.can?(ProjectUsers, :rerun_job, current_user, project_user),
       can_edit_data_retention:
@@ -848,7 +846,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
         %{"run_id" => run_id, "step_id" => step_id},
         socket
       ) do
-    if socket.assigns.can_rerun_job do
+    if socket.assigns.can_run_workflow do
       case Lightning.Repo.update(%{socket.assigns.changeset | action: :update}) do
         {:ok, workflow} ->
           {:ok, run} =
@@ -885,12 +883,12 @@ defmodule LightningWeb.WorkflowLive.Edit do
       current_user: current_user,
       workflow_params: workflow_params,
       can_edit_job: can_edit_job,
-      can_run_job: can_run_job
+      can_run_workflow: can_run_workflow
     } = socket.assigns
 
     socket = socket |> apply_params(workflow_params)
 
-    if can_run_job && can_edit_job do
+    if can_run_workflow && can_edit_job do
       Helpers.save_and_run(
         socket.assigns.changeset,
         params,
@@ -1066,7 +1064,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
         manual_run_form: manual_run_form,
         changeset: changeset,
         can_edit_job: can_edit_job,
-        can_run_job: can_run_job
+        can_run_workflow: can_run_workflow
       } ->
         form_valid =
           if manual_run_form.source.errors == [
@@ -1079,7 +1077,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
         !form_valid or
           !changeset.valid? or
-          !(can_edit_job or can_run_job)
+          !(can_edit_job or can_run_workflow)
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -624,8 +624,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
         ),
       can_run_workflow:
         Permissions.can?(ProjectUsers, :run_workflow, current_user, project_user),
-      can_rerun_job:
-        Permissions.can?(ProjectUsers, :rerun_job, current_user, project_user),
       can_edit_data_retention:
         Permissions.can?(
           ProjectUsers,

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -335,7 +335,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
 
   def render(assigns) do
     ~H"""
-    <div id="create_edit_webhook_auth_method">
+    <div id="write_webhook_auth_method">
       <%!-- <%= if @webhook_auth_method.auth_type do %> --%>
       <.form
         :let={f}

--- a/test/lightning/policies/project_user_permissions_test.exs
+++ b/test/lightning/policies/project_user_permissions_test.exs
@@ -108,10 +108,9 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
            viewer: viewer
          } do
       ~w(
-        create_job
         create_workflow
         delete_workflow
-        edit_job
+        edit_workflow
         provision_project
         edit_project_description
         edit_project_name
@@ -129,10 +128,9 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
            editor: editor
          } do
       ~w(
-        create_job
         create_workflow
         delete_workflow
-        edit_job
+        edit_workflow
         create_project_credential
         provision_project
         run_workflow
@@ -159,10 +157,9 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
            admin: admin
          } do
       ~w(
-          create_job
           create_workflow
           delete_workflow
-          edit_job
+          edit_workflow
           edit_project_description
           edit_project_name
           provision_project
@@ -180,10 +177,9 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
            owner: owner
          } do
       ~w(
-        create_job
         create_workflow
         delete_workflow
-        edit_job
+        edit_workflow
         edit_project_description
         edit_project_name
         provision_project

--- a/test/lightning/policies/project_user_permissions_test.exs
+++ b/test/lightning/policies/project_user_permissions_test.exs
@@ -112,10 +112,10 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_workflow
         delete_workflow
         edit_job
+        provision_project
         edit_project_description
         edit_project_name
-        provision_project
-        create_webhook_auth_method
+        write_webhook_auth_method
         create_project_credential
         rerun_job
         run_job
@@ -134,9 +134,8 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         create_workflow
         delete_workflow
         edit_job
-        provision_project
-        create_webhook_auth_method
         create_project_credential
+        provision_project
         rerun_job
         run_job
       )a |> (&assert_can(ProjectUsers, &1, editor, project)).()
@@ -150,6 +149,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
       ~w(
           edit_project_description
           edit_project_name
+          write_webhook_auth_method
         )a |> (&refute_can(ProjectUsers, &1, editor, project)).()
     end
   end
@@ -168,7 +168,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
           edit_project_description
           edit_project_name
           provision_project
-          create_webhook_auth_method
+          write_webhook_auth_method
           create_project_credential
           rerun_job
           run_job
@@ -190,7 +190,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         edit_project_description
         edit_project_name
         provision_project
-        create_webhook_auth_method
+        write_webhook_auth_method
         create_project_credential
         rerun_job
         run_job

--- a/test/lightning/policies/project_user_permissions_test.exs
+++ b/test/lightning/policies/project_user_permissions_test.exs
@@ -117,8 +117,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         edit_project_name
         write_webhook_auth_method
         create_project_credential
-        rerun_job
-        run_job
+        run_workflow
       )a |> (&refute_can(ProjectUsers, &1, viewer, project)).()
     end
   end
@@ -136,8 +135,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         edit_job
         create_project_credential
         provision_project
-        rerun_job
-        run_job
+        run_workflow
       )a |> (&assert_can(ProjectUsers, &1, editor, project)).()
     end
 
@@ -170,8 +168,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
           provision_project
           write_webhook_auth_method
           create_project_credential
-          rerun_job
-          run_job
+          run_workflow
         )a |> (&assert_can(ProjectUsers, &1, admin, project)).()
     end
   end
@@ -192,8 +189,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         provision_project
         write_webhook_auth_method
         create_project_credential
-        rerun_job
-        run_job
+        run_workflow
       )a |> (&assert_can(ProjectUsers, &1, owner, project)).()
     end
   end

--- a/test/lightning/version_control/github_client_test.exs
+++ b/test/lightning/version_control/github_client_test.exs
@@ -57,7 +57,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
                 code: :installation_not_found,
                 message: "Github Installation APP ID is misconfigured"
               }} =
-               VersionControl.run_sync(p_repo.project_id, "some-user-name")
+               VersionControl.initiate_sync(p_repo.project_id, "some-user-name")
     end
 
     @tag :capture_log
@@ -131,7 +131,7 @@ defmodule Lightning.VersionControl.GithubClientTest do
       p_repo = insert(:project_repo_connection)
 
       assert {:ok, :fired} =
-               VersionControl.run_sync(p_repo.project_id, "some-user-name")
+               VersionControl.initiate_sync(p_repo.project_id, "some-user-name")
     end
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2,6 +2,7 @@ defmodule LightningWeb.ProjectLiveTest do
   use LightningWeb.ConnCase, async: false
 
   alias Lightning.Repo
+  alias Lightning.Name
 
   import Phoenix.LiveViewTest
   import Lightning.ProjectsFixtures
@@ -1313,22 +1314,11 @@ defmodule LightningWeb.ProjectLiveTest do
       end)
     end
 
-    test "all project users can see the project webhook auth methods", %{
-      conn: conn
-    } do
+    test "all project users can see the project webhook auth methods" do
       project = insert(:project)
       auth_methods = insert_list(4, :webhook_auth_method, project: project)
 
-      for project_user <-
-            Enum.map([:editor, :admin, :owner, :viewer], fn role ->
-              insert(:project_user,
-                role: role,
-                project: project,
-                user: build(:user)
-              )
-            end) do
-        conn = log_in_user(conn, project_user.user)
-
+      for conn <- project_user_conns(project, [:editor, :admin, :owner, :viewer]) do
         {:ok, _view, html} =
           live(
             conn,
@@ -1341,7 +1331,7 @@ defmodule LightningWeb.ProjectLiveTest do
       end
     end
 
-    test "owners or admins can add a new project webhook auth method, editors and viewers can't",
+    test "owners/admins can add a new project webhook auth method, editors/viewers can't",
          %{
            conn: conn
          } do
@@ -1350,16 +1340,7 @@ defmodule LightningWeb.ProjectLiveTest do
       settings_path =
         Routes.project_project_settings_path(conn, :index, project.id)
 
-      for project_user <-
-            Enum.map([:admin, :owner], fn role ->
-              insert(:project_user,
-                role: role,
-                project: project,
-                user: build(:user)
-              )
-            end) do
-        conn = log_in_user(conn, project_user.user)
-
+      for conn <- project_user_conns(project, [:owner, :admin]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -1386,7 +1367,7 @@ defmodule LightningWeb.ProjectLiveTest do
                |> element("form#choose_auth_type_form_#{modal_id}")
                |> has_element?()
 
-        credential_name = "#{project_user.role}credentialname"
+        credential_name = Name.generate()
 
         refute render(view) =~ credential_name
 
@@ -1417,16 +1398,7 @@ defmodule LightningWeb.ProjectLiveTest do
         assert html =~ credential_name
       end
 
-      for project_user <-
-            Enum.map([:editor, :viewer], fn role ->
-              insert(:project_user,
-                role: role,
-                project: project,
-                user: build(:user)
-              )
-            end) do
-        conn = log_in_user(conn, project_user.user)
-
+      for conn <- project_user_conns(project, [:editor, :viewer]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -1470,7 +1442,7 @@ defmodule LightningWeb.ProjectLiveTest do
       refute view |> element("#new_auth_method_modal") |> has_element?()
     end
 
-    test "owners and admins can add edit a project webhook auth method",
+    test "owners/admins can add edit a project webhook auth method, editors/viewers can't",
          %{
            conn: conn
          } do
@@ -1485,16 +1457,7 @@ defmodule LightningWeb.ProjectLiveTest do
       settings_path =
         Routes.project_project_settings_path(conn, :index, project.id)
 
-      for project_user <-
-            Enum.map([:admin, :owner], fn role ->
-              insert(:project_user,
-                role: role,
-                project: project,
-                user: build(:user)
-              )
-            end) do
-        conn = log_in_user(conn, project_user.user)
-
+      for conn <- project_user_conns(project, [:owner, :admin]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -1509,7 +1472,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
         assert view |> element("##{modal_id}") |> has_element?()
 
-        credential_name = "#{project_user.role}credentialname"
+        credential_name = Name.generate()
 
         refute render(view) =~ credential_name
 
@@ -1536,16 +1499,7 @@ defmodule LightningWeb.ProjectLiveTest do
         assert html =~ credential_name
       end
 
-      for project_user <-
-            Enum.map([:editor, :viewer], fn role ->
-              insert(:project_user,
-                role: role,
-                project: project,
-                user: build(:user)
-              )
-            end) do
-        conn = log_in_user(conn, project_user.user)
-
+      for conn <- project_user_conns(project, [:editor, :viewer]) do
         {:ok, view, _html} =
           live(
             conn,

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1318,7 +1318,8 @@ defmodule LightningWeb.ProjectLiveTest do
       project = insert(:project)
       auth_methods = insert_list(4, :webhook_auth_method, project: project)
 
-      for conn <- project_user_conns(project, [:editor, :admin, :owner, :viewer]) do
+      for conn <-
+            build_project_user_conns(project, [:editor, :admin, :owner, :viewer]) do
         {:ok, _view, html} =
           live(
             conn,
@@ -1340,7 +1341,7 @@ defmodule LightningWeb.ProjectLiveTest do
       settings_path =
         Routes.project_project_settings_path(conn, :index, project.id)
 
-      for conn <- project_user_conns(project, [:owner, :admin]) do
+      for conn <- build_project_user_conns(project, [:owner, :admin]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -1398,7 +1399,7 @@ defmodule LightningWeb.ProjectLiveTest do
         assert html =~ credential_name
       end
 
-      for conn <- project_user_conns(project, [:editor, :viewer]) do
+      for conn <- build_project_user_conns(project, [:editor, :viewer]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -1457,7 +1458,7 @@ defmodule LightningWeb.ProjectLiveTest do
       settings_path =
         Routes.project_project_settings_path(conn, :index, project.id)
 
-      for conn <- project_user_conns(project, [:owner, :admin]) do
+      for conn <- build_project_user_conns(project, [:owner, :admin]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -1499,7 +1500,7 @@ defmodule LightningWeb.ProjectLiveTest do
         assert html =~ credential_name
       end
 
-      for conn <- project_user_conns(project, [:editor, :viewer]) do
+      for conn <- build_project_user_conns(project, [:editor, :viewer]) do
         {:ok, view, _html} =
           live(
             conn,

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1341,7 +1341,7 @@ defmodule LightningWeb.ProjectLiveTest do
       end
     end
 
-    test "authorized project users can add a new project webhook auth method",
+    test "owners or admins can add a new project webhook auth method, editors and viewers can't",
          %{
            conn: conn
          } do
@@ -1351,7 +1351,7 @@ defmodule LightningWeb.ProjectLiveTest do
         Routes.project_project_settings_path(conn, :index, project.id)
 
       for project_user <-
-            Enum.map([:editor, :admin, :owner], fn role ->
+            Enum.map([:admin, :owner], fn role ->
               insert(:project_user,
                 role: role,
                 project: project,
@@ -1416,6 +1416,31 @@ defmodule LightningWeb.ProjectLiveTest do
 
         assert html =~ credential_name
       end
+
+      for project_user <-
+            Enum.map([:editor, :viewer], fn role ->
+              insert(:project_user,
+                role: role,
+                project: project,
+                user: build(:user)
+              )
+            end) do
+        conn = log_in_user(conn, project_user.user)
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            settings_path
+          )
+
+        assert view
+               |> element("button#add_new_auth_method:disabled")
+               |> has_element?()
+
+        modal_id = "new_auth_method_modal"
+
+        refute view |> element("##{modal_id}") |> has_element?()
+      end
     end
 
     test "project viewers cannot add a new project webhook auth method", %{
@@ -1445,7 +1470,7 @@ defmodule LightningWeb.ProjectLiveTest do
       refute view |> element("#new_auth_method_modal") |> has_element?()
     end
 
-    test "authorized project users can add edit a project webhook auth method",
+    test "owners and admins can add edit a project webhook auth method",
          %{
            conn: conn
          } do
@@ -1461,7 +1486,7 @@ defmodule LightningWeb.ProjectLiveTest do
         Routes.project_project_settings_path(conn, :index, project.id)
 
       for project_user <-
-            Enum.map([:editor, :admin, :owner], fn role ->
+            Enum.map([:admin, :owner], fn role ->
               insert(:project_user,
                 role: role,
                 project: project,
@@ -1510,6 +1535,33 @@ defmodule LightningWeb.ProjectLiveTest do
 
         assert html =~ credential_name
       end
+
+      for project_user <-
+            Enum.map([:editor, :viewer], fn role ->
+              insert(:project_user,
+                role: role,
+                project: project,
+                user: build(:user)
+              )
+            end) do
+        conn = log_in_user(conn, project_user.user)
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            settings_path
+          )
+
+        assert view
+               |> element(
+                 "a#edit_auth_method_link_#{auth_method.id}.cursor-not-allowed"
+               )
+               |> has_element?()
+
+        modal_id = "edit_auth_#{auth_method.id}_modal"
+
+        refute view |> element("##{modal_id}") |> has_element?()
+      end
     end
 
     test "project viewers cannot edit a project webhook auth method", %{
@@ -1539,7 +1591,9 @@ defmodule LightningWeb.ProjectLiveTest do
         )
 
       assert view
-             |> element("a#edit_auth_method_link_#{auth_method.id}")
+             |> element(
+               "a#edit_auth_method_link_#{auth_method.id}.cursor-not-allowed"
+             )
              |> has_element?()
 
       refute view
@@ -1562,7 +1616,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
       project_user =
         insert(:project_user,
-          role: :editor,
+          role: :admin,
           project: project,
           user: build(:user)
         )
@@ -1639,7 +1693,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
       project_user =
         insert(:project_user,
-          role: :editor,
+          role: :admin,
           project: project,
           user: build(:user)
         )
@@ -1702,11 +1756,11 @@ defmodule LightningWeb.ProjectLiveTest do
     end
   end
 
-  test "authorized project users can delete a project webhook auth method",
+  test "owners and admins can delete a project webhook auth method",
        %{conn: conn} do
     project = insert(:project)
 
-    for role <- [:owner, :admin, :editor] do
+    for role <- [:owner, :admin] do
       auth_method =
         insert(:webhook_auth_method,
           project: project,
@@ -1737,6 +1791,10 @@ defmodule LightningWeb.ProjectLiveTest do
 
       modal_id = "delete_auth_#{auth_method.id}_modal"
 
+      assert view
+             |> element("#delete_auth_method_#{modal_id}_#{auth_method.id}")
+             |> has_element?()
+
       view
       |> form("#delete_auth_method_#{modal_id}_#{auth_method.id}",
         delete_confirmation_changeset: %{confirmation: "DELETE"}
@@ -1751,6 +1809,42 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert flash["info"] ==
                "Your Webhook Authentication method has been deleted."
+    end
+
+    for role <- [:editor, :viewer] do
+      auth_method =
+        insert(:webhook_auth_method,
+          project: project,
+          auth_type: :basic
+        )
+
+      project_user =
+        insert(:project_user,
+          role: role,
+          project: project,
+          user: build(:user)
+        )
+
+      settings_path =
+        Routes.project_project_settings_path(conn, :index, project.id)
+
+      conn = log_in_user(conn, project_user.user)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          settings_path
+        )
+
+      refute view
+             |> element("a#delete_auth_method_link_#{auth_method.id}")
+             |> has_element?()
+
+      modal_id = "delete_auth_#{auth_method.id}_modal"
+
+      refute view
+             |> element("#delete_auth_method_#{modal_id}_#{auth_method.id}")
+             |> has_element?()
     end
   end
 

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -94,7 +94,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: first_step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
       |> Floki.parse_fragment!()
@@ -112,7 +112,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: second_step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
       |> Floki.parse_fragment!()
@@ -130,7 +130,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: third_step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
       |> Floki.parse_fragment!()
@@ -170,7 +170,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: first_step,
         run: run2,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
 
@@ -186,7 +186,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: run2_last_step,
         run: run2,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
 
@@ -229,7 +229,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
       |> Floki.parse_fragment!()
@@ -243,7 +243,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: step,
         run: run,
         project_id: project_id,
-        can_rerun_job: false,
+        can_run_workflow: false,
         can_edit_data_retention: true
       )
       |> Floki.parse_fragment!()

--- a/test/lightning_web/live/run_live/components_test.exs
+++ b/test/lightning_web/live/run_live/components_test.exs
@@ -291,7 +291,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
 
@@ -321,7 +321,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: false
       )
 
@@ -385,7 +385,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: true
       )
 
@@ -415,7 +415,7 @@ defmodule LightningWeb.RunLive.ComponentsTest do
         step: step,
         run: run,
         project_id: project_id,
-        can_rerun_job: true,
+        can_run_workflow: true,
         can_edit_data_retention: false
       )
 

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -143,7 +143,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: work_order,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: true
         )
 
@@ -165,7 +165,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           work_order: work_order,
           show_details: true,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_run_workflow: true,
           can_edit_data_retention: true
         )
@@ -203,7 +203,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: work_order,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: true
         )
 
@@ -248,7 +248,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: work_order,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: true
         )
 
@@ -285,7 +285,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: work_order,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: false
         )
 
@@ -321,7 +321,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: %{work_order | dataclip: insert(:dataclip)},
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: false
         )
         |> Floki.parse_fragment!()
@@ -369,7 +369,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: work_order,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: true
         )
 
@@ -408,7 +408,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: work_order,
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: false
         )
 
@@ -447,7 +447,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           id: work_order.id,
           work_order: %{work_order | dataclip: insert(:dataclip)},
           project: project,
-          can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: false
         )
         |> Floki.parse_fragment!()

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -166,6 +166,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
           show_details: true,
           project: project,
           can_rerun_job: true,
+          can_run_workflow: true,
           can_edit_data_retention: true
         )
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -20,7 +20,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       %{job: job}
     end
 
-    test "open credential modal from the job inspector (edit_job)", %{
+    test "open credential modal from the job inspector (edit_workflow)", %{
       conn: conn,
       project: project,
       job: job

--- a/test/lightning_web/live/workflow_live/trigger_test.exs
+++ b/test/lightning_web/live/workflow_live/trigger_test.exs
@@ -1,6 +1,10 @@
 defmodule LightningWeb.WorkflowLive.TriggerTest do
   use LightningWeb.ConnCase, async: true
 
+  alias Lightning.Name
+  alias Lightning.Repo
+  alias Lightning.Workflows.WebhookAuthMethod
+
   import Phoenix.LiveViewTest
   import Lightning.Factories
 
@@ -11,39 +15,18 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
     workflow = insert(:workflow, project: project)
     trigger = insert(:trigger, type: :webhook, workflow: workflow)
 
-    %{conn: admin_conn, user: admin_user} =
-      register_and_log_in_user(%{conn: build_conn()})
-
-    insert(:project_user,
-      role: :admin,
-      project: project,
-      user: admin_user
-    )
-
     [
       workflow: workflow,
-      trigger: trigger,
-      admin_conn: admin_conn,
-      admin_user: admin_user
+      trigger: trigger
     ]
   end
 
-  test "authorized users can see link to add authentication method", %{
-    conn: conn,
+  test "owner/admin can see link to add auth method, editor/viewer can't", %{
     project: project,
     workflow: workflow,
     trigger: trigger
   } do
-    for project_user <-
-          Enum.map([:admin, :owner], fn role ->
-            insert(:project_user,
-              role: role,
-              project: project,
-              user: build(:user)
-            )
-          end) do
-      conn = log_in_user(conn, project_user.user)
-
+    for conn <- project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -54,16 +37,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       assert view |> element("#webhooks_auth_method_modal") |> has_element?()
     end
 
-    for project_user <-
-          Enum.map([:editor, :viewer], fn role ->
-            insert(:project_user,
-              role: role,
-              project: project,
-              user: build(:user)
-            )
-          end) do
-      conn = log_in_user(conn, project_user.user)
-
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -78,171 +52,192 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
     end
   end
 
-  test "user can see existing trigger authentication methods", %{
-    conn: conn,
+  test "all users can see existing trigger authentication methods", %{
     project: project,
     workflow: workflow,
     trigger: trigger
   } do
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin, :editor, :viewer]) do
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    auth_method =
-      insert(:webhook_auth_method,
-        project: project,
-        auth_type: :basic,
-        triggers: [trigger]
-      )
+      auth_method =
+        insert(:webhook_auth_method,
+          project: project,
+          auth_type: :basic,
+          triggers: [trigger]
+        )
 
-    refute html =~ auth_method.name
+      refute html =~ auth_method.name
 
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert html =~ auth_method.name
+      assert html =~ auth_method.name
+    end
   end
 
-  test "admin can successfully create a basic authentication method, editor cant",
+  test "owner/admin can successfully create a basic authentication method, editor/viewer can't",
        %{
-         conn: conn,
-         admin_conn: admin_conn,
          project: project,
          workflow: workflow,
          trigger: trigger
        } do
     modal_id = "webhooks_auth_method_modal"
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("##{modal_id}") |> has_element?()
+      refute view |> element("##{modal_id}") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("##{modal_id}") |> has_element?()
+      assert view |> element("##{modal_id}") |> has_element?()
 
-    html =
+      html =
+        view
+        |> form("#choose_auth_type_form_#{modal_id}",
+          webhook_auth_method: %{auth_type: "basic"}
+        )
+        |> render_submit()
+
+      assert html =~ "Create auth method"
+
+      auth_method_name = Name.generate()
+
+      refute render(view) =~ auth_method_name
+
       view
-      |> form("#choose_auth_type_form_#{modal_id}",
-        webhook_auth_method: %{auth_type: "basic"}
+      |> form("#form_#{modal_id}_new_webhook_auth_method",
+        webhook_auth_method: %{
+          name: auth_method_name,
+          username: "testusername",
+          password: "testpassword123"
+        }
       )
       |> render_submit()
 
-    assert html =~ "Create auth method"
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    auth_method_name = "funnyauthmethodname"
+      assert flash["info"] == "Webhook auth method created successfully"
 
-    refute render(view) =~ auth_method_name
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    view
-    |> form("#form_#{modal_id}_new_webhook_auth_method",
-      webhook_auth_method: %{
-        name: auth_method_name,
-        username: "testusername",
-        password: "testpassword123"
-      }
-    )
-    |> render_submit()
+      assert html =~ auth_method_name
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      assert %Postgrex.Result{num_rows: 1} =
+               Ecto.Adapters.SQL.query!(
+                 Repo,
+                 "delete from trigger_webhook_auth_methods"
+               )
 
-    assert flash["info"] == "Webhook auth method created successfully"
-
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
-
-    assert html =~ auth_method_name
+      Repo.get_by(WebhookAuthMethod, name: auth_method_name)
+      |> Repo.delete()
+    end
   end
 
-  test "admin can successfully create an API authentication method, user can't",
+  test "admin can successfully create an API authentication method, editor/viewer can't",
        %{
-         conn: conn,
-         admin_conn: admin_conn,
          project: project,
          workflow: workflow,
          trigger: trigger
        } do
     modal_id = "webhooks_auth_method_modal"
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("##{modal_id}") |> has_element?()
+      refute view |> element("##{modal_id}") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("##{modal_id}") |> has_element?()
+      assert view |> element("##{modal_id}") |> has_element?()
 
-    html =
-      view
-      |> form("#choose_auth_type_form_#{modal_id}",
-        webhook_auth_method: %{auth_type: "api"}
-      )
-      |> render_submit()
+      html =
+        view
+        |> form("#choose_auth_type_form_#{modal_id}",
+          webhook_auth_method: %{auth_type: "api"}
+        )
+        |> render_submit()
 
-    assert html =~ "Create auth method"
-    assert html =~ "API Key"
-    refute html =~ "password"
+      assert html =~ "Create auth method"
+      assert html =~ "API Key"
+      refute html =~ "password"
 
-    auth_method_name = "funnyapiauthmethodname"
+      auth_method_name = Name.generate()
 
-    refute render(view) =~ auth_method_name
+      refute render(view) =~ auth_method_name
 
-    assert view
-           |> form("#form_#{modal_id}_new_webhook_auth_method",
-             webhook_auth_method: %{
-               name: auth_method_name
-             }
-           )
-           |> render_submit()
+      assert view
+             |> form("#form_#{modal_id}_new_webhook_auth_method",
+               webhook_auth_method: %{
+                 name: auth_method_name
+               }
+             )
+             |> render_submit()
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert flash["info"] == "Webhook auth method created successfully"
+      assert flash["info"] == "Webhook auth method created successfully"
 
-    {:ok, _view, html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert html =~ auth_method_name
+      assert html =~ auth_method_name
+
+      assert %Postgrex.Result{num_rows: 1} =
+               Ecto.Adapters.SQL.query!(
+                 Repo,
+                 "delete from trigger_webhook_auth_methods"
+               )
+
+      Repo.get_by(WebhookAuthMethod, name: auth_method_name)
+      |> Repo.delete()
+    end
   end
 
   test "admin can successfully update an authentication method, editor cant", %{
-    conn: conn,
-    admin_conn: admin_conn,
     project: project,
     workflow: workflow,
     trigger: trigger
@@ -256,67 +251,68 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
 
     modal_id = "webhooks_auth_method_modal"
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("##{modal_id}") |> has_element?()
+      refute view |> element("##{modal_id}") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("##{modal_id}") |> has_element?()
+      assert view |> element("##{modal_id}") |> has_element?()
 
-    html =
-      view
-      |> element("#edit_auth_method_link_#{auth_method.id}")
-      |> render_click()
+      html =
+        view
+        |> element("#edit_auth_method_link_#{auth_method.id}")
+        |> render_click()
 
-    assert html =~ "Edit webhook auth method"
+      assert html =~ "Edit webhook auth method"
 
-    new_auth_method_name = "funnyapiauthmethodname"
+      new_auth_method_name = Name.generate()
 
-    assert view
-           |> form("#form_#{modal_id}_#{auth_method.id}")
-           |> render_submit(%{
-             webhook_auth_method: %{
-               name: new_auth_method_name,
-               username: "newusername",
-               password: "newpassword123"
-             }
-           })
+      assert view
+             |> form("#form_#{modal_id}_#{auth_method.id}")
+             |> render_submit(%{
+               webhook_auth_method: %{
+                 name: new_auth_method_name,
+                 username: "newusername",
+                 password: "newpassword123"
+               }
+             })
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert flash["info"] == "Webhook auth method updated successfully"
+      assert flash["info"] == "Webhook auth method updated successfully"
 
-    updated_auth_method =
-      Lightning.Repo.get(Lightning.Workflows.WebhookAuthMethod, auth_method.id)
+      updated_auth_method = Repo.get(WebhookAuthMethod, auth_method.id)
 
-    refute updated_auth_method.name == auth_method.name
-    assert updated_auth_method.name == new_auth_method_name
+      refute updated_auth_method.name == auth_method.name
+      assert updated_auth_method.name == new_auth_method_name
 
-    # only auth method name is updated
-    refute auth_method.username == "username"
-    assert auth_method.username == updated_auth_method.username
+      # only auth method name is updated
+      refute auth_method.username == "username"
+      assert auth_method.username == updated_auth_method.username
 
-    refute auth_method.password == "newpassword123"
-    assert auth_method.password == updated_auth_method.password
+      refute auth_method.password == "newpassword123"
+      assert auth_method.password == updated_auth_method.password
+    end
   end
 
-  test "admin can successfully remove an authentication method from a trigger, user can't",
+  test "owner/admin can remove an auth method from a trigger, editor/viewer can't",
        %{
-         conn: conn,
-         admin_conn: admin_conn,
          project: project,
          workflow: workflow,
          trigger: trigger
@@ -328,39 +324,57 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
         triggers: [trigger]
       )
 
-    {:ok, view, _html} =
-      live(
-        conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:editor, :viewer]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    refute view |> element("#webhooks_auth_method_modal") |> has_element?()
+      refute view |> element("#webhooks_auth_method_modal") |> has_element?()
+    end
 
-    {:ok, view, _html} =
-      live(
-        admin_conn,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+    for conn <- project_user_conns(project, [:owner, :admin]) do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert view |> element("#webhooks_auth_method_modal") |> has_element?()
+      assert view |> element("#webhooks_auth_method_modal") |> has_element?()
 
-    view
-    |> element("#select_#{auth_method.id}")
-    |> render_click()
+      view
+      |> element("#select_#{auth_method.id}")
+      |> render_click()
 
-    view |> element("#update_trigger_auth_methods_button") |> render_click()
+      view |> element("#update_trigger_auth_methods_button") |> render_click()
 
-    flash =
-      assert_redirect(
-        view,
-        ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
-      )
+      flash =
+        assert_redirect(
+          view,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
 
-    assert flash["info"] == "Trigger webhook auth methods updated successfully"
+      assert flash["info"] == "Trigger webhook auth methods updated successfully"
 
-    updated_trigger =
-      Lightning.Repo.preload(trigger, [:webhook_auth_methods], force: true)
+      updated_trigger =
+        Repo.preload(trigger, [:webhook_auth_methods], force: true)
 
-    assert updated_trigger.webhook_auth_methods == []
+      assert updated_trigger.webhook_auth_methods == []
+
+      # Then we add it back for the next test role! ============================
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[s: trigger.id]}"
+        )
+
+      view
+      |> element("#select_#{auth_method.id}")
+      |> render_click()
+
+      view |> element("#update_trigger_auth_methods_button") |> render_click()
+      # ========================================================================
+    end
   end
 end

--- a/test/lightning_web/live/workflow_live/trigger_test.exs
+++ b/test/lightning_web/live/workflow_live/trigger_test.exs
@@ -26,7 +26,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
     workflow: workflow,
     trigger: trigger
   } do
-    for conn <- project_user_conns(project, [:owner, :admin]) do
+    for conn <- build_project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -37,7 +37,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       assert view |> element("#webhooks_auth_method_modal") |> has_element?()
     end
 
-    for conn <- project_user_conns(project, [:editor, :viewer]) do
+    for conn <- build_project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -57,7 +57,8 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
     workflow: workflow,
     trigger: trigger
   } do
-    for conn <- project_user_conns(project, [:owner, :admin, :editor, :viewer]) do
+    for conn <-
+          build_project_user_conns(project, [:owner, :admin, :editor, :viewer]) do
       {:ok, _view, html} =
         live(
           conn,
@@ -91,7 +92,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
        } do
     modal_id = "webhooks_auth_method_modal"
 
-    for conn <- project_user_conns(project, [:editor, :viewer]) do
+    for conn <- build_project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -101,7 +102,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       refute view |> element("##{modal_id}") |> has_element?()
     end
 
-    for conn <- project_user_conns(project, [:owner, :admin]) do
+    for conn <- build_project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -168,7 +169,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
        } do
     modal_id = "webhooks_auth_method_modal"
 
-    for conn <- project_user_conns(project, [:editor, :viewer]) do
+    for conn <- build_project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -178,7 +179,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       refute view |> element("##{modal_id}") |> has_element?()
     end
 
-    for conn <- project_user_conns(project, [:owner, :admin]) do
+    for conn <- build_project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -251,7 +252,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
 
     modal_id = "webhooks_auth_method_modal"
 
-    for conn <- project_user_conns(project, [:editor, :viewer]) do
+    for conn <- build_project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -261,7 +262,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       refute view |> element("##{modal_id}") |> has_element?()
     end
 
-    for conn <- project_user_conns(project, [:owner, :admin]) do
+    for conn <- build_project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -324,7 +325,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
         triggers: [trigger]
       )
 
-    for conn <- project_user_conns(project, [:editor, :viewer]) do
+    for conn <- build_project_user_conns(project, [:editor, :viewer]) do
       {:ok, view, _html} =
         live(
           conn,
@@ -334,7 +335,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
       refute view |> element("#webhooks_auth_method_modal") |> has_element?()
     end
 
-    for conn <- project_user_conns(project, [:owner, :admin]) do
+    for conn <- build_project_user_conns(project, [:owner, :admin]) do
       {:ok, view, _html} =
         live(
           conn,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -164,7 +164,7 @@ defmodule LightningWeb.ConnCase do
 
   @doc """
   """
-  def project_user_conns(project, roles) do
+  def build_project_user_conns(project, roles) do
     Enum.map(roles, fn role ->
       project_user =
         Lightning.Factories.insert(:project_user,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -161,4 +161,20 @@ defmodule LightningWeb.ConnCase do
     |> Phoenix.ConnTest.init_test_session(%{})
     |> Plug.Conn.put_session(:user_token, token)
   end
+
+  @doc """
+  """
+  def project_user_conns(project, roles) do
+    Enum.map(roles, fn role ->
+      project_user =
+        Lightning.Factories.insert(:project_user,
+          role: role,
+          project: project,
+          user: Lightning.Factories.build(:user)
+        )
+
+      Phoenix.ConnTest.build_conn()
+      |> log_in_user(project_user.user)
+    end)
+  end
 end


### PR DESCRIPTION
Better to put this all in one PR as it's all permissions stuff and each branches off the previous. This PR:

1. Ensures that only owners and admins can edit webhook auth methods for a project to fix #1692 
2. Collapses `:create_webhook_auth` and `:edit_webhook_auth` into a single `:write_webhook_auth` permission
3. Removes unused permissions and collapses `run` and `rerun` into one thing. I'd really like to simplify our permissions. The only two permissions we should have on workflows are `write` and `readonly`: If you can create one, you can edit one, and you can delete one. In some cases, I bet we'll want to separate `delete` out, but in many cases it will be much cleaner to simply use `write_thing` and `read_thing`. More is _not_ better when it comes to programming and communicating these permissions to end users on the docs site and in training
4. Stops `:editor` from managing github repo connections to fix #1703 
5. Stops `:viewer` from initiating github syncs to fix #1704 

❗❗ **I'd like a _careful_ review** 🙏  **of how I'm blocking these github actions with permissions.** Is this the correct way to do it? I both disable the button with a permissions check, and then also check again on the `handle_event`.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
