### PR TITLE
Fix render settings default panel on first load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix render settings default panel on first load
+  [#1971](https://github.com/OpenFn/lightning/pull/1971)
+
 ## [v2.4.11] - 2024-05-15
 
 ### Changed

--- a/assets/js/hooks/TabSelector.ts
+++ b/assets/js/hooks/TabSelector.ts
@@ -46,20 +46,23 @@ export default {
 
     window.addEventListener('hashchange', this._onHashChange);
 
-    // The observer is not used on the settings page, i.e this condition 
-    // can be removed if same approach is applied to the inspector 
+    // Get the last segment of the current path
+    const lastPathSegment = window.location.pathname.split('/').at(-1);
+
+    // The observer is not used on the settings page, i.e this condition
+    // can be removed if same approach is applied to the inspector
     // possibly having the #log on the url when the run is created.
-    if (window.location.pathname.split('/').at(-1) == 'settings') {
+    if (lastPathSegment === 'settings') {
       this.hashChanged(this.defaultHash);
     } else {
-      const observer = new MutationObserver((mutationsList, observer) => {
+      const observer = new MutationObserver(mutationsList => {
         for (const mutation of mutationsList) {
           if (mutation.type === 'childList') {
             this.hashChanged(this.getHash() || this.defaultHash);
           }
         }
       });
-  
+
       const config = { childList: true, subtree: true };
       observer.observe(document.body, config);
     }

--- a/assets/js/hooks/TabSelector.ts
+++ b/assets/js/hooks/TabSelector.ts
@@ -46,16 +46,23 @@ export default {
 
     window.addEventListener('hashchange', this._onHashChange);
 
-    const observer = new MutationObserver((mutationsList, observer) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'childList') {
-          this.hashChanged(this.getHash() || this.defaultHash);
+    // The observer is not used on the settings page, i.e this condition 
+    // can be removed if same approach is applied to the inspector 
+    // possibly having the #log on the url when the run is created.
+    if (window.location.pathname.split('/').at(-1) == 'settings') {
+      this.hashChanged(this.defaultHash);
+    } else {
+      const observer = new MutationObserver((mutationsList, observer) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === 'childList') {
+            this.hashChanged(this.getHash() || this.defaultHash);
+          }
         }
-      }
-    });
-
-    const config = { childList: true, subtree: true };
-    observer.observe(document.body, config);
+      });
+  
+      const config = { childList: true, subtree: true };
+      observer.observe(document.body, config);
+    }
   },
   hashChanged(nextHash: string) {
     let activePanel: HTMLElement | null = null;


### PR DESCRIPTION
## Validation Steps

1. Run Lightning and refresh the Dashboard
2. Click on Settings menu and the project panel should appear like:

## Notes for the reviewer

Apply active and inactive styles and select the default panel on `mounted` hook.

The `if` on `window.location` shows that the observer is not used anymore for the settings page.

## Related issue

Fixes #1971

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
