### PR TITLE
Handle dataclip JSON text search more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,15 @@ and this project adheres to
 
 ### Changed
 
+- Changed dataclip search from string `LIKE` to tsvector on keys and values.
+  While this will limit partial string matching to the beginning of words (not
+  the middle or end) it will make searching way more performant
+  [#1939](https://github.com/OpenFn/lightning/issues/1939)
+
 ### Fixed
+
+- Regular database timeouts when searching across dataclip bodies
+  [#1794](https://github.com/OpenFn/lightning/issues/1794)
 
 ## [v2.2.1] - 2024-03-27
 

--- a/lib/lightning/repo.ex
+++ b/lib/lightning/repo.ex
@@ -7,7 +7,21 @@ defmodule Lightning.Repo do
 
   @impl true
   def init(_type, config) do
-    {:ok, Keyword.put(config, :url, System.get_env("DATABASE_URL"))}
+    {:ok,
+     config
+     |> Keyword.put(:url, System.get_env("DATABASE_URL"))
+     |> Keyword.put(:pool_size, env_to_int("DATABASE_POOL_SIZE", "10"))
+     |> Keyword.put(:timeout, env_to_int("DATABASE_TIMEOUT", "20000"))
+     |> Keyword.put(:queue_target, env_to_int("DATABASE_QUEUE_TARGET", "10000"))
+     |> Keyword.put(
+       :queue_interval,
+       env_to_int("DATABASE_QUEUE_INTERVAL", "1000")
+     )}
+  end
+
+  defp env_to_int(env, default) do
+    System.get_env(env, default)
+    |> String.to_integer()
   end
 
   @doc """

--- a/lib/lightning/repo.ex
+++ b/lib/lightning/repo.ex
@@ -7,16 +7,7 @@ defmodule Lightning.Repo do
 
   @impl true
   def init(_type, config) do
-    {:ok,
-     config
-     |> Keyword.put(:url, System.get_env("DATABASE_URL"))
-     |> Keyword.put(:pool_size, env_to_int("DATABASE_POOL_SIZE", "10"))
-     |> Keyword.put(:timeout, env_to_int("DATABASE_TIMEOUT", "20000"))
-     |> Keyword.put(:queue_target, env_to_int("DATABASE_QUEUE_TARGET", "10000"))
-     |> Keyword.put(
-       :queue_interval,
-       env_to_int("DATABASE_QUEUE_INTERVAL", "1000")
-     )}
+    {:ok, Keyword.put(config, :url, System.get_env("DATABASE_URL"))}
   end
 
   defp env_to_int(env, default) do

--- a/lib/lightning/repo.ex
+++ b/lib/lightning/repo.ex
@@ -10,11 +10,6 @@ defmodule Lightning.Repo do
     {:ok, Keyword.put(config, :url, System.get_env("DATABASE_URL"))}
   end
 
-  defp env_to_int(env, default) do
-    System.get_env(env, default)
-    |> String.to_integer()
-  end
-
   @doc """
   A small wrapper around `Repo.transaction/2`.
 

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -41,7 +41,8 @@ defmodule LightningWeb.RunLive.Index do
     cancelled: :boolean,
     killed: :boolean,
     exception: :boolean,
-    lost: :boolean
+    lost: :boolean,
+    rejected: :boolean
   }
 
   @empty_page %{
@@ -89,7 +90,6 @@ defmodule LightningWeb.RunLive.Index do
       )
 
     statuses = [
-      %{id: :rejected, label: "Rejected"},
       %{id: :pending, label: "Enqueued"},
       %{id: :running, label: "Running"},
       %{id: :success, label: "Success"},
@@ -98,7 +98,8 @@ defmodule LightningWeb.RunLive.Index do
       %{id: :cancelled, label: "Cancelled"},
       %{id: :killed, label: "Killed"},
       %{id: :exception, label: "Exception"},
-      %{id: :lost, label: "Lost"}
+      %{id: :lost, label: "Lost"},
+      %{id: :rejected, label: "Rejected"}
     ]
 
     search_fields = [

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -720,6 +720,7 @@
                 page={@page}
                 async_page={@async_page}
                 url={@pagination_path}
+                help_text="Use whole words or the start of words for better results; partial string matching often won't find substrings in the middle or at the end of a word."
               />
             </div>
           </div>

--- a/lib/lightning_web/pagination.ex
+++ b/lib/lightning_web/pagination.ex
@@ -104,10 +104,7 @@ defmodule LightningWeb.Pagination do
           <%= if @page.total_entries == 0 do %>
             <p class="text-sm text-secondary-700">
               No results found
-              <Common.tooltip
-                id="no-results-tooltip"
-                title={@help_text}
-              />
+              <Common.tooltip id="no-results-tooltip" title={@help_text} />
             </p>
           <% else %>
             <p class="text-sm text-secondary-700">

--- a/lib/lightning_web/pagination.ex
+++ b/lib/lightning_web/pagination.ex
@@ -92,6 +92,7 @@ defmodule LightningWeb.Pagination do
   attr :async_page, Phoenix.LiveView.AsyncResult, default: nil
   attr :page, :map, required: true
   attr :url, :any, required: true
+  attr :help_text, :string, default: nil
 
   def pagination_bar(assigns) do
     ~H"""
@@ -101,7 +102,13 @@ defmodule LightningWeb.Pagination do
           <p class="text-sm text-secondary-700"></p>
         <% else %>
           <%= if @page.total_entries == 0 do %>
-            <p class="text-sm text-secondary-700">No results found</p>
+            <p class="text-sm text-secondary-700">
+              No results found
+              <Common.tooltip
+                id="no-results-tooltip"
+                title={@help_text}
+              />
+            </p>
           <% else %>
             <p class="text-sm text-secondary-700">
               Showing

--- a/priv/repo/migrations/20240329123721_add_dataclips_ts_vector_column.exs
+++ b/priv/repo/migrations/20240329123721_add_dataclips_ts_vector_column.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddDataclipsTsVectorColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dataclips) do
+      add :search_vector, :tsvector, null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20240329123743_generate_dataclip_search_vectors.exs
+++ b/priv/repo/migrations/20240329123743_generate_dataclip_search_vectors.exs
@@ -1,0 +1,42 @@
+defmodule Lightning.Repo.Migrations.GenerateDataclipSearchVectors do
+  require Logger
+  use Ecto.Migration
+
+  def change do
+    execute(
+      # Calculate the search vectors in batches of 1000 rows until all rows have
+      # been processed.
+      fn ->
+        Stream.unfold(1, fn n ->
+          if n > 0 do
+            %{num_rows: n} = update_search_vector(1000)
+            Logger.info("Updated search_vector for #{n} rows")
+
+            {:ok, n}
+          else
+            nil
+          end
+        end)
+        |> Stream.run()
+      end,
+      ""
+    )
+  end
+
+  defp update_search_vector(limit) do
+    repo().query!(
+      """
+      UPDATE dataclips
+      SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"')
+      WHERE id IN (
+        SELECT id
+        FROM dataclips
+        WHERE search_vector IS NULL
+        LIMIT $1
+      )
+      """,
+      [limit],
+      log: :debug
+    )
+  end
+end

--- a/priv/repo/migrations/20240329123804_add_dataclip_search_vector_trigger.exs
+++ b/priv/repo/migrations/20240329123804_add_dataclip_search_vector_trigger.exs
@@ -1,0 +1,34 @@
+defmodule Lightning.Repo.Migrations.AddDataclipSearchVectorTrigger do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      """
+      CREATE OR REPLACE FUNCTION public.update_dataclip_search_vector()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+        begin
+          UPDATE dataclips SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"') WHERE id = NEW.id;
+          RETURN NEW;
+        end
+      $function$ ;
+      """,
+      "DROP FUNCTION IF EXISTS update_dataclip_search_vector;"
+    )
+
+    table = "dataclips"
+
+    execute(
+      """
+      CREATE TRIGGER set_search_vector
+      AFTER INSERT ON #{table} FOR EACH ROW
+      WHEN (NEW."search_vector" IS NULL)
+      EXECUTE PROCEDURE update_dataclip_search_vector();
+      """,
+      """
+      DROP TRIGGER IF EXISTS set_search_vector ON #{table};
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20240329123821_add_tsvector_index_to_dataclips.exs
+++ b/priv/repo/migrations/20240329123821_add_tsvector_index_to_dataclips.exs
@@ -1,0 +1,7 @@
+defmodule Lightning.Repo.Migrations.AddTsvectorIndexToDataclips do
+  use Ecto.Migration
+
+  def change do
+    create index(:dataclips, [:search_vector], using: :gin)
+  end
+end

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -911,6 +911,27 @@ defmodule Lightning.InvocationTest do
                ).entries
     end
 
+    test "search on logs does NOT return 'stem' matches... only exact matches",
+         %{project: project} do
+      assert [] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "played",
+                   "search_fields" => ["log"]
+                 })
+               ).entries
+
+      assert [] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "playings",
+                   "search_fields" => ["log"]
+                 })
+               ).entries
+    end
+
     test "search on logs can find partial string matches at the start of words",
          %{project: project} do
       assert [_found] =
