### PR TITLE
1819 better version strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ priv/openfn
 .env
 .env.dev
 .dev.env
+.dev.override.env
+.test.override.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 - Change all System.get_env calls in runtime.exs to use dotenvy
   [#1968](https://github.com/OpenFn/lightning/issues/1968)
+- Send richer version info as part of usage tracking submission.
+  [#1819](https://github.com/OpenFn/lightning/issues/1819)
 
 ### Fixed
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,6 +12,7 @@ config :tesla, Lightning.VersionControl.GithubClient,
 config :tesla, Mix.Tasks.Lightning.InstallAdaptorIcons, adapter: Tesla.Mock
 
 config :tesla, Lightning.UsageTracking.Client, adapter: Tesla.Mock
+config :tesla, Lightning.UsageTracking.GithubClient, adapter: Tesla.Mock
 
 # Configure your database
 #

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -73,4 +73,18 @@ defmodule Lightning.Helpers do
   def json_safe(a) when is_atom(a) and not is_boolean(a), do: Atom.to_string(a)
 
   def json_safe(any), do: any
+
+  def version_data do
+    %{branch: branch, commit: commit, image_tag: image} =
+      :lightning
+      |> Application.get_env(:image_info)
+      |> Enum.into(%{})
+
+    %{
+      branch: branch,
+      commit: commit,
+      image: image,
+      spec_version: "v#{Application.spec(:lightning, :vsn)}"
+    }
+  end
 end

--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -201,12 +201,7 @@ defmodule Lightning.UsageTracking do
   end
 
   defp commit_for_submission(commit) do
-    commit
-    |> GithubClient.open_fn_commit?()
-    |> then(fn
-      true -> commit
-      _not_true -> "sanitised"
-    end)
+    if GithubClient.open_fn_commit?(commit), do: commit, else: "sanitised"
   end
 
   defp image_for_submission(version, version) do

--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -4,8 +4,10 @@ defmodule Lightning.UsageTracking do
   """
   import Ecto.Query
 
+  alias Lightning.Helpers
   alias Lightning.Repo
   alias Lightning.UsageTracking.DailyReportConfiguration
+  alias Lightning.UsageTracking.GithubClient
   alias Lightning.UsageTracking.Report
   alias Lightning.UsageTracking.ReportData
   alias Lightning.UsageTracking.ReportWorker
@@ -191,4 +193,26 @@ defmodule Lightning.UsageTracking do
     })
     |> Repo.update!()
   end
+
+  def lightning_version do
+    %{image: image, commit: commit, spec_version: vsn} = Helpers.version_data()
+
+    "#{vsn}:#{image_for_submission(image, vsn)}:#{commit_for_submission(commit)}"
+  end
+
+  defp commit_for_submission(commit) do
+    commit
+    |> GithubClient.open_fn_commit?()
+    |> then(fn
+      true -> commit
+      _not_true -> "sanitised"
+    end)
+  end
+
+  defp image_for_submission(version, version) do
+    "match"
+  end
+
+  defp image_for_submission("edge" = _image, _spec_version), do: "edge"
+  defp image_for_submission(_image, _spec_version), do: "other"
 end

--- a/lib/lightning/usage_tracking/client.ex
+++ b/lib/lightning/usage_tracking/client.ex
@@ -9,9 +9,12 @@ defmodule Lightning.UsageTracking.Client do
   alias Lightning.UsageTracking.ResponseProcessor
 
   def submit_metrics(metrics, host) do
-    {_ok, env} = host |> build_client() |> post("/api/metrics", metrics)
+    response =
+      host
+      |> build_client()
+      |> post("/api/metrics", metrics)
 
-    if ResponseProcessor.successful?(env), do: :ok, else: :error
+    if ResponseProcessor.successful?(response), do: :ok, else: :error
   end
 
   defp build_client(host) do

--- a/lib/lightning/usage_tracking/client.ex
+++ b/lib/lightning/usage_tracking/client.ex
@@ -9,14 +9,9 @@ defmodule Lightning.UsageTracking.Client do
   alias Lightning.UsageTracking.ResponseProcessor
 
   def submit_metrics(metrics, host) do
-    build_client(host)
-    |> post("/api/metrics", metrics)
-    |> elem(1)
-    |> ResponseProcessor.successful?()
-    |> then(fn
-      true -> :ok
-      false -> :error
-    end)
+    {_ok, env} = host |> build_client() |> post("/api/metrics", metrics)
+
+    if ResponseProcessor.successful?(env), do: :ok, else: :error
   end
 
   defp build_client(host) do

--- a/lib/lightning/usage_tracking/github_client.ex
+++ b/lib/lightning/usage_tracking/github_client.ex
@@ -12,11 +12,12 @@ defmodule Lightning.UsageTracking.GithubClient do
   def open_fn_commit?("" = _commit_sha), do: false
 
   def open_fn_commit?(commit_sha) do
-    @host
-    |> build_client
-    |> head("OpenFn/lightning/commit/#{commit_sha}")
-    |> elem(1)
-    |> ResponseProcessor.successful_200?()
+    {_ok, env} =
+      @host
+      |> build_client()
+      |> head("OpenFn/lightning/commit/#{commit_sha}")
+
+    ResponseProcessor.successful_200?(env)
   end
 
   def build_client(host) do

--- a/lib/lightning/usage_tracking/github_client.ex
+++ b/lib/lightning/usage_tracking/github_client.ex
@@ -1,0 +1,25 @@
+defmodule Lightning.UsageTracking.GithubClient do
+  @moduledoc """
+  A github client to make unauthenticated HTTP requests to Github.
+  """
+  use Tesla, only: [:head], docs: false
+
+  alias Lightning.UsageTracking.ResponseProcessor
+
+  @host "https://github.com/"
+
+  def open_fn_commit?(nil = _commit_sha), do: false
+  def open_fn_commit?("" = _commit_sha), do: false
+
+  def open_fn_commit?(commit_sha) do
+    @host
+    |> build_client
+    |> head("OpenFn/lightning/commit/#{commit_sha}")
+    |> elem(1)
+    |> ResponseProcessor.successful_200?()
+  end
+
+  def build_client(host) do
+    Tesla.client([{Tesla.Middleware.BaseUrl, host}])
+  end
+end

--- a/lib/lightning/usage_tracking/github_client.ex
+++ b/lib/lightning/usage_tracking/github_client.ex
@@ -12,12 +12,12 @@ defmodule Lightning.UsageTracking.GithubClient do
   def open_fn_commit?("" = _commit_sha), do: false
 
   def open_fn_commit?(commit_sha) do
-    {_ok, env} =
+    response =
       @host
       |> build_client()
       |> head("OpenFn/lightning/commit/#{commit_sha}")
 
-    ResponseProcessor.successful_200?(env)
+    ResponseProcessor.successful_200?(response)
   end
 
   def build_client(host) do

--- a/lib/lightning/usage_tracking/report_data.ex
+++ b/lib/lightning/usage_tracking/report_data.ex
@@ -4,11 +4,10 @@ defmodule Lightning.UsageTracking.ReportData do
 
 
   """
+  alias Lightning.UsageTracking
   alias Lightning.UsageTracking.DailyReportConfiguration
   alias Lightning.UsageTracking.ProjectMetricsService
   alias Lightning.UsageTracking.UserService
-
-  @lightning_version Lightning.MixProject.project()[:version]
 
   def generate(configuration, cleartext_enabled, date) do
     %{
@@ -29,7 +28,7 @@ defmodule Lightning.UsageTracking.ReportData do
       no_of_active_users: UserService.no_of_active_users(date),
       no_of_users: UserService.no_of_users(date),
       operating_system: operating_system_name(),
-      version: @lightning_version
+      version: UsageTracking.lightning_version()
     })
   end
 

--- a/lib/lightning/usage_tracking/response_processor.ex
+++ b/lib/lightning/usage_tracking/response_processor.ex
@@ -1,6 +1,6 @@
 defmodule Lightning.UsageTracking.ResponseProcessor do
   @moduledoc """
-  Utility module to abstract deaing with some of the Tesla plumbing
+  Utility module to abstract dealing with some of the Tesla plumbing
 
   """
   def successful?(%Tesla.Env{status: status}) do
@@ -8,4 +8,7 @@ defmodule Lightning.UsageTracking.ResponseProcessor do
   end
 
   def successful?(_response), do: false
+
+  def successful_200?(%Tesla.Env{status: 200}), do: true
+  def successful_200?(_response), do: false
 end

--- a/lib/lightning/usage_tracking/response_processor.ex
+++ b/lib/lightning/usage_tracking/response_processor.ex
@@ -3,12 +3,12 @@ defmodule Lightning.UsageTracking.ResponseProcessor do
   Utility module to abstract dealing with some of the Tesla plumbing
 
   """
-  def successful?(%Tesla.Env{status: status}) do
+  def successful?({:ok, %Tesla.Env{status: status}}) do
     status >= 200 && status < 300
   end
 
   def successful?(_response), do: false
 
-  def successful_200?(%Tesla.Env{status: 200}), do: true
+  def successful_200?({:ok, %Tesla.Env{status: 200}}), do: true
   def successful_200?(_response), do: false
 end

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -2,14 +2,12 @@ defmodule LightningWeb.Components.Common do
   @moduledoc false
   use LightningWeb, :component
 
+  alias Lightning.Helpers
   alias Phoenix.LiveView.JS
 
   def version_chip(assigns) do
-    image_info = Application.get_env(:lightning, :image_info)
-    image = image_info[:image_tag]
-    branch = image_info[:branch]
-    commit = image_info[:commit]
-    vsn = "v#{Application.spec(:lightning, :vsn)}"
+    %{image: image, branch: branch, commit: commit, spec_version: vsn} =
+      Helpers.version_data()
 
     {display, message, type} =
       cond do

--- a/test/lightning/helpers_test.exs
+++ b/test/lightning/helpers_test.exs
@@ -1,7 +1,8 @@
 defmodule Lightning.HelpersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
-  import Lightning.Helpers, only: [coerce_json_field: 2]
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+  import Lightning.Helpers, only: [coerce_json_field: 2, version_data: 0]
 
   test "coerce_json_field/2 will transform a json string inside a map by it's key" do
     input = %{
@@ -53,5 +54,41 @@ defmodule Lightning.HelpersTest do
              name: "Sadio Mane",
              goals: 123
            }
+  end
+
+  describe "version_data" do
+    test "returns data that can be used to represent the instance version" do
+      put_temporary_env(:lightning, :image_info,
+        branch: "foo-bar",
+        commit: "abc123",
+        image_tag: "vx.y.z"
+      )
+
+      expected = %{
+        branch: "foo-bar",
+        commit: "abc123",
+        image: "vx.y.z",
+        spec_version: "v#{Application.spec(:lightning, :vsn)}"
+      }
+
+      assert version_data() == expected
+    end
+
+    test "correctly deals with nil values" do
+      put_temporary_env(:lightning, :image_info,
+        branch: nil,
+        commit: nil,
+        image_tag: nil
+      )
+
+      expected = %{
+        branch: nil,
+        commit: nil,
+        image: nil,
+        spec_version: "v#{Application.spec(:lightning, :vsn)}"
+      }
+
+      assert version_data() == expected
+    end
   end
 end

--- a/test/lightning/usage_tracking/github_client_test.exs
+++ b/test/lightning/usage_tracking/github_client_test.exs
@@ -1,0 +1,50 @@
+defmodule Lightning.UsageTracking.GithubClientTest do
+  use ExUnit.Case, async: false
+
+  import Tesla.Mock
+
+  alias Lightning.UsageTracking.GithubClient
+
+  @commit_sha "abc123"
+  @url "https://github.com/OpenFn/lightning/commit/#{@commit_sha}"
+
+  test "returns true if commit sha exists on OpenFn Lightning repo" do
+    url = @url
+
+    mock(fn
+      %{
+        method: :head,
+        url: ^url,
+        query: [],
+        headers: [],
+        body: nil,
+        status: nil
+      } ->
+        %Tesla.Env{status: 200}
+    end)
+
+    assert GithubClient.open_fn_commit?(@commit_sha) == true
+  end
+
+  test "returns false if commit sha doesn't exist on OpenFn Lightning repo" do
+    url = @url
+
+    mock(fn
+      %{
+        method: :head,
+        url: ^url
+      } ->
+        %Tesla.Env{status: 404}
+    end)
+
+    assert GithubClient.open_fn_commit?(@commit_sha) == false
+  end
+
+  test "returns false if commit sha is nil" do
+    assert GithubClient.open_fn_commit?(nil) == false
+  end
+
+  test "returns false if commit sha is an empty string" do
+    assert GithubClient.open_fn_commit?("") == false
+  end
+end

--- a/test/lightning/usage_tracking/report_worker_test.exs
+++ b/test/lightning/usage_tracking/report_worker_test.exs
@@ -4,8 +4,9 @@ defmodule Lightning.UsageTracking.ReportWorkerTest do
   import Mock
   import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
 
-  alias Lightning.UsageTracking.Client
   alias Lightning.UsageTracking
+  alias Lightning.UsageTracking.Client
+  alias Lightning.UsageTracking.GithubClient
   alias Lightning.UsageTracking.Report
   alias Lightning.UsageTracking.ReportData
   alias Lightning.UsageTracking.ReportWorker
@@ -14,7 +15,9 @@ defmodule Lightning.UsageTracking.ReportWorkerTest do
   @host "https://foo.bar"
 
   describe "tracking is enabled - cleartext uuids are disabled" do
-    setup do
+    setup_with_mocks([
+      {GithubClient, [], [open_fn_commit?: fn _ -> true end]}
+    ]) do
       cleartext_uuids_enabled = false
 
       report_config =
@@ -110,7 +113,9 @@ defmodule Lightning.UsageTracking.ReportWorkerTest do
   end
 
   describe "tracking is enabled - cleartext uuids are enabled" do
-    setup do
+    setup_with_mocks([
+      {GithubClient, [], [open_fn_commit?: fn _ -> true end]}
+    ]) do
       cleartext_uuids_enabled = true
 
       report_config =
@@ -206,7 +211,9 @@ defmodule Lightning.UsageTracking.ReportWorkerTest do
   end
 
   describe "tracking is enabled - but report for given date exists" do
-    setup do
+    setup_with_mocks([
+      {GithubClient, [], [open_fn_commit?: fn _ -> true end]}
+    ]) do
       UsageTracking.enable_daily_report(DateTime.utc_now())
 
       put_temporary_env(:lightning, :usage_tracking,

--- a/test/lightning/usage_tracking/response_processor_test.exs
+++ b/test/lightning/usage_tracking/response_processor_test.exs
@@ -5,51 +5,51 @@ defmodule Lightning.UsageTracking.ResponseProcessorTest do
 
   describe ".successful?/1" do
     test "returns false with a status outside the 2xx range" do
-      env = %Tesla.Env{status: 199}
+      response = {:ok, %Tesla.Env{status: 199}}
 
-      refute(ResponseProcessor.successful?(env))
+      refute(ResponseProcessor.successful?(response))
 
-      env = %Tesla.Env{status: 300}
+      response = {:ok, %Tesla.Env{status: 300}}
 
-      refute(ResponseProcessor.successful?(env))
+      refute(ResponseProcessor.successful?(response))
     end
 
     test "returns true within the 2xx range" do
-      env = %Tesla.Env{status: 200}
+      response = {:ok, %Tesla.Env{status: 200}}
 
-      assert(ResponseProcessor.successful?(env))
+      assert(ResponseProcessor.successful?(response))
 
-      env = %Tesla.Env{status: 299}
+      response = {:ok, %Tesla.Env{status: 299}}
 
-      assert(ResponseProcessor.successful?(env))
+      assert(ResponseProcessor.successful?(response))
     end
 
     test "anything other than a Tesla.Env struct is considered unsuccessful" do
-      refute(ResponseProcessor.successful?(:nxdomain))
-      refute(ResponseProcessor.successful?(:econnrefused))
+      refute(ResponseProcessor.successful?({:error, :nxdomain}))
+      refute(ResponseProcessor.successful?({:error, :econnrefused}))
     end
   end
 
   describe ".successful_200?/1" do
     test "returns false with a status that is not 200" do
-      env = %Tesla.Env{status: 201}
+      response = {:ok, %Tesla.Env{status: 201}}
 
-      assert ResponseProcessor.successful_200?(env) == false
+      assert ResponseProcessor.successful_200?(response) == false
 
-      env = %Tesla.Env{status: 400}
+      response = {:ok, %Tesla.Env{status: 400}}
 
-      assert ResponseProcessor.successful_200?(env) == false
+      assert ResponseProcessor.successful_200?(response) == false
     end
 
     test "returns true for a 200 response" do
-      env = %Tesla.Env{status: 200}
+      response = {:ok, %Tesla.Env{status: 200}}
 
-      assert(ResponseProcessor.successful_200?(env))
+      assert(ResponseProcessor.successful_200?(response))
     end
 
     test "anything other than a Tesla.Env struct is considered unsuccessful" do
-      assert ResponseProcessor.successful_200?(:nxdomain) == false
-      assert ResponseProcessor.successful_200?(:econnrefused) == false
+      assert ResponseProcessor.successful_200?({:error, :nxdomain}) == false
+      assert ResponseProcessor.successful_200?({:error, :econnrefused}) == false
     end
   end
 end

--- a/test/lightning/usage_tracking/response_processor_test.exs
+++ b/test/lightning/usage_tracking/response_processor_test.exs
@@ -3,28 +3,53 @@ defmodule Lightning.UsageTracking.ResponseProcessorTest do
 
   alias Lightning.UsageTracking.ResponseProcessor
 
-  test "returns false with a status outside the 2xx range" do
-    env = %Tesla.Env{status: 199}
+  describe ".successful?/1" do
+    test "returns false with a status outside the 2xx range" do
+      env = %Tesla.Env{status: 199}
 
-    refute(ResponseProcessor.successful?(env))
+      refute(ResponseProcessor.successful?(env))
 
-    env = %Tesla.Env{status: 300}
+      env = %Tesla.Env{status: 300}
 
-    refute(ResponseProcessor.successful?(env))
+      refute(ResponseProcessor.successful?(env))
+    end
+
+    test "returns true within the 2xx range" do
+      env = %Tesla.Env{status: 200}
+
+      assert(ResponseProcessor.successful?(env))
+
+      env = %Tesla.Env{status: 299}
+
+      assert(ResponseProcessor.successful?(env))
+    end
+
+    test "anything other than a Tesla.Env struct is considered unsuccessful" do
+      refute(ResponseProcessor.successful?(:nxdomain))
+      refute(ResponseProcessor.successful?(:econnrefused))
+    end
   end
 
-  test "returns true within the 2xx range" do
-    env = %Tesla.Env{status: 200}
+  describe ".successful_200?/1" do
+    test "returns false with a status that is not 200" do
+      env = %Tesla.Env{status: 201}
 
-    assert(ResponseProcessor.successful?(env))
+      assert ResponseProcessor.successful_200?(env) == false
 
-    env = %Tesla.Env{status: 299}
+      env = %Tesla.Env{status: 400}
 
-    assert(ResponseProcessor.successful?(env))
-  end
+      assert ResponseProcessor.successful_200?(env) == false
+    end
 
-  test "anything other than a Tesla.Env struct is considered unsuccessful" do
-    refute(ResponseProcessor.successful?(:nxdomain))
-    refute(ResponseProcessor.successful?(:econnrefused))
+    test "returns true for a 200 response" do
+      env = %Tesla.Env{status: 200}
+
+      assert(ResponseProcessor.successful_200?(env))
+    end
+
+    test "anything other than a Tesla.Env struct is considered unsuccessful" do
+      assert ResponseProcessor.successful_200?(:nxdomain) == false
+      assert ResponseProcessor.successful_200?(:econnrefused) == false
+    end
   end
 end

--- a/test/lightning/usage_tracking_test.exs
+++ b/test/lightning/usage_tracking_test.exs
@@ -1,9 +1,13 @@
 defmodule Lightning.UsageTrackingTest do
-  use Lightning.DataCase
+  use Lightning.DataCase, async: false
+
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+  import Mock
 
   alias Lightning.Repo
   alias Lightning.UsageTracking
   alias Lightning.UsageTracking.DailyReportConfiguration
+  alias Lightning.UsageTracking.GithubClient
   alias Lightning.UsageTracking.Report
   alias Lightning.UsageTracking.ReportData
   alias Lightning.UsageTracking.ReportWorker
@@ -581,7 +585,9 @@ defmodule Lightning.UsageTrackingTest do
   end
 
   describe ".insert_report - cleartext uuids disabled" do
-    setup do
+    setup_with_mocks([
+      {GithubClient, [], [open_fn_commit?: fn _ -> true end]}
+    ]) do
       cleartext_uuids_enabled = false
 
       date = ~D[2024-02-05]
@@ -663,7 +669,9 @@ defmodule Lightning.UsageTrackingTest do
   end
 
   describe ".insert_report - cleartext uuids enabled" do
-    setup do
+    setup_with_mocks([
+      {GithubClient, [], [open_fn_commit?: fn _ -> true end]}
+    ]) do
       cleartext_uuids_enabled = false
 
       date = ~D[2024-02-05]
@@ -815,5 +823,114 @@ defmodule Lightning.UsageTrackingTest do
                submitted_at: nil
              } = updated_report
     end
+  end
+
+  describe ".lightning_version - commit is an openfn commit" do
+    setup_with_mocks([
+      {
+        GithubClient,
+        [],
+        [
+          open_fn_commit?: fn
+            "abc123" -> true
+            other_sha -> flunk("Commit sha #{other_sha} passed to GithubClient")
+          end
+        ]
+      }
+    ]) do
+      commit = "abc123"
+      spec_version = "v#{Application.spec(:lightning, :vsn)}"
+
+      %{
+        commit: commit,
+        spec_version: spec_version
+      }
+    end
+
+    test "indicates when the image is `edge`", %{
+      commit: commit,
+      spec_version: spec_version
+    } do
+      set_env(branch: "ignored", commit: commit, image_tag: "edge")
+
+      assert UsageTracking.lightning_version() ==
+               "#{spec_version}:edge:#{commit}"
+    end
+
+    test "indicates when the image matches the spec version", %{
+      commit: commit,
+      spec_version: spec_version
+    } do
+      set_env(branch: "ignored", commit: commit, image_tag: spec_version)
+
+      assert UsageTracking.lightning_version() ==
+               "#{spec_version}:match:#{commit}"
+    end
+
+    test "indicates when the image is neither version nor `edge`", %{
+      commit: commit,
+      spec_version: spec_version
+    } do
+      set_env(branch: "ignored", commit: commit, image_tag: "unique")
+
+      assert UsageTracking.lightning_version() ==
+               "#{spec_version}:other:#{commit}"
+    end
+  end
+
+  describe ".lightning_version/0 - commit is not an openfn commit" do
+    setup_with_mocks([
+      {
+        GithubClient,
+        [],
+        [
+          open_fn_commit?: fn
+            "abc123" -> false
+            other_sha -> flunk("Commit sha #{other_sha} passed to GithubClient")
+          end
+        ]
+      }
+    ]) do
+      commit = "abc123"
+      spec_version = "v#{Application.spec(:lightning, :vsn)}"
+
+      %{
+        commit: commit,
+        spec_version: spec_version
+      }
+    end
+
+    test "indicates when the image is `edge`", %{
+      commit: commit,
+      spec_version: version
+    } do
+      set_env(branch: "ignored", commit: commit, image_tag: "edge")
+
+      assert UsageTracking.lightning_version() == "#{version}:edge:sanitised"
+    end
+
+    test "indicates when the image matches the spec version", %{
+      commit: commit,
+      spec_version: spec_version
+    } do
+      set_env(branch: "ignored", commit: commit, image_tag: spec_version)
+
+      assert UsageTracking.lightning_version() ==
+               "#{spec_version}:match:sanitised"
+    end
+
+    test "indicates when the image is neither version nor `edge`", %{
+      commit: commit,
+      spec_version: spec_version
+    } do
+      set_env(branch: "ignored", commit: commit, image_tag: "unique")
+
+      assert UsageTracking.lightning_version() ==
+               "#{spec_version}:other:sanitised"
+    end
+  end
+
+  defp set_env(values) do
+    put_temporary_env(:lightning, :image_info, values)
   end
 end


### PR DESCRIPTION
## Validation Steps

- Ensure that you have a local version of ImpactTracker running.
- Ensure that `USAGE_TRACKER_HOST` for your local Lightning env is pointing to your local ImpactTracker instance.
- Ensure that `USAGE_TRACKING_ENABLED` is either not set or set to `true`.
- Ensure that `IMAGE_TAG` is set to `v2.3.1`
- Ensure that `BRANCH` i set to `doesnotmatter`
- Ensure that `COMMIT` is set to `a61eaea`
- In a (Lightning) IEx session, run the following to execute the code:

```
today = DateTime.utc_now() |> DateTime.to_date()
today_as_string = today |> Date.to_iso8601()

Lightning.UsageTracking.disable_daily_report()
Lightning.UsageTracking.enable_daily_report(~U[2024-03-07 12:00:00.000000Z])
Lightning.Demo.reset_demo()
Lightning.UsageTracking.ReportWorker.perform(%Oban.Job{args: %{"date" => today_as_string}})
```

- In the same Lightning IEx session, run the below to validate the changes (there should be no errors):

```
alias Lightning.UsageTracking.Report
import Ecto.Query
query = from r in Report, order_by: [desc: r.inserted_at], limit: 1

last_report = query |> Repo.one()

%{submitted: true, report_date: ^today} = last_report
```

- In an ImpactTracker IEx session, the below should complete without any errors:

```
today = DateTime.utc_now() |> DateTime.to_date()

import Ecto.Query
alias ImpactTracker.Repo
alias ImpactTracker.Submission
query = from s in Submission, order_by: [desc: s.inserted_at], limit: 1, preload: [projects: [:workflows]]
last_submission = query |> Repo.one()

%{lightning_version: "v2.3.1:match:a61eaea"} = last_submission
```

## Notes for the reviewer

This PR tries to send the richest version representation through while still not revealing anything about the instance that is sending the data. As an example of this, if the value of `COMMIT` is not a commit associated with the OpenFn Lightning repository, the commit is not included for fear that it could be used to identify an instance.

The PR has two distinct pieces of work, each represented by a commit:

- Extracting existing version functionality into a Helper
- Using this version functionality to populate the usage tracking submission. 

## Related issue

Fixes #1819 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
