### PR TITLE
limit activation of workflows

### DIFF
--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -12,11 +12,11 @@ defmodule Lightning.Extensions.UsageLimiting do
   defmodule Action do
     @moduledoc false
     @type t :: %__MODULE__{
-            type: :new_run | :new_workflow | :new_user,
+            type: :new_run | :activate_workflow | :new_user,
             amount: pos_integer()
           }
 
-    defstruct type: nil, amount: 1
+    defstruct type: nil, amount: 1, changeset: nil
   end
 
   defmodule Context do

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -16,7 +16,7 @@ defmodule Lightning.Extensions.UsageLimiting do
             amount: pos_integer()
           }
 
-    defstruct type: nil, amount: 1, changeset: nil
+    defstruct type: nil, amount: 1
   end
 
   defmodule Context do

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -12,17 +12,15 @@ defmodule Lightning.Projects.Provisioner do
   import Ecto.Query
 
   alias Lightning.Accounts.User
-  alias Lightning.Extensions.UsageLimiting.Action
-  alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Projects.Project
   alias Lightning.Projects.ProjectUser
   alias Lightning.Repo
-  alias Lightning.Services.UsageLimiter
   alias Lightning.VersionControl.ProjectRepoConnection
   alias Lightning.Workflows.Edge
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
+  alias Lightning.Workflows.WorkflowUsageLimiter
 
   @doc """
   Import a project.
@@ -125,12 +123,7 @@ defmodule Lightning.Projects.Provisioner do
     |> cast_assoc(:edges, with: &edge_changeset/2)
     |> Workflow.validate()
     |> then(fn changeset ->
-      case UsageLimiter.limit_action(
-             %Action{type: :activate_workflow, changeset: changeset},
-             %Context{
-               project_id: get_field(changeset, :project_id)
-             }
-           ) do
+      case WorkflowUsageLimiter.limit_workflow_activation(changeset) do
         :ok ->
           changeset
 

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -44,7 +44,8 @@ defmodule Lightning.Projects.Provisioner do
     |> maybe_add_project_user(user_or_repo_connection)
     |> Repo.insert_or_update()
     |> case do
-      {:ok, %{id: id}} ->
+      {:ok, %{id: id, workflows: workflows}} ->
+        Enum.each(workflows, &Lightning.Workflows.Events.workflow_updated/1)
         {:ok, load_project(id)}
 
       {:error, changeset} ->

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -193,6 +193,15 @@ defmodule Lightning.Workflows do
 
       Repo.update_all(workflow_triggers_query, set: [enabled: false])
     end)
+    |> tap(fn
+      {:ok, _result} ->
+        workflow
+        |> Repo.preload([:triggers], force: true)
+        |> Events.workflow_updated()
+
+      _error ->
+        :ok
+    end)
   end
 
   @doc """

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -85,12 +85,10 @@ defmodule Lightning.Workflows do
   def upsert_workflow(%Ecto.Changeset{} = changeset) do
     changeset
     |> Repo.insert_or_update()
-    |> tap(fn
-      {:ok, workflow} ->
+    |> tap(fn result ->
+      with {:ok, workflow} <- result do
         Events.workflow_updated(workflow)
-
-      _error ->
-        :ok
+      end
     end)
   end
 
@@ -193,14 +191,12 @@ defmodule Lightning.Workflows do
 
       Repo.update_all(workflow_triggers_query, set: [enabled: false])
     end)
