### PR TITLE
Limit GitHub version control

### DIFF
--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -12,7 +12,12 @@ defmodule Lightning.Extensions.UsageLimiting do
   defmodule Action do
     @moduledoc false
     @type t :: %__MODULE__{
-            type: :new_run | :activate_workflow | :new_user | :alert_failure,
+            type:
+              :new_run
+              | :activate_workflow
+              | :new_user
+              | :alert_failure
+              | :github_sync,
             amount: pos_integer()
           }
 

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -31,7 +31,9 @@ defmodule Lightning.Projects.Provisioner do
           User.t() | ProjectRepoConnection.t(),
           map()
         ) ::
-          {:error, Ecto.Changeset.t(Project.t())}
+          {:error,
+           Ecto.Changeset.t(Project.t())
+           | Lightning.Extensions.UsageLimiting.message()}
           | {:ok, Project.t()}
   def import_document(nil, %User{} = user, data) do
     import_document(%Project{}, user, data)

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -16,6 +16,7 @@ defmodule Lightning.Projects.Provisioner do
   alias Lightning.Projects.ProjectUser
   alias Lightning.Repo
   alias Lightning.VersionControl.ProjectRepoConnection
+  alias Lightning.VersionControl.VersionControlUsageLimiter
   alias Lightning.Workflows.Edge
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger
@@ -32,22 +33,25 @@ defmodule Lightning.Projects.Provisioner do
         ) ::
           {:error, Ecto.Changeset.t(Project.t())}
           | {:ok, Project.t()}
-  def import_document(nil, %User{} = user, data),
-    do: import_document(%Project{}, user, data)
+  def import_document(nil, %User{} = user, data) do
+    import_document(%Project{}, user, data)
+  end
 
   def import_document(project, user_or_repo_connection, data) do
-    project
-    |> preload_dependencies()
-    |> parse_document(data)
-    |> maybe_add_project_user(user_or_repo_connection)
-    |> Repo.insert_or_update()
-    |> case do
-      {:ok, %{workflows: workflows} = project} ->
-        Enum.each(workflows, &Lightning.Workflows.Events.workflow_updated/1)
-        {:ok, preload_dependencies(project)}
+    with :ok <- VersionControlUsageLimiter.limit_github_sync(project.id) do
+      project
+      |> preload_dependencies()
+      |> parse_document(data)
+      |> maybe_add_project_user(user_or_repo_connection)
+      |> Repo.insert_or_update()
+      |> case do
+        {:ok, %{workflows: workflows} = project} ->
+          Enum.each(workflows, &Lightning.Workflows.Events.workflow_updated/1)
+          {:ok, preload_dependencies(project)}
 
-      {:error, changeset} ->
-        {:error, changeset}
+        {:error, changeset} ->
+          {:error, changeset}
+      end
     end
   end
 

--- a/lib/lightning/version_control/version_control_usage_limiter.ex
+++ b/lib/lightning/version_control/version_control_usage_limiter.ex
@@ -1,0 +1,22 @@
+defmodule Lightning.VersionControl.VersionControlUsageLimiter do
+  @moduledoc false
+
+  alias Lightning.Extensions.UsageLimiting
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.Services.UsageLimiter
+
+  @spec limit_github_sync(project_id :: Ecto.UUID.t()) ::
+          :ok | {:error, UsageLimiting.message()}
+  def limit_github_sync(project_id) do
+    case UsageLimiter.limit_action(%Action{type: :github_sync}, %Context{
+           project_id: project_id
+         }) do
+      :ok ->
+        :ok
+
+      {:error, _reason, error} ->
+        {:error, error}
+    end
+  end
+end

--- a/lib/lightning/version_control/version_control_usage_limiter.ex
+++ b/lib/lightning/version_control/version_control_usage_limiter.ex
@@ -6,9 +6,9 @@ defmodule Lightning.VersionControl.VersionControlUsageLimiter do
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Services.UsageLimiter
 
