### PR TITLE
Send OAuth2 refresh errors to the logger

### DIFF
--- a/lib/lightning/auth_providers/common.ex
+++ b/lib/lightning/auth_providers/common.ex
@@ -89,7 +89,7 @@ defmodule Lightning.AuthProviders.Common do
   Retrieves user information from the OAuth provider.
   """
   def get_userinfo(client, token, wellknown_url) do
-    {:ok, wellknown} = get_wellknown(wellknown_url)
+    {:ok, wellknown} = get_wellknown(wellknown_url) |> IO.inspect()
 
     OAuth2.Client.get(%{client | token: token}, wellknown.userinfo_endpoint)
   end

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -113,6 +113,24 @@ defmodule LightningWeb.RunChannel do
       :not_found ->
         {:reply, {:error, %{errors: %{id: ["Credential not found!"]}}}, socket}
 
+      # TODO - would it be OK to send the actual error back to the logger?
+      # https://github.com/OpenFn/lightning/issues/1842#issuecomment-2109682877
+      # @openfn/ws-worker@1.1.9-pre will now handle this!
+      # {:error, %{body: %{"error" => "invalid_grant", "error_description" => "expired access/refresh token"}}
+      {:error,
+       %{
+         body: %{
+           "error" => error,
+           "error_description" => error_description
+         }
+       }} ->
+        # TODO - how can we ensure this is safe to send back?
+        {:reply,
+         {
+           :error,
+           %{errors: %{id: ["#{inspect(error)}: #{inspect(error_description)}"]}}
+         }, socket}
+
       {:error, error} ->
         Logger.error(fn ->
           """

--- a/lib/lightning_web/live/credential_live/form_component.ex
+++ b/lib/lightning_web/live/credential_live/form_component.ex
@@ -48,6 +48,8 @@ defmodule LightningWeb.CredentialLive.FormComponent do
 
   @impl true
   def update(%{body: body}, socket) do
+    IO.inspect(body, label: "Token in body")
+
     {:ok,
      update(socket, :changeset, fn changeset, %{credential: credential} ->
        params = changeset.params |> Map.put("body", body)
@@ -61,6 +63,8 @@ defmodule LightningWeb.CredentialLive.FormComponent do
 
     users = list_users()
     scopes = get_scopes(assigns.credential)
+
+    IO.inspect(assigns.credential.body)
 
     sandbox_value = get_sandbox_value(assigns.credential)
 
@@ -424,7 +428,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
                   label="Sandbox instance?"
                   phx-change="check_sandbox"
                   phx-target={@myself}
-                  id="salesforce_sandbox_instance_checkbox"
+                  id={"salesforce_sandbox_instance_checkbox_#{@credential.id || "new"}"}
                 />
 
                 <.input
@@ -436,7 +440,7 @@ defmodule LightningWeb.CredentialLive.FormComponent do
                   value={@api_version}
                   phx-change="api_version"
                   phx-target={@myself}
-                  id="salesforce_api_version_input"
+                  id={"salesforce_api_version_input_#{@credential.id || "new"}"}
                 />
                 <%= fieldset %>
               </div>
@@ -530,8 +534,6 @@ defmodule LightningWeb.CredentialLive.FormComponent do
       action={@action}
       schema={@schema}
       update_body={@update_body}
-      sandbox_value={@sandbox_value}
-      api_version={@api_version}
       scopes_changed={@scopes_changed}
     >
       <%= render_slot(@inner_block, l) %>
@@ -767,6 +769,8 @@ defmodule LightningWeb.CredentialLive.FormComponent do
          credential_params
        ) do
     %{credential: form_credential} = socket.assigns
+
+    IO.inspect(credential_params, label: "params")
 
     with {:same_user, true} <-
            {:same_user,

--- a/lib/lightning_web/live/credential_live/oauth_component.ex
+++ b/lib/lightning_web/live/credential_live/oauth_component.ex
@@ -21,8 +21,6 @@ defmodule LightningWeb.CredentialLive.OauthComponent do
   attr :action, :any, required: true
   attr :scopes_changed, :boolean, default: false
   attr :schema, :string, required: true
-  attr :sandbox_value, :boolean, default: false
-  attr :api_version, :string, default: ""
   slot :inner_block
 
   def fieldset(assigns) do
@@ -55,8 +53,6 @@ defmodule LightningWeb.CredentialLive.OauthComponent do
            scopes_changed: @scopes_changed,
            token_body_changeset: @token_body_changeset,
            update_body: @update_body,
-           sandbox_value: @sandbox_value,
-           api_version: @api_version,
            schema: @schema,
            id: "inner-form-#{@id}"
          ],
@@ -565,14 +561,14 @@ defmodule LightningWeb.CredentialLive.OauthComponent do
           id: _id,
           action: _action,
           scopes_changed: _scopes_changed,
-          sandbox_value: _sandbox_value,
-          api_version: _api_version,
           token_body_changeset: _changeset,
           update_body: _body,
           schema: _schema
         } = params,
         socket
       ) do
+    IO.inspect("ARE YOU BEING CALLED ?")
+
     token =
       params.token_body_changeset
       |> Ecto.Changeset.apply_changes()
