### PR TITLE
Configuration plumbing for daily usage tracking

### DIFF
--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -1,0 +1,42 @@
+defmodule Lightning.UsageTracking do
+  @moduledoc """
+  The UsageTracking context.
+  """
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.DailyReportConfiguration
+
+  def enable_daily_report(enabled_at) do
+    start_reporting_after = DateTime.to_date(enabled_at)
+
+    case Repo.one(DailyReportConfiguration) do
+      config = %{tracking_enabled_at: nil, start_reporting_after: nil} ->
+        config
+        |> DailyReportConfiguration.changeset(%{
+          tracking_enabled_at: enabled_at,
+          start_reporting_after: start_reporting_after
+        })
+        |> Repo.update!()
+
+      nil ->
+        %DailyReportConfiguration{
+          tracking_enabled_at: enabled_at,
+          start_reporting_after: start_reporting_after
+        }
+        |> Repo.insert!()
+
+      config ->
+        config
+    end
+  end
+
+  def disable_daily_report do
+    if config = Repo.one(DailyReportConfiguration) do
+      config
+      |> DailyReportConfiguration.changeset(%{
+        tracking_enabled_at: nil,
+        start_reporting_after: nil
+      })
+      |> Repo.update!()
+    end
+  end
+end

--- a/lib/lightning/usage_tracking/daily_report_configuration.ex
+++ b/lib/lightning/usage_tracking/daily_report_configuration.ex
@@ -1,0 +1,23 @@
+defmodule Lightning.UsageTracking.DailyReportConfiguration do
+  @moduledoc """
+  Configuration for the creation of daily reports
+
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "usage_tracking_daily_report_configurations" do
+    field :instance_id, Ecto.UUID, autogenerate: true
+    field :tracking_enabled_at, :utc_datetime_usec
+    field :start_reporting_after, :date
+
+    timestamps()
+  end
+
+  def changeset(configuration, attrs) do
+    configuration
+    |> cast(attrs, [:tracking_enabled_at, :start_reporting_after])
+  end
+end

--- a/lib/lightning/usage_tracking/day_worker.ex
+++ b/lib/lightning/usage_tracking/day_worker.ex
@@ -1,0 +1,24 @@
+defmodule Lightning.UsageTracking.DayWorker do
+  @moduledoc """
+  Worker to manage per-day report generation
+
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 1
+
+  alias Lightning.UsageTracking
+
+  @impl Oban.Worker
+  def perform(_opts) do
+    env = Application.get_env(:lightning, :usage_tracking)
+
+    if env[:enabled] do
+      UsageTracking.enable_daily_report(DateTime.utc_now())
+    else
+      UsageTracking.disable_daily_report()
+    end
+
+    :ok
+  end
+end

