### PR TITLE
🔧 Fix Misleading 'Not Working' Message for OAuth Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
 
 ### Fixed
 
+- Replace the "not working?" prompt by "All good, but if your credential stops
+  working, you may need to re-authorize here.".
+  [#2102](https://github.com/OpenFn/lightning/issues/1872)
+
 ## [v2.5.0-pre2] - 2024-05-17
 
 ### Changed

--- a/lib/lightning_web/live/components/oauth.ex
+++ b/lib/lightning_web/live/components/oauth.ex
@@ -74,7 +74,7 @@ defmodule LightningWeb.Components.Oauth do
       <div class="flex items-center">
         <img
           src={@userinfo["picture"]}
-          class="h-14 w-14 rounded-full"
+          class="h-20 w-20 rounded-full"
           alt={@userinfo["name"]}
           onerror={"this.onerror=null;this.src='#{Routes.static_path(
               @socket,
@@ -89,8 +89,8 @@ defmodule LightningWeb.Components.Oauth do
           <p class="text-sm text-gray-500">
             <a href="#"><%= @userinfo["email"] %></a>
           </p>
-          <div class="text-sm mt-1">
-            Not working?
+          <div class="text-sm mt-2">
+            All good, but if your credential stops working, you may need to re-authorize
             <.link
               href={@authorize_url}
               target="_blank"
@@ -98,7 +98,7 @@ defmodule LightningWeb.Components.Oauth do
               phx-click="authorize_click"
               class="hover:underline text-primary-900"
             >
-              Reauthorize.
+              here.
             </.link>
           </div>
         </div>


### PR DESCRIPTION
## Validation Steps

## Notes for the reviewer

## Related issue

Re #2102 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
