### PR TITLE
Preserve Custom Values During Token Refresh by Merging New and Old Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Preserve Custom Values During Token Refresh by Merging New and Old Tokens
+  [#2131](https://github.com/OpenFn/lightning/issues/2131)
+
 ## [v2.5.1]
 
 - Don't compile Phoenix Storybook in production and test environments

--- a/lib/lightning/auth_providers/oauth_http_client.ex
+++ b/lib/lightning/auth_providers/oauth_http_client.ex
@@ -60,7 +60,7 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     |> maybe_introspect(client)
     |> case do
       {:ok, new_token} ->
-        {:ok, Map.put_new(new_token, "refresh_token", token["refresh_token"])}
+        {:ok, Map.merge(token, new_token)}
 
       {:error, error} ->
         {:error, error}

--- a/test/lightning/oauth_http_client_test.exs
+++ b/test/lightning/oauth_http_client_test.exs
@@ -40,7 +40,7 @@ defmodule Lightning.AuthProviders.OauthHTTPClientTest do
   end
 
   describe "refresh_token/4" do
-    test "refreshes the token successfully" do
+    test "refreshes the token successfully and merges with old token" do
       client_id = "id"
       client_secret = "secret"
       refresh_token = "validRefreshToken"
@@ -50,6 +50,19 @@ defmodule Lightning.AuthProviders.OauthHTTPClientTest do
         "refresh_token" => "validRefreshToken",
         "access_token" => "newToken123",
         "token_type" => "bearer"
+      }
+
+      old_token = %{
+        "refresh_token" => refresh_token,
+        "access_token" => "oldToken123",
+        "custom_key" => "custom_value"
+      }
+
+      expected_merged_token = %{
+        "refresh_token" => "validRefreshToken",
+        "access_token" => "newToken123",
+        "token_type" => "bearer",
+        "custom_key" => "custom_value"
       }
 
       expect(Lightning.AuthProviders.OauthHTTPClient.Mock, :call, fn
@@ -74,10 +87,10 @@ defmodule Lightning.AuthProviders.OauthHTTPClientTest do
             client_secret: client_secret,
             token_endpoint: token_endpoint
           },
-          %{"refresh_token" => refresh_token}
+          old_token
         )
 
-      assert {:ok, response_body} == result
+      assert {:ok, expected_merged_token} == result
     end
 
     test "handles error when refresh token is invalid" do


### PR DESCRIPTION
## Validation Steps

## Notes for the reviewer

## Related issue

Fixes #2130 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
