### PR TITLE
Persist run options & set at creation (not claim)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,8 +67,10 @@
 # ==============================================================================
 # <><><> JOB EXECUTION SETTINGS <><><>
 
-# You can configure the max run duration for jobs in milliseconds. This should
-# be lower than the pod termination grace period if using Kubernetes.
+# You can configure the max run duration for jobs and an additional grace period
+#in seconds. Combined, these should be lower than the pod termination grace
+# period if you are using Kubernetes.
+# RUN_GRACE_PERIOD_SECONDS=10
 # WORKER_MAX_RUN_DURATION_SECONDS=60
 
 # TODO: these aren't specified in Runtime, do they belong to the worker process?

--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,7 @@
 # <><><> JOB EXECUTION SETTINGS <><><>
 
 # You can configure the max run duration for jobs and an additional grace period
-#in seconds. Combined, these should be lower than the pod termination grace
+# in seconds. Combined, these should be lower than the pod termination grace
 # period if you are using Kubernetes.
 # RUN_GRACE_PERIOD_SECONDS=10
 # WORKER_MAX_RUN_DURATION_SECONDS=60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,17 @@ and this project adheres to
 
 - Change Default Text For New Job Nodes
   [#2014](https://github.com/OpenFn/lightning/pull/2014)
+- Persisted run options when runs are _created_, not when they are _claimed_.
+  This has the benefit of "locking in" the behavior desired by the user at the
+  time they demand a run, not whenever the worker picks it up.
+  [#2085](https://github.com/OpenFn/lightning/pull/2085)
+- Made `RUN_GRACE_PERIOD_SECONDS` a configurable ENV instead of 20% of the
+  `WORKER_MAX_RUN_DURATION`
+  [#2085](https://github.com/OpenFn/lightning/pull/2085)
 
 ### Fixed
 
+- Stopped Janitor from calling runs lost if they have special runtime options
 - Dataclip Viewer now responds to page resize and internal page layout
   [#2120](https://github.com/OpenFn/lightning/issues/2120)
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -47,9 +47,11 @@ Note that for secure deployments, it's recommended to use a combination of
 ### Limits
 
 - `WORKER_MAX_RUN_MEMORY_MB` - how much memory (in MB) can a single run use?
+- `RUN_GRACE_PERIOD_SECONDS` - how long _after_ the `MAX_RUN_DURATION_SECONDS`
+  should the server wait for the worker to send back data on a run.
 - `WORKER_MAX_RUN_DURATION_SECONDS` - the maximum duration (in seconds) that
-  workflows are allowed to run (keep this below your termination_grace_period if
-  using kubernetes)
+  workflows are allowed to run (keep this plus `RUN_GRACE_PERIOD_SECONDS` below
+  your termination_grace_period if using kubernetes)
 - `WORKER_CAPACITY` - the number of runs a ws-worker instance will take on
   concurrently.
 - `MAX_DATACLIP_SIZE_MB` - the maximum size (in MB) of a dataclip created via

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -271,6 +271,10 @@ config :lightning, :plausible,
   data_domain: env!("PLAUSIBLE_DATA_DOMAIN", :string, nil)
 
 config :lightning,
+       :run_grace_period_seconds,
+       env!("RUN_GRACE_PERIOD_SECONDS", :integer, 10)
+
+config :lightning,
        :max_run_duration_seconds,
        env!("WORKER_MAX_RUN_DURATION_SECONDS", :integer, 60)
 

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -137,7 +137,7 @@ defmodule Lightning.Config do
   end
 
   @doc """
-  The grace period is configurable and is be used to wait for an additional
+  The grace period is configurable and is used to wait for an additional
   amount of time after a given run was meant to be finished.
 
   The returned value is in seconds.

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -37,8 +37,7 @@ defmodule Lightning.Config do
 
     @impl true
     def grace_period do
-      (Application.get_env(:lightning, :max_run_duration_seconds) * 0.2)
-      |> trunc()
+      Application.get_env(:lightning, :run_grace_period_seconds)
     end
 
     @impl true
@@ -138,8 +137,8 @@ defmodule Lightning.Config do
   end
 
   @doc """
-  The grace period is 20% of the max run duration and may be used to wait for
-  an additional amount of time after a run was meant to be finished.
+  The grace period is configurable and is be used to wait for an additional
+  amount of time after a given run was meant to be finished.
 
   The returned value is in seconds.
   """

--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -11,6 +11,9 @@ defmodule Lightning.Extensions.UsageLimiter do
   def limit_action(_action, _context), do: :ok
 
   @impl true
-  def get_run_options(_context),
-    do: [run_timeout_ms: Lightning.Config.default_max_run_duration() * 1000]
+  def get_run_options(context),
+    do: [
+      save_dataclips: Lightning.Projects.save_dataclips?(context.project_id),
+      run_timeout_ms: Lightning.Config.default_max_run_duration() * 1000
+    ]
 end

--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -11,9 +11,13 @@ defmodule Lightning.Extensions.UsageLimiter do
   def limit_action(_action, _context), do: :ok
 
   @impl true
-  def get_run_options(context),
-    do: [
+  def get_run_options(context) do
+    IO.inspect(context, label: "I get called!")
+
+    [
       save_dataclips: Lightning.Projects.save_dataclips?(context.project_id),
       run_timeout_ms: Lightning.Config.default_max_run_duration() * 1000
     ]
+    |> IO.inspect(label: "And I return the right things!")
+  end
 end

--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -12,12 +12,9 @@ defmodule Lightning.Extensions.UsageLimiter do
 
   @impl true
   def get_run_options(context) do
-    IO.inspect(context, label: "I get called!")
-
     [
       save_dataclips: Lightning.Projects.save_dataclips?(context.project_id),
       run_timeout_ms: Lightning.Config.default_max_run_duration() * 1000
     ]
-    |> IO.inspect(label: "And I return the right things!")
   end
 end

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -41,5 +41,5 @@ defmodule Lightning.Extensions.UsageLimiting do
               :ok | error()
 
   @callback get_run_options(context :: Context.t()) ::
-              LightningWeb.RunWithOptions.run_options()
+              Lightning.Runs.RunOptions.keyword_list()
 end

--- a/lib/lightning/janitor.ex
+++ b/lib/lightning/janitor.ex
@@ -32,10 +32,16 @@ defmodule Lightning.Janitor do
   unfinished runs, and marks them as lost.
   """
   def find_and_update_lost do
-    Runs.Query.lost()
-    |> Repo.all()
-    |> Enum.each(fn run ->
-      Runs.mark_run_lost(run)
+    stream =
+      Runs.Query.lost()
+      |> Repo.stream()
+
+    Repo.transaction(fn ->
+      stream
+      |> Stream.each(fn run ->
+        Runs.mark_run_lost(run)
+      end)
+      |> Stream.run()
     end)
   end
 end

--- a/lib/lightning/janitor.ex
+++ b/lib/lightning/janitor.ex
@@ -32,12 +32,10 @@ defmodule Lightning.Janitor do
   unfinished runs, and marks them as lost.
   """
   def find_and_update_lost do
-    now = DateTime.utc_now()
-
-    Runs.Query.lost(now)
+    Runs.Query.lost()
     |> Repo.all()
-    |> Enum.each(fn att ->
-      Runs.mark_run_lost(att)
+    |> Enum.each(fn run ->
+      Runs.mark_run_lost(run)
     end)
   end
 end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -95,6 +95,22 @@ defmodule Lightning.Projects do
   def get_project(id), do: Repo.get(Project, id)
 
   @doc """
+  Should input or output dataclips be saved for runs in this project?
+  """
+  def save_dataclips?(id) do
+    from(
+      p in Project,
+      where: p.id == ^id,
+      select: p.retention_policy
+    )
+    |> Repo.one!()
+    |> case do
+      :retain_all -> true
+      :erase_all -> false
+    end
+  end
+
+  @doc """
   Gets a single project_user.
 
   Raises `Ecto.NoResultsError` if the ProjectUser does not exist.

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -384,20 +384,6 @@ defmodule Lightning.Projects do
     end)
   end
 
-  @spec project_retention_policy_for(Run.t()) ::
-          Project.retention_policy_type()
-  def project_retention_policy_for(%Run{work_order_id: wo_id}) do
-    query =
-      from(wo in WorkOrder,
-        join: wf in assoc(wo, :workflow),
-        join: p in assoc(wf, :project),
-        where: wo.id == ^wo_id,
-        select: p.retention_policy
-      )
-
-    Repo.one(query)
-  end
-
   def project_runs_query(project) do
     from(att in Run,
       join: wo in assoc(att, :work_order),

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -283,10 +283,10 @@ defmodule Lightning.Runs do
     Handlers.StartStep.call(run, params)
   end
 
-  @spec complete_step(map(), Lightning.Projects.Project.retention_policy_type()) ::
+  @spec complete_step(map(), Lightning.Run.RunOptions) ::
           {:ok, Lightning.Invocation.Step.t()} | {:error, Ecto.Changeset.t()}
-  def complete_step(params, retention_policy \\ :retain_all) do
-    Handlers.CompleteStep.call(params, retention_policy)
+  def complete_step(params, options) do
+    Handlers.CompleteStep.call(params, options)
   end
 
   @spec mark_run_lost(Lightning.Run.t()) ::

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -340,6 +340,5 @@ defmodule Lightning.Runs do
     )
   end
 
-  defp track_run_queue_delay({:error, _changeset}) do
-  end
+  defp track_run_queue_delay({:error, _changeset}), do: nil
 end

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -283,9 +283,9 @@ defmodule Lightning.Runs do
     Handlers.StartStep.call(run, params)
   end
 
-  @spec complete_step(map(), Lightning.Run.RunOptions) ::
+  @spec complete_step(map(), Lightning.Runs.RunOptions) ::
           {:ok, Lightning.Invocation.Step.t()} | {:error, Ecto.Changeset.t()}
-  def complete_step(params, options) do
+  def complete_step(params, options \\ Lightning.Runs.RunOptions) do
     Handlers.CompleteStep.call(params, options)
   end
 

--- a/lib/lightning/runs/handlers.ex
+++ b/lib/lightning/runs/handlers.ex
@@ -178,7 +178,7 @@ defmodule Lightning.Runs.Handlers do
         output_dataclip = get_change(changeset, :output_dataclip)
 
         case {options, output_dataclip, output_dataclip_id} do
-          {%Runs.RunOptions{output_dataclips: false}, _, _} ->
+          {%Runs.RunOptions{save_dataclips: false}, _, _} ->
             changeset
 
           {_, nil, nil} ->
@@ -212,7 +212,7 @@ defmodule Lightning.Runs.Handlers do
       Repo.transact(fn ->
         with %Step{} = step <- get_step(complete_step.step_id),
              {:ok, _} <-
-               maybe_save_dataclip(complete_step, options.output_dataclips) do
+               maybe_save_dataclip(complete_step, options) do
           step
           |> Step.finished(
             complete_step.output_dataclip_id,
@@ -243,7 +243,7 @@ defmodule Lightning.Runs.Handlers do
              project_id: project_id,
              output_dataclip_id: dataclip_id
            },
-           true
+           %Lightning.Runs.RunOptions{save_dataclips: false}
          ) do
       if is_nil(dataclip_id) do
         {:ok, nil}
@@ -261,7 +261,7 @@ defmodule Lightning.Runs.Handlers do
 
     defp maybe_save_dataclip(
            %__MODULE__{output_dataclip: nil},
-           _output_dataclips
+           _run_options
          ) do
       {:ok, nil}
     end
@@ -272,7 +272,7 @@ defmodule Lightning.Runs.Handlers do
              project_id: project_id,
              output_dataclip_id: dataclip_id
            },
-           _output_dataclips
+           _run_options
          ) do
       Dataclip.new(%{
         id: dataclip_id,

--- a/lib/lightning/runs/handlers.ex
+++ b/lib/lightning/runs/handlers.ex
@@ -160,7 +160,7 @@ defmodule Lightning.Runs.Handlers do
       field :finished_at, :utc_datetime_usec
     end
 
-    def new(params, retention_policy) do
+    def new(params, options) do
       cast(%__MODULE__{}, params, [
         :run_id,
         :output_dataclip,
@@ -177,8 +177,8 @@ defmodule Lightning.Runs.Handlers do
         output_dataclip_id = get_change(changeset, :output_dataclip_id)
         output_dataclip = get_change(changeset, :output_dataclip)
 
-        case {retention_policy, output_dataclip, output_dataclip_id} do
-          {:erase_all, _, _} ->
+        case {options, output_dataclip, output_dataclip_id} do
+          {%Runs.RunOptions{output_dataclips: false}, _, _} ->
             changeset
 
           {_, nil, nil} ->
@@ -198,20 +198,21 @@ defmodule Lightning.Runs.Handlers do
       ])
     end
 
-    def call(params, retention_policy) do
+    def call(params, options) do
       with {:ok, complete_step} <-
-             params |> new(retention_policy) |> apply_action(:validate),
-           {:ok, step} <- update_step(complete_step, retention_policy) do
+             params |> new(options) |> apply_action(:validate),
+           {:ok, step} <- update_step(complete_step, options) do
         Runs.Events.step_completed(complete_step.run_id, step)
 
         {:ok, step}
       end
     end
 
-    defp update_step(complete_step, retention_policy) do
+    defp update_step(complete_step, options) do
       Repo.transact(fn ->
         with %Step{} = step <- get_step(complete_step.step_id),
-             {:ok, _} <- maybe_save_dataclip(complete_step, retention_policy) do
+             {:ok, _} <-
+               maybe_save_dataclip(complete_step, options.output_dataclips) do
           step
           |> Step.finished(
             complete_step.output_dataclip_id,
@@ -242,7 +243,7 @@ defmodule Lightning.Runs.Handlers do
              project_id: project_id,
              output_dataclip_id: dataclip_id
            },
-           :erase_all
+           true
          ) do
       if is_nil(dataclip_id) do
         {:ok, nil}
@@ -260,7 +261,7 @@ defmodule Lightning.Runs.Handlers do
 
     defp maybe_save_dataclip(
            %__MODULE__{output_dataclip: nil},
-           _retention_policy
+           _output_dataclips
          ) do
       {:ok, nil}
     end
@@ -271,7 +272,7 @@ defmodule Lightning.Runs.Handlers do
              project_id: project_id,
              output_dataclip_id: dataclip_id
            },
-           _retention_policy
+           _output_dataclips
          ) do
       Dataclip.new(%{
         id: dataclip_id,

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -21,7 +21,7 @@ defmodule Lightning.Runs.Query do
     grace_period_ms = Lightning.Config.grace_period() * 1000
 
     # TODO: Remove after live deployment rollouts are done. ====================
-    fallback_max = Application.get_env(:lightning, :max_run_duration_seconds)
+    fallback_max = Lightning.Config.default_max_run_duration()
 
     fallback_oldest_claim =
       now

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -10,28 +10,29 @@ defmodule Lightning.Runs.Query do
 
   @doc """
   Return all runs that have been claimed by a worker before the earliest
-  acceptable start time (determined by the longest acceptable run time) but are
+  acceptable start time (determined by the run options and grace period) but are
   still incomplete. This indicates that we may have lost contact with the worker
   that was responsible for executing the run.
   """
-  @spec lost(DateTime.t()) :: Ecto.Queryable.t()
-  def lost(%DateTime{} = now) do
-    max_run_duration_seconds =
-      Application.get_env(:lightning, :max_run_duration_seconds)
+  @spec lost() :: Ecto.Queryable.t()
+  def lost() do
+    now = DateTime.utc_now()
 
-    grace_period = Lightning.Config.grace_period()
-
-    oldest_valid_claim =
-      now
-      |> DateTime.add(-max_run_duration_seconds, :second)
-      |> DateTime.add(-grace_period, :second)
+    grace_period_ms = Lightning.Config.grace_period() * 1000
 
     final_states = Run.final_states()
 
-    from(att in Run,
-      where: is_nil(att.finished_at),
-      where: att.state not in ^final_states,
-      where: att.claimed_at < ^oldest_valid_claim
+    from(r in Run,
+      where: is_nil(r.finished_at),
+      where: r.state not in ^final_states,
+      where:
+        fragment(
+          "? + ((? ->> 'run_timeout_ms')::int + ?) * '1 millisecond'::interval < ?",
+          r.claimed_at,
+          r.options,
+          ^grace_period_ms,
+          ^now
+        )
     )
   end
 end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -14,8 +14,8 @@ defmodule Lightning.Runs.Query do
   still incomplete. This indicates that we may have lost contact with the worker
   that was responsible for executing the run.
   """
-  @spec lost() :: Ecto.Queryable.t()
-  def lost() do
+  @spec lost :: Ecto.Queryable.t()
+  def lost do
     now = DateTime.utc_now()
 
     grace_period_ms = Lightning.Config.grace_period() * 1000

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -16,7 +16,7 @@ defmodule Lightning.Runs.Query do
   """
   @spec lost :: Ecto.Queryable.t()
   def lost do
-    now = DateTime.utc_now()
+    now = Lightning.current_time()
 
     grace_period_ms = Lightning.Config.grace_period() * 1000
 

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -64,7 +64,7 @@ defmodule Lightning.Run do
       join_through: RunStep,
       preload_order: [asc: :started_at]
 
-    field :options, :map
+    embeds_one :options, Lightning.Runs.RunOptions
 
     field :state, Ecto.Enum,
       values:

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -10,7 +10,7 @@ defmodule Lightning.Run do
   import Lightning.Validators
 
   alias Lightning.Accounts.User
-  alias Lightning.Extensions.UsageLimiter
+  alias Lightning.Services.UsageLimiter
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Invocation.LogLine
   alias Lightning.Invocation.Step

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -10,6 +10,8 @@ defmodule Lightning.Run do
   import Lightning.Validators
 
   alias Lightning.Accounts.User
+  alias Lightning.Extensions.UsageLimiter
+  alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Invocation.LogLine
   alias Lightning.Invocation.Step
   alias Lightning.RunStep
@@ -62,6 +64,8 @@ defmodule Lightning.Run do
       join_through: RunStep,
       preload_order: [asc: :started_at]
 
+    field :options, :map
+
     field :state, Ecto.Enum,
       values:
         Enum.concat(
@@ -93,6 +97,7 @@ defmodule Lightning.Run do
     |> put_assoc(:starting_trigger, trigger)
     |> put_assoc(:dataclip, attrs[:dataclip])
     |> put_assoc(:snapshot, attrs[:snapshot])
+    |> add_options(attrs.dataclip.project_id)
     |> validate_required_assoc(:dataclip)
     |> validate_required_assoc(:snapshot)
     |> validate_required_assoc(:starting_trigger)
@@ -105,6 +110,7 @@ defmodule Lightning.Run do
     |> put_assoc(:dataclip, attrs[:dataclip])
     |> put_assoc(:snapshot, attrs[:snapshot])
     |> put_assoc(:starting_job, job)
+    |> add_options(attrs.dataclip.project_id)
     |> validate_required_assoc(:created_by)
     |> validate_required_assoc(:dataclip)
     |> validate_required_assoc(:snapshot)
@@ -125,6 +131,19 @@ defmodule Lightning.Run do
     |> validate_required([:work_order_id, :snapshot_id])
     |> assoc_constraint(:work_order)
     |> validate()
+  end
+
+  @doc """
+  Adds options (project-level logging options, resource limits such as timeout
+  and memory usage, etc.) to the run before storing in the DB.
+  """
+  def add_options(changeset, project_id) do
+    put_change(
+      changeset,
+      :options,
+      UsageLimiter.get_run_options(%Context{project_id: project_id})
+      |> Enum.into(%{})
+    )
   end
 
   def start(run) do

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -10,11 +10,11 @@ defmodule Lightning.Run do
   import Lightning.Validators
 
   alias Lightning.Accounts.User
-  alias Lightning.Services.UsageLimiter
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Invocation.LogLine
   alias Lightning.Invocation.Step
   alias Lightning.RunStep
+  alias Lightning.Services.UsageLimiter
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Trigger

--- a/lib/lightning/runs/run_options.ex
+++ b/lib/lightning/runs/run_options.ex
@@ -7,6 +7,6 @@ defmodule Lightning.Runs.RunOptions do
 
   embedded_schema do
     field :save_dataclips, :boolean, default: true
-    field :run_timeout_ms, :integer, default: 10_000
+    field :run_timeout_ms, :integer, default: 60_000
   end
 end

--- a/lib/lightning/runs/run_options.ex
+++ b/lib/lightning/runs/run_options.ex
@@ -6,8 +6,7 @@ defmodule Lightning.Runs.RunOptions do
   use Ecto.Schema
 
   embedded_schema do
-    field :burn_input_after_reading, :boolean, default: false
-    field :output_dataclips, :boolean, default: true
+    field :save_dataclips, :boolean, default: true
     field :run_timeout_ms, :integer, default: 10_000
   end
 end

--- a/lib/lightning/runs/run_options.ex
+++ b/lib/lightning/runs/run_options.ex
@@ -1,0 +1,13 @@
+defmodule Lightning.Runs.RunOptions do
+  @moduledoc """
+  Options that are passed to the worker to control configurable limits and
+  behaviors during run execution and reporting.
+  """
+  use Ecto.Schema
+
+  embedded_schema do
+    field :burn_input_after_reading, :boolean, default: false
+    field :output_dataclips, :boolean, default: true
+    field :run_timeout_ms, :integer, default: 10_000
+  end
+end

--- a/lib/lightning/runs/run_options.ex
+++ b/lib/lightning/runs/run_options.ex
@@ -15,6 +15,7 @@ defmodule Lightning.Runs.RunOptions do
           run_timeout_ms: integer()
         ]
 
+  @primary_key false
   embedded_schema do
     field :save_dataclips, :boolean, default: true
     field :run_timeout_ms, :integer, default: 60_000

--- a/lib/lightning/runs/run_options.ex
+++ b/lib/lightning/runs/run_options.ex
@@ -5,6 +5,16 @@ defmodule Lightning.Runs.RunOptions do
   """
   use Ecto.Schema
 
+  @type t :: %__MODULE__{
+          save_dataclips: boolean(),
+          run_timeout_ms: integer()
+        }
+
+  @type keyword_list :: [
+          save_dataclips: boolean(),
+          run_timeout_ms: integer()
+        ]
+
   embedded_schema do
     field :save_dataclips, :boolean, default: true
     field :run_timeout_ms, :integer, default: 60_000

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -344,6 +344,7 @@ defmodule Lightning.WorkOrders do
         |> put_assoc(:starting_job, starting_job)
         |> put_assoc(:steps, steps)
         |> put_assoc(:created_by, creating_user)
+        |> Run.add_options(dataclip.project_id)
         |> validate_required_assoc(:snapshot)
         |> validate_required_assoc(:dataclip)
         |> validate_required_assoc(:work_order)

--- a/lib/lightning/workers.ex
+++ b/lib/lightning/workers.ex
@@ -56,7 +56,7 @@ defmodule Lightning.Workers do
 
   @spec generate_run_token(
           Lightning.Run.t(),
-          LightningWeb.RunWithOptions.run_options()
+          Lightning.Runs.RunOptions.t()
         ) :: binary()
   def generate_run_token(run, run_options) do
     run_timeout_ms = run_options[:run_timeout_ms]

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -5,12 +5,9 @@ defmodule LightningWeb.RunChannel do
   use LightningWeb, :channel
 
   alias Lightning.Credentials
-  # alias Lightning.Extensions.UsageLimiting.Context
-  # alias Lightning.Projects
   alias Lightning.Repo
   alias Lightning.Runs
   alias Lightning.Scrubber
-  # alias Lightning.Services.UsageLimiter
   alias Lightning.Workers
   alias LightningWeb.RunWithOptions
 

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -7,6 +7,16 @@ defmodule LightningWeb.RunWithOptions do
   alias Lightning.Workflows.Snapshot.Job
   alias Lightning.Workflows.Snapshot.Trigger
 
+  @doc """
+  Plan.render takes a "run" from `Lightning` and renders a "plan"—a JSON object
+  that contains information required by the `Worker` to start execution.
+
+  Note that there is a lot of overlap between the `RunOptions` stored in
+  Lightning and the optional arguments that are passed to the worker. (I.e.,
+  they are almost the same.) This render function is the single source of truth
+  for that mapping: it takes a bunch of Lightning resources and turns them into
+  a Worker-executable plan for a run.
+  """
   @spec render(Run.t()) :: map()
   def render(%Run{} = run) do
     %{
@@ -15,7 +25,8 @@ defmodule LightningWeb.RunWithOptions do
       "jobs" => run.snapshot.jobs |> Enum.map(&render/1),
       "edges" => run.snapshot.edges |> Enum.map(&render/1),
       "starting_node_id" => run.starting_trigger_id || run.starting_job_id,
-      "dataclip_id" => run.dataclip_id
+      "dataclip_id" => run.dataclip_id,
+      "options" => options_for_worker(run.options)
     }
   end
 
@@ -65,5 +76,17 @@ defmodule LightningWeb.RunWithOptions do
       nil -> nil
       c -> c.id
     end
+  end
+
+  @doc """
+  Converts `Lightning.Runs.RunOptions` to a map of options that are expected by
+  the worker.
+  """
+  @spec options_for_worker(Runs.RunOptions) :: map()
+  def options_for_worker(%Lightning.Runs.RunOptions{} = options) do
+    %{
+      "output_dataclips" => options.save_dataclips,
+      "run_timeout_ms" => options.run_timeout_ms
+    }
   end
 end

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -7,19 +7,7 @@ defmodule LightningWeb.RunWithOptions do
   alias Lightning.Workflows.Snapshot.Job
   alias Lightning.Workflows.Snapshot.Trigger
 
-  @type run_options :: [
-          output_dataclips: boolean(),
-          run_timeout_ms: non_neg_integer()
-        ]
-
-  @spec render(Run.t(), run_options()) :: map()
-  def render(%Run{} = run, options) do
-    options =
-      options |> Keyword.take([:output_dataclips, :run_timeout_ms]) |> Map.new()
-
-    run |> render() |> Map.put("options", options)
-  end
-
+  @spec render(Run.t()) :: map()
   def render(%Run{} = run) do
     %{
       "id" => run.id,

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -85,8 +85,8 @@ defmodule LightningWeb.RunWithOptions do
   @spec options_for_worker(Runs.RunOptions) :: map()
   def options_for_worker(%Lightning.Runs.RunOptions{} = options) do
     %{
-      "output_dataclips" => options.save_dataclips,
-      "run_timeout_ms" => options.run_timeout_ms
+      output_dataclips: options.save_dataclips,
+      run_timeout_ms: options.run_timeout_ms
     }
   end
 end

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -82,7 +82,7 @@ defmodule LightningWeb.RunWithOptions do
   Converts `Lightning.Runs.RunOptions` to a map of options that are expected by
   the worker.
   """
-  @spec options_for_worker(Runs.RunOptions) :: map()
+  @spec options_for_worker(Lightning.Runs.RunOptions.t()) :: map()
   def options_for_worker(%Lightning.Runs.RunOptions{} = options) do
     %{
       output_dataclips: options.save_dataclips,

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.WorkerChannel do
   """
   use LightningWeb, :channel
 
-  alias Lightning.Extensions.UsageLimiter
+  alias Lightning.Services.UsageLimiter
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Runs
   alias Lightning.Workers

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -4,9 +4,9 @@ defmodule LightningWeb.WorkerChannel do
   """
   use LightningWeb, :channel
 
-  alias Lightning.Services.UsageLimiter
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Runs
+  alias Lightning.Services.UsageLimiter
   alias Lightning.Workers
 
   @impl true

--- a/priv/repo/migrations/20240514133610_add_options_to_runs.exs
+++ b/priv/repo/migrations/20240514133610_add_options_to_runs.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddOptionsToRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      add :options, :map
+    end
+  end
+end

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -266,7 +266,9 @@ defmodule Lightning.FailureAlertTest do
       expect(Lightning.MockConfig, :default_max_run_duration, fn -> 1 end)
 
       run_options =
-        UsageLimiter.get_run_options(%Context{project_id: 123})
+        UsageLimiter.get_run_options(%Context{
+          project_id: run.work_order.workflow.project_id
+        })
 
       {:ok, %{}, socket} =
         LightningWeb.WorkerSocket

--- a/test/lightning/janitor_test.exs
+++ b/test/lightning/janitor_test.exs
@@ -12,6 +12,8 @@ defmodule Lightning.JanitorTest do
       %{triggers: [trigger]} = workflow = insert(:simple_workflow)
       dataclip = insert(:dataclip)
 
+      an_hour_in_seconds = 3600
+
       work_order =
         insert(:workorder,
           workflow: workflow,
@@ -25,7 +27,7 @@ defmodule Lightning.JanitorTest do
           starting_trigger: trigger,
           dataclip: dataclip,
           state: :started,
-          claimed_at: DateTime.utc_now() |> DateTime.add(-3600)
+          claimed_at: DateTime.utc_now() |> DateTime.add(-an_hour_in_seconds)
         )
 
       unfinished_step =
@@ -35,13 +37,61 @@ defmodule Lightning.JanitorTest do
           exit_reason: nil
         )
 
+      normal_run =
+        insert(:run,
+          work_order: work_order,
+          starting_trigger: trigger,
+          dataclip: dataclip,
+          state: :started,
+          claimed_at: DateTime.utc_now()
+        )
+
+      allowable_long_run =
+        insert(:run,
+          work_order: work_order,
+          starting_trigger: trigger,
+          dataclip: dataclip,
+          state: :started,
+          options: %Lightning.Runs.RunOptions{
+            # give a special timeout of an hour _plus_ 5 more seconds
+            run_timeout_ms: an_hour_in_seconds * 1000 + 5000
+          },
+          claimed_at: DateTime.utc_now() |> DateTime.add(-an_hour_in_seconds)
+        )
+
+      lost_long_run =
+        insert(:run,
+          work_order: work_order,
+          starting_trigger: trigger,
+          dataclip: dataclip,
+          state: :started,
+          options: %Lightning.Runs.RunOptions{
+            # give a special timeout of an hour _minus_ 20 seconds
+            run_timeout_ms: an_hour_in_seconds * 1000 - 20_000
+          },
+          claimed_at: DateTime.utc_now() |> DateTime.add(-an_hour_in_seconds)
+        )
+
       Janitor.find_and_update_lost()
 
+      # should be marked lost
       reloaded_run = Repo.get(Run, lost_run.id)
       reloaded_step = Repo.get(Invocation.Step, unfinished_step.id)
 
       assert reloaded_run.state == :lost
       assert reloaded_step.exit_reason == "lost"
+
+      # should NOT be marked lost, normal runtime
+      reloaded_normal_run = Repo.get(Run, normal_run.id)
+      assert reloaded_normal_run.state !== :lost
+
+      # should NOT be marked lost, long runtime
+      reloaded_allowable_long_run = Repo.get(Run, allowable_long_run.id)
+      assert reloaded_allowable_long_run.state !== :lost
+
+      # should be marked lost, despite having a long runtime
+      reloaded_lost_long_run = Repo.get(Run, lost_long_run.id)
+      assert reloaded_lost_long_run.state == :lost
     end
   end
 end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -654,24 +654,6 @@ defmodule Lightning.ProjectsTest do
     end
   end
 
-  describe "project_retention_policy_for/1" do
-    test "returns the correct retention policy for the project associated to the Run" do
-      for policy <- Ecto.Enum.values(Project, :retention_policy) do
-        project = insert(:project, retention_policy: policy)
-        dataclip = insert(:dataclip, project: project)
-
-        %{triggers: [trigger]} =
-          workflow = insert(:simple_workflow, project: project)
-
-        %{runs: [run]} =
-          work_order_for(trigger, workflow: workflow, dataclip: dataclip)
-          |> insert()
-
-        assert Projects.project_retention_policy_for(run) == policy
-      end
-    end
-  end
-
   describe "list_project_admin_emails/1" do
     test "lists emails for users with admin or owner roles in the project" do
       project = insert(:project)

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -60,10 +60,10 @@ defmodule Lightning.Runs.QueryTest do
           dataclip: dataclip,
           state: :claimed,
           options: %Lightning.Runs.RunOptions{
-            # set via default to milliseconds, plus 5000 extra milliseconds
+            # set via default to milliseconds, plus 5000 extra seconds
             run_timeout_ms: default_max * 1000 + 5000
           },
-          claimed_at: DateTime.add(now, -(default_max + 2))
+          claimed_at: DateTime.add(now, -(default_max + 14))
         )
 
       lost_runs =

--- a/test/lightning/runs/telemetry_test.exs
+++ b/test/lightning/runs/telemetry_test.exs
@@ -1,0 +1,50 @@
+defmodule Lightning.Runs.TelemetryTest do
+  use Lightning.DataCase, async: false
+
+  import Mock
+  import Lightning.Factories
+
+  alias Lightning.Runs
+
+  describe "start_run/1" do
+    setup do
+      dataclip = insert(:dataclip)
+      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+
+      %{runs: [run]} =
+        workorder =
+        work_order_for(trigger, workflow: workflow, dataclip: dataclip)
+        |> insert()
+
+      {:ok, run} =
+        Repo.update(run |> Ecto.Changeset.change(state: :claimed))
+
+      Lightning.WorkOrders.subscribe(workflow.project_id)
+
+      %{run: run, workorder_id: workorder.id}
+    end
+
+    test "does not trigger a metric if starting the run was unsuccessful",
+         %{run: run} do
+      ref =
+        :telemetry_test.attach_event_handlers(
+          self(),
+          [[:domain, :run, :queue]]
+        )
+
+      with_mock(
+        Lightning.Repo,
+        transaction: fn _multi -> {:error, nil, nil, nil} end
+      ) do
+        Runs.start_run(run)
+      end
+
+      refute_received {
+        [:domain, :run, :queue],
+        ^ref,
+        %{delay: _delay},
+        %{}
+      }
+    end
+  end
+end

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -1,8 +1,7 @@
 defmodule Lightning.RunsTest do
-  use Lightning.DataCase
+  use Lightning.DataCase, async: true
 
   import Lightning.Factories
-  import Mock
   import Ecto.Query
 
   alias Ecto.Multi
@@ -536,15 +535,6 @@ defmodule Lightning.RunsTest do
       }
     end
 
-    test "indicates if a response was unsuccessful", %{run: run} do
-      with_mock(
-        Lightning.Repo,
-        transaction: fn _multi -> {:error, nil, %Ecto.Changeset{}, nil} end
-      ) do
-        assert Runs.start_run(run) == {:error, %Ecto.Changeset{}}
-      end
-    end
-
     test "triggers a metric if starting the run was successful",
          %{run: run} do
       ref =
@@ -566,29 +556,6 @@ defmodule Lightning.RunsTest do
         [:domain, :run, :queue],
         ^ref,
         %{delay: ^delay},
-        %{}
-      }
-    end
-
-    test "does not trigger a metric if starting the run was unsuccessful",
-         %{run: run} do
-      ref =
-        :telemetry_test.attach_event_handlers(
-          self(),
-          [[:domain, :run, :queue]]
-        )
-
-      with_mock(
-        Lightning.Repo,
-        transaction: fn _multi -> {:error, nil, nil, nil} end
-      ) do
-        Runs.start_run(run)
-      end
-
-      refute_received {
-        [:domain, :run, :queue],
-        ^ref,
-        %{delay: _delay},
         %{}
       }
     end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -8,15 +8,6 @@ defmodule Lightning.VersionControlTest do
 
   import Lightning.GithubHelpers
 
-  setup do
-    Mox.stub_with(
-      Lightning.Extensions.MockUsageLimiter,
-      Lightning.Extensions.UsageLimiter
-    )
-
-    :ok
-  end
-
   describe "create_github_connection/2" do
     test "user with valid oauth token creates connection successfully" do
       Mox.verify_on_exit!()

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -727,7 +727,6 @@ defmodule LightningWeb.RunChannelTest do
       options = run_from_socket.options
       IO.inspect(options, label: "and why is run from socket options...")
 
-
       # TODO - I see that the UsageLimiter is getting called and setting options
       # properly with `save_dataclips: false, run_timeout_ms: 1000`...
       # so why is this assertion false?

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -24,6 +24,8 @@ defmodule LightningWeb.RunChannelTest do
       end
     )
 
+    Mox.stub(Lightning.MockConfig, :default_max_run_duration, fn -> 1 end)
+
     :ok
   end
 
@@ -130,8 +132,6 @@ defmodule LightningWeb.RunChannelTest do
       workflow: workflow,
       credential: credential
     } do
