### PR TITLE
Remove validation of stale project credentials

### DIFF
--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -768,9 +768,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
        ) do
     %{credential: form_credential} = socket.assigns
 
-    with {:uptodate, true} <-
-           {:uptodate, credential_projects_up_to_date?(form_credential)},
-         {:same_user, true} <-
+    with {:same_user, true} <-
            {:same_user,
             socket.assigns.current_user.id == socket.assigns.credential.user_id},
          {:ok, _credential} <-
@@ -780,18 +778,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
        |> put_flash(:info, "Credential updated successfully")
        |> push_redirect(to: socket.assigns.return_to)}
     else
-      {:uptodate, false} ->
-        credential = Credentials.get_credential_for_update!(form_credential.id)
-
-        {:noreply,
-         socket
-         |> assign(credential: credential)
-         |> put_flash(
-           :error,
-           "Credential was updated by another session. Please try again."
-         )
-         |> push_redirect(to: socket.assigns.return_to)}
-
       {:same_user, false} ->
         {:noreply,
          socket
@@ -850,12 +836,5 @@ defmodule LightningWeb.CredentialLive.FormComponent do
 
     all_projects
     |> Enum.reject(fn {_, credential_id} -> credential_id in existing_ids end)
-  end
-
-  defp credential_projects_up_to_date?(form_credential) do
-    db_credential = Credentials.get_credential_for_update!(form_credential.id)
-
-    Map.get(db_credential, :project_credentials) ==
-      Map.get(form_credential, :project_credentials)
   end
 end

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -11,7 +11,6 @@ defmodule LightningWeb.CredentialLiveTest do
   import Ecto.Query
 
   alias Lightning.Credentials
-  alias Phoenix.LiveView.JS
 
   @create_attrs %{
     name: "some name",
@@ -673,65 +672,6 @@ defmodule LightningWeb.CredentialLiveTest do
       view |> form("#credential-form-#{credential.id}") |> render_submit()
 
       assert_redirected(view, ~p"/credentials")
-    end
-
-    test "shows a flash error when project credentials list is stale/outdated",
-         %{
-           conn: conn,
-           project: project,
-           user: user
-         } do
-      %{project_credentials: [proj_credential1]} =
-        credential =
-        insert(:credential,
-          user_id: user.id,
-          body: %{
-            a: 1
-          },
-          project_credentials: [
-            %{project_id: project.id}
-          ],
-          schema: "raw"
-        )
-        |> Repo.preload([:projects, :project_credentials])
-
-      {:ok, view, _html} = live(conn, ~p"/credentials")
-
-      # user session 1 opens the edit modal
-      JS.focus_first(to: "#edit-credential-#{credential.id}-modal-content")
-
-      assert view
-             |> form("#credential-form-#{credential.id}",
-               credential: %{name: "new name"}
-             )
-             |> render_change()
-
-      # user session 2 adds a project to this credential
-      project_other_session =
-        insert(:project, project_users: [%{user_id: user.id}])
-
-      update_attrs = %{
-        project_credentials: [
-          Map.from_struct(proj_credential1),
-          %{project_id: project_other_session.id}
-        ]
-      }
-
-      assert {:ok, credential} =
-               Credentials.update_credential(credential, update_attrs)
-
-      # user session 1 submits the form without the new project credential
-      view
-      |> form("#credential-form-#{credential.id}")
-      |> render_submit()
-      |> follow_redirect(conn, ~p"/credentials")
-
-      assert {"/credentials",
-              %{
-                "error" =>
-                  "Credential was updated by another session. Please try again."
-              }} =
-               assert_redirect(view)
     end
 
     test "marks a credential for use in a 'production' system", %{


### PR DESCRIPTION
## Validation Steps

Please see issue Loom

## Notes for the reviewer

This validation was introduced due to #1795 which happens on stale project credentials. However it causes a side effect when saving Salesforce credential. So for now it's better remove the validation until it's fixed covering Salesforce or Facebook tokens as described in the issue.

## Related issue

Fixes #1861 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
