### PR TITLE
Apply usage limit to bulk-reruns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Apply usage limit to bulk-reruns
+  [#1931](https://github.com/OpenFn/lightning/issues/1931)
+
 ## [v2.2.0] - 2024-03-21
 
 ### Added

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -4,7 +4,6 @@ defmodule Lightning.Extensions.UsageLimiting do
   """
   @type error_reason ::
           :too_many_runs
-          | :too_many_batch_runs
           | :runs_hard_limit
           | :unknown_project
   @type message :: Lightning.Extensions.Message.t()
@@ -13,11 +12,11 @@ defmodule Lightning.Extensions.UsageLimiting do
   defmodule Action do
     @moduledoc false
     @type t :: %__MODULE__{
-            type: :new_run | :new_run_batch | :new_workflow,
+            type: :new_run | :new_workflow,
             amount: pos_integer()
           }
 
-    defstruct [:type, :amount]
+    defstruct type: nil, amount: 1
   end
 
   defmodule Context do

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -2,16 +2,22 @@ defmodule Lightning.Extensions.UsageLimiting do
   @moduledoc """
   Rate limiting for Lightning workloads that depends on Runtime.
   """
-  @type error_reason :: :too_many_runs | :runs_hard_limit | :unknown_project
+  @type error_reason ::
+          :too_many_runs
+          | :too_many_batch_runs
+          | :runs_hard_limit
+          | :unknown_project
   @type message :: Lightning.Extensions.Message.t()
+  @type error :: {:error, error_reason(), message()}
 
   defmodule Action do
     @moduledoc false
     @type t :: %__MODULE__{
-            type: :new_run | :new_workflow
+            type: :new_run | :new_run_batch | :new_workflow,
+            amount: pos_integer()
           }
 
-    defstruct [:type]
+    defstruct [:type, :amount]
   end
 
   defmodule Context do
@@ -25,8 +31,8 @@ defmodule Lightning.Extensions.UsageLimiting do
   end
 
   @callback check_limits(context :: Context.t()) ::
-              :ok | {:error, error_reason(), message()}
+              :ok | error()
 
   @callback limit_action(action :: Action.t(), context :: Context.t()) ::
-              :ok | {:error, error_reason(), message()}
+              :ok | error()
 end

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -34,6 +34,9 @@ defmodule Lightning.WorkOrders do
 
   alias Ecto.Multi
   alias Lightning.Accounts.User
+  alias Lightning.Extensions.UsageLimiting
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Graph
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Step
@@ -41,6 +44,7 @@ defmodule Lightning.WorkOrders do
   alias Lightning.Run
   alias Lightning.Runs
   alias Lightning.RunStep
+  alias Lightning.Services.UsageLimiter
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
@@ -53,6 +57,7 @@ defmodule Lightning.WorkOrders do
           {:workflow, Workflow.t()}
           | {:dataclip, Dataclip.t()}
           | {:created_by, User.t()}
+          | {:project_id, Ecto.UUID.t()}
           | {:without_run, boolean()}
 
   @doc """
@@ -355,7 +360,7 @@ defmodule Lightning.WorkOrders do
   @spec retry_many(
           [WorkOrder.t(), ...] | [RunStep.t(), ...],
           [work_order_option(), ...]
-        ) :: {:ok, count :: integer()}
+        ) :: {:ok, count :: integer()} | UsageLimiting.error()
   def retry_many([%WorkOrder{} | _rest] = workorders, opts) do
     attrs = Map.new(opts)
     orders_ids = Enum.map(workorders, & &1.id)
@@ -391,35 +396,54 @@ defmodule Lightning.WorkOrders do
 
     runs = Repo.all(first_runs_query)
 
