### PR TITLE
Don't send project emails when creating starter project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Stopped sending emails when creating a starter project
+  [#2161](https://github.com/OpenFn/lightning/issues/2161)
+
 ## [v2.5.4] - 2024-05-31
 
 ### Added
@@ -50,8 +53,6 @@ and this project adheres to
   [#2079](https://github.com/OpenFn/lightning/issues/2079)
 - Dataclip Viewer now responds to page resize and internal page layout
   [#2120](https://github.com/OpenFn/lightning/issues/2120)
-- Stopped sending emails when creating a starter project
-  [#2161](https://github.com/OpenFn/lightning/issues/2161)
 
 ## [v2.5.3] - 2024-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
   [#2079](https://github.com/OpenFn/lightning/issues/2079)
 - Dataclip Viewer now responds to page resize and internal page layout
   [#2120](https://github.com/OpenFn/lightning/issues/2120)
+- Stopped sending emails when creating a starter project
+  [#2161](https://github.com/OpenFn/lightning/issues/2161)
 
 ## [v2.5.3] - 2024-05-27
 

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -166,12 +166,15 @@ defmodule Lightning.SetupUtils do
 
   def create_starter_project(name, project_users) do
     {:ok, project} =
-      Projects.create_project(%{
-        name: name,
-        history_retention_period:
-          Application.get_env(:lightning, :default_retention_period),
-        project_users: project_users
-      })
+      Projects.create_project(
+        %{
+          name: name,
+          history_retention_period:
+            Application.get_env(:lightning, :default_retention_period),
+          project_users: project_users
+        },
+        false
+      )
 
     {:ok, workflow} =
       Workflows.save_workflow(%{

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -1,6 +1,7 @@
 defmodule Lightning.SetupUtilsTest do
   alias Lightning.Invocation
   use Lightning.DataCase, async: true
+  import Swoosh.TestAssertions
 
   alias Lightning.{Accounts, Projects, Workflows, Jobs, SetupUtils}
   alias Lightning.Accounts.User
@@ -222,6 +223,8 @@ defmodule Lightning.SetupUtilsTest do
              """
 
       assert job_3.adaptor == "@openfn/language-dhis2@latest"
+
+      assert_no_email_sent()
     end
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -11,6 +11,7 @@ defmodule LightningWeb.ProjectLiveTest do
     only: [put_temporary_env: 3]
 
   import Lightning.GithubHelpers
+  import Swoosh.TestAssertions
 
   import Mox
 
@@ -147,6 +148,18 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert_patch(index_live, Routes.project_index_path(conn, :index))
       assert render(index_live) =~ "Project created successfully"
+
+      project_name = String.replace(@create_attrs.raw_name, " ", "-")
+
+      assert_email_sent(
+        to: [{"", user_1.email}],
+        subject: "Project #{project_name}"
+      )
+
+      assert_email_sent(
+        to: [{"", user_2.email}],
+        subject: "Project #{project_name}"
+      )
     end
 
     test "project owners can delete a project from the settings page",


### PR DESCRIPTION
## Notes for the reviewer

- Added test that validates that validates both the superadmin end and setup utils end
- Currently, users cannot create their own projects. This will need to implemented when we add that feature


## Related issue

Fixes #2161 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
