### PR TITLE
Remove duplicated unused ids on run viewer

### DIFF
--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -96,7 +96,7 @@ defmodule LightningWeb.RunLive.Show do
                   <:value>
                     <%= if run.finished_at do %>
                       <Common.wrapper_tooltip
-                        id={run.id <> "start-tip"}
+                        id={run.id <> "finish-tip"}
                         tooltip={DateTime.to_iso8601(run.finished_at)}
                       >
                         <%= Timex.Format.DateTime.Formatters.Relative.format!(
@@ -125,7 +125,7 @@ defmodule LightningWeb.RunLive.Show do
                 steps={@steps}
                 class="flex-1 items-center"
               >
-                <.link patch={"?step=#{step.id}"} id={"select-step-#{step.id}"}>
+                <.link patch={"?step=#{step.id}"}>
                   <.step_item
                     step={step}
                     is_clone={


### PR DESCRIPTION
## Validation Steps

1. Go to history page
2. Expand one work order and click to view run (on a link like Run 3e3856ca)
3. Open the console and verify there is no `Multiple IDS detected error`

## Notes for the reviewer

Not an operational fix, just cleans up the console from errors and these ids are not used neither on navigation nor on rendering.

Specific tests can refer to the anchor tag by href if need in the future or by parent `data-step-id`.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