-    results =
-      Enum.map(runs, fn run ->
-        starting_job =
-          if job = run.starting_job do
-            job
-          else
-            [edge] = run.starting_trigger.edges
-            edge.target_job
-          end
+    with project_id <- Keyword.fetch!(opts, :project_id),
+         :ok <-
+           UsageLimiter.limit_action(
+             %Action{type: :new_run_batch, amount: length(runs)},
+             %Context{
+               project_id: project_id
+             }
+           ) do
+      results =
+        Enum.map(runs, fn run ->
+          starting_job =
+            if job = run.starting_job do
+              job
+            else
+              [edge] = run.starting_trigger.edges
+              edge.target_job
+            end
 
-        do_retry(
-          run.work_order,
-          run.dataclip,
-          starting_job,
-          [],
-          attrs[:created_by]
-        )
-      end)
+          do_retry(
+            run.work_order,
+            run.dataclip,
+            starting_job,
+            [],
+            attrs[:created_by]
+          )
+        end)
 
-    {:ok, Enum.count(results, fn result -> match?({:ok, _}, result) end)}
+      {:ok, Enum.count(results, fn result -> match?({:ok, _}, result) end)}
+    end
   end
 
   def retry_many([%RunStep{} | _rest] = run_steps, opts) do
-    results =
-      Enum.map(run_steps, fn run_step ->
-        retry(run_step.run_id, run_step.step_id, opts)
-      end)
+    with project_id <- Keyword.fetch!(opts, :project_id),
+         runs <- Enum.uniq_by(run_steps, & &1.run_id),
+         :ok <-
+           UsageLimiter.limit_action(
+             %Action{type: :new_run_batch, amount: length(runs)},
+             %Context{
+               project_id: project_id
+             }
+           ) do
+      results =
+        Enum.map(run_steps, fn run_step ->
+          retry(run_step.run_id, run_step.step_id, opts)
+        end)
 
-    {:ok, Enum.count(results, fn result -> match?({:ok, _}, result) end)}
+      {:ok, Enum.count(results, fn result -> match?({:ok, _}, result) end)}
+    end
   end
 
   def retry_many([], _opts) do

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -399,7 +399,7 @@ defmodule Lightning.WorkOrders do
     with project_id <- Keyword.fetch!(opts, :project_id),
          :ok <-
            UsageLimiter.limit_action(
-             %Action{type: :new_run_batch, amount: length(runs)},
+             %Action{type: :new_run, amount: length(runs)},
              %Context{
                project_id: project_id
              }
@@ -432,7 +432,7 @@ defmodule Lightning.WorkOrders do
          runs <- Enum.uniq_by(run_steps, & &1.run_id),
          :ok <-
            UsageLimiter.limit_action(
-             %Action{type: :new_run_batch, amount: length(runs)},
+             %Action{type: :new_run, amount: length(runs)},
              %Context{
                project_id: project_id
              }

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -439,6 +439,12 @@ defmodule LightningWeb.RunLive.Index do
      )}
   end
 
+  def handle_event("invalid-rerun:" <> error_message, _params, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, error_message)}
+  end
+
   defp find_workflow_name(workflows, workflow_id) do
     Enum.find_value(workflows, fn {name, id} ->
       if id == workflow_id do
@@ -578,5 +584,17 @@ defmodule LightningWeb.RunLive.Index do
     end
 
     socket
+  end
+
+  def validate_bulk_rerun(selected_work_orders, %{id: project_id}) do
+    with {:error, _reason, %{text: error_message}} <-
+           UsageLimiter.limit_action(
+             %Action{type: :new_run_batch, amount: length(selected_work_orders)},
+             %Context{
+               project_id: project_id
+             }
+           ) do
+      "invalid-rerun:#{error_message}"
+    end
   end
 end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -364,6 +364,11 @@ defmodule LightningWeb.RunLive.Index do
         {:noreply,
          socket
          |> put_flash(:error, "Oops! an error occured during retries.")}
+
+      {:error, _reason, %{text: error_message}} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, error_message)}
     end
   end
 
@@ -444,7 +449,10 @@ defmodule LightningWeb.RunLive.Index do
 
   defp handle_bulk_rerun(socket, %{"type" => "selected", "job" => job_id}) do
     socket.assigns.selected_work_orders