--- a/priv/repo/migrations/20240304143312_create_usage_tracking_daily_report_configurations.exs
+++ b/priv/repo/migrations/20240304143312_create_usage_tracking_daily_report_configurations.exs
@@ -1,0 +1,14 @@
+defmodule Lightning.Repo.Migrations.CreateUsageTrackingDailyReportConfigurations do
+  use Ecto.Migration
+
+  def change do
+    create table(:usage_tracking_daily_report_configurations, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :instance_id, :uuid, null: false
+      add :tracking_enabled_at, :utc_datetime_usec, null: true
+      add :start_reporting_after, :date, null: true
+
+      timestamps()
+    end
+  end
+end

--- a/test/lightning/usage_tracking/day_worker_test.exs
+++ b/test/lightning/usage_tracking/day_worker_test.exs
@@ -1,0 +1,46 @@
+defmodule Lightning.UsageTracking.DayWorkerTest do
+  use Lightning.DataCase
+
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+
+  alias Lightning.Repo
+  alias Lightning.UsageTracking
+  alias Lightning.UsageTracking.DailyReportConfiguration
+  alias Lightning.UsageTracking.DayWorker
+
+  describe "tracking is enabled" do
+    setup do
+      put_temporary_env(:lightning, :usage_tracking, enabled: true)
+    end
+
+    test "enables the configuration" do
+      DayWorker.perform(%{})
+
+      %{tracking_enabled_at: enabled_at} = Repo.one(DailyReportConfiguration)
+
+      assert DateTime.diff(DateTime.utc_now(), enabled_at, :second) < 5
+    end
+
+    test "returns :ok" do
+      assert DayWorker.perform(%{}) == :ok
+    end
+  end
+
+  describe "tracking is not enabled" do
+    setup do
+      put_temporary_env(:lightning, :usage_tracking, enabled: false)
+    end
+
+    test "disables the configuration" do
+      UsageTracking.enable_daily_report(DateTime.utc_now())
+
+      DayWorker.perform(%{})
+
+      assert %{tracking_enabled_at: nil} = Repo.one(DailyReportConfiguration)
+    end
+
+    test "returns :ok" do
+      assert DayWorker.perform(%{}) == :ok
+    end
+  end
+end

--- a/test/lightning/usage_tracking_test.exs
+++ b/test/lightning/usage_tracking_test.exs
@@ -1,0 +1,203 @@
+defmodule Lightning.UsageTrackingTest do
+  use Lightning.DataCase
+
+  alias Lightning.Repo
+  alias Lightning.UsageTracking
+  alias Lightning.UsageTracking.DailyReportConfiguration
+
+  describe ".enable_daily_report/1 - no configuration exists" do
+    setup do
+      {:ok, tracking_enabled_at, _offset} =
+        DateTime.from_iso8601("2024-03-01T18:23:23.000000Z")
+
+      start_reporting_after = Date.from_iso8601!("2024-03-01")
+
+      %{
+        tracking_enabled_at: tracking_enabled_at,
+        start_reporting_after: start_reporting_after
+      }
+    end
+
+    test "creates record", %{
+      tracking_enabled_at: tracking_enabled_at,
+      start_reporting_after: start_reporting_after
+    } do
+      UsageTracking.enable_daily_report(tracking_enabled_at)
+
+      report_config = Repo.one!(DailyReportConfiguration)
+
+      assert %{
+               tracking_enabled_at: ^tracking_enabled_at,
+               start_reporting_after: ^start_reporting_after
+             } = report_config
+    end
+
+    test "returns the configuration", %{
+      tracking_enabled_at: tracking_enabled_at,
+      start_reporting_after: start_reporting_after
+    } do
+      report_config = UsageTracking.enable_daily_report(tracking_enabled_at)
+
+      assert %DailyReportConfiguration{
+               tracking_enabled_at: ^tracking_enabled_at,
+               start_reporting_after: ^start_reporting_after
+             } = report_config
+    end
+  end
+
+  describe ".enable_daily_report/1 - configuration exists with populated dates" do
+    setup do
+      {:ok, tracking_enabled_at, _offset} =
+        DateTime.from_iso8601("2024-03-01T18:23:23.000000Z")
+
+      {:ok, existing_tracking_enabled_at, _offset} =
+        DateTime.from_iso8601("2024-02-01T10:10:10.000000Z")
+
+      existing_start_reporting_after = Date.from_iso8601!("2024-02-01")
+
+      %{
+        tracking_enabled_at: tracking_enabled_at,
+        existing_start_reporting_after: existing_start_reporting_after,
+        existing_tracking_enabled_at: existing_tracking_enabled_at
+      }
+    end
+
+    test "does not update the record", %{
+      tracking_enabled_at: tracking_enabled_at,
+      existing_tracking_enabled_at: existing_tracking_enabled_at,
+      existing_start_reporting_after: existing_start_reporting_after
+    } do
+      insert(
+        :usage_tracking_daily_report_configuration,
+        tracking_enabled_at: existing_tracking_enabled_at,
+        start_reporting_after: existing_start_reporting_after
+      )
+
+      UsageTracking.enable_daily_report(tracking_enabled_at)
+
+      report_config = Repo.one!(DailyReportConfiguration)
+
+      assert %{
+               tracking_enabled_at: ^existing_tracking_enabled_at,
+               start_reporting_after: ^existing_start_reporting_after
+             } = report_config
+    end
+
+    test "returns the config", %{
+      tracking_enabled_at: tracking_enabled_at,
+      existing_tracking_enabled_at: existing_tracking_enabled_at,
+      existing_start_reporting_after: existing_start_reporting_after
+    } do
+      %DailyReportConfiguration{
+        tracking_enabled_at: existing_tracking_enabled_at,
+        start_reporting_after: existing_start_reporting_after
+      }
+      |> Repo.insert!()
+
+      report_config = UsageTracking.enable_daily_report(tracking_enabled_at)
+
+      assert %{
+               tracking_enabled_at: ^existing_tracking_enabled_at,
+               start_reporting_after: ^existing_start_reporting_after
+             } = report_config
+    end
+  end
+
+  describe ".enable_daily_report/1 - record exists but dates are not populated" do
+    setup do
+      {:ok, tracking_enabled_at, _offset} =
+        DateTime.from_iso8601("2024-03-01T18:23:23.000000Z")
+
+      start_reporting_after = Date.from_iso8601!("2024-03-01")
+
+      %{
+        tracking_enabled_at: tracking_enabled_at,
+        start_reporting_after: start_reporting_after
+      }
+    end
+
+    test "updates the record", %{
+      tracking_enabled_at: tracking_enabled_at,
+      start_reporting_after: start_reporting_after
+    } do
+      %DailyReportConfiguration{} |> Repo.insert!()
+
+      UsageTracking.enable_daily_report(tracking_enabled_at)
+
+      report_config = Repo.one!(DailyReportConfiguration)
+
+      assert %{
+               tracking_enabled_at: ^tracking_enabled_at,
+               start_reporting_after: ^start_reporting_after
+             } = report_config
+    end
+
+    test "returns the updated record", %{
+      tracking_enabled_at: tracking_enabled_at,
+      start_reporting_after: start_reporting_after
+    } do
+      %DailyReportConfiguration{} |> Repo.insert!()
+
+      report_config = UsageTracking.enable_daily_report(tracking_enabled_at)
+
+      assert %{
+               tracking_enabled_at: ^tracking_enabled_at,
+               start_reporting_after: ^start_reporting_after
+             } = report_config
+    end
+  end
+
+  describe "disable_daily_report/1 - record exists" do
+    setup do
+      {:ok, existing_tracking_enabled_at, _offset} =
+        DateTime.from_iso8601("2024-02-01T10:10:10.000000Z")
+
+      existing_start_reporting_after = Date.from_iso8601!("2024-02-01")
+
+      %{
+        existing_start_reporting_after: existing_start_reporting_after,
+        existing_tracking_enabled_at: existing_tracking_enabled_at
+      }
+    end
+
+    test "sets the dates to nil", %{
+      existing_tracking_enabled_at: existing_tracking_enabled_at,
+      existing_start_reporting_after: existing_start_reporting_after
+    } do
+      %DailyReportConfiguration{
+        tracking_enabled_at: existing_tracking_enabled_at,
+        start_reporting_after: existing_start_reporting_after
+      }
+      |> Repo.insert!()
+
+      UsageTracking.disable_daily_report()
+
+      report_config = Repo.one!(DailyReportConfiguration)
+
+      assert %{tracking_enabled_at: nil, start_reporting_after: nil} =
+               report_config
+    end
+
+    test "returns the updated record", %{
+      existing_tracking_enabled_at: existing_tracking_enabled_at,
+      existing_start_reporting_after: existing_start_reporting_after
+    } do
+      %DailyReportConfiguration{
+        tracking_enabled_at: existing_tracking_enabled_at,
+        start_reporting_after: existing_start_reporting_after
+      }
+      |> Repo.insert!()
+
+      report_config = UsageTracking.disable_daily_report()
+
+      assert %{tracking_enabled_at: nil, start_reporting_after: nil} =
+               report_config
+    end
+  end
+
+  describe "disable_daily_report/1 - no record exists" do
+    test "returns nil" do
+      assert UsageTracking.disable_daily_report() == nil
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -147,6 +147,10 @@ defmodule Lightning.Factories do
     }
   end
 
