### PR TITLE
Generate dummy jobs for report dates

### DIFF
--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -2,27 +2,22 @@ defmodule Lightning.UsageTracking do
   @moduledoc """
   The UsageTracking context.
   """
+  import Ecto.Query
+
   alias Lightning.Repo
   alias Lightning.UsageTracking.DailyReportConfiguration
+  alias Lightning.UsageTracking.Report
+  alias Lightning.UsageTracking.ReportWorker
 
   def enable_daily_report(enabled_at) do
     start_reporting_after = DateTime.to_date(enabled_at)
 
     case Repo.one(DailyReportConfiguration) do
       config = %{tracking_enabled_at: nil, start_reporting_after: nil} ->
-        config
-        |> DailyReportConfiguration.changeset(%{
-          tracking_enabled_at: enabled_at,
-          start_reporting_after: start_reporting_after
-        })
-        |> Repo.update!()
+        enable_config(config, enabled_at, start_reporting_after)
 
       nil ->
-        %DailyReportConfiguration{
-          tracking_enabled_at: enabled_at,
-          start_reporting_after: start_reporting_after
-        }
-        |> Repo.insert!()
+        create_enabled_config(enabled_at, start_reporting_after)
 
       config ->
         config
@@ -38,5 +33,122 @@ defmodule Lightning.UsageTracking do
       })
       |> Repo.update!()
     end
+  end
+
+  defp create_enabled_config(enabled_at, start_reporting_after) do
+    %DailyReportConfiguration{
+      tracking_enabled_at: enabled_at,
+      start_reporting_after: start_reporting_after
+    }
+    |> Repo.insert!()
+  end
+
+  defp enable_config(config, enabled_at, start_reporting_after) do
+    config
+    |> DailyReportConfiguration.changeset(%{
+      tracking_enabled_at: enabled_at,
+      start_reporting_after: start_reporting_after
+    })
+    |> Repo.update!()
+  end
+
+  def start_reporting_after(date) do
+    case Repo.one(DailyReportConfiguration) do
+      %{tracking_enabled_at: nil} ->
+        :error
+
+      nil ->
+        :error
+
+      config ->
+        config
+        |> DailyReportConfiguration.changeset(%{start_reporting_after: date})
+        |> Repo.update!()
+
+        :ok
+    end
+  end
+
+  def reportable_dates(start_after, today, batch_size) do
+    case Date.diff(today, start_after) do
+      diff when diff > 2 ->
+        build_reportable_dates(start_after, today, batch_size)
+
+      _too_small_a_diff ->
+        []
+    end
+  end
+
+  defp build_reportable_dates(start_after, today, batch_size) do
+    start_after
+    |> candidate_dates(today)
+    |> remove_existing_dates()
+    |> Enum.take(batch_size)
+  end
+
+  defp candidate_dates(start_after, today) do
+    start_date = start_after |> Date.add(1)
+    end_date = today |> Date.add(-1)
+
+    Date.range(start_date, end_date)
+  end
+
+  defp remove_existing_dates(candidate_dates) do
+    candidate_dates
+    |> MapSet.new()
+    |> MapSet.difference(existing_report_dates(candidate_dates))
+  end
+
+  defp existing_report_dates(candidate_dates) do
+    [start_date, end_date] = find_boundaries(candidate_dates)
+
+    query =
+      from r in Report,
+        where: r.report_date >= ^start_date and r.report_date < ^end_date,
+        select: r.report_date,
+        order_by: [asc: r.report_date]
+
+    Repo.all(query) |> MapSet.new()
+  end
+
+  defp find_boundaries(date_range) do
+    date_range
+    |> Enum.to_list()
+    |> then(fn [start | other_dates] -> [start, other_dates] end)
+    |> then(fn [start, dates] -> [start, hd(Enum.reverse(dates))] end)
+  end
+
+  def enqueue_reports(true = _enabled, reference_time, batch_size) do
+    %{start_reporting_after: start_after} =
+      enable_daily_report(reference_time)
+
+    today = DateTime.to_date(reference_time)
+
+    start_after
+    |> reportable_dates(today, batch_size)
+    |> update_configuration()
+    |> Enum.each(&enqueue/1)
+
+    :ok
+  end
+
+  def enqueue_reports(false = _enabled, _reference_time, _batch_size) do
+    disable_daily_report()
+
+    :ok
+  end
+
+  defp update_configuration([earliest_report_date | _other] = dates) do
+    start_reporting_after = Date.add(earliest_report_date, -1)
+
+    start_reporting_after(start_reporting_after)
+
+    dates
+  end
+
+  defp update_configuration([] = dates), do: dates
+
+  defp enqueue(date) do
+    Oban.insert(Lightning.Oban, ReportWorker.new(%{date: date}))
   end
 end

