### PR TITLE
Enqueue retry run with a multi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
 
 - Fix sync to branch only targetting main branch
   [#1892](https://github.com/OpenFn/lightning/issues/1892)
+- Fix enqueue run without the workflow info
+  [#1981](https://github.com/OpenFn/lightning/issues/1981)
 
 ## [v2.3.1] - 2024-04-03
 

--- a/lib/lightning/extensions/fifo_run_queue.ex
+++ b/lib/lightning/extensions/fifo_run_queue.ex
@@ -14,8 +14,6 @@ defmodule Lightning.Extensions.FifoRunQueue do
   @impl true
   def enqueue(%Multi{} = multi), do: Repo.transaction(multi)
 
-  def enqueue(run), do: Repo.insert(run)
-
   @impl true
   def claim(demand) do
     fifo_runs_query =

--- a/lib/lightning/extensions/run_queue.ex
+++ b/lib/lightning/extensions/run_queue.ex
@@ -3,14 +3,8 @@ defmodule Lightning.Extensions.RunQueue do
   Extension to customize the scheduling of workloads on Lightning Runtime.
   """
 
-  @callback enqueue(
-              run ::
-                Lightning.Run.t()
-                | Ecto.Changeset.t(Lightning.Run.t())
-                | Ecto.Multi.t()
-            ) ::
-              {:ok, Lightning.Run.t()}
-              | {:error, Ecto.Changeset.t(Lightning.Run.t())}
+  @callback enqueue(run :: Ecto.Multi.t()) ::
+              {:ok, %{required(Ecto.Multi.name()) => any()}}
               | {:error, Ecto.Multi.name(), any(),
                  %{required(Ecto.Multi.name()) => any()}}
 

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -2,6 +2,8 @@ defmodule Lightning.Runs do
   @moduledoc """
   Gathers operations to create, update and delete Runs.
   """
+  @behaviour Lightning.Extensions.RunQueue
+
   import Ecto.Query
 
   alias Lightning.Invocation.LogLine
@@ -16,6 +18,7 @@ defmodule Lightning.Runs do
   @doc """
   Enqueue a run to be processed.
   """
+  @impl Lightning.Extensions.RunQueue
   def enqueue(run) do
     RunQueue.enqueue(run)
   end
@@ -26,6 +29,7 @@ defmodule Lightning.Runs do
   # The `demand` parameter is used to request more than a since run,
   # all implementation should default to 1.
   # """
+  @impl Lightning.Extensions.RunQueue
   def claim(demand \\ 1) do
     RunQueue.claim(demand)
   end
@@ -33,6 +37,7 @@ defmodule Lightning.Runs do
   # @doc """
   # Removes a run from the queue.
   # """
+  @impl Lightning.Extensions.RunQueue
   def dequeue(run) do
     RunQueue.dequeue(run)
   end


### PR DESCRIPTION
## Validation Steps

Automated tests.

## Notes for the reviewer

Calls `Runs.enqueue` always with a multi to include the workflow.

Please notice the `Repo.transaction` moved from one place to another and the transformations done by `Repo.transact` are not used so it's okay to use `Repo.transaction` from the `Runs.enqueue/Lightning.Extensions.FifoRunQueue`.

## Related issue

Fixes #1981

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
