### PR TITLE
Require exactly one owner for each project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 - Changed Snapshot `get_or_create_latest_for` to accept multis allow controlling
   of which repo it uses.
+- Require exactly one owner for each project
+  [#1991](https://github.com/OpenFn/lightning/issues/1991)
 
 ### Fixed
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -279,9 +279,10 @@ defmodule Lightning.Projects do
   @spec add_project_users(Project.t(), [map(), ...]) ::
           {:ok, [ProjectUser.t(), ...]} | {:error, Ecto.Changeset.t()}
   def add_project_users(project, project_users) do
-    # make the current users an empty list to avoid deleting existing project users
-    project = %{project | project_users: []}
-    params = %{project_users: project_users}
+    project = Repo.preload(project, :project_users)
+    # include the current list to ensure project owner validations work correctly
+    current_users = Enum.map(project.project_users, fn pu -> %{id: pu.id} end)
+    params = %{project_users: project_users ++ current_users}
 
     with {:ok, updated_project} <- update_project_with_users(project, params) do
       {:ok, updated_project.project_users}

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -140,11 +140,11 @@ defmodule Lightning.Projects.Project do
         add_error(
           changeset,
           :owner,
-          "you have not specified an owner for the project"
+          "Every project must have exactly one owner. Please specify one below."
         )
 
       _more_than_1 ->
-        add_error(changeset, :owner, "a project can have only one owner")
+        add_error(changeset, :owner, "A project can have only one owner.")
     end
   end
 end

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -117,11 +117,12 @@ defmodule Lightning.Projects.Project do
 
   def project_with_users_changeset(project, attrs) do
     project
-    |> changeset(attrs)
+    |> cast(attrs, [:id, :name, :description])
     |> cast_assoc(:project_users,
       required: true,
       sort_param: :users_sort
     )
+    |> validate()
     |> validate_project_owner()
   end
 

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -60,7 +60,6 @@ defmodule Lightning.Projects.Project do
       :history_retention_period,
       :dataclip_retention_period
     ])
-    |> cast_assoc(:project_users)
     |> validate()
   end
 
@@ -114,5 +113,37 @@ defmodule Lightning.Projects.Project do
     project
     |> cast(attrs, [:name])
     |> validate_confirmation(:name, message: "doesn't match the project name")
+  end
+
+  def project_with_users_changeset(project, attrs) do
+    project
+    |> changeset(attrs)
+    |> cast_assoc(:project_users,
+      required: true,
+      sort_param: :users_sort
+    )
+    |> validate_project_owner()
+  end
+
+  defp validate_project_owner(changeset) do
+    changeset
+    |> get_assoc(:project_users)
+    |> Enum.count(fn project_user ->
+      get_field(project_user, :role) == :owner
+    end)
+    |> case do
+      1 ->
+        changeset
+
+      0 ->
+        add_error(
+          changeset,
+          :owner,
+          "you have not specified an owner for the project"
+        )
+
+      _more_than_1 ->
+        add_error(changeset, :owner, "a project can have only one owner")
+    end
   end
 end

--- a/lib/lightning/projects/project_user.ex
+++ b/lib/lightning/projects/project_user.ex
@@ -38,7 +38,7 @@ defmodule Lightning.Projects.ProjectUser do
     belongs_to :project, Project
     field :delete, :boolean, virtual: true
     field :failure_alert, :boolean, default: true
-    field :role, RolesEnum, default: :editor
+    field :role, RolesEnum
     field :digest, DigestEnum, default: :weekly
 
     timestamps()
