### PR TITLE
Add indexes to improve search performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
   [#1836](https://github.com/OpenFn/lightning/issues/1836)
 - Added ability to remove project collaborators
   [#1837](https://github.com/OpenFn/lightning/issues/1837)
+- TSVector index to log_lines, and gin index to dataclips
+  [#1898](https://github.com/OpenFn/lightning/issues/1898)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- TSVector index to log_lines, and gin index to dataclips
+  [#1898](https://github.com/OpenFn/lightning/issues/1898)
+
 ### Changed
 
 ### Fixed
@@ -41,8 +44,6 @@ and this project adheres to
   [#1836](https://github.com/OpenFn/lightning/issues/1836)
 - Added ability to remove project collaborators
   [#1837](https://github.com/OpenFn/lightning/issues/1837)
-- TSVector index to log_lines, and gin index to dataclips
-  [#1898](https://github.com/OpenFn/lightning/issues/1898)
 
 ### Changed
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -483,7 +483,7 @@ defmodule Lightning.Invocation do
       :body, dynamic ->
         dynamic(
           [input_dataclip: dataclip],
-          ^dynamic or ilike(type(dataclip.body, :string), ^"%#{search_term}%")
+          ^dynamic or like(type(dataclip.body, :string), ^"%#{search_term}%")
         )
 
       :id, dynamic ->

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -130,7 +130,6 @@ defmodule LightningWeb.RunLive.Index do
     do: %{
       "workflow_id" => "",
       "search_term" => "",
-      "body" => "true",
       "log" => "true",
       "date_after" =>
         Timex.now() |> Timex.shift(days: -30) |> DateTime.to_string(),

--- a/priv/repo/migrations/20240319112421_add_dataclip_gin_index.exs
+++ b/priv/repo/migrations/20240319112421_add_dataclip_gin_index.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddDataclipGinIndex do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:dataclips, [:body], concurrently: true, using: :gin)
+  end
+end

--- a/priv/repo/migrations/20240319114811_add_log_lines_ts_vector_column.exs
+++ b/priv/repo/migrations/20240319114811_add_log_lines_ts_vector_column.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddLogLinesTSVectorColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:log_lines) do
+      add :search_vector, :tsvector, null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20240319115810_generate_log_line_search_vectors.exs
+++ b/priv/repo/migrations/20240319115810_generate_log_line_search_vectors.exs
@@ -1,0 +1,42 @@
+defmodule Lightning.Repo.Migrations.GenerateLogLineSearchVectors do
+  require Logger
+  use Ecto.Migration
+
+  def change do
+    execute(
+      # Calculate the search vectors in batches of 2500 rows until all rows have
+      # been processed.
+      fn ->
+        Stream.unfold(1, fn n ->
+          if n > 0 do
+            %{num_rows: n} = update_search_vector(2500)
+            Logger.info("Updated search_vector for #{n} rows")
+
+            {:ok, n}
+          else
+            nil
+          end
+        end)
+        |> Stream.run()
+      end,
+      ""
+    )
+  end
+
+  defp update_search_vector(limit) do
+    repo().query!(
+      """
+      UPDATE log_lines
+      SET search_vector = to_tsvector('english', message)
+      WHERE id IN (
+        SELECT id
+        FROM log_lines
+        WHERE search_vector IS NULL
+        LIMIT $1
+      )
+      """,
+      [limit],
+      log: :debug
+    )
+  end
+end

--- a/priv/repo/migrations/20240319122652_add_search_vector_trigger.exs
+++ b/priv/repo/migrations/20240319122652_add_search_vector_trigger.exs
@@ -1,0 +1,58 @@
+defmodule Lightning.Repo.Migrations.AddSearchVectorTrigger do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      """
+      CREATE TEXT SEARCH DICTIONARY english_stem_nostop (
+        Template = pg_catalog.simple
+      );
+      """,
+      "DROP TEXT SEARCH CONFIGURATION english_nostop"
+    )
+
+    execute(
+      """
+      CREATE TEXT SEARCH CONFIGURATION public.english_nostop ( COPY = pg_catalog.english );
+      """,
+      "DROP TEXT SEARCH DICTIONARY english_stem_nostop"
+    )
+
+    execute(
+      """
+      ALTER TEXT SEARCH CONFIGURATION public.english_nostop
+        ALTER MAPPING FOR asciiword, asciihword, hword_asciipart, hword, hword_part, word WITH english_stem_nostop;
+      """,
+      ""
+    )
+
+    execute(
+      """
+      CREATE OR REPLACE FUNCTION public.update_search_vector()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+        begin
+          UPDATE log_lines SET search_vector = to_tsvector('english_nostop', message) WHERE id = NEW.id;
+          RETURN NEW;
+        end
+      $function$ ;
+      """,
+      "DROP FUNCTION IF EXISTS update_search_vector;"
+    )
+
+    table = "log_lines"
+
+    execute(
+      """
+      CREATE TRIGGER set_search_vector
+      AFTER INSERT ON #{table} FOR EACH ROW
+      WHEN (NEW."search_vector" IS NULL)
+      EXECUTE PROCEDURE update_search_vector();
+      """,
+      """
+      DROP TRIGGER IF EXISTS set_search_vector ON #{table};
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20240319125628_add_tsvector_index_to_log_lines.exs
+++ b/priv/repo/migrations/20240319125628_add_tsvector_index_to_log_lines.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddTsvectorIndexToLogLines do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:log_lines, [:search_vector], using: :gin)
+  end
+end

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -1031,12 +1031,18 @@ defmodule LightningWeb.WorkOrderLiveTest do
       refute workflow_displayed(view, "workflow 1")
       refute workflow_displayed(view, "workflow 2")
 
-      view |> search_for("xxxx", [:body, :log])
+      view
+      |> search_for("xxxx", [:log])
 
       refute workflow_displayed(view, "workflow 1")
       refute workflow_displayed(view, "workflow 2")
 
-      view |> search_for("eliaswalyba", [:body, :log])
+      view
+      |> form("#run-toggle-form", filters: %{"body" => "true"})
+      |> render_change()
+
+      view
+      |> search_for("eliaswalyba", [:body, :log])
 
       assert workflow_displayed(view, "workflow 1")
       refute workflow_displayed(view, "workflow 2")
@@ -1688,7 +1694,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
   end
 
   def search_for(view, term, types) when types == [] do
-    search_for(view, term, [:body, :log])
+    search_for(view, term, [:log])
   end
 
   def search_for(view, term, types) do


### PR DESCRIPTION
## Validation Steps

After running the migrations:

- Using `psql`, run `\d dataclips` and find the resulting: `"dataclips_body_index" gin (body)`
- All existing log lines should have their `search_vector` column filled.
- Any new log lines should also have their search column filled.

## Notes for the reviewer

I have not reviewed the queries in the History page as to how they would use the indexes yet, chances are there are changes required there to leverage them.

Searching log lines is a known quantity since it is just text, but with dataclips it could be tricky. The GIN index assumes containment queries, but unlike trigger matches (which used json containment queries) users might need to be educated and/or the UI handle conercing and validation of text inputs into containment queries.

## Related issue

Fixes #1898

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
