### PR TITLE
Fix nightly history delete query timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   [#1931](https://github.com/OpenFn/lightning/issues/1931)
 - Fix edge case that could result in duplicate usage tracking submissions.
   [#1853](https://github.com/OpenFn/lightning/issues/1853)
+- Fix query timeout issue on history retention deletion
+  [#1937](https://github.com/OpenFn/lightning/issues/1937)
 
 ## [v2.2.0] - 2024-03-21
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -288,7 +288,20 @@ end
 
 database_url = System.get_env("DATABASE_URL")
 
-config :lightning, Lightning.Repo, url: database_url
+config :lightning, Lightning.Repo,
+  url: database_url,
+  pool_size: env!("DATABASE_POOL_SIZE", :integer, 10),
+  timeout: env!("DATABASE_TIMEOUT", :integer, 15_000)
+
+if System.get_env("DATABASE_QUEUE_TARGET") do
+  config :lightning, Lightning.Repo,
+    queue_target: env!("DATABASE_QUEUE_TARGET", :integer, 10_000)
+end
+
+if System.get_env("DATABASE_QUEUE_INTERVAL") do
+  config :lightning, Lightning.Repo,
+    queue_interval: env!("DATABASE_QUEUE_INTERVAL", :integer, 1000)
+end
 
 if config_env() == :prod do
   unless database_url do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -291,17 +291,9 @@ database_url = System.get_env("DATABASE_URL")
 config :lightning, Lightning.Repo,
   url: database_url,
   pool_size: env!("DATABASE_POOL_SIZE", :integer, 10),
-  timeout: env!("DATABASE_TIMEOUT", :integer, 15_000)
-
-if System.get_env("DATABASE_QUEUE_TARGET") do
-  config :lightning, Lightning.Repo,
-    queue_target: env!("DATABASE_QUEUE_TARGET", :integer, 10_000)
-end
-
-if System.get_env("DATABASE_QUEUE_INTERVAL") do
-  config :lightning, Lightning.Repo,
-    queue_interval: env!("DATABASE_QUEUE_INTERVAL", :integer, 1000)
-end
+  timeout: env!("DATABASE_TIMEOUT", :integer, 15_000),
+  queue_target: env!("DATABASE_QUEUE_TARGET", :integer, 50),
+  queue_interval: env!("DATABASE_QUEUE_INTERVAL", :integer, 1000)
 
 if config_env() == :prod do
   unless database_url do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -306,7 +306,6 @@ if config_env() == :prod do
     # TODO: determine why we see this certs verification warn for the repo conn
     # ssl_opts: [log_level: :error],
     url: database_url,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     socket_options: maybe_ipv6
 
   # The secret key base is used to sign/encrypt cookies and other secrets.

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -679,7 +679,7 @@ defmodule Lightning.Projects do
     |> Multi.delete_all(:runs, runs_query)
     |> Multi.delete_all(:workorders, workorders_query)
     |> Multi.delete_all(:dataclips, dataclips_query)
-    |> Repo.transaction()
+    |> Repo.transaction(timeout: 100_000)
     |> case do
       {:ok, result} ->
         {:ok, result}

--- a/lib/lightning/repo.ex
+++ b/lib/lightning/repo.ex
@@ -7,7 +7,21 @@ defmodule Lightning.Repo do
 
   @impl true
   def init(_type, config) do
-    {:ok, Keyword.put(config, :url, System.get_env("DATABASE_URL"))}
+    {:ok,
+     config
+     |> Keyword.put(:url, System.get_env("DATABASE_URL"))
+     |> Keyword.put(:pool_size, env_to_int("DATABASE_POOL_SIZE", "10"))
+     |> Keyword.put(:timeout, env_to_int("DATABASE_TIMEOUT", "20000"))
+     |> Keyword.put(:queue_target, env_to_int("DATABASE_QUEUE_TARGET", "10000"))
+     |> Keyword.put(
+       :queue_interval,
+       env_to_int("DATABASE_QUEUE_INTERVAL", "1000")
+     )}
+  end
+
+  defp env_to_int(env, default) do
+    System.get_env(env, default)
+    |> String.to_integer()
   end
 
   @doc """

--- a/lib/lightning/repo.ex
+++ b/lib/lightning/repo.ex
@@ -7,16 +7,7 @@ defmodule Lightning.Repo do
 
   @impl true
   def init(_type, config) do
-    {:ok,
-     config
-     |> Keyword.put(:url, System.get_env("DATABASE_URL"))
-     |> Keyword.put(:pool_size, env_to_int("DATABASE_POOL_SIZE", "10"))
-     |> Keyword.put(:timeout, env_to_int("DATABASE_TIMEOUT", "20000"))
-     |> Keyword.put(:queue_target, env_to_int("DATABASE_QUEUE_TARGET", "10000"))
-     |> Keyword.put(
-       :queue_interval,
-       env_to_int("DATABASE_QUEUE_INTERVAL", "1000")
-     )}
+    {:ok, Keyword.put(config, :url, System.get_env("DATABASE_URL"))}
   end
 
   defp env_to_int(env, default) do

--- a/lib/lightning/repo.ex
+++ b/lib/lightning/repo.ex
@@ -10,11 +10,6 @@ defmodule Lightning.Repo do
     {:ok, Keyword.put(config, :url, System.get_env("DATABASE_URL"))}
   end
 
-  defp env_to_int(env, default) do
-    System.get_env(env, default)
-    |> String.to_integer()
-  end
-
   @doc """
   A small wrapper around `Repo.transaction/2`.
 

--- a/priv/repo/migrations/20240326155113_drop_jsonb_gin_index_from_dataclips.exs
+++ b/priv/repo/migrations/20240326155113_drop_jsonb_gin_index_from_dataclips.exs
@@ -1,0 +1,11 @@
+defmodule Lightning.Repo.Migrations.DropJsonbGinIndexFromDataclips do
+  use Ecto.Migration
+
+  def up do
+    drop index(:dataclips, [:body])
+  end
+
+  def down do
+    create index(:dataclips, [:body], concurrently: true, using: :gin)
+  end
+end

--- a/priv/repo/migrations/20240326155113_drop_jsonb_gin_index_from_dataclips.exs
+++ b/priv/repo/migrations/20240326155113_drop_jsonb_gin_index_from_dataclips.exs
@@ -1,8 +1,14 @@
 defmodule Lightning.Repo.Migrations.DropJsonbGinIndexFromDataclips do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def up do
     drop index(:dataclips, [:body])
+
+    create index(:steps, [:input_dataclip_id])
+    create index(:steps, [:output_dataclip_id])
   end
 
   def down do


### PR DESCRIPTION
This PR does a few things:
1. @stuartc , it drops that `dataclips.body` as I think that may have been slowing down the dataclip delete. (Per #1939 , we don't want this index anymore.)
2. It grants a longer timeout to this nightly query. You can pass query timeout options directly to `Repo` and `Multi` commands... this is exactly what we want if there is a query which won't happen often. This multi is used inside an `Enum.each`, so it will run serially, rather than in parallel and we won't be in danger of blocking all our DB connections.
3. It uses the new `Dotenvy` style for configuring useful DB options. (This was useful for performance tweaking in v1.) CC @stuartc again here. Is this how you're envisioning Dotenvy gets used?

Fixes #1937 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
