### PR TITLE
Fix inspector crash when adaptor version is changed while no credential is picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed issue where updating adaptor name and version of job node in the
+  workflow canvas crashes the app when no credential is selected
+  [#99](https://github.com/OpenFn/lightning/issues/99)
+
 ## [v2.4.13] - 2024-05-16
 
 ### Fixed

--- a/lib/lightning_web/live/workflow_live/editor_pane.ex
+++ b/lib/lightning_web/live/workflow_live/editor_pane.ex
@@ -83,8 +83,10 @@ defmodule LightningWeb.WorkflowLive.EditorPane do
     {:noreply, socket}
   end
 
-  defp fetch_credential(project_credential_id) do
-    project_credential_id &&
-      Credentials.get_credential_by_project_credential(project_credential_id)
+  defp fetch_credential(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, _uuid} -> Credentials.get_credential_by_project_credential(id)
+      :error -> nil
+    end
   end
 end


### PR DESCRIPTION
## Validation Steps

### Before this fix (on main branch):

1. Go to the workflow canvas
2. Select a job
3. Make sure no credential is associated with it
4. Change the adapter name and version
5. Open the inspector panel
6. Watch the app throw a tantrum and crash 😞 

### After this fix (on this branch):

1. Go to the workflow canvas
2. Select a job
3. Make sure no credential is associated with it
4. Change the adapter name and version
5. Open the inspector panel
6. Bask in the serenity of a smoothly running app 🧘🏽‍♂️ 


## Notes for the reviewer

## Related issue

Fixes #99

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
