### PR TITLE
Fix unresponsive UX for manual job creation on long queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- Give priority to manual runs (over webhook requests and cron) so that active
+  users on the inspector don't have to wait ages for thier work during high load
+  periods [#1918](https://github.com/OpenFn/lightning/issues/1918)
+
 ### Fixed
 
 ## [v2.1.0] - 2024-03-20

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -95,7 +95,7 @@ defmodule Lightning.Run do
   end
 
   def for(%Job{} = job, attrs) do
-    %__MODULE__{}
+    %__MODULE__{priority: attrs[:priority]}
     |> change()
     |> put_assoc(:starting_job, job)
     |> put_assoc(:created_by, attrs[:created_by])

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -104,7 +104,8 @@ defmodule Lightning.WorkOrders do
       build_for(manual.job, %{
         workflow: manual.workflow,
         dataclip: dataclip,
-        created_by: manual.created_by
+        created_by: manual.created_by,
+        priority: :immediate
       })
     end)
     |> Multi.put(:workflow, manual.workflow)
@@ -195,7 +196,8 @@ defmodule Lightning.WorkOrders do
     |> put_assoc(:runs, [
       Run.for(job, %{
         dataclip: attrs[:dataclip],
-        created_by: attrs[:created_by]
+        created_by: attrs[:created_by],
+        priority: attrs[:priority]
       })
     ])
     |> validate_required_assoc(:workflow)

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -139,15 +139,14 @@ defmodule Lightning.WorkOrdersTest do
                )
                |> Ecto.Changeset.apply_action(:validate)
 
-      assert {:ok, workorder} = WorkOrders.create_for(manual)
-      assert [run] = workorder.runs
-
+      assert {:ok, %{runs: [run]} = workorder} = WorkOrders.create_for(manual)
       assert workorder.dataclip.type == :saved_input
 
       assert workorder.dataclip.body == %{
                "key_left" => "value_left"
              }
 
+      assert run.priority == :immediate
       assert run.created_by.id == user.id
 
       assert_received %Events.RunCreated{


### PR DESCRIPTION
## Validation Steps

1. Create 500 webhooks requests (simulation of multiple simultaneous users)
2. Edit a job on the workflow and click on Create work order
**Without** the fix the user needs to wait all 500 requests to finish to get the UI to respond.

Closes #1918

## Notes for the reviewer

@taylordowns2000 this was a quick one and happens when there are many jobs enqueued.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