-  @spec limit_github_sync(project_id :: Ecto.UUID.t()) ::
+  @spec limit_github_sync(project_id :: Ecto.UUID.t() | nil) ::
           :ok | {:error, UsageLimiting.message()}
-  def limit_github_sync(project_id) do
+  def limit_github_sync(project_id) when is_binary(project_id) do
     case UsageLimiter.limit_action(%Action{type: :github_sync}, %Context{
            project_id: project_id
          }) do
@@ -19,4 +19,6 @@ defmodule Lightning.VersionControl.VersionControlUsageLimiter do
         {:error, error}
     end
   end
+
+  def limit_github_sync(nil), do: :ok
 end

--- a/lib/lightning_web/components/github_components.ex
+++ b/lib/lightning_web/components/github_components.ex
@@ -11,6 +11,7 @@ defmodule LightningWeb.Components.GithubComponents do
 
   attr :user, Lightning.Accounts.User, required: true
   attr :github_query_params, :map
+  attr :disabled, :boolean, default: false
 
   def connect_to_github_link(assigns) do
     assigns =
@@ -21,7 +22,7 @@ defmodule LightningWeb.Components.GithubComponents do
       id={@id}
       href={"https://github.com/login/oauth/authorize?" <> Plug.Conn.Query.encode(@github_query_params)}
       target="_blank"
-      class={@class}
+      class={[@class, "#{if @disabled, do: "bg-primary-300 cursor-not-allowed"}"]}
       {if @user.github_oauth_token, do: ["phx-hook": "Tooltip", "aria-label": "Your token has expired"], else: []}
     >
       <%= if @user.github_oauth_token, do: "Reconnect", else: "Connect" %> your Github Account

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -186,6 +186,13 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
       {:error, %Ecto.Changeset{} = changeset} ->
         assign(socket, changeset: changeset)
 
+      {:error, %{text: error_msg}} ->
+        socket
+        |> put_flash(:error, error_msg)
+        |> push_navigate(
+          to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
+        )
+
       {:error, _other} ->
         socket
         |> put_flash(:error, "Oops! Could not connect to Github")
@@ -206,6 +213,13 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
       :ok ->
         socket
         |> put_flash(:info, "Connection made successfully!")
+        |> push_navigate(
+          to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
+        )
+
+      {:error, %{text: error_msg}} ->
+        socket
+        |> put_flash(:error, error_msg)
         |> push_navigate(
           to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
         )
@@ -232,6 +246,13 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
       :ok ->
         socket
         |> put_flash(:info, "Github sync initiated successfully!")
+        |> push_navigate(
+          to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
+        )
+
+      {:error, %{text: error_msg}} ->
+        socket
+        |> put_flash(:error, error_msg)
         |> push_navigate(
           to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
         )

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -22,6 +22,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   require Logger
 
   on_mount {LightningWeb.Hooks, :project_scope}
+  on_mount {LightningWeb.Hooks, :limit_github_sync}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -678,7 +678,15 @@
           <div class="hidden sm:block" aria-hidden="true">
             <div class="py-2"></div>
           </div>
-
+          <div>
+            <%= if assigns[:github_banner] do %>
+              <%= Phoenix.LiveView.TagEngine.component(
+                @github_banner.function,
+                @github_banner.attrs,
+                {__ENV__.module, __ENV__.function, __ENV__.file, __ENV__.line}
+              ) %>
+            <% end %>
+          </div>
           <%= if  @github_enabled do %>
             <%= if @project_repo_connection do %>
               <.live_component
@@ -723,6 +731,7 @@
                     <GithubComponents.connect_to_github_link
                       id="connect-github-link"
                       user={@current_user}
+                      disabled={is_map(assigns[:github_banner])}
                     />
                   </div>
                 </div>

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -37,7 +37,6 @@ defmodule Lightning.Projects.ProvisionerTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        1,
         fn _action, _context -> :ok end
       )
 