-    |> tap(fn
-      {:ok, _result} ->
+    |> tap(fn result ->
+      with {:ok, _} <- result do
         workflow
         |> Repo.preload([:triggers], force: true)
         |> Events.workflow_updated()
-
-      _error ->
-        :ok
+      end
     end)
   end
 

--- a/lib/lightning/workflows/events.ex
+++ b/lib/lightning/workflows/events.ex
@@ -1,0 +1,21 @@
+defmodule Lightning.Workflows.Events do
+  @moduledoc false
+
+  defmodule WorkflowUpdated do
+    @moduledoc false
+    defstruct workflow: nil
+  end
+
+  def workflow_updated(workflow) do
+    Lightning.broadcast(
+      topic(workflow.project_id),
+      %WorkflowUpdated{workflow: workflow}
+    )
+  end
+
+  def subscribe(project_id) do
+    Lightning.subscribe(topic(project_id))
+  end
+
+  defp topic(project_id), do: "project:#{project_id}"
+end

--- a/lib/lightning/workflows/events.ex
+++ b/lib/lightning/workflows/events.ex
@@ -17,5 +17,5 @@ defmodule Lightning.Workflows.Events do
     Lightning.subscribe(topic(project_id))
   end
 
-  defp topic(project_id), do: "project:#{project_id}"
+  defp topic(project_id), do: "workflow_events:#{project_id}"
 end

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -31,7 +31,7 @@ defmodule Lightning.Workflows.Trigger do
     field :comment, :string
     field :custom_path, :string
     field :cron_expression, :string
-    field :enabled, :boolean
+    field :enabled, :boolean, default: true
     belongs_to :workflow, Workflow
 
     has_many :edges, Lightning.Workflows.Edge, foreign_key: :source_trigger_id

--- a/lib/lightning/workflows/workflow.ex
+++ b/lib/lightning/workflows/workflow.ex
@@ -68,4 +68,17 @@ defmodule Lightning.Workflows.Workflow do
     workflow
     |> cast(attrs, [:deleted_at])
   end
+
+  @spec workflow_activated?(Ecto.Changeset.t()) :: boolean()
+  def workflow_activated?(changeset) do
+    changeset
+    |> get_assoc(:triggers)
+    |> Enum.any?(fn trigger_changeset ->
+      if trigger_changeset.data.__meta__.state == :built do
+        get_field(trigger_changeset, :enabled) == true
+      else
+        get_change(trigger_changeset, :enabled) == true
+      end
+    end)
+  end
 end

--- a/lib/lightning/workflows/workflow_usage_limiter.ex
+++ b/lib/lightning/workflows/workflow_usage_limiter.ex
@@ -1,0 +1,23 @@
+defmodule Lightning.Workflows.WorkflowUsageLimiter do
+  @moduledoc false
+  alias Lightning.Extensions.UsageLimiting
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.Workflows.Workflow
+  alias Lightning.Services.UsageLimiter
+
+  @spec limit_workflow_activation(Ecto.Changeset.t(Workflow.t())) ::
+          :ok | UsageLimiting.error()
+  def limit_workflow_activation(workflow_changeset) do
+    if Workflow.workflow_activated?(workflow_changeset) do
+      UsageLimiter.limit_action(
+        %Action{type: :activate_workflow},
+        %Context{
+          project_id: Ecto.Changeset.get_field(workflow_changeset, :project_id)
+        }
+      )
+    else
+      :ok
+    end
+  end
+end

--- a/lib/lightning/workflows/workflow_usage_limiter.ex
+++ b/lib/lightning/workflows/workflow_usage_limiter.ex
@@ -3,8 +3,8 @@ defmodule Lightning.Workflows.WorkflowUsageLimiter do
   alias Lightning.Extensions.UsageLimiting
   alias Lightning.Extensions.UsageLimiting.Action
   alias Lightning.Extensions.UsageLimiting.Context
-  alias Lightning.Workflows.Workflow
   alias Lightning.Services.UsageLimiter
+  alias Lightning.Workflows.Workflow
 
   @spec limit_workflow_activation(Ecto.Changeset.t(Workflow.t())) ::
           :ok | UsageLimiting.error()

--- a/lib/lightning/workflows/workflow_usage_limiter.ex
+++ b/lib/lightning/workflows/workflow_usage_limiter.ex
@@ -3,6 +3,7 @@ defmodule Lightning.Workflows.WorkflowUsageLimiter do
   alias Lightning.Extensions.UsageLimiting
   alias Lightning.Extensions.UsageLimiting.Action
   alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.Projects.Project
   alias Lightning.Services.UsageLimiter
   alias Lightning.Workflows.Workflow
 
@@ -19,5 +20,13 @@ defmodule Lightning.Workflows.WorkflowUsageLimiter do
     else
       :ok
     end
+  end
+
+  @spec limit_workflow_creation(project :: Project.t()) ::
+          :ok | UsageLimiting.error()
+  def limit_workflow_creation(project) do
+    %Workflow{project_id: project.id}
+    |> Workflow.changeset(%{triggers: [%{enabled: true}]})
+    |> limit_workflow_activation()
   end
 end

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -4,6 +4,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
 
   alias Lightning.DashboardStats.ProjectMetrics
   alias Lightning.Projects.Project
+  alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrders.SearchParams
   alias Timex.Format.DateTime.Formatters.Relative
 
@@ -212,25 +213,45 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     """
   end
 
+  attr :can_create_workflow, :boolean, required: true
+  attr :project, :map, required: true
+
   def create_workflow_card(assigns) do
+    limit_error = limit_workflow_creation_error(assigns.project)
+
+    assigns =
+      assigns
+      |> assign_new(:disabled, fn ->
+        !assigns.can_create_workflow || is_binary(limit_error)
+      end)
+      |> assign_new(:tooltip, fn ->
+        limit_error || "You are not authorized to perform this action."
+      end)
+
     ~H"""
     <div>
-      <button
-        phx-click={show_modal("workflow_modal")}
+      <.button
+        disabled={@disabled}
+        tooltip={@tooltip}
+        phx-click={if !@disabled, do: show_modal("workflow_modal")}
         class="col-span-1 w-full rounded-md"
-        role={@can_create_workflow && "button"}
+        role="button"
         id="open-modal-button"
       >
-        <div class={"flex flex-1 items-center justify-between truncate rounded-md border border-gray-200 text-white " <> (if @can_create_workflow, do: "bg-primary-600 hover:bg-primary-700", else: "bg-gray-400")}>
-          <div class="flex-1 truncate px-4 py-2 text-sm text-left">
-            <span class="font-medium">
-              Create new workflow
-            </span>
-          </div>
-        </div>
-      </button>
+        Create new workflow
+      </.button>
     </div>
     """
+  end
+
+  defp limit_workflow_creation_error(project) do
+    case WorkflowUsageLimiter.limit_workflow_creation(project) do
+      :ok ->
+        nil
+
+      {:error, _reason, %{text: error_msg}} ->
+        error_msg
+    end
   end
 
   attr :metrics, ProjectMetrics, required: true

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -932,6 +932,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
         {:error, _reason, %{text: error_text}} ->
           {:noreply, put_flash(socket, :error, error_text)}
 
+        {:error, %{text: message}} ->
+          {:noreply, put_flash(socket, :error, message)}
+
         {:error, changeset} ->
           {
             :noreply,
@@ -1004,9 +1007,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
          |> put_flash(:error, "You are not authorized to perform this action.")}
 
       {:error, %{text: message}} ->
-        {:noreply,
-         socket
-         |> put_flash(:error, message)}
+        {:noreply, put_flash(socket, :error, message)}
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -24,7 +24,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
            }
          ) do
       :ok ->
-        Repo.insert_or_update(changeset)
+        Workflows.upsert_workflow(changeset)
 
       {:error, _reason, message} ->
         {:error, message}

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -10,6 +10,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
   alias Lightning.Services.UsageLimiter
 
   alias Lightning.Workflows
+  alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrder
   alias Lightning.WorkOrders
 
@@ -17,12 +18,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
           {:ok, Workflows.Workflow.t()}
           | {:error, Ecto.Changeset.t() | UsageLimiting.message()}
   def save_workflow(changeset) do
-    case UsageLimiter.limit_action(
-           %Action{type: :activate_workflow, changeset: changeset},
-           %Context{
-             project_id: Ecto.Changeset.get_field(changeset, :project_id)
-           }
-         ) do
+    case WorkflowUsageLimiter.limit_workflow_activation(changeset) do
       :ok ->
         Workflows.save_workflow(changeset)
 

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -24,7 +24,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
            }
          ) do
       :ok ->
-        Workflows.upsert_workflow(changeset)
+        Workflows.save_workflow(changeset)
 
       {:error, _reason, message} ->
         {:error, message}

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -124,8 +124,7 @@ defmodule Lightning.Projects.ProvisionerTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        2,
-        fn _action, _context -> :ok end
+        fn %{type: :activate_workflow}, _context -> :ok end
       )
 
       %{body: body} = valid_document(project.id)
@@ -154,8 +153,7 @@ defmodule Lightning.Projects.ProvisionerTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        3,
-        fn _action, _context -> :ok end
+        fn %{type: :activate_workflow}, _context -> :ok end
       )
 
       %{body: body} = valid_document(project.id)
@@ -204,8 +202,8 @@ defmodule Lightning.Projects.ProvisionerTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        4,
-        fn _action, _context -> :ok end
+        2,
+        fn %{type: :activate_workflow}, _context -> :ok end
       )
 
       %{body: body, workflow_id: workflow_id} = valid_document(project.id)
@@ -277,8 +275,7 @@ defmodule Lightning.Projects.ProvisionerTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        3,
-        fn _action, _context -> :ok end
+        fn %{type: :activate_workflow}, _context -> :ok end
       )
 
       %{
@@ -330,8 +327,7 @@ defmodule Lightning.Projects.ProvisionerTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        3,
-        fn _action, _context -> :ok end
+        fn %{type: :activate_workflow}, _context -> :ok end
       )
 
       %{
@@ -363,13 +359,6 @@ defmodule Lightning.Projects.ProvisionerTest do
       project: project,
       user: user
     } do
-      Mox.expect(
-        Lightning.Extensions.MockUsageLimiter,
-        :limit_action,
-        1,
-        fn _action, _context -> :ok end
-      )
-
       body = %{
         "id" => project.id,
         "name" => "test-project",

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -53,11 +53,11 @@ defmodule Lightning.WorkflowsTest do
       assert workflow.name == "some-name"
     end
 
-    test "update_workflow/2 with valid data updates the workflow" do
+    test "save_workflow/2 with valid data updates the workflow" do
       workflow = insert(:workflow)
       update_attrs = %{name: "some-updated-name"}
 
-      assert {:ok, workflow} = Workflows.update_workflow(workflow, update_attrs)
+      assert {:ok, workflow} = Workflows.save_workflow(workflow, update_attrs)
 
       assert workflow.name == "some-updated-name"
     end
@@ -146,7 +146,7 @@ defmodule Lightning.WorkflowsTest do
       assert workflow.name == "some-other-name"
     end
 
-    test "using update_workflow/2" do
+    test "using save_workflow/2" do
       project = insert(:project)
 
       job_id = Ecto.UUID.generate()
@@ -184,7 +184,7 @@ defmodule Lightning.WorkflowsTest do
       }
 
       assert {:ok, workflow} =
-               Lightning.Workflows.update_workflow(workflow, valid_attrs)
+               Lightning.Workflows.save_workflow(workflow, valid_attrs)
 
       assert Repo.get_by(Lightning.Workflows.Job,
                id: job_id,
@@ -201,7 +201,7 @@ defmodule Lightning.WorkflowsTest do
       }
 
       assert {:ok, workflow} =
-               Lightning.Workflows.update_workflow(workflow, valid_attrs)
+               Lightning.Workflows.save_workflow(workflow, valid_attrs)
 
       assert workflow.name == "some-name"
       assert workflow.edges |> Enum.empty?()

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -57,7 +57,9 @@ defmodule Lightning.WorkflowsTest do
       workflow = insert(:workflow)
       update_attrs = %{name: "some-updated-name"}
 
-      assert {:ok, workflow} = Workflows.save_workflow(workflow, update_attrs)
+      assert {:ok, workflow} =
+               Lightning.Workflows.change_workflow(workflow, update_attrs)
+               |> Lightning.Workflows.save_workflow()
 
       assert workflow.name == "some-updated-name"
     end
@@ -184,7 +186,8 @@ defmodule Lightning.WorkflowsTest do
       }
 
       assert {:ok, workflow} =
-               Lightning.Workflows.save_workflow(workflow, valid_attrs)
+               Lightning.Workflows.change_workflow(workflow, valid_attrs)
+               |> Lightning.Workflows.save_workflow()
 
       assert Repo.get_by(Lightning.Workflows.Job,
                id: job_id,
@@ -201,7 +204,8 @@ defmodule Lightning.WorkflowsTest do
       }
 
       assert {:ok, workflow} =
-               Lightning.Workflows.save_workflow(workflow, valid_attrs)
+               Lightning.Workflows.change_workflow(workflow, valid_attrs)
+               |> Lightning.Workflows.save_workflow()
 
       assert workflow.name == "some-name"
       assert workflow.edges |> Enum.empty?()

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -34,6 +34,27 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       assert html =~ "Some banner text"
     end
 
+    test "renders error tooltip when limit has been reached", %{
+      conn: conn,
+      project: %{id: project_id}
+    } do
+      Mox.verify_on_exit!()
+      error_message = "some funny error message"
+
+      Mox.expect(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        2,
+        fn %{type: :activate_workflow}, %{project_id: ^project_id} ->
+          {:error, :too_many_workflows, %{text: error_message}}
+        end
+      )
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}/w")
+
+      assert html =~ error_message
+    end
+
     test "only users with MFA enabled can access workflows for a project with MFA requirement",
          %{
            conn: conn


### PR DESCRIPTION
## Notes for the reviewer

- Renames the action to `:activate_workflow` instead of `:new_workflow`
- Checks if the workflow is activated before making call to the limiter.
- `:activate_workflow` is added to the api provisioning flow as well. 
- Introduces a `WorkflowUpdated` event which emitted when the workflow is created/updated. Also when the workflow is marked for deletion  


## Related issue

Fixes #1992 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
