### PR TITLE
stop over-scrubbing on empty secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 ### Fixed
 
+- Prevented secret scrubber from over-eagerly adding \*\*\* between all
+  characters if an empty string secret was provided as a credential field value
+  (e.g., {"username": "come-on-in", "password": ""})
+  [#1585](https://github.com/OpenFn/Lightning/issues/1585)
 - Fixed bug that was duplicating inbound http_requests, resulting in unnecessary
   data storage  
   [#1695](https://github.com/OpenFn/Lightning/issues/1695)

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -102,7 +102,7 @@ defmodule Lightning.Scrubber do
   def encode_samples(samples, basic_auth \\ []) do
     stringified_samples =
       samples
-      |> Enum.filter(fn x -> not is_boolean(x) end)
+      |> Enum.reject(fn x -> is_boolean(x) or x == "" end)
       |> Enum.map(fn x -> if is_integer(x), do: Integer.to_string(x), else: x end)
 
     base64_secrets =

--- a/test/lightning/scrubber_test.exs
+++ b/test/lightning/scrubber_test.exs
@@ -30,6 +30,13 @@ defmodule Lightning.ScrubberTest do
       assert scrubbed == ["Successfully logged in as *** using ***"]
     end
 
+    test "doesn't put *** between every character when given an empty string secret" do
+      secrets = ["123", ""]
+      scrubber = start_supervised!({Lightning.Scrubber, samples: secrets})
+      scrubbed = Scrubber.scrub(scrubber, ["Hello world, 123 is my password"])
+      assert scrubbed == ["Hello world, *** is my password"]
+    end
+
     test "doesn't replace booleans with ***" do
       secrets = ["ip_addr", "db_name", "my_user", "my_password", 5432, false]
       scrubber = start_supervised!({Lightning.Scrubber, samples: secrets})


### PR DESCRIPTION
This fixes #1585 by removing `""` from the secrets list. I.e., we now consider `""` safe to log.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