@@ -85,10 +84,9 @@ defmodule Lightning.Projects.ProvisionerTest do
         second_job_id: second_job_id
       } = valid_document()
 
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        1,
         fn _action, _context -> :ok end
       )
 
@@ -124,10 +122,12 @@ defmodule Lightning.Projects.ProvisionerTest do
       project: %{id: project_id} = project,
       user: user
     } do
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        fn %{type: :activate_workflow}, %{project_id: ^project_id} -> :ok end
+        fn _action, %{project_id: ^project_id} ->
+          :ok
+        end
       )
 
       %{body: body} = valid_document(project.id)
@@ -156,10 +156,12 @@ defmodule Lightning.Projects.ProvisionerTest do
       project: %{id: project_id} = project,
       user: user
     } do
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        fn %{type: :activate_workflow}, %{project_id: ^project_id} -> :ok end
+        fn _action, %{project_id: ^project_id} ->
+          :ok
+        end
       )
 
       %{body: body} = valid_document(project.id)
@@ -205,11 +207,12 @@ defmodule Lightning.Projects.ProvisionerTest do
       project: %{id: project_id} = project,
       user: user
     } do
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        2,
-        fn %{type: :activate_workflow}, %{project_id: ^project_id} -> :ok end
+        fn _action, %{project_id: ^project_id} ->
+          :ok
+        end
       )
 
       %{body: body, workflow_id: workflow_id} = valid_document(project.id)
