### PR TITLE
Handle error translations for jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Translate job error messages using errors.po file
+  [#1935](https://github.com/OpenFn/lightning/issues/1935)
+
 ### Fixed
 
 ## [v2.2.1] - 2024-03-27

--- a/assets/js/workflow-diagram/nodes/Node.tsx
+++ b/assets/js/workflow-diagram/nodes/Node.tsx
@@ -30,7 +30,7 @@ type LabelProps = React.PropsWithChildren<{
 
 function errorsMessage(errors: ErrorObject): string {
   const messages = Object.entries(errors).map(([key, errorArray]) => {
-    return `${key} ${errorArray.join(', ')}`;
+    return `${errorArray.join(', ')}`;
   });
 
   return messages.join(', ');

--- a/lib/lightning/workflows/job.ex
+++ b/lib/lightning/workflows/job.ex
@@ -71,6 +71,7 @@ defmodule Lightning.Workflows.Job do
       :workflow_id
     ])
     |> validate()
+    |> update_change(:name, &String.trim/1)
     |> unique_constraint(:name,
       name: "jobs_name_workflow_id_index",
       message: "job name has already been taken"

--- a/lib/lightning/workflows/job.ex
+++ b/lib/lightning/workflows/job.ex
@@ -71,15 +71,25 @@ defmodule Lightning.Workflows.Job do
       :workflow_id
     ])
     |> validate()
-    |> unique_constraint(:name, name: "jobs_name_workflow_id_index")
+    |> unique_constraint(:name,
+      name: "jobs_name_workflow_id_index",
+      message: "job name has already been taken"
+    )
   end
 
   def validate(changeset) do
     changeset
-    |> validate_required([:name, :body, :adaptor])
+    |> validate_required(:name, message: "job name can't be blank")
+    |> validate_required(:body, message: "job body can't be blank")
+    |> validate_required(:adaptor, message: "job adaptor can't be blank")
     |> assoc_constraint(:workflow)
-    |> validate_length(:name, max: 100)
-    |> validate_format(:name, ~r/^[a-zA-Z0-9_\- ]*$/)
+    |> validate_length(:name,
+      max: 100,
+      message: "job name should be at most %{count} character(s)"
+    )
+    |> validate_format(:name, ~r/^[a-zA-Z0-9_\- ]*$/,
+      message: "job name has invalid format"
+    )
   end
 
   @doc """

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -502,7 +502,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   defp expand_job_editor(assigns) do
-    is_empty = editor_is_empty(assigns.form, assigns.job)
+    {is_empty, _} = editor_is_empty(assigns.form, assigns.job)
 
     button_base_classes =
       ~w(

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -514,7 +514,12 @@ defmodule LightningWeb.WorkflowLive.Edit do
           do: ~w(ring-red-300),
           else: ~w(ring-gray-300)
 
-    assigns = assign(assigns, is_empty: is_empty, button_classes: button_classes)
+    assigns =
+      assign(assigns,
+        is_empty: is_empty,
+        button_classes: button_classes,
+        error_message: error_message
+      )
 
     ~H"""
     <.link patch={"#{@base_url}?s=#{@job.id}&m=expand"} class={@button_classes}>
@@ -522,7 +527,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     </.link>
 
     <.save_is_blocked_error :if={@is_empty}>
-      <%= error_message %>
+      <%= @error_message %>
     </.save_is_blocked_error>
     """
   end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -502,7 +502,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   defp expand_job_editor(assigns) do
-    {is_empty, _} = editor_is_empty(assigns.form, assigns.job)
+    {is_empty, error_message} = editor_is_empty(assigns.form, assigns.job)
 
     button_base_classes =
       ~w(
@@ -522,7 +522,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     </.link>
 
     <.save_is_blocked_error :if={@is_empty}>
-      The step can't be blank
+      <%= error_message %>
     </.save_is_blocked_error>
     """
   end

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -4,6 +4,26 @@ msgstr "This field can't be blank."
 msgid "has already been taken"
 msgstr "This email address already exists."
 
