### PR TITLE
Broadcast created run for trigger

### DIFF
--- a/lib/lightning/workorders/events.ex
+++ b/lib/lightning/workorders/events.ex
@@ -13,7 +13,7 @@ defmodule Lightning.WorkOrders.Events do
 
   defmodule RunCreated do
     @moduledoc false
-    defstruct run: nil
+    defstruct run: nil, project_id: nil
   end
 
   defmodule RunUpdated do
@@ -38,7 +38,7 @@ defmodule Lightning.WorkOrders.Events do
   def run_created(project_id, run) do
     Lightning.broadcast(
       topic(project_id),
-      %RunCreated{run: run}
+      %RunCreated{run: run, project_id: project_id}
     )
   end
 

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -31,7 +31,8 @@ defmodule Lightning.WorkOrdersTest do
       workflow: workflow,
       trigger: trigger
     } do
-      Lightning.WorkOrders.subscribe(workflow.project_id)
+      project_id = workflow.project_id
+      Lightning.WorkOrders.subscribe(project_id)
       dataclip = insert(:dataclip)
 
       {:ok, workorder} =
@@ -48,6 +49,10 @@ defmodule Lightning.WorkOrdersTest do
       assert run.dataclip_id == dataclip.id
 
       workorder_id = workorder.id
+
+      assert_received %Lightning.WorkOrders.Events.RunCreated{
+        project_id: ^project_id
+      }
 
       assert_received %Lightning.WorkOrders.Events.WorkOrderCreated{
         work_order: %{id: ^workorder_id}
@@ -84,8 +89,8 @@ defmodule Lightning.WorkOrdersTest do
 
     test "creates a manual workorder", %{workflow: workflow, job: job} do
       user = insert(:user)
-
-      Lightning.WorkOrders.subscribe(workflow.project_id)
+      project_id = workflow.project_id
+      Lightning.WorkOrders.subscribe(project_id)
 
       assert {:ok, manual} =
                Lightning.WorkOrders.Manual.new(
@@ -114,7 +119,9 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.created_by.id == user.id
 
-      assert_received %Lightning.WorkOrders.Events.RunCreated{}
+      assert_received %Lightning.WorkOrders.Events.RunCreated{
+        project_id: ^project_id
+      }
 
       workorder_id = workorder.id
 


### PR DESCRIPTION
## Notes for the reviewer

In order to track the runs count we need to know that a run was created for a trigger (same way it's broadcast for manual).
Also adds the `project_id` to the `RunCreated` to allow the tracking per project.

## Related issue

Refs #1754 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
