### PR TITLE
Allow customized menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Allow menu items customization
+  [#1988](https://github.com/OpenFn/lightning/issues/1988)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -5,7 +5,39 @@ defmodule LightningWeb.LayoutComponents do
   import PetalComponents.Dropdown
   import PetalComponents.Avatar
 
+  @menu_items Application.compile_env(:lightning, :menu_items, [])
+
   def menu_items(assigns) do
+    custom_menu_items =
+      @menu_items
+      |> Enum.filter(fn {assign_set, _items} ->
+        not is_nil(assigns[assign_set])
+      end)
+      |> Enum.flat_map(fn {_assign_set, items} -> items end)
+
+    if Enum.empty?(custom_menu_items) do
+      default_menu_items(assigns)
+    else
+      assigns = assign(assigns, custom_menu_items: custom_menu_items)
+
+      ~H"""
+      <div class="mt-4">
+        <%= for {to, icon, text, menu_item} <- @custom_menu_items do %>
+          <Settings.menu_item to={to} active={@active_menu_item == menu_item}>
+            <%= Phoenix.LiveView.TagEngine.component(
+              icon,
+              [class: "h-5 w-5 inline-block"],
+              {__ENV__.module, __ENV__.function, __ENV__.file, __ENV__.line}
+            ) %>
+            <span class="inline-block align-middle"><%= text %></span>
+          </Settings.menu_item>
+        <% end %>
+      </div>
+      """
+    end
+  end
+
+  def default_menu_items(assigns) do
     ~H"""
     <%= if assigns[:projects] do %>
       <div class="relative my-4 mx-2 px-2">

--- a/lib/lightning_web/live/components/settings.ex
+++ b/lib/lightning_web/live/components/settings.ex
@@ -21,7 +21,7 @@ defmodule LightningWeb.Components.Settings do
       )
 
     ~H"""
-    <div class="h-12 mx-4">
+    <div class="h-12 mx-2">
       <%= if assigns[:href] do %>
         <.link href={@href} target="_blank" class={@class}>
           <%= if assigns[:inner_block] do %>


### PR DESCRIPTION
## Validation Steps

Setup an umbrella app and set the config:
```
config :lightning, :menu_items,
  <some_assign_set>: [
    {"/some_path", &<Heroicons.some_icon>/1, "Menu Name", <active_menu_item_atom>}
```

## Notes for the reviewer

This change preserves the default menu items when custom ones are not set.

## Related issue

Fixes #1988 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
