### PR TITLE
new users should be the owners of their projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- When automatically creating a project for a newly registered user (via the
+  `INIT_PROJECT_FOR_NEW_USER=true` environment variable) that user should be the
+  `owner` of the project.
+  [#1927](https://github.com/OpenFn/lightning/issues/1927)
 - Give priority to manual runs (over webhook requests and cron) so that active
   users on the inspector don't have to wait ages for thier work during high load
   periods [#1918](https://github.com/OpenFn/lightning/issues/1918)

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -18,7 +18,7 @@ defmodule LightningWeb.UserRegistrationController do
 
     Lightning.SetupUtils.create_starter_project(
       project_name,
-      [%{user_id: user_id, role: :admin}]
+      [%{user_id: user_id, role: :owner}]
     )
   end
 


### PR DESCRIPTION
## Validation Steps

1. Create a new account on Lightning for an instance that's configured to auto-generate projects. (`INIT_PROJECT_FOR_NEW_USER=true`)
2. Note your role on the new project.

## Related issue

Fixes #1927 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
