### PR TITLE
Limit worker run timeout

### DIFF
--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -9,4 +9,7 @@ defmodule Lightning.Extensions.UsageLimiter do
 
   @impl true
   def limit_action(_action, _context), do: :ok
+
+  @impl true
+  def get_run_options(_context), do: []
 end

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -34,4 +34,7 @@ defmodule Lightning.Extensions.UsageLimiting do
 
   @callback limit_action(action :: Action.t(), context :: Context.t()) ::
               :ok | error()
+
+  @callback get_run_options(context :: Context.t()) ::
+              LightningWeb.RunWithOptions.run_options()
 end

--- a/lib/lightning/services/usage_limiter.ex
+++ b/lib/lightning/services/usage_limiter.ex
@@ -16,5 +16,10 @@ defmodule Lightning.Services.UsageLimiter do
     adapter().limit_action(action, context)
   end
 
+  @impl true
+  def get_run_options(context) do
+    adapter().get_run_options(context)
+  end
+
   defp adapter, do: adapter(:usage_limiter)
 end

--- a/lib/lightning_web/channels/run_options.ex
+++ b/lib/lightning_web/channels/run_options.ex
@@ -1,6 +1,0 @@
-defmodule LightningWeb.RunOptions do
-  @moduledoc false
-  @type t :: %__MODULE__{}
-  @derive Jason.Encoder
-  defstruct [:output_dataclips]
-end

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -7,10 +7,17 @@ defmodule LightningWeb.RunWithOptions do
   alias Lightning.Workflows.Snapshot.Job
   # alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Snapshot.Trigger
-  alias LightningWeb.RunOptions
 
-  @spec render(Run.t(), RunOptions.t()) :: map()
+  @type run_options :: [
+          output_dataclips: boolean(),
+          run_timeout_ms: non_neg_integer()
+        ]
+
+  @spec render(Run.t(), run_options()) :: map()
   def render(%Run{} = run, options) do
+    options =
+      options |> Keyword.take([:output_dataclips, :run_timeout_ms]) |> Map.new()
+
     run |> render() |> Map.put("options", options)
   end
 

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -239,8 +239,14 @@ defmodule LightningWeb.RunChannelTest do
     } do
       project = insert(:project, retention_policy: :erase_all)
 
+      workflow_context =
+        create_workflow(%{project: project, credential: credential})
+
       %{run: run} =
-        create_run(%{project: project, credential: credential})
+        create_run(
+          %{project: project, credential: credential}
+          |> Map.merge(workflow_context)
+        )
 
       %{socket: socket} = create_socket(%{run: run})
       project_id = project.id

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -10,6 +10,15 @@ defmodule LightningWeb.RunChannelTest do
   import Lightning.Factories
   import Lightning.BypassHelpers
 
+  setup _ do
+    Mox.stub_with(
+      Lightning.Extensions.MockUsageLimiter,
+      Lightning.Extensions.UsageLimiter
+    )
+
+    :ok
+  end
+
   describe "joining" do
     test "without providing a token" do
       assert LightningWeb.UserSocket
@@ -157,7 +166,7 @@ defmodule LightningWeb.RunChannelTest do
                "edges" => edges,
                "starting_node_id" => run.starting_trigger_id,
                "dataclip_id" => run.dataclip_id,
-               "options" => %LightningWeb.RunOptions{output_dataclips: true}
+               "options" => %{output_dataclips: true}
              }
     end
 
@@ -221,8 +230,37 @@ defmodule LightningWeb.RunChannelTest do
                "edges" => edges,
                "starting_node_id" => run.starting_trigger_id,
                "dataclip_id" => run.dataclip_id,
-               "options" => %LightningWeb.RunOptions{output_dataclips: false}
+               "options" => %{output_dataclips: false}
              }
+    end
+
+    test "fetch:plan includes options from usage limiter", %{
+      credential: credential
+    } do
+      project = insert(:project, retention_policy: :erase_all)
+
+      %{run: run} =
+        create_run(%{project: project, credential: credential})
+
+      %{socket: socket} = create_socket(%{run: run})
+      project_id = project.id
+
+      extra_options = [run_timeout_ms: 5000]
+
+      Mox.expect(
+        Lightning.Extensions.MockUsageLimiter,
+        :get_run_options,
+        fn %{project_id: ^project_id} -> extra_options end
+      )
+
+      ref = push(socket, "fetch:plan", %{})
+
+      assert_reply ref, :ok, payload
+
+      expected_options =
+        Map.merge(%{output_dataclips: false}, Map.new(extra_options))
+
+      assert match?(%{"options" => ^expected_options}, payload)
     end
 
     test "fetch:dataclip handles all types", %{

--- a/test/support/stub_usage_limiter.ex
+++ b/test/support/stub_usage_limiter.ex
@@ -30,4 +30,7 @@ defmodule Lightning.Extensions.StubUsageLimiter do
   def limit_action(_action, _context) do
     {:error, :too_many_runs, %Message{text: "Runs limit exceeded"}}
   end
+
+  @impl true
+  def get_run_options(_context), do: []
 end


### PR DESCRIPTION
## Notes for the reviewer

- Gets rid of `RunOptions` struct in favour of a `Keyword list`. It's much easier to define optional keys with `Keyword`s. 
- Introduces a new `callback` called `get_run_option` which returns an empty list in the default implementation. These options are considered "extra". And therefore in order to get the run options, we create the `default options` (the previous options) and merge with options from the implementation.


## Related issue

Paves way for: https://github.com/OpenFn/thunderbolt/issues/45

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
