### PR TITLE
Refactor count workorders to reuse search code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to
 
 ### Changed
 
-- Improve performance and memory consumption on queries and logic for digest
-  mailer [#2121](https://github.com/OpenFn/lightning/issues/2121)
+- Refactor count workorders to reuse search code  
+  [#2121](https://github.com/OpenFn/lightning/issues/2121)
 
 ### Fixed
 
@@ -83,6 +83,8 @@ and this project adheres to
   credentials [#2131](https://github.com/OpenFn/lightning/issues/2131)
 
 ## [v2.5.1]
+
+### Fixed
 
 - Don't compile Phoenix Storybook in production and test environments
   [#2119](https://github.com/OpenFn/lightning/pull/2119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to
 
 ### Changed
 
-- Counts workorders for email digest
-  [#2121](https://github.com/OpenFn/lightning/issues/2121)
+- Improve performance and memory consumption on queries and logic for digest
+  mailer [#2121](https://github.com/OpenFn/lightning/issues/2121)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to
 
 ### Changed
 
+- Counts workorders for email digest
+  [#2121](https://github.com/OpenFn/lightning/issues/2121)
+
 ### Fixed
 
 - Stopped sending emails when creating a starter project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to
 - Preserve custom values (like `apiVersion`) during token refresh for OAuth2
   credentials [#2131](https://github.com/OpenFn/lightning/issues/2131)
 
-## [v2.5.1]
+## [v2.5.1] - 2024-05-21
 
 ### Fixed
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -353,7 +353,7 @@ defmodule Lightning.Invocation do
     |> Repo.paginate(params)
   end
 
-  def search_workorders_without_wiped_dataclips(
+  def search_workorders_for_retry(
         %Project{id: project_id},
         search_params
       ) do

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -325,6 +325,11 @@ defmodule Lightning.Invocation do
     search_workorders(project, search_params, %{})
   end
 
+  @spec search_workorders(
+          Lightning.Projects.Project.t(),
+          SearchParams.t(),
+          keyword | map
+        ) :: Scrivener.Page.t(WorkOrder.t())
   def search_workorders(
         %Project{id: project_id},
         %SearchParams{search_term: search_term} = search_params,
@@ -372,7 +377,7 @@ defmodule Lightning.Invocation do
   end
 
   defp search_workorders_query(
-         base_query,
+         query,
          %SearchParams{status: status_list} = search_params
        ) do
     status_filter =
@@ -382,7 +387,7 @@ defmodule Lightning.Invocation do
         status_list
       end
 
-    base_query
+    query
     |> filter_by_workorder_id(search_params.workorder_id)
     |> filter_by_workflow_id(search_params.workflow_id)
     |> filter_by_statuses(status_filter)

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -326,7 +326,7 @@ defmodule Lightning.Invocation do
   end
 
   def search_workorders(
-        %Project{} = project,
+        %Project{id: project_id},
         %SearchParams{search_term: search_term} = search_params,
         params \\ %{}
       ) do
@@ -347,21 +347,34 @@ defmodule Lightning.Invocation do
         end
       )
 
-    project
+    project_id
+    |> base_query()
     |> search_workorders_query(search_params)
     |> Repo.paginate(params)
   end
 
-  def count_workorders(%Project{} = project, search_params) do
-    project
-    |> count_workorders_query(search_params)
+  def search_workorders_without_wiped_dataclips(
+        %Project{id: project_id},
+        search_params
+      ) do
+    project_id
+    |> base_query_without_preload()
+    |> search_workorders_query(search_params)
+    |> exclude_wiped_dataclips()
+    |> Repo.all()
+  end
+
+  def count_workorders(%Project{id: project_id}, search_params) do
+    project_id
+    |> base_query_without_preload()
+    |> search_workorders_query(search_params)
     |> Repo.aggregate(:count)
   end
 
-  def search_workorders_query(
-        %Project{id: project_id},
-        %SearchParams{status: status_list} = search_params
-      ) do
+  defp search_workorders_query(
+         base_query,
+         %SearchParams{status: status_list} = search_params
+       ) do
     status_filter =
       if SearchParams.all_statuses_set?(search_params) do
         []
@@ -369,7 +382,7 @@ defmodule Lightning.Invocation do
         status_list
       end
 
-    base_query_with_preload(project_id)
+    base_query
     |> filter_by_workorder_id(search_params.workorder_id)
     |> filter_by_workflow_id(search_params.workflow_id)
     |> filter_by_statuses(status_filter)
@@ -383,38 +396,13 @@ defmodule Lightning.Invocation do
     )
   end
 
-  def count_workorders_query(
-        %Project{id: project_id},
-        %SearchParams{status: status_list} = search_params
-      ) do
-    status_filter =
-      if SearchParams.all_statuses_set?(search_params) do
-        []
-      else
-        status_list
-      end
-
-    base_query(project_id)
-    |> filter_by_workorder_id(search_params.workorder_id)
-    |> filter_by_workflow_id(search_params.workflow_id)
-    |> filter_by_statuses(status_filter)
-    |> filter_by_wo_date_after(search_params.wo_date_after)
-    |> filter_by_wo_date_before(search_params.wo_date_before)
-    |> filter_by_date_after(search_params.date_after)
-    |> filter_by_date_before(search_params.date_before)
-    |> filter_by_body_or_log_or_id(
-      search_params.search_fields,
-      search_params.search_term
-    )
-  end
-
-  def exclude_wiped_dataclips(work_order_query) do
+  defp exclude_wiped_dataclips(work_order_query) do
     work_order_query
     |> join(:inner, [workorder: wo], assoc(wo, :dataclip), as: :dataclip)
     |> where([dataclip: d], is_nil(d.wiped_at))
   end
 
-  defp base_query_with_preload(project_id) do
+  defp base_query(project_id) do
     from(
       workorder in WorkOrder,
       as: :workorder,
@@ -433,14 +421,15 @@ defmodule Lightning.Invocation do
     )
   end
 
-  defp base_query(project_id) do
+  defp base_query_without_preload(project_id) do
     from(
       workorder in WorkOrder,
       as: :workorder,
       join: workflow in assoc(workorder, :workflow),
       as: :workflow,
       where: workflow.project_id == ^project_id,
-      select: workorder.id,
+      select: workorder,
+      order_by: [desc_nulls_first: workorder.last_activity],
       distinct: true
     )
   end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -467,7 +467,7 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_without_wiped_dataclips(filter)
+    |> Invocation.search_workorders_for_retry(filter)
     |> WorkOrders.retry_many(job_id,
       created_by: socket.assigns.current_user,
       project_id: socket.assigns.project.id
@@ -486,7 +486,7 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_without_wiped_dataclips(filter)
+    |> Invocation.search_workorders_for_retry(filter)
     |> WorkOrders.retry_many(
       created_by: socket.assigns.current_user,
       project_id: socket.assigns.project.id

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -467,9 +467,7 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_query(filter)
-    |> Invocation.exclude_wiped_dataclips()
-    |> Lightning.Repo.all()
+    |> Invocation.search_workorders_without_wiped_dataclips(filter)
     |> WorkOrders.retry_many(job_id,
       created_by: socket.assigns.current_user,
       project_id: socket.assigns.project.id
@@ -488,9 +486,7 @@ defmodule LightningWeb.RunLive.Index do
     filter = SearchParams.new(socket.assigns.filters)
 
     socket.assigns.project
-    |> Invocation.search_workorders_query(filter)
-    |> Invocation.exclude_wiped_dataclips()
-    |> Lightning.Repo.all()
+    |> Invocation.search_workorders_without_wiped_dataclips(filter)
     |> WorkOrders.retry_many(
       created_by: socket.assigns.current_user,
       project_id: socket.assigns.project.id

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -212,6 +212,41 @@ defmodule Lightning.InvocationTest do
     ).entries()
   end
 
+  describe "search_workorders_without_wiped_dataclips/2" do
+    test "returns workorders without preloading and without wiped dataclips" do
+      project = insert(:project)
+      dataclip = insert(:dataclip)
+      wiped_dataclip = insert(:dataclip, wiped_at: Timex.now())
+
+      %{workflow: workflow, trigger: trigger} =
+        build_workflow(project: project)
+
+      workorders =
+        insert_list(2, :workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip
+        )
+
+      insert_list(2, :workorder,
+        workflow: workflow,
+        trigger: trigger,
+        dataclip: wiped_dataclip
+      )
+
+      assert found_workorders =
+               Invocation.search_workorders_without_wiped_dataclips(
+                 project,
+                 SearchParams.new(%{"status" => SearchParams.status_list()})
+               )
+
+      assert MapSet.new(workorders, & &1.id) ==
+               MapSet.new(found_workorders, & &1.id)
+
+      refute Enum.any?(found_workorders, &Ecto.assoc_loaded?(&1.snapshot))
+    end
+  end
+
   describe "search_workorders/1" do
     test "returns workorders ordered inserted at desc, with nulls first" do
       project = insert(:project)

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -212,7 +212,7 @@ defmodule Lightning.InvocationTest do
     ).entries()
   end
 
-  describe "search_workorders_without_wiped_dataclips/2" do
+  describe "search_workorders_for_retry/2" do
     test "returns workorders without preloading and without wiped dataclips" do
       project = insert(:project)
       dataclip = insert(:dataclip)
@@ -235,7 +235,7 @@ defmodule Lightning.InvocationTest do
       )
 
       assert found_workorders =
-               Invocation.search_workorders_without_wiped_dataclips(
+               Invocation.search_workorders_for_retry(
                  project,
                  SearchParams.new(%{"status" => SearchParams.status_list()})
                )
@@ -243,7 +243,10 @@ defmodule Lightning.InvocationTest do
       assert MapSet.new(workorders, & &1.id) ==
                MapSet.new(found_workorders, & &1.id)
 
+      refute Enum.any?(found_workorders, &Ecto.assoc_loaded?(&1.dataclip))
       refute Enum.any?(found_workorders, &Ecto.assoc_loaded?(&1.snapshot))
+      refute Enum.any?(found_workorders, &Ecto.assoc_loaded?(&1.workflow))
+      refute Enum.any?(found_workorders, &Ecto.assoc_loaded?(&1.runs))
     end
   end
 

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -702,30 +702,6 @@ defmodule Lightning.InvocationTest do
     end
   end
 
-  describe "search_workorders_query/2" do
-    test "ignores status filter when all statuses are queried" do
-      project = insert(:project)
-
-      query =
-        Invocation.search_workorders_query(
-          project,
-          SearchParams.new(%{"status" => ["pending"]})
-        )
-
-      {sql, _value} = Repo.to_sql(:all, query)
-      assert sql =~ ~S["state" = ]
-
-      query =
-        Invocation.search_workorders_query(
-          project,
-          SearchParams.new(%{"status" => SearchParams.status_list()})
-        )
-
-      {sql, _value} = Repo.to_sql(:all, query)
-      refute sql =~ ~S["state" = ]
-    end
-  end
-
   describe "searching across workorders" do
     setup do
       project = insert(:project)


### PR DESCRIPTION
## Validation Steps

`$ mix test test/lightning/digest_email_worker_test.exs`

## Notes for the reviewer

As a continuation of #2118:

- Reuse `search_workorders_query` for counting
- Reuse `search_workorders_query` to return workorders for retries (with dataclips not wiped)

Keeps same behavior as https://github.com/OpenFn/lightning/pull/2123.

## Related issue

Refs #2121

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