@@ -950,7 +971,7 @@ defmodule Lightning.InvocationTest do
                ).entries
     end
 
-    test "search on dataclips can find partial string matches anywhere in the keys",
+    test "search on dataclips can find partial string matches at the start of keys",
          %{
            project: project
          } do
@@ -967,12 +988,12 @@ defmodule Lightning.InvocationTest do
                Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
-                   "search_term" => "f_bir",
+                   "search_term" => "bir",
                    "search_fields" => ["body"]
                  })
                ).entries
 
-      assert [_found] =
+      assert [] =
                Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
@@ -982,7 +1003,7 @@ defmodule Lightning.InvocationTest do
                ).entries
     end
 
-    test "search on dataclips can find partial string matches anywhere in the values",
+    test "search on dataclips can find partial string matches at the start of values",
          %{
            project: project
          } do
@@ -995,7 +1016,7 @@ defmodule Lightning.InvocationTest do
                  })
                ).entries
 
-      assert [_found] =
+      assert [] =
                Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
@@ -1008,7 +1029,7 @@ defmodule Lightning.InvocationTest do
                Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
-                   "search_term" => "92-0",
+                   "search_term" => "199",
                    "search_fields" => ["body"]
                  })
                ).entries

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -324,7 +324,7 @@ defmodule Lightning.InvocationTest do
                total_pages: 1,
                entries: entries
              } =
