### PR TITLE
Custom metric to track number of finalised runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+- Add custom metric to track the number of finalised runs.
+  [#1790](https://github.com/OpenFn/lightning/issues/1790)
 
 ### Changed
 

--- a/lib/lightning/runs/prom_ex_plugin.ex
+++ b/lib/lightning/runs/prom_ex_plugin.ex
@@ -12,8 +12,11 @@ defmodule Lightning.Runs.PromExPlugin do
   alias Lightning.Repo
   alias Lightning.Run
 
+  require Run
+
   @available_count_event [:lightning, :run, :queue, :available]
   @average_claim_event [:lightning, :run, :queue, :claim]
+  @finalised_count_event [:lightning, :run, :queue, :finalised]
   @stalled_event [:lightning, :run, :queue, :stalled]
 
   @impl true
@@ -116,7 +119,7 @@ defmodule Lightning.Runs.PromExPlugin do
     Polling.build(
       :lightning_run_queue_metrics,
       period_in_seconds * 1000,
-      {__MODULE__, :run_queue_metrics, [run_age_seconds]},
+      {__MODULE__, :run_queue_metrics, [run_age_seconds, period_in_seconds]},
       [
         last_value(
           [
@@ -137,17 +140,29 @@ defmodule Lightning.Runs.PromExPlugin do
           event_name: @available_count_event,
           description: "The number of available runs in the queue",
           measurement: :count
+        ),
+        last_value(
+          [:lightning, :run, :queue, :finalised, :count],
+          event_name: @finalised_count_event,
+          description:
+            "The number of runs finalised during the consideration window",
+          measurement: :count
         )
       ]
     )
   end
 
-  def run_queue_metrics(run_age_seconds) do
-    if pid = Process.whereis(Repo) do
-      check_repo_state(pid)
+  def run_queue_metrics(run_age_seconds, consideration_window_seconds) do
+    if repo_pid = Process.whereis(Repo) do
+      check_repo_state(repo_pid)
 
       trigger_run_claim_duration(run_age_seconds)
       trigger_available_runs_count()
+
+      trigger_finalised_runs_count(
+        DateTime.utc_now()
+        |> DateTime.add(-consideration_window_seconds)
+      )
     end
   end
 
@@ -210,5 +225,26 @@ defmodule Lightning.Runs.PromExPlugin do
       %{count: Repo.aggregate(query, :count)},
       %{}
     )
+  end
+
+  defp trigger_finalised_runs_count(threshold_time) do
+    count = count_finalised_runs(threshold_time)
+
+    :telemetry.execute(
+      @finalised_count_event,
+      %{count: count},
+      %{}
+    )
+  end
+
+  def count_finalised_runs(threshold_time) do
+    final_states = Run.final_states()
+
+    query =
+      from r in Run,
+        where: r.state in ^final_states,
+        where: r.finished_at > ^threshold_time
+
+    query |> Repo.aggregate(:count)
   end
 end

--- a/test/lightning/metadata_service_test.exs
+++ b/test/lightning/metadata_service_test.exs
@@ -1,5 +1,5 @@
 defmodule Lightning.MetadataServiceTest do
-  use Lightning.DataCase, async: true
+  use Lightning.DataCase, async: false
 
   alias Lightning.MetadataService
   import Lightning.CredentialsFixtures


### PR DESCRIPTION
## Validation Steps

- Start a local lightning instance running and open an IEx session
- Browse to `http://localhost:4000/metrics` - if you search for `lightning_run_queue_finalised_count` on the page, it will most likely have a value of 0.
- In the IEx session:

```
alias Lightning.Repo
alias Lightning.Run

runs = Run |> Repo.all()
number_of_runs = runs |> Enum.count() # if this is zero, you will need to run the demo setup.
finished_at  = DateTime.add(DateTime.utc_now(), 30)

import Ecto.Changeset
# NOTE: Once you have executed the below code move on to the next step of the instructions immediately. 
# If you find that it you do not have enough time, you can set the `finished_at` value further into the future.
for run <- runs do
  run |> change(%{finished_at: DateTime.add(DateTime.utc_now(), 30)}) |> Repo.update!()
end
```

- Return to `http://localhost:4000/metrics` - if you refresh the page you should see the value of `lightning_run_queue_finalised_count` change to match the `number_of_runs` from the IEx session above, and then return to zero.

## Notes for the reviewer

This change introduces a new metric that tracks the number of runs finished in the last n seconds where n also corresponds to the period of the metric polling job.

## Related issue

Fixes #1790 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
