### PR TITLE
use Monaco for the log viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Replace LiveView Log Viewer component with React Monaco
+  [#1863](https://github.com/OpenFn/lightning/issues/1863)
+
 ### Changed
 
 ### Fixed

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -218,40 +218,6 @@ div.line-num::before {
   max-width: min-content;
 }
 
-/* Wrapped styles for LogViewer to make the resulting HTML more compact */
-.log-viewer__prefix {
-  @apply border-r
-  border-slate-500/75
-    px-2
-    text-right
-  text-slate-400
-  group-data-[highlight]:border-yellow-400
-    group-data-[highlight]:border-r-2
-    group-data-[highlight]:pr-[calc(0.5rem-1px)]
-  group-hover:bg-slate-600/75
-  group-hover:text-slate-300
-    font-mono
-    proportional-nums;
-
-  &::before {
-    content: attr(data-line-prefix);
-    padding-left: 0.1em;
-    max-width: min-content;
-  }
-}
-
-.log-viewer__message {
-  @apply px-2 group-hover:bg-slate-600/50
-   cursor-text selection:bg-slate-500/50
-   group-first:pt-[0.1rem]
-   font-mono proportional-nums;
-
-  > pre {
-    @apply whitespace-break-spaces;
-    @apply break-all;
-  }
-}
-
 .log-viewer-highlighted {
-  @apply bg-yellow-400 ml-0.5 !w-1;
+  @apply bg-yellow-400 ml-0.5 !w-0.5;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -219,5 +219,5 @@ div.line-num::before {
 }
 
 .log-viewer-highlighted {
-  @apply bg-yellow-400 ml-0.5 !w-0.5;
+  @apply bg-yellow-400 ml-1 !w-0.5;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -222,7 +222,7 @@ div.line-num::before {
 .log-viewer__prefix {
   @apply border-r
   border-slate-500/75
-    px-2 
+    px-2
     text-right
   text-slate-400
   group-data-[highlight]:border-yellow-400
@@ -230,7 +230,7 @@ div.line-num::before {
     group-data-[highlight]:pr-[calc(0.5rem-1px)]
   group-hover:bg-slate-600/75
   group-hover:text-slate-300
-    font-mono 
+    font-mono
     proportional-nums;
 
   &::before {
@@ -241,13 +241,17 @@ div.line-num::before {
 }
 
 .log-viewer__message {
-  @apply px-2 group-hover:bg-slate-600/50 
+  @apply px-2 group-hover:bg-slate-600/50
    cursor-text selection:bg-slate-500/50
-   group-first:pt-[0.1rem] 
+   group-first:pt-[0.1rem]
    font-mono proportional-nums;
 
   > pre {
     @apply whitespace-break-spaces;
     @apply break-all;
   }
+}
+
+.log-viewer-highlighted {
+  @apply bg-yellow-400 ml-0.5 !w-1;
 }

--- a/assets/css/monaco-style-overrides.css
+++ b/assets/css/monaco-style-overrides.css
@@ -2,6 +2,7 @@
 .monaco-editor,
 .monaco-editor .overflow-guard {
   background-color: transparent !important;
+  border-radius: 0.375rem;
 }
 .monaco-editor .margin {
   border-top-left-radius: 0.375rem; /* matches rounded-md */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,12 +30,14 @@ import JobEditor from './job-editor';
 import JobEditorResizer from './job-editor-resizer/mount';
 import WorkflowEditor from './workflow-editor';
 import DataclipViewer from './dataclip-viewer';
+import LogViewer from './log-viewer';
 
 let hooks = {
   JobEditor,
   JobEditorResizer,
   WorkflowEditor,
   DataclipViewer,
+  LogViewer,
   ...Hooks,
 };
 

--- a/assets/js/dataclip-viewer/component.tsx
+++ b/assets/js/dataclip-viewer/component.tsx
@@ -38,7 +38,7 @@ const DataclipViewer = ({ dataclipId }: { dataclipId: string }) => {
   const [content, setContent] = useState<string>('');
 
   useEffect(() => {
-    fetchDataclipContent(dataclipId).then(setContent)
+    fetchDataclipContent(dataclipId).then(setContent);
   }, [dataclipId]);
 
   return (
@@ -57,6 +57,10 @@ const DataclipViewer = ({ dataclipId }: { dataclipId: string }) => {
         fontFamily: 'Fira Code VF',
         fontSize: 14,
         fontLigatures: true,
+        minimap: {
+          enabled: false,
+        },
+        wordWrap: 'on',
       }}
     />
   );

--- a/assets/js/hooks/TabSelector.ts
+++ b/assets/js/hooks/TabSelector.ts
@@ -47,8 +47,10 @@ export default {
     window.addEventListener('hashchange', this._onHashChange);
 
     const pathSegments = window.location.pathname.split('/');
-    const isJobInspectorPage = pathSegments.length > 3 && 
-      pathSegments.at(1) === 'projects' && pathSegments.at(3) === 'w';
+    const isJobInspectorPage =
+      pathSegments.length > 3 &&
+      pathSegments.at(1) === 'projects' &&
+      pathSegments.at(3) === 'w';
 
     // The observer is still needed for the job inspector tabs
     if (isJobInspectorPage) {
@@ -103,9 +105,9 @@ export default {
   },
   applyStyles(activeTab: HTMLElement | null, inactiveTabs: HTMLElement[]) {
     inactiveTabs.forEach(elem => {
-      console.log(elem.dataset);
+      // console.log(elem.dataset);
       if (elem.hasAttribute('data-disabled')) {
-        console.log(elem);
+        // console.log(elem);
 
         elem.classList.remove(...this.activeClasses);
         elem.classList.remove(...this.inactiveClasses);

--- a/assets/js/job-editor/JobEditor.tsx
+++ b/assets/js/job-editor/JobEditor.tsx
@@ -163,7 +163,7 @@ export default ({
   return (
     <>
       <div className="cursor-pointer"></div>
-      <div className={`flex h-full flex-${vertical ? 'col' : 'row'} bg-vs-dark`}>
+      <div className={`flex h-full flex-${vertical ? 'col' : 'row'}`}>
         <div className="flex-1 rounded-md">
           <Editor
             source={source}

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -109,6 +109,7 @@ const LogViewer = ({
           enabled: false,
         },
         wordWrap: 'on',
+        lineNumbersMinChars: 3,
       }}
     />
   );

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -65,6 +65,16 @@ const LogViewer = ({
   const onMount = (editor: any) => {
     editorRef.current = editor;
     maybeHighlightStep();
+
+    // Define a language for our logs
+    monacoRef.current.languages.register({ id: 'openFnLogs' });
+
+    // Define a simple tokenizer for the language
+    monacoRef.current.languages.setMonarchTokensProvider('openFnLogs', {
+      tokenizer: {
+        root: [[/^.{1,4}/, 'logSource']],
+      },
+    });
   };
 
   function maybeHighlightStep() {
@@ -93,9 +103,10 @@ const LogViewer = ({
 
   return (
     <MonacoEditor
-      defaultLanguage="plaintext"
+      defaultLanguage="openFnLogs"
+      language="openFnLogs"
       theme="default"
-      value={logs.map(log => `(${log.source}) ${log.message}`).join('\n')}
+      value={logs.map(log => `${log.source} ${log.message}`).join('\n')}
       loading={<div>Loading...</div>}
       beforeMount={beforeMount}
       onMount={onMount}
@@ -105,6 +116,7 @@ const LogViewer = ({
         fontFamily: 'Fira Code VF',
         fontSize: 14,
         fontLigatures: true,
+        folding: false,
         minimap: {
           enabled: false,
         },

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -1,15 +1,7 @@
 import { MonacoEditor, Monaco } from '../monaco';
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { createRoot } from 'react-dom/client';
-
-export type LogLine = {
-  id: string;
-  message: string;
-  source: string;
-  level: string;
-  step_id: string;
-  timestamp: string;
-};
+import { useLogStore, LogLine } from './store';
 
 // The VER logs are multiline
 function splitLogMessages(logs: LogLine[]): LogLine[] {
@@ -51,31 +43,23 @@ function findLogIndicesByStepId(
 export function mount(el: HTMLElement) {
   const componentRoot = createRoot(el);
 
-  render([]);
-
-  function render(logs: LogLine[]) {
-    if (el.dataset.runId === undefined) {
-      throw new Error(
-        'runId is missing from the element dataset. Ensure you have set data-run-id on the element.'
-      );
-    }
-    componentRoot.render(<LogViewer logs={logs} hookEl={el} />);
+  if (el.dataset.runId === undefined) {
+    throw new Error(
+      'runId is missing from the element dataset. Ensure you have set data-run-id on the element.'
+    );
   }
+  componentRoot.render(<LogViewer hookEl={el} />);
 
   function unmount() {
     return componentRoot.unmount();
   }
 
-  return { unmount, render };
+  return { unmount };
 }
 
-const LogViewer = ({
-  logs,
-  hookEl,
-}: {
-  logs: LogLine[];
-  hookEl: HTMLElement;
-}) => {
+const LogViewer = ({ hookEl }: { hookEl: HTMLElement }) => {
+  const logs: LogLine[] = useLogStore(state => state.logLines);
+
   // let runId = hookEl.dataset.runId;
   let stepId = hookEl.dataset.stepId;
   // let logs: LogLine[] = [];

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -1,7 +1,6 @@
-import MonacoEditor, { Monaco } from '@monaco-editor/react';
+import { MonacoEditor, Monaco } from '../monaco';
 import React, { useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { setTheme } from '../monaco';
 
 export type LogLine = {
   id: string;
@@ -105,7 +104,6 @@ const LogViewer = ({
 
   const beforeMount = (monaco: Monaco) => {
     monacoRef.current = monaco;
-    setTheme(monaco);
   };
 
   const onMount = (editor: any) => {
@@ -156,7 +154,7 @@ const LogViewer = ({
         },
         wordWrap: 'on',
         lineNumbersMinChars: 12,
-        lineNumbers: originalLineNumber => {
+        lineNumbers: (originalLineNumber: number) => {
           const log = splitLogs[originalLineNumber - 1];
           if (log) {
             return `${originalLineNumber} (${log.source})`;

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -21,12 +21,11 @@ function findLogIndicesByStepId(
 
 export function mount(
   el: HTMLElement,
-  store: ReturnType<typeof createLogStore>,
-  stepId: string | undefined
+  store: ReturnType<typeof createLogStore>
 ) {
   const componentRoot = createRoot(el);
 
-  componentRoot.render(<LogViewer logStore={store} stepId={stepId} />);
+  componentRoot.render(<LogViewer logStore={store} />);
 
   function unmount() {
     return componentRoot.unmount();
@@ -39,7 +38,6 @@ const LogViewer = ({
   logStore,
 }: {
   logStore: ReturnType<typeof createLogStore>;
-  stepId: string | undefined;
 }) => {
   const stepId = logStore(state => state.stepId);
   const highlightedRanges = logStore(

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -1,0 +1,169 @@
+import MonacoEditor, { Monaco } from '@monaco-editor/react';
+import React, { useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { setTheme } from '../monaco';
+
+export type LogLine = {
+  id: string;
+  message: string;
+  source: string;
+  level: string;
+  step_id: string;
+};
+
+type LogMetadata = {
+  id: string;
+  source: string;
+  step_id: string;
+  line: number;
+};
+
+// The VER logs are multiline
+function splitLogMessages(logs: LogLine[]): LogLine[] {
+  const newLogs: LogLine[] = [];
+
+  logs.forEach(log => {
+    // Split the message on every newline.
+    const messages = log.message.split('\n');
+    messages.forEach(message => {
+      // Create a new log entry for each line, copying other attributes.
+      newLogs.push({
+        ...log,
+        message: message,
+      });
+    });
+  });
+
+  return newLogs;
+}
+
+function findLogIndicesByStepId(
+  logs: LogLine[],
+  stepId: string
+): { first: number | null; last: number | null } {
+  let first: number | null = null;
+  let last: number | null = null;
+  logs.forEach((log, index) => {
+    if (log.step_id === stepId) {
+      last = index;
+      if (first === null) {
+        first = index;
+      }
+    }
+  });
+
+  return { first, last };
+}
+
+export function mount(el: HTMLElement) {
+  const componentRoot = createRoot(el);
+
+  render([]);
+
+  function render(logs: LogLine[]) {
+    if (el.dataset.runId === undefined) {
+      throw new Error(
+        'runId is missing from the element dataset. Ensure you have set data-run-id on the element.'
+      );
+    }
+    componentRoot.render(
+      <LogViewer
+        logs={logs}
+        runId={el.dataset.runId}
+        stepId={el.dataset.stepId}
+      />
+    );
+  }
+
+  function unmount() {
+    return componentRoot.unmount();
+  }
+
+  return { unmount, render };
+}
+
+const LogViewer = ({
+  logs,
+  stepId,
+}: {
+  logs: LogLine[];
+  stepId: string | undefined;
+}) => {
+  // const [logs, setLogs] = useState<LogLine[]>([]);
+  const monacoRef = useRef<Monaco | null>(null);
+  const editorRef = useRef<any | null>(null);
+
+  // window.addEventListener(`phx:logs-${runId}`, (event: CustomEvent) => {
+  //   console.log('phx:logs', event.detail.logs);
+  //   setLogs(logs.concat(event.detail.logs));
+  // });
+
+  const splitLogs = splitLogMessages(logs);
+
+  const beforeMount = (monaco: Monaco) => {
+    monacoRef.current = monaco;
+    setTheme(monaco);
+  };
+
+  const onMount = (editor: any) => {
+    editorRef.current = editor;
+  };
+
+  if (
+    stepId !== undefined &&
+    logs.length > 0 &&
+    monacoRef.current !== null &&
+    editorRef.current !== null
+  ) {
+    let monaco = monacoRef.current;
+    let editor = editorRef.current;
+    const { first, last } = findLogIndicesByStepId(splitLogs, stepId);
+    if (first !== null && last !== null) {
+      console.log('first', first, 'last', last);
+      console.log('monaco editor', editor);
+      console.log('monaco editor type', editor.getEditorType());
+
+      const decos = editor.createDecorationsCollection([
+        {
+          range: new monaco.Range(first + 1, 1, last + 1, 1),
+          options: {
+            inlineClassName: 'bg-yellow-400 w-1 ml-0.5',
+          },
+        },
+      ]);
+
+      console.log('decos', decos);
+      editor.revealLine(first + 1);
+    }
+  }
+
+  return (
+    <MonacoEditor
+      defaultLanguage="plaintext"
+      theme="default"
+      value={logs.map(log => `${log.message}`).join('\n')}
+      loading={<div>Loading...</div>}
+      beforeMount={beforeMount}
+      onMount={onMount}
+      options={{
+        readOnly: true,
+        scrollBeyondLastLine: false,
+        fontFamily: 'Fira Code VF',
+        fontSize: 14,
+        fontLigatures: true,
+        minimap: {
+          enabled: false,
+        },
+        wordWrap: 'on',
+        lineNumbersMinChars: 8,
+        lineNumbers: originalLineNumber => {
+          const log = splitLogs[originalLineNumber - 1];
+          if (log) {
+            return `${originalLineNumber} (${log.source})`;
+          }
+          return `${originalLineNumber}`;
+        },
+      }}
+    />
+  );
+};

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -65,25 +65,23 @@ const LogViewer = ({
   }, [stepId]);
 
   useEffect(() => {
-    if (monaco && editor ) {
-        console.log(highlightedRanges);
-        
-        const decorations = highlightedRanges.map(range => {
-          return {
-            range: new monaco.Range(range.start, 1, range.end, 1),
-            options: {
-              isWholeLine: true,
-              linesDecorationsClassName: 'log-viewer-highlighted',
-            },
-          };
-        });
+    if (monaco && editor) {
+      const decorations = highlightedRanges.map(range => {
+        return {
+          range: new monaco.Range(range.start, 1, range.end, 1),
+          options: {
+            isWholeLine: true,
+            linesDecorationsClassName: 'log-viewer-highlighted',
+          },
+        };
+      });
 
-        if (decorationsCollection.current) {
-          decorationsCollection.current.set(decorations);
-        } else {
-          decorationsCollection.current =
-            editor.createDecorationsCollection(decorations);
-        }
+      if (decorationsCollection.current) {
+        decorationsCollection.current.set(decorations);
+      } else {
+        decorationsCollection.current =
+          editor.createDecorationsCollection(decorations);
+      }
     }
   }, [highlightedRanges, monaco, editor, formattedLogLines]);
 

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -1,32 +1,20 @@
-// index.tsx
 import { PhoenixHook } from '../hooks/PhoenixHook';
-import type { mount, LogLine } from './component';
+import { useLogStore, LogLine } from './store'; // Import the store
+import { mount } from './component';
 
 type LogViewer = PhoenixHook<{
   component: ReturnType<typeof mount> | null;
-  componentModule: Promise<{ mount: typeof mount }>;
-  logLines: LogLine[];
 }>;
 
 export default {
   mounted(this: LogViewer) {
-    this.logLines = [];
-    this.componentModule = import('./component');
-
-    this.componentModule.then(({ mount }) => {
-      this.component = mount(this.el);
-    });
+    this.component = mount(this.el);
 
     this.handleEvent(
       `logs-${this.el.dataset.runId}`,
       (event: { logs: LogLine[] }) => {
         console.log('Received logs', event.logs);
-        this.logLines = this.logLines.concat(event.logs);
-        this.logLines.sort(
-          (a, b) =>
-            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-        );
-        this.component?.render(this.logLines);
+        useLogStore.getState().addLogLines(event.logs);
       }
     );
   },

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -26,15 +26,16 @@ export default {
     }
 
     this.store = createLogStore();
+    this.store.getState().setStepId(this.el.dataset.stepId);
 
-    this.component = mount(this.viewerEl, this.store, this.el.dataset.stepId);
+    this.component = mount(this.viewerEl, this.store);
 
     this.handleEvent(
       `logs-${this.el.dataset.runId}`,
       (event: { logs: LogLine[] }) => {
         if (this.loadingEl && this.viewerEl) {
-          this.loadingEl.style.display = 'none';
-          this.viewerEl.style.display = 'block';
+          this.viewerEl.classList.remove('hidden');
+          this.loadingEl.classList.add('hidden');
         }
         this.store.getState().addLogLines(event.logs);
       }
@@ -42,11 +43,12 @@ export default {
   },
 
   updated() {
-    this.viewerEl?.dispatchEvent(
-      new CustomEvent('log-viewer:highlight-step', {
-        detail: { stepId: this.el.dataset.stepId },
-      })
-    );
+    this.store.getState().setStepId(this.el.dataset.stepId);
+    // this.el.dispatchEvent(
+    //   new CustomEvent('log-viewer:highlight-step', {
+    //     detail: { stepId: this.el.dataset.stepId },
+    //   })
+    // );
   },
 
   destroyed() {

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -1,0 +1,29 @@
+// index.tsx
+import { PhoenixHook } from '../hooks/PhoenixHook';
+import type { mount, LogLine } from './component';
+
+type LogViewer = PhoenixHook<{
+  component: ReturnType<typeof mount> | null;
+  componentModule: Promise<{ mount: typeof mount }>;
+  logs: LogLine[];
+}>;
+
+export default {
+  mounted(this: LogViewer) {
+    this.logs = [];
+    this.componentModule = import('./component');
+
+    this.componentModule.then(({ mount }) => {
+      this.component = mount(this.el);
+
+      this.handleEvent(`logs-${this.el.dataset.runId}`, event => {
+        this.logs = this.logs.concat(event.logs);
+        this.component?.render(this.logs);
+      });
+    });
+  },
+
+  destroyed() {
+    this.component?.unmount();
+  },
+} as LogViewer;

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -5,24 +5,23 @@ import type { mount, LogLine } from './component';
 type LogViewer = PhoenixHook<{
   component: ReturnType<typeof mount> | null;
   componentModule: Promise<{ mount: typeof mount }>;
-  logs: LogLine[];
 }>;
 
 export default {
   mounted(this: LogViewer) {
-    this.logs = [];
     this.componentModule = import('./component');
 
     this.componentModule.then(({ mount }) => {
       this.component = mount(this.el);
-
-      this.handleEvent(`logs-${this.el.dataset.runId}`, event => {
-        this.logs = this.logs.concat(event.logs);
-        this.component?.render(this.logs);
-      });
     });
   },
-
+  updated() {
+    this.el.dispatchEvent(
+      new CustomEvent('log-viewer:updated', {
+        detail: { stepId: this.el.dataset.stepId },
+      })
+    );
+  },
   destroyed() {
     this.component?.unmount();
   },

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -20,6 +20,7 @@ export default {
     this.handleEvent(
       `logs-${this.el.dataset.runId}`,
       (event: { logs: LogLine[] }) => {
+        console.log('Received logs', event.logs);
         this.logLines = this.logLines.concat(event.logs);
         this.logLines.sort(
           (a, b) =>

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -1,9 +1,10 @@
 import { PhoenixHook } from '../hooks/PhoenixHook';
-import { useLogStore, LogLine } from './store';
+import { createLogStore, LogLine } from './store';
 import { mount } from './component';
 
 type LogViewer = PhoenixHook<{
   component: ReturnType<typeof mount> | null;
+  store: ReturnType<typeof createLogStore>;
   viewerEl: HTMLElement | null;
   loadingEl: HTMLElement | null;
 }>;
@@ -24,7 +25,9 @@ export default {
       throw new Error('Viewer or loading element not found');
     }
 
-    this.component = mount(this.viewerEl, this.el.dataset.stepId);
+    this.store = createLogStore();
+
+    this.component = mount(this.viewerEl, this.store, this.el.dataset.stepId);
 
     this.handleEvent(
       `logs-${this.el.dataset.runId}`,
@@ -33,7 +36,7 @@ export default {
           this.loadingEl.style.display = 'none';
           this.viewerEl.style.display = 'block';
         }
-        useLogStore.getState().addLogLines(event.logs);
+        this.store.getState().addLogLines(event.logs);
       }
     );
   },

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -1,30 +1,51 @@
 import { PhoenixHook } from '../hooks/PhoenixHook';
-import { useLogStore, LogLine } from './store'; // Import the store
+import { useLogStore, LogLine } from './store';
 import { mount } from './component';
 
 type LogViewer = PhoenixHook<{
   component: ReturnType<typeof mount> | null;
+  viewerEl: HTMLElement | null;
+  loadingEl: HTMLElement | null;
 }>;
 
 export default {
   mounted(this: LogViewer) {
-    this.component = mount(this.el);
+    const viewerId = this.el.dataset.viewerEl;
+    const loadingId = this.el.dataset.loadingEl;
+
+    if (!viewerId || !loadingId) {
+      throw new Error('Viewer or loading element data attributes are not set');
+    }
+
+    this.viewerEl = document.getElementById(viewerId);
+    this.loadingEl = document.getElementById(loadingId);
+
+    if (!this.viewerEl || !this.loadingEl) {
+      throw new Error('Viewer or loading element not found');
+    }
+
+    this.component = mount(this.viewerEl, this.el.dataset.stepId);
 
     this.handleEvent(
       `logs-${this.el.dataset.runId}`,
       (event: { logs: LogLine[] }) => {
-        console.log('Received logs', event.logs);
+        if (this.loadingEl && this.viewerEl) {
+          this.loadingEl.style.display = 'none';
+          this.viewerEl.style.display = 'block';
+        }
         useLogStore.getState().addLogLines(event.logs);
       }
     );
   },
+
   updated() {
-    this.el.dispatchEvent(
+    this.viewerEl?.dispatchEvent(
       new CustomEvent('log-viewer:highlight-step', {
         detail: { stepId: this.el.dataset.stepId },
       })
     );
   },
+
   destroyed() {
     this.component?.unmount();
   },

--- a/assets/js/log-viewer/index.ts
+++ b/assets/js/log-viewer/index.ts
@@ -5,19 +5,33 @@ import type { mount, LogLine } from './component';
 type LogViewer = PhoenixHook<{
   component: ReturnType<typeof mount> | null;
   componentModule: Promise<{ mount: typeof mount }>;
+  logLines: LogLine[];
 }>;
 
 export default {
   mounted(this: LogViewer) {
+    this.logLines = [];
     this.componentModule = import('./component');
 
     this.componentModule.then(({ mount }) => {
       this.component = mount(this.el);
     });
+
+    this.handleEvent(
+      `logs-${this.el.dataset.runId}`,
+      (event: { logs: LogLine[] }) => {
+        this.logLines = this.logLines.concat(event.logs);
+        this.logLines.sort(
+          (a, b) =>
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+        );
+        this.component?.render(this.logLines);
+      }
+    );
   },
   updated() {
     this.el.dispatchEvent(
-      new CustomEvent('log-viewer:updated', {
+      new CustomEvent('log-viewer:highlight-step', {
         detail: { stepId: this.el.dataset.stepId },
       })
     );

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -33,17 +33,19 @@ function splitLogMessages(logs: LogLine[]): LogLine[] {
   return newLogs;
 }
 
-export const useLogStore = create<LogStore>(set => ({
-  logLines: [],
-  addLogLines: newLogs =>
-    set(state => {
-      const splitLogs = splitLogMessages(newLogs);
-      const logs = [...state.logLines, ...splitLogs];
+export const createLogStore = () => {
+  return create<LogStore>(set => ({
+    logLines: [],
+    addLogLines: newLogs =>
+      set(state => {
+        const splitLogs = splitLogMessages(newLogs);
+        const logs = [...state.logLines, ...splitLogs];
 
-      logs.sort(
-        (a, b) =>
-          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-      );
-      return { logLines: logs };
-    }),
-}));
+        logs.sort(
+          (a, b) =>
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+        );
+        return { logLines: logs };
+      }),
+  }));
+};

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -28,7 +28,7 @@ function findSelectedRanges(logs: LogLine[], stepId: string | undefined) {
   }>(
     ({ ranges, marker }, log) => {
       // Get the number of newlines in the message, used to determine the end index.
-      const newLineCount = [...log.message.matchAll(/\r\n/g)].length;
+      const newLineCount = [...log.message.matchAll(/\n/g)].length;
       const nextMarker = marker + 1 + newLineCount;
 
       if (log.step_id !== stepId) {
@@ -62,7 +62,7 @@ function coerceLogs(logs: LogLine[]): LogLine[] {
   return logs.map(log => ({
     ...log,
     timestamp: new Date(log.timestamp),
-    message: log.message.replace(/\n/g, '\r\n'),
+    message: log.message.replace(/\n/g, `\n${log.source} `),
   }));
 }
 

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -62,7 +62,6 @@ function coerceLogs(logs: LogLine[]): LogLine[] {
   return logs.map(log => ({
     ...log,
     timestamp: new Date(log.timestamp),
-    message: log.message.replace(/\n/g, `\n${log.source} `),
   }));
 }
 

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+export type LogLine = {
+  id: string;
+  message: string;
+  source: string;
+  level: string;
+  step_id: string;
+  timestamp: string;
+};
+
+type LogStore = {
+  logLines: LogLine[];
+  addLogLines: (newLogs: LogLine[]) => void;
+};
+
+export const useLogStore = create<LogStore>(set => ({
+  logLines: [],
+  addLogLines: newLogs =>
+    set(state => {
+      const logs = [...state.logLines, ...newLogs];
+
+      logs.sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      );
+      return { logLines: logs };
+    }),
+}));

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -14,10 +14,30 @@ type LogStore = {
   addLogLines: (newLogs: LogLine[]) => void;
 };
 
+// The VER logs are multiline
+function splitLogMessages(logs: LogLine[]): LogLine[] {
+  const newLogs: LogLine[] = [];
+
+  logs.forEach(log => {
+    // Split the message on every newline.
+    const messages = log.message.split('\n');
+    messages.forEach(message => {
+      // Create a new log entry for each line, copying other attributes.
+      newLogs.push({
+        ...log,
+        message: message,
+      });
+    });
+  });
+
+  return newLogs;
+}
+
 export const useLogStore = create<LogStore>(set => ({
   logLines: [],
   addLogLines: newLogs =>
     set(state => {
+      newLogs = splitLogMessages(newLogs);
       const logs = [...state.logLines, ...newLogs];
 
       logs.sort(

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -37,8 +37,8 @@ export const useLogStore = create<LogStore>(set => ({
   logLines: [],
   addLogLines: newLogs =>
     set(state => {
-      newLogs = splitLogMessages(newLogs);
-      const logs = [...state.logLines, ...newLogs];
+      const splitLogs = splitLogMessages(newLogs);
+      const logs = [...state.logLines, ...splitLogs];
 
       logs.sort(
         (a, b) =>

--- a/assets/js/monaco/index.tsx
+++ b/assets/js/monaco/index.tsx
@@ -28,9 +28,11 @@ export const MonacoEditor = ({
   ...props
 }) => {
   const monacoRef = useRef<any>(null);
+  const editorRef = useRef<any>(null);
 
   const handleOnMount = useCallback((editor: any, monaco: Monaco) => {
     monacoRef.current = monaco;
+    editorRef.current = editor;
     setTheme(monaco);
     onMount(editor, monaco);
   }, []);
@@ -39,7 +41,7 @@ export const MonacoEditor = ({
     <ResizeObserver
       onResize={({ width, height }) => {
         // TODO maybe either debounce or track sizes
-        monacoRef.current?.editor.layout({ width, height: height });
+        editorRef.current?.layout({ width, height: height });
       }}
     >
       <Editor onMount={handleOnMount} {...props} />

--- a/assets/js/monaco/index.tsx
+++ b/assets/js/monaco/index.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useCallback } from 'react';
 import ResizeObserver from 'rc-resize-observer';
 import Editor, { Monaco } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
 
 export function setTheme(monaco: Monaco) {
   monaco.editor.defineTheme('default', {
@@ -24,7 +25,7 @@ export function setTheme(monaco: Monaco) {
 export { Monaco };
 
 export const MonacoEditor = ({
-  onMount = (editor: any, monaco: Monaco) => {},
+  onMount = (editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {},
   ...props
 }) => {
   const monacoRef = useRef<any>(null);

--- a/assets/js/monaco/index.tsx
+++ b/assets/js/monaco/index.tsx
@@ -6,7 +6,7 @@ export function setTheme(monaco: Monaco) {
   monaco.editor.defineTheme('default', {
     base: 'vs-dark',
     inherit: true,
-    rules: [],
+    rules: [{ token: 'logSource', foreground: '#868686', fontStyle: 'italic' }],
     colors: {
       'editor.foreground': '#E2E8F0',
       'editor.background': '#334155', // slate-700

--- a/assets/js/monaco/index.tsx
+++ b/assets/js/monaco/index.tsx
@@ -25,11 +25,11 @@ export function setTheme(monaco: Monaco) {
 export { Monaco };
 
 export const MonacoEditor = ({
-  onMount = (editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {},
+  onMount = (_editor: editor.IStandaloneCodeEditor, _monaco: Monaco) => {},
   ...props
 }) => {
-  const monacoRef = useRef<any>(null);
-  const editorRef = useRef<any>(null);
+  const monacoRef = useRef<Monaco | null>(null);
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
   const handleOnMount = useCallback((editor: any, monaco: Monaco) => {
     monacoRef.current = monaco;
@@ -41,8 +41,10 @@ export const MonacoEditor = ({
   return (
     <ResizeObserver
       onResize={({ width, height }) => {
-        // TODO maybe either debounce or track sizes
-        editorRef.current?.layout({ width, height: height });
+        if (width > 0 && height > 0) {
+          // TODO maybe either debounce or track sizes
+          editorRef.current?.layout({ width, height });
+        }
       }}
     >
       <Editor onMount={handleOnMount} {...props} />

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -17,14 +17,14 @@ module.exports = {
   ],
   theme: {
     minWidth: {
-      '0': '0',
+      0: '0',
       '1/4': '25%',
       '1/3': '33%',
       '1/2': '50%',
       '3/4': '75%',
-      'full': '100%',
-      'min': 'min-content',
-      'max': 'max-content'
+      full: '100%',
+      min: 'min-content',
+      max: 'max-content',
     },
     extend: {
       colors: {
@@ -93,7 +93,7 @@ module.exports = {
     // Embeds Heroicons (https://heroicons.com) into your app.css bundle
     // See your `CoreComponents.icon/1` for more information.
     //
-    plugin(function({ matchComponents, theme }) {
+    plugin(function ({ matchComponents, theme }) {
       let iconsDir = path.join(__dirname, './vendor/heroicons/optimized');
       let values = {};
       let icons = [

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "Node16",
     "rootDir": "../",
-    "lib": ["dom", "ES2022"],
+    "lib": ["dom", "ES2023"],
     "jsx": "react",
     "strict": true,
     "esModuleInterop": true,

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -30,7 +30,7 @@ defmodule Lightning.Invocation.LogLine do
         }
 
   @derive {Jason.Encoder,
-           only: [:id, :source, :level, :message, :step_id, :run_id]}
+           only: [:id, :source, :level, :message, :timestamp, :step_id, :run_id]}
 
   @primary_key false
   @foreign_key_type :binary_id

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -29,6 +29,9 @@ defmodule Lightning.Invocation.LogLine do
           run: Run.t() | Ecto.Association.NotLoaded.t() | nil
         }
 
+  @derive {Jason.Encoder,
+           only: [:id, :source, :level, :message, :step_id, :run_id]}
+
   @primary_key false
   @foreign_key_type :binary_id
   schema "log_lines" do

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -45,9 +45,7 @@ defmodule LightningWeb.Components.Viewers do
   def log_viewer(assigns) do
     ~H"""
     <%= if @run_state in Lightning.Run.final_states() and @logs_empty? do %>
-      <div class={[
-        "m-2 relative p-12 text-center col-span-full"
-      ]}>
+      <div class={["m-2 relative p-12 text-center col-span-full"]}>
         <span class="relative inline-flex">
           <div class="inline-flex">
             No logs were received for this run.
@@ -65,18 +63,15 @@ defmodule LightningWeb.Components.Viewers do
         data-loading-el={"#{@id}-nothing-yet"}
         data-viewer-el={"#{@id}-viewer"}
       >
-        <div
-          id={"#{@id}-nothing-yet"}
-          class={[
-            "m-2 relative rounded-md",
-            "p-12 text-center col-span-full w-full"
-          ]}
-        >
-          <.text_ping_loader>
-            Nothing yet
-          </.text_ping_loader>
-        </div>
-        <div class="relative flex grow">
+        <div class="relative grow">
+          <div
+            id={"#{@id}-nothing-yet"}
+            class="m-2  rounded-md p-12 text-center bg-slate-700 font-mono text-gray-200"
+          >
+            <.text_ping_loader>
+              Nothing yet
+            </.text_ping_loader>
+          </div>
           <div id={"#{@id}-viewer"} class="hidden absolute inset-0 rounded-md"></div>
         </div>
       </div>
@@ -156,10 +151,7 @@ defmodule LightningWeb.Components.Viewers do
             is_nil(@dataclip)
         }
         id={"#{@id}-nothing-yet"}
-        class={[
-          "m-2 relative rounded-md",
-          "p-12 text-center col-span-full"
-        ]}
+        class="m-2 relative rounded-md p-12 text-center bg-slate-700 font-mono text-gray-200"
       >
         <.text_ping_loader>
           Nothing yet

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -33,21 +33,20 @@ defmodule LightningWeb.Components.Viewers do
   """
 
   attr :id, :string, required: true
-
   attr :run_id, :string, required: true
-
   attr :run_state, :any, required: true
-
   attr :logs_empty?, :boolean, required: true
-
   attr :selected_step_id, :string
+
+  attr :class, :string,
+    default: nil,
+    doc: "Additional classes to add to the log viewer container"
 
   def log_viewer(assigns) do
     ~H"""
     <%= if @run_state in Lightning.Run.final_states() and @logs_empty? do %>
       <div class={[
-        "m-2 relative rounded-md",
-        "p-12 text-center col-span-full"
+        "m-2 relative p-12 text-center col-span-full"
       ]}>
         <span class="relative inline-flex">
           <div class="inline-flex">
@@ -58,7 +57,7 @@ defmodule LightningWeb.Components.Viewers do
     <% else %>
       <div
         id={@id}
-        class="h-full"
+        class={["flex grow", @class]}
         phx-hook="LogViewer"
         phx-update="ignore"
         data-run-id={@run_id}
@@ -77,7 +76,9 @@ defmodule LightningWeb.Components.Viewers do
             Nothing yet
           </.text_ping_loader>
         </div>
-        <div id={"#{@id}-viewer"} class="h-full rounded-md hidden"></div>
+        <div class="relative flex grow">
+          <div id={"#{@id}-viewer"} class="hidden absolute inset-0 rounded-md"></div>
+        </div>
       </div>
     <% end %>
     """

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -34,78 +34,38 @@ defmodule LightningWeb.Components.Viewers do
 
   attr :id, :string, required: true
 
-  attr :stream, :list,
-    required: true,
-    doc: "A stream of `Lightning.Invocation.LogLine` structs"
-
-  attr :stream_empty?, :boolean, required: true
+  attr :run_id, :string, required: true
 
   attr :run_state, :any, required: true
 
-  attr :highlight_id, :string,
-    default: nil,
-    doc: "The id of the log line to highlight, matching the `step_id` field"
+  attr :logs_empty?, :boolean, required: true
 
-  attr :class, :string,
-    default: nil,
-    doc: "Additional classes to add to the log viewer container"
+  attr :selected_step_id, :string
 
   def log_viewer(assigns) do
     ~H"""
-    <div class={[
-      "rounded-md shadow-sm bg-slate-700 border-slate-300",
-      "text-slate-200 text-sm font-mono proportional-nums w-full"
-    ]}>
+    <%= if @run_state in Lightning.Run.final_states() and @logs_empty? do %>
+      <div class={[
+        "m-2 relative rounded-md",
+        "p-12 text-center col-span-full"
+      ]}>
+        <span class="relative inline-flex">
+          <div class="inline-flex">
+            No logs were received for this run.
+          </div>
+        </span>
+      </div>
+    <% else %>
       <div
         id={@id}
-        phx-hook="LogLineHighlight"
-        data-highlight-id={@highlight_id}
-        phx-update="stream"
-        class={[
-          "overscroll-contain scroll-smooth",
-          "grid grid-flow-row-dense grid-cols-[min-content_1fr]",
-          "log-viewer",
-          @class
-        ]}
+        class="h-full"
+        phx-hook="LogViewer"
+        phx-update="ignore"
+        data-run-id={@run_id}
+        data-step-id={@selected_step_id}
       >
-        <div
-          :for={{dom_id, log_line} <- @stream}
-          class="group contents"
-          data-highlight-id={log_line.step_id}
-          id={dom_id}
-        >
-          <div class="log-viewer__prefix" data-line-prefix={log_line.source}></div>
-          <span data-log-line class="log-viewer__message">
-            <pre><%= log_line.message %></pre>
-          </span>
-        </div>
       </div>
-      <%= if @run_state in Lightning.Run.final_states() and @stream_empty? do %>
-        <div class={[
-          "m-2 relative rounded-md",
-          "p-12 text-center col-span-full"
-        ]}>
-          <span class="relative inline-flex">
-            <div class="inline-flex">
-              No logs were received for this run.
-            </div>
-          </span>
-        </div>
-      <% else %>
-        <div
-          :if={@stream_empty?}
-          id={"#{@id}-nothing-yet"}
-          class={[
-            "m-2 relative rounded-md",
-            "p-12 text-center col-span-full"
-          ]}
-        >
-          <.text_ping_loader>
-            Nothing yet
-          </.text_ping_loader>
-        </div>
-      <% end %>
-    </div>
+    <% end %>
     """
   end
 

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -63,7 +63,21 @@ defmodule LightningWeb.Components.Viewers do
         phx-update="ignore"
         data-run-id={@run_id}
         data-step-id={@selected_step_id}
+        data-loading-el={"#{@id}-nothing-yet"}
+        data-viewer-el={"#{@id}-viewer"}
       >
+        <div
+          id={"#{@id}-nothing-yet"}
+          class={[
+            "m-2 relative rounded-md",
+            "p-12 text-center col-span-full"
+          ]}
+        >
+          <.text_ping_loader>
+            Nothing yet
+          </.text_ping_loader>
+        </div>
+        <div id={"#{@id}-viewer"} class="h-full hidden"></div>
       </div>
     <% end %>
     """

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -69,7 +69,7 @@ defmodule LightningWeb.Components.Viewers do
           id={"#{@id}-nothing-yet"}
           class={[
             "m-2 relative rounded-md",
-            "p-12 text-center col-span-full"
+            "p-12 text-center col-span-full w-full"
           ]}
         >
           <.text_ping_loader>

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -77,7 +77,7 @@ defmodule LightningWeb.Components.Viewers do
             Nothing yet
           </.text_ping_loader>
         </div>
-        <div id={"#{@id}-viewer"} class="h-full hidden"></div>
+        <div id={"#{@id}-viewer"} class="h-full rounded-md hidden"></div>
       </div>
     <% end %>
     """

--- a/lib/lightning_web/live/dev/components_live.ex
+++ b/lib/lightning_web/live/dev/components_live.ex
@@ -54,19 +54,19 @@ defmodule LightningWeb.Dev.ComponentsLive do
             </div>
           </.variation>
           <.variation title="With data">
-            <Viewers.log_viewer
+            <%!-- <Viewers.log_viewer
               id="log-viewer-data"
               stream={@log_lines}
               run_state={%Run{state: :success}}
               highlight_id={@highlight_id}
               stream_empty?={false}
-            />
+            /> --%>
           </.variation>
           <.variation title="Empty">
             <Viewers.log_viewer
               id="log-viewer"
-              stream={[]}
-              stream_empty?={true}
+              logs_empty?={true}
+              run_id="run-id"
               run_state={%Run{state: :crashed}}
             />
           </.variation>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -114,7 +114,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
             </Common.panel_content>
             <Common.panel_content for_hash="log" class="grow overflow-auto">
               <div class="flex flex-col h-full @5xl/viewer:flex-row">
-                <div class="z-50 min-h-0 max-h-[30%] 0 mb-2 overflow-auto flex-none flex @5xl/viewer:flex-row flex-col @5xl/viewer:max-h-[100%]">
+                <div class="z-50 min-h-0 max-h-[30%] mb-2 overflow-auto flex-none flex @5xl/viewer:flex-row flex-col @5xl/viewer:max-h-[100%]">
                   <.step_list
                     :let={step}
                     id={"log-tab-step-list-#{run.id}"}
@@ -136,8 +136,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     />
                   </.step_list>
                 </div>
-
-                <div class="relative flex-1 grow inset-0 rounded-md">
+                <div class="flex flex-1 grow">
                   <Viewers.log_viewer
                     id={"run-log-#{run.id}"}
                     run_id={run.id}

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -112,7 +112,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 />
               </.step_list>
             </Common.panel_content>
-            <Common.panel_content for_hash="log" class="h-full mb-2">
+            <Common.panel_content for_hash="log" class="grow overflow-auto">
               <div class="flex flex-col h-full @5xl/viewer:flex-row">
                 <div class="min-h-0 max-h-[30%] 0 mb-2 overflow-auto flex-none flex @5xl/viewer:flex-row flex-col @5xl/viewer:max-h-[100%]">
                   <.step_list
@@ -137,7 +137,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                   </.step_list>
                 </div>
 
-                <div class="flex min-h-0 h-full grow bg-slate-700 overflow-auto rounded-md">
+                <div class="flex-1 grow inset-0 overflow-auto rounded-md">
                   <%!-- <Viewers.log_viewer
                     id={"run-log-#{run.id}"}
                     highlight_id={@selected_step_id}
@@ -145,14 +145,16 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     stream={@streams.log_lines}
                     stream_empty?={@log_lines_stream_empty?}
                   /> --%>
-                  <div
-                    id={"run-log-#{run.id}"}
-                    class="h-full"
-                    phx-hook="LogViewer"
-                    phx-update="ignore"
-                    data-run-id={run.id}
-                    data-step-id={@selected_step_id}
-                  >
+                  <div class="h-full relative">
+                    <div
+                      id={"run-log-#{run.id}"}
+                      class="h-full"
+                      phx-hook="LogViewer"
+                      phx-update="ignore"
+                      data-run-id={run.id}
+                      data-step-id={@selected_step_id}
+                    >
+                    </div>
                   </div>
                 </div>
               </div>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -138,13 +138,13 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 </div>
 
                 <div class="flex min-h-0 h-full grow bg-slate-700 overflow-auto rounded-md">
-                  <Viewers.log_viewer
+                  <%!-- <Viewers.log_viewer
                     id={"run-log-#{run.id}"}
                     highlight_id={@selected_step_id}
                     run_state={run.state}
                     stream={@streams.log_lines}
                     stream_empty?={@log_lines_stream_empty?}
-                  />
+                  /> --%>
                 </div>
               </div>
             </Common.panel_content>
@@ -270,8 +270,6 @@ defmodule LightningWeb.RunLive.RunViewerLive do
        job_id: Map.get(session, "job_id"),
        steps: []
      )
-     |> stream(:log_lines, [])
-     |> assign(:log_lines_stream_empty?, true)
      |> assign(:input_dataclip, nil)
      |> assign(:output_dataclip, nil)
      |> assign(:run, AsyncResult.loading())

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -114,7 +114,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
             </Common.panel_content>
             <Common.panel_content for_hash="log" class="grow overflow-auto">
               <div class="flex flex-col h-full @5xl/viewer:flex-row">
-                <div class="min-h-0 max-h-[30%] 0 mb-2 overflow-auto flex-none flex @5xl/viewer:flex-row flex-col @5xl/viewer:max-h-[100%]">
+                <div class="z-50 min-h-0 max-h-[30%] 0 mb-2 overflow-auto flex-none flex @5xl/viewer:flex-row flex-col @5xl/viewer:max-h-[100%]">
                   <.step_list
                     :let={step}
                     id={"log-tab-step-list-#{run.id}"}
@@ -137,7 +137,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                   </.step_list>
                 </div>
 
-                <div class="flex-1 grow inset-0 overflow-auto rounded-md">
+                <div class="relative flex-1 grow inset-0 rounded-md">
                   <Viewers.log_viewer
                     id={"run-log-#{run.id}"}
                     run_id={run.id}

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -145,6 +145,15 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     stream={@streams.log_lines}
                     stream_empty?={@log_lines_stream_empty?}
                   /> --%>
+                  <div
+                    id={"run-log-#{run.id}"}
+                    class="h-full"
+                    phx-hook="LogViewer"
+                    phx-update="ignore"
+                    data-run-id={run.id}
+                    data-step-id={@selected_step_id}
+                  >
+                  </div>
                 </div>
               </div>
             </Common.panel_content>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -138,24 +138,13 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 </div>
 
                 <div class="flex-1 grow inset-0 overflow-auto rounded-md">
-                  <%!-- <Viewers.log_viewer
+                  <Viewers.log_viewer
                     id={"run-log-#{run.id}"}
-                    highlight_id={@selected_step_id}
-                    run_state={run.state}
-                    stream={@streams.log_lines}
-                    stream_empty?={@log_lines_stream_empty?}
-                  /> --%>
-                  <div class="h-full relative">
-                    <div
-                      id={"run-log-#{run.id}"}
-                      class="h-full"
-                      phx-hook="LogViewer"
-                      phx-update="ignore"
-                      data-run-id={run.id}
-                      data-step-id={@selected_step_id}
-                    >
-                    </div>
-                  </div>
+                    run_id={run.id}
+                    run_state={@run.result.state}
+                    logs_empty?={@log_lines_empty?}
+                    selected_step_id={@selected_step_id}
+                  />
                 </div>
               </div>
             </Common.panel_content>
@@ -285,6 +274,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
      |> assign(:output_dataclip, nil)
      |> assign(:run, AsyncResult.loading())
      |> assign(:log_lines, AsyncResult.loading())
+     |> assign(:log_lines_empty?, true)
      |> assign(
        can_edit_data_retention:
          Permissions.can?(

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -176,22 +176,13 @@ defmodule LightningWeb.RunLive.Show do
               </Common.tab_bar>
 
               <Common.panel_content for_hash="log" class="flex-1">
-                <%!-- <Viewers.log_viewer
+                <Viewers.log_viewer
                   id={"run-log-#{run.id}"}
-                  highlight_id={@selected_step_id}
-                  stream={@streams.log_lines}
+                  run_id={run.id}
                   run_state={@run.result.state}
-                  stream_empty?={@log_lines_stream_empty?}
-                /> --%>
-                <div
-                  id={"run-log-#{run.id}"}
-                  class="h-full"
-                  phx-hook="LogViewer"
-                  phx-update="ignore"
-                  data-run-id={run.id}
-                  data-step-id={@selected_step_id}
-                >
-                </div>
+                  logs_empty?={@log_lines_empty?}
+                  selected_step_id={@selected_step_id}
+                />
               </Common.panel_content>
               <Common.panel_content for_hash="input" class="flex-1">
                 <Viewers.step_dataclip_viewer
@@ -243,6 +234,7 @@ defmodule LightningWeb.RunLive.Show do
      |> assign(:output_dataclip, nil)
      |> assign(:run, AsyncResult.loading())
      |> assign(:log_lines, AsyncResult.loading())
+     |> assign(:log_lines_empty?, true)
      |> assign(
        can_edit_data_retention:
          Permissions.can?(

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -30,7 +30,7 @@ defmodule LightningWeb.RunLive.Show do
         </LayoutComponents.header>
       </:header>
 
-      <LayoutComponents.centered class="@container/main">
+      <LayoutComponents.centered class="@container/main h-full">
         <.async_result :let={run} assign={@run}>
           <:loading>
             <.loading_filler />
@@ -39,8 +39,8 @@ defmodule LightningWeb.RunLive.Show do
             there was an error loading the run
           </:failed>
 
-          <div class="flex gap-6 @5xl/main:flex-row flex-col">
-            <div class="basis-1/3 flex-none flex gap-6 @5xl/main:flex-col flex-row">
+          <div class="flex gap-6 @5xl/main:flex-row flex-col h-full">
+            <div class="@5xl/main:basis-1/3 flex gap-y-6 @5xl/main:flex-col flex-row">
               <.detail_list
                 id={"run-detail-#{run.id}"}
                 class="flex-1 @5xl/main:flex-none"
@@ -138,7 +138,7 @@ defmodule LightningWeb.RunLive.Show do
                 </.link>
               </.step_list>
             </div>
-            <div class="basis-2/3 flex-none flex flex-col gap-4">
+            <div class="@5xl/main:basis-2/3 grow flex flex-col gap-4">
               <Common.tab_bar orientation="horizontal" id="1" default_hash="log">
                 <Common.tab_item orientation="horizontal" hash="log">
                   <.icon

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -175,14 +175,23 @@ defmodule LightningWeb.RunLive.Show do
                 </Common.tab_item>
               </Common.tab_bar>
 
-              <Common.panel_content for_hash="log">
-                <Viewers.log_viewer
+              <Common.panel_content for_hash="log" class="flex-1">
+                <%!-- <Viewers.log_viewer
                   id={"run-log-#{run.id}"}
                   highlight_id={@selected_step_id}
                   stream={@streams.log_lines}
                   run_state={@run.result.state}
                   stream_empty?={@log_lines_stream_empty?}
-                />
+                /> --%>
+                <div
+                  id={"run-log-#{run.id}"}
+                  class="h-full"
+                  phx-hook="LogViewer"
+                  phx-update="ignore"
+                  data-run-id={run.id}
+                  data-step-id={@selected_step_id}
+                >
+                </div>
               </Common.panel_content>
               <Common.panel_content for_hash="input" class="flex-1">
                 <Viewers.step_dataclip_viewer
@@ -230,8 +239,6 @@ defmodule LightningWeb.RunLive.Show do
        selected_step_id: nil,
        steps: []
      )
-     |> stream(:log_lines, [])
-     |> assign(:log_lines_stream_empty?, true)
      |> assign(:input_dataclip, nil)
      |> assign(:output_dataclip, nil)
      |> assign(:run, AsyncResult.loading())

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -178,6 +178,7 @@ defmodule LightningWeb.RunLive.Show do
               <Common.panel_content for_hash="log" class="flex-1">
                 <Viewers.log_viewer
                   id={"run-log-#{run.id}"}
+                  class="h-full"
                   run_id={run.id}
                   run_state={@run.result.state}
                   logs_empty?={@log_lines_empty?}

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -132,7 +132,9 @@ defmodule LightningWeb.RunLive.Streaming do
           ) do
         {:noreply,
          socket
-         |> push_event("logs", %{logs: [log_line]})}
+         |> push_event("logs-#{socket.assigns.run.result.id}", %{
+           logs: [log_line]
+         })}
       end
     end
   end

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -103,8 +103,7 @@ defmodule LightningWeb.RunLive.Streaming do
       def handle_info({:log_line_chunk, lines}, socket) do
         {:noreply,
          socket
-         |> stream(:log_lines, lines)
-         |> assign(:log_lines_stream_empty?, false)}
+         |> push_event("logs-#{socket.assigns.run.result.id}", %{logs: lines})}
       end
 
       def handle_info(
@@ -133,8 +132,7 @@ defmodule LightningWeb.RunLive.Streaming do
           ) do
         {:noreply,
          socket
-         |> stream_insert(:log_lines, log_line)
-         |> assign(:log_lines_stream_empty?, false)}
+         |> push_event("logs", %{logs: [log_line]})}
       end
     end
   end

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -103,6 +103,7 @@ defmodule LightningWeb.RunLive.Streaming do
       def handle_info({:log_line_chunk, lines}, socket) do
         {:noreply,
          socket
+         |> assign(:log_lines_empty?, false)
          |> push_event("logs-#{socket.assigns.run.result.id}", %{logs: lines})}
       end
 
@@ -132,6 +133,7 @@ defmodule LightningWeb.RunLive.Streaming do
           ) do
         {:noreply,
          socket
+         |> assign(:log_lines_empty?, false)
          |> push_event("logs-#{socket.assigns.run.result.id}", %{
            logs: [log_line]
          })}

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -124,7 +124,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
     </div>
     <div
       :if={@selected_dataclip && is_nil(@selected_dataclip.wiped_at)}
-      class="grow overflow-y-auto rounded-md"
+      class="grow overflow-y-auto"
     >
       <LightningWeb.Components.Viewers.dataclip_viewer
         dataclip={@selected_dataclip}

--- a/test/lightning_web/live/components/viewer_test.exs
+++ b/test/lightning_web/live/components/viewer_test.exs
@@ -13,14 +13,13 @@ defmodule LightningWeb.Components.ViewerTest do
     end
 
     test "renders correct information", %{
-      workflow: %{jobs: [job | _rest], project: project}
+      workflow: %{jobs: [job | _rest]}
     } do
-      wiped_dataclip = insert(:dataclip, body: nil, wiped_at: DateTime.utc_now())
-
       finished_step =
         insert(:step,
           job: job,
-          input_dataclip: wiped_dataclip,
+          input_dataclip:
+            insert(:dataclip, body: nil, wiped_at: DateTime.utc_now()),
           output_dataclip: nil,
           finished_at: DateTime.utc_now()
         )
@@ -29,25 +28,13 @@ defmodule LightningWeb.Components.ViewerTest do
       html =
         render_component(&Viewers.log_viewer/1,
           id: "test",
-          stream: [],
-          stream_empty?: true,
-          step: finished_step,
+          logs_empty?: true,
+          selected_step_id: finished_step.id,
           run_state: :lost,
-          dataclip: %Phoenix.LiveView.AsyncResult{
-            ok?: false,
-            loading: [:input_dataclip]
-          },
-          input_or_output: :input,
-          project_id: project.id,
-          admin_contacts: ["test@email.com"],
-          can_edit_data_retention: true
+          run_id: "run-id"
         )
 
       assert html =~ "No logs were received for this run."
-      refute html =~ "Nothing yet"
-      refute html =~ "data for this step has not been retained"
-      refute html =~ "this policy\n      </a>\n      for future runs"
-      refute html =~ "test@email.com"
     end
   end
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -1580,10 +1580,11 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         render(run_view)
 
         # log tab shows correct information
-        html =
-          run_view |> element("div[data-panel-hash='log']") |> render_async()
 
-        assert html =~ log_line.message
+        assert has_element?(
+                 run_view,
+                 "div[data-panel-hash='log'] [phx-hook='LogViewer'][data-run-id='#{run.id}']"
+               )
 
         # input tab shows correct information
 


### PR DESCRIPTION
## Notes for the reviewer

- [x] Split the logs by `\n` so as to get the correct line numbers when highlighting step logs
- [x] Move the `source` from the line numbers to the content
- [x] Pass the store as a prop to avoid duplicating the lines
- [x] Style the highlighter to match the previous one
- [x] Make the main viewer to fill the rest of remaining space in the screen. Or just make it bigger 🤷‍♂️ . This is quite tricky because we also don't want to affect the dataclip viewers. `absolute` positioning seems like the way o go, but what would be the height? 🤷 


## Related issue

Fixes #1863

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
