### PR TITLE
fix ballooning toggling button on history page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   [#1731](https://github.com/OpenFn/Lightning/issues/1731)
 
 ### Fixed
+- Expand work order button balloons randomly
+  [#1737](https://github.com/OpenFn/Lightning/issues/1737)
 
 ## [v2.0.0] - 2024-02-10
 

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -162,7 +162,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
             <%= if @work_order.runs !== [] do %>
               <button
                 id={"toggle_details_for_#{@work_order.id}"}
-                class="w-auto rounded-full p-3 hover:bg-gray-100"
+                class="w-10 rounded-full p-3 hover:bg-gray-100"
                 phx-click="toggle_details"
                 phx-target={@myself}
               >
@@ -304,7 +304,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
     ~H"""
     <%= if wo_dataclip_available?(@work_order) do %>
       <.link
-        id={"view-dataclip-#{@work_order.dataclip_id}"}
+        id={"view-dataclip-#{@work_order.dataclip_id}-for-#{@work_order.id}"}
         navigate={
           ~p"/projects/#{@work_order.workflow.project_id}/dataclips/#{@work_order.dataclip_id}/show"
         }
@@ -320,7 +320,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
       </.link>
     <% else %>
       <span
-        id={"view-dataclip-#{@work_order.dataclip_id}"}
+        id={"view-dataclip-#{@work_order.dataclip_id}-for-#{@work_order.id}"}
         title={@work_order.dataclip_id}
         class="font-normal text-xs whitespace-nowrap text-ellipsis
               p-1 rounded-md font-mono text-indigo-300 cursor-pointer

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -228,17 +228,23 @@ defmodule LightningWeb.WorkOrderLiveTest do
       parsed_html = Floki.parse_fragment!(html)
 
       refute parsed_html
-             |> Floki.find(~s{a#view-dataclip-#{wiped_dataclip.id}})
+             |> Floki.find(
+               ~s{a#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+             )
              |> Enum.any?(),
              "dataclip link not available"
 
       assert parsed_html
-             |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+             |> Floki.find(
+               ~s{span#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+             )
              |> Enum.any?()
 
       dataclip_element =
         parsed_html
-        |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+        |> Floki.find(
+          ~s{span#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+        )
         |> hd()
 
       dataclip_html = Floki.raw_html(dataclip_element)
@@ -264,17 +270,23 @@ defmodule LightningWeb.WorkOrderLiveTest do
       parsed_html = Floki.parse_fragment!(html)
 
       refute parsed_html
-             |> Floki.find(~s{a#view-dataclip-#{wiped_dataclip.id}})
+             |> Floki.find(
+               ~s{a#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+             )
              |> Enum.any?(),
              "dataclip link not available"
 
       assert parsed_html
-             |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+             |> Floki.find(
+               ~s{span#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+             )
              |> Enum.any?()
 
       dataclip_html =
         parsed_html
-        |> Floki.find(~s{span#view-dataclip-#{wiped_dataclip.id}})
+        |> Floki.find(
+          ~s{span#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+        )
         |> hd()
         |> Floki.raw_html()
 
@@ -298,7 +310,9 @@ defmodule LightningWeb.WorkOrderLiveTest do
         |> Floki.parse_fragment!()
 
       assert parsed_html
-             |> Floki.find(~s{a#view-dataclip-#{wiped_dataclip.id}})
+             |> Floki.find(
+               ~s{a#view-dataclip-#{wiped_dataclip.id}-for-#{work_order.id}}
+             )
              |> Enum.any?(),
              "dataclip link available"
     end


### PR DESCRIPTION
## Notes for the reviewer

- Gives the toggle button a fixed width
- Got some warnings when work orders have the same dataclip. This PR ensures unique ids for dataclip links.  


## Related issue

Fixes #1737 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