-      expect(Lightning.MockConfig, :default_max_run_duration, 2, fn -> 1 end)
-
       id = run.id
       ref = push(socket, "fetch:plan", %{})
 
@@ -179,7 +179,7 @@ defmodule LightningWeb.RunChannelTest do
                "dataclip_id" => run.dataclip_id,
                "options" => %{
                  output_dataclips: true,
-                 run_timeout_ms: 60_000
+                 run_timeout_ms: 1000
                }
              }
     end
@@ -187,8 +187,6 @@ defmodule LightningWeb.RunChannelTest do
     test "fetch:plan for project with erase_all retention setting", %{
       credential: credential
     } do
-      expect(Lightning.MockConfig, :default_max_run_duration, 2, fn -> 1 end)
-
       project = insert(:project, retention_policy: :erase_all)
 
       workflow_context =
@@ -524,8 +522,6 @@ defmodule LightningWeb.RunChannelTest do
           %{},
           Lightning.Config.worker_token_signer()
         )
-
-      expect(Lightning.MockConfig, :default_max_run_duration, fn -> 1 end)
 
       run_options =
         Lightning.Extensions.MockUsageLimiter.get_run_options(%Context{

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -718,11 +718,15 @@ defmodule LightningWeb.RunChannelTest do
          context do
       %{socket: socket, run: run, workflow: workflow, project: project} = context
 
-      run_from_socket = socket.assigns.run
-      options = run_from_socket.options
-
       # dataclip is saved but wiped
       assert project.retention_policy == :erase_all
+
+      IO.inspect(run.options, label: "so why is run options...")
+
+      run_from_socket = socket.assigns.run
+      options = run_from_socket.options
+      IO.inspect(options, label: "and why is run from socket options...")
+
 
       # TODO - I see that the UsageLimiter is getting called and setting options
       # properly with `save_dataclips: false, run_timeout_ms: 1000`...

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -139,6 +139,8 @@ defmodule LightningWeb.RunChannelTest do
     } do
       expect(Lightning.MockConfig, :default_max_run_duration, 2, fn -> 1 end)
 
+      IO.inspect(project, label: "project")
+
       id = run.id
       ref = push(socket, "fetch:plan", %{})
 
@@ -177,9 +179,6 @@ defmodule LightningWeb.RunChannelTest do
         )
         |> Enum.map(&stringify_keys/1)
 
