### PR TITLE
Add workaround for LiveView form recovery bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to
 
 ### Fixed
 
+- Non-responsive workflow canvas after web socket disconnection
+  [#1750](https://github.com/OpenFn/lightning/issues/1750)
+
 ## [v2.0.2] - 2024-02-14
 
 ### Fixed

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -304,6 +304,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           phx-hook="SaveViaCtrlS"
           phx-change="validate"
         >
+          <input type="hidden" name="_ignore_me" />
           <.single_inputs_for
             :let={{jf}}
             :if={@selected_job}
@@ -785,6 +786,16 @@ defmodule LightningWeb.WorkflowLive.Edit do
            "You can't delete a step that has already been ran."
          )}
     end
+  end
+
+  # TODO: remove this and the matching hidden input when issue resolved in LiveView.
+  # The hidden input is a workaround for a bug in LiveView where the form is
+  # considered for recovery because it has a submit button, but skips the
+  # recovery because it has no inputs.
+  # This causes the LiveView to not be set as joined, and further diffs to
+  # not be applied.
+  def handle_event("validate", %{"_ignore_me" => _}, socket) do
+    {:noreply, socket}
   end
 
   def handle_event("validate", %{"workflow" => params}, socket) do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -788,6 +788,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
+  def handle_event("validate", %{"workflow" => params}, socket) do
+    {:noreply, handle_new_params(socket, params)}
+  end
+
   # TODO: remove this and the matching hidden input when issue resolved in LiveView.
   # The hidden input is a workaround for a bug in LiveView where the form is
   # considered for recovery because it has a submit button, but skips the
@@ -796,10 +800,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
   # not be applied.
   def handle_event("validate", %{"_ignore_me" => _}, socket) do
     {:noreply, socket}
-  end
-
-  def handle_event("validate", %{"workflow" => params}, socket) do
-    {:noreply, handle_new_params(socket, params)}
   end
 
   def handle_event("save", params, socket) do


### PR DESCRIPTION
## Validation Steps

_How can a reviewer validate your work?_

Follow the reproduction steps on the issue.

**Note** this can only be reproduced when there is a reverse proxy in place that has a stream timeout.

Either test this on staging, or setup Caddy locally (or any other proxy) like this:

```sh
docker run --rm -t \
  --add-host host:$(ip route get 1 | sed 's/^.*src \([^ ]*\).*$/\1/;q') \
  -v $PWD/Caddyfile:/etc/caddy/Caddyfile \
  -p 8080 \
  caddy:2.7.6
```

> The above adds a hostname record to the container pointing back at your 'localhost' or very likely the interface your container in running on.

and a Caddyfile like this:

```Caddyfile
:8080 {
    reverse_proxy host:4000 {
      stream_timeout 30s
    }
}
```

Go to [localhost:8080](http://localhost:8080) and you should see the app.

## Related issue

Fixes #1750

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
