### PR TITLE
Don't preload all steps for a run if we only want to know "has any?"

### DIFF
--- a/lib/lightning/invocation/query.ex
+++ b/lib/lightning/invocation/query.ex
@@ -37,6 +37,12 @@ defmodule Lightning.Invocation.Query do
   end
 
   @doc """
+  To be used in preloads for `workflow > job > step` when the presence of any
+  step is all the information we need. As in, "Does this job have any steps?"
+  """
+  def any_step, do: from(s in Step, limit: 1)
+
+  @doc """
   The last step for a job for a particular exit reason, used in scheduler
   """
   @spec steps_with_reason(Ecto.Queryable.t(), String.t()) :: Ecto.Queryable.t()

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -712,7 +712,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
           |> Lightning.Repo.preload([
             :edges,
             triggers: Trigger.with_auth_methods_query(),
-            jobs: {Workflows.jobs_ordered_subquery(), [:credential, :steps]}
+            jobs:
+              {Workflows.jobs_ordered_subquery(),
+               [:credential, steps: Invocation.Query.any_step()]}
           ])
 
         socket |> assign_workflow(workflow) |> assign(page_title: workflow.name)
@@ -1355,7 +1357,15 @@ defmodule LightningWeb.WorkflowLive.Edit do
           {:cont, nil}
 
         %Job{} = job ->
-          {:halt, [field, job |> Lightning.Repo.preload([:credential, :steps])]}
+          {:halt,
+           [
+             field,
+             job
+             |> Lightning.Repo.preload([
+               :credential,
+               steps: Invocation.Query.any_step()
+             ])
+           ]}
 
         %Trigger{} = trigger ->
           {:halt,


### PR DESCRIPTION
This is more a short term solution than a long term one, but it stops the canvas from trying to fetch really large arrays of `steps` from the DB when all we want to know is, "does this job have any associated steps, yes or no?"

Fixes #1726

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
