### PR TITLE
Generalise PromexPlugin methods

### DIFF
--- a/lib/lightning/runs/prom_ex_plugin.ex
+++ b/lib/lightning/runs/prom_ex_plugin.ex
@@ -106,7 +106,7 @@ defmodule Lightning.Runs.PromExPlugin do
     Polling.build(
       :lightning_run_queue_metrics,
       5000,
-      {__MODULE__, :run_claim_duration, [run_age_seconds]},
+      {__MODULE__, :run_queue_metrics, [run_age_seconds]},
       [
         last_value(
           [
@@ -126,12 +126,10 @@ defmodule Lightning.Runs.PromExPlugin do
     )
   end
 
-  def run_claim_duration(run_age_seconds) do
-    trigger_run_claim_duration(Process.whereis(Repo), run_age_seconds)
-  end
-
-  defp trigger_run_claim_duration(nil, _run_age_seconds) do
-    nil
+  def run_queue_metrics(run_age_seconds) do
+    if pid = Process.whereis(Repo) do
+      trigger_run_claim_duration(pid, run_age_seconds)
+    end
   end
 
   defp trigger_run_claim_duration(repo_pid, run_age_seconds) do

--- a/test/lightning/runs/prom_ex_plugin_test.exs
+++ b/test/lightning/runs/prom_ex_plugin_test.exs
@@ -70,7 +70,7 @@ defmodule Lightning.Runs.PromExPluginText do
       expected_mfa =
         {
           Lightning.Runs.PromExPlugin,
-          :run_claim_duration,
+          :run_queue_metrics,
           [@run_performance_age_seconds]
         }
 
@@ -188,12 +188,12 @@ defmodule Lightning.Runs.PromExPluginText do
     end
   end
 
-  describe ".run_claim_duration" do
+  describe ".run_queue_metrics" do
     setup do
       %{event: [:lightning, :run, :queue, :claim], age: 20}
     end
 
-    test "executes a metric that returns the average queue delay",
+    test "triggers a metric that returns the average queue delay",
          %{event: event, age: age} do
       # Comfortable offset in the hopes it will prevent flickering
       eligible_offset = -(age - 10)
@@ -219,7 +219,7 @@ defmodule Lightning.Runs.PromExPluginText do
       expected_performance_ms =
         (duration_until_claimed_1 + duration_until_claimed_2) * 1000 / 2
 
-      PromExPlugin.run_claim_duration(age)
+      PromExPlugin.run_queue_metrics(age)
 
       assert_received {
         ^event,
@@ -229,7 +229,7 @@ defmodule Lightning.Runs.PromExPluginText do
       }
     end
 
-    test "does not fire a metric if the Repo is not available when called",
+    test "does not trigger metrics if the Repo is not available when called",
          %{event: event, age: age} do
       # This scenario occurs during server startup
       ref =
@@ -243,7 +243,7 @@ defmodule Lightning.Runs.PromExPluginText do
         [:passthrough],
         whereis: fn _name -> nil end
       ) do
-        PromExPlugin.run_claim_duration(age)
+        PromExPlugin.run_queue_metrics(age)
       end
 
       refute_received {

--- a/test/lightning_web/live/components/common_test.exs
+++ b/test/lightning_web/live/components/common_test.exs
@@ -105,8 +105,8 @@ defmodule LightningWeb.Components.CommonTest do
     test "displays the Lightning version without an icon" do
       html = render_component(&LightningWeb.Components.Common.version_chip/1)
 
-      assert html =~ "Lightning v2.0.5"
-      assert html =~ "OpenFn/Lightning v2.0.5"
+      assert html =~ "Lightning v#{Application.spec(:lightning, :vsn)}"
+      assert html =~ "OpenFn/Lightning v#{Application.spec(:lightning, :vsn)}"
       refute html =~ "<svg"
     end
   end


### PR DESCRIPTION
## Validation Steps

Start Lighting locally with the following env vars:

```
PROMEX_ENABLED=true                                                                                     
PROMEX_UPLOAD_GRAFANA_DASHBOARDS_ON_START=false                                                          
PROMEX_DATASOURCE_ID=promex                                                                             
PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=no 
```

Trigger a number of runs , and then navigate to `/metrics`.  Search for the `lightning_run_queue_claim_average_duration_milliseconds` metric and it should have a non-zero value.

## Notes for the reviewer

This is mostly a cosmetic change - future PRs will add more metrics to the `run_queue_metrics` method, so I renamed here to cut down on the noise and re-positioned the Process lookup so that it can cover more than just one method.

## Related issue

#1790 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
