### PR TITLE
Commit the work order along with the run on the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   [#1954](https://github.com/OpenFn/lightning/issues/1954)
 - Support for a GET endpoint to "check" webhook URL availability
   [#1063](https://github.com/OpenFn/lightning/issues/1063)
+- Allow external apps to control the run enqueue db transaction
+  [#1958](https://github.com/OpenFn/lightning/issues/1958)
 
 ### Changed
 

--- a/lib/lightning/extensions/fifo_run_queue.ex
+++ b/lib/lightning/extensions/fifo_run_queue.ex
@@ -7,14 +7,14 @@ defmodule Lightning.Extensions.FifoRunQueue do
 
   import Ecto.Query
 
+  alias Ecto.Multi
   alias Lightning.Repo
   alias Lightning.Runs.Queue
 
   @impl true
-  def enqueue(run) do
-    run
-    |> Repo.insert()
-  end
+  def enqueue(%Multi{} = multi), do: Repo.transaction(multi)
+
+  def enqueue(run), do: Repo.insert(run)
 
   @impl true
   def claim(demand) do

--- a/lib/lightning/extensions/run_queue.ex
+++ b/lib/lightning/extensions/run_queue.ex
@@ -5,10 +5,14 @@ defmodule Lightning.Extensions.RunQueue do
 
   @callback enqueue(
               run ::
-                Lightning.Run.t() | Ecto.Changeset.t(Lightning.Run.t())
+                Lightning.Run.t()
+                | Ecto.Changeset.t(Lightning.Run.t())
+                | Ecto.Multi.t()
             ) ::
               {:ok, Lightning.Run.t()}
               | {:error, Ecto.Changeset.t(Lightning.Run.t())}
+              | {:error, Ecto.Multi.name(), any(),
+                 %{required(Ecto.Multi.name()) => any()}}
 
   @callback claim(demand :: non_neg_integer()) ::
               {:ok, [Lightning.Run.t()]}


### PR DESCRIPTION
## Validation Steps

Automated tests

## Notes for the reviewer

The code is semantically _the same_, the `Repo.transaction` only moved from one point to another.

## Related issue

Solves #1958

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