-               Lightning.Invocation.search_workorders(
+               Invocation.search_workorders(
                  project,
                  SearchParams.new(%{"status" => ["pending", "crashed"]}),
                  %{
@@ -357,7 +357,7 @@ defmodule Lightning.InvocationTest do
                total_pages: 1,
                entries: entries
              } =
-               Lightning.Invocation.search_workorders(
+               Invocation.search_workorders(
                  project,
                  SearchParams.new(%{"status" => SearchParams.status_list()}),
                  %{
@@ -387,7 +387,7 @@ defmodule Lightning.InvocationTest do
         total_pages: total_pages,
         entries: entries
       } =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"status" => ["crashed"]}),
           %{
@@ -406,7 +406,7 @@ defmodule Lightning.InvocationTest do
         total_pages: total_pages,
         entries: entries
       } =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"status" => ["crashed"]}),
           %{
@@ -425,7 +425,7 @@ defmodule Lightning.InvocationTest do
         total_pages: total_pages,
         entries: entries
       } =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"status" => ["crashed"]}),
           %{
@@ -591,7 +591,7 @@ defmodule Lightning.InvocationTest do
       insert_list(3, :workorder, workflow: workflow2, state: :crashed)
 
       workflow1_results =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"workflow_id" => workflow1.id})
         ).entries
@@ -603,7 +603,7 @@ defmodule Lightning.InvocationTest do
              end)
 
       workflow2_results =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"workflow_id" => workflow2.id})
         ).entries
@@ -625,7 +625,7 @@ defmodule Lightning.InvocationTest do
       workorder_2 = insert(:workorder, workflow: workflow, state: :success)
 
       page_result =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"workorder_id" => workorder_1.id})
         )
@@ -634,7 +634,7 @@ defmodule Lightning.InvocationTest do
       assert entry.id == workorder_1.id
 
       page_result =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{"workorder_id" => workorder_2.id})
         )
