### PR TITLE
don't use compile time variable for priv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,6 @@ and this project adheres to
 
 - Show flash error when editing stale project credentials
   [#1795](https://github.com/OpenFn/lightning/issues/1795)
-
-## [v2.0.7] - 2024-02-29
-
-### Fixed
-
 - Fixed bug with Github sync installation on docker-based deployments
   [#1845](https://github.com/OpenFn/lightning/issues/1845)
 

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -13,8 +13,6 @@ defmodule Lightning.VersionControl do
   alias Lightning.VersionControl.GithubError
   alias Lightning.VersionControl.ProjectRepoConnection
 
-  @github_assets_dir Application.app_dir(:lightning, "priv/github")
-
   @doc """
   Creates a connection between a project and a github repo
   """
@@ -184,10 +182,14 @@ defmodule Lightning.VersionControl do
   end
 
   defp pull_yml do
-    @github_assets_dir |> Path.join("pull.yml") |> File.read!()
+    :code.priv_dir(:lightning)
+    |> Path.join("github/pull.yml")
+    |> File.read!()
   end
 
   defp deploy_yml do
-    @github_assets_dir |> Path.join("deploy.yml") |> File.read!()
+    :code.priv_dir(:lightning)
+    |> Path.join("github/deploy.yml")
+    |> File.read!()
   end
 end

--- a/test/integration/github_installation_test.exs
+++ b/test/integration/github_installation_test.exs
@@ -9,7 +9,6 @@ defmodule Lightning.Integration.GithubInstallationTest do
   @github_repo "OpenFn/github_integration_testing"
   @github_base_branch "main"
   @github_installation_id "41010069"
-  @github_assets_dir Application.app_dir(:lightning, "priv/github")
 
   @moduletag :integration
 
@@ -127,7 +126,12 @@ defmodule Lightning.Integration.GithubInstallationTest do
       assert File.exists?(downloaded_yml_path)
 
       assert File.read!(downloaded_yml_path) ==
-               [@github_assets_dir, yml_file] |> Path.join() |> File.read!()
+               [
+                 :code.priv_dir(:lightning),
+                 "deploy/#{yml_file}"
+               ]
+               |> Path.join()
+               |> File.read!()
     end
 
     # all other previous files exist in the current dir


### PR DESCRIPTION
By using a compile time module attribute, we're not able to access the right filepath while running inside a release, inside docker, and inside k8s. this PR does two things:
1. checks for priv at runtime
2. changes the priv path from `Application.app_dir(:lightning, "priv")` to `:code.priv_dir(:lightning)` because @jyeshe mentions it's more robust and specific for future deployments/features

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
