### PR TITLE
require user names in registration changeset

### DIFF
--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -98,6 +98,7 @@ defmodule Lightning.Accounts.User do
         ]
     )
     |> validate_email()
+    |> validate_name()
     |> validate_password(opts)
     |> validate_change(:terms_accepted, fn :terms_accepted, terms_accepted ->
       if terms_accepted do

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -447,7 +447,7 @@ defmodule Lightning.AccountsTest do
     test "returns a changeset" do
       assert %Ecto.Changeset{} = changeset = Accounts.change_user_registration()
 
-      assert changeset.required == [:password, :email]
+      assert changeset.required == [:password, :first_name, :last_name, :email]
     end
 
     test "allows fields to be set" do

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -12,7 +12,8 @@ defmodule Lightning.AccountsFixtures do
     Enum.into(attrs, %{
       email: unique_user_email(),
       password: valid_user_password(),
-      first_name: valid_first_name()
+      first_name: valid_first_name(),
+      last_name: "Last"
     })
   end
 


### PR DESCRIPTION
## Notes for the reviewer
Currently user names are required in the user registration form, but this was not enforced in the changeset. 


## Related issue

Paves way for: https://github.com/OpenFn/thunderbolt/issues/125

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
