### PR TITLE
Fix for LiveView error when viewing a Run/Step and the socket reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ and this project adheres to
 
 - Disable Credential Save Button Until All Form Fields Are Validated
   [#2099](https://github.com/OpenFn/lightning/issues/2099)
-
 - Fix Credential Modal Closure Error When Workflow Is Unsaved
   [#2101](https://github.com/OpenFn/lightning/pull/2101)
+- Fix error when socket reconnects and user is viewing a run via the inspector
+  [#2148](https://github.com/OpenFn/lightning/issues/2148)
 
 ## [v2.5.2] - 2024-05-23
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -910,10 +910,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
     {:noreply, socket |> assign_manual_run_form(changeset)}
   end
 
+  # Handle empty manual run form submission, this happens when the dataclip
+  # dropdown is disabled and the socket reconnects.
+  def handle_event("manual_run_change", %{}, socket) do
+    {:noreply, socket}
+  end
+
   # The retry_from_run event is for creating a new run for an existing work
   # order, just like clicking "rerun from here" on the history page.
-
-  @impl true
   def handle_event(
         "rerun",
         %{"run_id" => run_id, "step_id" => step_id},

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -912,7 +912,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   # Handle empty manual run form submission, this happens when the dataclip
   # dropdown is disabled and the socket reconnects.
-  def handle_event("manual_run_change", %{}, socket) do
+  def handle_event("manual_run_change", _params, socket) do
     {:noreply, socket}
   end
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -140,6 +140,10 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
              )
              |> has_element?()
 
+      # Check that the liveview can handle an empty submit (dataclip dropdown is disabled)
+      # which happens on socket reconnects.
+      view |> element(~s{#manual-job-#{job.id} form}) |> render_change()
+
       assert view |> render_click("manual_run_submit", %{"manual" => %{}}) =~
                "You are not authorized to perform this action."
     end


### PR DESCRIPTION
## Validation Steps

Open a previously run work order (via the inspect button) at any step.
When you see the editor/inspector page, either restart your server or wait for a socket timeout (if behind a reverse-proxy or load balancer).

## Related issue

Fixes #2148 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
