### PR TITLE
allow null dataclips in search vector generate script

### DIFF
--- a/priv/repo/migrations/20240329123743_generate_dataclip_search_vectors.exs
+++ b/priv/repo/migrations/20240329123743_generate_dataclip_search_vectors.exs
@@ -32,6 +32,7 @@ defmodule Lightning.Repo.Migrations.GenerateDataclipSearchVectors do
         SELECT id
         FROM dataclips
         WHERE search_vector IS NULL
+        AND body IS NOT NULL
         LIMIT $1
       )
       """,


### PR DESCRIPTION
If someone (no idea who... just... someone 🥲) attempts to generate dataclip search vectors without this additional where clause, they could get stuck in a loop as the tsvector for a jsonb column with a null value is null. 

## Validation Steps

- Before running this migration, make sure you have at least 1 dataclip with a `null` body.

