### PR TITLE
Disable emails on reset demo create project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Disable emails on reset demo create project
+  [#2063](https://github.com/OpenFn/lightning/pull/2063)
+
 ## [v2.4.8] - 2024-05-13
 
 ### Added

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -181,14 +181,17 @@ defmodule Lightning.Projects do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_project(attrs \\ %{}) do
+  def create_project(attrs \\ %{}, schedule_email? \\ true) do
     %Project{}
     |> Project.project_with_users_changeset(attrs)
     |> Repo.insert()
     |> tap(fn result ->
       with {:ok, project} <- result do
         Events.project_created(project)
-        schedule_project_addition_emails(%Project{project_users: []}, project)
+
+        if schedule_email? do
+          schedule_project_addition_emails(%Project{project_users: []}, project)
+        end
       end
     end)
   end

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -282,11 +282,14 @@ defmodule Lightning.SetupUtils do
 
   def create_openhie_project(project_users) do
     {:ok, openhie_project} =
-      Projects.create_project(%{
-        name: "openhie-project",
-        id: "4adf2644-ed4e-4f97-a24c-ab35b3cb1efa",
-        project_users: project_users
-      })
+      Projects.create_project(
+        %{
+          name: "openhie-project",
+          id: "4adf2644-ed4e-4f97-a24c-ab35b3cb1efa",
+          project_users: project_users
+        },
+        false
+      )
 
     {:ok, openhie_workflow} =
       Workflows.save_workflow(%{
@@ -502,10 +505,13 @@ defmodule Lightning.SetupUtils do
 
   def create_dhis2_project(project_users) do
     {:ok, project} =
-      Projects.create_project(%{
-        name: "dhis2-project",
-        project_users: project_users
-      })
+      Projects.create_project(
+        %{
+          name: "dhis2-project",
+          project_users: project_users
+        },
+        false
+      )
 
     {:ok, dhis2_workflow} =
       Workflows.save_workflow(%{


### PR DESCRIPTION
## Notes for the reviewer

Avoids Oban dependency when calling `Lightning.reset_demo`.

## Related issue

Fixes #2063 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
