### PR TITLE
Submit V2 data to ImpactTracker

### DIFF
--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -152,4 +152,11 @@ defmodule Lightning.UsageTracking do
   defp enqueue(date) do
     Oban.insert(Lightning.Oban, ReportWorker.new(%{date: date}))
   end
+
+  def find_enabled_daily_report_config do
+    case Repo.one(DailyReportConfiguration) do
+      %{tracking_enabled_at: nil} -> nil
+      possible_config -> possible_config
+    end
+  end
 end

--- a/lib/lightning/usage_tracking/project_metrics_service.ex
+++ b/lib/lightning/usage_tracking/project_metrics_service.ex
@@ -1,0 +1,64 @@
+defmodule Lightning.UsageTracking.ProjectMetricsService do
+  @moduledoc """
+  Builds project-related metrics.
+
+
+  """
+  import Ecto.Query
+
+  alias Lightning.Projects.Project
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.UserService
+  alias Lightning.UsageTracking.WorkflowMetricsService
+
+  def find_eligible_projects(date) do
+    report_time = report_date_as_time(date)
+
+    query =
+      from p in Project,
+        where: p.inserted_at <= ^report_time,
+        preload: [:users, [workflows: [:jobs, runs: [steps: [:job]]]]]
+
+    query |> Repo.all()
+  end
+
+  def generate_metrics(project, cleartext_enabled, date) do
+    %Project{id: id, users: users} = project
+
+    %{
+      no_of_active_users: UserService.no_of_active_users(date, users),
+      no_of_users: UserService.no_of_users(date, users),
+      workflows: instrument_workflows(project, cleartext_enabled, date)
+    }
+    |> Map.merge(instrument_identity(id, cleartext_enabled))
+  end
+
+  defp instrument_identity(identity, false = _cleartext_enabled) do
+    %{
+      cleartext_uuid: nil,
+      hashed_uuid: identity |> build_hash()
+    }
+  end
+
+  defp instrument_identity(identity, true = _cleartext_enabled) do
+    identity
+    |> instrument_identity(false)
+    |> Map.merge(%{cleartext_uuid: identity})
+  end
+
+  defp build_hash(uuid), do: Base.encode16(:crypto.hash(:sha256, uuid))
+
+  defp instrument_workflows(project, cleartext_enabled, date) do
+    project.workflows
+    |> WorkflowMetricsService.find_eligible_workflows(date)
+    |> Enum.map(fn workflow ->
+      WorkflowMetricsService.generate_metrics(workflow, cleartext_enabled, date)
+    end)
+  end
+
+  defp report_date_as_time(date) do
+    {:ok, datetime, _offset} = "#{date}T23:59:59Z" |> DateTime.from_iso8601()
+
+    datetime
+  end
+end

--- a/lib/lightning/usage_tracking/report_worker.ex
+++ b/lib/lightning/usage_tracking/report_worker.ex
@@ -7,11 +7,45 @@ defmodule Lightning.UsageTracking.ReportWorker do
     queue: :background,
     max_attempts: 1
 
+  alias Lightning.Repo
+  alias Lightning.UsageTracking
+  alias Lightning.UsageTracking.Client
+  alias Lightning.UsageTracking.Report
+  alias Lightning.UsageTracking.ReportData
+
   require Logger
   @impl Oban.Worker
-  def perform(%{args: %{"date" => date}}) do
-    Logger.info("ReportWorker was asked to report on #{date}")
+  def perform(%{args: %{"date" => date_string}}) do
+    date = Date.from_iso8601!(date_string)
+
+    env = Application.get_env(:lightning, :usage_tracking)
+
+    config = UsageTracking.find_enabled_daily_report_config()
+
+    if env[:enabled] && config do
+      cleartext_uuids_enabled = env[:cleartext_uuids_enabled]
+
+      host = env[:host]
+
+      data = ReportData.generate(config, cleartext_uuids_enabled, date)
+
+      Client.submit_metrics(data, host) |> create_report(data, date)
+    end
 
     :ok
+  end
+
+  defp create_report(:ok, data, date) do
+    %Report{
+      data: data,
+      report_date: date,
+      submitted: true,
+      submitted_at: DateTime.utc_now()
+    }
+    |> Repo.insert()
+  end
+
+  defp create_report(:error, data, date) do
+    %Report{data: data, report_date: date} |> Repo.insert()
   end
 end

--- a/lib/lightning/usage_tracking/run_service.ex
+++ b/lib/lightning/usage_tracking/run_service.ex
@@ -1,0 +1,35 @@
+defmodule Lightning.UsageTracking.RunService do
+  @moduledoc """
+  Supports the generation of metrics related to runs and steps.
+
+
+  """
+  def finished_runs(all_runs, date) do
+    all_runs
+    |> finished_on(date)
+  end
+
+  def finished_steps(runs, date) do
+    runs
+    |> Enum.flat_map(& &1.steps)
+    |> finished_on(date)
+  end
+
+  def unique_jobs(steps, date) do
+    steps
+    |> finished_on(date)
+    |> Enum.map(& &1.job)
+    |> Enum.uniq_by(& &1.id)
+  end
+
+  defp finished_on(collection, date) do
+    collection
+    |> Enum.filter(fn
+      %{finished_at: nil} ->
+        false
+
+      %{finished_at: finished_at} ->
+        finished_at |> DateTime.to_date() == date
+    end)
+  end
+end

--- a/lib/lightning/usage_tracking/user_queries.ex
+++ b/lib/lightning/usage_tracking/user_queries.ex
@@ -1,0 +1,52 @@
+defmodule Lightning.UsageTracking.UserQueries do
+  @moduledoc """
+  Contains queries used to determine user-related metrics.
+
+
+  """
+  import Ecto.Query
+
+  alias Lightning.Accounts.User
+  alias Lightning.Accounts.UserToken
+
+  def existing_users(date) do
+    report_time = report_date_as_time(date)
+
+    from u in User, where: u.inserted_at <= ^report_time
+  end
+
+  def existing_users(date, user_list) do
+    list_ids = user_list |> Enum.map(& &1.id)
+
+    from eu in existing_users(date), where: eu.id in ^list_ids
+  end
+
+  def active_users(date) do
+    report_time = report_date_as_time(date)
+
+    {:ok, threshold_time, _offset} =
+      date
+      |> Date.add(-90)
+      |> then(&"#{&1}T23:59:59Z")
+      |> DateTime.from_iso8601()
+
+    from eu in existing_users(date),
+      distinct: eu.id,
+      join: ut in UserToken,
+      on: ut.user_id == eu.id,
+      where: ut.context == "session",
+      where: ut.inserted_at > ^threshold_time and ut.inserted_at <= ^report_time
+  end
+
+  def active_users(date, user_list) do
+    list_ids = user_list |> Enum.map(& &1.id)
+
+    from au in active_users(date), where: au.id in ^list_ids
+  end
+
+  defp report_date_as_time(date) do
+    {:ok, datetime, _offset} = "#{date}T23:59:59Z" |> DateTime.from_iso8601()
+
+    datetime
+  end
+end

--- a/lib/lightning/usage_tracking/user_service.ex
+++ b/lib/lightning/usage_tracking/user_service.ex
@@ -1,0 +1,25 @@
+defmodule Lightning.UsageTracking.UserService do
+  @moduledoc """
+  Returns counts for the various user-related metrics.
+
+
+  """
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.UserQueries
+
+  def no_of_users(date) do
+    UserQueries.existing_users(date) |> Repo.aggregate(:count)
+  end
+
+  def no_of_users(date, user_list) do
+    UserQueries.existing_users(date, user_list) |> Repo.aggregate(:count)
+  end
+
+  def no_of_active_users(date) do
+    UserQueries.active_users(date) |> Repo.aggregate(:count)
+  end
+
+  def no_of_active_users(date, user_list) do
+    UserQueries.active_users(date, user_list) |> Repo.aggregate(:count)
+  end
+end

