### PR TITLE
Increase frequency of usage tracking crons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- Run the usage tracking submission job more frequently to reduce the risk of
+  Oban unavailability at a particular time.
+  [#1778](https://github.com/OpenFn/lightning/issues/1778)
+
 ### Fixed
 
 ## [v2.3.0] - 2024-04-02

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -185,7 +185,7 @@ usage_tracking_daily_batch_size =
 
 usage_tracking_cron = [
   {
-    "30 1 * * *",
+    "30 1,9,17 * * *",
     Lightning.UsageTracking.DayWorker,
     args: %{"batch_size" => usage_tracking_daily_batch_size}
   }


### PR DESCRIPTION
## Validation Steps

Given that this PR is purely a configuration change, I guess the easiest way would be to validate the new cron syntax and confirm that it will result in the `DayWorker` being run at 01:30, 09:30 and 17:30 UTC.

## Notes for the reviewer

There is a chance that a Lightning instance may have regular periods of downtime that coincide with the scheduled reporting period (e.g. something like `unattended-upgrades`). To make usage tracking submissions tolerant of this, this PR changes the cron to run 3 times per day. 

On an instance that is current with usage tracking reports, the additional submissions will not result in additional submissions as the 01:30 submission will generate the report for the previous day and subsequent runs will no-op as there will be nothing for them to do.

## Related issue

Fixes #1778 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