-    |> WorkOrders.retry_many(job_id, created_by: socket.assigns.current_user)
+    |> WorkOrders.retry_many(job_id,
+      created_by: socket.assigns.current_user,
+      project_id: socket.assigns.project.id
+    )
   end
 
   defp handle_bulk_rerun(socket, %{"type" => "all", "job" => job_id}) do
@@ -454,12 +462,18 @@ defmodule LightningWeb.RunLive.Index do
     |> Invocation.search_workorders_query(filter)
     |> Invocation.exclude_wiped_dataclips()
     |> Lightning.Repo.all()
-    |> WorkOrders.retry_many(job_id, created_by: socket.assigns.current_user)
+    |> WorkOrders.retry_many(job_id,
+      created_by: socket.assigns.current_user,
+      project_id: socket.assigns.project.id
+    )
   end
 
   defp handle_bulk_rerun(socket, %{"type" => "selected"}) do
     socket.assigns.selected_work_orders
-    |> WorkOrders.retry_many(created_by: socket.assigns.current_user)
+    |> WorkOrders.retry_many(
+      created_by: socket.assigns.current_user,
+      project_id: socket.assigns.project.id
+    )
   end
 
   defp handle_bulk_rerun(socket, %{"type" => "all"}) do
@@ -469,7 +483,10 @@ defmodule LightningWeb.RunLive.Index do
     |> Invocation.search_workorders_query(filter)
     |> Invocation.exclude_wiped_dataclips()
     |> Lightning.Repo.all()
-    |> WorkOrders.retry_many(created_by: socket.assigns.current_user)
+    |> WorkOrders.retry_many(
+      created_by: socket.assigns.current_user,
+      project_id: socket.assigns.project.id
+    )
   end
 
   defp all_selected?(work_orders, entries) do

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -589,7 +589,7 @@ defmodule LightningWeb.RunLive.Index do
   def validate_bulk_rerun(selected_work_orders, %{id: project_id}) do
     with {:error, _reason, %{text: error_message}} <-
            UsageLimiter.limit_action(
-             %Action{type: :new_run_batch, amount: length(selected_work_orders)},
+             %Action{type: :new_run, amount: length(selected_work_orders)},
              %Context{
                project_id: project_id
              }

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -611,7 +611,14 @@
                           <button
                             type="button"
                             class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                            phx-click={show_modal("bulk-rerun-from-start-modal")}
+                            phx-click={
+                              with :ok <-
+                                     validate_bulk_rerun(
+                                       @selected_work_orders,
+                                       @project
+                                     ),
+                                   do: show_modal("bulk-rerun-from-start-modal")
+                            }
                           >
                             Retry
                           </button>
@@ -623,7 +630,14 @@
                             id="bulk-rerun-from-job-modal-trigger"
                             type="button"
                             class="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                            phx-click={show_modal("bulk-rerun-from-job-modal")}
+                            phx-click={
+                              with :ok <-
+                                     validate_bulk_rerun(
+                                       @selected_work_orders,
+                                       @project
+                                     ),
+                                   do: show_modal("bulk-rerun-from-job-modal")
+                            }
                           >
                             Retry from step
                           </button>

--- a/mix.exs
+++ b/mix.exs
@@ -158,7 +158,7 @@ defmodule Lightning.MixProject do
         "lightning.install_schemas",
         "ecto.setup"
       ],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "assets.deploy": [

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -3,6 +3,9 @@ defmodule Lightning.WorkOrdersTest do
 
   import Lightning.Factories
 
+  alias Lightning.Extensions.MockUsageLimiter
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.Message
   alias Lightning.WorkOrders
   alias Lightning.WorkOrders.Events
 
@@ -409,6 +412,10 @@ defmodule Lightning.WorkOrdersTest do
 
   describe "retry_many/3" do
     setup do
+      Mox.stub(MockUsageLimiter, :limit_action, fn _action, _ctx ->
+        :ok
+      end)
+
       [job_a, job_b, job_c] = jobs = build_list(3, :job)
       trigger = build(:trigger, type: :webhook)
 
@@ -514,7 +521,11 @@ defmodule Lightning.WorkOrdersTest do
                starting_job_id: job_a.id
              )
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], job_a.id, created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder], job_a.id,
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       retry_run =
         Repo.get_by(Lightning.Run,
@@ -584,7 +595,11 @@ defmodule Lightning.WorkOrdersTest do
                starting_job_id: job_b.id
              )
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], job_b.id, created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder], job_b.id,
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       retry_run =
         Repo.get_by(Lightning.Run,
@@ -670,7 +685,11 @@ defmodule Lightning.WorkOrdersTest do
         assert run.id in [run_1.id, run_2.id]
       end
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], job_a.id, created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder], job_a.id,
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       runs = Ecto.assoc(workorder, :runs) |> Repo.all()
 
