### PR TITLE
Polling metric - count available runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+- Polling metric to track number of available runs.
+  [#1790](https://github.com/OpenFn/lightning/issues/1790)
 
 - Allows limiting creation of new runs and retries.
   [#1754](https://github.com/OpenFn/Lightning/issues/1754)


### PR DESCRIPTION
## Validation Steps

Start Lightning up locally with the following env vars:

```
PROMEX_ENABLED=true                                                                                     
PROMEX_UPLOAD_GRAFANA_DASHBOARDS_ON_START=false                                                          
PROMEX_DATASOURCE_ID=promex                                                                             
PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=no
```

If you have a sizeable number of runs (50 or so) in your local database, the easiest way to observe changes in this metric is to update the state of all of the runs to `available` and then navigate to  `/metrics` - the `lightning_run_queue_available_count` should have a non-zero value which will decrease as the runs are caimed.


## Notes for the reviewer

This poilling metric counts the number of runs in the available state.


## Related issue

#1790 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
