### PR TITLE
Don't include deleted workflows in the provisioning API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
 
 - Fix github cli deploy action failing to auto-commit
   [#1995](https://github.com/OpenFn/lightning/issues/1995)
+- Fix proviosning API includes deleted workflows in project state
+  [#2001](https://github.com/OpenFn/lightning/issues/2001)
 
 ## [v2.4.1-pre] 2024-04-18
 

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -40,7 +40,7 @@ defmodule Lightning.Projects.Project do
     has_many :project_credentials, ProjectCredential
     has_many :credentials, through: [:project_credentials, :credential]
 
-    has_many :workflows, Workflow, where: [deleted_at: nil]
+    has_many :workflows, Workflow
     has_many :jobs, through: [:workflows, :jobs]
 
     timestamps()

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -40,7 +40,7 @@ defmodule Lightning.Projects.Project do
     has_many :project_credentials, ProjectCredential
     has_many :credentials, through: [:project_credentials, :credential]
 
-    has_many :workflows, Workflow
+    has_many :workflows, Workflow, where: [deleted_at: nil]
     has_many :jobs, through: [:workflows, :jobs]
 
     timestamps()

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -81,26 +81,12 @@ defmodule Lightning.Projects.Provisioner do
     ])
   end
 
-  # @doc """
-  # Load a project by ID, including all workflows and their associated jobs,
-  # triggers and edges.
+  @doc """
+  Preload all dependencies for a project.
 
-  # Returns `nil` if the project does not exist.
-  # """
-  # @spec load_project(Ecto.UUID.t()) :: Project.t() | nil
-  # def load_project(id) do
-  #   from(p in Project,
-  #     where: p.id == ^id,
-  #     left_join: w in assoc(p, :workflows),
-  #     where: is_nil(w.deleted_at),
-  #     preload: [
-  #       :project_users,
-  #       workflows: {w, [:jobs, :triggers, :edges]}
-  #     ]
-  #   )
-  #   |> Repo.one()
-  # end
-
+  Exclude deleted workflows.
+  """
+  @spec preload_dependencies(Project.t()) :: Project.t()
   def preload_dependencies(project) do
     w = from(w in Workflow, where: is_nil(w.deleted_at))
 

--- a/lib/lightning_web/controllers/api/provisioning_controller.ex
+++ b/lib/lightning_web/controllers/api/provisioning_controller.ex
@@ -41,14 +41,15 @@ defmodule LightningWeb.API.ProvisioningController do
   """
   def show(conn, params) do
     with project = %Project{} <-
-           Provisioner.load_project(params["id"]) || {:error, :not_found},
+           Projects.get_project(params["id"]) || {:error, :not_found},
          :ok <-
            Permissions.can(
              Provisioning,
              :describe_project,
              conn.assigns.current_resource,
              project
-           ) do
+           ),
+         project <- Provisioner.preload_dependencies(project) do
       conn
       |> put_status(:ok)
       |> render("create.json", project: project)
@@ -61,7 +62,7 @@ defmodule LightningWeb.API.ProvisioningController do
   """
   def show_yaml(conn, %{"id" => id}) do
     with %Projects.Project{} = project <-
-           Lightning.Projects.get_project(id) || {:error, :not_found},
+           Projects.get_project(id) || {:error, :not_found},
          :ok <-
            Permissions.can(
              Provisioning,

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -543,7 +543,7 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
       assert post(conn, ~p"/api/provision", body) |> json_response(201)
     end
 
-    test "an existing project with workflows marked for deletion can be deleted successfully",
+    test "returns 201 for an existing project with workflows marked for deletion",
          %{
            conn: conn
          } do


### PR DESCRIPTION
## Validation Steps

1. Delete a workflow in lightning project
2. Perform a `cli pull` for the project. i.e `openfn pull <project_id`. The workflow deleted in step 1 above won't be included in your `state.json`
3. Perform a `cli deploy`. The operation should complete successfully. Initially, it was failing with an `Internal Server Error` as seen in sentry: https://openfn.sentry.io/issues/4884904031/events/244bfa2438984080b07040f442b98811/


## Notes for the reviewer
- Adds a filter to the `workflows assoc` in the project schema. 


## Related issue

Fixes #2001 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
