### PR TITLE
close #1720

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,3 +186,8 @@ PURGE_DELETED_AFTER_DAYS=7
 # By default, impact tracking metrics will be reported to https://impact.openfn.org. Use the
 # below if you wish to change that.
 # USAGE_TRACKER_HOST=https://impact.openfn.org
+
+# OpenFn.org hosts a public sandbox that gets reset every night. If you'd like to
+# make your instance "resettable" (a highly descrutive action—this destroys all
+# data in your instance) you can set the following environment variable to "yes"
+# IS_RESETTABLE_DEMO=no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- Require setting `IS_RESETTABLE_DEMO` to "yes" via ENV before allowing the
+  destructive `Demo.reset_demo/0` function from being called.
+  [#1720](https://github.com/OpenFn/lightning/issues/1720)
+
 ### Fixed
 
 ## [v2.0.5] - 2024-02-25

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -84,16 +84,19 @@ Note that for secure deployments, it's recommended to use a combination of
 - `URL_HOST` - the host, used for writing urls (e.g., `demo.openfn.org`)
 - `URL_PORT` - the port, usually `443` for production
 - `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)
-- `USAGE_TRACKER_HOST` - the host that receives usage tracking submissions 
+- `USAGE_TRACKER_HOST` - the host that receives usage tracking submissions
   (defaults to https://impact.openfn.org)
-- `USAGE_TRACKING_ENABLED` - enables the submission of anonymised usage data
-  to OpenFn (defaults to `true`).
-- `USAGE_TRACKING_UUIDS` - indicates whether submissions should include cleartext
-  uuids or not. Options are `cleartext` or `hashed_only`, with the default being
-  `hashed_only`.
+- `USAGE_TRACKING_ENABLED` - enables the submission of anonymised usage data to
+  OpenFn (defaults to `true`).
+- `USAGE_TRACKING_UUIDS` - indicates whether submissions should include
+  cleartext uuids or not. Options are `cleartext` or `hashed_only`, with the
+  default being `hashed_only`.
 - `QUEUE_RESULT_RETENTION_PERIOD_SECONDS` - the number of seconds to keep
   completed (successful) `ObanJobs` in the queue (not to be confused with runs
   and/or history)
+- `IS_RESETTABLE_DEMO` - If set to `yes` it allows this instance to be reset to
+  the initial "Lightning Demo" state. Note that this will destroy _most_ of what
+  you have in your database!
 
 ### Google
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,6 +18,10 @@ if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
   config :lightning, LightningWeb.Endpoint, server: true
 end
 
+config :lightning,
+       :is_resettable_demo,
+       System.get_env("IS_RESETTABLE_DEMO") == "yes"
+
 decoded_cert =
   System.get_env("GITHUB_CERT")
   |> case do


### PR DESCRIPTION
## Validation Steps

- Try to call `Lightning.Demo.reset_demo` before setting `IS_RESETTABLE_DEMO` to `yes` in your `.env.dev` - nothing should happen.
- (If you want to reset!!!) set that environment variable to `yes` and then run the same command - you should get your database reset to the demo state

## Notes

This fixes #1720 but I have _not_ done anything special with Vapor. The default I'm proposing here is that this is not allowed anywhere unless the env is specified. If we want something more sophisticated later, I'd want to understand the value of it before doing too much. (AFAIK, the only consumer for this is the company that's hosting demo.openfn.org 😉 and devs that should think twice before calling the command locally anyway.) In the current implementation, adding to you `.env.dev` feels right to me.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
