### PR TITLE
Disable Credential Save Button Until All Form Fields Are Validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Disable Credential Save Button Until All Form Fields Are Validated
+  [#2099](https://github.com/OpenFn/lightning/issues/2099)
+
 ## [v2.5.2] - 2024-05-23
 
 ### Fixed

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -144,7 +144,6 @@ defmodule Lightning.Credentials do
     changeset =
       %Credential{}
       |> change_credential(attrs)
-      |> cast_body_change()
 
     Multi.new()
     |> Multi.insert(
@@ -225,11 +224,9 @@ defmodule Lightning.Credentials do
 
   defp cast_body_change(changeset), do: changeset
 
-  defp put_typed_body(body, "raw"), do: {:ok, body}
-
-  defp put_typed_body(body, "salesforce_oauth"), do: {:ok, body}
-
-  defp put_typed_body(body, "oauth"), do: {:ok, body}
+  defp put_typed_body(body, schema_name)
+       when schema_name in ["raw", "salesforce_oauth", "googlesheets", "oauth"],
+       do: {:ok, body}
 
   defp put_typed_body(body, schema_name) do
     schema = get_schema(schema_name)

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -486,6 +486,7 @@ defmodule Lightning.Credentials do
       credential,
       attrs |> coerce_json_field("body")
     )
+    |> cast_body_change()
   end
 
   @spec sensitive_values_for(Ecto.UUID.t() | Credential.t() | nil) :: [any()]


### PR DESCRIPTION
## Validation Steps

1. Attempt to create a new credential
2. Notice that the save button is enabled only if all required fields are filled in with valid data

## Notes for the reviewer

## Related issue

Fixes #2099 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