@@ -278,10 +281,12 @@ defmodule Lightning.Projects.ProvisionerTest do
     end
 
     test "removing a record", %{project: %{id: project_id} = project, user: user} do
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        fn %{type: :activate_workflow}, %{project_id: ^project_id} -> :ok end
+        fn _action, %{project_id: ^project_id} ->
+          :ok
+        end
       )
 
       %{
@@ -333,10 +338,12 @@ defmodule Lightning.Projects.ProvisionerTest do
       project: %{id: project_id} = project,
       user: user
     } do
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        fn %{type: :activate_workflow}, %{project_id: ^project_id} -> :ok end
+        fn _action, %{project_id: ^project_id} ->
+          :ok
+        end
       )
 
       %{
@@ -365,9 +372,17 @@ defmodule Lightning.Projects.ProvisionerTest do
     end
 
     test "marking a new/changed record for deletion", %{
-      project: project,
+      project: %{id: project_id} = project,
       user: user
     } do
+      Mox.stub(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, %{project_id: ^project_id} ->
+          :ok
+        end
+      )
+
       body = %{
         "id" => project.id,
         "name" => "test-project",
@@ -394,10 +409,13 @@ defmodule Lightning.Projects.ProvisionerTest do
       %{body: body} = valid_document(project_id)
       error_msg = "Oopsie Doopsie"
 
-      Mox.expect(
-        Lightning.Extensions.MockUsageLimiter,
+      Lightning.Extensions.MockUsageLimiter
+      |> Mox.expect(
         :limit_action,
-        1,
+        fn %{type: :github_sync}, %{project_id: ^project_id} -> :ok end
+      )
+      |> Mox.expect(
+        :limit_action,
         fn _action, %{project_id: ^project_id} ->
           {:error, :too_many_workflows, %{text: error_msg}}
         end
@@ -415,10 +433,9 @@ defmodule Lightning.Projects.ProvisionerTest do
     } do
       %{body: body, workflow_id: workflow_id} = valid_document(project.id)
 
-      Mox.expect(
+      Mox.stub(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        1,
         fn _action, %{project_id: ^project_id} ->
           :ok
         end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -8,6 +8,15 @@ defmodule Lightning.VersionControlTest do
 
   import Lightning.GithubHelpers
 
+  setup do
+    Mox.stub_with(
+      Lightning.Extensions.MockUsageLimiter,
+      Lightning.Extensions.UsageLimiter
+    )
+
+    :ok
+  end
+
   describe "create_github_connection/2" do
     test "user with valid oauth token creates connection successfully" do
       Mox.verify_on_exit!()

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -3204,6 +3204,103 @@ defmodule LightningWeb.ProjectLiveTest do
       assert flash["info"] == "Connection made successfully"
     end
 
+    test "users get an error when saving repo connection if the usage limiter returns an error",
+         %{
+           conn: conn
+         } do
+      expected_installation = %{
+        "id" => 1234,
+        "account" => %{
+          "type" => "User",
+          "login" => "username"
+        }
+      }
+
+      expected_repo = %{
+        "full_name" => "someaccount/somerepo",
+        "default_branch" => "main"
+      }
+
+      expected_branch = %{"name" => "somebranch"}
+
+      %{id: project_id} = project = insert(:project)
+
+      {conn, user} = setup_project_user(conn, project, :admin)
+      set_valid_github_oauth_token!(user)
+
+      expect_get_user_installations(200, %{
+        "installations" => [expected_installation]
+      })
+
+      expect_create_installation_token(expected_installation["id"])
+      expect_get_installation_repos(200, %{"repositories" => [expected_repo]})
+
+      Lightning.Extensions.MockUsageLimiter
+      |> Mox.stub(:check_limits, fn %{project_id: ^project_id} -> :ok end)
+      |> Mox.stub(:limit_action, fn %{type: :github_sync},
+                                    %{project_id: ^project_id} ->
+        :ok
+      end)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#vcs"
+        )
+
+      render_async(view)
+
+      # lets select the installation
+      view
+      |> form("#project-repo-connection-form",
+        connection: %{github_installation_id: expected_installation["id"]}
+      )
+      |> render_change()
+
+      # we should now have the repos listed
+      render_async(view)
+
+      # lets select the repo
+      expect_create_installation_token(expected_installation["id"])
+
+      expect_get_repo_branches(expected_repo["full_name"], 200, [expected_branch])
+
+      view
+      |> form("#project-repo-connection-form",
+        connection: %{
+          github_installation_id: expected_installation["id"],
+          repo: expected_repo["full_name"]
+        }
+      )
+      |> render_change()
+
+      # we should now have the branches listed
+      render_async(view)
+
+      # let us submit
+
+      error_msg = "Some funny error message"
+
+      Lightning.Extensions.MockUsageLimiter
+      |> Mox.expect(:limit_action, fn %{type: :github_sync},
+                                      %{project_id: ^project_id} ->
+        {:error, :disabled, %{text: error_msg}}
+      end)
+
+      view
+      |> form("#project-repo-connection-form")
+      |> render_submit(
+        connection: %{
+          branch: expected_branch["name"],
+          sync_direction: "pull",
+          accept: true
+        }
+      )
+
+      flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
+      assert flash["error"] == error_msg
+    end
+
     test "all users can see a saved repo connection", %{conn: conn} do
       project = insert(:project)
 
@@ -3479,6 +3576,100 @@ defmodule LightningWeb.ProjectLiveTest do
         flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
 
         assert flash["info"] == "Connection made successfully!"
+      end
+    end
+
+    test "authorized users get an error when reconnecting if the usage limiter returns an error",
+         %{conn: conn} do
+      %{id: project_id} = project = insert(:project)
+
+      repo_connection =
+        insert(:project_repo_connection,
+          project: project,
+          repo: "someaccount/somerepo",
+          branch: "somebranch",
+          github_installation_id: "1234",
+          access_token: "someaccesstoken"
+        )
+
+      expected_installation = %{
+        "id" => repo_connection.github_installation_id,
+        "account" => %{
+          "type" => "User",
+          "login" => "username"
+        }
+      }
+
+      expected_access_token_endpoint =
+        "https://api.github.com/app/installations/#{repo_connection.github_installation_id}/access_tokens"
+
+      for {conn, user} <-
+            setup_project_users(conn, project, [:admin, :owner]) do
+        set_valid_github_oauth_token!(user)
+
+        Mox.expect(Lightning.Tesla.Mock, :call, 5, fn
+          # list installations for checking if the user has access to the intallation.
+          %{url: "https://api.github.com/user/installations"}, _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: %{"installations" => [expected_installation]}
+             }}
+
+          # get installation access token. This is called twice.
+          # When fetching repos and when verifying connection
+          %{url: ^expected_access_token_endpoint}, _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 201,
+               body: %{"token" => "some-token"}
+             }}
+
+          # list repos
+          %{url: "https://api.github.com/installation/repositories"}, _opts ->
+            {:ok, %Tesla.Env{status: 200, body: %{"repositories" => []}}}
+
+          # another call for verifying connection. Probably for checking if a file exists
+          # ignoring to halt the pipeline
+          %{url: _url}, _opts ->
+            {:error, "something unexpected happened"}
+        end)
+
+        Lightning.Extensions.MockUsageLimiter
+        |> Mox.stub(:check_limits, fn %{project_id: ^project_id} -> :ok end)
+        |> Mox.stub(:limit_action, fn %{type: :github_sync},
+                                      %{project_id: ^project_id} ->
+          :ok
+        end)
+
+        {:ok, view, _html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#vcs"
+          )
+
+        render_async(view)
+
+        assert has_element?(view, "#reconnect-project-button")
+
+        # let's reconnect
+        error_msg = "Some funny error message"
+
+        Lightning.Extensions.MockUsageLimiter
+        |> Mox.expect(:limit_action, fn %{type: :github_sync},
+                                        %{project_id: ^project_id} ->
+          {:error, :disabled, %{text: error_msg}}
+        end)
+
+        view
+        |> form("#reconnect-project-form")
+        |> render_submit(
+          connection: %{"sync_direction" => "pull", "accept" => "true"}
+        )
+
+        flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
+
+        assert flash["error"] == error_msg
       end
     end
 
