### PR TITLE
fix inspector view stuck at processing when manual run has crashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
   [#1703](https://github.com/OpenFn/Lightning/issues/1703)
 - Fixed permissions issue that allowed viewers to initiate syncs to github
   [#1704](https://github.com/OpenFn/Lightning/issues/1704)
+- Fixed inspector view stuck at processing when following a crashed run
+  [#1711](https://github.com/OpenFn/Lightning/issues/1711)
 
 ## [v2.0.0-rc8] - 2024-01-30
 

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -137,30 +137,46 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 />
               </Common.panel_content>
               <Common.panel_content for_hash="input" class="grow overflow-auto">
-                <Viewers.step_dataclip_viewer
-                  id={"step-input-#{@selected_step_id}"}
-                  class="overflow-auto h-full"
-                  stream={@streams.input_dataclip}
-                  step={@selected_step}
-                  dataclip={@input_dataclip}
-                  input_or_output={:input}
-                  project_id={@project.id}
-                  admin_contacts={@admin_contacts}
-                  can_edit_data_retention={@can_edit_data_retention}
-                />
+                <%= if @run.ok? && @selected_step_id do %>
+                  <Viewers.step_dataclip_viewer
+                    id={"step-input-#{@selected_step_id}"}
+                    class="overflow-auto h-full"
+                    stream={@streams.input_dataclip}
+                    step={@selected_step}
+                    dataclip={@input_dataclip}
+                    input_or_output={:input}
+                    project_id={@project.id}
+                    admin_contacts={@admin_contacts}
+                    can_edit_data_retention={@can_edit_data_retention}
+                  />
+                <% else %>
+                  <div class="border-2 border-gray-200 border-dashed rounded-lg px-8 pt-6 pb-8 mb-4 flex flex-col">
+                    <p class="text-sm text-center">
+                      No input/output available
+                    </p>
+                  </div>
+                <% end %>
               </Common.panel_content>
               <Common.panel_content for_hash="output" class="grow overflow-auto">
-                <Viewers.step_dataclip_viewer
-                  id={"step-output-#{@selected_step_id}"}
-                  class="overflow-auto h-full"
-                  stream={@streams.output_dataclip}
-                  step={@selected_step}
-                  dataclip={@output_dataclip}
-                  input_or_output={:output}
-                  project_id={@project.id}
-                  admin_contacts={@admin_contacts}
-                  can_edit_data_retention={@can_edit_data_retention}
-                />
+                <%= if @run.ok? && @selected_step_id do %>
+                  <Viewers.step_dataclip_viewer
+                    id={"step-output-#{@selected_step_id}"}
+                    class="overflow-auto h-full"
+                    stream={@streams.output_dataclip}
+                    step={@selected_step}
+                    dataclip={@output_dataclip}
+                    input_or_output={:output}
+                    project_id={@project.id}
+                    admin_contacts={@admin_contacts}
+                    can_edit_data_retention={@can_edit_data_retention}
+                  />
+                <% else %>
+                  <div class="border-2 border-gray-200 border-dashed rounded-lg px-8 pt-6 pb-8 mb-4 flex flex-col">
+                    <p class="text-sm text-center">
+                      No input/output available
+                    </p>
+                  </div>
+                <% end %>
               </Common.panel_content>
             </div>
           </div>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -1,6 +1,7 @@
 defmodule LightningWeb.RunLive.RunViewerLive do
   use LightningWeb, {:live_view, container: {:div, []}}
   use LightningWeb.RunLive.Streaming, chunk_size: 100
+  require Lightning.Run
 
   import LightningWeb.RunLive.Components
 
@@ -137,7 +138,13 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 />
               </Common.panel_content>
               <Common.panel_content for_hash="input" class="grow overflow-auto">
-                <%= if @run.ok? && @selected_step_id do %>
+                <%= if @run.ok? && @run.result.state in Lightning.Run.final_states() && is_nil(@selected_step_id) do %>
+                  <div class="border-2 border-gray-200 border-dashed rounded-lg px-8 pt-6 pb-8 mb-4 flex flex-col">
+                    <p class="text-sm text-center">
+                      No input/output available. This step was never started.
+                    </p>
+                  </div>
+                <% else %>
                   <Viewers.step_dataclip_viewer
                     id={"step-input-#{@selected_step_id}"}
                     class="overflow-auto h-full"
@@ -149,16 +156,16 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     admin_contacts={@admin_contacts}
                     can_edit_data_retention={@can_edit_data_retention}
                   />
-                <% else %>
-                  <div class="border-2 border-gray-200 border-dashed rounded-lg px-8 pt-6 pb-8 mb-4 flex flex-col">
-                    <p class="text-sm text-center">
-                      No input/output available
-                    </p>
-                  </div>
                 <% end %>
               </Common.panel_content>
               <Common.panel_content for_hash="output" class="grow overflow-auto">
-                <%= if @run.ok? && @selected_step_id do %>
+                <%= if @run.ok? && @run.result.state in Lightning.Run.final_states() && is_nil(@selected_step_id) do %>
+                  <div class="border-2 border-gray-200 border-dashed rounded-lg px-8 pt-6 pb-8 mb-4 flex flex-col">
+                    <p class="text-sm text-center">
+                      No input/output available. This step was never started.
+                    </p>
+                  </div>
+                <% else %>
                   <Viewers.step_dataclip_viewer
                     id={"step-output-#{@selected_step_id}"}
                     class="overflow-auto h-full"
@@ -170,12 +177,6 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     admin_contacts={@admin_contacts}
                     can_edit_data_retention={@can_edit_data_retention}
                   />
-                <% else %>
-                  <div class="border-2 border-gray-200 border-dashed rounded-lg px-8 pt-6 pb-8 mb-4 flex flex-col">
-                    <p class="text-sm text-center">
-                      No input/output available
-                    </p>
-                  </div>
                 <% end %>
               </Common.panel_content>
             </div>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -1,7 +1,6 @@
 defmodule LightningWeb.RunLive.RunViewerLive do
   use LightningWeb, {:live_view, container: {:div, []}}
   use LightningWeb.RunLive.Streaming, chunk_size: 100
-  require Lightning.Run
 
   import LightningWeb.RunLive.Components
 
@@ -12,6 +11,8 @@ defmodule LightningWeb.RunLive.RunViewerLive do
   alias Lightning.Projects.Project
   alias LightningWeb.Components.Viewers
   alias Phoenix.LiveView.AsyncResult
+
+  require Lightning.Run
 
   @impl true
   def render(assigns) do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -11,6 +11,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   alias Lightning.Projects
   alias Lightning.Runs
   alias Lightning.Runs.Events.StepCompleted
+  alias Lightning.Runs.Events.RunUpdated
   alias Lightning.Workflows
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger
@@ -88,7 +89,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
               current_user={@current_user}
               project={@project}
               socket={@socket}
-              follow_run_id={@follow_run_id}
+              follow_run_id={@follow_run && @follow_run.id}
               close_url={
                 "#{@base_url}?s=#{@selected_job.id}"
               }
@@ -128,7 +129,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       id="save-and-run"
                       phx-hook="DefaultRunViaCtrlEnter"
                       {if step_retryable?(@step, @manual_run_form, @selectable_dataclips), do:
-                        [type: "button", "phx-click": "rerun", "phx-value-run_id": @follow_run_id, "phx-value-step_id": @step.id],
+                        [type: "button", "phx-click": "rerun", "phx-value-run_id": @follow_run.id, "phx-value-step_id": @step.id],
                       else:
                           [type: "submit", form: @manual_run_form.id]}
                       class={[
@@ -141,14 +142,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       ]}
                       disabled={
                         @save_and_run_disabled ||
-                          processing(@follow_run_id, @step) ||
+                          processing(@follow_run) ||
                           selected_dataclip_wiped?(
                             @manual_run_form,
                             @selectable_dataclips
                           )
                       }
                     >
-                      <%= if processing(@follow_run_id, @step) do %>
+                      <%= if processing(@follow_run) do %>
                         <.icon
                           name="hero-arrow-path-mini"
                           class="w-4 h-4 animate-spin mr-1"
@@ -457,7 +458,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
     selected_dataclip && !is_nil(selected_dataclip.wiped_at)
   end
 
-  defp processing(run_id, step), do: run_id && !step
+  defp processing(%{exit_reason: nil}), do: true
+  defp processing(_run), do: false
 
   defp deletion_tooltip_message(has_multiple_jobs) do
     if has_multiple_jobs do
@@ -642,7 +644,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
      |> assign(
        active_menu_item: :overview,
        expanded_job: nil,
-       follow_run_id: nil,
+       follow_run: nil,
        step: nil,
        manual_run_form: nil,
        page_title: "",
@@ -986,6 +988,16 @@ defmodule LightningWeb.WorkflowLive.Edit do
      |> assign(selectable_dataclips: selectable_dataclips)}
   end
 
+  def handle_info(
+        %RunUpdated{run: run},
+        %{assigns: %{follow_run: %{id: follow_run_id}}} = socket
+      )
+      when run.id === follow_run_id do
+    {:noreply,
+     socket
+     |> assign(follow_run: run)}
+  end
+
   def handle_info(%{}, socket), do: {:noreply, socket}
 
   defp maybe_show_manual_run(socket) do
@@ -1000,8 +1012,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
       %{selected_job: job, selection_mode: "expand"} = assigns
       when not is_nil(job) ->
         dataclip =
-          assigns[:follow_run_id] &&
-            get_selected_dataclip(assigns[:follow_run_id], job.id)
+          assigns[:follow_run] &&
+            get_selected_dataclip(assigns[:follow_run].id, job.id)
 
         changeset =
           WorkOrders.Manual.new(
@@ -1016,9 +1028,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
           Invocation.list_dataclips_for_job(%Job{id: job.id})
 
         step =
-          assigns[:follow_run_id] &&
+          assigns[:follow_run] &&
             Invocation.get_step_for_run_and_job(
-              assigns[:follow_run_id],
+              assigns[:follow_run].id,
               job.id
             )
 
@@ -1291,18 +1303,20 @@ defmodule LightningWeb.WorkflowLive.Edit do
   defp maybe_follow_run(socket, query_params) do
     case query_params do
       %{"a" => run_id} when is_binary(run_id) ->
+        run = Runs.get(run_id)
+
         step =
           Invocation.get_step_for_run_and_job(
             run_id,
             socket.assigns.selected_job.id
           )
 
-        Runs.subscribe(%Lightning.Run{id: run_id})
+        Runs.subscribe(run)
 
-        socket |> assign(follow_run_id: run_id, step: step)
+        socket |> assign(follow_run: run, step: step)
 
       _ ->
-        socket |> assign(follow_run_id: nil)
+        socket |> assign(follow_run: nil)
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -10,8 +10,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
   alias Lightning.Policies.ProjectUsers
   alias Lightning.Projects
   alias Lightning.Runs
-  alias Lightning.Runs.Events.StepCompleted
   alias Lightning.Runs.Events.RunUpdated
+  alias Lightning.Runs.Events.StepCompleted
   alias Lightning.Workflows
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -107,7 +107,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   project={@project}
                   admin_contacts={@admin_contacts}
                   can_edit_data_retention={@can_edit_data_retention}
-                  follow_run_id={@follow_run_id}
+                  follow_run_id={@follow_run && @follow_run.id}
                   show_wiped_dataclip_selector={@show_wiped_dataclip_selector}
                 />
               </:collapsible_panel>
@@ -458,7 +458,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
     selected_dataclip && !is_nil(selected_dataclip.wiped_at)
   end
 
-  defp processing(%{exit_reason: nil}), do: true
+  defp processing(%{state: state}) do
+    !(state in Lightning.Run.final_states())
+  end
+
   defp processing(_run), do: false
 
   defp deletion_tooltip_message(has_multiple_jobs) do

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -1093,6 +1093,9 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       run_id = Plug.Conn.Query.decode(uri.query)["a"]
       run = Lightning.Repo.get!(Lightning.Run, run_id)
 
+      # Get the Output/Logs View
+      run_view = find_live_child(view, "run-viewer-#{run.id}")
+
       # action button is rendered correctly
       refute has_element?(view, "button", "Rerun from here")
 
@@ -1100,6 +1103,17 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
              "currently processing"
 
       refute has_element?(view, "button", "Create New Work Order")
+
+      render_async(run_view)
+      # input tab shows correct information
+      html = run_view |> element("div[data-panel-hash='input']") |> render()
+      assert html =~ "Nothing yet"
+      refute html =~ "No input/output available. This step was never started."
+
+      # output tab shows correct information
+      html = run_view |> element("div[data-panel-hash='output']") |> render()
+      assert html =~ "Nothing yet"
+      refute html =~ "No input/output available. This step was never started."
 
       # let's subscribe to events to make sure we're in sync with liveview
       Lightning.Runs.subscribe(run)
@@ -1133,6 +1147,19 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       refute has_element?(view, "button", "Rerun from here")
       refute has_element?(view, "button", "Processing"), "nolonger processing"
       assert has_element?(view, "button", "Create New Work Order")
+
+      # make sure event is processed by the run viewer
+      render_async(run_view)
+
+      # input tab shows correct information
+      html = run_view |> element("div[data-panel-hash='input']") |> render()
+      refute html =~ "Nothing yet"
+      assert html =~ "No input/output available. This step was never started."
+
+      # output tab shows correct information
+      html = run_view |> element("div[data-panel-hash='output']") |> render()
+      refute html =~ "Nothing yet"
+      assert html =~ "No input/output available. This step was never started."
     end
   end
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -477,15 +477,18 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         insert(:workorder,
           workflow: workflow,
           dataclip: dataclip,
+          state: :failed,
           runs: [
             build(:run,
               dataclip: dataclip,
               starting_job: job_1,
+              state: :failed,
               steps: [
                 build(:step,
                   job: job_1,
                   input_dataclip: dataclip,
                   output_dataclip: build(:dataclip),
+                  exit_reason: "fail",
                   started_at: build(:timestamp),
                   finished_at: build(:timestamp)
                 )
@@ -769,10 +772,12 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         insert(:workorder,
           workflow: workflow,
           dataclip: input_dataclip,
+          state: :success,
           runs: [
             build(:run,
               dataclip: input_dataclip,
               starting_job: job_1,
+              state: :success,
               steps: [
                 build(:step,
                   job: job_1,
@@ -886,10 +891,12 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         insert(:workorder,
           workflow: workflow,
           dataclip: wiped_dataclip,
+          state: :success,
           runs: [
             build(:run,
               dataclip: wiped_dataclip,
               starting_job: job_1,
+              state: :success,
               steps: [
                 build(:step,
                   job: job_1,


### PR DESCRIPTION
## Notes for the reviewer

- [x] Inspector view hangs on the "processing" mode...
- [x] RunDetail shows input/output as "Nothing yet" rather than "crashed, no input/output available"
- [x] Tests


## Related issue

Fixes #1711

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
