### PR TITLE
Polling period is configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,6 +175,9 @@ PURGE_DELETED_AFTER_DAYS=7
 # The maximum age of a Run that will be considered when measuring Run performance.
 # METRICS_RUN_PERFORMANCE_AGE_SECONDS=120
 
+# The polling period for run queue metrics (defaults to 5 seconds).
+# METRICS_RUN_QUEUE_METRICS_PERIOD_SECONDS=5
+
 # To disable the reporting of anonymised metrics to the OpenFn Usage tracker, set
 # USAGE_TRACKING_ENABLED to `false`.
 # USAGE_TRACKING_ENABLED=false

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -352,6 +352,10 @@ config :lightning, :metrics,
   run_performance_age_seconds:
     String.to_integer(
       System.get_env("METRICS_RUN_PERFORMANCE_AGE_SECONDS", "300")
+    ),
+  run_queue_metrics_period_seconds:
+    String.to_integer(
+      System.get_env("METRICS_RUN_QUEUE_METRICS_PERIOD_SECONDS", "5")
     )
 
 config :lightning, :usage_tracking,

--- a/lib/lightning/prom_ex.ex
+++ b/lib/lightning/prom_ex.ex
@@ -68,6 +68,11 @@ defmodule Lightning.PromEx do
         :run_performance_age_seconds
       ]
 
+    run_queue_metrics_period_seconds =
+      Application.get_env(:lightning, :metrics)[
+        :run_queue_metrics_period_seconds
+      ]
+
     [
       # PromEx built in plugins
       Plugins.Application,
@@ -80,8 +85,9 @@ defmodule Lightning.PromEx do
       # Add your own PromEx metrics plugins
       {
         Lightning.Runs.PromExPlugin,
-        stalled_run_threshold_seconds: stalled_run_threshold_seconds,
-        run_performance_age_seconds: run_performance_age_seconds
+        run_queue_metrics_period_seconds: run_queue_metrics_period_seconds,
+        run_performance_age_seconds: run_performance_age_seconds,
+        stalled_run_threshold_seconds: stalled_run_threshold_seconds
       }
     ]
   end

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -33,6 +33,11 @@ defmodule Lightning.PromExTest do
         :run_performance_age_seconds
       ]
 
+    run_metrics_period =
+      Application.get_env(:lightning, :metrics)[
+        :run_queue_metrics_period_seconds
+      ]
+
     expected = [
       PromEx.Plugins.Application,
       PromEx.Plugins.Beam,
@@ -43,8 +48,9 @@ defmodule Lightning.PromExTest do
       PromEx.Plugins.PhoenixLiveView,
       {
         Lightning.Runs.PromExPlugin,
-        stalled_run_threshold_seconds: stalled_run_threshold_seconds,
-        run_performance_age_seconds: performance_age_seconds
+        run_queue_metrics_period_seconds: run_metrics_period,
+        run_performance_age_seconds: performance_age_seconds,
+        stalled_run_threshold_seconds: stalled_run_threshold_seconds
       }
     ]
 

--- a/test/lightning/runs/prom_ex_plugin_test.exs
+++ b/test/lightning/runs/prom_ex_plugin_test.exs
@@ -6,6 +6,8 @@ defmodule Lightning.Runs.PromExPluginText do
 
   alias Lightning.Runs.PromExPlugin
 
+  @queue_metrics_period_seconds 5
+  @poll_rate @queue_metrics_period_seconds * 1000
   @run_performance_age_seconds 4
   @stalled_run_threshold_seconds 333
 
@@ -53,7 +55,7 @@ defmodule Lightning.Runs.PromExPluginText do
         plugin_config() |> find_metric_group(:lightning_stalled_run_metrics)
 
       assert %PromEx.MetricTypes.Polling{
-               poll_rate: 5000,
+               poll_rate: @poll_rate,
                measurements_mfa: ^expected_mfa,
                metrics: [metric | _]
              } = stalled_run_polling
@@ -78,7 +80,7 @@ defmodule Lightning.Runs.PromExPluginText do
         plugin_config() |> find_metric_group(:lightning_run_queue_metrics)
 
       assert %PromEx.MetricTypes.Polling{
-               poll_rate: 5000,
+               poll_rate: @poll_rate,
                measurements_mfa: ^expected_mfa
              } = run_performance_polling
     end
@@ -357,6 +359,7 @@ defmodule Lightning.Runs.PromExPluginText do
   defp plugin_config do
     [
       {:run_performance_age_seconds, @run_performance_age_seconds},
+      {:run_queue_metrics_period_seconds, @queue_metrics_period_seconds},
       {:stalled_run_threshold_seconds, @stalled_run_threshold_seconds}
     ]
   end


### PR DESCRIPTION
* In preparation for new metrics

## Validation Steps

Start Lightning up locally with the following env vars:

```
PROMEX_ENABLED=true                                                                                     
PROMEX_UPLOAD_GRAFANA_DASHBOARDS_ON_START=false                                                          
PROMEX_DATASOURCE_ID=promex                                                                             
PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=no
```

Trigger a number of runs , and then navigate to `/metrics`. Search for the `lightning_run_queue_claim_average_duration_milliseconds` metric and it should have a non-zero value. 

## Notes for the reviewer

One of the upcoming metrics will track the number of runs being finalised within a given period. Therefore the period that the metric considers should align with the rate at which the metric polls. This change allows those two values to be aligned.

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