--- a/lib/lightning/usage_tracking/workflow_metrics_service.ex
+++ b/lib/lightning/usage_tracking/workflow_metrics_service.ex
@@ -1,0 +1,62 @@
+defmodule Lightning.UsageTracking.WorkflowMetricsService do
+  @moduledoc """
+  Builds workflow-related metrics.
+
+
+  """
+  alias Lightning.UsageTracking.RunService
+
+  def find_eligible_workflows(workflows, date) do
+    workflows
+    |> Enum.filter(fn workflow -> eligible_workflow?(workflow, date) end)
+  end
+
+  def generate_metrics(workflow, cleartext_enabled, date) do
+    runs = RunService.finished_runs(workflow.runs, date)
+    steps = RunService.finished_steps(workflow.runs, date)
+    active_jobs = RunService.unique_jobs(steps, date)
+
+    %{
+      no_of_active_jobs: Enum.count(active_jobs),
+      no_of_jobs: Enum.count(workflow.jobs),
+      no_of_runs: Enum.count(runs),
+      no_of_steps: Enum.count(steps)
+    }
+    |> Map.merge(instrument_identity(workflow.id, cleartext_enabled))
+  end
+
+  defp instrument_identity(identity, false = _cleartext_enabled) do
+    %{
+      cleartext_uuid: nil,
+      hashed_uuid: identity |> build_hash()
+    }
+  end
+
+  defp instrument_identity(identity, true = _cleartext_enabled) do
+    identity
+    |> instrument_identity(false)
+    |> Map.merge(%{cleartext_uuid: identity})
+  end
+
+  defp build_hash(uuid), do: Base.encode16(:crypto.hash(:sha256, uuid))
+
+  defp eligible_workflow?(%{deleted_at: nil, inserted_at: inserted_at}, date) do
+    if Date.compare(inserted_at, date) == :gt do
+      false
+    else
+      true
+    end
+  end
+
+  defp eligible_workflow?(
+         %{deleted_at: deleted_at, inserted_at: inserted_at},
+         date
+       ) do
+    if Date.compare(inserted_at, date) == :gt ||
+         Date.compare(deleted_at, date) != :gt do
+      false
+    else
+      true
+    end
+  end
+end

--- a/priv/repo/migrations/20240307092144_add_unique_index_to_usage_tracking_reports_report_date.exs
+++ b/priv/repo/migrations/20240307092144_add_unique_index_to_usage_tracking_reports_report_date.exs
@@ -1,0 +1,7 @@
+defmodule Lightning.Repo.Migrations.AddUniqueIndexToUsageTrackingReportsReportDate do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:usage_tracking_reports, [:report_date])
+  end
+end