+  def usage_tracking_daily_report_configuration_factory do
+    %Lightning.UsageTracking.DailyReportConfiguration{}
+  end
+
   # ----------------------------------------------------------------------------
   # Helpers
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Validation Steps

Executing `Lightning.UsageTracking.DayWorker.perform(%{})` will produce one of the following results:
- If `USAGE_TRACKING_ENABLED` is `true`, and no `DailyReportConfiguration` exists, an instance of `DailyReportConfiguration` will be created with `tracking_enabled_at` and `start_report_after` set.
- If `USAGE_TRACKING_ENABLED` is `true`, and a `DailyReportConfiguration` record already exists and `tracking_enabled_at` and `start_report_after` are already set, it will be unchanged.
- If `USAGE_TRACKING_ENABLED` is `true`, and a `DailyReportConfiguration` record already exists but `tracking_enabled_at` and `start_report_after` are nil, these will be set.
- If `USAGE_TRACKING_ENABLED` is `false` and a `DailyReportConfiguration` record already exists and `tracking_enabled_at` and `start_report_after` are already set, `tracking_enabled_at` and `start_report_after` will be set to nil.
- If `USAGE_TRACKING_ENABLED` is `false` and a `DailyReportConfiguration` record does not exist, nothing will change.

## Notes for the reviewer

This is the first part of a revised implementation of the usage tracking. The intent is that usage tracking will be captured in per-day buckets, with the latest (assuming there is no reporting backlog) relating to the previous day (UTC). 

When the functionality is complete it will provide for retroactive generation of reports but will also respect the date at which the tracking was enabled. This PR introduces code that manages the setting of the appropriate report dates taking into account the current state of usage tracking (enabled or disabled).

## Related issue

#1853

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
