### PR TITLE
Add schemas installation step in Dockerfile-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix missing credential types when running Lightning using Docker
+  [#2010](https://github.com/OpenFn/lightning/issues/2010)
+
 ## [v2.4.1] 2024-04-19
 
 ### Fixed

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -58,6 +58,7 @@ RUN mix deps.compile
 COPY priv priv
 COPY lib lib
 RUN mix lightning.install_runtime
+RUN mix lightning.install_schemas
 RUN mix lightning.install_adaptor_icons
 
 COPY bin bin


### PR DESCRIPTION
## Validation Steps

### Before this PR

1. Go to main
2. Run Lightning using Docker following the README instructions
3. Try to create a credential
4. See that the only available credential type is Raw JSON

This is due to the fact that the instruction `RUN mix lightning.install_schemas` is missing in the `Dockerfile-dev` file. This PR adds that line into the file.

### After this PR

1. Checkout the branch of this PR
2. Run Lightning using Docker following the README instructions
3. Try to create a credential
4. See that the all the credential types are available

## Notes for the reviewer

## Related issue

Fixes #2010 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