@@ -821,7 +840,11 @@ defmodule Lightning.WorkOrdersTest do
       runs_ids = Enum.map(runs, & &1.id)
       assert Enum.sort(runs_ids) == Enum.sort([run_1.id, run_2.id])
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], job_b.id, created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder], job_b.id,
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       runs = Ecto.assoc(workorder, :runs) |> Repo.all()
 
@@ -893,7 +916,8 @@ defmodule Lightning.WorkOrdersTest do
       # we've reversed the order here
       {:ok, 2} =
         WorkOrders.retry_many([workorder_2, workorder_1], job_a.id,
-          created_by: user
+          created_by: user,
+          project_id: workflow.project_id
         )
 
       retry_run_1 =
@@ -910,6 +934,90 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run_1.inserted_at
              |> DateTime.before?(retry_run_2.inserted_at)
+    end
+
+    test(
+      "retrying multiple workorders returns error on limit exceeded",
+      %{
+        workflow: workflow,
+        trigger: trigger,
+        jobs: [job_a, job_b, job_c],
+        user: user
+      }
+    ) do
+      Mox.stub(MockUsageLimiter, :limit_action, fn %Action{
+                                                     type: :new_run_batch,
+                                                     amount: n
+                                                   },
+                                                   _context ->
+        {:error, :too_many_batch_runs,
+         %Message{
+           text:
+             "You have attempted to enqueue #{n} runs but you have only 1 remaining in your current billig period"
+         }}
+      end)
+
+      [workorder_1, workorder_2] =
+        insert_list(2, :workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: build(:dataclip),
+          runs: [
+            %{
+              state: :failed,
+              dataclip: build(:dataclip),
+              starting_trigger: trigger,
+              steps: [
+                insert(:step,
+                  job: job_a,
+                  input_dataclip: build(:dataclip),
+                  output_dataclip: build(:dataclip)
+                ),
+                insert(:step,
+                  job: job_b,
+                  input_dataclip: build(:dataclip),
+                  output_dataclip: build(:dataclip)
+                ),
+                insert(:step,
+                  job: job_c,
+                  input_dataclip: build(:dataclip),
+                  output_dataclip: build(:dataclip)
+                )
+              ]
+            }
+          ]
+        )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_1.id,
+               starting_job_id: job_a.id
+             )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_2.id,
+               starting_job_id: job_a.id
+             )
+
+      # we've reversed the order here
+      assert {:error, :too_many_batch_runs,
+              %{
+                text:
+                  "You have attempted to enqueue 2 runs but you have only 1 remaining in your current billig period"
+              }} =
+               WorkOrders.retry_many([workorder_2, workorder_1], job_a.id,
+                 created_by: user,
+                 project_id: workflow.project_id
+               )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_1.id,
+               starting_job_id: job_a.id
+             )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_2.id,
+               starting_job_id: job_a.id
+             )
     end
 
     test "retrying multiple workorders only retries workorders with the given job",
