### PR TITLE
Block retrying of runs having wiped dataclips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed inspector dataclip body not getting updated after dataclip is wiped
+  [#1718](https://github.com/OpenFn/Lightning/issues/1718)
+- Fixed work orders getting retried despite having wiped dataclips
+  [#1721](https://github.com/OpenFn/Lightning/issues/1721)
+
 ## [v2.0.0-rc9] 2024-02-05
 
 ### Added
@@ -97,7 +102,7 @@ and this project adheres to
 
 ### Fixed
 
-- Fix Run via Docker  
+- Fix Run via Docker
   [#1653](https://github.com/OpenFn/Lightning/issues/1653)
 - Fix remaining warnings, enable "warnings as errors"
   [#1642](https://github.com/OpenFn/Lightning/issues/1642)

--- a/lib/lightning/runs/events.ex
+++ b/lib/lightning/runs/events.ex
@@ -19,6 +19,11 @@ defmodule Lightning.Runs.Events do
     defstruct log_line: nil
   end
 
+  defmodule DataclipUpdated do
+    @moduledoc false
+    defstruct dataclip: nil
+  end
+
   def step_started(run_id, step) do
     Lightning.broadcast(
       topic(run_id),
@@ -44,6 +49,13 @@ defmodule Lightning.Runs.Events do
     Lightning.broadcast(
       topic(log_line.run_id),
       %LogAppended{log_line: log_line}
+    )
+  end
+
+  def dataclip_updated(run_id, dataclip) do
+    Lightning.broadcast(
+      topic(run_id),
+      %DataclipUpdated{dataclip: dataclip}
     )
   end
 

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -160,7 +160,7 @@ defmodule LightningWeb.RunChannel do
       Runs.wipe_dataclips(socket.assigns.run)
     end
 
-    {:reply, {:ok, {:binary, body}}, socket}
+    {:reply, {:ok, {:binary, body || "null"}}, socket}
   end
 
   def handle_in("step:start", payload, socket) do

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -239,6 +239,11 @@ defmodule LightningWeb.RunLive.RunViewerLive do
     {:noreply, socket |> apply_selected_step_id(id)}
   end
 
+  @impl true
+  def handle_info(%Lightning.Runs.Events.DataclipUpdated{}, socket) do
+    {:noreply, socket}
+  end
+
   def handle_steps_change(socket) do
     # either a job_id or a step_id is passed in
     # if a step_id is passed in, we can highlight the log lines immediately

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -265,4 +265,9 @@ defmodule LightningWeb.RunLive.Show do
 
     {:noreply, socket |> apply_selected_step_id(selected_step_id)}
   end
+
+  @impl true
+  def handle_info(%Lightning.Runs.Events.DataclipUpdated{}, socket) do
+    {:noreply, socket}
+  end
 end

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -272,6 +272,10 @@ defmodule LightningWeb.RunLive.Streaming do
          |> stream_insert(:log_lines, log_line)
          |> assign(:log_lines_stream_empty?, false)}
       end
+
+      def handle_info(%Runs.Events.DataclipUpdated{}, socket) do
+        {:noreply, socket}
+      end
     end
   end
 

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -272,10 +272,6 @@ defmodule LightningWeb.RunLive.Streaming do
          |> stream_insert(:log_lines, log_line)
          |> assign(:log_lines_stream_empty?, false)}
       end
-
-      def handle_info(%Runs.Events.DataclipUpdated{}, socket) do
-        {:noreply, socket}
-      end
     end
   end
 

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -289,6 +289,15 @@ defmodule LightningWeb.RunChannelTest do
       ref = push(socket, "fetch:dataclip", %{})
 
       assert_reply ref, :ok, {:binary, ~s<{"foo": "bar"}>}
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      dataclip
+      |> Ecto.Changeset.change(body: nil, wiped_at: now)
+      |> Repo.update()
+
+      ref = push(socket, "fetch:dataclip", %{})
+      assert_reply ref, :ok, {:binary, "null"}
     end
 
     test "fetch:dataclip wipes dataclip body for projects with erase_all retention policy",

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -998,7 +998,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
              "create new workorder button is disabled"
     end
 
-    test "selected dataclip viewer is updated correctly if dataclip is wiped and step completed",
+    test "selected dataclip viewer is updated correctly if dataclip is wiped",
          %{
            conn: conn,
            project: project,
@@ -1042,9 +1042,6 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       # let's subscribe to events to make sure we're in sync with liveview
       Lightning.Runs.subscribe(run)
 
-      # lets wipe the dataclip
-      Lightning.Runs.wipe_dataclips(run)
-
       # start step without dataclip
       {:ok, %{id: step_id}} =
         Lightning.Runs.start_step(%{
@@ -1061,17 +1058,13 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       html = view |> element("#manual-job-#{job_1.id}") |> render()
       assert html =~ unique_val, "dataclip body is present when the step starts"
 
-      # complete step without dataclip
-      {:ok, _step} =
-        Lightning.Runs.complete_step(%{
-          step_id: step_id,
-          reason: "success",
-          run_id: run.id,
-          project_id: project.id
-        })
+      # lets wipe the dataclip
+      Lightning.Runs.wipe_dataclips(run)
 
-      assert_received %Lightning.Runs.Events.StepCompleted{
-        step: %{id: ^step_id}
+      dataclip_id = input_dataclip.id
+
+      assert_received %Lightning.Runs.Events.DataclipUpdated{
+        dataclip: %{id: ^dataclip_id}
       }
 
       # make sure that the event is processed by liveview


### PR DESCRIPTION
## Notes for the reviewer

- [x] Emits `DataclipUpdated` whenever the `run` `dataclip` is `wiped`. This is handled by the `Workflow Edit LiveView` which in turn blocks the `rerun` button in the inspector if needed
- [x] **Gets rid of unneeded reassigning of the `manual_run_form` when the `Step` is `Completed`.**. This is potentially why the `codecov` has reduced. 
- [x] Blocks retrying of a `run` having a `wiped dataclip`. In the case of `retry_many`, we're also handling the possibility of having `runs/wo` with `wiped` dataclips
- [x] The `Run Channel` doesn't crash if it gets a request for a `wiped dataclip`  

## Related issue

Fixes #1718
Fixes #1721 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