-      run_options =
-        UsageLimiter.get_run_options(%Context{project_id: project.id})
-
       assert payload == %{
                "id" => id,
                "triggers" => triggers,
@@ -188,8 +187,8 @@ defmodule LightningWeb.RunChannelTest do
                "starting_node_id" => run.starting_trigger_id,
                "dataclip_id" => run.dataclip_id,
                "options" => %{
-                 output_dataclips: true,
-                 run_timeout_ms: run_options[:run_timeout_ms]
+                 "output_dataclips" => true,
+                 "run_timeout_ms" => 10_000
                }
              }
     end
@@ -249,9 +248,6 @@ defmodule LightningWeb.RunChannelTest do
         )
         |> Enum.map(&stringify_keys/1)
 
-      run_options =
-        UsageLimiter.get_run_options(%Context{project_id: project.id})
-
       assert payload == %{
                "id" => id,
                "triggers" => triggers,
@@ -261,7 +257,7 @@ defmodule LightningWeb.RunChannelTest do
                "dataclip_id" => run.dataclip_id,
                "options" => %{
                  output_dataclips: false,
-                 run_timeout_ms: run_options[:run_timeout_ms]
+                 run_timeout_ms: run.options.run_timeout_ms
                }
              }
     end

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -12,11 +12,6 @@ defmodule LightningWeb.RunChannelTest do
   import Lightning.BypassHelpers
 
   setup do