--- a/lib/lightning/usage_tracking/day_worker.ex
+++ b/lib/lightning/usage_tracking/day_worker.ex
@@ -10,14 +10,12 @@ defmodule Lightning.UsageTracking.DayWorker do
   alias Lightning.UsageTracking
 
   @impl Oban.Worker
-  def perform(_opts) do
-    env = Application.get_env(:lightning, :usage_tracking)
-
-    if env[:enabled] do
-      UsageTracking.enable_daily_report(DateTime.utc_now())
-    else
-      UsageTracking.disable_daily_report()
-    end
+  def perform(%{args: %{"batch_size" => batch_size}}) do
+    UsageTracking.enqueue_reports(
+      Application.get_env(:lightning, :usage_tracking)[:enabled],
+      DateTime.utc_now(),
+      batch_size
+    )
 
     :ok
   end

--- a/lib/lightning/usage_tracking/report.ex
+++ b/lib/lightning/usage_tracking/report.ex
@@ -10,6 +10,7 @@ defmodule Lightning.UsageTracking.Report do
     field :data, :map
     field :submitted, :boolean
     field :submitted_at, :utc_datetime_usec
+    field :report_date, :date
 
     timestamps()
   end

--- a/lib/lightning/usage_tracking/report_worker.ex
+++ b/lib/lightning/usage_tracking/report_worker.ex
@@ -1,0 +1,17 @@
+defmodule Lightning.UsageTracking.ReportWorker do
+  @moduledoc """
+  Worker to generate report for given day
+
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 1
+
+  require Logger
+  @impl Oban.Worker
+  def perform(%{args: %{"date" => date}}) do
+    Logger.info("ReportWorker was asked to report on #{date}")
+
+    :ok
+  end
+end

--- a/priv/repo/migrations/20240305125958_add_report_date_to_usage_tracking_reports.exs
+++ b/priv/repo/migrations/20240305125958_add_report_date_to_usage_tracking_reports.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddReportDateToUsageTrackingReports do
+  use Ecto.Migration
+
+  def change do
+    alter table(:usage_tracking_reports) do
+      add :report_date, :date, null: true
+    end
+  end
+end

--- a/test/lightning/usage_tracking/day_worker_test.exs
+++ b/test/lightning/usage_tracking/day_worker_test.exs
@@ -7,40 +7,63 @@ defmodule Lightning.UsageTracking.DayWorkerTest do
   alias Lightning.UsageTracking
   alias Lightning.UsageTracking.DailyReportConfiguration
   alias Lightning.UsageTracking.DayWorker
+  alias Lightning.UsageTracking.ReportWorker
 
-  describe "tracking is enabled" do
+  @batch_size 4
+  @range_in_days 7
+
+  describe "perform/1 without reference time & tracking enabled" do
+    # These tests have some tolerance built in when dealing with times
+    # to prevent the tests flickering - e.g if .utc_now() changes during
+    # the execution of the test
     setup do
       put_temporary_env(:lightning, :usage_tracking, enabled: true)
     end
 
     test "enables the configuration" do
-      DayWorker.perform(%{})
+      perform_job(DayWorker, %{batch_size: @batch_size})
 
       %{tracking_enabled_at: enabled_at} = Repo.one(DailyReportConfiguration)
 
-      assert DateTime.diff(DateTime.utc_now(), enabled_at, :second) < 5
+      assert DateTime.diff(DateTime.utc_now(), enabled_at, :second) < 2
+    end
+
+    test "does not enqueue more jobs than the batch size" do
+      assert @batch_size < @range_in_days - 1
+
+      enabled_at = DateTime.add(DateTime.utc_now(), -@range_in_days, :day)
+
+      UsageTracking.enable_daily_report(enabled_at)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(DayWorker, %{batch_size: @batch_size})
+      end)
+
+      assert length(all_enqueued(worker: ReportWorker)) == @batch_size
     end
 
     test "returns :ok" do
-      assert DayWorker.perform(%{}) == :ok
+      assert(perform_job(DayWorker, %{batch_size: @batch_size}) == :ok)
     end
   end
 
-  describe "tracking is not enabled" do
+  describe "perform/1 without reference time passed in - tracking is disabled" do
     setup do
       put_temporary_env(:lightning, :usage_tracking, enabled: false)
+
+      UsageTracking.enable_daily_report(DateTime.utc_now())
+
+      :ok
     end
 
     test "disables the configuration" do
-      UsageTracking.enable_daily_report(DateTime.utc_now())
-
-      DayWorker.perform(%{})
+      perform_job(DayWorker, %{batch_size: @batch_size})
 
       assert %{tracking_enabled_at: nil} = Repo.one(DailyReportConfiguration)
     end
 
     test "returns :ok" do
-      assert DayWorker.perform(%{}) == :ok
+      assert(perform_job(DayWorker, %{batch_size: @batch_size}) == :ok)
     end
   end
 end

--- a/test/lightning/usage_tracking/worker_test.exs
+++ b/test/lightning/usage_tracking/worker_test.exs
@@ -58,7 +58,7 @@ defmodule Lightning.UsageTracking.WorkerTest do
       report = Report |> Repo.one()
 
       assert %Report{submitted: true} = report
-      assert DateTime.utc_now() > report.submitted_at
+      assert DateTime.diff(DateTime.utc_now(), report.submitted_at, :second) < 2
       assert_data_populated(report)
     end
 

--- a/test/lightning/usage_tracking_test.exs
+++ b/test/lightning/usage_tracking_test.exs
@@ -4,6 +4,7 @@ defmodule Lightning.UsageTrackingTest do
   alias Lightning.Repo
   alias Lightning.UsageTracking
   alias Lightning.UsageTracking.DailyReportConfiguration
+  alias Lightning.UsageTracking.ReportWorker
 
   describe ".enable_daily_report/1 - no configuration exists" do
     setup do
@@ -147,7 +148,7 @@ defmodule Lightning.UsageTrackingTest do
     end
   end
 
-  describe "disable_daily_report/1 - record exists" do
+  describe ".disable_daily_report/1 - record exists" do
     setup do
       {:ok, existing_tracking_enabled_at, _offset} =
         DateTime.from_iso8601("2024-02-01T10:10:10.000000Z")
@@ -195,9 +196,362 @@ defmodule Lightning.UsageTrackingTest do
     end
   end
 
-  describe "disable_daily_report/1 - no record exists" do
+  describe ".disable_daily_report/1 - no record exists" do
     test "returns nil" do
       assert UsageTracking.disable_daily_report() == nil
+    end
+  end
+
+  describe ".start_reporting_after/1 - enabled configuration exists" do
+    setup do
+      %DailyReportConfiguration{
+        tracking_enabled_at: DateTime.utc_now(),
+        start_reporting_after: ~D[2024-03-01]
+      }
+      |> Repo.insert!()
+
+      %{date: ~D[2024-03-05]}
+    end
+
+    test "updates the start_reporting_after date", %{date: date} do
+      UsageTracking.start_reporting_after(date)
+
+      assert %{start_reporting_after: ^date} =
+               Repo.one!(DailyReportConfiguration)
+    end
+
+    test "returns :ok", %{date: date} do
+      assert UsageTracking.start_reporting_after(date) == :ok
+    end
+  end
+
+  describe ".start_reporting_after/1 - no configuration exists" do
+    setup do
+      %{date: ~D[2024-03-05]}
+    end
+
+    test "does nothing", %{date: date} do
+      UsageTracking.start_reporting_after(date)
+
+      assert Repo.one(DailyReportConfiguration) == nil
+    end
+
+    test "returns :error", %{date: date} do
+      assert UsageTracking.start_reporting_after(date) == :error
+    end
+  end
+
+  describe ".start_reporting_after/1 - disabled configuration exists" do
+    setup do
+      existing_date = ~D[2024-03-01]
+
+      %DailyReportConfiguration{
+        tracking_enabled_at: nil,
+        start_reporting_after: existing_date
+      }
+      |> Repo.insert!()
+
+      %{date: ~D[2024-03-05], existing_date: existing_date}
+    end
+
+    test "does not update the record", config do
+      %{date: date, existing_date: existing_date} = config
+
+      UsageTracking.start_reporting_after(date)
+
+      assert %{
+               tracking_enabled_at: nil,
+               start_reporting_after: ^existing_date
+             } = Repo.one!(DailyReportConfiguration)
+    end
+
+    test "returns :error", %{date: date} do
+      assert UsageTracking.start_reporting_after(date) == :error
+    end
+  end
+
+  describe ".reportable_dates/1" do
+    setup do
+      %{batch_size: 10}
+    end
+
+    test "returns range of reportable dates between the boundary dates", %{
+      batch_size: batch_size
+    } do
+      start_after = ~D[2024-02-12]
+      today = ~D[2024-02-20]
+
+      expected_dates = [
+        ~D[2024-02-13],
+        ~D[2024-02-14],
+        ~D[2024-02-15],
+        ~D[2024-02-16],
+        ~D[2024-02-17],
+        ~D[2024-02-18],
+        ~D[2024-02-19]
+      ]
+
+      dates = UsageTracking.reportable_dates(start_after, today, batch_size)
+
+      assert dates == expected_dates
+    end
+
+    test "returns empty list if no reportable dates", %{
+      batch_size: batch_size
+    } do
+      start_after = ~D[2024-02-19]
+      today = ~D[2024-02-20]
+
+      assert UsageTracking.reportable_dates(start_after, today, batch_size) == []
+    end
+
+    test "returns empty list if start_after is today", %{
+      batch_size: batch_size
+    } do
+      start_after = ~D[2024-02-20]
+      today = ~D[2024-02-20]
+
+      assert UsageTracking.reportable_dates(start_after, today, batch_size) == []
+    end
+
+    test "returns empty list if start_after is after today", %{
+      batch_size: batch_size
+    } do
+      start_after = ~D[2024-02-21]
+      today = ~D[2024-02-20]
+
+      assert UsageTracking.reportable_dates(start_after, today, batch_size) == []
+    end
+
+    test "excludes any reportable days for which reports exist", %{
+      batch_size: batch_size
+    } do
+      start_after = ~D[2024-02-12]
+      today = ~D[2024-02-20]
+
+      _before_start =
+        insert(:usage_tracking_report, report_date: ~D[2024-02-11])
+
+      _exclude_date_1 =
+        insert(:usage_tracking_report, report_date: ~D[2024-02-17])
+
+      _exclude_date_2 =
+        insert(:usage_tracking_report, report_date: ~D[2024-02-14])
+
+      _nil_date =
+        insert(:usage_tracking_report, report_date: nil)
+
+      expected_dates = [
+        ~D[2024-02-13],
+        ~D[2024-02-15],
+        ~D[2024-02-16],
+        ~D[2024-02-18],
+        ~D[2024-02-19]
+      ]
+
+      dates = UsageTracking.reportable_dates(start_after, today, batch_size)
+
+      assert dates == expected_dates
+    end
+
+    test "number of reportable days is constrained by batch size" do
+      start_after = ~D[2024-02-12]
+      today = ~D[2024-02-20]
+      batch_size = 3
+
+      # Use existing reports to ensure that the batching is applied to the output
+      # dates and not the input dates. The presence of these two entries will
+      # remove the first two dates from consideration for batching.
+      _batch_padding_1 =
+        insert(:usage_tracking_report, report_date: ~D[2024-02-13])
+
+      _batch_padding_2 =
+        insert(:usage_tracking_report, report_date: ~D[2024-02-14])
+
+      expected_dates = [
+        ~D[2024-02-15],
+        ~D[2024-02-16],
+        ~D[2024-02-17]
+      ]
+
+      dates = UsageTracking.reportable_dates(start_after, today, batch_size)
+
+      assert dates == expected_dates
+    end
+  end
+
+  describe ".enqueue_reports/3 - tracking is enabled" do
+    setup do
+      reference_time = DateTime.utc_now()
+      range_in_days = 7
+      batch_size = 10
+      enabled_at = DateTime.add(reference_time, -range_in_days, :day)
+
+      first_report_date =
+        enabled_at
+        |> DateTime.add(1, :day)
+        |> DateTime.to_date()
+
+      last_report_date =
+        reference_time
+        |> DateTime.add(-1, :day)
+        |> DateTime.to_date()
+
+      reportable_dates =
+        first_report_date
+        |> Date.range(last_report_date)
+        |> Enum.to_list()
+
+      %{
+        batch_size: batch_size,
+        enabled_at: enabled_at,
+        range_in_days: range_in_days,
+        reference_time: reference_time,
+        reportable_dates: reportable_dates
+      }
+    end
+
+    test "enables the configuration", %{
+      reference_time: reference_time,
+      batch_size: batch_size
+    } do
+      UsageTracking.enqueue_reports(true, reference_time, batch_size)
+
+      %{tracking_enabled_at: enabled_at} = Repo.one(DailyReportConfiguration)
+
+      assert DateTime.diff(DateTime.utc_now(), enabled_at, :second) < 5
+    end
+
+    test "enqueues jobs to process outstanding days", %{
+      batch_size: batch_size,
+      enabled_at: enabled_at,
+      reference_time: reference_time,
+      reportable_dates: reportable_dates
+    } do
+      UsageTracking.enable_daily_report(enabled_at)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        UsageTracking.enqueue_reports(true, reference_time, batch_size)
+      end)
+
+      for date <- reportable_dates do
+        assert_enqueued(worker: ReportWorker, args: %{date: date})
+      end
+    end
+
+    test "does not enqueue more than the batch size", %{
+      enabled_at: enabled_at,
+      reference_time: reference_time,
+      reportable_dates: reportable_dates
+    } do
+      batch_size = length(reportable_dates) - 2
+      included_dates = reportable_dates |> Enum.take(batch_size)
+      excluded_dates = reportable_dates |> Enum.take(-2)
+
+      UsageTracking.enable_daily_report(enabled_at)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        UsageTracking.enqueue_reports(true, reference_time, batch_size)
+
+        for date <- included_dates do
+          assert_enqueued(worker: ReportWorker, args: %{date: date})
+        end
+
+        for date <- excluded_dates do
+          refute_enqueued(worker: ReportWorker, args: %{date: date})
+        end
+      end)
+    end
+
+    test "updates the config based on reportable dates", %{
+      batch_size: batch_size,
+      enabled_at: enabled_at,
+      reference_time: reference_time,
+      reportable_dates: reportable_dates
+    } do
+      [report_date_1 | [report_date_2 | _other_dates]] = reportable_dates
+
+      # Add some existing reports so that the start_reporting_after will take
+      # these into account
+      insert(:usage_tracking_report, report_date: report_date_1)
+      insert(:usage_tracking_report, report_date: report_date_2)
+
+      UsageTracking.enable_daily_report(enabled_at)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        UsageTracking.enqueue_reports(true, reference_time, batch_size)
+      end)
+
+      report_config = DailyReportConfiguration |> Repo.one!()
+
+      assert report_config.start_reporting_after == report_date_2
+    end
+
+    test "does not update config if there are no reportable dates", %{
+      batch_size: batch_size,
+      reference_time: reference_time
+    } do
+      enabled_at = DateTime.add(reference_time, -1, :day)
+
+      %{start_reporting_after: existing_date} =
+        UsageTracking.enable_daily_report(enabled_at)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        UsageTracking.enqueue_reports(true, reference_time, batch_size)
+      end)
+
+      report_config = DailyReportConfiguration |> Repo.one!()
+
+      assert report_config.start_reporting_after == existing_date
+    end
+
+    test "returns :ok", %{
+      batch_size: batch_size,
+      reference_time: reference_time
+    } do
+      assert UsageTracking.enqueue_reports(
+               true,
+               reference_time,
+               batch_size
+             ) == :ok
+    end
+  end
+
+  describe ".enqueue_reports/3 - tracking is disabled" do
+    setup do
+      batch_size = 10
+      reference_time = DateTime.utc_now()
+
+      UsageTracking.enable_daily_report(reference_time)
+
+      %{
+        batch_size: batch_size,
+        reference_time: reference_time
+      }
+    end
+
+    test "disables the configuration", %{
+      batch_size: batch_size,
+      reference_time: reference_time
+    } do
+      assert UsageTracking.enqueue_reports(
+               false,
+               reference_time,
+               batch_size
+             )
+
+      %{tracking_enabled_at: nil} = Repo.one(DailyReportConfiguration)
+    end
+
+    test "returns :ok", %{
+      batch_size: batch_size,
+      reference_time: reference_time
+    } do
+      assert UsageTracking.enqueue_reports(
+               false,
+               reference_time,
+               batch_size
+             ) == :ok
     end
   end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -151,6 +151,17 @@ defmodule Lightning.Factories do
     %Lightning.UsageTracking.DailyReportConfiguration{}
   end
 
+  def usage_tracking_report_factory do
+    now = DateTime.utc_now()
+
+    %Lightning.UsageTracking.Report{
+      data: %{},
+      submitted: true,
+      submitted_at: now,
+      report_date: DateTime.to_date(now)
+    }
+  end
+
   # ----------------------------------------------------------------------------
   # Helpers
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Validation Steps

This code introduces the functionality that identifies which reports need to be reported on and enqueues jobs to process these days. The report job will just log that it has received a request to process a date and (for now) do nothing further.

Therefore, to test, run the following in IEx:

```
Lightning.UsageTracking.disable_daily_report()
Lightning.UsageTracking.enable_daily_report(~U[2024-03-07 12:00:00Z])
Lightning.UsageTracking.DayWorker.perform(%Oban.Job{args: %{"batch_size" => 5}})
```

You should then see the ReportWorker jobs report the following:

```
....
[info] ReportWorker was asked to report on 2024-03-08
[info] ReportWorker was asked to report on 2024-03-09
[info] ReportWorker was asked to report on 2024-03-10
[info] ReportWorker was asked to report on 2024-03-11
[info] ReportWorker was asked to report on 2024-03-12
```

## Notes for the reviewer

Code Coverage is complaining as I have one line that is not covered in the ReportWorker. As this line simply writes to the log for debugging purposes (and the validation steps listed above) and will be replaced by working code in the next PR, I would argue that a test is not required in this case.

## Related issue

#1853 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
