### PR TITLE
Change how we display the version of the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Refactored image and version info
+  [#2097](https://github.com/OpenFn/lightning/pull/2097)
+
 ### Fixed
 
 - Removes stacked viewer after switching tabs and steps.
@@ -31,9 +34,8 @@ and this project adheres to
 - Fixed issue where updating an existing Salesforce credential to use a
   `sandbox` endpoint would not properly re-authenticate.
   [#1842](https://github.com/OpenFn/lightning/issues/1842)
-- Navigate directly to settings from url hash and renders default panel 
-  when there is no hash. 
-  [#1971](https://github.com/OpenFn/lightning/issues/1971)
+- Navigate directly to settings from url hash and renders default panel when
+  there is no hash. [#1971](https://github.com/OpenFn/lightning/issues/1971)
 
 ## [v2.4.12] - 2024-05-15
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -301,9 +301,6 @@ if api_key = env!("MAILGUN_API_KEY", :string, nil) do
     domain: env!("MAILGUN_DOMAIN", :string)
 end
 
-url_port = env!("URL_PORT", :integer, 443)
-url_scheme = env!("URL_SCHEME", :string, "https")
-
 # Use the `PRIMARY_ENCRYPTION_KEY` env variable if available, else fall back
 # to defaults.
 # Defaults are set for `dev` and `test` modes.
@@ -347,8 +344,10 @@ config :lightning, Lightning.Repo,
   queue_target: env!("DATABASE_QUEUE_TARGET", :integer, 50),
   queue_interval: env!("DATABASE_QUEUE_INTERVAL", :integer, 1000)
 
+url_scheme = env!("URL_SCHEME", :string, "https")
 host = env!("URL_HOST", :string, "example.com")
 port = env!("PORT", :integer, 4000)
+url_port = env!("URL_PORT", :integer, 443)
 
 if config_env() == :prod do
   unless database_url do
@@ -451,14 +450,6 @@ if config_env() == :test do
   config :ex_unit,
     assert_receive_timeout: env!("ASSERT_RECEIVE_TIMEOUT", :integer, 600)
 end
-
-# TODO: set this up properly: https://github.com/OpenFn/thunderbolt/issues/60
-# release =
-#   case image_tag do
-#     nil -> "mix-v#{Application.spec(:lightning, :vsn)}"
-#     "edge" -> commit
-#     _other -> image_tag
-#   end
 
 config :sentry,
   dsn: env!("SENTRY_DSN", :string, nil),

--- a/lib/lightning.ex
+++ b/lib/lightning.ex
@@ -13,8 +13,8 @@ defmodule Lightning do
 
     This behaviour is used to mock specific functions in tests.
     """
-    @pubsub Lightning.PubSub
     @behaviour Lightning
+    @pubsub Lightning.PubSub
 
     @impl true
     def current_time do
@@ -68,7 +68,7 @@ defmodule Lightning do
   def subscribe(topic), do: impl().subscribe(topic)
 
   @spec release() :: release_info()
-  def release(), do: impl().release()
+  def release, do: impl().release()
 
   defp impl do
     Application.get_env(:lightning, __MODULE__, API)

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -73,18 +73,4 @@ defmodule Lightning.Helpers do
   def json_safe(a) when is_atom(a) and not is_boolean(a), do: Atom.to_string(a)
 
   def json_safe(any), do: any
-
-  def version_data do
-    %{branch: branch, commit: commit, image_tag: image} =
-      :lightning
-      |> Application.get_env(:image_info)
-      |> Enum.into(%{})
-
-    %{
-      branch: branch,
-      commit: commit,
-      image: image,
-      spec_version: "v#{Application.spec(:lightning, :vsn)}"
-    }
-  end
 end

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -299,7 +299,7 @@ defmodule LightningWeb.Components.Common do
           :http_request -> ~w[bg-green-500 text-green-900]
           :global -> ~w[bg-blue-500 text-blue-900]
           :saved_input -> ~w[bg-yellow-500 text-yellow-900]
-          _ -> []
+          _other -> []
         end
 
     assigns = assign(assigns, class: class)

--- a/test/lightning/helpers_test.exs
+++ b/test/lightning/helpers_test.exs
@@ -1,8 +1,7 @@
 defmodule Lightning.HelpersTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
-  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
-  import Lightning.Helpers, only: [coerce_json_field: 2, version_data: 0]
+  import Lightning.Helpers, only: [coerce_json_field: 2]
 
   test "coerce_json_field/2 will transform a json string inside a map by it's key" do
     input = %{
@@ -54,41 +53,5 @@ defmodule Lightning.HelpersTest do
              name: "Sadio Mane",
              goals: 123
            }
-  end
-
-  describe "version_data" do
-    test "returns data that can be used to represent the instance version" do
-      put_temporary_env(:lightning, :image_info,
-        branch: "foo-bar",
-        commit: "abc123",
-        image_tag: "vx.y.z"
-      )
-
-      expected = %{
-        branch: "foo-bar",
-        commit: "abc123",
-        image: "vx.y.z",
-        spec_version: "v#{Application.spec(:lightning, :vsn)}"
-      }
-
-      assert version_data() == expected
-    end
-
-    test "correctly deals with nil values" do
-      put_temporary_env(:lightning, :image_info,
-        branch: nil,
-        commit: nil,
-        image_tag: nil
-      )
-
-      expected = %{
-        branch: nil,
-        commit: nil,
-        image: nil,
-        spec_version: "v#{Application.spec(:lightning, :vsn)}"
-      }
-
-      assert version_data() == expected
-    end
   end
 end

--- a/test/lightning/usage_tracking/report_data_test.exs
+++ b/test/lightning/usage_tracking/report_data_test.exs
@@ -1,7 +1,6 @@
 defmodule Lightning.UsageTracking.ReportDataTest do
   use Lightning.DataCase, async: false
 
-  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
   import Mock
 
   alias Lightning.UsageTracking
@@ -416,11 +415,15 @@ defmodule Lightning.UsageTracking.ReportDataTest do
   defp setup_data_for_version_generation(context) do
     commit = "abc123"
 
-    put_temporary_env(:lightning, :image_info,
-      branch: "foo-bar",
-      commit: commit,
-      image_tag: "edge"
-    )
+    Mox.stub(LightningMock, :release, fn ->
+      %{
+        label: "v#{Application.spec(:lightning, :vsn)}",
+        commit: commit,
+        image_tag: "edge",
+        branch: "main",
+        vsn: Application.spec(:lightning, :vsn)
+      }
+    end)
 
     context
     |> Map.merge(%{

--- a/test/lightning/workers_test.exs
+++ b/test/lightning/workers_test.exs
@@ -3,6 +3,12 @@ defmodule Lightning.WorkersTest do
 
   alias Lightning.Workers.Token
 
+  setup do
+    Mox.stub_with(LightningMock, Lightning.API)
+
+    :ok
+  end
+
   describe "Token" do
     test "can generate a token" do
       {:ok, token, claims} =

--- a/test/lightning_web/live/components/common_test.exs
+++ b/test/lightning_web/live/components/common_test.exs
@@ -1,16 +1,21 @@
 defmodule LightningWeb.Components.CommonTest do
-  use LightningWeb.ConnCase, async: false
+  use LightningWeb.ConnCase, async: true
 
-  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
   import Phoenix.LiveViewTest
 
   describe "version_chip on docker release" do
     setup do
-      put_temporary_env(:lightning, :image_info,
-        image_tag: "v#{Application.spec(:lightning, :vsn)}",
-        branch: "main",
-        commit: "abcdef7"
-      )
+      Mox.stub(LightningMock, :release, fn ->
+        %{
+          label: "v#{Application.spec(:lightning, :vsn)}",
+          commit: "abcdef7",
+          image_tag: "v#{Application.spec(:lightning, :vsn)}",
+          branch: "main",
+          vsn: Application.spec(:lightning, :vsn)
+        }
+      end)
+
+      :ok
     end
 
     test "displays the version and a badge" do
@@ -27,15 +32,17 @@ defmodule LightningWeb.Components.CommonTest do
   end
 
   describe "version_chip on docker edge" do
-    setup do
-      put_temporary_env(:lightning, :image_info,
-        image_tag: "edge",
-        branch: "main",
-        commit: "abcdef7"
-      )
-    end
-
     test "displays the SHA and a cube" do
+      Mox.stub(LightningMock, :release, fn ->
+        %{
+          label: "v#{Application.spec(:lightning, :vsn)}",
+          commit: "abcdef7",
+          image_tag: "edge",
+          branch: "main",
+          vsn: Application.spec(:lightning, :vsn)
+        }
+      end)
+
       html = render_component(&LightningWeb.Components.Common.version_chip/1)
 
       assert html =~ "Docker image tag found"
@@ -48,39 +55,18 @@ defmodule LightningWeb.Components.CommonTest do
     end
   end
 
-  describe "version_chip on tag mismatch" do
-    setup do
-      put_temporary_env(:lightning, :image_info,
-        image_tag: "vX.Y.Z",
-        branch: "main",
-        commit: "abcdef7"
-      )
-    end
-
-    test "displays the version and a badge" do
-      html = render_component(&LightningWeb.Components.Common.version_chip/1)
-
-      assert html =~
-               "Detected image tag that does not match application version"
-
-      assert html =~ "v#{elem(:application.get_key(:lightning, :vsn), 1)}"
-
-      # Check for the warning icon
-      assert html =~
-               "M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-    end
-  end
-
   describe "version_chip on tag mismatch where image_tag == 'edge'" do
-    setup do
-      put_temporary_env(:lightning, :image_info,
-        image_tag: "edge",
-        branch: "main",
-        commit: "abcdef7"
-      )
-    end
-
     test "displays the SHA and a cube" do
+      Mox.stub(LightningMock, :release, fn ->
+        %{
+          label: "v#{Application.spec(:lightning, :vsn)}",
+          commit: "abcdef7",
+          image_tag: "edge",
+          branch: "main",
+          vsn: Application.spec(:lightning, :vsn)
+        }
+      end)
+
       html = render_component(&LightningWeb.Components.Common.version_chip/1)
 
       assert html =~ "Docker image tag found"
@@ -94,15 +80,17 @@ defmodule LightningWeb.Components.CommonTest do
   end
 
   describe "version_chip all other cases" do
-    setup do
-      put_temporary_env(:lightning, :image_info,
-        image_tag: nil,
-        branch: "main",
-        commit: "abcdef7"
-      )
-    end
-
     test "displays the Lightning version without an icon" do
+      Mox.stub(LightningMock, :release, fn ->
+        %{
+          label: "v#{Application.spec(:lightning, :vsn)}",
+          commit: "abcdef7",
+          image_tag: nil,
+          branch: "main",
+          vsn: Application.spec(:lightning, :vsn)
+        }
+      end)
+
       html = render_component(&LightningWeb.Components.Common.version_chip/1)
 
       assert html =~ "Lightning v#{Application.spec(:lightning, :vsn)}"

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -35,7 +35,7 @@ defmodule LightningWeb.ChannelCase do
   setup tags do
     Mox.stub_with(Lightning.MockConfig, Lightning.Config.API)
 
-    Mox.stub_with(Lightning.Mock, Lightning.Stub)
+    Mox.stub_with(LightningMock, Lightning.Stub)
 
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -42,6 +42,8 @@ defmodule LightningWeb.ConnCase do
   setup tags do
     Mox.stub_with(Lightning.MockConfig, Lightning.Config.API)
 
+    Mox.stub_with(LightningMock, Lightning.API)
+
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -36,6 +36,8 @@ defmodule Lightning.DataCase do
   setup tags do
     Mox.stub_with(Lightning.MockConfig, Lightning.Config.API)
 
+    Mox.stub_with(LightningMock, Lightning.API)
+
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)
 

--- a/test/support/mock.ex
+++ b/test/support/mock.ex
@@ -1,6 +1,6 @@
 defmodule Lightning.Stub do
   @moduledoc false
-  @behaviour Lightning.API
+  @behaviour Lightning
 
   @impl true
   def current_time, do: Lightning.API.current_time()
@@ -11,11 +11,14 @@ defmodule Lightning.Stub do
   @impl true
   def subscribe(topic), do: Lightning.API.subscribe(topic)
 
+  @impl true
+  def release(), do: Lightning.API.release()
+
   @doc """
   Resets the current time to the current time.
   """
   def reset_time do
-    Lightning.Mock
+    LightningMock
     |> Mox.stub(:current_time, fn -> DateTime.utc_now() end)
   end
 
@@ -23,9 +26,7 @@ defmodule Lightning.Stub do
   Freezes the current time to the given time.
   """
   def freeze_time(time) do
-    Lightning.Mock
+    LightningMock
     |> Mox.stub(:current_time, fn -> time end)
   end
 end
-
-Mox.defmock(Lightning.Mock, for: Lightning.API)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -33,6 +33,9 @@ Mox.defmock(Lightning.Extensions.MockUsageLimiter,
 Mox.defmock(Lightning.MockConfig, for: Lightning.Config)
 Application.put_env(:lightning, Lightning.Config, Lightning.MockConfig)
 
+Mox.defmock(LightningMock, for: Lightning)
+Application.put_env(:lightning, Lightning, LightningMock)
+
 Application.put_env(:lightning, Lightning.Extensions,
   rate_limiter: Lightning.Extensions.MockRateLimiter,
   usage_limiter: Lightning.Extensions.MockUsageLimiter,


### PR DESCRIPTION
## Notes for the reviewer

- Moved API to use `Lightning` so we can mock/stub it.
- Underneath everything is available on `config(:lightning, :release)`
- Added a `:label` key to `:release` allowing control from outside.
- Sentry uses `:label` by default now.


## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
