### PR TITLE
Select the inspector log tab by pushing an URL hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to
   [#99](https://github.com/OpenFn/lightning/issues/99)
 - Removes stacked viewer after switching tabs and steps.
   [#2064](https://github.com/OpenFn/lightning/issues/2064)
+- Select the inspector log tab by pushing an URL hash.
+  [#2051](https://github.com/OpenFn/lightning/issues/2051)
 
 ## [v2.4.13] - 2024-05-16
 

--- a/assets/js/hooks/TabSelector.ts
+++ b/assets/js/hooks/TabSelector.ts
@@ -31,7 +31,8 @@ export default {
 
     // Trigger a URL hash change when the server sends a 'push-hash' event.
     this.handleEvent<{ hash: string }>('push-hash', ({ hash }) => {
-      window.location.hash = hash;
+      this.hashChanged(hash);
+      window.location.hash = "#" + hash;
     });
 
     this._onHashChange = _evt => {
@@ -46,25 +47,7 @@ export default {
 
     window.addEventListener('hashchange', this._onHashChange);
 
-    const pathSegments = window.location.pathname.split('/');
-    const isJobInspectorPage = pathSegments.length > 3 && 
-      pathSegments.at(1) === 'projects' && pathSegments.at(3) === 'w';
-
-    // The observer is still needed for the job inspector tabs
-    if (isJobInspectorPage) {
-      const observer = new MutationObserver(mutationsList => {
-        for (const mutation of mutationsList) {
-          if (mutation.type === 'childList') {
-            this.hashChanged(this.getHash() || this.defaultHash);
-          }
-        }
-      });
-
-      const config = { childList: true, subtree: true };
-      observer.observe(document.body, config);
-    } else {
-      this.hashChanged(this.getHash() || this.defaultHash);
-    }
+    this.hashChanged(this.getHash() || this.defaultHash);
   },
   hashChanged(nextHash: string) {
     let activePanel: HTMLElement | null = null;

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1052,9 +1052,18 @@ defmodule LightningWeb.WorkflowLive.Edit do
         %{assigns: %{follow_run: %{id: follow_run_id}}} = socket
       )
       when run.id === follow_run_id do
-    {:noreply,
-     socket
-     |> assign(follow_run: run)}
+    socket =
+      socket
+      |> assign(follow_run: run)
+      |> then(fn socket ->
+        if run.state == :started do
+          push_event(socket, "push-hash", %{hash: "log"})
+        else
+          socket
+        end
+      end)
+
+    {:noreply, socket}
   end
 
   def handle_info(%{}, socket), do: {:noreply, socket}


### PR DESCRIPTION
## Validation Steps

1. Open the job inspector
3. Create a work order
4. It shows the log without TabSelector errors after the run is started. 

## Notes for the reviewer

Uses LV to JS event to push a hash to render the hidden log panel when a new work order is created on job inspector.

## Related issue

Fixes #2051 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
