### PR TITLE
Fix Credential Modal Closure Error When Workflow Is Unsaved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix Credential Modal Closure Error When Workflow Is Unsaved
+  [#2101](https://github.com/OpenFn/lightning/pull/2101)
+
 ## [v2.5.1]
 
 - Don't compile Phoenix Storybook in production and test environments

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -296,9 +296,7 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
   end
 
   def handle_event("close_modal", _, socket) do
-    {:noreply,
-     socket
-     |> push_navigate(to: socket.assigns.return_to)}
+    {:noreply, push_event(socket, "close_modal", %{})}
   end
 
   @impl true

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -731,16 +731,9 @@ defmodule LightningWeb.ProjectLiveTest do
 
       refute html =~ credential_name
 
-      {:ok, _view, html} =
-        view
-        |> element("#cancel-credential-type-picker", "Cancel")
-        |> render_click()
-        |> follow_redirect(
-          conn,
-          ~p"/projects/#{project}/settings#credentials"
-        )
-
-      refute html =~ credential_name
+      refute view
+             |> element("#cancel-credential-type-picker", "Cancel")
+             |> render_click() =~ credential_name
     end
 
     test "project admin can't edit project name and description with invalid data",


### PR DESCRIPTION
## Validation Steps

### Steps to Reproduce the Bug

1. **Create a Workflow**: Navigate to the workflow creation section and initiate a new workflow.
2. **Do Not Save the Workflow**: Leave the workflow unsaved.
3. **Attempt to Create a Credential**: In the Job view, click on 'New credential' to open the credential type picker modal.
4. **Close the Modal**: Close the credential type picker modal without making a selection.
5. **Observe the Crash**: Notice that the application crashes.

### Steps to Test the Fix

1. **Create a Workflow**: Navigate to the workflow creation section and initiate a new workflow.
2. **Do Not Save the Workflow**: Leave the workflow unsaved.
3. **Attempt to Create a Credential**: In the Job view, click on 'New credential' to open the credential type picker modal.
4. **Close the Modal**: Close the credential type picker modal without making a selection.
5. **Verify the Fix**: Confirm that the application does not crash and continues to function correctly.

## Notes for the reviewer

## Related issue

Fixes #2101 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
