### PR TITLE
Handle Log, Input, and Output tab's messages when a run is lost 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Allows limiting creation of new runs and retries.
   [#1754](https://github.com/OpenFn/Lightning/issues/1754)
+- Add specific messages for log, input, and output tabs when a run is lost
+  [#1757](https://github.com/OpenFn/lightning/issues/1757)
 
 ### Changed
 

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -16,6 +16,8 @@ defmodule LightningWeb.Components.Viewers do
   alias LightningWeb.Components.Icon
   alias Phoenix.LiveView.AsyncResult
 
+  require Lightning.Run
+
   @doc """
   Renders out a log line stream
 
@@ -38,6 +40,8 @@ defmodule LightningWeb.Components.Viewers do
     doc: "A stream of `Lightning.Invocation.LogLine` structs"
 
   attr :stream_empty?, :boolean, required: true
+
+  attr :run_state, :any, required: true
 
   attr :highlight_id, :string,
     default: nil,
@@ -77,18 +81,31 @@ defmodule LightningWeb.Components.Viewers do
           </span>
         </div>
       </div>
-      <div
-        :if={@stream_empty?}
-        id={"#{@id}-nothing-yet"}
-        class={[
+      <%= if @run_state in Lightning.Run.final_states() and @stream_empty? do %>
+        <div class={[
           "m-2 relative rounded-md",
           "p-12 text-center col-span-full"
-        ]}
-      >
-        <.text_ping_loader>
-          Nothing yet
-        </.text_ping_loader>
-      </div>
+        ]}>
+          <span class="relative inline-flex">
+            <div class="inline-flex">
+              No logs were received for this run.
+            </div>
+          </span>
+        </div>
+      <% else %>
+        <div
+          :if={@stream_empty?}
+          id={"#{@id}-nothing-yet"}
+          class={[
+            "m-2 relative rounded-md",
+            "p-12 text-center col-span-full"
+          ]}
+        >
+          <.text_ping_loader>
+            Nothing yet
+          </.text_ping_loader>
+        </div>
+      <% end %>
     </div>
     """
   end
@@ -102,6 +119,10 @@ defmodule LightningWeb.Components.Viewers do
     """
 
   attr :stream_empty?, :boolean, required: true
+
+  attr :run_state, :any, required: true
+
+  attr :input_or_output, :atom, required: true, values: [:input, :output]
 
   attr :class, :string,
     default: nil,
@@ -140,18 +161,31 @@ defmodule LightningWeb.Components.Viewers do
           </div>
         </div>
       </div>
-      <div
-        :if={@stream_empty?}
-        id={"#{@id}-nothing-yet"}
-        class={[
+      <%= if @run_state in Lightning.Run.final_states() and @stream_empty? do %>
+        <div class={[
           "m-2 relative rounded-md",
           "p-12 text-center col-span-full"
-        ]}
-      >
-        <.text_ping_loader>
-          Nothing yet
-        </.text_ping_loader>
-      </div>
+        ]}>
+          <span class="relative inline-flex">
+            <div class="inline-flex">
+              No <%= @input_or_output %> state could be saved for this run.
+            </div>
+          </span>
+        </div>
+      <% else %>
+        <div
+          :if={@stream_empty?}
+          id={"#{@id}-nothing-yet"}
+          class={[
+            "m-2 relative rounded-md",
+            "p-12 text-center col-span-full"
+          ]}
+        >
+          <.text_ping_loader>
+            Nothing yet
+          </.text_ping_loader>
+        </div>
+      <% end %>
     </div>
     """
   end
@@ -165,6 +199,8 @@ defmodule LightningWeb.Components.Viewers do
     """
 
   attr :stream_empty?, :boolean, required: true
+
+  attr :run_state, :any, required: true
 
   attr :class, :string,
     default: nil,
@@ -197,6 +233,8 @@ defmodule LightningWeb.Components.Viewers do
         class={@class}
         stream={@stream}
         stream_empty?={@stream_empty?}
+        input_or_output={@input_or_output}
+        run_state={@run_state}
         type={
           case @dataclip do
             %AsyncResult{ok?: true, result: %{type: type}} -> type

--- a/lib/lightning_web/live/dev/components_live.ex
+++ b/lib/lightning_web/live/dev/components_live.ex
@@ -2,6 +2,7 @@ defmodule LightningWeb.Dev.ComponentsLive do
   # Internal Development Page for viewing and working on components.
   # Access this page at /dev/components
   @moduledoc false
+  alias Lightning.Run
   use LightningWeb, {:live_view, layout: {LightningWeb.Layouts, :blank}}
 
   alias LightningWeb.Components.Viewers
@@ -45,6 +46,8 @@ defmodule LightningWeb.Dev.ComponentsLive do
               <Viewers.dataclip_viewer
                 id="dataclip-viewer"
                 stream={@streams.dataclip}
+                run_state={%Run{state: :success}}
+                input_or_output={:output}
                 stream_empty?={false}
                 class=""
               />
@@ -54,12 +57,18 @@ defmodule LightningWeb.Dev.ComponentsLive do
             <Viewers.log_viewer
               id="log-viewer-data"
               stream={@log_lines}
+              run_state={%Run{state: :success}}
               highlight_id={@highlight_id}
               stream_empty?={false}
             />
           </.variation>
           <.variation title="Empty">
-            <Viewers.log_viewer id="log-viewer" stream={[]} stream_empty?={true} />
+            <Viewers.log_viewer
+              id="log-viewer"
+              stream={[]}
+              stream_empty?={true}
+              run_state={%Run{state: :crashed}}
+            />
           </.variation>
         </ul>
       </div>

--- a/lib/lightning_web/live/dev/components_live.ex
+++ b/lib/lightning_web/live/dev/components_live.ex
@@ -2,9 +2,9 @@ defmodule LightningWeb.Dev.ComponentsLive do
   # Internal Development Page for viewing and working on components.
   # Access this page at /dev/components
   @moduledoc false
-  alias Lightning.Run
   use LightningWeb, {:live_view, layout: {LightningWeb.Layouts, :blank}}
 
+  alias Lightning.Run
   alias LightningWeb.Components.Viewers
 
   @impl true

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -135,6 +135,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 <Viewers.log_viewer
                   id={"run-log-#{run.id}"}
                   highlight_id={@selected_step_id}
+                  run_state={run.state}
                   stream={@streams.log_lines}
                   stream_empty?={@log_lines_stream_empty?}
                 />
@@ -150,6 +151,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                   <Viewers.step_dataclip_viewer
                     id={"step-input-#{@selected_step_id}"}
                     class="overflow-auto h-full"
+                    run_state={@run.result.state}
                     stream={@streams.input_dataclip}
                     stream_empty?={@input_dataclip_stream_empty?}
                     step={@selected_step}
@@ -174,6 +176,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     class="overflow-auto h-full"
                     stream={@streams.output_dataclip}
                     stream_empty?={@output_dataclip_stream_empty?}
+                    run_state={@run.result.state}
                     step={@selected_step}
                     dataclip={@output_dataclip}
                     input_or_output={:output}

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -172,6 +172,7 @@ defmodule LightningWeb.RunLive.Show do
                   id={"run-log-#{run.id}"}
                   highlight_id={@selected_step_id}
                   stream={@streams.log_lines}
+                  run_state={@run.result.state}
                   stream_empty?={@log_lines_stream_empty?}
                 />
               </Common.panel_content>
@@ -180,6 +181,7 @@ defmodule LightningWeb.RunLive.Show do
                   id={"step-input-#{@selected_step_id}"}
                   stream={@streams.input_dataclip}
                   stream_empty?={@input_dataclip_stream_empty?}
+                  run_state={@run.result.state}
                   step={@selected_step}
                   dataclip={@input_dataclip}
                   input_or_output={:input}
@@ -193,6 +195,7 @@ defmodule LightningWeb.RunLive.Show do
                   id={"step-output-#{@selected_step_id}"}
                   stream={@streams.output_dataclip}
                   stream_empty?={@output_dataclip_stream_empty?}
+                  run_state={@run.result.state}
                   step={@selected_step}
                   dataclip={@output_dataclip}
                   input_or_output={:output}


### PR DESCRIPTION
## Validation Steps

1. Select a lost run
2. Open the details for one of it's steps
3. See the message `No logs were received for this run.` instead of the 'Nothing yet' message for the log viewer. And see the message `No ${input/output} state could be saved for this run.` instead of the 'Nothing yet' message for the input/output tab

## Notes for the reviewer

## Related issue

Fixes #1757 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
