### PR TITLE
Fix Output & Logs fails to show intermittently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 - Adds more detail to work order states on dashboard
   [#1677](https://github.com/OpenFn/lightning/issues/1677)
+- Fix Output & Logs in inspector fails to show sometimes
+  [#1702](https://github.com/OpenFn/lightning/issues/1702)
 
 ## [v2.0.0-rc11] - 2024-02-08
 

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -133,7 +133,6 @@ defmodule LightningWeb.WorkflowLive.JobView do
               "project_id" => @project.id,
               "user_id" => @current_user.id
             },
-            sticky: true,
             container: {:div, class: "h-full"}
           ) %>
         <% else %>

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -131,6 +131,12 @@ defmodule LightningWeb.ConnCase do
   @doc """
   Setup helper that creates a user adds them as project user with a given role and logs them them in
   """
+  def setup_project_users(conn, project, roles) when is_list(roles) do
+    for role <- roles do
+      setup_project_user(conn, project, role)
+    end
+  end
+
   def setup_project_user(conn, project, role) do
     user = Lightning.Factories.insert(:user)
 

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -86,7 +86,7 @@ defmodule Lightning.Factories do
 
   def log_line_factory do
     %Lightning.Invocation.LogLine{
-      id: Ecto.UUID.generate(),
+      id: fn -> Ecto.UUID.generate() end,
       message: sequence(:log_line, &"somelog#{&1}"),
       timestamp: build(:timestamp)
     }


### PR DESCRIPTION
## Notes for the reviewer

- Makes the nested `run viewer` `non-sticky`. This ensures that it gets mounted every time the parent is opened


## Related issue

Fixes #1702 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
