### PR TITLE
Limit failure alerts usage

### DIFF
--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -12,7 +12,7 @@ defmodule Lightning.Extensions.UsageLimiting do
   defmodule Action do
     @moduledoc false
     @type t :: %__MODULE__{
-            type: :new_run | :activate_workflow | :new_user,
+            type: :new_run | :activate_workflow | :new_user | :alert_failure,
             amount: pos_integer()
           }
 

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -196,6 +196,35 @@ defmodule Lightning.FailureAlertTest do
       refute_email_sent(subject: "\"workflow-a\" failed.")
     end
 
+    test "does not send failure emails if the usage limiter returns an error", %{
+      runs: [run_1 | _rest],
+      project: %{id: project_id}
+    } do
+      Mox.expect(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn %{type: :alert_failure}, %{project_id: ^project_id} ->
+          :ok
+        end
+      )
+
+      FailureAlerter.alert_on_failure(run_1)
+
+      assert_email_sent(subject: "\"workflow-a\" failed.")
+
+      Mox.expect(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn %{type: :alert_failure}, %{project_id: ^project_id} ->
+          {:error, :not_enabled, %{text: "Failure alerts not enabled"}}
+        end
+      )
+
+      FailureAlerter.alert_on_failure(run_1)
+
+      refute_email_sent(subject: "\"workflow-a\" failed.")
+    end
+
     test "does not increment the rate-limiter counter when an email is not delivered.",
          %{runs: [run, _, _], workorders: [workorder, _, _]} do
       [time_scale: time_scale, rate_limit: rate_limit] =

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -9,6 +9,22 @@ defmodule Lightning.FailureAlertTest do
   alias Lightning.Workers
   alias Lightning.FailureAlerter
 
+  setup do
+    Mox.stub(Lightning.Extensions.MockUsageLimiter, :check_limits, fn _context ->
+      :ok
+    end)
+
+    Mox.stub(
+      Lightning.Extensions.MockUsageLimiter,
+      :limit_action,
+      fn _action, _context ->
+        :ok
+      end
+    )
+
+    :ok
+  end
+
   describe "FailureAlert" do
     setup do
       period =

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -10,10 +10,22 @@ defmodule LightningWeb.RunChannelTest do
   import Lightning.Factories
   import Lightning.BypassHelpers
 
-  setup _ do
+  setup do
     Mox.stub_with(
       Lightning.Extensions.MockUsageLimiter,
       Lightning.Extensions.UsageLimiter
+    )
+
+    Mox.stub(Lightning.Extensions.MockUsageLimiter, :check_limits, fn _context ->
+      :ok
+    end)
+
+    Mox.stub(
+      Lightning.Extensions.MockUsageLimiter,
+      :limit_action,
+      fn _action, _context ->
+        :ok
+      end
     )
 
     :ok


### PR DESCRIPTION
These changes pave way for limiting of failure alerts usage

## Related Issue
Tracked by: https://github.com/OpenFn/thunderbolt/issues/46

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
