### PR TITLE
Fix github cli deploy action failing to auto-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+
 - Add custom metric to track the number of finalised runs.
   [#1790](https://github.com/OpenFn/lightning/issues/1790)
 
@@ -25,6 +26,9 @@ and this project adheres to
   set. [#1789](https://github.com/OpenFn/lightning/issues/1789)
 
 ### Fixed
+
+- Fix github cli deploy action failing to auto-commit
+  [#1995](https://github.com/OpenFn/lightning/issues/1995)
 
 ## [v2.4.0] - 2024-04-12
 

--- a/priv/github/deploy.yml
+++ b/priv/github/deploy.yml
@@ -7,6 +7,8 @@ jobs:
   deploy-to-lightning:
     runs-on: ubuntu-latest
     name: A job to deploy to Lightning
+    permissions:
+      contents: write
     steps:
       - name: openfn deploy
         uses: openfn/cli-deploy-action@v1.0.0


### PR DESCRIPTION
## Notes for the reviewer

- Adds `write` permission to the deploy action


## Related issue

Fixes #1995 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
