### PR TITLE
Fix OAuth2 not an already existing atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Unable to refresh OAuth2 credentials after token expiration
+  [#1735](https://github.com/OpenFn/Lightning/issues/1735)
+
 ## [v2.0.1] - 2024-02-13
 
 ### Changed

--- a/lib/lightning/auth_providers/common.ex
+++ b/lib/lightning/auth_providers/common.ex
@@ -39,7 +39,8 @@ defmodule Lightning.AuthProviders.Common do
 
       extra_params =
         token.other_params
-        |> Enum.map(fn {key, value} -> {String.to_atom(key), value} end)
+        |> Enum.reject(fn {key, _} -> key not in ["scope", "instance_url"] end)
+        |> Enum.map(fn {key, value} -> {String.to_existing_atom(key), value} end)
         |> Map.new()
 
       token_params

--- a/lib/lightning/auth_providers/common.ex
+++ b/lib/lightning/auth_providers/common.ex
@@ -39,7 +39,7 @@ defmodule Lightning.AuthProviders.Common do
 
       extra_params =
         token.other_params
-        |> Enum.map(fn {key, value} -> {String.to_existing_atom(key), value} end)
+        |> Enum.map(fn {key, value} -> {String.to_atom(key), value} end)
         |> Map.new()
 
       token_params

--- a/lib/lightning/auth_providers/common.ex
+++ b/lib/lightning/auth_providers/common.ex
@@ -39,7 +39,9 @@ defmodule Lightning.AuthProviders.Common do
 
       extra_params =
         token.other_params
-        |> Enum.reject(fn {key, _} -> key not in ["scope", "instance_url"] end)
+        |> Enum.filter(fn {key, _} ->
+          key in ~W[access_token refresh_token expires_at scope instance_url]
+        end)
         |> Enum.map(fn {key, value} -> {String.to_existing_atom(key), value} end)
         |> Map.new()
 


### PR DESCRIPTION
## Notes for the reviewer

When we run a workflow with a OAuth2 credential that has an expired token we refresh it before excuting the run. That was failing due to usage of `String.to_existing_atom/1` when we process the result of the OAuth2 provider. This PR changes the usage of `String.to_existing_atom/1` to `String.to_atom/1` which doesn't blow when the atom doesn't exist but just creates it.

## Related issue

Fixes #1735 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