--- a/test/lightning/usage_tracking/project_metrics_service_test.exs
+++ b/test/lightning/usage_tracking/project_metrics_service_test.exs
@@ -1,0 +1,360 @@
+defmodule Lightning.UsageTracking.ProjectMetricsServiceTest do
+  use Lightning.DataCase
+
+  alias Lightning.Projects.Project
+  alias Lightning.UsageTracking.ProjectMetricsService
+  alias Lightning.UsageTracking.WorkflowMetricsService
+
+  setup do
+    project_id = "3cfb674b-e878-470d-b7c0-cfa8f7e003ae"
+
+    active_user_count = 2
+
+    project =
+      build_project(
+        active_user_count,
+        project_id,
+        active_user_threshold_time: ~U[2023-11-08 00:00:00Z],
+        report_time: ~U[2024-02-05 23:59:59Z]
+      )
+
+    eligible_workflow_1 =
+      insert(:workflow, project: project, inserted_at: ~U[2024-02-05 23:59:59Z])
+      |> Repo.preload([:runs, :jobs])
+
+    eligible_workflow_2 =
+      insert(:workflow, project: project, inserted_at: ~U[2024-02-05 23:59:59Z])
+      |> Repo.preload([:runs, :jobs])
+
+    ineligible_workflow =
+      insert(:workflow, project: project, inserted_at: ~U[2024-02-06 00:00:00Z])
+      |> Repo.preload([:runs, :jobs])
+
+    other_project =
+      build_project(
+        3,
+        Ecto.UUID.generate(),
+        active_user_threshold_time: ~U[2023-11-08 00:00:00Z],
+        report_time: ~U[2024-02-05 23:59:59Z]
+      )
+
+    _other_workflow =
+      insert(:workflow,
+        project: other_project,
+        inserted_at: ~U[2024-02-05 23:59:59Z]
+      )
+
+    %{
+      active_user_count: active_user_count,
+      date: ~D[2024-02-05],
+      eligible_workflow_1: eligible_workflow_1,
+      eligible_workflow_2: eligible_workflow_2,
+      hashed_id:
+        "EECF8CFDD120E8DF8D9A12CA92AC3E815908223F95CFB11F19261A3C0EB34AEC",
+      ineligible_workflow: ineligible_workflow,
+      project:
+        Repo.get(Project, project_id)
+        |> Repo.preload([:users, workflows: [:runs, :jobs]]),
+      project_id: project_id
+    }
+  end
+
+  describe ".find_eligible_projects" do
+    setup do
+      %{date: ~D[2024-02-05]}
+    end
+
+    test "returns all projects created before the date", %{date: date} do
+      eligible_project_1 =
+        insert(:project, inserted_at: ~U[2024-02-05 23:59:58Z])
+
+      eligible_project_2 =
+        insert(:project, inserted_at: ~U[2024-02-04 23:59:59Z])
+
+      ineligible_project_1 =
+        insert(:project, inserted_at: ~U[2024-02-06 00:00:00Z])
+
+      ineligible_project_2 =
+        insert(:project, inserted_at: ~U[2024-02-06 00:00:01Z])
+
+      result = ProjectMetricsService.find_eligible_projects(date)
+
+      assert result |> contains?(eligible_project_1)
+      assert result |> contains?(eligible_project_2)
+      refute result |> contains?(ineligible_project_1)
+      refute result |> contains?(ineligible_project_2)
+    end
+  end
+
+  describe ".generate_metrics/3 - cleartext disabled" do
+    setup context do
+      context |> Map.merge(%{enabled: false})
+    end
+
+    test "includes the hashed project id", %{
+      date: date,
+      enabled: enabled,
+      hashed_id: hashed_id,
+      project: project
+    } do
+      assert %{
+               hashed_uuid: ^hashed_id
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "excludes the cleartext uuid", %{
+      date: date,
+      enabled: enabled,
+      project: project
+    } do
+      assert %{
+               cleartext_uuid: nil
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes the number of project users", %{
+      active_user_count: active_user_count,
+      date: date,
+      enabled: enabled,
+      project: project
+    } do
+      user_count = active_user_count + 1
+
+      assert %{
+               no_of_users: ^user_count
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes the number of active users", %{
+      active_user_count: active_user_count,
+      date: date,
+      enabled: enabled,
+      project: project
+    } do
+      assert %{
+               no_of_active_users: ^active_user_count
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes data for workflows existing on or before date", %{
+      date: date,
+      eligible_workflow_1: eligible_workflow_1,
+      eligible_workflow_2: eligible_workflow_2,
+      enabled: enabled,
+      ineligible_workflow: ineligible_workflow,
+      project: project
+    } do
+      %{workflows: workflows} =
+        ProjectMetricsService.generate_metrics(project, enabled, date)
+
+      workflows
+      |> assert_workflow_metrics(
+        workflow: eligible_workflow_1,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      workflows
+      |> assert_workflow_metrics(
+        workflow: eligible_workflow_2,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      workflows
+      |> refute_workflow_metrics(
+        workflow: ineligible_workflow,
+        cleartext_enabled: enabled,
+        date: date
+      )
+    end
+  end
+
+  describe ".generate_metrics/3 - cleartext enabled" do
+    setup context do
+      context |> Map.merge(%{enabled: true})
+    end
+
+    test "includes the hashed project id", %{
+      date: date,
+      enabled: enabled,
+      hashed_id: hashed_id,
+      project: project
+    } do
+      assert %{
+               hashed_uuid: ^hashed_id
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes the cleartext uuid", %{
+      date: date,
+      enabled: enabled,
+      project: project
+    } do
+      project_id = project.id
+
+      assert %{
+               cleartext_uuid: ^project_id
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes the number of project users", %{
+      active_user_count: active_user_count,
+      date: date,
+      enabled: enabled,
+      project: project
+    } do
+      user_count = active_user_count + 1
+
+      assert %{
+               no_of_users: ^user_count
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes the number of active users", %{
+      active_user_count: active_user_count,
+      date: date,
+      enabled: enabled,
+      project: project
+    } do
+      assert %{
+               no_of_active_users: ^active_user_count
+             } = ProjectMetricsService.generate_metrics(project, enabled, date)
+    end
+
+    test "includes data for workflows existing on or before date", %{
+      date: date,
+      eligible_workflow_1: eligible_workflow_1,
+      eligible_workflow_2: eligible_workflow_2,
+      enabled: enabled,
+      ineligible_workflow: ineligible_workflow,
+      project: project
+    } do
+      %{workflows: workflows} =
+        ProjectMetricsService.generate_metrics(project, enabled, date)
+
+      workflows
+      |> assert_workflow_metrics(
+        workflow: eligible_workflow_1,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      workflows
+      |> assert_workflow_metrics(
+        workflow: eligible_workflow_2,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      workflows
+      |> refute_workflow_metrics(
+        workflow: ineligible_workflow,
+        cleartext_enabled: enabled,
+        date: date
+      )
+    end
+  end
+
+  defp build_project(count, project_id, opts) do
+    active_user_threshold_time = opts |> Keyword.get(:active_user_threshold_time)
+    report_time = opts |> Keyword.get(:report_time)
+
+    project =
+      insert(
+        :project,
+        id: project_id,
+        project_users:
+          build_project_users(
+            count,
+            active_user_threshold_time,
+            report_time
+          )
+      )
+
+    project |> Repo.preload([:users, workflows: [:jobs, :runs]])
+  end
+
+  defp build_project_users(count, active_user_threshold_time, report_time) do
+    active_users =
+      build_list(
+        count,
+        :project_user,
+        user: fn ->
+          insert_active_user(active_user_threshold_time, report_time)
+        end
+      )
+
+    user =
+      build(
+        :project_user,
+        user: fn ->
+          insert_user(active_user_threshold_time, report_time)
+        end
+      )
+
+    [user | active_users]
+  end
+
+  defp insert_active_user(active_user_threshold_time, report_time) do
+    user = insert_user(active_user_threshold_time, report_time)
+
+    insert(
+      :user_token,
+      context: "session",
+      user: user,
+      inserted_at: active_user_threshold_time
+    )
+
+    user
+  end
+
+  defp insert_user(active_user_threshold_time, report_time) do
+    user = insert(:user, inserted_at: report_time)
+
+    precedes_active_threshold =
+      active_user_threshold_time
+      |> DateTime.add(-1, :second)
+
+    insert(
+      :user_token,
+      context: "session",
+      user: user,
+      inserted_at: precedes_active_threshold
+    )
+
+    user
+  end
+
+  defp assert_workflow_metrics(workflows_metrics, opts) do
+    workflow = opts |> Keyword.get(:workflow)
+    cleartext_enabled = opts |> Keyword.get(:cleartext_enabled)
+    date = opts |> Keyword.get(:date)
+
+    workflow_metrics = workflows_metrics |> find_instrumentation(workflow.id)
+
+    expected_metrics =
+      WorkflowMetricsService.generate_metrics(workflow, cleartext_enabled, date)
+
+    assert workflow_metrics == expected_metrics
+  end
+
+  defp refute_workflow_metrics(workflows_metrics, opts) do
+    workflow = opts |> Keyword.get(:workflow)
+
+    refute workflows_metrics |> find_instrumentation(workflow.id)
+  end
+
+  defp find_instrumentation(instrumented_collection, identity) do
+    hashed_uuid = build_hash(identity)
+
+    instrumented_collection
+    |> Enum.find(fn record -> record.hashed_uuid == hashed_uuid end)
+  end
+
+  defp build_hash(uuid), do: Base.encode16(:crypto.hash(:sha256, uuid))
+
+  defp contains?(result, desired_project) do
+    result |> Enum.find(fn project -> project.id == desired_project.id end)
+  end
+end

--- a/test/lightning/usage_tracking/report_data_test.exs
+++ b/test/lightning/usage_tracking/report_data_test.exs
@@ -2,9 +2,11 @@ defmodule Lightning.UsageTracking.ReportDataTest do
   use Lightning.DataCase
 
   alias Lightning.Projects.Project
-  alias Lightning.Workflows.Workflow
+  alias Lightning.UsageTracking
   alias Lightning.UsageTracking.Configuration
+  alias Lightning.UsageTracking.ProjectMetricsService
   alias Lightning.UsageTracking.ReportData
+  alias Lightning.Workflows.Workflow
 
   describe ".generate/2 - cleartext uuids disabled" do
     setup [:setup_config, :setup_cleartext_uuids_disabled]
@@ -28,10 +30,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
 
     test "cleartext uuid of reporting instance is nil",
          %{config: config, cleartext_enabled: enabled} do
-      assert(
-        %{instance: %{cleartext_uuid: nil}} =
-          ReportData.generate(config, enabled)
-      )
+      assert %{instance: %{cleartext_uuid: nil}} =
+               ReportData.generate(config, enabled)
     end
 
     test "indicates the version of lightning present on the instance",
@@ -49,10 +49,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
       _eligible_user_3 = insert(:user, disabled: false)
       _ineligible_user = insert(:user, disabled: true)
 
-      assert(
-        %{instance: %{no_of_users: 3}} =
-          ReportData.generate(config, enabled)
-      )
+      assert %{instance: %{no_of_users: 3}} =
+               ReportData.generate(config, enabled)
     end
 
     test "includes the operating system details",
@@ -63,10 +61,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
 
       assert String.match?(os_name, ~r/.{5,}/)
 
-      assert(
-        %{instance: %{operating_system: ^os_name}} =
-          ReportData.generate(config, enabled)
-      )
+      assert %{instance: %{operating_system: ^os_name}} =
+               ReportData.generate(config, enabled)
     end
 
     test "includes project details",
@@ -112,10 +108,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
          %{config: config, cleartext_enabled: enabled} do
       %{instance_id: instance_id} = config
 
-      assert(
-        %{instance: %{cleartext_uuid: ^instance_id}} =
-          ReportData.generate(config, enabled)
-      )
+      assert %{instance: %{cleartext_uuid: ^instance_id}} =
+               ReportData.generate(config, enabled)
     end
 
     test "indicates the version of lightning present on the instance",
@@ -133,10 +127,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
       _eligible_user_3 = insert(:user, disabled: false)
       _ineligible_user = insert(:user, disabled: true)
 
-      assert(
-        %{instance: %{no_of_users: 3}} =
-          ReportData.generate(config, enabled)
-      )
+      assert %{instance: %{no_of_users: 3}} =
+               ReportData.generate(config, enabled)
     end
 
     test "includes the operating system details",
@@ -147,10 +139,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
 
       assert String.match?(os_name, ~r/.{5,}/)
 
-      assert(
-        %{instance: %{operating_system: ^os_name}} =
-          ReportData.generate(config, enabled)
-      )
+      assert %{instance: %{operating_system: ^os_name}} =
+               ReportData.generate(config, enabled)
     end
 
     test "includes project details",
@@ -172,8 +162,405 @@ defmodule Lightning.UsageTracking.ReportDataTest do
     end
   end
 
+  describe ".generate/3 - cleartext uuids disabled" do
+    setup [
+      :setup_daily_report_config,
+      :setup_cleartext_uuids_disabled,
+      :setup_date
+    ]
+
+    test "sets the time that the report was generated at", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      %{generated_at: generated_at} =
+        ReportData.generate(report_config, enabled, date)
+
+      assert DateTime.diff(DateTime.utc_now(), generated_at, :second) < 1
+    end
+
+    test "contains hashed uuid of reporting instance", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      %{instance_id: instance_id} = report_config
+
+      %{instance: %{hashed_uuid: hashed_uuid}} =
+        ReportData.generate(report_config, enabled, date)
+
+      assert hashed_uuid == build_hash(instance_id)
+    end
+
+    test "cleartext uuid of reporting instance is nil", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      assert %{
+               instance: %{cleartext_uuid: nil}
+             } = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "indicates the version of lightning present on the instance", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      # Temporarily water-down the test to address constraints imposed by CI.
+      %{instance: %{version: version}} =
+        ReportData.generate(report_config, enabled, date)
+
+      assert String.match?(version, ~r/\A\d+\.\d+\.\d+\z/)
+    end
+
+    test "includes the total number of users", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      _user_1 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _user_2 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _user_3 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      assert %{
+               instance: %{no_of_users: 3}
+             } = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "includes the total number of active users", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      within_threshold_date = Date.add(date, -89)
+
+      {:ok, within_threshold_time, _offset} =
+        DateTime.from_iso8601("#{within_threshold_date}T10:00:00Z")
+
+      outside_threshold_date = Date.add(date, -90)
+
+      {:ok, outside_threshold_time, _offset} =
+        DateTime.from_iso8601("#{outside_threshold_date}T10:00:00Z")
+
+      user_1 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: user_1
+        )
+
+      user_2 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _inactive_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: outside_threshold_time,
+          user: user_2
+        )
+
+      assert %{
+               instance: %{no_of_active_users: 1}
+             } = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "includes the operating system details", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      {_os_family, os_name_atom} = :os.type()
+
+      os_name = os_name_atom |> Atom.to_string()
+
+      assert String.match?(os_name, ~r/.{5,}/)
+
+      assert %{instance: %{operating_system: ^os_name}} =
+               ReportData.generate(report_config, enabled, date)
+    end
+
+    test "includes project details for projects created before date", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      after_date = Date.add(date, 1)
+
+      project_1 = build_project(2, date)
+      project_2 = build_project(5, after_date)
+      project_3 = build_project(3, date)
+
+      %{projects: projects} = ReportData.generate(report_config, enabled, date)
+
+      # assert projects |> count() == 2
+
+      projects
+      |> assert_project_metrics(
+        project: project_1,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      projects
+      |> assert_project_metrics(
+        project: project_3,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      projects |> assert_no_project_metrics(project_2)
+    end
+
+    test "indicates the version of the report data structure in use", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      assert %{version: "2"} = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "indicates the applicable report date", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      assert %{report_date: ^date} =
+               ReportData.generate(report_config, enabled, date)
+    end
+  end
+
+  describe ".generate/3 - cleartext uuids enabled" do
+    setup [
+      :setup_daily_report_config,
+      :setup_cleartext_uuids_enabled,
+      :setup_date
+    ]
+
+    test "sets the time that the report was generated at", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      %{generated_at: generated_at} =
+        ReportData.generate(report_config, enabled, date)
+
+      assert DateTime.diff(DateTime.utc_now(), generated_at, :second) < 1
+    end
+
+    test "contains hashed uuid of reporting instance", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      %{instance_id: instance_id} = report_config
+
+      %{instance: %{hashed_uuid: hashed_uuid}} =
+        ReportData.generate(report_config, enabled, date)
+
+      assert hashed_uuid == build_hash(instance_id)
+    end
+
+    test "cleartext uuid of reporting instance is populated", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      %{instance_id: instance_id} = report_config
+
+      assert %{
+               instance: %{cleartext_uuid: ^instance_id}
+             } = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "indicates the version of lightning present on the instance", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      # Temporarily water-down the test to address constraints imposed by CI.
+      %{instance: %{version: version}} =
+        ReportData.generate(report_config, enabled, date)
+
+      assert String.match?(version, ~r/\A\d+\.\d+\.\d+\z/)
+    end
+
+    test "includes the total number of users", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      _user_1 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _user_2 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _user_3 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      assert %{
+               instance: %{no_of_users: 3}
+             } = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "includes the total number of active users", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      within_threshold_date = Date.add(date, -89)
+
+      {:ok, within_threshold_time, _offset} =
+        DateTime.from_iso8601("#{within_threshold_date}T10:00:00Z")
+
+      outside_threshold_date = Date.add(date, -90)
+
+      {:ok, outside_threshold_time, _offset} =
+        DateTime.from_iso8601("#{outside_threshold_date}T10:00:00Z")
+
+      user_1 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: user_1
+        )
+
+      user_2 =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _inactive_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: outside_threshold_time,
+          user: user_2
+        )
+
+      assert %{
+               instance: %{no_of_active_users: 1}
+             } = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "includes the operating system details", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      {_os_family, os_name_atom} = :os.type()
+
+      os_name = os_name_atom |> Atom.to_string()
+
+      assert String.match?(os_name, ~r/.{5,}/)
+
+      assert %{instance: %{operating_system: ^os_name}} =
+               ReportData.generate(report_config, enabled, date)
+    end
+
+    test "includes project details for projects created before date", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      after_date = Date.add(date, 1)
+
+      project_1 = build_project(2, date)
+      project_2 = build_project(5, after_date)
+      project_3 = build_project(3, date)
+
+      %{projects: projects} = ReportData.generate(report_config, enabled, date)
+
+      # assert projects |> count() == 2
+
+      projects
+      |> assert_project_metrics(
+        project: project_1,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      projects
+      |> assert_project_metrics(
+        project: project_3,
+        cleartext_enabled: enabled,
+        date: date
+      )
+
+      projects |> assert_no_project_metrics(project_2)
+    end
+
+    test "indicates the version of the report data structure in use", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      assert %{version: "2"} = ReportData.generate(report_config, enabled, date)
+    end
+
+    test "indicates the applicable report date", %{
+      cleartext_enabled: enabled,
+      config: report_config,
+      date: date
+    } do
+      assert %{report_date: ^date} =
+               ReportData.generate(report_config, enabled, date)
+    end
+  end
+
   defp setup_config(context) do
     Map.merge(context, %{config: Repo.insert!(%Configuration{})})
+  end
+
+  defp setup_daily_report_config(context) do
+    Map.merge(
+      context,
+      %{config: UsageTracking.enable_daily_report(DateTime.utc_now())}
+    )
   end
 
   defp setup_cleartext_uuids_disabled(context) do
@@ -183,6 +570,8 @@ defmodule Lightning.UsageTracking.ReportDataTest do
   defp setup_cleartext_uuids_enabled(context) do
     Map.merge(context, %{cleartext_enabled: true})
   end
+
+  defp setup_date(context), do: Map.merge(context, %{date: ~D[2024-02-25]})
 
   defp build_hash(uuid), do: Base.encode16(:crypto.hash(:sha256, uuid))
 
@@ -205,7 +594,38 @@ defmodule Lightning.UsageTracking.ReportDataTest do
       end
     end
 
-    project
+    project |> Repo.preload([:users, workflows: [:jobs, runs: [:steps]]])
+  end
+
+  defp build_project(count, date) do
+    {:ok, inserted_at, _offset} = DateTime.from_iso8601("#{date}T10:11:12Z")
+
+    project =
+      insert(
+        :project,
+        name: "proj-#{count}",
+        inserted_at: inserted_at,
+        project_users: build_project_users(count)
+      )
+
+    workflows = insert_list(1, :workflow, name: "wf-#{count}", project: project)
+
+    for workflow <- workflows do
+      [job | _] = insert_list(count, :job, workflow: workflow)
+      work_orders = insert_list(count, :workorder, workflow: workflow)
+
+      for work_order <- work_orders do
+        insert_runs_with_steps(
+          count: count,
+          project: project,
+          work_order: work_order,
+          job: job,
+          finished_at: inserted_at
+        )
+      end
+    end
+
+    project |> Repo.preload([:users, workflows: [:jobs, runs: [steps: [:job]]]])
   end
 
   defp build_project_users(count) do
@@ -217,12 +637,14 @@ defmodule Lightning.UsageTracking.ReportDataTest do
     project = Keyword.get(options, :project)
     work_order = Keyword.get(options, :work_order)
     job = Keyword.get(options, :job)
+    finished_at = Keyword.get(options, :finished_at)
 
     dataclip_builder = fn -> build(:dataclip, project: project) end
 
     insert_list(
       count,
       :run,
+      finished_at: finished_at,
       work_order: work_order,
       dataclip: dataclip_builder,
       starting_job: job,
@@ -230,6 +652,7 @@ defmodule Lightning.UsageTracking.ReportDataTest do
         build_list(
           count,
           :step,
+          finished_at: finished_at,
           input_dataclip: dataclip_builder,
           output_dataclip: dataclip_builder,
           job: job
@@ -286,8 +709,7 @@ defmodule Lightning.UsageTracking.ReportDataTest do
     hashed_uuid = build_hash(identity)
 
     instrumented_collection
-    |> Enum.filter(fn record -> record.hashed_uuid == hashed_uuid end)
-    |> hd()
+    |> Enum.find(fn record -> record.hashed_uuid == hashed_uuid end)
   end
 
   defp assert_cleartext_uuid(instrumented_record, id, _enabled = true) do
@@ -300,5 +722,22 @@ defmodule Lightning.UsageTracking.ReportDataTest do
 
   defp no_of_steps(runs) do
     runs |> Enum.reduce(0, fn run, acc -> acc + (run.steps |> count()) end)
+  end
+
+  defp assert_project_metrics(projects_metrics, opts) do
+    project = opts |> Keyword.get(:project)
+    cleartext_enabled = opts |> Keyword.get(:cleartext_enabled)
+    date = opts |> Keyword.get(:date)
+
+    project_metrics = projects_metrics |> find_instrumentation(project.id)
+
+    expected_metrics =
+      ProjectMetricsService.generate_metrics(project, cleartext_enabled, date)
+
+    assert project_metrics == expected_metrics
+  end
+
+  defp assert_no_project_metrics(projects_metrics, project) do
+    refute projects_metrics |> find_instrumentation(project.id)
   end
 end

--- a/test/lightning/usage_tracking/report_worker_test.exs
+++ b/test/lightning/usage_tracking/report_worker_test.exs
@@ -1,0 +1,286 @@
+defmodule Lightning.UsageTracking.ReportWorkerTest do
+  use Lightning.DataCase
+
+  import Mock
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+
+  alias Lightning.UsageTracking.Client
+  alias Lightning.UsageTracking
+  alias Lightning.UsageTracking.Report
+  alias Lightning.UsageTracking.ReportData
+  alias Lightning.UsageTracking.ReportWorker
+
+  @date ~D[2024-02-25]
+  @host "https://foo.bar"
+
+  describe "tracking is enabled - cleartext uuids are disabled" do
+    setup do
+      cleartext_uuids_enabled = false
+
+      report_config =
+        UsageTracking.enable_daily_report(DateTime.utc_now())
+
+      put_temporary_env(:lightning, :usage_tracking,
+        cleartext_uuids_enabled: cleartext_uuids_enabled,
+        enabled: true,
+        host: @host
+      )
+
+      expected_report_data =
+        ReportData.generate(report_config, cleartext_uuids_enabled, @date)
+
+      %{expected_report_data: expected_report_data}
+    end
+
+    test "submits the metrics to the ImpactTracker", config do
+      %{expected_report_data: expected_report_data} = config
+
+      %{instance: expected_instance_data} = expected_report_data
+
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+
+        assert_called(
+          Client.submit_metrics(
+            %{instance: expected_instance_data},
+            @host
+          )
+        )
+      end
+    end
+
+    test "persists a report indicating successful submission", config do
+      %{expected_report_data: expected_report_data} = config
+
+      %{"instance" => expected_instance_data} =
+        expected_report_data |> stringify_keys()
+
+      report_date = @date
+
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+      end
+
+      report = Report |> Repo.one()
+
+      assert(
+        %Report{
+          submitted: true,
+          report_date: ^report_date,
+          data: %{"instance" => ^expected_instance_data}
+        } = report
+      )
+
+      assert DateTime.diff(DateTime.utc_now(), report.submitted_at, :second) < 2
+    end
+
+    test "persists a report indicating unsuccessful submission", config do
+      %{expected_report_data: expected_report_data} = config
+
+      %{"instance" => expected_instance_data} =
+        expected_report_data |> stringify_keys()
+
+      report_date = @date
+
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_error/2 do
+        perform_job(ReportWorker, %{date: @date})
+      end
+
+      report = Report |> Repo.one()
+
+      assert(
+        %Report{
+          submitted: false,
+          report_date: ^report_date,
+          data: %{"instance" => ^expected_instance_data},
+          submitted_at: nil
+        } = report
+      )
+    end
+
+    test "indicates that the job executed successfully" do
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        assert perform_job(ReportWorker, %{date: @date}) == :ok
+      end
+    end
+  end
+
+  describe "tracking is enabled - cleartext uuids are enabled" do
+    setup do
+      cleartext_uuids_enabled = true
+
+      report_config =
+        UsageTracking.enable_daily_report(DateTime.utc_now())
+
+      put_temporary_env(:lightning, :usage_tracking,
+        cleartext_uuids_enabled: cleartext_uuids_enabled,
+        enabled: true,
+        host: @host
+      )
+
+      expected_report_data =
+        ReportData.generate(report_config, cleartext_uuids_enabled, @date)
+
+      %{expected_report_data: expected_report_data}
+    end
+
+    test "submits the metrics to the ImpactTracker", config do
+      %{expected_report_data: expected_report_data} = config
+
+      %{instance: expected_instance_data} = expected_report_data
+
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+
+        assert_called(
+          Client.submit_metrics(
+            %{instance: expected_instance_data},
+            @host
+          )
+        )
+      end
+    end
+
+    test "persists a report indicating successful submission", config do
+      %{expected_report_data: expected_report_data} = config
+
+      %{"instance" => expected_instance_data} =
+        expected_report_data |> stringify_keys()
+
+      report_date = @date
+
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+      end
+
+      report = Report |> Repo.one()
+
+      assert(
+        %Report{
+          submitted: true,
+          report_date: ^report_date,
+          data: %{"instance" => ^expected_instance_data}
+        } = report
+      )
+
+      assert DateTime.diff(DateTime.utc_now(), report.submitted_at, :second) < 2
+    end
+
+    test "persists a report indicating unsuccessful submission", config do
+      %{expected_report_data: expected_report_data} = config
+
+      %{"instance" => expected_instance_data} =
+        expected_report_data |> stringify_keys()
+
+      report_date = @date
+
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_error/2 do
+        perform_job(ReportWorker, %{date: @date})
+      end
+
+      report = Report |> Repo.one()
+
+      assert(
+        %Report{
+          submitted: false,
+          report_date: ^report_date,
+          data: %{"instance" => ^expected_instance_data},
+          submitted_at: nil
+        } = report
+      )
+    end
+
+    test "indicates that the job executed successfully" do
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        assert perform_job(ReportWorker, %{date: @date}) == :ok
+      end
+    end
+  end
+
+  describe "tracking is enabled - but no config" do
+    setup do
+      UsageTracking.disable_daily_report()
+
+      put_temporary_env(:lightning, :usage_tracking,
+        enabled: true,
+        host: @host
+      )
+    end
+
+    test "does not submit metrics to the ImpactTracker" do
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+
+        assert_not_called(Client.submit_metrics(:_, :_))
+      end
+    end
+
+    test "does not persist a report submission" do
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+      end
+
+      refute Repo.one(Report)
+    end
+  end
+
+  describe "tracking is disabled" do
+    setup do
+      UsageTracking.enable_daily_report(DateTime.utc_now())
+
+      put_temporary_env(:lightning, :usage_tracking,
+        enabled: false,
+        host: @host
+      )
+    end
+
+    test "does not submit metrics to the ImpactTracker" do
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+
+        assert_not_called(Client.submit_metrics(:_, :_))
+      end
+    end
+
+    test "does not persist a report submission" do
+      with_mock Client,
+        submit_metrics: &mock_submit_metrics_ok/2 do
+        perform_job(ReportWorker, %{date: @date})
+      end
+
+      refute Repo.one(Report)
+    end
+  end
+
+  defp mock_submit_metrics_ok(_metrics, _host), do: :ok
+  defp mock_submit_metrics_error(_metrics, _host), do: :error
+
+  defp stringify_keys(map) do
+    map
+    |> Map.keys()
+    |> Enum.reduce(%{}, fn key, acc ->
+      acc |> stringify_key(key, map[key])
+    end)
+  end
+
+  defp stringify_key(acc, key, val) when is_map(val) and not is_struct(val) do
+    acc
+    |> Map.merge(%{to_string(key) => stringify_keys(val)})
+  end
+
+  defp stringify_key(acc, key, val) do
+    acc
+    |> Map.merge(%{to_string(key) => val})
+  end
+end

--- a/test/lightning/usage_tracking/run_service_test.exs
+++ b/test/lightning/usage_tracking/run_service_test.exs
@@ -1,0 +1,172 @@
+defmodule Lightning.UsageTracking.RunServiceTest do
+  use Lightning.DataCase
+
+  alias Lightning.Run
+  alias Lightning.UsageTracking.RunService
+
+  require Run
+
+  @date ~D[2024-02-05]
+  @finished_at ~U[2024-02-05 12:11:10Z]
+  @other_finished_at ~U[2024-02-04 12:11:10Z]
+
+  describe ".finished_runs/2" do
+    test "returns the subset of runs finished on the given date" do
+      finished_on_report_date = insert_finished_runs(@finished_at)
+      finished_on_other_date = insert_finished_runs(@other_finished_at)
+      unfinished = insert_unfinished_runs()
+
+      run_list = finished_on_other_date ++ finished_on_report_date ++ unfinished
+
+      assert(
+        RunService.finished_runs(run_list, @date) == finished_on_report_date
+      )
+    end
+
+    defp insert_finished_runs(finished_at) do
+      Run.final_states()
+      |> Enum.map(fn state ->
+        insert(
+          :run,
+          state: state,
+          finished_at: finished_at,
+          work_order: build(:workorder),
+          dataclip: build(:dataclip),
+          starting_job: build(:job)
+        )
+      end)
+    end
+
+    defp insert_unfinished_runs do
+      [:available, :claimed, :started]
+      |> Enum.map(fn state ->
+        insert(
+          :run,
+          state: state,
+          work_order: build(:workorder),
+          dataclip: build(:dataclip),
+          starting_job: build(:job)
+        )
+      end)
+    end
+  end
+
+  describe ".finished_steps/2" do
+    test "returns all run steps that finished on report date" do
+      run_1 =
+        insert(
+          :run,
+          work_order: build(:workorder),
+          dataclip: build(:dataclip),
+          starting_job: build(:job)
+        )
+
+      run_2 =
+        insert(
+          :run,
+          work_order: build(:workorder),
+          dataclip: build(:dataclip),
+          starting_job: build(:job)
+        )
+
+      finished_1 = insert_steps(run_1)
+      finished_2 = insert_steps(run_2)
+
+      run_1 = run_1 |> Repo.preload(:steps)
+      run_2 = run_2 |> Repo.preload(:steps)
+
+      runs = [run_1, run_2]
+      expected_ids = for step <- finished_1 ++ finished_2, do: step.id
+
+      actual_ids =
+        for step <- RunService.finished_steps(runs, @date) do
+          step.id
+        end
+
+      assert(actual_ids == expected_ids)
+    end
+
+    defp insert_steps(run) do
+      insert_step = fn ->
+        insert(
+          :step,
+          finished_at: @finished_at,
+          job: fn -> build(:job) end
+        )
+      end
+
+      finished =
+        insert_list(
+          2,
+          :run_step,
+          run: run,
+          step: insert_step
+        )
+
+      _finished_other =
+        insert(
+          :run_step,
+          run: run,
+          step:
+            insert(
+              :step,
+              finished_at: @other_finished_at,
+              job: build(:job)
+            )
+        )
+
+      _unfinished =
+        insert(
+          :run_step,
+          run: run,
+          step:
+            insert(
+              :step,
+              finished_at: nil,
+              job: build(:job)
+            )
+        )
+
+      for run_step <- finished, do: run_step.step
+    end
+  end
+
+  describe "unique_jobs/2" do
+    test "returns unique jobs across all steps finished on report date" do
+      job_1 = insert(:job)
+      job_2 = insert(:job)
+      job_3 = insert(:job)
+      job_4 = insert(:job)
+
+      finished_on_date_1 = insert_step(job_1, @finished_at)
+      finished_on_date_2 = insert_step(job_2, @finished_at)
+      finished_on_date_3 = insert_step(job_1, @finished_at)
+      finished_on_another_date = insert_step(job_3, @other_finished_at)
+      unfinished = insert_step(job_4, nil)
+
+      steps = [
+        finished_on_date_1,
+        finished_on_another_date,
+        finished_on_date_3,
+        finished_on_date_2,
+        unfinished
+      ]
+
+      assert RunService.unique_jobs(steps, @date) == [job_1, job_2]
+    end
+
+    defp insert_step(job, finished_at) do
+      insert(
+        :run_step,
+        run:
+          build(
+            :run,
+            work_order: build(:workorder),
+            starting_job: job,
+            dataclip: build(:dataclip)
+          ),
+        step: build(:step, finished_at: finished_at, job: job)
+      ).step
+    end
+  end
+end

--- a/test/lightning/usage_tracking/user_queries_test.exs
+++ b/test/lightning/usage_tracking/user_queries_test.exs
@@ -1,0 +1,237 @@
+defmodule Lightning.UsageTracking.UserQueriesTest do
+  use Lightning.DataCase
+
+  @date ~D[2024-02-05]
+
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.UserQueries
+
+  describe "existing_users/1" do
+    test "includes users created on or before the date" do
+      eligible_user_1 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-05 23:59:59Z]
+        )
+
+      eligible_user_2 =
+        insert(
+          :user,
+          disabled: true,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      ineligible_user_after_date =
+        insert(
+          :user,
+          inserted_at: ~U[2024-02-06 00:00:01Z]
+        )
+
+      result = UserQueries.existing_users(@date) |> Repo.all()
+
+      assert result |> contains(eligible_user_1)
+      assert result |> contains(eligible_user_2)
+      refute result |> contains(ineligible_user_after_date)
+    end
+  end
+
+  describe "existing_users/2" do
+    test "returns subset of user list inserted on or before the date" do
+      eligible_user_1 =
+        insert(:user, inserted_at: ~U[2024-02-05 23:59:59Z])
+
+      eligible_user_2 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      eligible_user_3 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      ineligible_user_after_date =
+        insert(:user, inserted_at: ~U[2024-02-06 00:00:01Z])
+
+      user_list = [
+        eligible_user_1,
+        ineligible_user_after_date,
+        eligible_user_3
+      ]
+
+      result = UserQueries.existing_users(@date, user_list) |> Repo.all()
+
+      assert result |> contains(eligible_user_1)
+      assert result |> contains(eligible_user_3)
+      refute result |> contains(eligible_user_2)
+      refute result |> contains(ineligible_user_after_date)
+    end
+  end
+
+  describe "active_users/1" do
+    test "returns users that have logged in in the last 30 days" do
+      user_1 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-08 00:00:00Z],
+          user: user_1
+        )
+
+      user_2 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2024-02-05 23:59:59Z],
+          user: user_2
+        )
+
+      user_3 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _ineligible_token_older_than_30_days =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-07 23:59:59Z],
+          user: user_3
+        )
+
+      user_4 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _ineligible_token_newer_than_report_date =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2024-02-06 00:00:01Z],
+          user: user_4
+        )
+
+      user_5 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _ineligible_token_not_session =
+        insert(
+          :user_token,
+          context: "api",
+          inserted_at: ~U[2024-02-05 00:00:01Z],
+          user: user_5
+        )
+
+      result = UserQueries.active_users(@date) |> Repo.all()
+
+      assert(result |> contains(user_1))
+      assert(result |> contains(user_2))
+      refute(result |> contains(user_3))
+      refute(result |> contains(user_4))
+      refute(result |> contains(user_5))
+    end
+
+    test "if user has more than one token, only includes user once" do
+      user_1 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token_user_1_1 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-08 00:00:00Z],
+          user: user_1
+        )
+
+      _active_token_user_1_2 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-08 00:00:01Z],
+          user: user_1
+        )
+
+      user_2 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token_user_2_1 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2024-02-05 23:59:59Z],
+          user: user_2
+        )
+
+      result = UserQueries.active_users(@date) |> Repo.all()
+
+      assert(result |> contains(user_1))
+      assert(result |> contains(user_2))
+      assert(length(result) == 2)
+    end
+  end
+
+  describe "active_users/2" do
+    test "returns subset of user list that have logged in the last 90 days" do
+      user_1 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token_user_1 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-08 00:00:00Z],
+          user: user_1
+        )
+
+      user_2 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token_user_2 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2024-02-05 23:59:59Z],
+          user: user_2
+        )
+
+      user_3 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _active_token_user_3 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-08 00:00:00Z],
+          user: user_3
+        )
+
+      user_4 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _ineligible_token_older_than_90_days =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: ~U[2023-11-07 23:59:59Z],
+          user: user_4
+        )
+
+      user_list = [
+        user_1,
+        user_4,
+        user_3
+      ]
+
+      result = UserQueries.active_users(@date, user_list) |> Repo.all()
+
+      assert(result |> contains(user_1))
+      assert(result |> contains(user_3))
+      refute(result |> contains(user_2))
+      refute(result |> contains(user_4))
+    end
+  end
+
+  defp contains(result, desired_user) do
+    result |> Enum.find(fn user -> user.id == desired_user.id end)
+  end
+end

