### PR TITLE
Fix bug with worker token expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
 
 ### Fixed
 
+- Correctly pass max allowed run time into the Run token, ensuring it's valid
+  for the entirety of the Runs execution time
+  [#2072](https://github.com/OpenFn/lightning/issues/2072)
+
 ## [v2.4.8] - 2024-05-13
 
 ### Added

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -34,10 +34,6 @@ defmodule Lightning.Config do
       )
     end
 
-    @doc """
-    The grace period is 20% of the max run duration and may be used to wait for
-    an additional amount of time after a run was meant to be finished.
-    """
     @impl true
     def grace_period do
       (Application.get_env(:lightning, :max_run_duration_seconds) * 0.2)
@@ -94,7 +90,7 @@ defmodule Lightning.Config do
         "no" ->
           false
 
-        _ ->
+        _other ->
           raise ArgumentError,
                 "expected true, false, yes or no, got: #{inspect(value)}"
       end
@@ -128,10 +124,19 @@ defmodule Lightning.Config do
     impl().worker_secret()
   end
 
+  @doc """
+  The grace period is 20% of the max run duration and may be used to wait for
+  an additional amount of time after a run was meant to be finished.
+
+  The returned value is in seconds.
+  """
   def grace_period do
     impl().grace_period()
   end
 
+  @doc """
+  Returns the default maximum run duration in seconds.
+  """
   def default_max_run_duration do
     impl().default_max_run_duration()
   end

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -45,6 +45,11 @@ defmodule Lightning.Config do
     end
 
     @impl true
+    def default_max_run_duration do
+      Application.get_env(:lightning, :max_run_duration_seconds)
+    end
+
+    @impl true
     def purge_deleted_after_days do
       Application.get_env(:lightning, :purge_deleted_after_days)
     end
@@ -101,6 +106,7 @@ defmodule Lightning.Config do
   @callback repo_connection_token_signer() :: Joken.Signer.t()
   @callback worker_secret() :: binary() | nil
   @callback grace_period() :: integer()
+  @callback default_max_run_duration() :: integer()
   @callback purge_deleted_after_days() :: integer()
   @callback check_flag?(atom()) :: boolean() | nil
 
@@ -124,6 +130,10 @@ defmodule Lightning.Config do
 
   def grace_period do
     impl().grace_period()
+  end
+
+  def default_max_run_duration do
+    impl().default_max_run_duration()
   end
 
   def repo_connection_token_signer do

--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -11,5 +11,6 @@ defmodule Lightning.Extensions.UsageLimiter do
   def limit_action(_action, _context), do: :ok
 
   @impl true
-  def get_run_options(_context), do: []
+  def get_run_options(_context),
+    do: [run_timeout_ms: Lightning.Config.default_max_run_duration() * 1000]
 end

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -56,14 +56,11 @@ defmodule LightningWeb.RunChannel do
     %{retention_policy: retention_policy, run: run, project_id: project_id} =
       socket.assigns
 
-    default_options = [
-      output_dataclips: include_output_dataclips?(retention_policy)
-    ]
-
-    extra_options =
-      UsageLimiter.get_run_options(%Context{project_id: project_id})
-
-    run_options = Keyword.merge(default_options, extra_options)
+    run_options =
+      Keyword.merge(
+        [output_dataclips: include_output_dataclips?(retention_policy)],
+        UsageLimiter.get_run_options(%Context{project_id: project_id})
+      )
 
     {:reply, {:ok, RunWithOptions.render(run, run_options)}, socket}
   end

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -1,15 +1,15 @@
 defmodule Lightning.FailureAlertTest do
-  alias Lightning.Extensions.UsageLimiter
   use LightningWeb.ChannelCase, async: true
 
   import Lightning.Factories
   import Lightning.Helpers, only: [ms_to_human: 1]
   import Swoosh.TestAssertions
 
+  alias Lightning.Extensions.UsageLimiter
+  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.FailureAlerter
   alias Lightning.Repo
   alias Lightning.Workers
