### PR TITLE
Run deploy github workflows one at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 
 ### Fixed
 
+- Don't let two deploy workflows run at the same time to prevent git collisions
+  [#2044](https://github.com/OpenFn/lightning/issues/2044)
 - Stopped sending emails when creating a starter project
   [#2161](https://github.com/OpenFn/lightning/issues/2161)
 

--- a/priv/github/deploy.yml
+++ b/priv/github/deploy.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   group: openfn-deployment
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy-to-lightning:

--- a/priv/github/deploy.yml
+++ b/priv/github/deploy.yml
@@ -3,6 +3,10 @@ on:
     branches:
       - <%= @branch %>
 
+concurrency:
+  group: openfn-deployment
+  cancel-in-progress: true
+
 jobs:
   deploy-to-lightning:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
this is just a concept:
1. needs testing
2. _maybe_ (probably) also needs the workflow to pull/merge previously made changes... see @mtuchi 's latest error when he reruns the workflow.

- we want workflow a to run
- then we want workflow b to run
- they are both triggered by the same commit, but they do different things because we have multiple unrelated openfn projects in the same repo.
- how do we stop the conflicts?

## Related Issue
Fixes #2044