-    Mox.stub_with(
-      Lightning.Extensions.MockUsageLimiter,
-      Lightning.Extensions.UsageLimiter
-    )
-
     Mox.stub(Lightning.Extensions.MockUsageLimiter, :check_limits, fn _context ->
       :ok
     end)
@@ -28,13 +23,6 @@ defmodule LightningWeb.RunChannelTest do
         :ok
       end
     )
-
-    # TODO - This seems unnecessary.
-    # Mox.stub(
-    #   Lightning.Extensions.MockUsageLimiter,
-    #   :get_run_options,
-    #   &Lightning.Extensions.UsageLimiter.get_run_options/1
-    # )
 
     :ok
   end
@@ -521,7 +509,12 @@ defmodule LightningWeb.RunChannelTest do
         insert(:run,
           work_order: work_order,
           starting_trigger: trigger,
-          dataclip: dataclip
+          dataclip: dataclip,
+          options:
+            Lightning.Extensions.MockUsageLimiter.get_run_options(%Context{
+              project_id: project.id
+            })
+            |> Enum.into(%{})
         )
 
       Lightning.Stub.reset_time()
@@ -720,16 +713,11 @@ defmodule LightningWeb.RunChannelTest do
 
       # dataclip is saved but wiped
       assert project.retention_policy == :erase_all
