### PR TITLE
Prevent double usage tracking submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
 
 - Apply usage limit to bulk-reruns
   [#1931](https://github.com/OpenFn/lightning/issues/1931)
+- Fix edge case that could result in duplicate usage tracking submissions.
+  [#1853](https://github.com/OpenFn/lightning/issues/1853)
 
 ## [v2.2.0] - 2024-03-21
 

--- a/lib/lightning/usage_tracking/report.ex
+++ b/lib/lightning/usage_tracking/report.ex
@@ -5,6 +5,8 @@ defmodule Lightning.UsageTracking.Report do
   """
   use Ecto.Schema
 
+  import Ecto.Changeset
+
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "usage_tracking_reports" do
     field :data, :map
@@ -13,5 +15,12 @@ defmodule Lightning.UsageTracking.Report do
     field :report_date, :date
 
     timestamps()
+  end
+
+  def changeset(report, params) do
+    report
+    |> cast(params, [:data, :report_date, :submitted, :submitted_at])
+    |> validate_required([:data, :report_date, :submitted])
+    |> unique_constraint(:report_date)
   end
 end

--- a/test/lightning/usage_tracking/report_test.exs
+++ b/test/lightning/usage_tracking/report_test.exs
@@ -1,0 +1,133 @@
+defmodule Lightning.UsageTracking.ReportTest do
+  use Lightning.DataCase
+
+  alias Ecto.Changeset
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.Report
+
+  describe ".changeset/2" do
+    setup do
+      %{
+        data: %{"foo" => "bar"},
+        date: ~D[2024-02-05],
+        submitted_at: DateTime.add(DateTime.utc_now(), -10, :second)
+      }
+    end
+
+    test "returns a valid changeset if all parameters are provided", %{
+      data: data,
+      date: date,
+      submitted_at: submitted_at
+    } do
+      params = %{
+        data: data,
+        report_date: date,
+        submitted: true,
+        submitted_at: submitted_at
+      }
+
+      changes = Report.changeset(%Report{}, params)
+
+      assert %Changeset{
+               valid?: true,
+               changes: %{
+                 data: ^data,
+                 report_date: ^date,
+                 submitted: true,
+                 submitted_at: ^submitted_at
+               }
+             } = changes
+    end
+
+    test "changeset is invalid if data is not provided", %{
+      date: date,
+      submitted_at: submitted_at
+    } do
+      params = %{
+        report_date: date,
+        submitted: true,
+        submitted_at: submitted_at
+      }
+
+      %{valid?: false, errors: errors} = Report.changeset(%Report{}, params)
+
+      assert [data: {"can't be blank", [validation: :required]}] = errors
+    end
+
+    test "changeset is invalid if the report date is not provided", %{
+      data: data,
+      submitted_at: submitted_at
+    } do
+      params = %{
+        data: data,
+        submitted: true,
+        submitted_at: submitted_at
+      }
+
+      %{valid?: false, errors: errors} = Report.changeset(%Report{}, params)
+
+      assert [report_date: {"can't be blank", [validation: :required]}] = errors
+    end
+
+    test "changeset is invalid if submitted is not provided", %{
+      data: data,
+      date: date,
+      submitted_at: submitted_at
+    } do
+      params = %{
+        data: data,
+        report_date: date,
+        submitted_at: submitted_at
+      }
+
+      %{valid?: false, errors: errors} = Report.changeset(%Report{}, params)
+
+      assert [submitted: {"can't be blank", [validation: :required]}] = errors
+    end
+
+    test "changeset is valid if submitted_at is not provided", %{
+      data: data,
+      date: date
+    } do
+      params = %{
+        data: data,
+        report_date: date,
+        submitted: true
+      }
+
+      %{valid?: true} = Report.changeset(%Report{}, params)
+    end
+
+    test "persistence fails i report already exists with date", %{
+      data: data,
+      date: date,
+      submitted_at: submitted_at
+    } do
+      insert(:usage_tracking_report, report_date: date)
+
+      params = %{
+        data: data,
+        report_date: date,
+        submitted: true,
+        submitted_at: submitted_at
+      }
+
+      result =
+        %Report{}
+        |> Report.changeset(params)
+        |> Repo.insert()
+
+      assert {:error, %{valid?: false, errors: errors}} = result
+
+      assert [
+               report_date: {
+                 "has already been taken",
+                 [
+                   {:constraint, :unique},
+                   {:constraint_name, "usage_tracking_reports_report_date_index"}
+                 ]
+               }
+             ] = errors
+    end
+  end
+end


### PR DESCRIPTION
## Validation Steps

_This PR fixes an issue where there was an edge case that would allow for duplicate submissions to `ImpactTracker`, if there was an existing report for a given date, followed by a second run for the same date (e..g the kind of thing that you may encounter if a job for the same day has been enqueued more than once)._

Ensure that you have a local version of `ImpactTracker` running. 

Ensure that you do not have any existing submissions for today by running the following in an `ImpactTracker` `IEx`  session:

```
alias ImpactTracker.Repo
alias ImpactTracker.Submission
today = DateTime.to_date(DateTime.utc_now())
Repo.get_by(Submission, report_date: today) # Should be nil
```

Ensure that `USAGE_TRACKER_HOST` for your local Lightning env is pointing to your local ImpactTracker instance.

Ensure that `USAGE_TRACKING_ENABLED` is either not set or set to `true`.

Create an existing report manually via a Lightning IEx session:

```
today = DateTime.utc_now() |> DateTime.to_date()
Lightning.UsageTracking.disable_daily_report()
config = Lightning.UsageTracking.enable_daily_report(DateTime.utc_now())
Lightning.UsageTracking.insert_report(config, false, today)
```

Now, from the Lightning IEx session, run  the report worker for today to attempt to create another report for today(it will fail silently):

```
today_as_string = today |> Date.to_iso8601()
Lightning.UsageTracking.ReportWorker.perform(%Oban.Job{args: %{"date" => today_as_string}})
```

Using the ImpactTracker IEx session, confirm that there are still no submissions, indicating that the worker run on Lightning did not result in a submission because of the existing report:

```
Repo.get_by(Submission, report_date: today) # Should still be nil

## Notes for the reviewer

Using `ReportWorker` as the entry point for the review will probably allow for the simplest flow through the code.

## Related issue

#1853

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
