### PR TITLE
Submit populated metric date for usage tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,9 +175,13 @@ PURGE_DELETED_AFTER_DAYS=7
 # The maximum age of a Run that will be considered when measuring Run performance.
 # METRICS_RUN_PERFORMANCE_AGE_SECONDS=120
 
-# To enable the reporting of anonymised metrics to the OpenFn Usage tracker, set
-# USAGE_TRACKING_ENABLED to `true`.
-USAGE_TRACKING_ENABLED=false
+# To disable the reporting of anonymised metrics to the OpenFn Usage tracker, set
+# USAGE_TRACKING_ENABLED to `false`.
+# USAGE_TRACKING_ENABLED=false
+
+# To submit cleartext UUIDs to the usage tracker (default: hashed_only),
+# set USAGE_TRACKING_UUIDS=cleartext.
+# USAGE_TRACKING_UUIDS=hashed_only
 
 # By default, impact tracking metrics will be reported to https://impact.openfn.org. Use the
 # below if you wish to change that.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+- Actual metrics will now be submitted by Lightning to the Usage Tracker.
+  [#1742](https://github.com/OpenFn/lightning/issues/1742)
 
 ### Changed
+- Usage Tracking submissions are now opt-out, rather than opt-in.
+  [#1742](https://github.com/OpenFn/lightning/issues/1742)
+- Usage Tracking submissions will now run daily rather than hourly.
+  [#1742](https://github.com/OpenFn/lightning/issues/1742)
 
 - Bumped @openfn/ws-worker to `v1.0` (this is used in dev mode when starting the
   worker from your mix app: `RTM=true iex -S mix phx.server`)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -84,6 +84,13 @@ Note that for secure deployments, it's recommended to use a combination of
 - `URL_HOST` - the host, used for writing urls (e.g., `demo.openfn.org`)
 - `URL_PORT` - the port, usually `443` for production
 - `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)
+- `USAGE_TRACKER_HOST` - the host that receives usage tracking submissions 
+  (defaults to https://impact.openfn.org)
+- `USAGE_TRACKING_ENABLED` - enables the submission of anonymised usage data
+  to OpenFn (defaults to `true`).
+- `USAGE_TRACKING_UUIDS` - indicates whether submissions should include cleartext
+  uuids or not. Options are `cleartext` or `hashed_only`, with the default being
+  `hashed_only`.
 - `QUEUE_RESULT_RETENTION_PERIOD_SECONDS` - the number of seconds to keep
   completed (successful) `ObanJobs` in the queue (not to be confused with runs
   and/or history)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -116,7 +116,7 @@ purge_cron =
     ],
     else: []
 
-usage_tracking_cron = [{"0 */1 * * *", Lightning.UsageTracking.Worker}]
+usage_tracking_cron = [{"0 2 * * *", Lightning.UsageTracking.Worker}]
 
 all_cron = base_oban_cron ++ purge_cron ++ usage_tracking_cron
 
@@ -351,5 +351,6 @@ config :lightning, :metrics,
     )
 
 config :lightning, :usage_tracking,
-  enabled: System.get_env("USAGE_TRACKING_ENABLED") == "true",
+  cleartext_uuids_enabled: System.get_env("USAGE_TRACKING_UUIDS") == "cleartext",
+  enabled: System.get_env("USAGE_TRACKING_ENABLED") != "false",
   host: System.get_env("USAGE_TRACKER_HOST", "https://impact.openfn.org")

--- a/lib/lightning/usage_tracking/o_s_instrumenter.ex
+++ b/lib/lightning/usage_tracking/o_s_instrumenter.ex
@@ -1,0 +1,22 @@
+defmodule Lightning.UsageTracking.OSInstrumenter do
+  @moduledoc """
+  Provides OS details for Usagetracking submission.
+
+
+  """
+  def instrument(operating_system_name) do
+    %{operating_system: operating_system_name}
+    |> Map.merge(operating_system_detail(operating_system_name))
+  end
+
+  defp operating_system_detail("linux" = _operating_system_name) do
+    case System.cmd("uname", ["-a"]) do
+      {detail, 0} -> %{operating_system_detail: String.trim(detail)}
+      _non_zero_response -> operating_system_detail(nil)
+    end
+  end
+
+  defp operating_system_detail(_operating_system_name) do
+    %{operating_system_detail: nil}
+  end
+end

--- a/lib/lightning/usage_tracking/report_data.ex
+++ b/lib/lightning/usage_tracking/report_data.ex
@@ -1,0 +1,101 @@
+defmodule Lightning.UsageTracking.ReportData do
+  @moduledoc """
+  Builds data set for submission to Usage Tracker
+
+
+  """
+  import Ecto.Query
+
+  alias Lightning.Accounts.User
+  alias Lightning.Projects.Project
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.Configuration
+  alias Lightning.UsageTracking.OSInstrumenter
+  alias Lightning.Workflows.Workflow
+
+  @lightning_version Lightning.MixProject.project()[:version]
+
+  def generate(configuration, cleartext_enabled) do
+    %{
+      generated_at: DateTime.utc_now(),
+      instance: instrument_instance(configuration, cleartext_enabled),
+      projects: instrument_projects(cleartext_enabled),
+      version: "1"
+    }
+  end
+
+  defp instrument_instance(configuration, cleartext_enabled) do
+    %Configuration{instance_id: instance_id} = configuration
+
+    instance_id
+    |> instrument_identity(cleartext_enabled)
+    |> Map.merge(%{
+      no_of_users: no_of_users(),
+      version: @lightning_version
+    })
+    |> Map.merge(OSInstrumenter.instrument(operating_system_name()))
+  end
+
+  defp instrument_identity(identity, false = _cleartext_enabled) do
+    %{
+      cleartext_uuid: nil,
+      hashed_uuid: identity |> build_hash()
+    }
+  end
+
+  defp instrument_identity(identity, true = _cleartext_enabled) do
+    identity
+    |> instrument_identity(false)
+    |> Map.merge(%{cleartext_uuid: identity})
+  end
+
+  defp build_hash(uuid), do: Base.encode16(:crypto.hash(:sha256, uuid))
+
+  defp no_of_users do
+    User |> where(disabled: false) |> Repo.aggregate(:count)
+  end
+
+  defp operating_system_name do
+    {_os_family, os_name} = :os.type()
+
+    os_name |> Atom.to_string()
+  end
+
+  defp instrument_projects(cleartext_enabled) do
+    Repo.all(
+      from p in Project,
+        preload: [:users, [workflows: [:jobs, runs: [:steps]]]]
+    )
+    |> Enum.map(&instrument_project(&1, cleartext_enabled))
+  end
+
+  defp instrument_project(project, cleartext_enabled) do
+    %Project{id: id, users: users, workflows: workflows} = project
+
+    instrument_identity(id, cleartext_enabled)
+    |> Map.merge(%{
+      no_of_users: count(users),
+      workflows:
+        workflows
+        |> Enum.map(&instrument_workflow(&1, cleartext_enabled))
+    })
+  end
+
+  defp instrument_workflow(workflow, cleartext_enabled) do
+    %Workflow{id: id, jobs: jobs, runs: runs} = workflow
+
+    instrument_identity(id, cleartext_enabled)
+    |> Map.merge(%{
+      no_of_jobs: count(jobs),
+      no_of_runs: count(runs),
+      no_of_steps: no_of_steps_for(runs)
+    })
+  end
+
+  defp no_of_steps_for(runs) do
+    runs
+    |> Enum.reduce(0, fn run, acc -> acc + count(run.steps) end)
+  end
+
+  defp count(collection), do: collection |> Enum.count()
+end

--- a/test/lightning/usage_tracking/o_s_instrumenter_test.exs
+++ b/test/lightning/usage_tracking/o_s_instrumenter_test.exs
@@ -1,0 +1,65 @@
+defmodule Lightning.UsageTracking.OSInstrumenterTest do
+  use ExUnit.Case
+  import Mock
+
+  alias Lightning.UsageTracking.OSInstrumenter
+
+  test "returns OS name with nil details if OS is not linux" do
+    operating_system_name = "not-linux"
+
+    assert(
+      %{
+        operating_system: ^operating_system_name,
+        operating_system_detail: nil
+      } = OSInstrumenter.instrument(operating_system_name)
+    )
+  end
+
+  test "returns extra detail if OS is linux" do
+    operating_system_name = "linux"
+    expected_detail = "Fedora blah"
+
+    with_mock System,
+      cmd: fn "uname", ["-a"] -> {expected_detail, 0} end do
+      assert(
+        %{
+          operating_system: ^operating_system_name,
+          operating_system_detail: ^expected_detail
+        } = OSInstrumenter.instrument(operating_system_name)
+      )
+    end
+  end
+
+  test "returns nil detail if lookup fials for linux" do
+    operating_system_name = "linux"
+
+    with_mock System,
+      cmd: fn "uname", ["-a"] -> {"does not matter", 1} end do
+      assert(
+        %{
+          operating_system: ^operating_system_name,
+          operating_system_detail: nil
+        } = OSInstrumenter.instrument(operating_system_name)
+      )
+    end
+  end
+
+  test "integration test for linux that only runs on linux" do
+    if :os.type() |> elem(1) == :linux do
+      operating_system_name = "linux"
+
+      {uname_output, 0} = System.cmd("uname", ["-a"])
+
+      expected_detail = uname_output |> String.trim()
+
+      assert String.match?(expected_detail, ~r/Linux/)
+
+      assert(
+        %{
+          operating_system: ^operating_system_name,
+          operating_system_detail: ^expected_detail
+        } = OSInstrumenter.instrument(operating_system_name)
+      )
+    end
+  end
+end

--- a/test/lightning/usage_tracking/report_data_test.exs
+++ b/test/lightning/usage_tracking/report_data_test.exs
@@ -1,0 +1,320 @@
+defmodule Lightning.UsageTracking.ReportDataTest do
+  use Lightning.DataCase
+
+  alias Lightning.Projects.Project
+  alias Lightning.Workflows.Workflow
+  alias Lightning.UsageTracking.Configuration
+  alias Lightning.UsageTracking.ReportData
+
+  def setup do
+    %{config: Repo.insert!(%Configuration{})}
+  end
+
+  describe ".generate/2 - cleartext uuids disabled" do
+    setup [:setup_config, :setup_cleartext_uuids_disabled]
+
+    test "sets the time that the report was generated at",
+         %{config: config, cleartext_enabled: enabled} do
+      %{generated_at: generated_at} = ReportData.generate(config, enabled)
+
+      assert DateTime.diff(DateTime.utc_now(), generated_at, :second) < 1
+    end
+
+    test "contains hashed uuid of reporting instance",
+         %{config: config, cleartext_enabled: enabled} do
+      %{instance_id: instance_id} = config
+
+      %{instance: %{hashed_uuid: hashed_uuid}} =
+        ReportData.generate(config, enabled)
+
+      assert hashed_uuid == build_hash(instance_id)
+    end
+
+    test "cleartext uuid of reporting instance is nil",
+         %{config: config, cleartext_enabled: enabled} do
+      assert(
+        %{instance: %{cleartext_uuid: nil}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "indicates the version of lightning present on the instance",
+         %{config: config, cleartext_enabled: enabled} do
+      version = Lightning.MixProject.project()[:version]
+
+      # Rudimentary sanity check as the actual assertion will be susceptible to
+      # an own goal - version string should be at least 5 chars
+      assert String.match?(version, ~r/.{5,}/)
+
+      assert(
+        %{instance: %{version: ^version}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "includes the total number of non-disabled users",
+         %{config: config, cleartext_enabled: enabled} do
+      _eligible_user_1 = insert(:user, disabled: false)
+      _eligible_user_2 = insert(:user, disabled: false)
+      _eligible_user_3 = insert(:user, disabled: false)
+      _ineligible_user = insert(:user, disabled: true)
+
+      assert(
+        %{instance: %{no_of_users: 3}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "includes the operating system details",
+         %{config: config, cleartext_enabled: enabled} do
+      {_os_family, os_name_atom} = :os.type()
+
+      os_name = os_name_atom |> Atom.to_string()
+
+      assert String.match?(os_name, ~r/.{5,}/)
+
+      assert(
+        %{instance: %{operating_system: ^os_name}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "includes project details",
+         %{config: config, cleartext_enabled: enabled} do
+      project_1 = build_project(2)
+      project_2 = build_project(3)
+
+      %{projects: projects} = ReportData.generate(config, enabled)
+
+      assert projects |> count() == 2
+
+      projects |> assert_instrumented(project_1, enabled)
+      projects |> assert_instrumented(project_2, enabled)
+    end
+
+    test "indicates the version of the report data structure in use",
+         %{config: config, cleartext_enabled: enabled} do
+      assert %{version: "1"} = ReportData.generate(config, enabled)
+    end
+  end
+
+  describe ".generate/2 - cleartext uuids enabled" do
+    setup [:setup_config, :setup_cleartext_uuids_enabled]
+
+    test "sets the time that the report was generated at",
+         %{config: config, cleartext_enabled: enabled} do
+      %{generated_at: generated_at} = ReportData.generate(config, enabled)
+
+      assert DateTime.diff(DateTime.utc_now(), generated_at, :second) < 1
+    end
+
+    test "contains hashed uuid of reporting instance",
+         %{config: config, cleartext_enabled: enabled} do
+      %{instance_id: instance_id} = config
+
+      %{instance: %{hashed_uuid: hashed_uuid}} =
+        ReportData.generate(config, enabled)
+
+      assert hashed_uuid == build_hash(instance_id)
+    end
+
+    test "cleartext uuid of reporting instance is populated",
+         %{config: config, cleartext_enabled: enabled} do
+      %{instance_id: instance_id} = config
+
+      assert(
+        %{instance: %{cleartext_uuid: ^instance_id}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "indicates the version of lightning present on the instance",
+         %{config: config, cleartext_enabled: enabled} do
+      version = Lightning.MixProject.project()[:version]
+
+      # Rudimentary sanity check as the actual assertion will be susceptible to
+      # an own goal - version string should be at least 5 chars
+      assert String.match?(version, ~r/.{5,}/)
+
+      assert(
+        %{instance: %{version: ^version}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "includes the total number of non-disabled users",
+         %{config: config, cleartext_enabled: enabled} do
+      _eligible_user_1 = insert(:user, disabled: false)
+      _eligible_user_2 = insert(:user, disabled: false)
+      _eligible_user_3 = insert(:user, disabled: false)
+      _ineligible_user = insert(:user, disabled: true)
+
+      assert(
+        %{instance: %{no_of_users: 3}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "includes the operating system details",
+         %{config: config, cleartext_enabled: enabled} do
+      {_os_family, os_name_atom} = :os.type()
+
+      os_name = os_name_atom |> Atom.to_string()
+
+      assert String.match?(os_name, ~r/.{5,}/)
+
+      assert(
+        %{instance: %{operating_system: ^os_name}} =
+          ReportData.generate(config, enabled)
+      )
+    end
+
+    test "includes project details",
+         %{config: config, cleartext_enabled: enabled} do
+      project_1 = build_project(2)
+      project_2 = build_project(3)
+
+      %{projects: projects} = ReportData.generate(config, enabled)
+
+      assert projects |> count() == 2
+
+      projects |> assert_instrumented(project_1, enabled)
+      projects |> assert_instrumented(project_2, enabled)
+    end
+
+    test "indicates the version of the report data structure in use",
+         %{config: config, cleartext_enabled: enabled} do
+      assert %{version: "1"} = ReportData.generate(config, enabled)
+    end
+  end
+
+  defp setup_config(context) do
+    Map.merge(context, %{config: Repo.insert!(%Configuration{})})
+  end
+
+  defp setup_cleartext_uuids_disabled(context) do
+    Map.merge(context, %{cleartext_enabled: false})
+  end
+
+  defp setup_cleartext_uuids_enabled(context) do
+    Map.merge(context, %{cleartext_enabled: true})
+  end
+
+  defp build_hash(uuid), do: Base.encode16(:crypto.hash(:sha256, uuid))
+
+  defp build_project(count) do
+    project = insert(:project, project_users: build_project_users(count))
+
+    workflows = insert_list(count, :workflow, project: project)
+
+    for workflow <- workflows do
+      [job | _] = insert_list(count, :job, workflow: workflow)
+      work_orders = insert_list(count, :workorder, workflow: workflow)
+
+      for work_order <- work_orders do
+        insert_runs_with_steps(
+          count: count,
+          project: project,
+          work_order: work_order,
+          job: job
+        )
+      end
+    end
+
+    project
+  end
+
+  defp build_project_users(count) do
+    build_list(count, :project_user, user: fn -> build(:user) end)
+  end
+
+  defp insert_runs_with_steps(options) do
+    count = Keyword.get(options, :count)
+    project = Keyword.get(options, :project)
+    work_order = Keyword.get(options, :work_order)
+    job = Keyword.get(options, :job)
+
+    dataclip_builder = fn -> build(:dataclip, project: project) end
+
+    insert_list(
+      count,
+      :run,
+      work_order: work_order,
+      dataclip: dataclip_builder,
+      starting_job: job,
+      steps: fn ->
+        build_list(
+          count,
+          :step,
+          input_dataclip: dataclip_builder,
+          output_dataclip: dataclip_builder,
+          job: job
+        )
+      end
+    )
+  end
+
+  defp assert_instrumented(
+         instrumented_projects,
+         project = %Project{},
+         cleartext_enabled
+       ) do
+    %Project{id: id, users: users, workflows: workflows} =
+      project |> Repo.preload([:users, :workflows])
+
+    instrumented_project = instrumented_projects |> find_instrumentation(id)
+
+    instrumented_project |> assert_cleartext_uuid(id, cleartext_enabled)
+
+    assert instrumented_project.no_of_users == users |> count()
+
+    for w <- workflows do
+      assert_instrumented(instrumented_project.workflows, w, cleartext_enabled)
+    end
+  end
+
+  defp assert_instrumented(
+         instrumented_workflows,
+         workflow = %Workflow{},
+         cleartext_enabled
+       ) do
+    %{id: id, jobs: jobs, runs: runs} =
+      workflow |> Repo.preload([:jobs, runs: [:steps]])
+
+    instrumented_workflow = instrumented_workflows |> find_instrumentation(id)
+
+    instrumented_workflow |> assert_cleartext_uuid(id, cleartext_enabled)
+
+    %{
+      no_of_jobs: instrumented_no_of_jobs,
+      no_of_runs: instrumented_no_of_runs,
+      no_of_steps: instrumented_no_of_steps
+    } = instrumented_workflow
+
+    assert instrumented_no_of_jobs == jobs |> count()
+    assert instrumented_no_of_runs == runs |> count()
+    assert instrumented_no_of_steps == runs |> no_of_steps()
+  end
+
+  defp count(collection), do: collection |> Enum.count()
+
+  defp find_instrumentation(instrumented_collection, identity) do
+    hashed_uuid = build_hash(identity)
+
+    instrumented_collection
+    |> Enum.filter(fn record -> record.hashed_uuid == hashed_uuid end)
+    |> hd()
+  end
+
+  defp assert_cleartext_uuid(instrumented_record, id, _enabled = true) do
+    assert instrumented_record.cleartext_uuid == id
+  end
+
+  defp assert_cleartext_uuid(instrumented_record, _id, _enabled = false) do
+    assert instrumented_record.cleartext_uuid == nil
+  end
+
+  defp no_of_steps(runs) do
+    runs |> Enum.reduce(0, fn run, acc -> acc + (run.steps |> count()) end)
+  end
+end


### PR DESCRIPTION
## Validation Steps

Run Lightning alongside ImpactTracker and point  `USAGE_TRACKER_HOST` to the local ImpactTracker instance.

From IEx in the Lightning environment, execute `Lightning.UsageTracking.Worker.perform(%{}). Once it has completed, the ImpactTracker database should have a submission entry that corresponds with the submission from Lightning.

## Notes for the reviewer

This sends actual metrics to the ImpactTracker - previously only empty data was sent through. 


## Related issue

Fixes #1742 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
