### PR TITLE
Backport existing usage report submission status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to
   [#1789](https://github.com/OpenFn/lightning/issues/1789)
 - Send richer version info as part of usage tracking submission.
   [#1819](https://github.com/OpenFn/lightning/issues/1819)
+- Update `submission_status` for any Usagetracking.Report that does not have
+  it set.
+  [#1789](https://github.com/OpenFn/lightning/issues/1789)
 
 ### Fixed
 

--- a/priv/repo/migrations/20240404095107_backport_usage_tracking_submissions_status.exs
+++ b/priv/repo/migrations/20240404095107_backport_usage_tracking_submissions_status.exs
@@ -1,0 +1,17 @@
+defmodule Lightning.Repo.Migrations.BackportUsageTrackingSubmissionsStatus do
+  use Ecto.Migration
+
+  def change do
+    execute """
+    UPDATE usage_tracking_reports
+    SET submission_status = 'failure'
+    WHERE submitted = false AND submission_status IS NULL
+    """
+
+    execute """
+    UPDATE usage_tracking_reports
+    SET submission_status = 'success'
+    WHERE submitted = true AND submission_status IS NULL
+    """
+  end
+end


### PR DESCRIPTION
## Validation Steps

Before switching to this branch, run the following code in an IEx session on `main`:

```
alias Lightning.Repo
alias Lightning.UsageTracking.Report

Report |> Repo.all() |> Enum.each(& Repo.delete(&1))

%Report{} |> Report.changeset(%{data: %{}, report_date: "2020-01-01", submitted: true, submitted_at: DateTime.utc_now()}) |> Repo.insert!()
%Report{} |> Report.changeset(%{data: %{}, report_date: "2020-01-02", submitted: false}) |> Repo.insert!()
```

Now, switch to this branch and run the migrations. Then, in an IEx session:

```
%{submission_status: :success} = Repo.get_by(Report, submitted: true) # should not raise
%{submission_status: :failure} = Repo.get_by(Report, submitted: false) # should not raise
```

## Notes for the reviewer



## Related issue

#1789 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