@@ -58,6 +58,10 @@ defmodule Lightning.Projects.ProjectUser do
     |> validate_required([:user_id])
     |> unique_constraint([:project_id, :user_id],
       message: "user already a member of this project."
+    )
+    |> unique_constraint([:project_id],
+      name: "project_owner_unique_index",
+      message: "project can have only one owner"
     )
     |> maybe_remove_user()
   end

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -71,7 +71,7 @@ defmodule Lightning.SetupUtils do
       workorders: [failure_dhis2_workorder]
     } =
       create_dhis2_project([
-        %{user_id: admin.id, role: :admin}
+        %{user_id: admin.id, role: :owner}
       ])
 
     %{

--- a/lib/lightning_web/live/project_live/form_component.ex
+++ b/lib/lightning_web/live/project_live/form_component.ex
@@ -54,16 +54,9 @@ defmodule LightningWeb.ProjectLive.FormComponent do
   end
 
   @impl true
-  def handle_event(
-        "validate",
-        %{"project" => project_params},
-        %{assigns: assigns} = socket
-      ) do
-    # we update the project here so that we can mantain the users in the changeset after validation
-    # project = %{assigns.project | project_users: assigns.project_users}
-
+  def handle_event("validate", %{"project" => project_params}, socket) do
     changeset =
-      assigns.project
+      socket.assigns.project
       |> Project.project_with_users_changeset(
         project_params
         |> coerce_raw_name_to_safe_name()
@@ -103,7 +96,10 @@ defmodule LightningWeb.ProjectLive.FormComponent do
   end
 
   defp save_project(socket, :edit, project_params) do
-    case Projects.update_project(socket.assigns.project, project_params) do
+    case Projects.update_project_with_users(
+           socket.assigns.project,
+           project_params
+         ) do
       {:ok, _project} ->
         {:noreply,
          socket
@@ -116,7 +112,7 @@ defmodule LightningWeb.ProjectLive.FormComponent do
   end
 
   defp save_project(socket, :new, project_params) do
-    case Projects.create_project(project_params) |> dbg() do
+    case Projects.create_project(project_params) do
       {:ok, _project} ->
         {:noreply,
          socket

--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -5,6 +5,7 @@
     id="project-form"
     phx-target={@myself}
     phx-change="validate"
+    phx-submit="save"
   >
     <div class="flex items-end gap-2">
       <div class="w-3/6">
@@ -20,28 +21,35 @@
         <.old_error field={f[:name]} />
       </div>
       <div class="">
-        <%= if (@changeset.valid?) do %>
+        <%= if to_string(f[:name].value) != "" do %>
           Your project will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
       <%= @name %></span>.
         <% end %>
       </div>
     </div>
-  </.form>
-  <div class="sm:flex sm:items-center mt-8">
-    <div class="sm:flex-auto">
-      <h1 class="text-base font-semibold leading-6 text-gray-600">
-        Manage project users
-      </h1>
+    <div class="sm:flex sm:items-center mt-8">
+      <div class="sm:flex-auto">
+        <h1 class="text-base font-semibold leading-6 text-gray-600">
+          Manage project users
+        </h1>
+      </div>
     </div>
-  </div>
-  <.form
-    :let={f}
-    for={@changeset}
-    id="project-users-form"
-    phx-target={@myself}
-    phx-submit="save"
-  >
-    <%= Phoenix.HTML.Form.hidden_input(f, :name) %>
+
+    <div
+      :if={@changeset.action && Enum.count(f[:owner].errors) > 0}
+      class="border-red-400 bg-red-50 p-4"
+    >
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <Heroicons.exclamation_triangle class="h-5 w-5 text-red-400" />
+        </div>
+        <div class="ml-3">
+          <p class="text-sm text-red-700">
+            <%= translate_error(hd(f[:owner].errors)) %>
+          </p>
+        </div>
+      </div>
+    </div>
     <div class="mt-2 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
@@ -57,19 +65,30 @@
             }
           >
             <:col :let={form} label="NAME">
-              <%= full_user_name(form.data.user) %>
+              <%= @users
+              |> find_user_by_id(form[:user_id].value)
+              |> full_user_name() %>
               <.input :if={form.data.id} type="hidden" field={form[:id]} />
               <.input type="hidden" field={form[:user_id]} />
+              <input
+                type="hidden"
+                name={"#{f.name}[users_sort][]"}
+                value={form.index}
+              />
             </:col>
             <:col :let={form} label="EMAIL">
-              <%= form.data.user.email %>
+              <%= find_user_by_id(@users, form[:user_id].value).email %>
             </:col>
             <:col :let={form} label="NO ACCESS" label_class="text-center">
               <div class="text-center">
-                <%= Phoenix.HTML.Form.radio_button(form, :role, nil,
-                  class:
-                    "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                ) %>
+                <.input
+                  id={form[:role].id <> "_no_access"}
+                  type="radio"
+                  field={form[:role]}
+                  class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                  checked={to_string(form[:role].value) == ""}
+                  value=""
+                />
               </div>
             </:col>
             <:col
@@ -79,10 +98,14 @@
               label_class="text-center"
             >
               <div class="text-center">
-                <%= Phoenix.HTML.Form.radio_button(form, :role, role,
-                  class:
-                    "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                ) %>
+                <.input
+                  id={form[:role].id <> "_" <> role}
+                  type="radio"
+                  field={form[:role]}
+                  class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                  checked={to_string(form[:role].value) == role}
+                  value={role}
+                />
               </div>
             </:col>
           </.new_table>

--- a/lib/lightning_web/live/project_live/form_component.html.heex
+++ b/lib/lightning_web/live/project_live/form_component.html.heex
@@ -27,7 +27,7 @@
         <% end %>
       </div>
     </div>
-    <div class="sm:flex sm:items-center mt-8">
+    <div class="sm:flex sm:items-center mt-8 mb-2">
       <div class="sm:flex-auto">
         <h1 class="text-base font-semibold leading-6 text-gray-600">
           Manage project users

--- a/priv/repo/migrations/20240502053312_add_unique_index_on_project_users.exs
+++ b/priv/repo/migrations/20240502053312_add_unique_index_on_project_users.exs
@@ -1,0 +1,10 @@
+defmodule Lightning.Repo.Migrations.AddUniqueIndexOnProjectUsers do
+  use Ecto.Migration
+
+  def change do
+    create unique_index("project_users", [:project_id],
+             where: "role = 'owner'",
+             name: "project_owner_unique_index"
+           )
+  end
+end

--- a/test/lightning/credentials/credential_test.exs
+++ b/test/lightning/credentials/credential_test.exs
@@ -13,29 +13,19 @@ defmodule Lightning.Credentials.CredentialTest do
 
     test "user_id not valid for transfer" do
       %{id: user_id, first_name: first_name, last_name: last_name} =
-        Lightning.AccountsFixtures.user_fixture(
-          first_name: "Elias",
-          last_name: "BA"
-        )
+        insert(:user, first_name: "Elias", last_name: "BA")
 
-      Lightning.Projects.create_project(%{
-        name: "project-a",
-        project_users: [%{user_id: user_id}]
-      })
+      insert(:project, name: "project-a", project_users: [%{user_id: user_id}])
 
-      {:ok, %Lightning.Projects.Project{id: project_id_b, name: project_name_b}} =
-        Lightning.Projects.create_project(%{
-          name: "project-b"
-        })
+      %{id: project_id_b, name: project_name_b} =
+        insert(:project, name: "project-b")
 
-      {:ok, %Lightning.Projects.Project{id: project_id_c, name: project_name_c}} =
-        Lightning.Projects.create_project(%{
-          name: "project-c"
-        })
+      %{id: project_id_c, name: project_name_c} =
+        insert(:project, name: "project-c")
 
       errors =
         Credential.changeset(
-          Lightning.CredentialsFixtures.credential_fixture(
+          insert(:credential,
             project_credentials: [
               %{project_id: project_id_b},
               %{project_id: project_id_c}
@@ -51,17 +41,17 @@ defmodule Lightning.Credentials.CredentialTest do
     end
 
     test "user_id is valid for transfer" do
-      %{id: user_id_1} = Lightning.AccountsFixtures.user_fixture()
-      %{id: user_id_2} = Lightning.AccountsFixtures.user_fixture()
+      %{id: user_id_1} = insert(:user)
+      %{id: user_id_2} = insert(:user)
 
-      {:ok, %Lightning.Projects.Project{id: project_id}} =
-        Lightning.Projects.create_project(%{
+      %{id: project_id} =
+        insert(:project,
           name: "some-name",
           project_users: [%{user_id: user_id_1}, %{user_id: user_id_2}]
-        })
+        )
 
       credential =
-        Lightning.CredentialsFixtures.credential_fixture(
+        insert(:credential,
           user_id: user_id_1,
           project_credentials: [%{project_id: project_id}]
         )

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -143,7 +143,8 @@ defmodule Lightning.ProjectsTest do
 
         assert [
                  {:owner,
-                  {"you have not specified an owner for the project", []}}
+                  {"Every project must have exactly one owner. Please specify one below.",
+                   []}}
                ] ==
                  errors
       end
@@ -160,7 +161,7 @@ defmodule Lightning.ProjectsTest do
                  ]
                })
 
-      assert [{:owner, {"a project can have only one owner", []}}] ==
+      assert [{:owner, {"A project can have only one owner.", []}}] ==
                errors
     end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -85,7 +85,8 @@ defmodule LightningWeb.ProjectLiveTest do
         |> form("#project-form", project: @create_attrs)
         |> render_submit()
 
-      assert html =~ "you have not specified an owner for the project"
+      assert html =~
+               "Every project must have exactly one owner. Please specify one below."
     end
 
     test "saves new project with members", %{conn: conn} do
@@ -102,14 +103,14 @@ defmodule LightningWeb.ProjectLiveTest do
 
       # error for no owner is not shown until you make a change
       refute render(index_live) =~
-               "you have not specified an owner for the project"
+               "Every project must have exactly one owner. Please specify one below."
 
       assert index_live
              |> form("#project-form", project: @invalid_attrs)
              |> render_change() =~ "can&#39;t be blank"
 
       assert render(index_live) =~
-               "you have not specified an owner for the project"
+               "Every project must have exactly one owner. Please specify one below."
 
       user_1_index = find_user_index_in_list(index_live, user_1)
       user_2_index = find_user_index_in_list(index_live, user_2)
@@ -127,7 +128,7 @@ defmodule LightningWeb.ProjectLiveTest do
         )
         |> render_change()
 
-      assert html =~ "a project can have only one owner"
+      assert html =~ "A project can have only one owner."
 
       index_live
       |> form("#project-form",

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2413,40 +2413,40 @@ defmodule LightningWeb.ProjectLiveTest do
          } do
       project = insert(:project)
 
-      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
-        project_user =
-          insert(:project_user,
-            project: project,
-            user: build(:user),
-            role: :owner
-          )
+      {conn, _user} = setup_project_user(conn, project, :admin)
 
-        {:ok, view, _html} =
-          live(
-            conn,
-            ~p"/projects/#{project.id}/settings#collaboration"
-          )
+      project_owner =
+        insert(:project_user,
+          project: project,
+          user: build(:user),
+          role: :owner
+        )
 
-        tooltip =
-          element(view, "#remove_project_user_#{project_user.id}_button-tooltip")
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#collaboration"
+        )
 
-        assert has_element?(tooltip)
-        assert render(tooltip) =~ "You cannot remove an owner"
+      tooltip =
+        element(view, "#remove_project_user_#{project_owner.id}_button-tooltip")
 
-        # modal is not present
-        refute has_element?(view, "#remove_#{project_user.id}_modal")
+      assert has_element?(tooltip)
+      assert render(tooltip) =~ "You cannot remove an owner"
 
-        # try sending the event either way
-        html =
-          render_click(view, "remove_project_user", %{
-            "project_user_id" => project_user.id
-          })
+      # modal is not present
+      refute has_element?(view, "#remove_#{project_owner.id}_modal")
 
-        assert html =~ "You are not authorized to perform this action"
+      # try sending the event either way
+      html =
+        render_click(view, "remove_project_user", %{
+          "project_user_id" => project_owner.id
+        })
 
-        # project user still exists
-        assert Repo.get(Lightning.Projects.ProjectUser, project_user.id)
-      end
+      assert html =~ "You are not authorized to perform this action"
+
+      # project user still exists
+      assert Repo.get(Lightning.Projects.ProjectUser, project_owner.id)
     end
 
     test "users cannot remove themselves",

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -11,15 +11,13 @@ defmodule Lightning.ProjectsFixtures do
   """
   @spec project_fixture(attrs :: Keyword.t()) :: Lightning.Projects.Project.t()
   def project_fixture(attrs \\ []) when is_list(attrs) do
-    {:ok, project} =
-      attrs
-      |> Enum.into(%{
+    attrs =
+      Enum.into(attrs, %{
         name: "a-test-project",
         project_users: []
       })
-      |> Lightning.Projects.create_project()
 
-    project
+    Factories.insert(:project, attrs)
   end
 
   def canonical_project_fixture(attrs \\ %{}) do


### PR DESCRIPTION
## Validation Steps

1. Login as `super@openfn.org`
2. Go to the admin settings and try to create a new project or edit an existing project

Test item:

- [x] An error is displayed when you don't choose an owner for the project
- [x] An error is displayed when you select more than one owner for the project
- [x] The project is created/updated successfully if you select one owner


## Notes for the reviewer

- Adds a unique constraint on `:project_id where role = "owner"`
- Introduces a new changeset and function responsible for handling the users


## Related issue

Fixes #1991 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
