### PR TITLE
Show flash error when editing stale project credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Show flash error when editing stale project credentials
+  [#1795](https://github.com/OpenFn/lightning/issues/1795)
+
 ## [v2.0.7] - 2024-02-29
 
 ### Fixed
@@ -50,8 +53,6 @@ and this project adheres to
 
 - Fix series of sentry issues related to OAuth credentials
   [#1799](https://github.com/OpenFn/lightning/issues/1799)
-- Show flash error when editing stale project credentials
-  [#1795](https://github.com/OpenFn/lightning/issues/1795)
 
 ## [v2.0.5] - 2024-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
 
 - Fix series of sentry issues related to OAuth credentials
   [#1799](https://github.com/OpenFn/lightning/issues/1799)
+- Show flash error when editing stale project credentials
+  [#1795](https://github.com/OpenFn/lightning/issues/1795)
 
 ## [v2.0.5] - 2024-02-25
 

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -173,8 +173,6 @@ defmodule Lightning.Credentials do
   def update_credential(%Credential{} = credential, attrs) do
     changeset = credential |> change_credential(attrs) |> cast_body_change()
 
-    # IO.inspect attrs
-
     Multi.new()
     |> Multi.update(:credential, changeset)
     |> derive_events(changeset)

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -118,6 +118,12 @@ defmodule Lightning.Credentials do
     Repo.one(query)
   end
 
+  def get_credential_for_update!(id) do
+    Credential
+    |> Repo.get!(id)
+    |> Repo.preload([:project_credentials, :projects])
+  end
+
   @doc """
   Creates a credential.
 
@@ -166,6 +172,8 @@ defmodule Lightning.Credentials do
   """
   def update_credential(%Credential{} = credential, attrs) do
     changeset = credential |> change_credential(attrs) |> cast_body_change()
+
+    # IO.inspect attrs
 
     Multi.new()
     |> Multi.update(:credential, changeset)

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -808,9 +808,8 @@ defmodule LightningWeb.CredentialLive.FormComponent do
 
   defp credential_up_to_date?(form_credential) do
     db_credential = Credentials.get_credential_for_update!(form_credential.id)
-    fields = Credential.__schema__(:fields)
+    fields = [:project_credentials | Credential.__schema__(:fields)]
 
-    Map.take(db_credential, fields) == Map.take(form_credential, fields) and
-      db_credential.project_credentials == form_credential.project_credentials
+    Map.take(db_credential, fields) == Map.take(form_credential, fields)
   end
 end

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -765,7 +765,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
          socket
          |> put_flash(
            :error,
-           "Invalid credentials. Please login again."
+           "Invalid credentials. Please log in again."
          )
          |> push_redirect(to: socket.assigns.return_to)}
 

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -13,6 +13,7 @@ defmodule LightningWeb.CredentialLive.Index do
     {:ok,
      assign(
        socket,
+       current_user: socket.assigns.current_user,
        credentials: list_credentials(socket.assigns.current_user.id),
        active_menu_item: :credentials,
        selected_credential_type: nil,

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -479,18 +479,17 @@ defmodule Lightning.CredentialsTest do
                })
     end
 
-    test "does not raise error when credential doesn't have the latest project credentials" do
-      user1 = insert(:user)
-      user2 = insert(:user)
+    test "raise error when credential doesn't have the latest project credentials" do
+      user = insert(:user)
 
       project1 =
         insert(:project,
-          project_users: [%{user_id: user1.id}, %{user_id: user2.id}]
+          project_users: [%{user_id: user.id}]
         )
 
       project2 =
         insert(:project,
-          project_users: [%{user_id: user1.id}, %{user_id: user2.id}]
+          project_users: [%{user_id: user.id}]
         )
 
       %{
@@ -501,7 +500,7 @@ defmodule Lightning.CredentialsTest do
       } =
         credential =
         insert(:credential,
-          user_id: user2.id,
+          user_id: user.id,
           body: %{
             a: "1"
           },

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -697,14 +697,9 @@ defmodule LightningWeb.CredentialLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/credentials")
 
+      # user session 1 opens the edit modal
       JS.focus_first(to: "#edit-credential-#{credential.id}-modal-content")
 
-      # user session 1 tries to update the credential
-      # view
-      # |> element("#project_list_for_#{credential.id}")
-      # |> render_change(selected_project: %{"id" => project.id})
-
-      # user session 1 starts to update the credential
       assert view
              |> form("#credential-form-#{credential.id}",
                credential: %{name: "new name"}
@@ -725,12 +720,11 @@ defmodule LightningWeb.CredentialLiveTest do
       assert {:ok, credential} =
                Credentials.update_credential(credential, update_attrs)
 
-      # user session 1 submits the form
-      assert {:ok, _view, _html} =
-               view
-               |> form("#credential-form-#{credential.id}")
-               |> render_submit()
-               |> follow_redirect(conn, ~p"/credentials")
+      # user session 1 submits the form without the new project credential
+      view
+      |> form("#credential-form-#{credential.id}")
+      |> render_submit()
+      |> follow_redirect(conn, ~p"/credentials")
 
       assert {"/credentials",
               %{

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -726,12 +726,11 @@ defmodule LightningWeb.CredentialLiveTest do
                Credentials.update_credential(credential, update_attrs)
 
       # user session 1 submits the form
-      # assert {:ok, _view, _html} =
-      view
-      |> form("#credential-form-#{credential.id}")
-      |> render_submit()
-
-      # |> follow_redirect(conn, ~p"/credentials")
+      assert {:ok, _view, _html} =
+               view
+               |> form("#credential-form-#{credential.id}")
+               |> render_submit()
+               |> follow_redirect(conn, ~p"/credentials")
 
       assert {"/credentials",
               %{

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -30,6 +30,7 @@ defmodule LightningWeb.ConnCase do
       import LightningWeb.ConnCase
 
       alias LightningWeb.Router.Helpers, as: Routes
+      alias Lightning.Repo
 
       import Lightning.LiveViewHelpers
       import Lightning.ModelHelpers


### PR DESCRIPTION
## Validation Steps

1. Setup demo
2. Run Lightning
3. Go to User credentials (under user profile)
4. Create a credential 
5. Open another browser window
6. Click on Edit credential on both windows
7. Associate the credential to a project and save on one window.
8. Edit only the body on the other window and save
9. A flash error should be displayed informing that the credential was edited by another session (stale data)

## Notes for the reviewer

This issue happens on a scenario of concurrent updates on a credential involving two sessions. It handles the error when saving a credential with stale/outdated project credentials list.

The solution would be easier by changing the default `on_replace=:raise` to `:update` but has_many for a good reason does not support it.

## Related issue

Fixes #1795 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
