### PR TITLE
Create demo users instead of register (same project)

### DIFF
--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -21,6 +21,8 @@ defmodule Lightning.Accounts do
 
   require Logger
 
+  defdelegate subscribe(), to: Events
+
   def has_activity_in_projects?(%User{id: id} = _user) do
     count =
       from(run in Lightning.Run,

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -147,7 +147,7 @@ defmodule Lightning.SetupUtils do
       end
 
     {:ok, admin} =
-      Accounts.register_user(%{
+      Accounts.create_user(%{
         first_name: "Amy",
         last_name: "Admin",
         email: "demo@openfn.org",
@@ -155,7 +155,7 @@ defmodule Lightning.SetupUtils do
       })
 
     {:ok, editor} =
-      Accounts.register_user(%{
+      Accounts.create_user(%{
         first_name: "Esther",
         last_name: "Editor",
         email: "editor@openfn.org",
@@ -163,7 +163,7 @@ defmodule Lightning.SetupUtils do
       })
 
     {:ok, viewer} =
-      Accounts.register_user(%{
+      Accounts.create_user(%{
         first_name: "Vikram",
         last_name: "Viewer",
         email: "viewer@openfn.org",


### PR DESCRIPTION
## Notes for the reviewer

- Creates the additional demo users instead of registering to avoid creation of a project for each one on umbrella app.
- Adds shortcut to subscribe

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
