### PR TITLE
Assure workflow is always passed to Run.enqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to
 
 ### Fixed
 
+- Assure workflow is always passed to Run.enqueue
+  [#2032](https://github.com/OpenFn/lightning/issues/2032)
+
 ## [v2.4.2] 2024-04-24
 
 ### Fixed

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -362,8 +362,7 @@ defmodule Lightning.WorkOrders do
     )
     |> Runs.enqueue()
     |> case do
-      {:ok, %{run: run}} ->
-        %{workflow: workflow} = Repo.preload(starting_job, [:workflow])
+      {:ok, %{run: run, workflow: workflow}} ->
         Events.work_order_updated(workflow.project_id, workorder)
         Events.run_created(workflow.project_id, run)
 

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -16,7 +16,9 @@ defmodule Lightning.RunsTest do
   describe "enqueue/1" do
     test "enqueues a run" do
       dataclip = insert(:dataclip)
-      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+
+      %{id: workflow_id, triggers: [trigger]} =
+        workflow = insert(:simple_workflow)
 
       work_order =
         insert(:workorder,
@@ -32,7 +34,7 @@ defmodule Lightning.RunsTest do
           dataclip: dataclip
         )
 
-      assert {:ok, %{run: queued_run}} =
+      assert {:ok, %{run: queued_run, workflow: %{id: ^workflow_id}}} =
                Multi.new() |> Multi.insert(:run, run) |> Runs.enqueue()
 
       assert queued_run.id == run.id

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -17,8 +17,7 @@ defmodule Lightning.RunsTest do
     test "enqueues a run" do
       dataclip = insert(:dataclip)
 
-      %{id: workflow_id, triggers: [trigger]} =
-        workflow = insert(:simple_workflow)
+      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
 
       work_order =
         insert(:workorder,
@@ -34,7 +33,7 @@ defmodule Lightning.RunsTest do
           dataclip: dataclip
         )
 
-      assert {:ok, %{run: queued_run, workflow: %{id: ^workflow_id}}} =
+      assert {:ok, %{run: queued_run}} =
                Multi.new() |> Multi.insert(:run, run) |> Runs.enqueue()
 
       assert queued_run.id == run.id


### PR DESCRIPTION
## Validation Steps

Only through debugging or umbrella app.

## Notes for the reviewer

Workflow should be informed to umbrella app.

## Related issue

Fixes #2032

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