@@ -983,7 +1091,8 @@ defmodule Lightning.WorkOrdersTest do
 
       {:ok, 1} =
         WorkOrders.retry_many([workorder_2, workorder_1], job_b.id,
-          created_by: user
+          created_by: user,
+          project_id: workflow.project_id
         )
 
       refute Repo.get_by(Lightning.Run,
@@ -996,10 +1105,117 @@ defmodule Lightning.WorkOrdersTest do
                starting_job_id: job_b.id
              )
     end
+
+    test "retrying multiple workorders returns an error on limit exceeded for steps",
+         %{
+           workflow: workflow,
+           trigger: trigger,
+           jobs: [job_a | _jobs],
+           user: user
+         } do
+      Mox.stub(MockUsageLimiter, :limit_action, fn %Action{
+                                                     type: :new_run_batch,
+                                                     amount: n
+                                                   },
+                                                   _context ->
+        {:error, :too_many_runs,
+         %Message{
+           text:
+             "You have attempted to enqueue #{n} runs but you have only 1 remaining in your current billig period"
+         }}
+      end)
+
+      workorder_1 =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: build(:dataclip)
+        )
+
+      run_1 =
+        insert(:run,
+          work_order: workorder_1,
+          state: :failed,
+          dataclip: build(:dataclip),
+          starting_trigger: trigger
+        )
+
+      run_step_1_a =
+        insert(:run_step,
+          step:
+            build(:step,
+              job: job_a,
+              input_dataclip: build(:dataclip),
+              output_dataclip: build(:dataclip)
+            ),
+          run: run_1
+        )
+
+      workorder_2 =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: build(:dataclip)
+        )
+
+      run_2 =
+        insert(:run,
+          work_order: workorder_2,
+          state: :failed,
+          dataclip: build(:dataclip),
+          starting_trigger: trigger
+        )
+
+      run_step_2_a =
+        insert(:run_step,
+          step:
+            build(:step,
+              job: job_a,
+              input_dataclip: build(:dataclip),
+              output_dataclip: build(:dataclip)
+            ),
+          run: run_2
+        )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_1.id,
+               starting_job_id: job_a.id
+             )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_2.id,
+               starting_job_id: job_a.id
+             )
+
+      # we've reversed the order here
+      assert {:error, :too_many_runs,
+              %{
+                text:
+                  "You have attempted to enqueue 2 runs but you have only 1 remaining in your current billig period"
+              }} =
+               WorkOrders.retry_many([run_step_2_a, run_step_1_a],
+                 created_by: user,
+                 project_id: workflow.project_id
+               )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_1.id,
+               starting_job_id: job_a.id
+             )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_2.id,
+               starting_job_id: job_a.id
+             )
+    end
   end
 
   describe "retry_many/2 for WorkOrders" do
     setup do
+      Mox.stub(MockUsageLimiter, :limit_action, fn _action, _ctx ->
+        :ok
+      end)
+
       [job_a, job_b, job_c] = jobs = build_list(3, :job)
       trigger = build(:trigger, type: :webhook)
 
@@ -1086,7 +1302,11 @@ defmodule Lightning.WorkOrdersTest do
         assert run.id in [run_1.id, run_2.id]
       end
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder],
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       runs = Ecto.assoc(workorder, :runs) |> Repo.all()
 
@@ -1161,7 +1381,8 @@ defmodule Lightning.WorkOrdersTest do
       # we've reversed the order here
       {:ok, 2} =
         WorkOrders.retry_many([workorder_2, workorder_1],
-          created_by: user
+          created_by: user,
+          project_id: workflow.project_id
         )
 
       retry_run_1 =
@@ -1211,7 +1432,11 @@ defmodule Lightning.WorkOrdersTest do
         assert run.id in [run_1.id]
       end
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder],
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       runs = Ecto.assoc(workorder, :runs) |> Repo.all()
 