@@ -600,18 +596,6 @@ defmodule LightningWeb.CredentialLive.OauthComponent do
 
   def update(%{scopes: scopes}, socket) do
     handle_scopes_update(scopes, socket)
-  end
-
-  def update(%{api_version: api_version}, socket) do
-    socket.assigns.token.result
-    |> token_to_params()
-    |> maybe_add_specific_provider_params(
-      socket.assigns,
-      socket.assigns.provider
-    )
-    |> socket.assigns.update_body.()
-
-    {:ok, socket |> assign(api_version: api_version)}
   end
 
   def update(%{sandbox: sandbox}, socket) do
@@ -644,8 +628,6 @@ defmodule LightningWeb.CredentialLive.OauthComponent do
            id: id,
            action: action,
            scopes_changed: scopes_changed,
-           sandbox_value: sandbox_value,
-           api_version: api_version,
            token_body_changeset: token_body_changeset,
            update_body: update_body,
            schema: schema
@@ -662,8 +644,6 @@ defmodule LightningWeb.CredentialLive.OauthComponent do
       token: AsyncResult.ok(token),
       update_body: update_body,
       adapter: adapter,
-      sandbox: sandbox_value,
-      api_version: api_version,
       provider: adapter.provider_name,
       action: action,
       scopes_changed: scopes_changed

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -1482,6 +1482,114 @@ defmodule LightningWeb.CredentialLiveTest do
                sandbox: true
              } = token
     end
+
+    test "update a prod salesforce credential to turn into a sandbox one", %{
+      user: user,
+      bypass: bypass,
+      conn: conn
+    } do
+      # TODO: replace this with a proper Mock via Lightning.Config
+      Lightning.ApplicationHelpers.put_temporary_env(:lightning, :oauth_clients,
+        google: [client_id: "foo"],
+        salesforce: [
+          client_id: "foo",
+          client_secret: "bar",
+          prod_wellknown_url: "http://localhost:#{bypass.port}/auth/.well-known",
+          sandbox_wellknown_url:
+            "http://localhost:#{bypass.port}/auth/.well-known"
+        ]
+      )
+
+      expect_wellknown(bypass)
+
+      expect_token(
+        bypass,
+        Lightning.AuthProviders.Common.get_wellknown!(
+          "http://localhost:#{bypass.port}/auth/.well-known"
+        ),
+        %{
+          access_token: "ya29.a0AVvZ...",
+          refresh_token: "1//03vpp6Li...",
+          expires_at: 3600,
+          token_type: "Bearer",
+          id_token: "eyJhbGciO...",
+          scope: "scope1 scope2"
+        }
+      )
+
+      expect_userinfo(
+        bypass,
+        Lightning.AuthProviders.Common.get_wellknown!(
+          "http://localhost:#{bypass.port}/auth/.well-known"
+        ),
+        """
+        {"picture": "image.png", "name": "Test User"}
+        """
+      )
+
+      expect_introspect(
+        bypass,
+        Lightning.AuthProviders.Common.get_wellknown!(
+          "http://localhost:#{bypass.port}/auth/.well-known"
+        ),
+        %{
+          access_token: "ya29.a0AVvZ...",
+          refresh_token: "1//03vpp6Li...",
+          expires_at: 3600,
+          token_type: "Bearer",
+          id_token: "eyJhbGciO...",
+          scope: "scope1 scope2"
+        }
+      )
+
+      credential =
+        insert(:credential,
+          schema: "salesforce_oauth",
+          user: user,
+          body: %{
+            access_token: "ya29.a0AVvZ...",
+            refresh_token: "1//03vpp6Li...",
+            expires_at: 3600,
+            scope: "scope1 scope2",
+            instance_url: "login.salesforce.com",
+            sandbox: true
+          }
+        )
+
+      token_body = Lightning.AuthProviders.Common.TokenBody.new(credential.body)
+
+      assert token_body.instance_url == "login.salesforce.com"
+      assert token_body.sandbox
+
+      {:ok, view, _html} = live(conn, ~p"/credentials")
+
+      assert view |> has_element?("#credential-form-#{credential.id}")
+
+      view
+      |> element("#salesforce_sandbox_instance_checkbox_#{credential.id}")
+      |> render_change(%{"sandbox" => "false"})
+
+      {:ok, _view, _html} =
+        view
+        |> form("#credential-form-#{credential.id}")
+        |> render_submit()
+        |> follow_redirect(
+          conn,
+          ~p"/credentials"
+        )
+
+      {_path, flash} = assert_redirect(view)
+      assert flash == %{"info" => "Credential updated successfully"}
+
+      credential = Repo.reload!(credential)
+
+      token_body =
+        Lightning.AuthProviders.Common.TokenBody.new(credential.body)
+        |> IO.inspect()
+
+      assert token_body.instance_url == "test.salesforce.com"
+      assert token_body.sandbox
+    end
   end
 
   describe "googlesheets credential" do


### PR DESCRIPTION
Fixes #2135 

This is the lightning side of https://github.com/OpenFn/lightning/issues/1842#issuecomment-2110272907

Questions about how we make this safe... both in terms of "is it a string" (see my simplistic `inspect`) and in terms of "how do we ensure we don't expose things we don't want to expose"?