### PR TITLE
remove cancel buttons on user profile email/pass change screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to
 
 ### Changed
 
+- Remove illogical cancel buttons on user/pass change screen
+  [#2067](https://github.com/OpenFn/lightning/issues/2067)
+
 ### Fixed
 
 ## [v2.4.6] - 2024-05-08

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -44,14 +44,6 @@
           <.old_error field={f[:current_password]} />
         </div>
         <div class="col-span-6">
-          <span>
-            <.link
-              navigate={Routes.settings_index_path(@socket, :index)}
-              class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-secondary-700 hover:bg-secondary-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-secondary-500"
-            >
-              Cancel
-            </.link>
-          </span>
           <LightningWeb.Components.Form.submit_button
             disabled={!@email_changeset.valid?}
             phx-disable-with="Sending confirmation email..."
@@ -115,19 +107,12 @@
         </div>
         <div class="col-span-6">
           <span>
-            <.link
-              navigate={Routes.dashboard_index_path(@socket, :index)}
-              class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-secondary-700 hover:bg-secondary-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-secondary-500"
+            <LightningWeb.Components.Form.submit_button
+              disabled={!@password_changeset.valid?}
+              phx-disable-with="Saving..."
             >
-              Cancel
-            </.link>
-          </span>
-          <span>
-            <%= Phoenix.HTML.Form.submit("Update password",
-              phx_disable_with: "Saving...",
-              class:
-                "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-            ) %>
+              Update password
+            </LightningWeb.Components.Form.submit_button>
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Validation Steps

Navigate to the user profile page and note that there is no longer a cancel button next to either form input. These cancel buttons don't really make sense here.

I could make them both take you "back" to the dashboard, but I don't want to... that's not a logical path from this interface. We're already at the root of the user scope. We could introduce a "clear unsaved changes in the form" button (usually "reset") but right now I think the best move is to drop it entirely.

Fixes #2067

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
