### PR TITLE
Change ERL_FLAGS to limit compile concurrency on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ jobs:
     docker:
       - image: elixir:<< parameters.elixir_version >>
       - image: cimg/postgres:15.3
+    environment:
+      ERL_FLAGS: +S 4:4
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,11 @@ jobs:
 
       - run:
           name: "Save Elixir and Erlang version for PLT caching"
-          command: echo "$ELIXIR_VERSION $OTP_VERSION" > .elixir_otp_version
+          command: echo "$ELIXIR_VERSION $OTP_VERSION" | tee .elixir_otp_version
+
+      - run:
+          name: "Introspect schedulers"
+          command: elixir -v
 
       - restore_cache:
           keys:

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Lightning.MixProject do
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [
-        warnings_as_errors: false
+        warnings_as_errors: true
       ],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-Code.put_compiler_option(:warnings_as_errors, false)
+Code.put_compiler_option(:warnings_as_errors, true)
 # Report which tests are synchronous
 # Rexbug.start("ExUnit.Server.add_sync_module/_")
 Mox.defmock(Lightning.Tesla.Mock, for: Tesla.Adapter)


### PR DESCRIPTION
Manually sets the Erlang scheduler count to `4:4`.

This appears to fix the compile warning we were getting repeatedly:

```
warning: invalid association `snapshot` in schema Lightning.Invocation.Step: associated module Lightning.Workflows.Snapshot is not an Ecto schema
  lib/lightning/invocation/step.ex:1: Lightning.Invocation.Step (module)

...
Compilation failed due to warnings while using the --warnings-as-errors option

Exited with code exit status 1
```

I couldn't reproduce this locally, on either x86 or aarch64 - using the official Elixir image we use in CI; also using `elixir --erl "+T 9" -S mix compile --force` to slow down the scheduler timings.

I found a note on the CircleCI [`resource_class`](https://circleci.com/docs/configuration-reference/#resourceclass) docs that noted:

> Java, Erlang and any other languages that introspect the /proc directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.

So I've added an `ERL_FLAGS` var to the job not only did the test suite run _way_ faster, it also doesn't appear to have any compile warnings (at least for the Ecto case).