--- a/test/lightning/usage_tracking/user_service_test.exs
+++ b/test/lightning/usage_tracking/user_service_test.exs
@@ -1,0 +1,192 @@
+defmodule Lightning.UsageTracking.UserServiceTest do
+  use Lightning.DataCase
+
+  alias Lightning.UsageTracking.UserService
+
+  @date ~D[2024-02-05]
+  describe "no_of_users/1" do
+    test "count includes all users created on/before date" do
+      _eligible_user_1 =
+        insert(:user, inserted_at: ~U[2024-02-05 23:59:59Z])
+
+      _eligible_user_2 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      _ineligible_user_after_date =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-06 00:00:01Z]
+        )
+
+      assert UserService.no_of_users(@date) == 2
+    end
+  end
+
+  describe ".no_of_users/2" do
+    test "returns subset of user list that exists before report date" do
+      eligible_user_1 =
+        insert(:user, inserted_at: ~U[2024-02-05 23:59:59Z])
+
+      _eligible_user_2 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      eligible_user_3 =
+        insert(:user, inserted_at: ~U[2024-02-04 01:00:00Z])
+
+      ineligible_user_after_date =
+        insert(:user, inserted_at: ~U[2024-02-06 00:00:01Z])
+
+      user_list = [
+        eligible_user_1,
+        ineligible_user_after_date,
+        eligible_user_3
+      ]
+
+      assert UserService.no_of_users(@date, user_list) == 2
+    end
+  end
+
+  describe ".no_of_active_users/1" do
+    test "returns a count of all active, enabled users" do
+      within_threshold_date = Date.add(@date, -89)
+
+      {:ok, within_threshold_time, _offset} =
+        DateTime.from_iso8601("#{within_threshold_date}T10:00:00Z")
+
+      outside_threshold_date = Date.add(@date, -90)
+
+      {:ok, outside_threshold_time, _offset} =
+        DateTime.from_iso8601("#{outside_threshold_date}T10:00:00Z")
+
+      enabled_user_1 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token_user_1 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: enabled_user_1
+        )
+
+      enabled_user_2 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token_user_2 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: enabled_user_2
+        )
+
+      enabled_user_3 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _inactive_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: outside_threshold_time,
+          user: enabled_user_3
+        )
+
+      assert UserService.no_of_active_users(@date) == 2
+    end
+  end
+
+  describe ".no_of_active_users/2" do
+    test "returns active subset of user list" do
+      within_threshold_date = Date.add(@date, -89)
+
+      {:ok, within_threshold_time, _offset} =
+        DateTime.from_iso8601("#{within_threshold_date}T10:00:00Z")
+
+      outside_threshold_date = Date.add(@date, -90)
+
+      {:ok, outside_threshold_time, _offset} =
+        DateTime.from_iso8601("#{outside_threshold_date}T10:00:00Z")
+
+      enabled_user_1 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token_user_1 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: enabled_user_1
+        )
+
+      enabled_user_2 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token_user_2 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: enabled_user_2
+        )
+
+      enabled_user_3 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _active_token_user_3 =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: within_threshold_time,
+          user: enabled_user_3
+        )
+
+      enabled_user_4 =
+        insert(
+          :user,
+          disabled: false,
+          inserted_at: ~U[2024-02-04 01:00:00Z]
+        )
+
+      _inactive_token =
+        insert(
+          :user_token,
+          context: "session",
+          inserted_at: outside_threshold_time,
+          user: enabled_user_4
+        )
+
+      user_list = [
+        enabled_user_1,
+        enabled_user_4,
+        enabled_user_3
+      ]
+
+      assert UserService.no_of_active_users(@date, user_list) == 2
+    end
+  end
+end

