### PR TITLE
Allow admins to set project retention period settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 ### Added
 - Push `.github/workflows/{pull,deploy}.yml` files when user connects branch
   [#1046](https://github.com/OpenFn/lightning/issues/1046)
+- Allow admins to set project retention periods
+  [#1760](https://github.com/OpenFn/lightning/issues/1760)
 
 ### Changed
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -94,6 +94,31 @@ defmodule Lightning.Accounts.UserNotifier do
   end
 
   @doc """
+  Deliver an email to notify the user about a data retention setting change made in their project
+  """
+  @spec send_data_retention_change_email(
+          user :: map(),
+          updated_project :: map()
+        ) :: {:ok, term()} | {:error, term()}
+  def send_data_retention_change_email(user, updated_project) do
+    deliver(
+      user.email,
+      "Important Update to Your #{updated_project.name} Data-Retention Policy",
+      """
+      Hi #{user.first_name},
+
+      We'd like to inform you that the data retention policy for your project, #{updated_project.name}, was recently updated.
+      If you haven't approved this, we recommend logging into your Lightning account to reset the retention policy.
+
+      Should you require assistance with your account, feel free to contact #{admin()}.
+
+      Best regards,
+      The OpenFn Team
+      """
+    )
+  end
+
+  @doc """
   Deliver an email to notify the user about their account being deleted
   """
   def send_deletion_notification_email(user) do

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -103,7 +103,7 @@ defmodule Lightning.Accounts.UserNotifier do
   def send_data_retention_change_email(user, updated_project) do
     deliver(
       user.email,
-      "Important Update to Your #{updated_project.name} Data-Retention Policy",
+      "Important Update to Your #{updated_project.name} Data Retention Policy",
       """
       Hi #{user.first_name},
 

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -84,6 +84,13 @@ defmodule Lightning.Projects.Project do
         changeset
       end
 
+    changeset =
+      if get_field(changeset, :retention_policy) == :erase_all do
+        put_change(changeset, :dataclip_retention_period, nil)
+      else
+        changeset
+      end
+
     history_retention_period = get_field(changeset, :history_retention_period)
 
     if changeset.valid? and is_integer(dataclip_retention_period) and

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -75,18 +75,18 @@ defmodule Lightning.Projects.Project do
   end
 
   defp validate_dataclip_retention_period(changeset) do
+    changeset =
+      if get_field(changeset, :retention_policy) == :erase_all do
+        put_change(changeset, :dataclip_retention_period, nil)
+      else
+        changeset
+      end
+
     dataclip_retention_period = get_change(changeset, :dataclip_retention_period)
 
     changeset =
       if dataclip_retention_period do
         validate_required(changeset, [:history_retention_period])
-      else
-        changeset
-      end
-
-    changeset =
-      if get_field(changeset, :retention_policy) == :erase_all do
-        put_change(changeset, :dataclip_retention_period, nil)
       else
         changeset
       end

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -18,6 +18,8 @@ defmodule Lightning.Projects.Project do
 
   @type retention_policy_type :: :retain_all | :retain_with_errors | :erase_all
 
+  @retention_periods [7, 14, 30, 90, 180, 365]
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "projects" do
@@ -29,6 +31,9 @@ defmodule Lightning.Projects.Project do
     field :retention_policy, Ecto.Enum,
       values: [:retain_all, :retain_with_errors, :erase_all],
       default: :retain_all
+
+    field :history_retention_period, :integer
+    field :dataclip_retention_period, :integer
 
     has_many :project_users, ProjectUser
     has_many :users, through: [:project_users, :user]
@@ -51,7 +56,9 @@ defmodule Lightning.Projects.Project do
       :description,
       :scheduled_deletion,
       :requires_mfa,
-      :retention_policy
+      :retention_policy,
+      :history_retention_period,
+      :dataclip_retention_period
     ])
     |> cast_assoc(:project_users)
     |> validate()
@@ -62,6 +69,32 @@ defmodule Lightning.Projects.Project do
     |> validate_length(:description, max: 240)
     |> validate_required([:name])
     |> validate_format(:name, ~r/^[a-z\-\d]+$/)
+    |> validate_inclusion(:history_retention_period, @retention_periods)
+    |> validate_inclusion(:dataclip_retention_period, @retention_periods)
+    |> validate_dataclip_retention_period()
+  end
+
+  defp validate_dataclip_retention_period(changeset) do
+    dataclip_retention_period = get_change(changeset, :dataclip_retention_period)
+
+    changeset =
+      if dataclip_retention_period do
+        validate_required(changeset, [:history_retention_period])
+      else
+        changeset
+      end
+
+    history_retention_period = get_field(changeset, :history_retention_period)
+
+    if changeset.valid? and dataclip_retention_period > history_retention_period do
+      add_error(
+        changeset,
+        :dataclip_retention_period,
+        "must be less or equal to the history retention period"
+      )
+    else
+      changeset
+    end
   end
 
   @doc """

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -91,7 +91,7 @@ defmodule Lightning.Projects.Project do
       add_error(
         changeset,
         :dataclip_retention_period,
-        "must be less or equal to the history retention period"
+        "dataclip retention period must be less or equal to the history retention period"
       )
     else
       changeset

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -86,7 +86,8 @@ defmodule Lightning.Projects.Project do
 
     history_retention_period = get_field(changeset, :history_retention_period)
 
-    if changeset.valid? and dataclip_retention_period > history_retention_period do
+    if changeset.valid? and is_integer(dataclip_retention_period) and
+         dataclip_retention_period > history_retention_period do
       add_error(
         changeset,
         :dataclip_retention_period,

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -234,6 +234,20 @@ defmodule LightningWeb.ProjectLive.Settings do
     end
   end
 
+  def handle_event(
+        "save_retention_settings",
+        %{"project" => project_params},
+        socket
+      ) do
+    if socket.assigns.can_edit_data_retention do
+      save_project(socket, project_params)
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "You are not authorized to perform this action.")}
+    end
+  end
+
   def handle_event("toggle-mfa", _params, socket) do
     if can_edit_project(socket.assigns) do
       project = socket.assigns.project

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -970,7 +970,7 @@
                   <div class="w-full border-t border-gray-300"></div>
                 </div>
                 <div>
-                  <div class={"text-black text-sm #{if to_string(f[:history_retention_period].value) == "", do: "text-opacity-30"}"}>
+                  <div class={"text-black text-sm #{if to_string(f[:history_retention_period].value) == "" or checked?(@project_changeset, :erase_all), do: "text-opacity-30"}"}>
                     <div class="font-medium">
                       Input/Output Data Retention Period
                     </div>
@@ -991,7 +991,8 @@
                       }
                       disabled={
                         !@can_edit_data_retention or
-                          to_string(f[:history_retention_period].value) == ""
+                          to_string(f[:history_retention_period].value) == "" or
+                          checked?(@project_changeset, :erase_all)
                       }
                       field={f[:dataclip_retention_period]}
                       class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -881,6 +881,13 @@
                     </div>
                     <div class="block mt-1 mb-3">
                       Select how long your run history is stored in OpenFn before being removed from the servers.
+                      <a
+                        target="_blank"
+                        href="https://docs.openfn.org/documentation/manage-projects/retention-periods"
+                        class="ml-1 text-indigo-600"
+                      >
+                        Learn more
+                      </a>
                       <br /> This includes all Work Orders, Runs, and Logs.
                     </div>
                   </div>
@@ -911,7 +918,8 @@
                     <div class="block mt-1 mb-3">
                       Should OpenFn store input/output data for workflow runs?
                       <a
-                        href="https://docs.openfn.org/documentation/next/manage-projects/io-data-storage"
+                        target="_blank"
+                        href="https://docs.openfn.org/documentation/manage-projects/io-data-storage"
                         class="ml-1 text-indigo-600"
                       >
                         Learn more...

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -871,133 +871,144 @@
               for={@project_changeset}
               id="retention-settings-form"
               phx-change="validate"
-              phx-submit="save"
-              class="space-y-4"
+              phx-submit="save_retention_settings"
             >
-              <div>
-                <div class="text-black text-sm">
-                  <div class="font-medium">
-                    History Retention Period
+              <div class="space-y-6">
+                <div>
+                  <div class="text-black text-sm">
+                    <div class="font-medium">
+                      History Retention Period
+                    </div>
+                    <div class="block mt-1 mb-3">
+                      Select how long your run history is stored in OpenFn before being removed from the servers.
+                      <br /> This includes all Work Orders, Runs, and Logs.
+                    </div>
                   </div>
-                  <div class="block mt-1 mb-3">
-                    Select how long your run history is stored in OpenFn before being removed from the servers.
-                    <br /> This includes all Work Orders, Runs, and Logs.
-                  </div>
-                </div>
 
-                <div class="space-y-2">
-                  <.input
-                    type="select"
-                    prompt="Select Period"
-                    options={
-                      Enum.map([7, 14, 30, 90, 180, 365], fn days ->
-                        "#{days} Days"
-                      end)
-                    }
-                    disabled={!@can_edit_data_retention}
-                    field={f[:history_retention_period]}
-                    class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                  />
-                </div>
-              </div>
-              <div>
-                <div class="text-black text-sm">
-                  <div class="font-medium">
-                    Input/Output Data Storage Policy
-                  </div>
-                  <div class="block mt-1 mb-3">
-                    Should OpenFn store input/output data for workflow runs?
-                    <a
-                      href="https://docs.openfn.org/documentation/next/manage-projects/io-data-storage"
-                      class="ml-1 text-indigo-600"
-                    >
-                      Learn more...
-                    </a>
+                  <div class="">
+                    <.input
+                      type="select"
+                      prompt="Select Period"
+                      options={
+                        Enum.map([7, 14, 30, 90, 180, 365], fn days ->
+                          {"#{days} Days", days}
+                        end)
+                      }
+                      disabled={!@can_edit_data_retention}
+                      field={f[:history_retention_period]}
+                      class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    />
                   </div>
                 </div>
+                <div class="inset-0 flex items-center" aria-hidden="true">
+                  <div class="w-full border-t border-gray-300"></div>
+                </div>
+                <div>
+                  <div class="text-black text-sm">
+                    <div class="font-medium">
+                      Input/Output Data Storage Policy
+                    </div>
+                    <div class="block mt-1 mb-3">
+                      Should OpenFn store input/output data for workflow runs?
+                      <a
+                        href="https://docs.openfn.org/documentation/next/manage-projects/io-data-storage"
+                        class="ml-1 text-indigo-600"
+                      >
+                        Learn more...
+                      </a>
+                    </div>
+                  </div>
 
-                <div class="space-y-2">
-                  <%!-- TODO: add this to the list of options for https://github.com/OpenFn/Lightning/issues/1694 --%>
-                  <%!-- {:retain_with_errors, "Only retain input/output data when a run fails"}, --%>
-                  <%= for {value, text} <- [
+                  <div class="space-y-2">
+                    <%!-- TODO: add this to the list of options for https://github.com/OpenFn/Lightning/issues/1694 --%>
+                    <%!-- {:retain_with_errors, "Only retain input/output data when a run fails"}, --%>
+                    <%= for {value, text} <- [
                   {:retain_all, "Retain input/output data for all workflow runs"},
                   {:erase_all, "Never retain input/output data (zero-persistence)"}
                   ] do %>
-                    <div class="relative flex items-start">
-                      <div class="flex h-6 items-center">
-                        <.input
-                          type="radio"
-                          id={value}
-                          disabled={!@can_edit_data_retention}
-                          field={f[:retention_policy]}
-                          checked={checked?(@project_changeset, value)}
-                          value={value}
-                          class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                        />
+                      <div class="relative flex items-start">
+                        <div class="flex h-6 items-center">
+                          <.input
+                            type="radio"
+                            id={value}
+                            disabled={!@can_edit_data_retention}
+                            field={f[:retention_policy]}
+                            checked={checked?(@project_changeset, value)}
+                            value={value}
+                            class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                          />
+                        </div>
+                        <div class="ml-3 leading-6">
+                          <label for={value} class="text-sm text-neutral-950">
+                            <%= text %>
+                          </label>
+                        </div>
                       </div>
-                      <div class="ml-3 leading-6">
-                        <label for={value} class="text-sm text-neutral-950">
-                          <%= text %>
-                        </label>
-                      </div>
+                    <% end %>
+                  </div>
+                  <div
+                    :if={not checked?(@project_changeset, :retain_all)}
+                    id="heads-up-description"
+                    class="mt-2 ml-7 text-gray-700 bg-orange-50 p-3 border-l-4 border-l-orange-400"
+                  >
+                    <span class="font-medium">Heads Up!</span>
+
+                    <p>
+                      When enabled, you will no longer be able to retry workflow runs as no data will be stored.
+                    </p>
+                  </div>
+                </div>
+                <div class="inset-0 flex items-center" aria-hidden="true">
+                  <div class="w-full border-t border-gray-300"></div>
+                </div>
+                <div>
+                  <div class={"text-black text-sm #{if to_string(f[:history_retention_period].value) == "", do: "text-opacity-30"}"}>
+                    <div class="font-medium">
+                      Input/Output Data Retention Period
                     </div>
-                  <% end %>
-                </div>
-                <div
-                  :if={not checked?(@project_changeset, :retain_all)}
-                  id="heads-up-description"
-                  class="mt-2 ml-7 text-gray-700 bg-orange-50 p-3 border-l-4 border-l-orange-400"
-                >
-                  <span class="font-medium">Heads Up!</span>
-
-                  <p>
-                    When enabled, you will no longer be able to retry workflow runs as no data will be stored.
-                  </p>
-                </div>
-              </div>
-              <div>
-                <div class="text-black text-sm">
-                  <div class="font-medium">
-                    Input/Output Data Retention Period
+                    <div class="block mt-1 mb-3">
+                      Select how long input/output data is stored. Once input/output data is removed for a given run, you will no longer
+                      be able to retry that run.
+                    </div>
                   </div>
-                  <div class="block mt-1 mb-3">
-                    Select how long input/output data is stored. Once input/output data is removed for a given run, you will no longer
-                    be able to retry that run.
+
+                  <div class="space-y-2">
+                    <.input
+                      type="select"
+                      prompt="Select Period"
+                      options={
+                        Enum.map([7, 14, 30, 90, 180, 365], fn days ->
+                          {"#{days} Days", days}
+                        end)
+                      }
+                      disabled={
+                        !@can_edit_data_retention or
+                          to_string(f[:history_retention_period].value) == ""
+                      }
+                      field={f[:dataclip_retention_period]}
+                      class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    />
                   </div>
                 </div>
-
-                <div class="space-y-2">
-                  <.input
-                    type="select"
-                    prompt="Select Period"
-                    options={
-                      Enum.map([7, 14, 30, 90, 180, 365], fn days ->
-                        "#{days} Days"
-                      end)
-                    }
+                <div class="mt-4">
+                  <button
+                    type="button"
                     disabled={!@can_edit_data_retention}
-                    field={f[:dataclip_retention_period]}
-                    class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                  />
+                    class="mt-3 mr-1 inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto bg-white text-gray-900"
+                    phx-click="cancel-retention-change"
+                  >
+                    Cancel
+                  </button>
+                  <Form.submit_button
+                    disabled={
+                      not @project_changeset.valid? or
+                        not @can_edit_data_retention
+                    }
+                    phx-disable-with="Saving"
+                  >
+                    Save
+                  </Form.submit_button>
                 </div>
-              </div>
-              <div class="mt-4">
-                <button
-                  disabled={!@can_edit_data_retention}
-                  class="mt-3 mr-1 inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto bg-white text-gray-900"
-                  phx-click="cancel-retention-change"
-                >
-                  Cancel
-                </button>
-                <Form.submit_button
-                  disabled={
-                    not @project_changeset.valid? or
-                      not @can_edit_data_retention
-                  }
-                  phx-disable-with="Saving"
-                >
-                  Save
-                </Form.submit_button>
               </div>
             </.form>
           </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -866,65 +866,120 @@
             <div class="py-2"></div>
           </div>
           <div class="bg-white p-4 rounded-md">
-            <div class="text-black text-sm">
-              <div class="font-medium">
-                Input/Output Data Storage Policy
-              </div>
-              <div class="block mt-1 mb-3">
-                Should OpenFn store input/output data for workflow runs?
-                <a
-                  href="https://docs.openfn.org/documentation/next/manage-projects/io-data-storage"
-                  class="ml-1 text-indigo-600"
-                >
-                  Learn more...
-                </a>
-              </div>
-            </div>
-
             <.form
               :let={f}
               for={@project_changeset}
               id="retention-settings-form"
               phx-change="validate"
               phx-submit="save"
+              class="space-y-4"
             >
-              <div class="space-y-2">
-                <%!-- TODO: add this to the list of options for https://github.com/OpenFn/Lightning/issues/1694 --%>
-                <%!-- {:retain_with_errors, "Only retain input/output data when a run fails"}, --%>
-                <%= for {value, text} <- [
+              <div>
+                <div class="text-black text-sm">
+                  <div class="font-medium">
+                    History Retention Period
+                  </div>
+                  <div class="block mt-1 mb-3">
+                    Select how long your run history is stored in OpenFn before being removed from the servers.
+                    <br /> This includes all Work Orders, Runs, and Logs.
+                  </div>
+                </div>
+
+                <div class="space-y-2">
+                  <.input
+                    type="select"
+                    prompt="Select Period"
+                    options={
+                      Enum.map([7, 14, 30, 90, 180, 365], fn days ->
+                        "#{days} Days"
+                      end)
+                    }
+                    disabled={!@can_edit_data_retention}
+                    field={f[:history_retention_period]}
+                    class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                  />
+                </div>
+              </div>
+              <div>
+                <div class="text-black text-sm">
+                  <div class="font-medium">
+                    Input/Output Data Storage Policy
+                  </div>
+                  <div class="block mt-1 mb-3">
+                    Should OpenFn store input/output data for workflow runs?
+                    <a
+                      href="https://docs.openfn.org/documentation/next/manage-projects/io-data-storage"
+                      class="ml-1 text-indigo-600"
+                    >
+                      Learn more...
+                    </a>
+                  </div>
+                </div>
+
+                <div class="space-y-2">
+                  <%!-- TODO: add this to the list of options for https://github.com/OpenFn/Lightning/issues/1694 --%>
+                  <%!-- {:retain_with_errors, "Only retain input/output data when a run fails"}, --%>
+                  <%= for {value, text} <- [
                   {:retain_all, "Retain input/output data for all workflow runs"},
                   {:erase_all, "Never retain input/output data (zero-persistence)"}
                   ] do %>
-                  <div class="relative flex items-start">
-                    <div class="flex h-6 items-center">
-                      <.input
-                        type="radio"
-                        id={value}
-                        disabled={!@can_edit_data_retention}
-                        field={f[:retention_policy]}
-                        checked={checked?(@project_changeset, value)}
-                        value={value}
-                        class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                      />
+                    <div class="relative flex items-start">
+                      <div class="flex h-6 items-center">
+                        <.input
+                          type="radio"
+                          id={value}
+                          disabled={!@can_edit_data_retention}
+                          field={f[:retention_policy]}
+                          checked={checked?(@project_changeset, value)}
+                          value={value}
+                          class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                        />
+                      </div>
+                      <div class="ml-3 leading-6">
+                        <label for={value} class="text-sm text-neutral-950">
+                          <%= text %>
+                        </label>
+                      </div>
                     </div>
-                    <div class="ml-3 leading-6">
-                      <label for={value} class="text-sm text-neutral-950">
-                        <%= text %>
-                      </label>
-                    </div>
-                  </div>
-                <% end %>
-              </div>
-              <div
-                :if={not checked?(@project_changeset, :retain_all)}
-                id="heads-up-description"
-                class="mt-2 ml-7 text-gray-700 bg-orange-50 p-3 border-l-4 border-l-orange-400"
-              >
-                <span class="font-medium">Heads Up!</span>
+                  <% end %>
+                </div>
+                <div
+                  :if={not checked?(@project_changeset, :retain_all)}
+                  id="heads-up-description"
+                  class="mt-2 ml-7 text-gray-700 bg-orange-50 p-3 border-l-4 border-l-orange-400"
+                >
+                  <span class="font-medium">Heads Up!</span>
 
-                <p>
-                  When enabled, you will no longer be able to retry workflow runs as no data will be stored.
-                </p>
+                  <p>
+                    When enabled, you will no longer be able to retry workflow runs as no data will be stored.
+                  </p>
+                </div>
+              </div>
+              <div>
+                <div class="text-black text-sm">
+                  <div class="font-medium">
+                    Input/Output Data Retention Period
+                  </div>
+                  <div class="block mt-1 mb-3">
+                    Select how long input/output data is stored. Once input/output data is removed for a given run, you will no longer
+                    be able to retry that run.
+                  </div>
+                </div>
+
+                <div class="space-y-2">
+                  <.input
+                    type="select"
+                    prompt="Select Period"
+                    options={
+                      Enum.map([7, 14, 30, 90, 180, 365], fn days ->
+                        "#{days} Days"
+                      end)
+                    }
+                    disabled={!@can_edit_data_retention}
+                    field={f[:dataclip_retention_period]}
+                    class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                  />
+                </div>
               </div>
               <div class="mt-4">
                 <button

--- a/priv/repo/migrations/20240226084658_add_retention_periods_to_projects.exs
+++ b/priv/repo/migrations/20240226084658_add_retention_periods_to_projects.exs
@@ -1,0 +1,10 @@
+defmodule Lightning.Repo.Migrations.AddRetentionPeriodsToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table("projects") do
+      add :history_retention_period, :integer
+      add :dataclip_retention_period, :integer
+    end
+  end
+end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -705,7 +705,7 @@ defmodule Lightning.ProjectsTest do
       {"Lightning", Application.get_env(:lightning, :email_addresses)[:admin]}
     )
     |> Swoosh.Email.subject(
-      "Important Update to Your #{project.name} Data-Retention Policy"
+      "Important Update to Your #{project.name} Data Retention Policy"
     )
     |> Swoosh.Email.text_body(body)
   end


### PR DESCRIPTION
## Validation Steps

https://github.com/OpenFn/lightning/assets/39288959/506af80a-d948-4abc-afcc-a3703fa2ae84


## Notes for the reviewer

- Uses the changeset to ensure that the `dataclip_retention_period` cannot be greator than the `history_retention_period`
- Sends an email to project admins and owners when the retention periods are updated
- [ ] Discussed with @christad92 that we may need to audit who/when the retention periods are updated


## Related issue

Fixes #1760 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
