### PR TITLE
Use DayWorker for recurring usage tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,9 +187,15 @@
 # set USAGE_TRACKING_UUIDS=cleartext.
 # USAGE_TRACKING_UUIDS=hashed_only
 
-# By default, impact tracking metrics will be reported to https://impact.openfn.org. Use the
-# below if you wish to change that.
+# By default, impact tracking metrics will be reported to
+# https://impact.openfn.org. Use the below if you wish to change that.
 # USAGE_TRACKER_HOST=https://impact.openfn.org
+
+# Restrict the number of days that reports will be generated for with each run of
+# `Lightning.UsageTracking.DayWorker. This will only have a noticeable effect in
+# cases where there is a backlog (e.g when the Worker has not run for an extended
+# period or where reports are being retroactively generated.
+# USAGE_TRACKING_DAILY_BATCH_SIZE=10
 
 # OpenFn.org hosts a public sandbox that gets reset every night. If you'd like to
 # make your instance "resettable" (a highly descrutive action—this destroys all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Replace v1 usage tracking with v2 usage tracking.
+  [#1853](https://github.com/OpenFn/lightning/issues/1853)
+
 ### Fixed
 
 ## [v2.0.10]
@@ -48,6 +51,8 @@ and this project adheres to
   [#1836](https://github.com/OpenFn/lightning/issues/1836)
 - Added ability to remove project collaborators
   [#1837](https://github.com/OpenFn/lightning/issues/1837)
+- Added new usage tracking submission code.
+  [#1853](https://github.com/OpenFn/lightning/issues/1853)
 
 ### Changed
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -85,7 +85,11 @@ Note that for secure deployments, it's recommended to use a combination of
 - `URL_PORT` - the port, usually `443` for production
 - `URL_SCHEME` - the scheme for writing urls, (e.g., `https`)
 - `USAGE_TRACKER_HOST` - the host that receives usage tracking submissions
-  (defaults to https://impact.openfn.org)
+  (defaults to https://impact.openfn.org).
+- `USAGE_TRACKING_DAILY_BATCH_SIZE` - the number of days that will be reported
+  on with each run of `UsageTracking.DayWorker`. This will only have a
+  noticeable effect in cases where there is a backlog, or where reports are
+  being generated retroactively (defaults to 10).
 - `USAGE_TRACKING_ENABLED` - enables the submission of anonymised usage data to
   OpenFn (defaults to `true`).
 - `USAGE_TRACKING_UUIDS` - indicates whether submissions should include

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -170,7 +170,18 @@ purge_cron =
     ],
     else: []
 
-usage_tracking_cron = [{"0 2 * * *", Lightning.UsageTracking.Worker}]
+usage_tracking_daily_batch_size =
+  "USAGE_TRACKING_DAILY_BATCH_SIZE"
+  |> System.get_env("10")
+  |> String.to_integer()
+
+usage_tracking_cron = [
+  {
+    "0 2 * * *",
+    Lightning.UsageTracking.DayWorker,
+    args: %{"batch_size" => usage_tracking_daily_batch_size}
+  }
+]
 
 all_cron = base_oban_cron ++ purge_cron ++ usage_tracking_cron
 


### PR DESCRIPTION
## Validation Steps

The only functional change to this PR is to replace the Oban cron entry for `UsageTracking.Worker` with an entry for `UsageTracking.DayWorker` (pronounced DayWalker :P).  To test this,  change the time that the `DayWorker` is due to run so that you do not need to wait until 02:00 UTC  - and then do the following:

Ensure that you have a local version of ImpactTracker running
Ensure that USAGE_TRACKER_HOST for your local Lightning env is pointing to your local ImpactTracker instance.
Ensure that USAGE_TRACKING_ENABLED is either not set or set to true
In a (Lightning) IEx session, run the following to execute the code:

```
today = DateTime.utc_now() |> DateTime.to_date()
yesterday = DateTime.add(DateTime.utc_now(), -1, :day)
today_as_string = today |> Date.to_iso8601()

Lightning.UsageTracking.disable_daily_report()
Lightning.UsageTracking.enable_daily_report(yesterday)
Lightning.Demo.reset_demo()
Lightning.UsageTracking.ReportWorker.perform(%Oban.Job{args: %{"date" => today_as_string}})
```

Once the time for the worker to run has passed, run the below to validate the changes (there should be no errors):

alias Lightning.UsageTracking.Report
import Ecto.Query
query = from r in Report, order_by: [desc: r.inserted_at], limit: 1

last_report = query |> Repo.one()

%{submitted: true, report_date: ^today} = last_report
In an ImpactTracker IEx session, the below should complete without any errors:

today = DateTime.utc_now() |> DateTime.to_date()

import Ecto.Query
alias ImpactTracker.Repo
alias ImpactTracker.Submission
query = from s in Submission, order_by: [desc: s.inserted_at], limit: 1, preload: [projects: [:workflows]]
last_submission = query |> Repo.one()

%{version: "2", report_date: ^today} = last_submission

## Notes for the reviewer



## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