-  alias Lightning.FailureAlerter
-  alias Lightning.Extensions.UsageLimiting.Context
 
   setup do
     Mox.stub(Lightning.Extensions.MockUsageLimiter, :check_limits, fn _context ->
@@ -275,8 +275,7 @@ defmodule Lightning.FailureAlertTest do
           LightningWeb.RunChannel,
           "run:#{run.id}",
           %{
-            "token" =>
-              Workers.generate_run_token(run, run_options[:run_timeout_ms])
+            "token" => Workers.generate_run_token(run, run_options)
           }
         )
 

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -1,11 +1,11 @@
 defmodule LightningWeb.RunChannelTest do
-  alias Lightning.Extensions.UsageLimiter
   use LightningWeb.ChannelCase, async: true
 
+  alias Lightning.Extensions.UsageLimiter
+  alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Step
   alias Lightning.Workers
-  alias Lightning.Extensions.UsageLimiting.Context
 
   import Ecto.Query
   import Lightning.TestUtils
@@ -97,10 +97,9 @@ defmodule LightningWeb.RunChannelTest do
       # A valid token, but the id doesn't match the channel name
       id = Ecto.UUID.generate()
       other_id = Ecto.UUID.generate()
-      run_timeout_ms = 1000
 
       bearer =
-        Workers.generate_run_token(%{id: id}, run_timeout_ms)
+        Workers.generate_run_token(%{id: id}, run_timeout_ms: 1000)
 
       assert {:error, %{reason: "unauthorized"}} =
                socket
@@ -114,10 +113,8 @@ defmodule LightningWeb.RunChannelTest do
     test "joining with a valid token but run is not found", %{socket: socket} do
       id = Ecto.UUID.generate()
 
-      run_timeout_ms = 1000
-
       bearer =
-        Workers.generate_run_token(%{id: id}, run_timeout_ms)
+        Workers.generate_run_token(%{id: id}, run_timeout_ms: 1000)
 
       assert {:error, %{reason: "not_found"}} =
                socket
@@ -546,8 +543,7 @@ defmodule LightningWeb.RunChannelTest do
           LightningWeb.RunChannel,
           "run:#{run.id}",
           %{
-            "token" =>
-              Workers.generate_run_token(run, run_options[:run_timeout_ms])
+            "token" => Workers.generate_run_token(run, run_options)
           }
         )
 
@@ -799,7 +795,7 @@ defmodule LightningWeb.RunChannelTest do
         |> subscribe_and_join(
           LightningWeb.RunChannel,
           "run:#{run.id}",
-          %{"token" => Workers.generate_run_token(run, 2)}
+          %{"token" => Workers.generate_run_token(run, run_timeout_ms: 2)}
         )
 
       %{socket: socket, run: run, workflow: workflow}
@@ -945,7 +941,7 @@ defmodule LightningWeb.RunChannelTest do
         |> subscribe_and_join(
           LightningWeb.RunChannel,
           "run:#{run.id}",
-          %{"token" => Workers.generate_run_token(run, 2)}
+          %{"token" => Workers.generate_run_token(run, run_timeout_ms: 2)}
         )
 
       %{
@@ -1187,7 +1183,7 @@ defmodule LightningWeb.RunChannelTest do
       |> subscribe_and_join(
         LightningWeb.RunChannel,
         "run:#{run.id}",
-        %{"token" => Workers.generate_run_token(run, 2)}
+        %{"token" => Workers.generate_run_token(run, run_timeout_ms: 2)}
       )
 
     %{socket: socket}

--- a/test/support/stub_usage_limiter.ex
+++ b/test/support/stub_usage_limiter.ex
@@ -1,6 +1,7 @@
 defmodule Lightning.Extensions.StubUsageLimiter do
   @behaviour Lightning.Extensions.UsageLimiting
 
+  alias Lightning.Config
   alias Lightning.Extensions.Message
 
   defmodule Banner do
@@ -32,5 +33,6 @@ defmodule Lightning.Extensions.StubUsageLimiter do
   end
 
   @impl true
-  def get_run_options(_context), do: []
+  def get_run_options(_context),
+    do: [run_timeout_ms: Config.default_max_run_duration()]
 end


### PR DESCRIPTION
The RunToken was not considering the max run duration when calculating the expiry date, leading to the worker not being able to reconnect to the socket (if it happened to disconnect for whatever reason) while the job was still running.

Fixes #2072