--- a/test/lightning/usage_tracking/workflow_metrics_service_test.exs
+++ b/test/lightning/usage_tracking/workflow_metrics_service_test.exs
@@ -1,0 +1,378 @@
+defmodule Lightning.UsageTracking.WorkflowMetricsServiceTest do
+  use Lightning.DataCase
+
+  alias Lightning.UsageTracking.WorkflowMetricsService
+
+  @date ~D[2024-02-05]
+  @finished_at ~U[2024-02-05 12:11:10Z]
+  @hashed_id "EECF8CFDD120E8DF8D9A12CA92AC3E815908223F95CFB11F19261A3C0EB34AEC"
+  @workflow_id "3cfb674b-e878-470d-b7c0-cfa8f7e003ae"
+
+  setup do
+    no_of_jobs = 6
+    no_of_work_orders = 3
+    no_of_runs_per_work_order = 2
+    no_of_unique_jobs_in_steps = 2
+    no_of_steps_per_unique_job = 4
+
+    workflow =
+      build_workflow(
+        @workflow_id,
+        no_of_jobs: no_of_jobs,
+        no_of_work_orders: no_of_work_orders,
+        no_of_runs_per_work_order: no_of_runs_per_work_order,
+        no_of_unique_jobs_in_steps: no_of_unique_jobs_in_steps,
+        no_of_steps_per_unique_job: no_of_steps_per_unique_job
+      )
+
+    _other_workflow =
+      build_workflow(
+        Ecto.UUID.generate(),
+        no_of_jobs: no_of_jobs + 1,
+        no_of_work_orders: no_of_work_orders + 1,
+        no_of_runs_per_work_order: no_of_runs_per_work_order + 1,
+        no_of_unique_jobs_in_steps: no_of_unique_jobs_in_steps + 1,
+        no_of_steps_per_unique_job: no_of_steps_per_unique_job + 1
+      )
+
+    no_of_runs = no_of_work_orders * no_of_runs_per_work_order
+
+    no_of_steps =
+      no_of_runs * no_of_unique_jobs_in_steps * no_of_steps_per_unique_job
+
+    %{
+      workflow: workflow,
+      no_of_jobs: no_of_jobs,
+      no_of_runs: no_of_runs,
+      no_of_steps: no_of_steps,
+      no_of_unique_jobs: no_of_unique_jobs_in_steps
+    }
+  end
+
+  describe "generate_metrics/3 - cleartext disabled" do
+    setup context do
+      context |> Map.merge(%{enabled: false})
+    end
+
+    test "includes the hashed workflow uuid", config do
+      %{workflow: workflow, enabled: enabled} = config
+
+      hashed_uuid = @hashed_id
+
+      assert(
+        %{
+          hashed_uuid: ^hashed_uuid
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "does not include the cleartext uuid", config do
+      %{workflow: workflow, enabled: enabled} = config
+
+      assert(
+        %{
+          cleartext_uuid: nil
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of jobs", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_jobs: no_of_jobs
+      } = config
+
+      assert(
+        %{
+          no_of_jobs: ^no_of_jobs
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of finished runs", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_runs: no_of_runs
+      } = config
+
+      assert(
+        %{
+          no_of_runs: ^no_of_runs
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of steps for the finished runs", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_steps: no_of_steps
+      } = config
+
+      assert(
+        %{
+          no_of_steps: ^no_of_steps
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of active jobs for the finished steps", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_unique_jobs: no_of_unique_jobs
+      } = config
+
+      assert(
+        %{
+          no_of_active_jobs: ^no_of_unique_jobs
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+  end
+
+  describe "generate_metrics/3 - cleartext enabled" do
+    setup context do
+      context |> Map.merge(%{enabled: true})
+    end
+
+    test "includes the hashed workflow uuid", config do
+      %{workflow: workflow, enabled: enabled} = config
+
+      hashed_uuid = @hashed_id
+
+      assert(
+        %{
+          hashed_uuid: ^hashed_uuid
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the cleartext uuid", config do
+      %{workflow: workflow, enabled: enabled} = config
+
+      cleartext_uuid = @workflow_id
+
+      assert(
+        %{
+          cleartext_uuid: ^cleartext_uuid
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of jobs", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_jobs: no_of_jobs
+      } = config
+
+      assert(
+        %{
+          no_of_jobs: ^no_of_jobs
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of finished runs", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_runs: no_of_runs
+      } = config
+
+      assert(
+        %{
+          no_of_runs: ^no_of_runs
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of finished steps", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_steps: no_of_steps
+      } = config
+
+      assert(
+        %{
+          no_of_steps: ^no_of_steps
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+
+    test "includes the number of active jobs for the finished steps", config do
+      %{
+        workflow: workflow,
+        enabled: enabled,
+        no_of_unique_jobs: no_of_unique_jobs
+      } = config
+
+      assert(
+        %{
+          no_of_active_jobs: ^no_of_unique_jobs
+        } = WorkflowMetricsService.generate_metrics(workflow, enabled, @date)
+      )
+    end
+  end
+
+  describe ".filter_eligible_workflows" do
+    test "returns workflows that existed on or before the date" do
+      date = ~D[2024-02-05]
+
+      eligible_workflow_1 =
+        insert(
+          :workflow,
+          name: "e-1",
+          inserted_at: ~U[2024-02-04 12:00:00Z],
+          deleted_at: nil
+        )
+
+      eligible_workflow_2 =
+        insert(
+          :workflow,
+          name: "e-2",
+          inserted_at: ~U[2024-02-05 23:59:59Z],
+          deleted_at: nil
+        )
+
+      eligible_workflow_3 =
+        insert(
+          :workflow,
+          name: "e-3",
+          inserted_at: ~U[2024-02-04 12:00:00Z],
+          deleted_at: ~U[2024-02-06 00:00:00Z]
+        )
+
+      eligible_workflow_4 =
+        insert(
+          :workflow,
+          name: "e-4",
+          inserted_at: ~U[2024-02-04 12:00:00Z],
+          deleted_at: ~U[2024-02-06 00:00:01Z]
+        )
+
+      ineligible_workflow_deleted_before_1 =
+        insert(
+          :workflow,
+          name: "ib-1",
+          inserted_at: ~U[2024-02-04 12:00:00Z],
+          deleted_at: ~U[2024-02-05 23:59:59Z]
+        )
+
+      ineligible_workflow_deleted_before_2 =
+        insert(
+          :workflow,
+          name: "ib-2",
+          inserted_at: ~U[2024-02-04 12:00:00Z],
+          deleted_at: ~U[2024-02-05 23:59:58Z]
+        )
+
+      ineligible_workflow_created_after_1 =
+        insert(
+          :workflow,
+          name: "ca-1",
+          inserted_at: ~U[2024-02-06 00:00:00Z],
+          deleted_at: nil
+        )
+
+      ineligible_workflow_created_after_2 =
+        insert(
+          :workflow,
+          name: "ca-2",
+          inserted_at: ~U[2024-02-06 00:00:01Z],
+          deleted_at: ~U[2024-02-06 00:00:02Z]
+        )
+
+      all_workflows = [
+        eligible_workflow_1,
+        ineligible_workflow_deleted_before_1,
+        ineligible_workflow_created_after_1,
+        eligible_workflow_2,
+        ineligible_workflow_deleted_before_2,
+        eligible_workflow_3,
+        ineligible_workflow_created_after_2,
+        eligible_workflow_4
+      ]
+
+      expected_workflows = [
+        eligible_workflow_1,
+        eligible_workflow_2,
+        eligible_workflow_3,
+        eligible_workflow_4
+      ]
+
+      workflows =
+        WorkflowMetricsService.find_eligible_workflows(all_workflows, date)
+
+      assert workflows == expected_workflows
+    end
+  end
+
+  defp build_workflow(workflow_id, opts) do
+    no_of_jobs = opts |> Keyword.get(:no_of_jobs)
+    no_of_work_orders = opts |> Keyword.get(:no_of_work_orders)
+    no_of_runs_per_work_order = opts |> Keyword.get(:no_of_runs_per_work_order)
+    no_of_unique_jobs_in_steps = opts |> Keyword.get(:no_of_unique_jobs_in_steps)
+    no_of_steps_per_unique_job = opts |> Keyword.get(:no_of_steps_per_unique_job)
+
+    workflow = insert(:workflow, id: workflow_id)
+
+    jobs =
+      no_of_jobs
+      |> insert_list(:job, workflow: workflow)
+      |> Enum.take(no_of_unique_jobs_in_steps)
+
+    work_orders = insert_list(no_of_work_orders, :workorder, workflow: workflow)
+
+    for work_order <- work_orders do
+      insert_runs_with_steps(
+        no_of_runs_per_work_order: no_of_runs_per_work_order,
+        no_of_steps_per_unique_job: no_of_steps_per_unique_job,
+        work_order: work_order,
+        jobs: jobs
+      )
+    end
+
+    workflow |> Repo.preload([:jobs, runs: [steps: [:job]]])
+  end
+
+  defp insert_runs_with_steps(opts) do
+    no_of_runs_per_work_order = opts |> Keyword.get(:no_of_runs_per_work_order)
+    no_of_steps_per_unique_job = opts |> Keyword.get(:no_of_steps_per_unique_job)
+    work_order = opts |> Keyword.get(:work_order)
+    jobs = opts |> Keyword.get(:jobs)
+
+    [starting_job | _] = jobs
+
+    insert_list(
+      no_of_runs_per_work_order,
+      :run,
+      work_order: work_order,
+      dataclip: &dataclip_builder/0,
+      finished_at: @finished_at,
+      state: :success,
+      starting_job: starting_job,
+      steps: fn -> build_steps(jobs, no_of_steps_per_unique_job) end
+    )
+  end
+
+  defp build_steps(jobs, no_of_steps_per_unique_job) do
+    jobs
+    |> Enum.flat_map(fn job ->
+      build_list(
+        no_of_steps_per_unique_job,
+        :step,
+        input_dataclip: &dataclip_builder/0,
+        output_dataclip: &dataclip_builder/0,
+        job: job,
+        finished_at: @finished_at
+      )
+    end)
+  end
+
+  defp dataclip_builder, do: build(:dataclip)
+end

--- a/test/lightning/usage_tracking_test.exs
+++ b/test/lightning/usage_tracking_test.exs
@@ -556,4 +556,25 @@ defmodule Lightning.UsageTrackingTest do
              ) == :ok
     end
   end
+
+  describe "find_enabled_daily_report_config/0" do
+    test "returns existing config if it is enabled" do
+      expected_config = UsageTracking.enable_daily_report(DateTime.utc_now())
+
+      returned_config = UsageTracking.find_enabled_daily_report_config()
+
+      assert returned_config == expected_config
+    end
+
+    test "returns nil if the config exists but is disabled" do
+      UsageTracking.enable_daily_report(DateTime.utc_now())
+      UsageTracking.disable_daily_report()
+
+      assert UsageTracking.find_enabled_daily_report_config() == nil
+    end
+
+    test "returns nil if the config does not exist" do
+      assert UsageTracking.find_enabled_daily_report_config() == nil
+    end
+  end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -142,6 +142,12 @@ defmodule Lightning.Factories do
     }
   end
 
+  def user_token_factory do
+    %Lightning.Accounts.UserToken{
+      token: fn -> Ecto.UUID.generate() end
+    }
+  end
+
   def backup_code_factory do
     %Lightning.Accounts.UserBackupCode{
       code: Lightning.Accounts.UserBackupCode.generate_backup_code()


### PR DESCRIPTION
## Validation Steps

- Ensure that you have a local version of ImpactTracker running
- Ensure that `USAGE_TRACKER_HOST` for your local Lightning env is pointing to your local ImpactTracker instance.
- Ensure that `USAGE_TRACKING_ENABLED` is either not set or set to `true`
- In a (Lightning) IEx session, run the following to execute the code:

```
today = DateTime.utc_now() |> DateTime.to_date()
today_as_string = today |> Date.to_iso8601()

Lightning.UsageTracking.disable_daily_report()
Lightning.UsageTracking.enable_daily_report(~U[2024-03-07 12:00:00Z])
Lightning.Demo.reset_demo()
Lightning.UsageTracking.ReportWorker.perform(%Oban.Job{args: %{"date" => today_as_string}})
```

In the same Lightning IEx session, run the below to validate the changes (there should be no errors):

```
alias Lightning.UsageTracking.Report
import Ecto.Query
query = from r in Report, order_by: [desc: r.inserted_at], limit: 1

last_report = query |> Repo.one()

%{submitted: true, report_date: ^today} = last_report
```

In an ImpactTracker IEx session, the below should complete without any errors:

```
today = DateTime.utc_now() |> DateTime.to_date()

import Ecto.Query
alias ImpactTracker.Repo
alias ImpactTracker.Submission
query = from s in Submission, order_by: [desc: s.inserted_at], limit: 1, preload: [projects: [:workflows]]
last_submission = query |> Repo.one()

%{version: "2", report_date: ^today} = last_submission
```

## Notes for the reviewer

**While this code is ready to be merged in, I would prefer to hold off on merging until I can confirm that my date-parsing change of earlier today has had the desired effect.**

There is still a fair amount of tidying up that can be done wrt this code, including collapsing the various *Service modules into `UsageTracking`. This will be done in follow-up PRs once this new reporting functionality is fully-functional and has been tested on prod.


## Related issue

#1853 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
