### PR TITLE
Remove env file on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ x-lightning: &default-app
       - 'NODE_ENV=${NODE_ENV:-development}'
   depends_on:
     - 'postgres'
-  env_file:
-    - '.env'
   restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
   stop_grace_period: '3s'
   tty: ${TTY:-false}
@@ -40,8 +38,6 @@ services:
         limits:
           cpus: '${DOCKER_WEB_CPUS:-0}'
           memory: '${DOCKER_WEB_MEMORY:-0}'
-    env_file:
-      - '.env'
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/lightning_dev
     depends_on:
@@ -66,8 +62,6 @@ services:
       web:
         condition: service_healthy
         restart: true
-    env_file:
-      - '.env'
     command:
       ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT-4000}/worker']
     restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'


### PR DESCRIPTION
## Validation Steps

https://github.com/OpenFn/lightning/blob/main/README.md#run-via-docker

## Notes for the reviewer

The `.env` is not required anymore to run Lightning.

It is able to run work orders:
```
web-1       |   Parameters: %{"error_message" => nil, "error_type" => nil, "final_dataclip_id" => "2c893098-3319-43c9-ae00-5aa20df7ecde", "reason" => "success"}
web-1       | [info] [SRV] ❯ workflow f5673a82-516a-48eb-86af-d8f2caac0086 complete: releasing worker
web-1       | [info] [SRV] ❯ Leaving run:f5673a82-516a-48eb-86af-d8f2caac0086
web-1       | [info] [SRV] ℹ f5673a82-516a-48eb-86af-d8f2caac0086 :: run:complete :: OK
```

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
