### PR TITLE
Stop users from creating credentials with deprecated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Stop users from creating deprecated Salesforce and GoogleSheets credentials.
+  [#2142](https://github.com/OpenFn/lightning/issues/2142)
+
 ### Fixed
 
 - Fix Credential Modal Closure Error When Workflow Is Unsaved

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -595,42 +595,12 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
         {name |> Phoenix.HTML.Form.humanize(), name, nil, nil}
       end)
 
-    oauth_clients_from_env =
-      Application.get_env(:lightning, :oauth_clients)
-
     schemas_options
     |> Enum.concat([{"Raw JSON", "raw", nil, nil}])
-    |> handle_oauth_item(
-      {"GoogleSheets", "googlesheets", ~p"/images/oauth-2.png", nil},
-      get_in(oauth_clients_from_env, [:google, :client_id])
-    )
-    |> handle_oauth_item(
-      {
-        "Salesforce",
-        "salesforce_oauth",
-        ~p"/images/oauth-2.png",
-        nil
-      },
-      get_in(oauth_clients_from_env, [:salesforce, :client_id])
-    )
+    # TODO: Gracefully determine which adaptors define custom credential types
+    # and which adaptors use OAuth2 credential types.
+    |> List.delete({"Googlesheets", "googlesheets", nil, nil})
     |> Enum.sort_by(& &1, :asc)
-  end
-
-  defp handle_oauth_item(list, {_label, id, _image, _} = item, client_id) do
-    if is_nil(client_id) || Enum.member?(list, item) do
-      # Replace
-      Enum.reject(list, fn {_first, second, _third, _} -> second == id end)
-    else
-      Enum.map(list, fn
-        {_old_label, old_id, _old_image, _} when old_id == id -> item
-        old_item -> old_item
-      end)
-      |> append_if_missing(item)
-    end
-  end
-
-  defp append_if_missing(list, item) do
-    if Enum.member?(list, item), do: list, else: list ++ [item]
   end
 
   defp list_users do


### PR DESCRIPTION
## Validation Steps

1. Create a `salesforce_oauth` or `googlesheets` credential on `main`.
2. Move to this branch.
3. Check that you can still see, use, edit your previous credentials.
4. Check that you **cannot** create a new `salesforce_oauth` or `googlesheets` credential.

## Notes for the reviewer

This is the first step to getting rid of the old credential types. Please note the TODO, but know that we're fine without a perfect solution right now.

Fixes #2142 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