+msgid "job name has already been taken"
+msgstr "Job name should be distinct."
+
+msgid "job name has invalid format"
+msgstr "Job name can't include special characters."
+
+msgid "job name can't be blank"
+msgstr "Job name can't be blank."
+
+msgid "job body can't be blank"
+msgstr "The step can't be blank."
+
+msgid "job adaptor can't be blank"
+msgstr "Job adaptor can't be blank."
+
+msgid "job name should be at most %{count} character(s)"
+msgid_plural "job name should be at most %{count} character(s)"
+msgstr[0] "Job name shouldn't be longer than %{count} characters."
+msgstr[1] "Job name shouldn't be longer than %{count} characters."
+
 msgid "should be at least %{count} character(s)"
 msgid_plural "should be at least %{count} character(s)"
 msgstr[0] "Password minimum length is %{count} characters."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -14,7 +14,7 @@ msgid "job name can't be blank"
 msgstr "Job name can't be blank."
 
 msgid "job body can't be blank"
-msgstr "The step can't be blank."
+msgstr "Code editor cannot be empty."
 
 msgid "job adaptor can't be blank"
 msgstr "Job adaptor can't be blank."

--- a/test/lightning/workflows/job_test.exs
+++ b/test/lightning/workflows/job_test.exs
@@ -38,7 +38,7 @@ defmodule Lightning.Workflows.JobTest do
         refute changeset.valid?
 
         assert changeset.errors[:name] ==
-                 {"has already been taken",
+                 {"job name has already been taken",
                   [
                     constraint: :unique,
                     constraint_name: "jobs_name_workflow_id_index"
@@ -49,20 +49,20 @@ defmodule Lightning.Workflows.JobTest do
     test "name can't be longer than 100 chars" do
       name = random_job_name(101)
       errors = Job.changeset(%Job{}, %{name: name}) |> errors_on()
-      assert errors[:name] == ["should be at most 100 character(s)"]
+      assert errors[:name] == ["job name should be at most 100 character(s)"]
     end
 
     test "name can't contain non url-safe chars" do
       ["My project @ OpenFn", "Can't have a / slash"]
       |> Enum.each(fn name ->
         errors = Job.changeset(%Job{}, %{name: name}) |> errors_on()
-        assert errors[:name] == ["has invalid format"]
+        assert errors[:name] == ["job name has invalid format"]
       end)
     end
 
     test "must have an adaptor" do
       errors = Job.changeset(%Job{}, %{adaptor: nil}) |> errors_on()
-      assert errors[:adaptor] == ["can't be blank"]
+      assert errors[:adaptor] == ["job adaptor can't be blank"]
     end
   end
 end

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -314,7 +314,7 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
                      "jobs" => [
                        %{
                          "id" => ["This field can't be blank."],
-                         "body" => ["The step can't be blank."]
+                         "body" => ["Code editor cannot be empty."]
                        },
                        %{
                          "name" => ["Job name can't be blank."],

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -314,10 +314,10 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
                      "jobs" => [
                        %{
                          "id" => ["This field can't be blank."],
-                         "body" => ["This field can't be blank."]
+                         "body" => ["The step can't be blank."]
                        },
                        %{
-                         "name" => ["This field can't be blank."],
+                         "name" => ["Job name can't be blank."],
                          "id" => ["This field can't be blank."]
                        }
                      ],

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -86,7 +86,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
               op: "add",
               path: "/jobs/0/errors",
               value: %{
-                "body" => ["The step can't be blank."],
+                "body" => ["Code editor cannot be empty."],
                 "name" => ["Job name can't be blank."]
               }
             },
@@ -101,7 +101,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
               path: "/errors/jobs",
               value: [
                 %{
-                  "body" => ["The step can't be blank."],
+                  "body" => ["Code editor cannot be empty."],
                   "name" => ["Job name can't be blank."]
                 }
               ]
@@ -242,12 +242,12 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       view |> change_editor_text("some body")
 
       refute view |> render() =~
-               "The step can&#39;t be blank."
+               "Code editor cannot be empty."
 
       view |> change_editor_text("")
 
       assert view |> render() =~
-               "The step can&#39;t be blank."
+               "Code editor cannot be empty."
     end
 
     test "allows editing job name", %{

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -86,8 +86,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
               op: "add",
               path: "/jobs/0/errors",
               value: %{
-                "body" => ["This field can't be blank."],
-                "name" => ["This field can't be blank."]
+                "body" => ["The step can't be blank."],
+                "name" => ["Job name can't be blank."]
               }
             },
             %{op: "add", path: "/jobs/0/body", value: ""},
@@ -101,8 +101,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
               path: "/errors/jobs",
               value: [
                 %{
-                  "body" => ["This field can't be blank."],
-                  "name" => ["This field can't be blank."]
+                  "body" => ["The step can't be blank."],
+                  "name" => ["Job name can't be blank."]
                 }
               ]
             }
@@ -242,12 +242,12 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       view |> change_editor_text("some body")
 
       refute view |> render() =~
-               "The step can&#39;t be blank"
+               "The step can&#39;t be blank."
 
       view |> change_editor_text("")
 
       assert view |> render() =~
-               "The step can&#39;t be blank"
+               "The step can&#39;t be blank."
     end
 
     test "allows editing job name", %{

--- a/test/lightning_web/live/workflow_live/workflow_params_test.exs
+++ b/test/lightning_web/live/workflow_live/workflow_params_test.exs
@@ -90,10 +90,10 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  ],
                  "jobs" => [
                    %{
-                     "body" => ["The step can't be blank."],
+                     "body" => ["Code editor cannot be empty."],
                      "name" => ["Job name can't be blank."]
                    },
-                   %{"body" => ["The step can't be blank."]}
+                   %{"body" => ["Code editor cannot be empty."]}
                  ],
                  "name" => ["This field can't be blank."]
                },
@@ -102,7 +102,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
                    "errors" => %{
-                     "body" => ["The step can't be blank."],
+                     "body" => ["Code editor cannot be empty."],
                      "name" => ["Job name can't be blank."]
                    },
                    "id" => ^job_1_id,
@@ -112,7 +112,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["The step can't be blank."]},
+                   "errors" => %{"body" => ["Code editor cannot be empty."]},
                    "id" => ^job_2_id,
                    "name" => "job-2",
                    "project_credential_id" => nil
@@ -180,12 +180,12 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                ],
                "errors" => %{
                  "jobs" => [
-                   %{"body" => ["The step can't be blank."]},
+                   %{"body" => ["Code editor cannot be empty."]},
                    %{
-                     "body" => ["The step can't be blank."],
+                     "body" => ["Code editor cannot be empty."],
                      "name" => ["Job name can't be blank."]
                    },
-                   %{"body" => ["The step can't be blank."]}
+                   %{"body" => ["Code editor cannot be empty."]}
                  ],
                  "name" => ["This field can't be blank."]
                },
