### PR TITLE
Delete Steps Associated With Runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   specific snapshot version and the latest version. Edit mode is available when
   displaying the latest version.
   [#1843](https://github.com/OpenFn/lightning/issues/1843)
+- Allow users to delete steps sssociated with runs in the Workflow Canvas
+  [#2027](https://github.com/OpenFn/lightning/issues/2027)
 
 ### Changed
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -910,7 +910,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       put_flash(
         socket,
         :info,
-        "Can't switch to the latest version; the job has been deleted from the workflow."
+        "Can't switch to the latest version, the job has been deleted from the workflow."
       )
     else
       {next_changeset, version} = switch_changeset(socket)

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -605,7 +605,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     <div
       id={"version-switcher-toggle-wrapper-#{@id}"}
       class="flex items-center justify-between"
-      {if @disabled, do: ["phx-hook": "Tooltip", "data-placement": "top", "aria-label": "Can't switch to the latest version; the job has been deleted from the workflow."], else: []}
+      {if @disabled, do: ["phx-hook": "Tooltip", "data-placement": "top", "aria-label": "Can't switch to the latest version, the job has been deleted from the workflow."], else: []}
     >
       <span class="flex flex-grow flex-col">
         <span class="inline-flex items-center px-2 py-1 font-medium text-yellow-600">

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -964,8 +964,11 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       view |> click_delete_job(job_b)
 
+      project_id = project.id
+
       assert_push_event(view, "patches-applied", %{
         patches: [
+          %{value: ^project_id, path: "/project_id", op: "replace"},
           %{op: "remove", path: "/jobs/1"},
           %{op: "remove", path: "/edges/1"}
         ]

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -363,7 +363,8 @@ defmodule Lightning.Factories do
         %{
           id: Ecto.UUID.generate(),
           source_job_id: source_job.id,
-          target_job_id: target_job.id
+          target_job_id: target_job.id,
+          condition_type: :always
         }
         |> Map.merge(extra |> Enum.into(%{}))
       )
@@ -384,7 +385,8 @@ defmodule Lightning.Factories do
             Enum.into(extra, %{
               id: Ecto.UUID.generate(),
               source_trigger_id: trigger.id,
-              target_job_id: job.id
+              target_job_id: job.id,
+              condition_type: :always
             })
           )
     }


### PR DESCRIPTION
## Validation Steps

1. Run a workflow that has at least 2 jobs
2. Select the last job node of that workflow
3. Notice that the delete button is no longer disabled
4. Hit the delete button to see the job node disappear from your canvas

## Notes for the reviewer

## Related issue

Fixes #2027 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
