### PR TITLE
Fix Credential Modal Closure Error When Workflow Is Unsaved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix Credential Modal Closure Error When Workflow Is Unsaved
+  [#2101](https://github.com/OpenFn/lightning/pull/2101)
+
 ## [v2.5.1]
 
 - Don't compile Phoenix Storybook in production and test environments

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -297,9 +297,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             end
           }
           can_create_project_credential={@can_edit_workflow}
-          return_to={
-            ~p"/projects/#{@project.id}/w/#{@workflow.id}?s=#{@selected_job.id}"
-          }
+          return_to={"#{@base_url}?name=#{@workflow.name}&s=#{@selected_job.id}"}
         />
         <.form
           id="workflow-form"

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -297,7 +297,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             end
           }
           can_create_project_credential={@can_edit_workflow}
-          return_to={"#{@base_url}?name=#{@workflow.name}&s=#{@selected_job.id}"}
+          return_to={return_to(@live_action, @base_url, @workflow, @selected_job)}
         />
         <.form
           id="workflow-form"
@@ -1453,5 +1453,15 @@ defmodule LightningWeb.WorkflowLive.Edit do
     else
       socket
     end
+  end
+
+  defp return_to(action, base_url, workflow, selected_job) do
+    query_params =
+      case action do
+        :edit -> %{s: selected_job.id}
+        :new -> %{name: workflow.name, s: selected_job.id}
+      end
+
+    "#{base_url}?#{URI.encode_query(query_params)}"
   end
 end


### PR DESCRIPTION
## Validation Steps

### Steps to Reproduce the Bug

1. **Create a Workflow**: Navigate to the workflow creation section and initiate a new workflow.
2. **Do Not Save the Workflow**: Leave the workflow unsaved.
3. **Attempt to Create a Credential**: In the Job view, click on 'New credential' to open the credential type picker modal.
4. **Close the Modal**: Close the credential type picker modal without making a selection.
5. **Observe the Crash**: Notice that the application crashes.

### Steps to Test the Fix

1. **Create a Workflow**: Navigate to the workflow creation section and initiate a new workflow.
2. **Do Not Save the Workflow**: Leave the workflow unsaved.
3. **Attempt to Create a Credential**: In the Job view, click on 'New credential' to open the credential type picker modal.
4. **Close the Modal**: Close the credential type picker modal without making a selection.
5. **Verify the Fix**: Confirm that the application does not crash and continues to function correctly.

## Notes for the reviewer

## Related issue

Fixes #2101 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
