### PR TITLE
authorized users can add existing users to a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   [#1873](https://github.com/OpenFn/lightning/issues/1873)
 - Adds ability to add project collaborators from existing users
   [#1836](https://github.com/OpenFn/lightning/issues/1836)
+- Added ability to remove project collaborators
+  [#1837](https://github.com/OpenFn/lightning/issues/1837)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+
 - Polling metric to track number of available runs.
   [#1790](https://github.com/OpenFn/lightning/issues/1790)
-
 - Allows limiting creation of new runs and retries.
   [#1754](https://github.com/OpenFn/Lightning/issues/1754)
 - Add specific messages for log, input, and output tabs when a run is lost
@@ -27,6 +27,8 @@ and this project adheres to
   [#1859](https://github.com/OpenFn/Lightning/issues/1859)
 - Publish an event when a new user is registered
   [#1873](https://github.com/OpenFn/lightning/issues/1873)
+- Adds ability to add project collaborators from existing users
+  [#1836](https://github.com/OpenFn/lightning/issues/1836)
 
 ### Changed
 

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -105,6 +105,14 @@ defmodule Lightning.Accounts do
   end
 
   @doc """
+  Returns the list of users with the given emails
+  """
+  def list_users_by_emails(emails) do
+    query = from u in User, where: u.email in ^emails
+    Repo.all(query)
+  end
+
+  @doc """
   Gets a user by email.
 
   ## Examples

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -94,7 +94,7 @@ defmodule Lightning.Accounts.UserNotifier do
   def deliver_project_addition_notification(user, project) do
     role = Projects.get_project_user_role(user, project) |> Atom.to_string()
 
-    url = ~p"/projects/#{project.id}/w"
+    url = LightningWeb.RouteHelpers.project_dashboard_url(project.id)
 
     deliver(user.email, "Project #{project.name}", """
 

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -16,6 +16,7 @@ defmodule Lightning.Policies.ProjectUsers do
           | :edit_project
           | :delete_project
           | :add_project_user
+          | :remove_project_user
           | :delete_workflow
           | :create_workflow
           | :edit_digest_alerts
@@ -70,7 +71,8 @@ defmodule Lightning.Policies.ProjectUsers do
              :write_github_connection,
              :edit_project,
              :edit_data_retention,
-             :add_project_user
+             :add_project_user,
+             :remove_project_user
            ],
       do: project_user.role in [:owner, :admin]
 

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -15,6 +15,7 @@ defmodule Lightning.Policies.ProjectUsers do
           | :access_project
           | :edit_project
           | :delete_project
+          | :add_project_user
           | :delete_workflow
           | :create_workflow
           | :edit_digest_alerts
@@ -51,6 +52,11 @@ defmodule Lightning.Policies.ProjectUsers do
   def authorize(:delete_project, %User{} = user, %Project{} = project),
     do: Projects.get_project_user_role(user, project) == :owner
 
+  def authorize(action, %User{} = user, %Project{} = project) do
+    project_user = Projects.get_project_user(project, user)
+    authorize(action, user, project_user)
+  end
+
   def authorize(action, %User{id: id}, %ProjectUser{user_id: user_id})
       when action in [
              :edit_digest_alerts,
@@ -58,25 +64,13 @@ defmodule Lightning.Policies.ProjectUsers do
            ],
       do: id == user_id
 
-  def authorize(action, %User{} = user, %Project{} = project)
-      when action in [
-             :edit_project
-           ],
-      do: Projects.get_project_user_role(user, project) in [:owner, :admin]
-
-  def authorize(action, %User{} = user, %Project{} = project) do
-    project_user = Projects.get_project_user(project, user)
-    authorize(action, user, project_user)
-  end
-
-  def authorize(:edit_data_retention, _user, %ProjectUser{role: role}) do
-    role in [:owner, :admin]
-  end
-
   def authorize(action, %User{}, %ProjectUser{} = project_user)
       when action in [
              :write_webhook_auth_method,
-             :write_github_connection
+             :write_github_connection,
+             :edit_project,
+             :edit_data_retention,
+             :add_project_user
            ],
       do: project_user.role in [:owner, :admin]
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -210,6 +210,11 @@ defmodule Lightning.Projects do
     |> Repo.update()
   end
 
+  @spec delete_project_user!(ProjectUser.t()) :: ProjectUser.t()
+  def delete_project_user!(%ProjectUser{} = project_user) do
+    Repo.delete!(project_user)
+  end
+
   @doc """
   Deletes a project and its related data, including workflows, work orders,
   steps, jobs, runs, triggers, project users, project credentials, and dataclips

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -20,7 +20,8 @@ defmodule LightningWeb.Components.NewInputs do
   attr :class, :any, default: ""
 
   attr :color_class, :any,
-    default: "bg-primary-600 hover:bg-primary-700 text-white"
+    default:
+      "bg-primary-600 hover:bg-primary-700 text-white focus:ring-primary-500 disabled:bg-primary-300"
 
   attr :rest, :global, include: ~w(disabled form name value)
   attr :tooltip, :any, default: nil
@@ -29,19 +30,14 @@ defmodule LightningWeb.Components.NewInputs do
 
   def button(assigns) do
     ~H"""
-    <.tooltip_when_disabled
-      id={@rest[:id]}
-      tooltip={@tooltip}
-      disabled={@rest[:disabled]}
-    >
+    <.tooltip_when_disabled id={@id} tooltip={@tooltip} disabled={@rest[:disabled]}>
       <button
         id={@id}
         type={@type}
         class={[
           "inline-flex justify-center items-center py-2 px-4 border border-transparent",
           "shadow-sm text-sm font-medium rounded-md focus:outline-none",
-          "focus:ring-2 focus:ring-offset-2 focus:ring-primary-500",
-          "disabled:bg-primary-300",
+          "focus:ring-2 focus:ring-offset-2",
           "phx-submit-loading:opacity-75",
           @color_class,
           @class

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -38,7 +38,7 @@ defmodule LightningWeb.Components.NewInputs do
         id={@id}
         type={@type}
         class={[
-          "inline-flex justify-center py-2 px-4 border border-transparent",
+          "inline-flex justify-center items-center py-2 px-4 border border-transparent",
           "shadow-sm text-sm font-medium rounded-md focus:outline-none",
           "focus:ring-2 focus:ring-offset-2 focus:ring-primary-500",
           "disabled:bg-primary-300",
@@ -186,13 +186,13 @@ defmodule LightningWeb.Components.NewInputs do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
-      <.label for={@id}><%= @label %></.label>
+      <.label :if={@label} class="mb-2" for={@id}><%= @label %></.label>
       <select
         id={@id}
         name={@name}
         class={[
-          "block w-full rounded-md border border-secondary-300 bg-white mt-2",
-          "text-sm shadow-sm",
+          "block w-full rounded-lg border border-secondary-300 bg-white",
+          "sm:text-sm shadow-sm",
           "focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50",
           "disabled:cursor-not-allowed"
         ]}
@@ -312,14 +312,14 @@ defmodule LightningWeb.Components.NewInputs do
   def input(assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
-      <.label for={@id}><%= @label %></.label>
+      <.label :if={@label} for={@id} class="mb-2"><%= @label %></.label>
       <input
         type={@type}
         name={@name}
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "focus:outline focus:outline-2 focus:outline-offset-1 mt-2 block w-full rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "focus:outline focus:outline-2 focus:outline-offset-1 block w-full rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
           "phx-no-feedback:border-slate-300 phx-no-feedback:focus:border-slate-400 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500",
           @class,
           @errors == [] &&

--- a/lib/lightning_web/live/project_live/collaborator_project.ex
+++ b/lib/lightning_web/live/project_live/collaborator_project.ex
@@ -1,0 +1,95 @@
+defmodule LightningWeb.ProjectLive.CollaboratorProject do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  embedded_schema do
+    embeds_many :collaborators, Collaborator, on_replace: :delete do
+      field :email, :string
+      field :user_id, :binary_id
+      field :role, Lightning.Projects.ProjectUser.RolesEnum
+    end
+  end
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [])
+    |> cast_embed(:collaborators,
+      with: &collaborators_changeset/2,
+      required: true,
+      drop_param: :collaborators_drop,
+      sort_param: :collaborators_sort
+    )
+  end
+
+  defp collaborators_changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:email, :role])
+    |> validate_required([:email, :role])
+  end
+
+  @spec prepare_for_insertion(%__MODULE__{}, map(), [map(), ...]) ::
+          {:ok, [map(), ...]} | {:error, Ecto.Changeset.t()}
+  def prepare_for_insertion(schema, attrs, current_project_users) do
+    changeset = changeset(schema, attrs)
+
+    changeset =
+      if changeset.valid? do
+        collaborators = get_embed(changeset, :collaborators)
+
+        emails = Enum.map(collaborators, &get_field(&1, :email))
+
+        existing_users = Lightning.Accounts.list_users_by_emails(emails)
+
+        updated_collaborators =
+          validate_collaborators(
+            collaborators,
+            existing_users,
+            current_project_users
+          )
+
+        put_embed(changeset, :collaborators, updated_collaborators)
+      else
+        changeset
+      end
+
+    with {:ok, %{collaborators: collaborators}} <-
+           apply_action(changeset, :insert) do
+      collaborators =
+        Enum.map(collaborators, fn c ->
+          Map.take(c, [:user_id, :role])
+        end)
+
+      {:ok, collaborators}
+    end
+  end
+
+  defp validate_collaborators(
+         collaborators,
+         existing_users,
+         current_project_users
+       ) do
+    Enum.map(collaborators, fn collaborator ->
+      existing_user =
+        Enum.find(existing_users, fn u ->
+          u.email == get_field(collaborator, :email)
+        end)
+
+      collaborator
+      |> put_change(:user_id, existing_user && existing_user.id)
+      |> validate_change(:email, fn :email, _email ->
+        cond do
+          is_nil(existing_user) ->
+            [email: "no user exists with this email"]
+
+          Enum.find(current_project_users, &(&1.user_id == existing_user.id)) ->
+            [email: "this user is already part of this project"]
+
+          true ->
+            []
+        end
+      end)
+    end)
+  end
+end

--- a/lib/lightning_web/live/project_live/collaborator_project.ex
+++ b/lib/lightning_web/live/project_live/collaborator_project.ex
@@ -1,5 +1,8 @@
 defmodule LightningWeb.ProjectLive.CollaboratorProject do
-  @moduledoc false
+  @moduledoc """
+  This schema is used for building the changeset for adding new collaborators to a project.
+  It is mirroring the `Project -> ProjectUser` relationship.
+  """
 
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/lightning_web/live/project_live/collaborator_project.ex
+++ b/lib/lightning_web/live/project_live/collaborator_project.ex
@@ -8,7 +8,7 @@ defmodule LightningWeb.ProjectLive.CollaboratorProject do
     embeds_many :collaborators, Collaborator, on_replace: :delete do
       field :email, :string
       field :user_id, :binary_id
-      field :role, Lightning.Projects.ProjectUser.RolesEnum
+      field :role, Ecto.Enum, values: [:viewer, :editor, :admin]
     end
   end
 
@@ -81,10 +81,10 @@ defmodule LightningWeb.ProjectLive.CollaboratorProject do
       |> validate_change(:email, fn :email, _email ->
         cond do
           is_nil(existing_user) ->
-            [email: "no user exists with this email"]
+            [email: "There is no account connected this email"]
 
           Enum.find(current_project_users, &(&1.user_id == existing_user.id)) ->
-            [email: "this user is already part of this project"]
+            [email: "This account is already part of this project"]
 
           true ->
             []

--- a/lib/lightning_web/live/project_live/collaborators.ex
+++ b/lib/lightning_web/live/project_live/collaborators.ex
@@ -30,6 +30,7 @@ defmodule LightningWeb.ProjectLive.Collaborators do
     schema
     |> cast(attrs, [:email, :role])
     |> validate_required([:email, :role])
+    |> validate_format(:email, ~r/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/)
   end
 
   @spec prepare_for_insertion(%__MODULE__{}, map(), [map(), ...]) ::

--- a/lib/lightning_web/live/project_live/collaborators.ex
+++ b/lib/lightning_web/live/project_live/collaborators.ex
@@ -1,4 +1,4 @@
-defmodule LightningWeb.ProjectLive.CollaboratorProject do
+defmodule LightningWeb.ProjectLive.Collaborators do
   @moduledoc """
   This schema is used for building the changeset for adding new collaborators to a project.
   It is mirroring the `Project -> ProjectUser` relationship.

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -5,25 +5,25 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
 
   alias Lightning.Accounts.UserNotifier
   alias Lightning.Projects
-  alias LightningWeb.ProjectLive.CollaboratorProject
+  alias LightningWeb.ProjectLive.Collaborators
   alias Phoenix.LiveView.JS
 
   @impl true
   def update(assigns, socket) do
-    collaborator_project = %CollaboratorProject{}
+    collaborators = %Collaborators{}
 
-    changeset = CollaboratorProject.changeset(collaborator_project, %{})
+    changeset = Collaborators.changeset(collaborators, %{})
 
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(collaborator_project: collaborator_project, changeset: changeset)}
+     |> assign(collaborators: collaborators, changeset: changeset)}
   end
 
   @impl true
   def handle_event("validate", %{"project" => params}, socket) do
     changeset =
-      CollaboratorProject.changeset(socket.assigns.collaborator_project, params)
+      Collaborators.changeset(socket.assigns.collaborators, params)
 
     {:noreply, assign(socket, changeset: changeset)}
   end
@@ -34,8 +34,8 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
         %{assigns: assigns} = socket
       ) do
     with {:ok, project_users} <-
-           CollaboratorProject.prepare_for_insertion(
-             assigns.collaborator_project,
+           Collaborators.prepare_for_insertion(
+             assigns.collaborators,
              params,
              assigns.project_users
            ),

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -1,0 +1,65 @@
+defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
+  @moduledoc false
+
+  use LightningWeb, :live_component
+
+  alias Lightning.Accounts.UserNotifier
+  alias Lightning.Projects
+  alias LightningWeb.ProjectLive.CollaboratorProject
+  alias Phoenix.LiveView.JS
+
+  @impl true
+  def update(assigns, socket) do
+    collaborator_project = %CollaboratorProject{}
+
+    changeset = CollaboratorProject.changeset(collaborator_project, %{})
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(collaborator_project: collaborator_project, changeset: changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"collaborator_project" => params}, socket) do
+    changeset =
+      CollaboratorProject.changeset(socket.assigns.collaborator_project, params)
+
+    {:noreply, assign(socket, changeset: changeset)}
+  end
+
+  def handle_event(
+        "add_collaborators",
+        %{"collaborator_project" => params},
+        %{assigns: assigns} = socket
+      ) do
+    with {:ok, project_users} <-
+           CollaboratorProject.prepare_for_insertion(
+             assigns.collaborator_project,
+             params,
+             assigns.project_users
+           ),
+         {:ok, updated_project} <-
+           Projects.update_project(%{assigns.project | project_users: []}, %{
+             project_users: project_users
+           }) do
+      send(self(), :collaborators_updated)
+      send_email_to_users(updated_project, updated_project.project_users)
+      {:noreply, socket}
+    else
+      {:error, changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+
+  defp send_email_to_users(project, project_users) do
+    project_users = Lightning.Repo.preload(project_users, [:user])
+
+    Enum.map(project_users, fn project_user ->
+      UserNotifier.deliver_project_addition_notification(
+        project_user.user,
+        project
+      )
+    end)
+  end
+end

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -21,7 +21,7 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
   end
 
   @impl true
-  def handle_event("validate", %{"collaborator_project" => params}, socket) do
+  def handle_event("validate", %{"project" => params}, socket) do
     changeset =
       CollaboratorProject.changeset(socket.assigns.collaborator_project, params)
 
@@ -30,7 +30,7 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
 
   def handle_event(
         "add_collaborators",
-        %{"collaborator_project" => params},
+        %{"project" => params},
         %{assigns: assigns} = socket
       ) do
     with {:ok, project_users} <-

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -3,7 +3,6 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
 
   use LightningWeb, :live_component
 
-  alias Lightning.Accounts.UserNotifier
   alias Lightning.Projects
   alias LightningWeb.ProjectLive.Collaborators
   alias Phoenix.LiveView.JS
@@ -39,27 +38,13 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
              params,
              assigns.project_users
            ),
-         {:ok, updated_project} <-
-           Projects.update_project(%{assigns.project | project_users: []}, %{
-             project_users: project_users
-           }) do
+         {:ok, _} <-
+           Projects.add_project_users(assigns.project, project_users) do
       send(self(), :collaborators_updated)
-      send_email_to_users(updated_project, updated_project.project_users)
       {:noreply, socket}
     else
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
     end
-  end
-
-  defp send_email_to_users(project, project_users) do
-    project_users = Lightning.Repo.preload(project_users, [:user])
-
-    Enum.map(project_users, fn project_user ->
-      UserNotifier.deliver_project_addition_notification(
-        project_user.user,
-        project
-      )
-    end)
   end
 end

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -23,13 +23,15 @@
       </div>
     </:title>
     <:subtitle>
-      <span class="italic text-xs">
+      <span class="text-xs">
         Enter the email address and role of new collaborator(s) to invite them to this project
       </span>
     </:subtitle>
 
     <.form
       :let={f}
+      id={"#{@id}_form"}
+      as={:project}
       for={@changeset}
       phx-target={@myself}
       phx-change="validate"
@@ -42,7 +44,7 @@
             field={f[:collaborators]}
             prepend={[%CollaboratorProject.Collaborator{}]}
           >
-            <div class="col-span-3 flex flex-col-reverse">
+            <div class="col-span-3">
               <.input
                 label="Email Address"
                 type="text"
@@ -51,7 +53,7 @@
                 required="true"
               />
             </div>
-            <div class="col-span-2 flex flex-col-reverse">
+            <div class="col-span-2 pt-8">
               <.input
                 type="select"
                 prompt="Select Role"
@@ -65,7 +67,7 @@
                 required="true"
               />
             </div>
-            <div class="col-span-1 flex flex-col-reverse">
+            <div class="col-span-1 pt-8">
               <input
                 type="hidden"
                 name={"#{f.name}[collaborators_sort][]"}

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -8,7 +8,7 @@
     <:title>
       <div class="flex justify-between">
         <span class="font-bold">
-          Add a new collaborator
+          Add new collaborator(s)
         </span>
 
         <button
@@ -106,7 +106,9 @@
             type="submit"
             phx-disable-with="Adding..."
           >
-            Save Collaborators
+            Save Collaborator<%= if(Enum.count(f[:collaborators].value) > 1,
+              do: "(s)"
+            ) %>
           </.button>
           <button
             type="button"

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -1,0 +1,120 @@
+<div>
+  <.modal
+    id={@id}
+    show={true}
+    on_close={JS.push("toggle_collaborators_modal")}
+    width="min-w-1/2 max-w-xl"
+  >
+    <:title>
+      <div class="flex justify-between">
+        <span class="font-bold">
+          Add a new collaborator
+        </span>
+
+        <button
+          phx-click="toggle_collaborators_modal"
+          type="button"
+          class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+          aria-label={gettext("close")}
+        >
+          <span class="sr-only">Close</span>
+          <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+        </button>
+      </div>
+    </:title>
+    <:subtitle>
+      <span class="italic text-xs">
+        Enter the email address and role of new collaborator(s) to invite them to this project
+      </span>
+    </:subtitle>
+
+    <.form
+      :let={f}
+      for={@changeset}
+      phx-target={@myself}
+      phx-change="validate"
+      phx-submit="add_collaborators"
+    >
+      <div class="px-6">
+        <div class="grid grid-cols-6 gap-4">
+          <.inputs_for
+            :let={cf}
+            field={f[:collaborators]}
+            prepend={[%CollaboratorProject.Collaborator{}]}
+          >
+            <div class="col-span-3 flex flex-col-reverse">
+              <.input
+                label="Email Address"
+                type="text"
+                field={cf[:email]}
+                placeholder="email@example.com"
+                required="true"
+              />
+            </div>
+            <div class="col-span-2 flex flex-col-reverse">
+              <.input
+                type="select"
+                prompt="Select Role"
+                field={cf[:role]}
+                options={
+                  Enum.map(
+                    ["viewer", "editor", "admin"],
+                    &{String.capitalize(&1), &1}
+                  )
+                }
+                required="true"
+              />
+            </div>
+            <div class="col-span-1 flex flex-col-reverse">
+              <input
+                type="hidden"
+                name={"#{f.name}[collaborators_sort][]"}
+                value={cf.index}
+              />
+              <button
+                :if={Enum.count(f[:collaborators].value) > 1}
+                type="button"
+                name={"#{f.name}[collaborators_drop][]"}
+                value={cf.index}
+                phx-click={JS.dispatch("change")}
+                class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+              >
+                <Heroicons.minus_circle class="w-5 h-5" />
+              </button>
+            </div>
+          </.inputs_for>
+        </div>
+        <div class="mt-5">
+          <input type="hidden" name={"#{f.name}[collaborators_drop][]"} />
+          <button
+            type="button"
+            name={"#{f.name}[collaborators_sort][]"}
+            value="new"
+            phx-click={JS.dispatch("change")}
+            class="inline-flex items-center gap-x-2 rounded-md bg-white px-3.5 py-2.5 text-sm  text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          >
+            <Heroicons.plus_circle class="w-5 h-5" /> Add Additonal Collaborator
+          </button>
+        </div>
+      </div>
+      <.modal_footer class="mx-6 mt-6">
+        <div class="flex flex-row-reverse gap-4">
+          <.button
+            id="save_collaborators_button"
+            type="submit"
+            phx-disable-with="Adding..."
+          >
+            Save Collaborators
+          </.button>
+          <button
+            type="button"
+            phx-click="toggle_collaborators_modal"
+            class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </.modal_footer>
+    </.form>
+  </.modal>
+</div>

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -41,7 +41,7 @@
         <.inputs_for
           :let={cf}
           field={f[:collaborators]}
-          prepend={[%CollaboratorProject.Collaborator{}]}
+          prepend={[%Collaborators.Collaborator{}]}
         >
           <div class="flex justify-between">
             <div class="min-w-1/2">

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -37,23 +37,22 @@
       phx-change="validate"
       phx-submit="add_collaborators"
     >
-      <div class="px-6">
-        <div class="grid grid-cols-6 gap-4">
-          <.inputs_for
-            :let={cf}
-            field={f[:collaborators]}
-            prepend={[%CollaboratorProject.Collaborator{}]}
-          >
-            <div class="col-span-3">
+      <div class="px-6 space-y-5">
+        <.inputs_for
+          :let={cf}
+          field={f[:collaborators]}
+          prepend={[%CollaboratorProject.Collaborator{}]}
+        >
+          <div class="flex justify-between">
+            <div class="min-w-1/2">
               <.input
-                label="Email Address"
                 type="text"
                 field={cf[:email]}
                 placeholder="email@example.com"
                 required="true"
               />
             </div>
-            <div class="col-span-2 pt-8">
+            <div class="min-w-1/4">
               <.input
                 type="select"
                 prompt="Select Role"
@@ -67,7 +66,7 @@
                 required="true"
               />
             </div>
-            <div class="col-span-1 pt-8">
+            <div class="">
               <input
                 type="hidden"
                 name={"#{f.name}[collaborators_sort][]"}
@@ -84,8 +83,9 @@
                 <Heroicons.minus_circle class="w-5 h-5" />
               </button>
             </div>
-          </.inputs_for>
-        </div>
+          </div>
+        </.inputs_for>
+
         <div class="mt-5">
           <input type="hidden" name={"#{f.name}[collaborators_drop][]"} />
           <button

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -105,9 +105,10 @@
             id="save_collaborators_button"
             type="submit"
             phx-disable-with="Adding..."
+            disabled={!@changeset.valid?}
           >
             Save Collaborator<%= if(Enum.count(f[:collaborators].value) > 1,
-              do: "(s)"
+              do: "s"
             ) %>
           </.button>
           <button

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -477,7 +477,7 @@ defmodule LightningWeb.ProjectLive.Settings do
     {:noreply,
      socket
      |> assign(project_users: project_users, show_collaborators_modal: false)
-     |> put_flash(:success, "Collaborators updated successfully!")}
+     |> put_flash(:info, "Collaborators updated successfully!")}
   end
 
   def handle_info({:branches_fetched, branches_result}, socket) do

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -64,6 +64,14 @@ defmodule LightningWeb.ProjectLive.Settings do
         project_user
       )
 
+    can_remove_project_user =
+      Permissions.can?(
+        ProjectUsers,
+        :remove_project_user,
+        current_user,
+        project_user
+      )
+
     can_edit_data_retention =
       Permissions.can?(
         ProjectUsers,
@@ -123,6 +131,7 @@ defmodule LightningWeb.ProjectLive.Settings do
        can_delete_project: can_delete_project,
        can_edit_project: can_edit_project,
        can_add_project_user: can_add_project_user,
+       can_remove_project_user: can_remove_project_user,
        can_edit_data_retention: can_edit_data_retention,
        can_write_webhook_auth_method: can_write_webhook_auth_method,
        can_create_project_credential: can_create_project_credential,
@@ -322,6 +331,34 @@ defmodule LightningWeb.ProjectLive.Settings do
       digest ->
         Projects.update_project_user(project_user, %{digest: digest})
         |> dispatch_flash(socket)
+    end
+  end
+
+  def handle_event(
+        "remove_project_user",
+        %{"project_user_id" => project_user_id},
+        %{assigns: assigns} = socket
+      ) do
+    project_user = Projects.get_project_user!(project_user_id)
+
+    if user_removable?(
+         project_user,
+         assigns.current_user,
+         assigns.can_remove_project_user
+       ) do
+      Projects.delete_project_user!(project_user)
+
+      {:noreply,
+       socket
+       |> put_flash(:info, "Collaborator removed successfully!")
+       |> assign(
+         :project_users,
+         Projects.get_project_users!(assigns.project.id)
+       )}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "You are not authorized to perform this action")}
     end
   end
 
@@ -623,7 +660,10 @@ defmodule LightningWeb.ProjectLive.Settings do
 
   def user(assigns) do
     ~H"""
-    <%= @project_user.user.first_name %> <%= @project_user.user.last_name %>
+    <div>
+      <%= @project_user.user.first_name %> <%= @project_user.user.last_name %>
+    </div>
+    <span class="text-xs"><%= @project_user.user.email %></span>
     """
   end
 
@@ -700,5 +740,76 @@ defmodule LightningWeb.ProjectLive.Settings do
       {:error, _error} ->
         put_flash(socket, :error, "Oops! Error connecting to github")
     end
+  end
+
+  defp confirm_user_removal_modal(assigns) do
+    ~H"""
+    <.modal id={@id} width="max-w-md">
+      <:title>
+        <div class="flex justify-between">
+          <span class="font-bold">
+            Remove <%= @project_user.user.first_name %> <%= @project_user.user.last_name %>
+          </span>
+
+          <button
+            phx-click={hide_modal(@id)}
+            type="button"
+            class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+            aria-label={gettext("close")}
+          >
+            <span class="sr-only">Close</span>
+            <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+          </button>
+        </div>
+      </:title>
+      <div class="px-6">
+        <p class="text-sm text-gray-500">
+          Are you sure you want to remove "<%= @project_user.user.first_name %> <%= @project_user.user.last_name %>" from this project?
+          They will nolonger have access.
+          Do you wish to proceed with this action?
+        </p>
+      </div>
+      <div class="flex flex-row-reverse gap-4 mx-6 mt-2">
+        <.button
+          id={"#{@id}_confirm_button"}
+          type="button"
+          phx-value-project_user_id={@project_user.id}
+          phx-click="remove_project_user"
+          color_class="bg-red-600 hover:bg-red-700 text-white"
+          phx-disable-with="Removing..."
+        >
+          Confirm
+        </.button>
+        <button
+          type="button"
+          phx-click={hide_modal(@id)}
+          class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </.modal>
+    """
+  end
+
+  defp remove_user_tooltip(project_user, current_user, can_remove_project_user) do
+    cond do
+      !can_remove_project_user ->
+        "You do not have permission to remove a user"
+
+      project_user.user_id == current_user.id ->
+        "You cannot remove yourself"
+
+      project_user.role == :owner ->
+        "You cannot remove an owner"
+
+      true ->
+        ""
+    end
+  end
+
+  defp user_removable?(project_user, current_user, can_remove_project_user) do
+    can_remove_project_user and project_user.role != :owner and
+      project_user.user_id != current_user.id
   end
 end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -476,7 +476,7 @@ defmodule LightningWeb.ProjectLive.Settings do
 
     {:noreply,
      socket
-     |> assign(project_users: project_users)
+     |> assign(project_users: project_users, show_collaborators_modal: false)
      |> put_flash(:success, "Collaborators updated successfully!")}
   end
 
@@ -508,6 +508,12 @@ defmodule LightningWeb.ProjectLive.Settings do
       _ ->
         {:noreply, socket}
     end
+  end
+
+  # catch all callback. Needed for tests because of Swoosh emails in tests
+  def handle_info(msg, socket) do
+    Logger.debug("Received unknown message: #{inspect(msg)}")
+    {:noreply, socket}
   end
 
   defp error_message(error) do

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -490,6 +490,7 @@
             <div class="flex items-center flex-row-reverse mb-8">
               <div class="mt-4 sm:ml-16 sm:mt-0">
                 <.button
+                  id="show_collaborators_modal_button"
                   type="button"
                   phx-click="toggle_collaborators_modal"
                   disabled={!@can_add_project_user}

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -512,6 +512,7 @@
                 <.th>Role</.th>
                 <.th>Failure Alert</.th>
                 <.th>Digest</.th>
+                <.th>Actions</.th>
               </.tr>
 
               <%= for project_user <- @project_users do %>
@@ -536,6 +537,43 @@
                   <.td>
                     <.digest
                       current_user={@current_user}
+                      project_user={project_user}
+                    />
+                  </.td>
+                  <.td>
+                    <.button
+                      id={"remove_project_user_#{project_user.id}_button"}
+                      type="button"
+                      phx-click={show_modal("remove_#{project_user.id}_modal")}
+                      color_class="bg-white text-gray-900 hover:bg-gray-50 disabled:bg-gray-100"
+                      class="gap-x-2 rounded-md  px-3.5 py-2.5 text-sm shadow-sm ring-1 ring-inset ring-gray-300 disabled:cursor-not-allowed"
+                      tooltip={
+                        remove_user_tooltip(
+                          project_user,
+                          @current_user,
+                          @can_remove_project_user
+                        )
+                      }
+                      disabled={
+                        !user_removable?(
+                          project_user,
+                          @current_user,
+                          @can_remove_project_user
+                        )
+                      }
+                    >
+                      <Heroicons.minus_circle class="w-5 h-5" />
+                      Remove Collaborator
+                    </.button>
+                    <.confirm_user_removal_modal
+                      :if={
+                        user_removable?(
+                          project_user,
+                          @current_user,
+                          @can_remove_project_user
+                        )
+                      }
+                      id={"remove_#{project_user.id}_modal"}
                       project_user={project_user}
                     />
                   </.td>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -495,7 +495,7 @@
                   phx-click="toggle_collaborators_modal"
                   disabled={!@can_add_project_user}
                 >
-                  Add collaborator
+                  Add Collaborator(s)
                 </.button>
                 <.live_component
                   :if={@can_add_project_user && @show_collaborators_modal}

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -486,42 +486,62 @@
           <div class="hidden sm:block" aria-hidden="true">
             <div class="py-2"></div>
           </div>
-          <.table id="collaborators">
-            <.tr>
-              <.th>Collaborator</.th>
-              <.th>Role</.th>
-              <.th>Failure Alert</.th>
-              <.th>Digest</.th>
-            </.tr>
-
-            <%= for project_user <- @project_users do %>
-              <.tr id={"project_user-#{project_user.id}"}>
-                <.td>
-                  <.user project_user={project_user} />
-                  <div :if={project_user.user.email == @current_user.email}>
-                    <small class="text-gray-400">
-                      <em>Well hello, you!</em>
-                    </small>
-                  </div>
-                </.td>
-                <.td>
-                  <.role project_user={project_user} />
-                </.td>
-                <.td>
-                  <.failure_alert
-                    current_user={@current_user}
-                    project_user={project_user}
-                  />
-                </.td>
-                <.td>
-                  <.digest
-                    current_user={@current_user}
-                    project_user={project_user}
-                  />
-                </.td>
+          <div>
+            <div class="flex items-center flex-row-reverse mb-8">
+              <div class="mt-4 sm:ml-16 sm:mt-0">
+                <.button
+                  type="button"
+                  phx-click="toggle_collaborators_modal"
+                  disabled={!@can_add_project_user}
+                >
+                  Add collaborator
+                </.button>
+                <.live_component
+                  :if={@can_add_project_user && @show_collaborators_modal}
+                  module={LightningWeb.ProjectLive.NewCollaboratorComponent}
+                  id="add_collaborators_modal"
+                  project={@project}
+                  project_users={@project_users}
+                />
+              </div>
+            </div>
+            <.table id="collaborators">
+              <.tr>
+                <.th>Collaborator</.th>
+                <.th>Role</.th>
+                <.th>Failure Alert</.th>
+                <.th>Digest</.th>
               </.tr>
-            <% end %>
-          </.table>
+
+              <%= for project_user <- @project_users do %>
+                <.tr id={"project_user-#{project_user.id}"}>
+                  <.td>
+                    <.user project_user={project_user} />
+                    <div :if={project_user.user.email == @current_user.email}>
+                      <small class="text-gray-400">
+                        <em>Well hello, you!</em>
+                      </small>
+                    </div>
+                  </.td>
+                  <.td>
+                    <.role project_user={project_user} />
+                  </.td>
+                  <.td>
+                    <.failure_alert
+                      current_user={@current_user}
+                      project_user={project_user}
+                    />
+                  </.td>
+                  <.td>
+                    <.digest
+                      current_user={@current_user}
+                      project_user={project_user}
+                    />
+                  </.td>
+                </.tr>
+              <% end %>
+            </.table>
+          </div>
         </LightningWeb.Components.Common.panel_content>
 
         <LightningWeb.Components.Common.panel_content for_hash="security">

--- a/lib/lightning_web/route_helpers.ex
+++ b/lib/lightning_web/route_helpers.ex
@@ -13,6 +13,14 @@ defmodule LightningWeb.RouteHelpers do
     )
   end
 
+  def project_dashboard_url(project_id) do
+    Routes.project_workflow_index_url(
+      LightningWeb.Endpoint,
+      :index,
+      project_id
+    )
+  end
+
   def oidc_callback_url do
     Routes.oidc_url(LightningWeb.Endpoint, :new)
   end

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -40,7 +40,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
           project_users: [%{user_id: user.id}]
         )
 
-      url = ~p"/projects/#{project.id}/w"
+      url = LightningWeb.RouteHelpers.project_dashboard_url(project.id)
 
       UserNotifier.deliver_project_addition_notification(
         user,

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2370,6 +2370,8 @@ defmodule LightningWeb.ProjectLiveTest do
         |> form("#add_collaborators_modal_form")
         |> render_change(project: %{"collaborators_drop" => [0]})
 
+        html = modal |> render() |> Floki.parse_fragment!()
+
         # we now have 1 email input and we dont have any button to remove the input
         assert Floki.find(html, "[type='text'][name$='[email]']") |> Enum.count() ==
                  1

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2266,6 +2266,283 @@ defmodule LightningWeb.ProjectLiveTest do
     end
   end
 
+  describe "projects settings:collaboration" do
+    setup :register_and_log_in_user
+
+    test "only authorized users can access the add collaborators modal", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:viewer, :editor]) do
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        button = element(view, "#show_collaborators_modal_button")
+        assert has_element?(button)
+
+        # modal is not present
+        refute has_element?(view, "#add_collaborators_modal")
+
+        # try clicking the button
+        assert_raise ArgumentError, ~r/is disabled/, fn ->
+          render_click(button)
+        end
+
+        # send event either way
+        refute render_click(view, "toggle_collaborators_modal") =~
+                 "Enter the email address and role of new collaborator"
+
+        # modal is still not present
+        refute has_element?(view, "#add_collaborators_modal")
+      end
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        button = element(view, "#show_collaborators_modal_button")
+        assert has_element?(button)
+
+        # modal is not present
+        refute has_element?(view, "#add_collaborators_modal")
+
+        # try clicking the button
+        assert render_click(button) =~
+                 "Enter the email address and role of new collaborator"
+
+        # modal is now present
+        assert has_element?(view, "#add_collaborators_modal")
+      end
+    end
+
+    test "user can add and remove inputs for adding collaborators", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        # Open Modal
+        view
+        |> element("#show_collaborators_modal_button")
+        |> render_click()
+
+        modal = element(view, "#add_collaborators_modal")
+
+        html = modal |> render() |> Floki.parse_fragment!()
+
+        # we only have 1 email input by default
+        assert Floki.find(html, "[type='text'][name$='[email]']") |> Enum.count() ==
+                 1
+
+        # we dont have any button to remove the input
+        assert Floki.find(html, "button[name$='[collaborators_drop][]']")
+               |> Enum.count() == 0
+
+        # lets click to add another row
+        view
+        |> form("#add_collaborators_modal_form")
+        |> render_change(project: %{"collaborators_sort" => [0, "new"]})
+
+        html = modal |> render() |> Floki.parse_fragment!()
+
+        # we now have 2 email inputs and 2 buttons to remove the inputs
+        assert Floki.find(html, "[type='text'][name$='[email]']") |> Enum.count() ==
+                 2
+
+        assert Floki.find(html, "button[name$='[collaborators_drop][]']")
+               |> Enum.count() == 2
+
+        # lets click to remove the first row
+        view
+        |> form("#add_collaborators_modal_form")
+        |> render_change(project: %{"collaborators_drop" => [0]})
+
+        # we now have 1 email input and we dont have any button to remove the input
+        assert Floki.find(html, "[type='text'][name$='[email]']") |> Enum.count() ==
+                 1
+
+        assert Floki.find(html, "button[name$='[collaborators_drop][]']")
+               |> Enum.count() == 0
+      end
+    end
+
+    test "adding a non existent user displays an appropriate error message", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        # Open Modal
+        view
+        |> element("#show_collaborators_modal_button")
+        |> render_click()
+
+        modal = element(view, "#add_collaborators_modal")
+
+        refute render(modal) =~ "There is no account connected this email"
+        email = "nonexists@localtests.com"
+        refute Lightning.Accounts.get_user_by_email(email)
+
+        # lets submit the form
+
+        view
+        |> form("#add_collaborators_modal_form",
+          project: %{
+            "collaborators" => %{"0" => %{"email" => email, "role" => "editor"}}
+          }
+        )
+        |> render_submit()
+
+        assert render(modal) =~ "There is no account connected this email"
+      end
+    end
+
+    test "adding an existing project user displays an appropriate error message",
+         %{
+           conn: conn
+         } do
+      project = insert(:project)
+
+      for {conn, user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        # Open Modal
+        view
+        |> element("#show_collaborators_modal_button")
+        |> render_click()
+
+        modal = element(view, "#add_collaborators_modal")
+
+        refute render(modal) =~ "This account is already part of this project"
+
+        # lets submit the form
+
+        view
+        |> form("#add_collaborators_modal_form",
+          project: %{
+            "collaborators" => %{
+              "0" => %{"email" => user.email, "role" => "editor"}
+            }
+          }
+        )
+        |> render_submit()
+
+        assert render(modal) =~ "This account is already part of this project"
+      end
+    end
+
+    test "adding an owner project user is not allowed",
+         %{
+           conn: conn
+         } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        # Open Modal
+        view
+        |> element("#show_collaborators_modal_button")
+        |> render_click()
+
+        modal = element(view, "#add_collaborators_modal")
+
+        refute render(modal) =~ "is invalid"
+
+        # lets submit the form
+        view
+        |> form("#add_collaborators_modal_form")
+        |> render_submit(
+          project: %{
+            "collaborators" => %{
+              "0" => %{"email" => "dummy@email.com", "role" => "owner"}
+            }
+          }
+        )
+
+        assert render(modal) =~ "is invalid"
+      end
+    end
+
+    test "user can add collaborators successfully",
+         %{
+           conn: conn
+         } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        {:ok, view, html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        [admin, editor, viewer] = insert_list(3, :user)
+
+        # user is not shown in the page
+        for new_user <- [admin, editor, viewer] do
+          refute html =~ new_user.last_name
+        end
+
+        # Open Modal
+        view
+        |> element("#show_collaborators_modal_button")
+        |> render_click()
+
+        # lets click to add 2 more rows
+        view
+        |> form("#add_collaborators_modal_form")
+        |> render_change(project: %{"collaborators_sort" => [0, "new", "new"]})
+
+        # lets submit the form
+        view
+        |> form("#add_collaborators_modal_form",
+          project: %{
+            "collaborators" => %{
+              "0" => %{"email" => admin.email, "role" => "admin"},
+              "1" => %{"email" => editor.email, "role" => "editor"},
+              "2" => %{"email" => viewer.email, "role" => "viewer"}
+            }
+          }
+        )
+        |> render_submit()
+
+        updated_html = render(view)
+        # users are shown in the page
+        for new_user <- [admin, editor, viewer] do
+          assert updated_html =~ new_user.last_name
+        end
+      end
+    end
+  end
+
   defp find_user_index_in_list(view, user) do
     Floki.parse_fragment!(render(view))
     |> Floki.find("#project-users-form tbody tr")

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2543,6 +2543,164 @@ defmodule LightningWeb.ProjectLiveTest do
         end
       end
     end
+
+    test "only authorized users can remove a collaborator", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:viewer, :editor]) do
+        project_user =
+          insert(:project_user,
+            project: project,
+            user: build(:user),
+            role: :viewer
+          )
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        tooltip =
+          element(view, "#remove_project_user_#{project_user.id}_button-tooltip")
+
+        assert has_element?(tooltip)
+        assert render(tooltip) =~ "You do not have permission to remove a user"
+
+        # modal is not present
+        refute has_element?(view, "#remove_#{project_user.id}_modal")
+
+        # try sending the event either way
+        html =
+          render_click(view, "remove_project_user", %{
+            "project_user_id" => project_user.id
+          })
+
+        assert html =~ "You are not authorized to perform this action"
+
+        # project user still exists
+        assert Repo.get(Lightning.Projects.ProjectUser, project_user.id)
+      end
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        project_user =
+          insert(:project_user,
+            project: project,
+            user: build(:user),
+            role: :viewer
+          )
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        tooltip =
+          element(view, "#remove_project_user_#{project_user.id}_button-tooltip")
+
+        refute has_element?(tooltip)
+
+        # modal is present
+        assert has_element?(view, "#remove_#{project_user.id}_modal")
+
+        # try clicking the confirm button
+        html =
+          view
+          |> element("#remove_#{project_user.id}_modal_confirm_button")
+          |> render_click()
+
+        refute html =~ "You are not authorized to perform this action"
+        assert html =~ "Collaborator removed successfully!"
+
+        # project user is removed
+        refute Repo.get(Lightning.Projects.ProjectUser, project_user.id)
+        # user is not deleted
+        assert Repo.get(Lightning.Accounts.User, project_user.user_id)
+      end
+    end
+
+    test "removing an owner project user is not allowed",
+         %{
+           conn: conn
+         } do
+      project = insert(:project)
+
+      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        project_user =
+          insert(:project_user,
+            project: project,
+            user: build(:user),
+            role: :owner
+          )
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        tooltip =
+          element(view, "#remove_project_user_#{project_user.id}_button-tooltip")
+
+        assert has_element?(tooltip)
+        assert render(tooltip) =~ "You cannot remove an owner"
+
+        # modal is not present
+        refute has_element?(view, "#remove_#{project_user.id}_modal")
+
+        # try sending the event either way
+        html =
+          render_click(view, "remove_project_user", %{
+            "project_user_id" => project_user.id
+          })
+
+        assert html =~ "You are not authorized to perform this action"
+
+        # project user still exists
+        assert Repo.get(Lightning.Projects.ProjectUser, project_user.id)
+      end
+    end
+
+    test "users cannot remove themselves",
+         %{
+           conn: conn
+         } do
+      project = insert(:project)
+
+      for {conn, user} <- setup_project_users(conn, project, [:owner, :admin]) do
+        project_user =
+          Repo.get_by(Lightning.Projects.ProjectUser, user_id: user.id)
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#collaboration"
+          )
+
+        tooltip =
+          element(view, "#remove_project_user_#{project_user.id}_button-tooltip")
+
+        assert has_element?(tooltip)
+        assert render(tooltip) =~ "You cannot remove yourself"
+
+        # modal is not present
+        refute has_element?(view, "#remove_#{project_user.id}_modal")
+
+        # try sending the event either way
+        html =
+          render_click(view, "remove_project_user", %{
+            "project_user_id" => project_user.id
+          })
+
+        assert html =~ "You are not authorized to perform this action"
+
+        # project user still exists
+        assert Repo.get(Lightning.Projects.ProjectUser, project_user.id)
+      end
+    end
   end
 
   defp find_user_index_in_list(view, user) do

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -131,6 +131,7 @@ defmodule Lightning.Factories do
       email: sequence(:email, &"email-#{&1}@example.com"),
       password: "hello world!",
       first_name: "anna",
+      last_name: sequence(:name, &"last-name-#{&1}"),
       hashed_password: Bcrypt.hash_pwd_salt("hello world!")
     }
   end


### PR DESCRIPTION
## Validation Steps

https://github.com/OpenFn/lightning/assets/39288959/2cab9955-d88b-445b-a6a2-901c95f94bc3

### Checklist

- [x] the button to open the modal is `disabled` for `viewer` and `editor`
- [x] when there is a single row for the inputs, the button to `remove collaborator` is `hidden`
- [x] an error text is displayed when you add a nonexistent user
- [x] an error text is displayed if the user is already part of the project
- [x] you cannot add an `owner` role
- [x] saves successfully if the user exists and is not part of the project 


## Notes for the reviewer

The implementation has been inspired by [this liveview example](https://hexdocs.pm/phoenix_live_view/0.20.12/Phoenix.Component.html#inputs_for/1-dynamically-adding-and-removing-inputs)

- Used an `embedded_schema` named `CollaboratorProject` for use in the form. This tries to mirror the `Project -> ProjectUser` relation. I couldn't come up with a better name, any ideas are welcome. EDIT: This has been renamed to `Collaborators`
- The add more/ remove buttons are working seamlessly with the help of `:drop_param` and `:sort_param` options for [Ecto.Changeset.cast_embed/3](https://hexdocs.pm/ecto/3.11.1/Ecto.Changeset.html#cast_embed/3)
- Found a refactor opportunity in the `ProjectUsers` `Policies` module. Potentially reduces the trips to the database.

## Related issue

Fixes #1836 
Fixes #1837 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
