### PR TITLE
block users from configuring failure alerts when the limiter returns error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Stop users from configuring failure alerts when the limiter returns error
+  [#2076](https://github.com/OpenFn/lightning/pull/2076)
+
 ## [v2.4.7] - 2024-05-11
 
 ### Fixed

--- a/lib/lightning/pipeline/failure_alerter.ex
+++ b/lib/lightning/pipeline/failure_alerter.ex
@@ -1,10 +1,8 @@
 defmodule Lightning.FailureAlerter do
   @moduledoc false
 
-  alias Lightning.Extensions.UsageLimiting.Action
-  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.Projects.ProjectAlertsLimiter
   alias Lightning.Run
-  alias Lightning.Services.UsageLimiter
 
   def alert_on_failure(nil), do: nil
 
@@ -14,7 +12,7 @@ defmodule Lightning.FailureAlerter do
   def alert_on_failure(%Run{} = run) do
     workflow = run.work_order.workflow
 
-    if :ok == limit_failure_alert(workflow.project_id) do
+    if :ok == ProjectAlertsLimiter.limit_failure_alert(workflow.project_id) do
       Lightning.Accounts.get_users_to_alert_for_project(%{
         id: workflow.project_id
       })
@@ -93,11 +91,5 @@ defmodule Lightning.FailureAlerter do
         nil
         # {:cancel, "Failure notification rate limit is reached"} or Logger
     end
-  end
-
-  defp limit_failure_alert(project_id) do
-    UsageLimiter.limit_action(%Action{type: :alert_failure}, %Context{
-      project_id: project_id
-    })
   end
 end

--- a/lib/lightning/projects/project_alerts_limiter.ex
+++ b/lib/lightning/projects/project_alerts_limiter.ex
@@ -1,0 +1,16 @@
+defmodule Lightning.Projects.ProjectAlertsLimiter do
+  @moduledoc false
+
+  alias Lightning.Extensions.UsageLimiting
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.Services.UsageLimiter
+
+  @spec limit_failure_alert(project_id :: Ecto.UUID.t()) ::
+          :ok | UsageLimiting.error()
+  def limit_failure_alert(project_id) do
+    UsageLimiter.limit_action(%Action{type: :alert_failure}, %Context{
+      project_id: project_id
+    })
+  end
+end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -543,6 +543,7 @@
                     <.failure_alert
                       current_user={@current_user}
                       project_user={project_user}
+                      can_receive_failure_alerts={@can_receive_failure_alerts}
                     />
                   </.td>
                   <.td>


### PR DESCRIPTION
## Notes for the reviewer

- Moves the limit function to a new module so that it can be reused by the UI and during the run execution
- Does not show the form when the limiter returns an error
- It always shows `Disabled` if the limiter returns an error. So even if the user had enabled the alerts previously, it will still display as `Disabled`


## Related issue

Fixes https://github.com/OpenFn/thunderbolt/issues/141

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
