### PR TITLE
Fix Sentry errors related to OAuth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix series of sentry issues related to OAuth credentials
+  [#1799](https://github.com/OpenFn/lightning/issues/1799)
+
 ## [v2.0.5] - 2024-02-25
 
 ### Added

--- a/lib/lightning/auth_providers/common.ex
+++ b/lib/lightning/auth_providers/common.ex
@@ -151,8 +151,8 @@ defmodule Lightning.AuthProviders.Common do
 
           {:ok, client}
 
-        {:error, :timeout} ->
-          {:error, :timeout}
+        {:error, reason} ->
+          {:error, reason}
       end
     end
   end

--- a/lib/lightning/auth_providers/common.ex
+++ b/lib/lightning/auth_providers/common.ex
@@ -205,6 +205,8 @@ defmodule Lightning.AuthProviders.Common do
        when status not in 200..202,
        do: {:error, nil}
 
+  defp handle_introspection_result({:error, _reason}, _token), do: {:error, nil}
+
   @doc """
   Checks if a token is still valid or must be refreshed. If expires_at is nil,
   it will return `false`, forcing a refresh. If the token has already expired or

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -40,7 +40,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
      |> assign(scopes: [])
      |> assign(type_options: type_options)
      |> assign(scopes_changed: false)
-     |> assign(authorization_status: :success)
      |> assign(schema: false)
      |> assign(available_projects: [])
      |> assign(allow_credential_transfer: allow_credential_transfer)}
@@ -54,10 +53,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
        Credentials.change_credential(credential, params)
      end)
      |> assign(scopes_changed: false)}
-  end
-
-  def update(%{authorization_status: status}, socket) do
-    {:ok, assign(socket, authorization_status: status)}
   end
 
   def update(%{projects: projects} = assigns, socket) do
@@ -372,7 +367,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
             :let={{fieldset, _valid?}}
             id={@credential.id || "new"}
             schema={@schema}
-            parent_id={@id}
             form={f}
             type={@schema}
             action={@action}
@@ -452,10 +446,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
             <div class="sm:flex sm:flex-row-reverse">
               <button
                 type="submit"
-                disabled={
-                  !@changeset.valid? or @scopes_changed or
-                    @authorization_status !== :success
-                }
+                disabled={!@changeset.valid? or @scopes_changed}
                 class="inline-flex w-full justify-center rounded-md disabled:bg-primary-300 bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-500 sm:ml-3 sm:w-auto"
               >
                 Save
@@ -480,7 +471,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
   attr :form, :map, required: true
   attr :action, :any, required: false
   attr :phx_target, :any, default: nil
-  attr :parent_id, :string, required: false
   attr :schema, :string, required: false
   attr :sandbox_value, :boolean, default: false
   attr :update_body, :any, required: false
@@ -495,7 +485,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
       form={@form}
       action={@action}
       schema={@schema}
-      parent_id={@parent_id}
       update_body={@update_body}
     >
       <%= render_slot(@inner_block, l) %>
@@ -511,7 +500,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
       form={@form}
       action={@action}
       schema={@schema}
-      parent_id={@parent_id}
       update_body={@update_body}
       sandbox_value={@sandbox_value}
       scopes_changed={@scopes_changed}

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -68,6 +68,7 @@ defmodule LightningWeb.CredentialLive.Index do
   @doc """
   A generic handler for forwarding updates from PubSub
   """
+  @impl true
   def handle_info({:forward, mod, opts}, socket) do
     send_update(mod, opts)
     {:noreply, socket}

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -65,11 +65,6 @@ defmodule LightningWeb.CredentialLive.Index do
      |> assign(credentials: list_credentials(socket.assigns.current_user.id))}
   end
 
-  @impl true
-  def handle_info({:credential_type_changed, type}, socket) do
-    {:noreply, socket |> assign(selected_credential_type: type)}
-  end
-
   @doc """
   A generic handler for forwarding updates from PubSub
   """

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -475,10 +475,6 @@ defmodule LightningWeb.ProjectLive.Settings do
     end
   end
 
-  def handle_info({:credential_type_changed, type}, socket) do
-    {:noreply, socket |> assign(:selected_credential_type, type)}
-  end
-
   defp error_message(error) do
     case error do
       %{code: :installation_not_found} ->

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -977,7 +977,10 @@ defmodule LightningWeb.CredentialLiveTest do
     test "rendering error component for various error type" do
       render_component(
         &LightningWeb.CredentialLive.OauthComponent.error_block/1,
-        type: :token_failed
+        type: :token_failed,
+        authorize_url: "https://www",
+        myself: nil,
+        provider: "Salesforce"
       ) =~ "Failed retrieving the token from the provider"
 
       render_component(
@@ -1038,7 +1041,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert_receive {:phoenix, :send_update, _}
+      # assert_receive {:phoenix, :send_update, _}
 
       # Wait for the userinfo endpoint to be called
       assert wait_for_assigns(edit_live, :userinfo, credential.id),
@@ -1157,7 +1160,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :authorization_status, credential.id)
+      assert wait_for_assigns(edit_live, :oauth_progress, credential.id)
 
       edit_live |> render()
 
@@ -1218,7 +1221,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :authorization_status, credential.id)
+      assert wait_for_assigns(edit_live, :oauth_progress, credential.id)
 
       edit_live |> render()
 
@@ -1475,8 +1478,6 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert_receive {:phoenix, :send_update, _}
-
       # Wait for the userinfo endpoint to be called
       assert wait_for_assigns(edit_live, :userinfo, credential.id),
              ":userinfo has not been set yet."
@@ -1576,7 +1577,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :authorization_status, credential.id)
+      assert wait_for_assigns(edit_live, :oauth_progress, credential.id)
 
       edit_live |> render()
 
@@ -1636,7 +1637,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, edit_live, _html} = live(conn, ~p"/credentials")
 
-      assert wait_for_assigns(edit_live, :authorization_status, credential.id)
+      assert wait_for_assigns(edit_live, :oauth_progress, credential.id)
 
       edit_live |> render()
 


### PR DESCRIPTION
## Validation Steps

1. Go to the credentials page
2. Create a credential
3. See if errors happen in the iex terminal

## Notes for the reviewer

This PR fixes 3 sentry errors that have been gathered in #1799 by refactoring the OAuthComponent to use `assign_async` instead of `Task.async` and removing unnecessary `handle_info/3` and `send_update/3` functions.

It is important to note that [the first of those 3 issues raised](https://openfn.sentry.io/issues/5006350903/?project=6446500&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0&utc=true) will be very rare but is not completely fixed. The reason is, that error is a Salesforce known issue (see [here](https://issues.salesforce.com/issue/a028c00000gAwCuAAK/returning-403-bad_oauth_token-response-to-userinfo-endpoint--httpsloginsalesforcecomidorgiduserid-on-hyperforce-instance-orgs)). There are only workarounds, but not a real fix.

## Related issue

Fixes #1799 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