@@ -1266,7 +1491,11 @@ defmodule Lightning.WorkOrdersTest do
         assert run.id in [run_1.id]
       end
 
-      {:ok, 1} = WorkOrders.retry_many([workorder], created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder],
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       runs = Ecto.assoc(workorder, :runs) |> Repo.all()
 
@@ -1349,7 +1578,8 @@ defmodule Lightning.WorkOrdersTest do
 
       {:ok, 1} =
         WorkOrders.retry_many([workorder_2, workorder_1],
-          created_by: user
+          created_by: user,
+          project_id: workflow.project_id
         )
 
       assert Repo.get_by(Lightning.Run,
@@ -1367,6 +1597,10 @@ defmodule Lightning.WorkOrdersTest do
 
   describe "retry_many/2 for RunSteps" do
     setup do
+      Mox.stub(MockUsageLimiter, :limit_action, fn _action, _ctx ->
+        :ok
+      end)
+
       [job_a, job_b, job_c] = jobs = build_list(3, :job)
       trigger = build(:trigger, type: :webhook)
 
@@ -1438,7 +1672,11 @@ defmodule Lightning.WorkOrdersTest do
                starting_job_id: job_a.id
              )
 
-      {:ok, 1} = WorkOrders.retry_many([run_step_a], created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([run_step_a],
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       retry_run =
         Repo.get_by(Lightning.Run,
@@ -1520,7 +1758,11 @@ defmodule Lightning.WorkOrdersTest do
                starting_job_id: run_step_b.step.job.id
              )
 
-      {:ok, 1} = WorkOrders.retry_many([run_step_b], created_by: user)
+      {:ok, 1} =
+        WorkOrders.retry_many([run_step_b],
+          created_by: user,
+          project_id: workflow.project_id
+        )
 
       retry_run =
         Repo.get_by(Lightning.Run,
@@ -1612,7 +1854,8 @@ defmodule Lightning.WorkOrdersTest do
       # we've reversed the order here
       {:ok, 2} =
         WorkOrders.retry_many([run_step_2_a, run_step_1_a],
-          created_by: user
+          created_by: user,
+          project_id: workflow.project_id
         )
 
       retry_run_1 =
@@ -1704,7 +1947,8 @@ defmodule Lightning.WorkOrdersTest do
 
       {:ok, 1} =
         WorkOrders.retry_many([run_step_2_a, run_step_1_a],
-          created_by: user
+          created_by: user,
+          project_id: workflow.project_id
         )
 
       assert Repo.get_by(Lightning.Run,

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -946,11 +946,11 @@ defmodule Lightning.WorkOrdersTest do
       }
     ) do
       Mox.stub(MockUsageLimiter, :limit_action, fn %Action{
-                                                     type: :new_run_batch,
+                                                     type: :new_run,
                                                      amount: n
                                                    },
                                                    _context ->
-        {:error, :too_many_batch_runs,
+        {:error, :too_many_runs,
          %Message{
            text:
              "You have attempted to enqueue #{n} runs but you have only 1 remaining in your current billig period"
@@ -999,7 +999,7 @@ defmodule Lightning.WorkOrdersTest do
              )
 
       # we've reversed the order here
-      assert {:error, :too_many_batch_runs,
+      assert {:error, :too_many_runs,
               %{
                 text:
                   "You have attempted to enqueue 2 runs but you have only 1 remaining in your current billig period"
@@ -1114,7 +1114,7 @@ defmodule Lightning.WorkOrdersTest do
            user: user
          } do
       Mox.stub(MockUsageLimiter, :limit_action, fn %Action{
-                                                     type: :new_run_batch,
+                                                     type: :new_run,
                                                      amount: n
                                                    },
                                                    _context ->


### PR DESCRIPTION
## Validation Steps

Via automated tests and umbrella app only.

## Notes for the reviewer

Applies usage limit to bulk-reruns when selecting one or multiple work orders on History Page.

*Note:* Additionally avoids creating users on setup.

## Related issue

Fixes #1931 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