-
-      IO.inspect(run.options, label: "so why is run options...")
+      assert run.work_order.workflow.project_id == project.id
 
       run_from_socket = socket.assigns.run
       options = run_from_socket.options
-      IO.inspect(options, label: "and why is run from socket options...")
 
-      # TODO - I see that the UsageLimiter is getting called and setting options
-      # properly with `save_dataclips: false, run_timeout_ms: 1000`...
-      # so why is this assertion false?
       assert %Lightning.Runs.RunOptions{save_dataclips: false} = options
 
       [job] = workflow.jobs
@@ -792,7 +780,12 @@ defmodule LightningWeb.RunChannelTest do
         insert(:run,
           work_order: work_order,
           starting_trigger: trigger,
-          dataclip: dataclip
+          dataclip: dataclip,
+          options:
+            Lightning.Extensions.MockUsageLimiter.get_run_options(%Context{
+              project_id: project.id
+            })
+            |> Enum.into(%{})
         )
 
       Lightning.Stub.reset_time()
@@ -938,7 +931,12 @@ defmodule LightningWeb.RunChannelTest do
           work_order: work_order,
           starting_trigger: trigger,
           dataclip: dataclip,
-          state: run_state
+          state: run_state,
+          options:
+            Lightning.Extensions.MockUsageLimiter.get_run_options(%Context{
+              project_id: project.id
+            })
+            |> Enum.into(%{})
         )
 
       Lightning.Stub.reset_time()

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -46,7 +46,8 @@ defmodule LightningWeb.RunWithOptionsTest do
             }
           ],
           "starting_node_id" => trigger.id,