@@ -3981,6 +4172,174 @@ defmodule LightningWeb.ProjectLiveTest do
         flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
 
         assert flash["info"] == "Github sync initiated successfully!"
+      end
+    end
+
+    test "authorized users get an error when initiating github sync if the usage limiter returns an error",
+         %{
+           conn: conn
+         } do
+      %{id: project_id} = project = insert(:project)
+
+      repo_connection =
+        insert(:project_repo_connection,
+          project: project,
+          repo: "someaccount/somerepo",
+          branch: "somebranch",
+          github_installation_id: "1234",
+          access_token: "someaccesstoken"
+        )
+
+      for {conn, _user} <-
+            setup_project_users(conn, project, [:editor, :admin, :owner]) do
+        # ensure project is all setup
+        repo_name = repo_connection.repo
+        branch_name = repo_connection.branch
+        installation_id = repo_connection.github_installation_id
+
+        expected_default_branch = "main"
+
+        expected_deploy_yml_path =
+          ".github/workflows/openfn-#{repo_connection.project_id}-deploy.yml"
+
+        expected_config_json_path =
+          "openfn-#{repo_connection.project_id}-config.json"
+
+        expected_secret_name =
+          "OPENFN_#{String.replace(repo_connection.project_id, "-", "_")}_API_KEY"
+
+        Lightning.Extensions.MockUsageLimiter
+        |> Mox.stub(:check_limits, fn %{project_id: ^project_id} -> :ok end)
+        |> Mox.stub(:limit_action, fn %{type: :github_sync},
+                                      %{project_id: ^project_id} ->
+          :ok
+        end)
+
+        Mox.expect(Lightning.Tesla.Mock, :call, 6, fn
+          # get installation access token.
+          # called when verifying connection
+          %{
+            url:
+              "https://api.github.com/app/installations/" <>
+                  ^installation_id <> "/access_tokens"
+          },
+          _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 201,
+               body: %{"token" => "some-token"}
+             }}
+
+          # get repo content
+          %{url: "https://api.github.com/repos/" <> ^repo_name}, _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: %{"default_branch" => expected_default_branch}
+             }}
+
+          # check if pull yml exists in the default branch
+          %{
+            method: :get,
+            query: [{:ref, "heads/" <> ^expected_default_branch}],
+            url:
+              "https://api.github.com/repos/" <>
+                  ^repo_name <> "/contents/.github/workflows/openfn-pull.yml"
+          },
+          _opts ->
+            {:ok, %Tesla.Env{status: 200, body: %{"sha" => "somesha"}}}
+
+          # check if deploy yml exists in the target branch
+          %{
+            method: :get,
+            query: [{:ref, "heads/" <> ^branch_name}],
+            url:
+              "https://api.github.com/repos/" <>
+                  ^repo_name <> "/contents/" <> ^expected_deploy_yml_path
+          },
+          _opts ->
+            {:ok, %Tesla.Env{status: 200, body: %{"sha" => "somesha"}}}
+
+          # check if config.json exists in the target branch
+          %{
+            method: :get,
+            query: [{:ref, "heads/" <> ^branch_name}],
+            url:
+              "https://api.github.com/repos/" <>
+                  ^repo_name <> "/contents/" <> ^expected_config_json_path
+          },
+          _opts ->
+            {:ok, %Tesla.Env{status: 200, body: %{"sha" => "somesha"}}}
+
+          # check if api key secret exists
+          %{
+            method: :get,
+            url:
+              "https://api.github.com/repos/" <>
+                  ^repo_name <> "/actions/secrets/" <> ^expected_secret_name
+          },
+          _opts ->
+            {:ok, %Tesla.Env{status: 200, body: %{}}}
+        end)
+
+        {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/settings#vcs")
+
+        html = render_async(view)
+
+        refute html =~ "Contact an editor or admin to sync."
+
+        button = element(view, "#initiate-sync-button")
+        assert has_element?(button)
+
+        # try clicking the button
+
+        error_msg = "Some funny error message"
+
+        Lightning.Extensions.MockUsageLimiter
+        |> Mox.expect(:limit_action, fn %{type: :github_sync},
+                                        %{project_id: ^project_id} ->
+          {:error, :disabled, %{text: error_msg}}
+        end)
+
+        render_click(button)
+
+        flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
+
+        assert flash["error"] == error_msg
+      end
+    end
+
+    test "error banner is displayed if github sync usage limiter returns an error",
+         %{
+           conn: conn
+         } do
+      import Phoenix.Component
+      %{id: project_id} = project = insert(:project)
+
+      for {conn, _user} <-
+            setup_project_users(conn, project, [:viewer, :editor, :admin, :owner]) do
+        error_msg = "I am a robot"
+
+        Lightning.Extensions.MockUsageLimiter
+        |> Mox.stub(:check_limits, fn %{project_id: ^project_id} -> :ok end)
+        |> Mox.expect(:limit_action, 2, fn %{type: :github_sync},
+                                           %{project_id: ^project_id} ->
+          {:error, :disabled,
+           %{
+             function: fn assigns ->
+               ~H"<p>I am an error message that says: <%= @error %></p>"
+             end,
+             attrs: %{error: error_msg}
+           }}
+        end)
+
+        {:ok, _view, html} =
+          live(
+            conn,
+            ~p"/projects/#{project.id}/settings#vcs"
+          )
+
+        assert html =~ error_msg
       end
     end
   end


### PR DESCRIPTION
## Validation Steps
- Check: https://github.com/OpenFn/thunderbolt/pull/116

## Notes for the reviewer

- Shows a banner on the github sync tab
- Disables the connect to github button in project settings.
- In case a user connects to github from their profile, they'll be able to see the installations form. They however won't be able to save the connection.
- Reconnecting a failed connection and initialising sync fails as well if the limiter returns an error


## Related issue

Fixes https://github.com/OpenFn/thunderbolt/issues/47

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
