### PR TITLE
fix: Provisioning API fails with `Comparison with nil is forbidden`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to
 
 ### Added
 
+### Changed
+
+### Fixed
+
+- Fix provioning API calls workflow limiter without the project ID
+  [#2057](https://github.com/OpenFn/lightning/issues/2057)
+
 ## [v2.4.4] - 2024-05-03
 
 ### Added

--- a/lib/lightning/workflows/workflow_usage_limiter.ex
+++ b/lib/lightning/workflows/workflow_usage_limiter.ex
@@ -7,16 +7,29 @@ defmodule Lightning.Workflows.WorkflowUsageLimiter do
   alias Lightning.Services.UsageLimiter
   alias Lightning.Workflows.Workflow
 
+  @spec limit_workflows_activation(Project.t(), [
+          Ecto.Changeset.t(Workflow.t()),
+          ...
+        ]) ::
+          :ok | UsageLimiting.error()
+  def limit_workflows_activation(project, workflow_changesets) do
+    activated_workflows_count =
+      Enum.count(workflow_changesets, &Workflow.workflow_activated?/1)
+
+    if activated_workflows_count > 0 do
+      limit_action(project.id, activated_workflows_count)
+    else
+      :ok
+    end
+  end
+
   @spec limit_workflow_activation(Ecto.Changeset.t(Workflow.t())) ::
           :ok | UsageLimiting.error()
   def limit_workflow_activation(workflow_changeset) do
     if Workflow.workflow_activated?(workflow_changeset) do
-      UsageLimiter.limit_action(
-        %Action{type: :activate_workflow},
-        %Context{
-          project_id: Ecto.Changeset.get_field(workflow_changeset, :project_id)
-        }
-      )
+      workflow_changeset
+      |> Ecto.Changeset.get_field(:project_id)
+      |> limit_action()
     else
       :ok
     end
@@ -28,5 +41,14 @@ defmodule Lightning.Workflows.WorkflowUsageLimiter do
     %Workflow{project_id: project.id}
     |> Workflow.changeset(%{triggers: [%{enabled: true}]})
     |> limit_workflow_activation()
+  end
+
+  defp limit_action(project_id, count \\ 1) do
+    UsageLimiter.limit_action(
+      %Action{type: :activate_workflow, amount: count},
+      %Context{
+        project_id: project_id
+      }
+    )
   end
 end


### PR DESCRIPTION
## Notes for the reviewer

- Gets the project ID from the project struct instead of the workflow changeset
- The tests have pinned the `project_id` in the `context` which ensures that it's actually getting passed. I haven't added an additional test because all these tests were failing after pinning the `project_id`.


## Related issue

Fixes #2057 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
