### PR TITLE
centralize register user side effects

### DIFF
--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -372,24 +372,11 @@ defmodule Lightning.Accounts do
           with {:ok, user} <- result do
             Events.user_registered(user)
             deliver_user_confirmation_instructions(user)
-            maybe_create_initial_project(user)
           end
         end)
 
       {:error, changeset} ->
         {:error, changeset}
-    end
-  end
-
-  defp maybe_create_initial_project(user) do
-    if Lightning.Config.check_flag?(:init_project_for_new_user) do
-      project_name =
-        "#{String.downcase(user.first_name)}-demo" |> String.replace(" ", "-")
-
-      Lightning.SetupUtils.create_starter_project(
-        project_name,
-        [%{user_id: user.id, role: :owner}]
-      )
     end
   end
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -57,14 +57,14 @@ defmodule Lightning.Accounts.UserNotifier do
   @doc """
   Deliver instructions to confirm account.
   """
-  def deliver_confirmation_instructions(user, url) do
+  def deliver_confirmation_instructions(user, token) do
     deliver(user.email, "Confirmation instructions", """
 
     Hi #{user.first_name},
 
-    Welcome and thanks for registering a new account on OpenFn/Lightning. Please confirm your account by visiting the URL below:
+    Welcome and thanks for registering a new account on OpenFn. Please confirm your account by visiting the URL below:
 
-    #{url}.
+    #{url(LightningWeb.Endpoint, ~p"/users/confirm/#{token}")} .
 
     If you didn't create an account with us, please ignore this.
 
@@ -74,14 +74,14 @@ defmodule Lightning.Accounts.UserNotifier do
   @doc """
   Deliver instructions to confirm account.
   """
-  def deliver_confirmation_instructions(enroller, user, url) do
+  def deliver_confirmation_instructions(enroller, user, token) do
     deliver(user.email, "New OpenFn Lightning account", """
 
     Hi #{user.first_name},
 
-    #{enroller.first_name} has just created an account for you on OpenFn/Lightning. You can complete your registration by visiting the URL below:
+    #{enroller.first_name} has just created an account for you on OpenFn. You can complete your registration by visiting the URL below:
 
-    #{url}.
+    #{url(LightningWeb.Endpoint, ~p"/users/confirm/#{token}")} .
 
     If you do not wish to have an account, please ignore this email.
 

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -102,7 +102,7 @@ defmodule Lightning.Config do
   @callback worker_secret() :: binary() | nil
   @callback grace_period() :: integer()
   @callback purge_deleted_after_days() :: integer()
-  @callback check_flag?(atom()) :: boolean()
+  @callback check_flag?(atom()) :: boolean() | nil
 
   @doc """
   Returns the Token signer used to sign and verify run tokens.

--- a/lib/lightning_web/controllers/user_confirmation_controller.ex
+++ b/lib/lightning_web/controllers/user_confirmation_controller.ex
@@ -9,10 +9,7 @@ defmodule LightningWeb.UserConfirmationController do
 
   def create(conn, %{"user" => %{"email" => email}}) do
     if user = Accounts.get_user_by_email(email) do
-      Accounts.deliver_user_confirmation_instructions(
-        user,
-        &Routes.user_confirmation_url(conn, :edit, &1)
-      )
+      Accounts.deliver_user_confirmation_instructions(user)
     end
 
     conn

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -13,6 +13,8 @@ defmodule LightningWeb.UserRegistrationController do
   def create(conn, %{"user" => user_params}) do
     case Accounts.register_user(user_params) do
       {:ok, user} ->
+        maybe_create_initial_project(user)
+
         conn
         |> put_flash(:info, "User created successfully.")
         |> UserAuth.log_in_user(user)
@@ -20,6 +22,18 @@ defmodule LightningWeb.UserRegistrationController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  defp maybe_create_initial_project(user) do
+    if Lightning.Config.check_flag?(:init_project_for_new_user) do
+      project_name =
+        "#{String.downcase(user.first_name)}-demo" |> String.replace(" ", "-")
+
+      Lightning.SetupUtils.create_starter_project(
+        project_name,
+        [%{user_id: user.id, role: :owner}]
+      )
     end
   end
 end

--- a/lib/lightning_web/controllers/user_registration_controller.ex
+++ b/lib/lightning_web/controllers/user_registration_controller.ex
@@ -10,32 +10,9 @@ defmodule LightningWeb.UserRegistrationController do
     render(conn, "new.html", changeset: changeset)
   end
 
-  defp create_initial_project(%Lightning.Accounts.User{
-         id: user_id,
-         first_name: first_name
-       }) do
-    project_name =
-      "#{String.downcase(first_name)}-demo" |> String.replace(" ", "-")
-
-    Lightning.SetupUtils.create_starter_project(
-      project_name,
-      [%{user_id: user_id, role: :owner}]
-    )
-  end
-
   def create(conn, %{"user" => user_params}) do
     case Accounts.register_user(user_params) do
       {:ok, user} ->
-        {:ok, _} =
-          Accounts.deliver_user_confirmation_instructions(
-            user,
-            &Routes.user_confirmation_url(conn, :edit, &1)
-          )
-
-        if Application.get_env(:lightning, :init_project_for_new_user) do
-          create_initial_project(user)
-        end
-
         conn
         |> put_flash(:info, "User created successfully.")
         |> UserAuth.log_in_user(user)

--- a/lib/lightning_web/live/user_live/form_component.ex
+++ b/lib/lightning_web/live/user_live/form_component.ex
@@ -49,8 +49,7 @@ defmodule LightningWeb.UserLive.FormComponent do
         {:ok, _} =
           Accounts.deliver_user_confirmation_instructions(
             socket.assigns.current_user,
-            user,
-            &Routes.user_confirmation_url(socket, :edit, &1)
+            user
           )
 
         {:noreply,

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -58,36 +58,54 @@ defmodule Lightning.Accounts.UserNotifierTest do
     end
 
     test "deliver_confirmation_instructions/2" do
+      token = "sometoken"
+
       UserNotifier.deliver_confirmation_instructions(
         %User{
           email: "real@email.com"
         },
-        "https://lightning/users/confirm/token"
+        token
       )
+
+      url =
+        LightningWeb.Router.Helpers.user_confirmation_url(
+          LightningWeb.Endpoint,
+          :edit,
+          token
+        )
 
       assert_email_sent(
         subject: "Confirmation instructions",
         to: "real@email.com",
         text_body:
-          "\nHi ,\n\nWelcome and thanks for registering a new account on OpenFn/Lightning. Please confirm your account by visiting the URL below:\n\nhttps://lightning/users/confirm/token.\n\nIf you didn't create an account with us, please ignore this.\n\n"
+          "\nHi ,\n\nWelcome and thanks for registering a new account on OpenFn. Please confirm your account by visiting the URL below:\n\n#{url} .\n\nIf you didn't create an account with us, please ignore this.\n\n"
       )
     end
 
     test "deliver_confirmation_instructions/3" do
+      token = "sometoken"
+
       UserNotifier.deliver_confirmation_instructions(
         %User{first_name: "Super User", email: "super@email.com"},
         %User{
           first_name: "Joe",
           email: "real@email.com"
         },
-        "https://lightning/users/confirm/token"
+        token
       )
+
+      url =
+        LightningWeb.Router.Helpers.user_confirmation_url(
+          LightningWeb.Endpoint,
+          :edit,
+          token
+        )
 
       assert_email_sent(
         subject: "New OpenFn Lightning account",
         to: "real@email.com",
         text_body:
-          "\nHi Joe,\n\nSuper User has just created an account for you on OpenFn/Lightning. You can complete your registration by visiting the URL below:\n\nhttps://lightning/users/confirm/token.\n\nIf you do not wish to have an account, please ignore this email.\n\n"
+          "\nHi Joe,\n\nSuper User has just created an account for you on OpenFn. You can complete your registration by visiting the URL below:\n\n#{url} .\n\nIf you do not wish to have an account, please ignore this email.\n\n"
       )
     end
 

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -6,7 +6,6 @@ defmodule Lightning.AccountsTest do
   alias Lightning.Accounts.UserBackupCode
   alias Lightning.Accounts.UserToken
   alias Lightning.Accounts.UserTOTP
-  alias Lightning.AccountsFixtures
   alias Lightning.Credentials
   alias Lightning.Jobs
   alias Lightning.JobsFixtures
@@ -19,8 +18,8 @@ defmodule Lightning.AccountsTest do
   import Lightning.Factories
 
   test "has_activity_in_projects?/1 returns true if user has activity in a project (is associated with a run) and false otherwise." do
-    user = AccountsFixtures.user_fixture()
-    another_user = AccountsFixtures.user_fixture()
+    user = insert(:user)
+    another_user = insert(:user)
 
     workflow = insert(:workflow)
     trigger = insert(:trigger, workflow: workflow)
@@ -46,12 +45,12 @@ defmodule Lightning.AccountsTest do
   end
 
   test "list_users/0 returns all users" do
-    user = user_fixture()
-    assert user in Accounts.list_users()
+    %{id: user_id} = insert(:user)
+    assert [%{id: ^user_id}] = Accounts.list_users()
   end
 
   test "list_api_token/1 returns all user tokens" do
-    user = user_fixture()
+    user = insert(:user)
 
     tokens =
       for(_ <- 1..3, do: Accounts.generate_api_token(user))
@@ -67,7 +66,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "returns the user if the email exists" do
-      %{id: id} = user = user_fixture()
+      %{id: id} = user = insert(:user)
       assert %User{id: ^id} = Accounts.get_user_by_email(user.email)
     end
   end
@@ -81,12 +80,12 @@ defmodule Lightning.AccountsTest do
     end
 
     test "does not return the user if the password is not valid" do
-      user = user_fixture()
+      user = insert(:user)
       refute Accounts.get_user_by_email_and_password(user.email, "invalid")
     end
 
     test "returns the user if the email and password are valid" do
-      %{id: id} = user = user_fixture()
+      %{id: id} = user = insert(:user)
 
       assert %User{id: ^id} =
                Accounts.get_user_by_email_and_password(
@@ -104,7 +103,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "returns the user with the given id" do
-      %{id: id} = user = user_fixture()
+      %{id: id} = user = insert(:user)
       assert %User{id: ^id} = Accounts.get_user!(user.id)
     end
   end
@@ -117,7 +116,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "returns the token with the given id" do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_api_token(user)
       %{id: id} = user_token = Repo.get_by(UserToken, token: token)
 
@@ -127,7 +126,7 @@ defmodule Lightning.AccountsTest do
 
   describe "get_user_totp/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       [user: user]
     end
 
@@ -145,7 +144,7 @@ defmodule Lightning.AccountsTest do
 
   describe "upsert_user_totp/2" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       [user: user]
     end
 
@@ -308,7 +307,7 @@ defmodule Lightning.AccountsTest do
 
   describe "delete_user_totp/1" do
     test "successfully deletes the given user TOTP and disables the mfa_flag" do
-      user = user_fixture()
+      user = insert(:user)
       user_totp = %UserTOTP{secret: NimbleTOTP.secret(), user_id: user.id}
       valid_code = NimbleTOTP.verification_code(user_totp.secret)
       {:ok, totp} = Accounts.upsert_user_totp(user_totp, %{code: valid_code})
@@ -363,7 +362,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "validates email uniqueness" do
-      %{email: email} = user_fixture()
+      %{email: email} = insert(:user)
       {:error, changeset} = Accounts.register_user(%{email: email})
       assert "has already been taken" in errors_on(changeset).email
 
@@ -531,7 +530,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "purging a user sets all project credentials that use their credentials to nil" do
-      user = user_fixture()
+      user = insert(:user)
       project = Lightning.ProjectsFixtures.project_fixture()
 
       project_credential_1 =
@@ -561,7 +560,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "purging user deletes all project credentials that involve this user's credentials" do
-      user = user_fixture()
+      user = insert(:user)
 
       CredentialsFixtures.project_credential_fixture(user_id: user.id)
       CredentialsFixtures.project_credential_fixture(user_id: user.id)
@@ -575,8 +574,8 @@ defmodule Lightning.AccountsTest do
     end
 
     test "purging a user deletes all of that user's credentials" do
-      user_1 = user_fixture()
-      user_2 = user_fixture()
+      user_1 = insert(:user)
+      user_2 = insert(:user)
 
       CredentialsFixtures.credential_fixture(user_id: user_1.id)
       CredentialsFixtures.credential_fixture(user_id: user_1.id)
@@ -652,7 +651,7 @@ defmodule Lightning.AccountsTest do
           scheduled_deletion: DateTime.utc_now() |> Timex.shift(seconds: -10)
         )
 
-      another_user = user_fixture()
+      another_user = insert(:user)
 
       project =
         Lightning.ProjectsFixtures.project_fixture(
@@ -683,7 +682,7 @@ defmodule Lightning.AccountsTest do
 
   describe "apply_user_email/3" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "requires email to change", %{user: user} do
@@ -713,7 +712,7 @@ defmodule Lightning.AccountsTest do
     end
 
     test "validates email uniqueness", %{user: user} do
-      %{email: email} = user_fixture()
+      %{email: email} = insert(:user)
 
       {:error, changeset} =
         Accounts.apply_user_email(user, valid_user_password(), %{email: email})
@@ -741,7 +740,7 @@ defmodule Lightning.AccountsTest do
 
   describe "deliver_update_email_instructions/3" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "sends token through notification", %{user: user} do
@@ -767,7 +766,7 @@ defmodule Lightning.AccountsTest do
 
   describe "update_user_email/2" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       # email = "current@example.com"
       email = unique_user_email()
 
@@ -843,7 +842,7 @@ defmodule Lightning.AccountsTest do
 
   describe "update_user_password/3" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "validates password", %{user: user} do
@@ -884,8 +883,6 @@ defmodule Lightning.AccountsTest do
           password: "new valid password"
         })
 
-      assert is_nil(user.password)
-
       assert Accounts.get_user_by_email_and_password(
                user.email,
                "new valid password"
@@ -906,7 +903,7 @@ defmodule Lightning.AccountsTest do
 
   describe "generate_user_session_token/1" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "generates a token", %{user: user} do
@@ -918,7 +915,7 @@ defmodule Lightning.AccountsTest do
       assert_raise Ecto.ConstraintError, fn ->
         Repo.insert!(%UserToken{
           token: user_token.token,
-          user_id: user_fixture().id,
+          user_id: insert(:user).id,
           context: "session"
         })
       end
@@ -927,7 +924,7 @@ defmodule Lightning.AccountsTest do
 
   describe "generate_auth_token/1" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "generates a token", %{user: user} do
@@ -939,7 +936,7 @@ defmodule Lightning.AccountsTest do
       assert_raise Ecto.ConstraintError, fn ->
         Repo.insert!(%UserToken{
           token: user_token.token,
-          user_id: user_fixture().id,
+          user_id: insert(:user).id,
           context: "auth"
         })
       end
@@ -948,7 +945,7 @@ defmodule Lightning.AccountsTest do
 
   describe "exchange_auth_token/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_auth_token(user)
       %{user: user, token: token}
     end
@@ -968,7 +965,7 @@ defmodule Lightning.AccountsTest do
 
   describe "generate_api_token/1" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "generates a token", %{user: user} do
@@ -982,7 +979,7 @@ defmodule Lightning.AccountsTest do
       assert_raise Ecto.ConstraintError, fn ->
         Repo.insert!(%UserToken{
           token: user_token.token,
-          user_id: user_fixture().id,
+          user_id: insert(:user).id,
           context: "api"
         })
       end
@@ -991,7 +988,7 @@ defmodule Lightning.AccountsTest do
 
   describe "get_user_by_api_token/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_api_token(user)
 
       user_token =
@@ -1014,7 +1011,7 @@ defmodule Lightning.AccountsTest do
 
   describe "delete_token/1" do
     test "deletes the token" do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_api_token(user)
       %{id: id} = user_token = Repo.get_by(UserToken, token: token)
 
@@ -1025,7 +1022,7 @@ defmodule Lightning.AccountsTest do
 
   describe "get_user_by_auth_token/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_auth_token(user)
       %{user: user, token: token}
     end
@@ -1049,7 +1046,7 @@ defmodule Lightning.AccountsTest do
 
   describe "delete_auth_token/1" do
     test "deletes the token" do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_auth_token(user)
       assert Accounts.delete_auth_token(token) == :ok
       refute Accounts.get_user_by_auth_token(token)
@@ -1058,7 +1055,7 @@ defmodule Lightning.AccountsTest do
 
   describe "get_user_by_session_token/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_user_session_token(user)
       %{user: user, token: token}
     end
@@ -1082,7 +1079,7 @@ defmodule Lightning.AccountsTest do
 
   describe "delete_session_token/1" do
     test "deletes the token" do
-      user = user_fixture()
+      user = insert(:user)
       token = Accounts.generate_user_session_token(user)
       assert Accounts.delete_session_token(token) == :ok
       refute Accounts.get_user_by_session_token(token)
@@ -1091,14 +1088,17 @@ defmodule Lightning.AccountsTest do
 
   describe "deliver_user_confirmation_instructions/2" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "sends token through notification", %{user: user} do
-      token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(user, url)
-        end)
+      {:ok, email} = Accounts.deliver_user_confirmation_instructions(user)
+
+      %{"token" => token} =
+        Regex.named_captures(
+          ~r/\/users\/confirm\/(?<token>\S+)/,
+          email.text_body
+        )
 
       {:ok, token} = Base.url_decode64(token, padding: false)
 
@@ -1113,14 +1113,18 @@ defmodule Lightning.AccountsTest do
 
   describe "deliver_user_confirmation_instructions/3" do
     setup do
-      %{superuser: superuser_fixture(), user: user_fixture()}
+      %{superuser: insert(:user, role: :superuser), user: insert(:user)}
     end
 
     test "sends token through notification", %{superuser: superuser, user: user} do
-      token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(superuser, user, url)
-        end)
+      {:ok, email} =
+        Accounts.deliver_user_confirmation_instructions(superuser, user)
+
+      %{"token" => token} =
+        Regex.named_captures(
+          ~r/\/users\/confirm\/(?<token>\S+)/,
+          email.text_body
+        )
 
       {:ok, token} = Base.url_decode64(token, padding: false)
 
@@ -1135,12 +1139,15 @@ defmodule Lightning.AccountsTest do
 
   describe "confirm_user/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
 
-      token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_confirmation_instructions(user, url)
-        end)
+      {:ok, email} = Accounts.deliver_user_confirmation_instructions(user)
+
+      %{"token" => token} =
+        Regex.named_captures(
+          ~r/\/users\/confirm\/(?<token>\S+)/,
+          email.text_body
+        )
 
       %{user: user, token: token}
     end
@@ -1171,7 +1178,7 @@ defmodule Lightning.AccountsTest do
 
   describe "deliver_user_reset_password_instructions/2" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "sends token through notification", %{user: user} do
@@ -1193,7 +1200,7 @@ defmodule Lightning.AccountsTest do
 
   describe "get_user_by_reset_password_token/1" do
     setup do
-      user = user_fixture()
+      user = insert(:user)
 
       token =
         extract_user_token(fn url ->
@@ -1224,7 +1231,7 @@ defmodule Lightning.AccountsTest do
 
   describe "reset_user_password/2" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "validates password", %{user: user} do
@@ -1249,10 +1256,8 @@ defmodule Lightning.AccountsTest do
     end
 
     test "updates the password", %{user: user} do
-      {:ok, updated_user} =
+      {:ok, _updated_user} =
         Accounts.reset_user_password(user, %{password: "new valid password"})
-
-      assert is_nil(updated_user.password)
 
       assert Accounts.get_user_by_email_and_password(
                user.email,
@@ -1272,14 +1277,14 @@ defmodule Lightning.AccountsTest do
 
   describe "delete_user/1" do
     test "delete_user/1 deletes the user" do
-      user = user_fixture()
+      user = insert(:user)
       assert {:ok, %User{}} = Accounts.delete_user(user)
       assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(user.id) end
     end
 
     test "removes any associated Run and RunStep records" do
-      user_1 = user_fixture()
-      user_2 = user_fixture()
+      user_1 = insert(:user)
+      user_2 = insert(:user)
 
       run_1 = insert_run(user_1)
       run_2 = insert_run(user_1)
@@ -1298,8 +1303,8 @@ defmodule Lightning.AccountsTest do
     end
 
     test "removes any associated LogLine records" do
-      user_1 = user_fixture()
-      user_2 = user_fixture()
+      user_1 = insert(:user)
+      user_2 = insert(:user)
 
       insert_run(user_1, build_list(2, :log_line))
       insert_run(user_1, build_list(2, :log_line))
@@ -1336,7 +1341,7 @@ defmodule Lightning.AccountsTest do
     test "schedule_user_deletion/2 sets a date in the future according to the :purge_deleted_after_days env" do
       days = Lightning.Config.purge_deleted_after_days()
 
-      user = user_fixture()
+      user = insert(:user)
       assert user.scheduled_deletion == nil
 
       now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -1350,7 +1355,7 @@ defmodule Lightning.AccountsTest do
 
   describe "SUDO mode" do
     setup do
-      %{user: user_fixture()}
+      %{user: insert(:user)}
     end
 
     test "generates sudo session token", %{user: user} do
@@ -1362,7 +1367,7 @@ defmodule Lightning.AccountsTest do
       assert_raise Ecto.ConstraintError, fn ->
         Repo.insert!(%UserToken{
           token: user_token.token,
-          user_id: user_fixture().id,
+          user_id: insert(:user).id,
           context: "sudo_session"
         })
       end
@@ -1372,7 +1377,7 @@ defmodule Lightning.AccountsTest do
       token = Accounts.generate_sudo_session_token(user)
       assert Accounts.sudo_session_token_valid?(user, token)
 
-      user2 = user_fixture()
+      user2 = insert(:user)
       refute Accounts.sudo_session_token_valid?(user2, token)
       token_schema = Repo.get_by(UserToken, token: token)
       query = "update user_tokens set inserted_at=$1 where token=$2"
@@ -1402,10 +1407,10 @@ defmodule Lightning.AccountsTest do
   test "has_one_superuser?/0" do
     refute Accounts.has_one_superuser?()
 
-    user_fixture()
+    insert(:user)
     refute Accounts.has_one_superuser?()
 
-    superuser_fixture()
+    insert(:user, role: :superuser)
     assert Accounts.has_one_superuser?()
   end
 

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -3,6 +3,7 @@ defmodule Lightning.AccountsFixtures do
   This module defines test helpers for creating
   entities via the `Lightning.Accounts` context.
   """
+  alias Lightning.Factories
 
   def unique_user_email, do: "user#{System.unique_integer()}@example.com"
   def valid_user_password, do: "hello world!"
@@ -17,12 +18,7 @@ defmodule Lightning.AccountsFixtures do
   end
 
   def user_fixture(attrs \\ []) when is_list(attrs) do
-    {:ok, user} =
-      attrs
-      |> valid_user_attributes()
-      |> Lightning.Accounts.register_user()
-
-    user
+    Factories.insert(:user, valid_user_attributes(attrs))
   end
 
   def superuser_fixture(attrs \\ []) when is_list(attrs) do


### PR DESCRIPTION
## Notes for the reviewer

- Moves sending of user confirmation email to the `Accounts.register_user` function. 
- Uses `Lightning.Config.check_flag?/1` instead of fetching the env directly


## Related issue

Allows for: https://github.com/OpenFn/thunderbolt/issues/125

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
