### PR TITLE
🔧 Ensure Refresh Token Inclusion in OAuth Token Post-Refresh

### DIFF
--- a/lib/lightning/auth_providers/oauth_http_client.ex
+++ b/lib/lightning/auth_providers/oauth_http_client.ex
@@ -58,6 +58,13 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     |> post(client.token_endpoint, body)
     |> handle_resp([200])
     |> maybe_introspect(client)
+    |> case do
+      {:ok, new_token} ->
+        {:ok, Map.put_new(new_token, "refresh_token", token["refresh_token"])}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   @doc """

--- a/lib/lightning_web/live/credential_live/generic_oauth_component.ex
+++ b/lib/lightning_web/live/credential_live/generic_oauth_component.ex
@@ -135,13 +135,6 @@ defmodule LightningWeb.CredentialLive.GenericOauthComponent do
 
   @impl true
   def handle_async(:token, {:ok, {:ok, token}}, socket) do
-    token =
-      Map.put_new(
-        token,
-        "refresh_token",
-        socket.assigns.credential.body["refresh_token"]
-      )
-
     params = Map.put(socket.assigns.changeset.params, "body", token)
     changeset = Credentials.change_credential(socket.assigns.credential, params)
     credential = Ecto.Changeset.apply_changes(changeset)

--- a/test/lightning/oauth_http_client_test.exs
+++ b/test/lightning/oauth_http_client_test.exs
@@ -47,6 +47,7 @@ defmodule Lightning.AuthProviders.OauthHTTPClientTest do
       token_endpoint = "http://example.com/refresh"
 
       response_body = %{
+        "refresh_token" => "validRefreshToken",
         "access_token" => "newToken123",
         "token_type" => "bearer"
       }


### PR DESCRIPTION
## Validation Steps

1. Use an expired Salesforce OAuth token in a job
2. See it succeed after token is refreshed
3. Try 1 & 2 again

## Notes for the reviewer

This PR addresses a critical issue to ensure the refresh token is retained during the OAuth token refresh process. Specifically, in Salesforce Sandbox environments, when requesting a token refresh, Salesforce issues a new token without including the refresh token key. Previously, this resulted in the loss of the refresh token value as the new token was saved without it.

## Related issue

Fixes #

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
