### PR TITLE
Allow users to connect to their GitHub accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ and this project adheres to
 
 ### Added
 
-### Changed
+- Enable users to connect to their Github accounts
+  [#1894](https://github.com/OpenFn/lightning/issues/1894)
 
-- Support for smaller screens on history and inspector.
-  [#1908](https://github.com/OpenFn/lightning/issues/1908)
+### Changed
 
 ### Fixed
 
@@ -70,8 +70,8 @@ and this project adheres to
 
 ### Added
 
-- Enable users to connect to their Github accounts
-  [#1894](https://github.com/OpenFn/lightning/issues/1894)
+- Support for smaller screens on history and inspector.
+  [#1908](https://github.com/OpenFn/lightning/issues/1908)
 - Polling metric to track number of available runs.
   [#1790](https://github.com/OpenFn/lightning/issues/1790)
 - Allows limiting creation of new runs and retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to
 
 ### Added
 
-- Enable users to connect to their Github accounts
+- Enable users to connect to their Github accounts in preparation for
+  streamlined GitHub project sync setup
   [#1894](https://github.com/OpenFn/lightning/issues/1894)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Support for smaller screens on history and inspector.
+  [#1908](https://github.com/OpenFn/lightning/issues/1908)
+
 ### Fixed
 
 ## [v2.2.0] - 2024-03-21
@@ -67,8 +70,8 @@ and this project adheres to
 
 ### Added
 
-- Support for smaller screens on history and inspector.
-  [#1908](https://github.com/OpenFn/lightning/issues/1908)
+- Enable users to connect to their Github accounts
+  [#1894](https://github.com/OpenFn/lightning/issues/1894)
 - Polling metric to track number of available runs.
   [#1790](https://github.com/OpenFn/lightning/issues/1790)
 - Allows limiting creation of new runs and retries.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,12 +68,24 @@ github_app_id =
 github_app_name =
   System.get_env("GITHUB_APP_NAME") ||
     Application.get_env(:lightning, :github_app, [])
-    |> Keyword.get(:app_id, nil)
+    |> Keyword.get(:app_name, nil)
+
+github_app_client_id =
+  System.get_env("GITHUB_APP_CLIENT_ID") ||
+    Application.get_env(:lightning, :github_app, [])
+    |> Keyword.get(:client_id, nil)
+
+github_app_client_secret =
+  System.get_env("GITHUB_APP_CLIENT_SECRET") ||
+    Application.get_env(:lightning, :github_app, [])
+    |> Keyword.get(:client_secret, nil)
 
 config :lightning, :github_app,
   cert: decoded_cert,
   app_id: github_app_id,
-  app_name: github_app_name
+  app_name: github_app_name,
+  client_id: github_app_client_id,
+  client_secret: github_app_client_secret
 
 if start_rtm = System.get_env("RTM") do
   unless start_rtm in ["true", "false"] do

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,6 +4,8 @@ import Config
 config :bcrypt_elixir, :log_rounds, 1
 
 # mock adapter for tesla
+config :tesla, adapter: Lightning.Tesla.Mock
+
 config :tesla, Lightning.VersionControl.GithubClient,
   adapter: Lightning.GithubClient.Mock
 
@@ -123,3 +125,26 @@ config :opentelemetry, :processors, [
 ]
 
 config :lightning, :is_resettable_demo, true
+
+config :lightning, :github_app,
+  app_id: "111111",
+  app_name: "test-github",
+  client_id: "abcd1234",
+  client_secret: "client1234",
+  cert: """
+  -----BEGIN RSA PRIVATE KEY-----
+  MIICWwIBAAKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw
+  33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW
+  +jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
+  AoGAD+onAtVye4ic7VR7V50DF9bOnwRwNXrARcDhq9LWNRrRGElESYYTQ6EbatXS
+  3MCyjjX2eMhu/aF5YhXBwkppwxg+EOmXeh+MzL7Zh284OuPbkglAaGhV9bb6/5Cp
+  uGb1esyPbYW+Ty2PC0GSZfIXkXs76jXAu9TOBvD0ybc2YlkCQQDywg2R/7t3Q2OE
+  2+yo382CLJdrlSLVROWKwb4tb2PjhY4XAwV8d1vy0RenxTB+K5Mu57uVSTHtrMK0
+  GAtFr833AkEA6avx20OHo61Yela/4k5kQDtjEf1N0LfI+BcWZtxsS3jDM3i1Hp0K
+  Su5rsCPb8acJo5RO26gGVrfAsDcIXKC+bQJAZZ2XIpsitLyPpuiMOvBbzPavd4gY
+  6Z8KWrfYzJoI/Q9FuBo6rKwl4BFoToD7WIUS+hpkagwWiz+6zLoX1dbOZwJACmH5
+  fSSjAkLRi54PKJ8TFUeOP15h9sQzydI8zJU+upvDEKZsZc/UhT/SySDOxQ4G/523
+  Y0sz/OZtSWcol/UMgQJALesy++GdvoIDLfJX5GBQpuFgFenRiRDabxrE9MNUZ2aP
+  FaFp+DyAe+b4nDwuJaW2LURbr8AEZga7oQj0uYxcYw==
+  -----END RSA PRIVATE KEY-----
+  """

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -263,6 +263,12 @@ defmodule Lightning.Accounts.User do
     change(user, confirmed_at: now)
   end
 
+  def github_token_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:github_oauth_token])
+    |> validate_required([:github_oauth_token])
+  end
+
   @doc """
   Verifies the password.
 

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -32,6 +32,7 @@ defmodule Lightning.Accounts.User do
     field :disabled, :boolean, default: false
     field :mfa_enabled, :boolean, default: false
     field :scheduled_deletion, :utc_datetime
+    field :github_oauth_token, Lightning.Encrypted.Map, redact: true
 
     has_one :user_totp, Lightning.Accounts.UserTOTP
     has_many :credentials, Lightning.Credentials.Credential

--- a/lib/lightning/version_control/events.ex
+++ b/lib/lightning/version_control/events.ex
@@ -1,0 +1,31 @@
+defmodule Lightning.VersionControl.Events do
+  defmodule OauthTokenAdded do
+    @moduledoc false
+    defstruct user: nil
+  end
+
+  defmodule OauthTokenFailed do
+    @moduledoc false
+    defstruct [:user, :error_response]
+  end
+
+  def oauth_token_added(user) do
+    Lightning.broadcast(
+      topic(user.id),
+      %OauthTokenAdded{user: user}
+    )
+  end
+
+  def oauth_token_failed(user, error_resp) do
+    Lightning.broadcast(
+      topic(user.id),
+      %OauthTokenFailed{user: user, error_response: error_resp}
+    )
+  end
+
+  def subscribe(%Lightning.Accounts.User{id: id}) do
+    Lightning.subscribe(topic(id))
+  end
+
+  defp topic(id), do: "version_control_events:#{id}"
+end

--- a/lib/lightning/version_control/github_client.ex
+++ b/lib/lightning/version_control/github_client.ex
@@ -70,6 +70,25 @@ defmodule Lightning.VersionControl.GithubClient do
     delete(client, "/repos/#{repo}/git/refs/#{ref}")
   end
 
+  def delete_app_grant(client, app_client_id, token) do
+    delete(client, "/applications/#{app_client_id}/grant",
+      body: %{access_token: token}
+    )
+  end
+
+  def build_oauth_client do
+    middleware = [
+      {Tesla.Middleware.BaseUrl, "https://github.com/login/oauth"},
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Headers,
+       [
+         {"accept", "application/vnd.github+json"}
+       ]}
+    ]
+
+    Tesla.client(middleware)
+  end
+
   def build_client(installation_id) do
     %{cert: cert, app_id: app_id} =
       Application.get_env(:lightning, :github_app)

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -8,8 +8,8 @@ defmodule Lightning.VersionControl do
 
   import Ecto.Query, warn: false
 
-  alias Lightning.Repo
   alias Lightning.Accounts.User
+  alias Lightning.Repo
   alias Lightning.VersionControl.Events
   alias Lightning.VersionControl.GithubClient
   alias Lightning.VersionControl.GithubError

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -275,6 +275,8 @@ defmodule Lightning.VersionControl do
     ])
   end
 
+  @spec save_oauth_token(User.t(), map(), notify: boolean()) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def save_oauth_token(%User{} = user, token, opts \\ [notify: true]) do
     token =
       token

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -142,9 +142,9 @@ defmodule Lightning.VersionControl do
       code: code
     ]
 
-    client = GithubClient.build_oauth_client()
+    tesla_client = GithubClient.build_oauth_client()
 
-    case Tesla.post(client, "/access_token", %{}, query: query_params) do
+    case Tesla.post(tesla_client, "/access_token", %{}, query: query_params) do
       {:ok, %{body: %{"access_token" => _} = body}} ->
         {:ok, body}
 
@@ -217,14 +217,10 @@ defmodule Lightning.VersionControl do
   # token that expires
   def fetch_user_access_token(
         %User{
-          github_oauth_token: %{"refresh_token_expires_at" => _expiry} = token
+          github_oauth_token: %{"refresh_token_expires_at" => _expiry}
         } = user
       ) do
-    if oauth_token_valid?(token) do
-      maybe_refresh_access_token(user)
-    else
-      {:error, :expired}
-    end
+    maybe_refresh_access_token(user)
   end
 
   # token that doesn't expire

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -142,9 +142,9 @@ defmodule Lightning.VersionControl do
       code: code
     ]
 
-    tesla_client = GithubClient.build_oauth_client()
-
-    case Tesla.post(tesla_client, "/access_token", %{}, query: query_params) do
+    GithubClient.build_oauth_client()
+    |> Tesla.post("/access_token", %{}, query: query_params)
+    |> case do
       {:ok, %{body: %{"access_token" => _} = body}} ->
         {:ok, body}
 

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -213,7 +213,7 @@ defmodule Lightning.VersionControl do
   If the access token has expired, it `refreshes` the token and updates the `User` column accordingly
   """
   @spec fetch_user_access_token(User.t()) ::
-          {:ok, String.t()} | {:error, :expired | map()}
+          {:ok, String.t()} | {:error, map()}
   # token that expires
   def fetch_user_access_token(
         %User{

--- a/lib/lightning_web/controllers/oauth_controller.ex
+++ b/lib/lightning_web/controllers/oauth_controller.ex
@@ -6,9 +6,9 @@ defmodule LightningWeb.OauthController do
 
   def new(conn, %{"provider" => "github", "code" => code}) do
     if user = conn.assigns.current_user do
-      case VersionControl.fetch_github_oauth_token(code) do
+      case VersionControl.exchange_code_for_oauth_token(code) do
         {:ok, token} ->
-          VersionControl.save_github_oauth_token(user, token)
+          VersionControl.save_oauth_token(user, token)
 
         {:error, reason} ->
           VersionControl.Events.oauth_token_failed(user, reason)

--- a/lib/lightning_web/controllers/oauth_controller.ex
+++ b/lib/lightning_web/controllers/oauth_controller.ex
@@ -1,0 +1,30 @@
+defmodule LightningWeb.OauthController do
+  use LightningWeb, :controller
+  alias Lightning.VersionControl
+
+  plug :fetch_current_user
+
+  def new(conn, %{"provider" => "github", "code" => code}) do
+    if user = conn.assigns.current_user do
+      case VersionControl.fetch_github_oauth_token(code) do
+        {:ok, token} ->
+          VersionControl.save_github_oauth_token(user, token)
+
+        {:error, reason} ->
+          VersionControl.Events.oauth_token_failed(user, reason)
+      end
+    end
+
+    html(conn, """
+      <html>
+        <body>
+          <script type="text/javascript">
+            window.onload = function() {
+              window.close();
+            }
+          </script>
+        </body>
+      </html>
+    """)
+  end
+end

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -3,11 +3,14 @@ defmodule LightningWeb.ProfileLive.Edit do
   LiveView for user profile page.
   """
   use LightningWeb, :live_view
+  alias LightningWeb.OauthCredentialHelper
 
   on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def mount(_params, _session, socket) do
+    # for github oauth setup
+    OauthCredentialHelper.subscribe("profile:#{socket.assigns.current_user.id}")
     {:ok, socket |> assign(:active_menu_item, :profile)}
   end
 
@@ -19,6 +22,11 @@ defmodule LightningWeb.ProfileLive.Edit do
        socket.assigns.live_action,
        params
      )}
+  end
+
+  def handle_info({:forward, mod, opts}, socket) do
+    send_update(mod, opts)
+    {:noreply, socket}
   end
 
   defp apply_action(socket, :edit, _params) do

--- a/lib/lightning_web/live/profile_live/edit.ex
+++ b/lib/lightning_web/live/profile_live/edit.ex
@@ -25,13 +25,13 @@ defmodule LightningWeb.ProfileLive.Edit do
 
   @impl true
   def handle_info(
-        %Lightning.VersionControl.Events.OauthTokenAdded{user: user},
+        %Lightning.VersionControl.Events.OauthTokenAdded{},
         socket
       ) do
     {:noreply,
      socket
-     |> assign(current_user: user)
-     |> put_flash(:info, "Github account linked successfully")}
+     |> put_flash(:info, "Github account linked successfully")
+     |> push_navigate(to: ~p"/profile")}
   end
 
   def handle_info(

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -138,6 +138,12 @@
     id={"#{@user.id}_mfa_section"}
     user={@user}
   />
+
+  <.live_component
+    module={LightningWeb.ProfileLive.GithubComponent}
+    id={"#{@user.id}_github_section"}
+    user={@user}
+  />
   <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2 mb-4">
     <div class="px-4 py-6 sm:p-8">
       <span class="text-xl">Delete account</span>

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -1,7 +1,6 @@
 defmodule LightningWeb.ProfileLive.GithubComponent do
-  @moduledoc """
-  Component to enable MFA on a User's account
-  """
+  @moduledoc false
+
   use LightningWeb, :live_component
   alias Lightning.VersionControl
 
@@ -48,6 +47,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
           </span>
           <%= if token_valid?(@user.github_oauth_token) do %>
             <.button
+              id="disconnect-github-button"
               type="button"
               phx-click={show_modal("disconnect_github_modal")}
               color_class="text-white bg-danger-600 hover:bg-danger-700"

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -3,6 +3,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
   Component to enable MFA on a User's account
   """
   use LightningWeb, :live_component
+  alias Lightning.VersionControl
 
   @impl true
   def update(%{user: _user} = assigns, socket) do
@@ -10,11 +11,30 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
   end
 
   @impl true
+  def handle_event("disconnect-github", _params, socket) do
+    case VersionControl.delete_oauth_grant(socket.assigns.user) do
+      {:ok, _user} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Github connection removed successfully")
+         |> push_navigate(to: ~p"/profile")}
+
+      {:error, _error} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           "Oops! An error occured while trying to remove the connection. Please try again"
+         )}
+    end
+  end
+
+  @impl true
   def render(assigns) do
     ~H"""
     <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2 mb-4">
       <div class="px-4 py-6 sm:p-8">
-        <div class="flex items-center justify-between mb-5">
+        <div class="flex items-center justify-between mb-5 gap-5">
           <span class="flex flex-grow flex-col">
             <span
               class="text-xl font-medium leading-6 text-gray-900"
@@ -26,21 +46,34 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
               Linking your OpenFn account to your Github account allows you to manage version control across your projects.
             </span>
           </span>
-          <%= if @user.github_oauth_token do %>
-            <.button>Disconnect from Github</.button>
+          <%= if token_valid?(@user.github_oauth_token) do %>
+            <.button
+              type="button"
+              phx-click="disconnect-github"
+              phx-target={@myself}
+              color_class="text-white bg-danger-500 hover:bg-danger-700"
+            >
+              Disconnect from Github
+            </.button>
           <% else %>
             <.link
+              id="connect-github-link"
               href={"https://github.com/login/oauth/authorize?" <> build_query_params(@socket)}
               target="_blank"
               class="text-center py-2 px-4 shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 text-white"
+              {if @user.github_oauth_token, do: ["phx-hook": "Tooltip", "aria-label": "Your token has expired"], else: []}
             >
-              Connect your Github Account
+              <%= if @user.github_oauth_token, do: "Reconnect", else: "Connect" %> your Github Account
             </.link>
           <% end %>
         </div>
       </div>
     </div>
     """
+  end
+
+  defp token_valid?(token) do
+    VersionControl.oauth_token_valid?(token)
   end
 
   defp build_query_params(socket) do

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -1,0 +1,70 @@
+defmodule LightningWeb.ProfileLive.GithubComponent do
+  @moduledoc """
+  Component to enable MFA on a User's account
+  """
+  use LightningWeb, :live_component
+  alias LightningWeb.OauthCredentialHelper
+
+  @impl true
+  def update(%{user: _user} = assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  def update(%{code: code}, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2 mb-4">
+      <div class="px-4 py-6 sm:p-8">
+        <div class="flex items-center justify-between mb-5">
+          <span class="flex flex-grow flex-col">
+            <span
+              class="text-xl font-medium leading-6 text-gray-900"
+              id={"#{@id}-label"}
+            >
+              Github Access
+            </span>
+            <span class="text-sm text-gray-500" id={"#{@id}-description"}>
+              Linking your OpenFn account to your Github account allows you to manage version control across your projects.
+            </span>
+          </span>
+          <%= if @user.github_oauth_token do %>
+            <.button>Disconnect from Github</.button>
+          <% else %>
+            <.link
+              href={"https://github.com/login/oauth/authorize" <> build_query_params(@socket, assigns)}
+              target="_blank"
+              class="text-center py-2 px-4 shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 text-white"
+            >
+              Connect your Github Account
+            </.link>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp build_query_params(socket, assigns) do
+    state =
+      OauthCredentialHelper.build_state(
+        "profile:#{assigns.user.id}",
+        __MODULE__,
+        assigns.id
+      )
+
+    client_id =
+      Application.get_env(:lightning, :github_app, [])
+      |> Keyword.get(:client_id, nil)
+
+    redirect_url = Routes.oidc_url(socket, :new)
+
+    params =
+      %{state: state, client_id: client_id, redirect_uri: redirect_url} |> dbg()
+
+    Plug.Conn.Query.encode(params)
+  end
+end

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -50,7 +50,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
               id="disconnect-github-button"
               type="button"
               phx-click={show_modal("disconnect_github_modal")}
-              color_class="text-white bg-danger-600 hover:bg-danger-700"
+              color_class="text-white bg-danger-500 hover:bg-danger-700"
             >
               Disconnect from Github
             </.button>

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -12,7 +12,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
 
   @impl true
   def handle_event("disconnect-github", _params, socket) do
-    case VersionControl.delete_oauth_grant(socket.assigns.user) do
+    case VersionControl.delete_github_ouath_grant(socket.assigns.user) do
       {:ok, _user} ->
         {:noreply,
          socket
@@ -49,12 +49,15 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
           <%= if token_valid?(@user.github_oauth_token) do %>
             <.button
               type="button"
-              phx-click="disconnect-github"
-              phx-target={@myself}
-              color_class="text-white bg-danger-500 hover:bg-danger-700"
+              phx-click={show_modal("disconnect_github_modal")}
+              color_class="text-white bg-danger-600 hover:bg-danger-700"
             >
               Disconnect from Github
             </.button>
+            <.confirm_github_disconnection_modal
+              id="disconnect_github_modal"
+              myself={@myself}
+            />
           <% else %>
             <.link
               id="connect-github-link"
@@ -86,5 +89,53 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
     params = %{client_id: client_id, redirect_uri: redirect_url}
 
     Plug.Conn.Query.encode(params)
+  end
+
+  defp confirm_github_disconnection_modal(assigns) do
+    ~H"""
+    <.modal id={@id} width="max-w-md">
+      <:title>
+        <div class="flex justify-between">
+          <span class="font-bold">
+            Disconnect from GitHub?
+          </span>
+          <button
+            phx-click={hide_modal(@id)}
+            type="button"
+            class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+            aria-label={gettext("close")}
+          >
+            <span class="sr-only">Close</span>
+            <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+          </button>
+        </div>
+      </:title>
+      <div class="px-6">
+        <p class="text-sm text-gray-500">
+          You are about to disconnect your OpenFn account from GitHub.
+          Until you reconnect, you will not be able to set up or modify version control for your projects.
+        </p>
+      </div>
+      <div class="flex flex-row-reverse gap-4 mx-6 mt-2">
+        <.button
+          id={"#{@id}_confirm_button"}
+          type="button"
+          color_class="bg-red-600 hover:bg-red-700 text-white"
+          phx-disable-with="Disconnecting..."
+          phx-click="disconnect-github"
+          phx-target={@myself}
+        >
+          Disconnect
+        </.button>
+        <button
+          type="button"
+          phx-click={hide_modal(@id)}
+          class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </.modal>
+    """
   end
 end

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -53,7 +53,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
                 phx-click={show_modal("disconnect_github_modal")}
                 color_class="text-white bg-danger-500 hover:bg-danger-700"
               >
-                Disconnect from Github
+                Disconnect from GitHub
               </.button>
               <.confirm_github_disconnection_modal
                 id="disconnect_github_modal"
@@ -67,7 +67,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
                 class="text-center py-2 px-4 shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 text-white"
                 {if @user.github_oauth_token, do: ["phx-hook": "Tooltip", "aria-label": "Your token has expired"], else: []}
               >
-                <%= if @user.github_oauth_token, do: "Reconnect", else: "Connect" %> your Github Account
+                <%= if @user.github_oauth_token, do: "Reconnect", else: "Connect" %> your GitHub account
               </.link>
             <% end %>
           <% else %>
@@ -77,7 +77,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
               disabled
               tooltip="Github OAuth has not been enabled for this instance."
             >
-              Connect to GitHub
+              Connect your GitHub account
             </.button>
           <% end %>
         </div>

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -45,34 +45,50 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
               Linking your OpenFn account to your Github account allows you to manage version control across your projects.
             </span>
           </span>
-          <%= if token_valid?(@user.github_oauth_token) do %>
-            <.button
-              id="disconnect-github-button"
-              type="button"
-              phx-click={show_modal("disconnect_github_modal")}
-              color_class="text-white bg-danger-500 hover:bg-danger-700"
-            >
-              Disconnect from Github
-            </.button>
-            <.confirm_github_disconnection_modal
-              id="disconnect_github_modal"
-              myself={@myself}
-            />
+          <%= if oauth_enabled?() do %>
+            <%= if token_valid?(@user.github_oauth_token) do %>
+              <.button
+                id="disconnect-github-button"
+                type="button"
+                phx-click={show_modal("disconnect_github_modal")}
+                color_class="text-white bg-danger-500 hover:bg-danger-700"
+              >
+                Disconnect from Github
+              </.button>
+              <.confirm_github_disconnection_modal
+                id="disconnect_github_modal"
+                myself={@myself}
+              />
+            <% else %>
+              <.link
+                id="connect-github-link"
+                href={"https://github.com/login/oauth/authorize?" <> build_query_params(@socket)}
+                target="_blank"
+                class="text-center py-2 px-4 shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 text-white"
+                {if @user.github_oauth_token, do: ["phx-hook": "Tooltip", "aria-label": "Your token has expired"], else: []}
+              >
+                <%= if @user.github_oauth_token, do: "Reconnect", else: "Connect" %> your Github Account
+              </.link>
+            <% end %>
           <% else %>
-            <.link
-              id="connect-github-link"
-              href={"https://github.com/login/oauth/authorize?" <> build_query_params(@socket)}
-              target="_blank"
-              class="text-center py-2 px-4 shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 text-white"
-              {if @user.github_oauth_token, do: ["phx-hook": "Tooltip", "aria-label": "Your token has expired"], else: []}
+            <.button
+              id="github-oauth-not-enabled"
+              type="button"
+              disabled
+              tooltip="Github OAuth has not been enabled for this instance."
             >
-              <%= if @user.github_oauth_token, do: "Reconnect", else: "Connect" %> your Github Account
-            </.link>
+              Connect to GitHub
+            </.button>
           <% end %>
         </div>
       </div>
     </div>
     """
+  end
+
+  defp oauth_enabled? do
+    Application.get_env(:lightning, :github_app, [])
+    |> Keyword.get(:client_id)
   end
 
   defp token_valid?(token) do

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -98,7 +98,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
   defp build_query_params(socket) do
     client_id =
       Application.get_env(:lightning, :github_app, [])
-      |> Keyword.get(:client_id, nil)
+      |> Keyword.fetch!(:client_id)
 
     redirect_url = Routes.oauth_url(socket, :new, "github")
 

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -3,15 +3,10 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
   Component to enable MFA on a User's account
   """
   use LightningWeb, :live_component
-  alias LightningWeb.OauthCredentialHelper
 
   @impl true
   def update(%{user: _user} = assigns, socket) do
     {:ok, assign(socket, assigns)}
-  end
-
-  def update(%{code: code}, socket) do
-    {:ok, socket}
   end
 
   @impl true
@@ -35,7 +30,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
             <.button>Disconnect from Github</.button>
           <% else %>
             <.link
-              href={"https://github.com/login/oauth/authorize" <> build_query_params(@socket, assigns)}
+              href={"https://github.com/login/oauth/authorize?" <> build_query_params(@socket)}
               target="_blank"
               class="text-center py-2 px-4 shadow-sm text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 bg-primary-600 hover:bg-primary-700 text-white"
             >
@@ -48,22 +43,14 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
     """
   end
 
-  defp build_query_params(socket, assigns) do
-    state =
-      OauthCredentialHelper.build_state(
-        "profile:#{assigns.user.id}",
-        __MODULE__,
-        assigns.id
-      )
-
+  defp build_query_params(socket) do
     client_id =
       Application.get_env(:lightning, :github_app, [])
       |> Keyword.get(:client_id, nil)
 
-    redirect_url = Routes.oidc_url(socket, :new)
+    redirect_url = Routes.oauth_url(socket, :new, "github")
 
-    params =
-      %{state: state, client_id: client_id, redirect_uri: redirect_url} |> dbg()
+    params = %{client_id: client_id, redirect_uri: redirect_url}
 
     Plug.Conn.Query.encode(params)
   end

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -41,6 +41,8 @@ defmodule LightningWeb.Router do
     get "/authenticate/callback", OidcController, :new
     get "/authenticate/:provider", OidcController, :show
     get "/authenticate/:provider/callback", OidcController, :new
+
+    get "/oauth/:provider/callback", OauthController, :new
   end
 
   ## JSON API

--- a/priv/repo/migrations/20240315130938_add_github_token_to_users.exs
+++ b/priv/repo/migrations/20240315130938_add_github_token_to_users.exs
@@ -3,7 +3,7 @@ defmodule Lightning.Repo.Migrations.AddGithubTokenToUsers do
 
   def change do
     alter table("users") do
-      add :github_oauth_token, :jsonb
+      add :github_oauth_token, :binary
     end
   end
 end

--- a/priv/repo/migrations/20240315130938_add_github_token_to_users.exs
+++ b/priv/repo/migrations/20240315130938_add_github_token_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddGithubTokenToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      add :github_oauth_token, :jsonb
+    end
+  end
+end

--- a/test/lightning/auth_providers/google_test.exs
+++ b/test/lightning/auth_providers/google_test.exs
@@ -4,6 +4,11 @@ defmodule Lightning.AuthProviders.GoogleTest do
 
   alias Lightning.AuthProviders.Common
 
+  setup _ do
+    Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
+    :ok
+  end
+
   describe "get_wellknown/0" do
     setup do
       bypass = Bypass.open()

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -217,4 +217,185 @@ defmodule Lightning.VersionControlTest do
       assert updated_connection.repo == "some/repo"
     end
   end
+
+  describe "exchange_code_for_oauth_token/1" do
+    test "returns ok for a response body with access_token" do
+      expected_token = %{"access_token" => "1234567"}
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn
+        %{url: "https://github.com/login/oauth/access_token"}, _opts ->
+          {:ok, %Tesla.Env{body: expected_token}}
+      end)
+
+      assert {:ok, ^expected_token} =
+               VersionControl.exchange_code_for_oauth_token("some-code")
+    end
+
+    test "returns error for a response body without access_token" do
+      expected_token = %{"something" => "else"}
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn
+        %{url: "https://github.com/login/oauth/access_token"}, _opts ->
+          {:ok, %Tesla.Env{body: expected_token}}
+      end)
+
+      assert {:error, ^expected_token} =
+               VersionControl.exchange_code_for_oauth_token("some-code")
+    end
+  end
+
+  describe "refresh_oauth_token/1" do
+    test "returns ok for a response body with access_token" do
+      expected_token = %{"access_token" => "1234567"}
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn
+        %{url: "https://github.com/login/oauth/access_token"}, _opts ->
+          {:ok, %Tesla.Env{body: expected_token}}
+      end)
+
+      assert {:ok, ^expected_token} =
+               VersionControl.refresh_oauth_token("some-token")
+    end
+
+    test "returns error for a response body without access_token" do
+      expected_token = %{"something" => "else"}
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn
+        %{url: "https://github.com/login/oauth/access_token"}, _opts ->
+          {:ok, %Tesla.Env{body: expected_token}}
+      end)
+
+      assert {:error, ^expected_token} =
+               VersionControl.refresh_oauth_token("some-token")
+    end
+  end
+
+  describe "fetch_user_access_token/1" do
+    test "returns error for a refresh token that has expired" do
+      expired_token = %{
+        "access_token" => "access-token",
+        "refresh_token" => "refresh-token",
+        "expires_at" => DateTime.utc_now() |> DateTime.add(-20),
+        "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(-20)
+      }
+
+      # reload so that we can get the token as they are from the db
+      user =
+        insert(:user, github_oauth_token: expired_token)
+        |> Lightning.Repo.reload!()
+
+      assert {:error, :expired} = VersionControl.fetch_user_access_token(user)
+    end
+
+    test "returns ok for an access token that is still active" do
+      active_token = %{
+        "access_token" => "access-token",
+        "refresh_token" => "refresh-token",
+        "expires_at" => DateTime.utc_now() |> DateTime.add(20),
+        "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(20)
+      }
+
+      # reload so that we can get the token as they are from the db
+      user =
+        insert(:user, github_oauth_token: active_token)
+        |> Lightning.Repo.reload!()
+
+      expected_token = active_token["access_token"]
+
+      assert {:ok, ^expected_token} =
+               VersionControl.fetch_user_access_token(user)
+    end
+
+    test "returns ok for an access token that has no expiry" do
+      active_token = %{"access_token" => "access-token"}
+
+      user = insert(:user, github_oauth_token: active_token)
+
+      expected_token = active_token["access_token"]
+
+      assert {:ok, ^expected_token} =
+               VersionControl.fetch_user_access_token(user)
+    end
+
+    test "refreshes the access_token if it has expired and updates the user info" do
+      active_token = %{
+        "access_token" => "access-token",
+        "refresh_token" => "refresh-token",
+        "expires_at" => DateTime.utc_now() |> DateTime.add(-20),
+        "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(100)
+      }
+
+      # reload so that we can get the token as they are from the db
+      user =
+        insert(:user, github_oauth_token: active_token)
+        |> Lightning.Repo.reload!()
+
+      assert user.github_oauth_token["access_token"] ==
+               active_token["access_token"]
+
+      expected_access_token = "updated-access-token"
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn
+        %{url: "https://github.com/login/oauth/access_token"}, _opts ->
+          {:ok, %Tesla.Env{body: %{"access_token" => expected_access_token}}}
+      end)
+
+      assert {:ok, ^expected_access_token} =
+               VersionControl.fetch_user_access_token(user)
+
+      updated_user = Lightning.Repo.reload!(user)
+
+      assert updated_user.github_oauth_token["access_token"] ==
+               expected_access_token
+    end
+  end
+
+  describe "save_oauth_token/2" do
+    test "adds expiry dates to the token if needed" do
+      user = insert(:user)
+
+      token = %{
+        "access_token" => "access-token",
+        "refresh_token" => "refresh-token",
+        "expires_in" => 3600,
+        "refresh_token_expires_in" => 7200
+      }
+
+      {:ok, updated_user} = VersionControl.save_oauth_token(user, token)
+
+      expected_access_token_expiry =
+        DateTime.utc_now()
+        |> DateTime.add(token["expires_in"])
+
+      expected_refresh_token_expiry =
+        DateTime.utc_now()
+        |> DateTime.add(token["refresh_token_expires_in"])
+
+      # https://hexdocs.pm/timex/Timex.html#compare/3
+      # comparing to second precision
+      assert Timex.compare(
+               updated_user.github_oauth_token["expires_at"],
+               expected_access_token_expiry,
+               :seconds
+             ) == 0
+
+      assert Timex.compare(
+               updated_user.github_oauth_token["refresh_token_expires_at"],
+               expected_refresh_token_expiry,
+               :seconds
+             ) == 0
+    end
+
+    test "does not add expiry dates if none is needed" do
+      user = insert(:user)
+
+      token = %{"access_token" => "access-token"}
+
+      {:ok, updated_user} = VersionControl.save_oauth_token(user, token)
+
+      assert updated_user.github_oauth_token == %{
+               "access_token" => "access-token"
+             }
+    end
+  end
 end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -271,22 +271,6 @@ defmodule Lightning.VersionControlTest do
   end
 
   describe "fetch_user_access_token/1" do
-    test "returns error for a refresh token that has expired" do
-      expired_token = %{
-        "access_token" => "access-token",
-        "refresh_token" => "refresh-token",
-        "expires_at" => DateTime.utc_now() |> DateTime.add(-20),
-        "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(-20)
-      }
-
-      # reload so that we can get the token as they are from the db
-      user =
-        insert(:user, github_oauth_token: expired_token)
-        |> Lightning.Repo.reload!()
-
-      assert {:error, :expired} = VersionControl.fetch_user_access_token(user)
-    end
-
     test "returns ok for an access token that is still active" do
       active_token = %{
         "access_token" => "access-token",

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -437,7 +437,7 @@ defmodule LightningWeb.ProfileLiveTest do
       {:ok, view, _html} = live(conn, ~p"/profile")
       connect_button = element(view, "#connect-github-link")
       assert has_element?(connect_button)
-      assert render(connect_button) =~ "Reconnect your Github Account"
+      assert render(connect_button) =~ "Reconnect your GitHub account"
       assert render(connect_button) =~ "Your token has expired"
       refute has_element?(view, "#disconnect-github-button")
     end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -38,6 +38,9 @@ defmodule LightningWeb.ChannelCase do
     Mox.stub_with(Lightning.Mock, Lightning.Stub)
     # Application.put_env(:lightning, Lightning, Lightning.Mock)
 
+    # Default to Hackney adapter so that Bypass dependent tests continue working
+    Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -40,6 +40,9 @@ defmodule LightningWeb.ConnCase do
   end
 
   setup tags do
+    # Default to Hackney adapter so that Bypass dependent tests continue working
+    Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -34,6 +34,9 @@ defmodule Lightning.DataCase do
   end
 
   setup tags do
+    # Default to Hackney adapter so that Bypass dependent tests continue working
+    Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@ Code.put_compiler_option(:warnings_as_errors, true)
 # Report which tests are synchronous
 # Rexbug.start("ExUnit.Server.add_sync_module/_")
 Mox.defmock(Lightning.GithubClient.Mock, for: Tesla.Adapter)
+Mox.defmock(Lightning.Tesla.Mock, for: Tesla.Adapter)
 
 :ok = Application.ensure_started(:ex_machina)
 


### PR DESCRIPTION
## Validation Steps
### Demo:
https://github.com/OpenFn/lightning/assets/39288959/caa3f05f-49c3-4f1a-9a41-1f4573383def
### Required ENVS:
- `GITHUB_APP_CLIENT_ID`
- `GITHUB_APP_CLIENT_SECRET`
### Checklist

- [x] User can connect
- [x] User can disconnect 


## Notes for the reviewer

- Adds a new column, `github_oauth_token` to the `users` table. This field is encrypted at rest, with the help of `Lightning.Encrypted.Map`
- Adds a new route, `/oauth/:provider/callback` and controller `OauthController`. I've decided NOT to use the existing route and controller `OidcController` because this new logic deals with users who are logged in. Maybe I should merge them in together? 🤷‍♂️ 
- Github supports both non-expiry and expiry tokens. I have handled both cases
- I have defined a global test adapter for `tesla`, `config :tesla, adapter: Lightning.Tesla.Mock`. I think I should have done this in https://github.com/OpenFn/lightning/pull/1781 instead of defining only one for the `GithubClient`. Consequently, I have been forced to `stub` this with the `Hackney adapter` so that the `Bypass` tests work. 


## Related issue

Fixes #1894 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested. 
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
- [x] The callback urls have been updated in the `prod` and `demo` Github Apps Setting
