### PR TITLE
Change Snapshot.create_or_create_latest_for to accept multis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Changed Snapshot `get_or_create_latest_for` to accept multis allow controlling
+  of which repo it uses.
+
 ### Fixed
 
 ## [v2.4.3] - 2024-05-01

--- a/lib/lightning/workorders/workorder.ex
+++ b/lib/lightning/workorders/workorder.ex
@@ -64,5 +64,6 @@ defmodule Lightning.WorkOrder do
     changeset
     |> assoc_constraint(:workflow)
     |> assoc_constraint(:snapshot)
+    |> foreign_key_constraint(:snapshot_id)
   end
 end


### PR DESCRIPTION
When using this function in environments with more than one Repo the create function would cause a lock to be created on a different connection causing deadlocks/timeouts.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