-          "triggers" => [%{"id" => trigger.id}]
+          "triggers" => [%{"id" => trigger.id}],
+          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 60000}
         }
 
       run = Runs.get_for_worker(run.id)
@@ -94,7 +95,8 @@ defmodule LightningWeb.RunWithOptionsTest do
             }
           ],
           "starting_node_id" => trigger.id,
-          "triggers" => [%{"id" => trigger.id}]
+          "triggers" => [%{"id" => trigger.id}],
+          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 60000}
         }
 
       assert RunWithOptions.render(run)
@@ -112,8 +114,8 @@ defmodule LightningWeb.RunWithOptionsTest do
       }
 
       expected_worker_options = %{
-        output_dataclips: false,
-        run_timeout_ms: 123
+        "output_dataclips" => true,
+        "run_timeout_ms" => 123
       }
 
       assert RunWithOptions.options_for_worker(lightning_options) ==

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -103,4 +103,21 @@ defmodule LightningWeb.RunWithOptionsTest do
                expected_result
     end
   end
+
+  describe "options_for_worker/1" do
+    test "converts RunOptions to options for the worker" do
+      lightning_options = %Lightning.Runs.RunOptions{
+        save_dataclips: true,
+        run_timeout_ms: 123
+      }
+
+      expected_worker_options = %{
+        output_dataclips: false,
+        run_timeout_ms: 123
+      }
+
+      assert RunWithOptions.options_for_worker(lightning_options) ==
+               expected_worker_options
+    end
+  end
 end

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -114,8 +114,8 @@ defmodule LightningWeb.RunWithOptionsTest do
       }
 
       expected_worker_options = %{
-        "output_dataclips" => true,
-        "run_timeout_ms" => 123
+        output_dataclips: true,
+        run_timeout_ms: 123
       }
 
       assert RunWithOptions.options_for_worker(lightning_options) ==

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -40,6 +40,11 @@ defmodule LightningWeb.ChannelCase do
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
 