@@ -193,7 +193,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["The step can't be blank."]},
+                   "errors" => %{"body" => ["Code editor cannot be empty."]},
                    "id" => ^job_3_id,
                    "name" => "job-3",
                    "project_credential_id" => nil
@@ -202,7 +202,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
                    "errors" => %{
-                     "body" => ["The step can't be blank."],
+                     "body" => ["Code editor cannot be empty."],
                      "name" => ["Job name can't be blank."]
                    },
                    "id" => ^job_1_id,
@@ -212,7 +212,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["The step can't be blank."]},
+                   "errors" => %{"body" => ["Code editor cannot be empty."]},
                    "id" => ^job_2_id,
                    "name" => "job-2",
                    "project_credential_id" => nil
@@ -243,10 +243,10 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  "jobs" => [
                    %{},
                    %{
-                     "body" => ["The step can't be blank."],
+                     "body" => ["Code editor cannot be empty."],
                      "name" => ["Job name can't be blank."]
                    },
-                   %{"body" => ["The step can't be blank."]}
+                   %{"body" => ["Code editor cannot be empty."]}
                  ],
                  "name" => ["This field can't be blank."]
                },
@@ -255,7 +255,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
                    "errors" => %{
-                     "body" => ["The step can't be blank."],
+                     "body" => ["Code editor cannot be empty."],
                      "name" => ["Job name can't be blank."]
                    },
                    "id" => ^job_1_id,
@@ -265,7 +265,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["The step can't be blank."]},
+                   "errors" => %{"body" => ["Code editor cannot be empty."]},
                    "id" => ^job_2_id,
                    "name" => "job-2",
                    "project_credential_id" => nil