@@ -676,7 +676,7 @@ defmodule Lightning.InvocationTest do
         )
 
       [found_workorder] =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{
             "date_after" => Timex.shift(now, minutes: -1),
@@ -700,7 +700,7 @@ defmodule Lightning.InvocationTest do
       insert(:workorder, workflow: workflow, inserted_at: future_time)
 
       [found_workorder] =
-        Lightning.Invocation.search_workorders(
+        Invocation.search_workorders(
           project,
           SearchParams.new(%{
             "wo_date_after" => Timex.shift(now, minutes: -1),
@@ -711,12 +711,69 @@ defmodule Lightning.InvocationTest do
       assert found_workorder.id == wo_now.id
     end
 
-    test "filters workorders by search term on body and/or run logs and/or workorder, run, or step ID" do
+    # to be replaced by paginator unit tests
+    @tag :skip
+    test "filters workorders sets timeout" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+
+      SearchParams.status_list()
+      |> Enum.map(fn status ->
+        insert_list(1_000, :workorder, workflow: workflow, state: status)
+      end)
+
+      try do
+        Invocation.search_workorders(
+          project,
+          SearchParams.new(%{"status" => SearchParams.status_list()}),
+          %{
+            page: 1,
+            page_size: 10,
+            options: [timeout: 30]
+          }
+        )
+      rescue
+        e in [DBConnection.ConnectionError] ->
+          assert e.message =~ "timeout"
+      end
+    end
+  end
+
+  describe "search_workorders_query/2" do
+    test "ignores status filter when all statuses are queried" do
+      project = insert(:project)
+
+      query =
+        Invocation.search_workorders_query(
+          project,
+          SearchParams.new(%{"status" => ["pending"]})
+        )
+
+      {sql, _value} = Repo.to_sql(:all, query)
+      assert sql =~ ~S["state" = ]
+
+      query =
+        Invocation.search_workorders_query(
+          project,
+          SearchParams.new(%{"status" => SearchParams.status_list()})
+        )
+
+      {sql, _value} = Repo.to_sql(:all, query)
+      refute sql =~ ~S["state" = ]
+    end
+  end
+
+  describe "searching across workorders" do
+    setup do
       project = insert(:project)
 
       dataclip =
         insert(:dataclip,
-          body: %{"player" => "Sadio Mane"},
+          body: %{
+            "player" => "Sadio Mane",
+            "date_of_birth" => "1992-04-10",
+            "fav_color" => "vert foncé"
+          },
           type: :global,
           project: project
         )
@@ -749,11 +806,217 @@ defmodule Lightning.InvocationTest do
       insert(:log_line,
         run: run,
         step: step,
-        message: "Sadio Mane is playing in Senegal",
+        message: "Sadio Mane is playing for Senegal",
         timestamp: Timex.now()
       )
 
-      assert Lightning.Invocation.search_workorders(
+      insert(:log_line,
+        run: run,
+        step: step,
+        message: "Bukayo Saka is playing for England",
+        timestamp: Timex.now()
+      )
+
+      %{
+        project: project,
+        dataclip: dataclip,
+        workorder: workorder,
+        run: run,
+        step: step
+      }
+    end
+
+    @tag skip: "Ooops. We don't support this yet."
+    test "search on UUIDs can find partial string matches at any point in the dataclip UUID",
+         %{project: project, dataclip: dataclip} do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => dataclip.id,
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => String.slice(dataclip.id, 4, 3),
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+    end
+
+    test "search on UUIDs can find partial string matches at any point in the work_order UUID",
+         %{project: project, workorder: workorder} do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => workorder.id,
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => String.slice(workorder.id, 4, 3),
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+    end
+
+    test "search on UUIDs can find partial string matches at any point in the run UUID",
+         %{project: project, run: run} do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => run.id,
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => String.slice(run.id, 4, 3),
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+    end
+
+    test "search on UUIDs can find partial string matches at any point in the step UUID",
+         %{project: project, step: step} do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => step.id,
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => String.slice(step.id, 7, 2),
+                   "search_fields" => ["id"]
+                 })
+               ).entries
+    end
+
+    test "search on logs can find partial string matches at the start of words",
+         %{project: project} do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "Buka",
+                   "search_fields" => ["log"]
+                 })
+               ).entries
+    end
+
+    @tag skip: "Ooops. We don't support this yet."
+    test "search on logs can find partial string matches at the end of words", %{
+      project: project
+    } do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "ngland",
+                   "search_fields" => ["log"]
+                 })
+               ).entries
+    end
+
+    test "search on logs can find partial string matches across words", %{
+      project: project
+    } do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "Bukayo Sa",
+                   "search_fields" => ["log"]
+                 })
+               ).entries
+    end
+
+    test "search on dataclips can find partial string matches anywhere in the keys",
+         %{
+           project: project
+         } do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "date_of",
+                   "search_fields" => ["body"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "f_bir",
+                   "search_fields" => ["body"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "irth",
+                   "search_fields" => ["body"]
+                 })
+               ).entries
+    end
+
+    test "search on dataclips can find partial string matches anywhere in the values",
+         %{
+           project: project
+         } do
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "vert",
+                   "search_fields" => ["body"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "ncé",
+                   "search_fields" => ["body"]
+                 })
+               ).entries
+
+      assert [_found] =
+               Invocation.search_workorders(
+                 project,
+                 SearchParams.new(%{
+                   "search_term" => "92-0",
+                   "search_fields" => ["body"]
+                 })
+               ).entries
+    end
+
+    test "filters workorders by search term on body and/or run logs and/or workorder, run, or step ID",
+         %{project: project, workorder: workorder, run: run, step: step} do
+      assert Invocation.search_workorders(
                project,
                SearchParams.new(%{
                  "search_term" => "won't match anything",
@@ -762,7 +1025,7 @@ defmodule Lightning.InvocationTest do
              ).entries == []
 
       assert [found_workorder] =
-               Lightning.Invocation.search_workorders(
+               Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
                    "search_term" => "senegal",
@@ -773,7 +1036,7 @@ defmodule Lightning.InvocationTest do
       assert found_workorder.id == workorder.id
 
       assert [] ==
-               Lightning.Invocation.search_workorders(
+               Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
                    "search_term" => "senegal",
@@ -782,7 +1045,7 @@ defmodule Lightning.InvocationTest do
                ).entries
 
       assert [] ==
-               Lightning.Invocation.search_workorders(
+               Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
                    "search_term" => "liverpool",
@@ -792,7 +1055,7 @@ defmodule Lightning.InvocationTest do
 
       # By ID
       assert [] ==
-               Lightning.Invocation.search_workorders(
+               Invocation.search_workorders(
                  project,
                  SearchParams.new(%{
                    "search_term" => "nonexistentid",
@@ -811,7 +1074,7 @@ defmodule Lightning.InvocationTest do
 
       for search_id <- search_ids do
         assert [found_workorder] =
-                 Lightning.Invocation.search_workorders(
+                 Invocation.search_workorders(
                    project,
                    SearchParams.new(%{
                      "search_term" => search_id,
@@ -823,57 +1086,6 @@ defmodule Lightning.InvocationTest do
 
         assert found_workorder.id == workorder.id
       end
-    end
-
-    # to be replaced by paginator unit tests
-    @tag :skip
-    test "filters workorders sets timeout" do
-      project = insert(:project)
-      workflow = insert(:workflow, project: project)
-
-      SearchParams.status_list()
-      |> Enum.map(fn status ->
-        insert_list(1_000, :workorder, workflow: workflow, state: status)
-      end)
-
-      try do
-        Lightning.Invocation.search_workorders(
-          project,
-          SearchParams.new(%{"status" => SearchParams.status_list()}),
-          %{
-            page: 1,
-            page_size: 10,
-            options: [timeout: 30]
-          }
-        )
-      rescue
-        e in [DBConnection.ConnectionError] ->
-          assert e.message =~ "timeout"
-      end
-    end
-  end
-
-  describe "search_workorders_query/2" do
-    test "ignores status filter when all statuses are queried" do
-      project = insert(:project)
-
-      query =
-        Lightning.Invocation.search_workorders_query(
-          project,
-          SearchParams.new(%{"status" => ["pending"]})
-        )
-
-      {sql, _value} = Repo.to_sql(:all, query)
-      assert sql =~ ~S["state" = ]
-
-      query =
-        Lightning.Invocation.search_workorders_query(
-          project,
-          SearchParams.new(%{"status" => SearchParams.status_list()})
-        )
-
-      {sql, _value} = Repo.to_sql(:all, query)
-      refute sql =~ ~S["state" = ]
     end
   end
 


### PR DESCRIPTION
## Validation Steps

1. Run the migrations to add `search_vector`, the new gin index, and the new trigger to `dataclips`.
2. Send a workorder to your a webhook trigger URL with some custom JSON
3. Go to history, search for something that only appears in the dataclip
4. Note that you can find whole strings for both keys and values 
5. Note that you can find partial strings for both keys and values when they _START_ a word
6. Note that you can't find partial strings when they occur in the middle or end of words... this is true for both `log_lines` and `dataclips`; it's OK for now, but we'll want to do better later.
7. Check out the new tests that lock in this functionality.

Fixes #1939
Fixes #1803
Fixes #1794  

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