+    Mox.stub_with(
+      Lightning.Extensions.MockUsageLimiter,
+      Lightning.Extensions.UsageLimiter
+    )
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -47,6 +47,11 @@ defmodule LightningWeb.ConnCase do
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
 
+    Mox.stub_with(
+      Lightning.Extensions.MockUsageLimiter,
+      Lightning.Extensions.UsageLimiter
+    )
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -41,6 +41,11 @@ defmodule Lightning.DataCase do
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
 
+    Mox.stub_with(
+      Lightning.Extensions.MockUsageLimiter,
+      Lightning.Extensions.UsageLimiter
+    )
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -98,7 +98,8 @@ defmodule Lightning.Factories do
 
   def run_factory do
     %Lightning.Run{
-      id: fn -> Ecto.UUID.generate() end
+      id: fn -> Ecto.UUID.generate() end,
+      options: %Lightning.Runs.RunOptions{}
     }
   end
 


### PR DESCRIPTION
To fix #2079 and close #2082, this changes the way we determine run options. It stores them in the DB at the time the run was created, rather than calculating them on the fly when a worker claims a run. This makes the application more predictable. Fewer surprises!

## Validation Steps

1. run migrations
2. start server
3. create a run
4. verify that the run options in the db are correct (see timeout and save_dataclips)
5. stop server, set default run timeout to something SUPER SHORT, restart WITHOUT a running worker
6. create a run
7. verify that options are set up correctly in DB.
8. stop server, set default run timeout to something big again, restart WITH a running worker.
9. notice that the worker respects the timeout from when the run was created, not from when the run was claimed.
10. repeat the same process as above, but modify the project settings persist-dataclips option. you'll see that the option that was selected when the run is _created_ is peristed and respected, not the option that was selected when the run was claimed.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature

---

~Required context (pre-reading) to review:~

~- https://github.com/OpenFn/lightning/issues/2079~
~- https://github.com/OpenFn/lightning/issues/2082~

~Note that if~ ✨ we like this idea ✨ , ~next we still need to:~

1. ~remove the "get options" bit that happens during claim~
12. ~ensure that these options are delivered properly via the channel to the worker~
13. ~check to see which options are set by the project admin (e.g., enable dataclip storage) and which options are set by the instance administrator (e.g., max run duration)~