### PR TITLE
Hide deprecated adaptors from version picklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to
 
 ### Changed
 
+- Don't show deprecated adaptor versions in the adaptor version picklist (to be
+  followed by some graceful deprecation handling/warning in
+  [later work](https://github.com/OpenFn/lightning/issues/2172))
+  [#2169](https://github.com/OpenFn/lightning/issues/2169)
+
 ### Fixed
 
 ## [v2.5.4] - 2024-05-31

--- a/lib/lightning/adaptor_registry.ex
+++ b/lib/lightning/adaptor_registry.ex
@@ -257,7 +257,10 @@ defmodule Lightning.AdaptorRegistry do
       repo: details["repository"]["url"],
       latest: details["dist-tags"]["latest"],
       versions:
-        Enum.map(details["versions"], fn {version, _detail} ->
+        Enum.reject(details["versions"], fn {_version, detail} ->
+          detail["deprecated"]
+        end)
+        |> Enum.map(fn {version, _detail} ->
           %{version: version}
         end)
     }


### PR DESCRIPTION
Fixes #2169 

## Validation Steps

- notice `language-salesforce@4.4.0` and `@5.0.1` in your adpator list on `main`.
- clear your local adaptor cache: `rm -rf /tmp/openfn/worker/repo`.
- switch to this branhc
- boot up lightning
- notice that `4.4.0` and `5.0.1` no longer appear

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