--- a/test/lightning_web/live/workflow_live/workflow_params_test.exs
+++ b/test/lightning_web/live/workflow_live/workflow_params_test.exs
@@ -90,10 +90,10 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  ],
                  "jobs" => [
                    %{
-                     "body" => ["This field can't be blank."],
-                     "name" => ["This field can't be blank."]
+                     "body" => ["The step can't be blank."],
+                     "name" => ["Job name can't be blank."]
                    },
-                   %{"body" => ["This field can't be blank."]}
+                   %{"body" => ["The step can't be blank."]}
                  ],
                  "name" => ["This field can't be blank."]
                },
@@ -102,8 +102,8 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
                    "errors" => %{
-                     "body" => ["This field can't be blank."],
-                     "name" => ["This field can't be blank."]
+                     "body" => ["The step can't be blank."],
+                     "name" => ["Job name can't be blank."]
                    },
                    "id" => ^job_1_id,
                    "name" => _,
@@ -112,7 +112,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["This field can't be blank."]},
+                   "errors" => %{"body" => ["The step can't be blank."]},
                    "id" => ^job_2_id,
                    "name" => "job-2",
                    "project_credential_id" => nil
@@ -180,12 +180,12 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                ],
                "errors" => %{
                  "jobs" => [
-                   %{"body" => ["This field can't be blank."]},
+                   %{"body" => ["The step can't be blank."]},
                    %{
-                     "body" => ["This field can't be blank."],
-                     "name" => ["This field can't be blank."]
+                     "body" => ["The step can't be blank."],
+                     "name" => ["Job name can't be blank."]
                    },
-                   %{"body" => ["This field can't be blank."]}
+                   %{"body" => ["The step can't be blank."]}
                  ],
                  "name" => ["This field can't be blank."]
                },
@@ -193,7 +193,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["This field can't be blank."]},
+                   "errors" => %{"body" => ["The step can't be blank."]},
                    "id" => ^job_3_id,
                    "name" => "job-3",
                    "project_credential_id" => nil
@@ -202,8 +202,8 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
                    "errors" => %{
-                     "body" => ["This field can't be blank."],
-                     "name" => ["This field can't be blank."]
+                     "body" => ["The step can't be blank."],
+                     "name" => ["Job name can't be blank."]
                    },
                    "id" => ^job_1_id,
                    "name" => "",
@@ -212,7 +212,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["This field can't be blank."]},
+                   "errors" => %{"body" => ["The step can't be blank."]},
                    "id" => ^job_2_id,
                    "name" => "job-2",
                    "project_credential_id" => nil
@@ -243,10 +243,10 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  "jobs" => [
                    %{},
                    %{
-                     "body" => ["This field can't be blank."],
-                     "name" => ["This field can't be blank."]
+                     "body" => ["The step can't be blank."],
+                     "name" => ["Job name can't be blank."]
                    },
-                   %{"body" => ["This field can't be blank."]}
+                   %{"body" => ["The step can't be blank."]}
                  ],
                  "name" => ["This field can't be blank."]
                },
@@ -255,8 +255,8 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
                    "errors" => %{
-                     "body" => ["This field can't be blank."],
-                     "name" => ["This field can't be blank."]
+                     "body" => ["The step can't be blank."],
+                     "name" => ["Job name can't be blank."]
                    },
                    "id" => ^job_1_id,
                    "name" => "",
@@ -265,7 +265,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParamsTest do
                  %{
                    "adaptor" => "@openfn/language-common@latest",
                    "body" => "",
-                   "errors" => %{"body" => ["This field can't be blank."]},
+                   "errors" => %{"body" => ["The step can't be blank."]},
                    "id" => ^job_2_id,
                    "name" => "job-2",
                    "project_credential_id" => nil


### PR DESCRIPTION
## Validation Steps

## Notes for the reviewer

This PR addresses error messages for the Job model. It proposes to generate custom generic error messages for the Ecto changesets associated to the Job model then translate those messages using the errors.po file. This will allow a better management of the error messages and it can be replicated for all the other form models of the app.

## Related issue

Fixes #1935

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
