### PR TITLE
1789 report resubmission worker 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,11 @@
 # period or where reports are being retroactively generated.
 # USAGE_TRACKING_DAILY_BATCH_SIZE=10
 
+# If an instance has been without internet access for an extended period, there
+# may be reports that require resubmission. This variable restricts the number
+# of reports resubmittd on each run.
+# USAGE_TRACKING_RESUBMISSION_BATCH_SIZE=10
+
 # OpenFn.org hosts a public sandbox that gets reset every night. If you'd like to
 # make your instance "resettable" (a highly descrutive action—this destroys all
 # data in your instance) you can set the following environment variable to "yes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to
 
 - Add custom metric to track the number of finalised runs.
   [#1790](https://github.com/OpenFn/lightning/issues/1790)
+- Allow for automatic resubmission of failed usage tracking report submissions.
+  [1789](https://github.com/OpenFn/lightning/issues/1789)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Allow for automatic resubmission of failed usage tracking report submissions.
+  [1789](https://github.com/OpenFn/lightning/issues/1789)
+
 ### Changed
 
 ### Fixed
@@ -91,8 +94,6 @@ and this project adheres to
 
 - Add custom metric to track the number of finalised runs.
   [#1790](https://github.com/OpenFn/lightning/issues/1790)
-- Allow for automatic resubmission of failed usage tracking report submissions.
-  [1789](https://github.com/OpenFn/lightning/issues/1789)
 
 ### Changed
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -121,6 +121,8 @@ configurtaion is:
   being generated retroactively (defaults to 10).
 - `USAGE_TRACKING_ENABLED` - enables the submission of anonymised usage data to
   OpenFn (defaults to `true`).
+- `USAGE_TRACKING_RESUBMISSION_BATCH_SIZE` - the number of failed reports that
+  will be submitted on each resubmission run (defaults to 10).
 - `USAGE_TRACKING_UUIDS` - indicates whether submissions should include
   cleartext uuids or not. Options are `cleartext` or `hashed_only`, with the
   default being `hashed_only`.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -219,6 +219,9 @@ base_cron = [
   {"1 2 * * *", Lightning.Projects, args: %{"type" => "data_retention"}}
 ]
 
+usage_tracking_resubmission_batch_size =
+  env!("USAGE_TRACKING_RESUBMISSION_BATCH_SIZE", :integer, 10)
+
 usage_tracking_cron = [
   {
     "30 1,9,17 * * *",
@@ -226,6 +229,11 @@ usage_tracking_cron = [
     args: %{
       "batch_size" => env!("USAGE_TRACKING_DAILY_BATCH_SIZE", :integer, 10)
     }
+  },
+  {
+    "* * * * *",
+    Lightning.UsageTracking.ResubmissionCandidatesWorker,
+    args: %{"batch_size" => usage_tracking_resubmission_batch_size}
   }
 ]
 

--- a/lib/lightning/usage_tracking.ex
+++ b/lib/lightning/usage_tracking.ex
@@ -6,6 +6,7 @@ defmodule Lightning.UsageTracking do
 
   alias Lightning.Helpers
   alias Lightning.Repo
+  alias Lightning.UsageTracking.Client
   alias Lightning.UsageTracking.DailyReportConfiguration
   alias Lightning.UsageTracking.GithubClient
   alias Lightning.UsageTracking.Report
@@ -213,4 +214,10 @@ defmodule Lightning.UsageTracking do
 
   defp image_for_submission("edge" = _image, _spec_version), do: "edge"
   defp image_for_submission(_image, _spec_version), do: "other"
+
+  def submit_report(report, host) do
+    report.data
+    |> Client.submit_metrics(host)
+    |> update_report_submission!(report)
+  end
 end

--- a/lib/lightning/usage_tracking/client.ex
+++ b/lib/lightning/usage_tracking/client.ex
@@ -4,7 +4,7 @@ defmodule Lightning.UsageTracking.Client do
 
 
   """
-  use Tesla, only: [:post], docs: false
+  use Tesla, only: [:head, :post], docs: false
 
   alias Lightning.UsageTracking.ResponseProcessor
 
@@ -17,7 +17,17 @@ defmodule Lightning.UsageTracking.Client do
     if ResponseProcessor.successful?(response), do: :ok, else: :error
   end
 
+  def reachable?(host) do
+    build_head_client(host)
+    |> head("/")
+    |> ResponseProcessor.successful?()
+  end
+
   defp build_client(host) do
     Tesla.client([{Tesla.Middleware.BaseUrl, host}, Tesla.Middleware.JSON])
+  end
+
+  defp build_head_client(host) do
+    Tesla.client([{Tesla.Middleware.BaseUrl, host}])
   end
 end

--- a/lib/lightning/usage_tracking/report_worker.ex
+++ b/lib/lightning/usage_tracking/report_worker.ex
@@ -8,7 +8,6 @@ defmodule Lightning.UsageTracking.ReportWorker do
     max_attempts: 1
 
   alias Lightning.UsageTracking
-  alias Lightning.UsageTracking.Client
 
   require Logger
   @impl Oban.Worker
@@ -24,9 +23,7 @@ defmodule Lightning.UsageTracking.ReportWorker do
 
       case UsageTracking.insert_report(config, cleartext_uuids_enabled, date) do
         {:ok, report} ->
-          report.data
-          |> Client.submit_metrics(env[:host])
-          |> UsageTracking.update_report_submission!(report)
+          report |> UsageTracking.submit_report(env[:host])
 
         _error ->
           nil

--- a/lib/lightning/usage_tracking/resubmission_candidates_worker.ex
+++ b/lib/lightning/usage_tracking/resubmission_candidates_worker.ex
@@ -1,0 +1,38 @@
+defmodule Lightning.UsageTracking.ResubmissionCandidatesWorker do
+  @moduledoc """
+  Worker to find reports that have failed submissions and enqueue jobs to
+  reprocess them.
+
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 1
+
+  import Ecto.Query
+
+  alias Lightning.Repo
+  alias Lightning.UsageTracking.Client
+  alias Lightning.UsageTracking.Report
+  alias Lightning.UsageTracking.ResubmissionWorker
+
+  @impl Oban.Worker
+  def perform(%{args: %{"batch_size" => batch_size}}) do
+    host = Application.get_env(:lightning, :usage_tracking)[:host]
+
+    if Client.reachable?(host) do
+      query =
+        from r in Report,
+          where: r.submission_status == :failure,
+          order_by: [asc: :inserted_at],
+          limit: ^batch_size
+
+      query
+      |> Repo.all()
+      |> Enum.each(fn report ->
+        Oban.insert(Lightning.Oban, ResubmissionWorker.new(%{id: report.id}))
+      end)
+    end
+
+    :ok
+  end
+end

--- a/lib/lightning/usage_tracking/resubmission_worker.ex
+++ b/lib/lightning/usage_tracking/resubmission_worker.ex
@@ -1,0 +1,40 @@
+defmodule Lightning.UsageTracking.ResubmissionWorker do
+  @moduledoc """
+  Worker to resubmit report that has failed submission.
+
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 1
+
+  import Ecto.Query
+
+  alias Lightning.Repo
+  alias Lightning.UsageTracking
+  alias Lightning.UsageTracking.Report
+
+  @impl Oban.Worker
+  def perform(%{args: %{"id" => id}}) do
+    env = Application.get_env(:lightning, :usage_tracking)
+
+    resubmit_report(id, env[:host], env[:enabled])
+
+    :ok
+  end
+
+  defp resubmit_report(id, host, true = _enabled) do
+    Repo.transaction(fn ->
+      query =
+        from r in Report,
+          where: r.id == ^id,
+          where: r.submission_status == :failure,
+          lock: "FOR UPDATE SKIP LOCKED"
+
+      if report = Repo.one(query) do
+        UsageTracking.submit_report(report, host)
+      end
+    end)
+  end
+
+  defp resubmit_report(_id, _host, false = _enabled), do: nil
+end

--- a/test/lightning/usage_tracking/client_test.exs
+++ b/test/lightning/usage_tracking/client_test.exs
@@ -54,4 +54,22 @@ defmodule Lightning.UsageTracking.ClientTest do
       assert Client.submit_metrics(metrics, @host) == :error
     end
   end
+
+  describe ".reachable?/1" do
+    setup do
+      %{url: "#{@host}/"}
+    end
+
+    test "indicates if host is reachable", %{url: url} do
+      mock(fn %{method: :head, url: ^url} -> %Tesla.Env{status: 200} end)
+
+      assert Client.reachable?(@host) == true
+    end
+
+    test "indicates if the host is not reachable", %{url: url} do
+      mock(fn %{method: :head, url: ^url} -> %Tesla.Env{status: 500} end)
+
+      assert Client.reachable?(@host) == false
+    end
+  end
 end

--- a/test/lightning/usage_tracking/resubmission_candidates_worker_test.exs
+++ b/test/lightning/usage_tracking/resubmission_candidates_worker_test.exs
@@ -1,0 +1,150 @@
+defmodule Lightning.UsageTracking.ResubmissionCandidatesWorkerTest do
+  use Lightning.DataCase, async: false
+
+  import Mock
+
+  alias Lightning.UsageTracking.Client
+  alias Lightning.UsageTracking.ResubmissionCandidatesWorker
+  alias Lightning.UsageTracking.ResubmissionWorker
+
+  @batch_size 5
+
+  describe "perform/1 - impact tracker is reachable" do
+    setup_with_mocks([
+      {Client, [], [reachable?: fn _host -> true end]}
+    ]) do
+      now = DateTime.utc_now()
+
+      failure_report_1 = now |> insert_report(:failure, -3)
+      failure_report_2 = now |> insert_report(:failure, -2)
+      failure_report_3 = now |> insert_report(:failure, -1)
+      success_report = now |> insert_report(:success, -4)
+
+      %{
+        failure_report_1: failure_report_1,
+        failure_report_2: failure_report_2,
+        failure_report_3: failure_report_3,
+        success_report: success_report
+      }
+    end
+
+    test "makes a call to the configured ImapctTracker instance" do
+      expected_host = Application.get_env(:lightning, :usage_tracking)[:host]
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(ResubmissionCandidatesWorker, %{batch_size: @batch_size})
+      end)
+
+      assert_called(Client.reachable?(expected_host))
+    end
+
+    test "indicates that the job completed successfully" do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert perform_job(
+                 ResubmissionCandidatesWorker,
+                 %{batch_size: @batch_size}
+               ) == :ok
+      end)
+    end
+
+    test "enqueues jobs to resubmit reports", %{
+      failure_report_1: failure_report_1,
+      failure_report_2: failure_report_2,
+      failure_report_3: failure_report_3,
+      success_report: success_report
+    } do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(ResubmissionCandidatesWorker, %{batch_size: @batch_size})
+      end)
+
+      assert_in_queue(failure_report_1)
+      assert_in_queue(failure_report_2)
+      assert_in_queue(failure_report_3)
+
+      refute_in_queue(success_report)
+    end
+
+    test "enforces the batch size to only resubmit the n earliest reports", %{
+      failure_report_1: failure_report_1,
+      failure_report_2: failure_report_2,
+      failure_report_3: failure_report_3,
+      success_report: success_report
+    } do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(ResubmissionCandidatesWorker, %{batch_size: 2})
+      end)
+
+      assert_in_queue(failure_report_1)
+      assert_in_queue(failure_report_2)
+      refute_in_queue(failure_report_3)
+
+      refute_in_queue(success_report)
+    end
+  end
+
+  describe "perform/1 - impact tracker is not reachable" do
+    setup_with_mocks([
+      {Client, [], [reachable?: fn _host -> false end]}
+    ]) do
+      now = DateTime.utc_now()
+
+      failure_report_1 = now |> insert_report(:failure, -3)
+      failure_report_2 = now |> insert_report(:failure, -2)
+      failure_report_3 = now |> insert_report(:failure, -1)
+      success_report = now |> insert_report(:success, -4)
+
+      %{
+        failure_report_1: failure_report_1,
+        failure_report_2: failure_report_2,
+        failure_report_3: failure_report_3,
+        success_report: success_report
+      }
+    end
+
+    test "makes a call to the configured ImapctTracker instance" do
+      expected_host = Application.get_env(:lightning, :usage_tracking)[:host]
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(ResubmissionCandidatesWorker, %{batch_size: @batch_size})
+      end)
+
+      assert_called(Client.reachable?(expected_host))
+    end
+
+    test "indicates that the job completed successfully" do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert perform_job(
+                 ResubmissionCandidatesWorker,
+                 %{batch_size: @batch_size}
+               ) == :ok
+      end)
+    end
+
+    test "does not enqueue any jobs to resubmit reports" do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(ResubmissionCandidatesWorker, %{batch_size: @batch_size})
+      end)
+
+      assert all_enqueued() == []
+    end
+  end
+
+  defp insert_report(now, status, time_offset) do
+    today = now |> DateTime.to_date()
+
+    insert(
+      :usage_tracking_report,
+      submission_status: status,
+      inserted_at: now |> DateTime.add(time_offset, :second),
+      report_date: today |> Date.add(time_offset)
+    )
+  end
+
+  defp assert_in_queue(report) do
+    assert_enqueued(worker: ResubmissionWorker, args: %{id: report.id})
+  end
+
+  defp refute_in_queue(report) do
+    refute_enqueued(worker: ResubmissionWorker, args: %{id: report.id})
+  end
+end

--- a/test/lightning/usage_tracking/resubmission_worker_test.exs
+++ b/test/lightning/usage_tracking/resubmission_worker_test.exs
@@ -1,0 +1,112 @@
+defmodule Lightning.UsageTracking.ResubmissionWorkerTest do
+  use Lightning.DataCase, async: false
+
+  import Tesla.Mock
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+
+  alias Lightning.UsageTracking.Report
+  alias Lightning.UsageTracking.ResubmissionWorker
+
+  setup do
+    host = "https://unobtainium.test"
+    data = %{"test" => "metrics"}
+
+    report =
+      insert(
+        :usage_tracking_report,
+        data: data,
+        submission_status: :failure
+      )
+
+    put_temporary_env(:lightning, :usage_tracking, enabled: true, host: host)
+
+    %{host: host, data: data, report: report}
+  end
+
+  describe "perform/1" do
+    test "submits the report to ImpactTracker", %{
+      data: data,
+      host: host,
+      report: report
+    } do
+      mock(fn env ->
+        if correct_host?(env, host) && data_match?(env, data) do
+          %Tesla.Env{status: 200, body: %{status: "great"}}
+        else
+          flunk("Unrecognised call to Impact Tracker")
+        end
+      end)
+
+      perform_job(ResubmissionWorker, %{id: report.id})
+    end
+
+    test "returns :ok", %{report: report} do
+      mock(fn _env -> %Tesla.Env{status: 200, body: %{status: "great"}} end)
+
+      assert perform_job(ResubmissionWorker, %{id: report.id}) == :ok
+    end
+  end
+
+  describe "perform/1 - resubmission is unsuccessful" do
+    test "returns :ok", %{report: report} do
+      mock(fn _env -> %Tesla.Env{status: 500, body: %{status: "notgreat"}} end)
+
+      assert perform_job(ResubmissionWorker, %{id: report.id}) == :ok
+    end
+  end
+
+  describe "perform/1 - failed record can not be found" do
+    setup context do
+      %{report: report} = context
+
+      report
+      |> Report.changeset(%{submission_status: :success})
+      |> Repo.update()
+
+      context
+    end
+
+    test "does not submit the report", %{report: report} do
+      mock(fn _env -> flunk("Not expecting call to Impact Tracker") end)
+
+      perform_job(ResubmissionWorker, %{id: report.id})
+    end
+
+    test "returns :ok", %{report: report} do
+      assert perform_job(ResubmissionWorker, %{id: report.id}) == :ok
+    end
+  end
+
+  describe "perform/1 - usage tracking is not enabled" do
+    setup context do
+      %{host: host} = context
+
+      put_temporary_env(:lightning, :usage_tracking,
+        enabled: false,
+        host: host
+      )
+
+      context
+    end
+
+    test "does not submit the report", %{report: report} do
+      mock(fn _env -> flunk("Not expecting call to Impact Tracker") end)
+
+      perform_job(ResubmissionWorker, %{id: report.id})
+    end
+
+    test "returns :ok", %{report: report} do
+      assert perform_job(ResubmissionWorker, %{id: report.id}) == :ok
+    end
+  end
+
+  defp data_match?(tesla_env, expected_data) do
+    submitted_data = Jason.decode!(tesla_env.body)
+
+    submitted_data == expected_data
+  end
+
+  defp correct_host?(tesla_env, host) do
+    String.contains?(tesla_env.url, host)
+  end
+end


### PR DESCRIPTION
## Validation Steps

- Ensure that usage tracking is not disabled - `USAGE_TRACKING_ENABLED` must either be commented out or set to true
- Ensure that your local Lightning instance will use the local Impact Tracker instance by setting `USAGE_TRACKER_HOST` to point to the Impact Tracker instance.
- **Do not start** your local ImpactTracker instance yet - the first part of the validation requires the report submission to fail.
- In a Lightning IEx session:

```
today = DateTime.utc_now() |> DateTime.to_date()
today_as_string = today |> Date.to_iso8601()

Lightning.UsageTracking.disable_daily_report()
Lightning.UsageTracking.enable_daily_report(~U[2024-03-07 12:00:00.000000Z])
Lightning.Demo.reset_demo()
Lightning.UsageTracking.ReportWorker.perform(%Oban.Job{args: %{"date" => today_as_string}})

alias Lightning.UsageTracking.Report
import Ecto.Query
query = from r in Report, order_by: [desc: r.inserted_at], limit: 1

last_report = query |> Repo.one()

%{report_date: ^today, submission_status: :failure} = last_report # Should not produce an error
```
- Now, start your local ImpactTracker instance and do something else for at least 2 minutes (go get some sunshine, read War and Peace... the usual).
- Now in the same Lightning IEx session, run:

```
last_report = query |> Repo.one()

%{report_date: ^today, submission_status: :success} = last_report # Should not produce an error
```

## Notes for the reviewer

This change allows Lightning to attempt resubmission of failed report submissions via an Oban cron job that runs every minute. 

I also did a little bit of refactoring and replaced some of the mocking that uses `Mock` with `Tesla.Mock`. This makes some of my tests a bit more robust and reduces the amount of code that is 'shadowed' by the mock but comes a the cost of bleeding a small amount of the Client implementation details. I think the benefit it is worth the cost. 

As this makes the PR very busy, I have tried to reduce the cognitive load by grouping changes within discrete commits.

## Related issue

Fixes #1789

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
