### PR TITLE
Fix date sorting bug when crossing year boundary

### DIFF
--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -83,6 +83,7 @@ defmodule Lightning.UsageTracking do
     start_after
     |> candidate_dates(today)
     |> remove_existing_dates()
+    |> Enum.sort(Date)
     |> Enum.take(batch_size)
   end
 


### PR DESCRIPTION
## Validation Steps

This change fixes a bug in the creation of report dates when the start and end date of a range span a year boundary. To test from IEx:

```
Lightning.UsageTracking.disable_daily_report()
Lightning.UsageTracking.enable_daily_report(~U[2023-12-25 12:00:00Z])
Lightning.UsageTracking.DayWorker.perform(%Oban.Job{args: %{"batch_size" => 10}})
```

You should see the following reports as `ReportWorker` instances are run. The sequence may differ depending on how Oban picks them up from the queue, but what is critical is that the jobs *only* represent the sequence of 10 days:

```
...
[info] ReportWorker was asked to report on 2023-12-26
...
[info] ReportWorker was asked to report on 2023-12-27
...
[info] ReportWorker was asked to report on 2023-12-28
...
[info] ReportWorker was asked to report on 2023-12-29
...
[info] ReportWorker was asked to report on 2023-12-30
...
[info] ReportWorker was asked to report on 2023-12-31
...
[info] ReportWorker was asked to report on 2024-01-01
...
[info] ReportWorker was asked to report on 2024-01-02
...
[info] ReportWorker was asked to report on 2024-01-03
...
[info] ReportWorker was asked to report on 2024-01-04
...
```

## Notes for the reviewer


## Related issue

#1853 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
