### PR TITLE
More robust usage tracking error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 ### Changed
 
 ### Fixed
+- Make handling of usage tracking errors more robust.
+  [#1787](https://github.com/OpenFn/lightning/issues/1787)
 
 ## [v2.0.3] 2024-02-21
 

--- a/lib/lightning/usage_tracking/response_processor.ex
+++ b/lib/lightning/usage_tracking/response_processor.ex
@@ -6,4 +6,6 @@ defmodule Lightning.UsageTracking.ResponseProcessor do
   def successful?(%Tesla.Env{status: status}) do
     status >= 200 && status < 300
   end
+
+  def successful?(_response), do: false
 end

--- a/test/lightning/usage_tracking/response_processor_test.exs
+++ b/test/lightning/usage_tracking/response_processor_test.exs
@@ -22,4 +22,9 @@ defmodule Lightning.UsageTracking.ResponseProcessorTest do
 
     assert(ResponseProcessor.successful?(env))
   end
+
+  test "anything other than a Tesla.Env struct is considered unsuccessful" do
+    refute(ResponseProcessor.successful?(:nxdomain))
+    refute(ResponseProcessor.successful?(:econnrefused))
+  end
 end


### PR DESCRIPTION
## Validation Steps

Update USAGE_TRACKER_HOST to point to a port on your local system but **do not** start ImpactTracker. In IEx, run `Lightning.UsageTracking.Worker.perform(%{})` - this should produce an error. In addition, it should have created a `Lightning.UsageTracking.Report` instance with `submitted` set to `false` and `submitted_at` set to nil.


## Related issue

Fixes #1787 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
