### PR TITLE
Adds Project and Account hooks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,9 @@ config :lightning, LightningWeb.Endpoint,
 config :lightning, Lightning.Extensions,
   rate_limiter: Lightning.Extensions.RateLimiter,
   usage_limiter: Lightning.Extensions.UsageLimiter,
-  run_queue: Lightning.Extensions.FifoRunQueue
+  run_queue: Lightning.Extensions.FifoRunQueue,
+  account_hook: Lightning.Extensions.AccountHook,
+  project_hook: Lightning.Extensions.ProjectHook
 
 # TODO: don't use this value in production
 config :joken, default_signer: "secret"

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -358,7 +358,7 @@ defmodule Lightning.Accounts do
   def register_user(attrs) do
     Repo.transact(fn ->
       with {:ok, user} <- AccountHook.handle_register_user(attrs) do
-        # always delivers and if transaction fails,
+        # always delivers and if the transaction fails,
         # the user will need to register again as usual
         deliver_user_confirmation_instructions(user)
         {:ok, user}

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -357,15 +357,13 @@ defmodule Lightning.Accounts do
   """
   def register_user(attrs) do
     Repo.transact(fn ->
-      with {:ok, user} <- AccountHook.handle_register_user(attrs) do
-        # always delivers and if the transaction fails,
-        # the user will need to register again as usual
-        deliver_user_confirmation_instructions(user)
-        {:ok, user}
-      end
+      AccountHook.handle_register_user(attrs)
     end)
     |> tap(fn result ->
-      with {:ok, user} <- result, do: Events.user_registered(user)
+      with {:ok, user} <- result do
+        Events.user_registered(user)
+        deliver_user_confirmation_instructions(user)
+      end
     end)
   end
 

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -2,7 +2,6 @@ defmodule Lightning.Accounts do
   @moduledoc """
   The Accounts context.
   """
-
   use Oban.Worker,
     queue: :background,
     max_attempts: 1
@@ -18,6 +17,7 @@ defmodule Lightning.Accounts do
   alias Lightning.Accounts.UserTOTP
   alias Lightning.Credentials
   alias Lightning.Repo
+  alias Lightning.Services.AccountHook
 
   require Logger
 
@@ -88,9 +88,9 @@ defmodule Lightning.Accounts do
   end
 
   def create_user(attrs) do
-    %User{}
-    |> User.changeset(attrs)
-    |> Repo.insert()
+    Repo.transact(fn ->
+      AccountHook.handle_create_user(attrs)
+    end)
   end
 
   @doc """
@@ -320,15 +320,9 @@ defmodule Lightning.Accounts do
   """
 
   def register_superuser(attrs) do
-    User.superuser_registration_changeset(attrs)
-    |> Ecto.Changeset.apply_action(:insert)
-    |> case do
-      {:ok, data} ->
-        struct(User, data) |> Repo.insert()
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
+    Repo.transact(fn ->
+      AccountHook.handle_register_superuser(attrs)
+    end)
   end
 
   @doc """
@@ -362,22 +356,17 @@ defmodule Lightning.Accounts do
 
   """
   def register_user(attrs) do
-    User.user_registration_changeset(attrs)
-    |> Ecto.Changeset.apply_action(:insert)
-    |> case do
-      {:ok, data} ->
-        struct(User, data)
-        |> Repo.insert()
-        |> tap(fn result ->
-          with {:ok, user} <- result do
-            Events.user_registered(user)
-            deliver_user_confirmation_instructions(user)
-          end
-        end)
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
+    Repo.transact(fn ->
+      with {:ok, user} <- AccountHook.handle_register_user(attrs) do
+        # always delivers and if transaction fails,
+        # the user will need to register again as usual
+        deliver_user_confirmation_instructions(user)
+        {:ok, user}
+      end
+    end)
+    |> tap(fn result ->
+      with {:ok, user} <- result, do: Events.user_registered(user)
+    end)
   end
 
   @doc """

--- a/lib/lightning/extensions/account_hook.ex
+++ b/lib/lightning/extensions/account_hook.ex
@@ -1,0 +1,34 @@
+defmodule Lightning.Extensions.AccountHook do
+  @moduledoc false
+  @behaviour Lightning.Extensions.AccountHooking
+
+  alias Ecto.Changeset
+  alias Lightning.Accounts.User
+  alias Lightning.Repo
+
+  @spec handle_register_user(map()) :: {:ok, User.t()} | {:error, Changeset.t()}
+  def handle_register_user(attrs) do
+    with {:ok, data} <-
+           User.user_registration_changeset(attrs)
+           |> Changeset.apply_action(:insert) do
+      Repo.insert(struct(User, data))
+    end
+  end
+
+  @spec handle_register_superuser(map()) ::
+          {:ok, User.t()} | {:error, Changeset.t()}
+  def handle_register_superuser(attrs) do
+    with {:ok, data} <-
+           User.superuser_registration_changeset(attrs)
+           |> Ecto.Changeset.apply_action(:insert) do
+      struct(User, data) |> Repo.insert()
+    end
+  end
+
+  @spec handle_create_user(map()) :: {:ok, User.t()} | {:error, Changeset.t()}
+  def handle_create_user(attrs) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/lightning/extensions/account_hooking.ex
+++ b/lib/lightning/extensions/account_hooking.ex
@@ -1,0 +1,16 @@
+defmodule Lightning.Extensions.AccountHooking do
+  @moduledoc """
+  Allows handling user creation or registration atomically without relying on async events.
+  """
+  alias Ecto.Changeset
+  alias Lightning.Accounts.User
+
+  @callback handle_register_user(attrs :: map()) ::
+              {:ok, User.t()} | {:error, Changeset.t()}
+
+  @callback handle_register_superuser(attrs :: map()) ::
+              {:ok, User.t()} | {:error, Changeset.t()}
+
+  @callback handle_create_user(attrs :: map()) ::
+              {:ok, User.t()} | {:error, Changeset.t()}
+end

--- a/lib/lightning/extensions/project_hook.ex
+++ b/lib/lightning/extensions/project_hook.ex
@@ -5,6 +5,7 @@ defmodule Lightning.Extensions.ProjectHook do
   @behaviour Lightning.Extensions.ProjectHooking
 
   alias Ecto.Changeset
+  alias Lightning.Projects
   alias Lightning.Projects.Project
   alias Lightning.Repo
 
@@ -14,5 +15,31 @@ defmodule Lightning.Extensions.ProjectHook do
     %Project{}
     |> Project.project_with_users_changeset(attrs)
     |> Repo.insert()
+  end
+
+  @spec handle_delete_project(Project.t()) ::
+          {:ok, Project.t()} | {:error, Changeset.t()}
+  def handle_delete_project(project) do
+    Projects.project_runs_query(project) |> Repo.delete_all()
+
+    Projects.project_run_step_query(project) |> Repo.delete_all()
+
+    Projects.project_workorders_query(project) |> Repo.delete_all()
+
+    Projects.project_steps_query(project) |> Repo.delete_all()
+
+    Projects.project_jobs_query(project) |> Repo.delete_all()
+
+    Projects.project_triggers_query(project) |> Repo.delete_all()
+
+    Projects.project_workflows_query(project) |> Repo.delete_all()
+
+    Projects.project_users_query(project) |> Repo.delete_all()
+
+    Projects.project_credentials_query(project) |> Repo.delete_all()
+
+    Projects.project_dataclips_query(project) |> Repo.delete_all()
+
+    Repo.delete(project)
   end
 end

--- a/lib/lightning/extensions/project_hook.ex
+++ b/lib/lightning/extensions/project_hook.ex
@@ -1,0 +1,18 @@
+defmodule Lightning.Extensions.ProjectHook do
+  @moduledoc """
+  Allows handling user creation or registration atomically without relying on async events.
+  """
+  @behaviour Lightning.Extensions.ProjectHooking
+
+  alias Ecto.Changeset
+  alias Lightning.Projects.Project
+  alias Lightning.Repo
+
+  @spec handle_create_project(map()) ::
+          {:ok, Project.t()} | {:error, Changeset.t()}
+  def handle_create_project(attrs) do
+    %Project{}
+    |> Project.project_with_users_changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/lightning/extensions/project_hooking.ex
+++ b/lib/lightning/extensions/project_hooking.ex
@@ -7,4 +7,7 @@ defmodule Lightning.Extensions.ProjectHooking do
 
   @callback handle_create_project(attrs :: map()) ::
               {:ok, Project.t()} | {:error, Changeset.t()}
+
+  @callback handle_delete_project(Project.t()) ::
+              {:ok, Project.t()} | {:error, Changeset.t()}
 end

--- a/lib/lightning/extensions/project_hooking.ex
+++ b/lib/lightning/extensions/project_hooking.ex
@@ -1,0 +1,10 @@
+defmodule Lightning.Extensions.ProjectHooking do
+  @moduledoc """
+  Allows handling project creation atomically without relying on async events.
+  """
+  alias Ecto.Changeset
+  alias Lightning.Projects.Project
+
+  @callback handle_create_project(attrs :: map()) ::
+              {:ok, Project.t()} | {:error, Changeset.t()}
+end

--- a/lib/lightning/services/account_hook.ex
+++ b/lib/lightning/services/account_hook.ex
@@ -1,0 +1,29 @@
+defmodule Lightning.Services.AccountHook do
+  @moduledoc """
+  Allows handling user creation or registration atomically without relying on async events.
+  """
+  @behaviour Lightning.Extensions.AccountHooking
+
+  import Lightning.Services.AdapterHelper
+
+  alias Ecto.Changeset
+  alias Lightning.Accounts.User
+
+  @spec handle_register_user(map()) :: {:ok, User.t()} | {:error, Changeset.t()}
+  def handle_register_user(attrs) do
+    adapter().handle_register_user(attrs)
+  end
+
+  @spec handle_register_superuser(map()) ::
+          {:ok, User.t()} | {:error, Changeset.t()}
+  def handle_register_superuser(attrs) do
+    adapter().handle_register_superuser(attrs)
+  end
+
+  @spec handle_create_user(map()) :: {:ok, User.t()} | {:error, Changeset.t()}
+  def handle_create_user(attrs) do
+    adapter().handle_create_user(attrs)
+  end
+
+  defp adapter, do: adapter(:account_hook)
+end

--- a/lib/lightning/services/project_hook.ex
+++ b/lib/lightning/services/project_hook.ex
@@ -15,5 +15,11 @@ defmodule Lightning.Services.ProjectHook do
     adapter().handle_create_project(attrs)
   end
 
+  @spec handle_delete_project(Project.t()) ::
+          {:ok, Project.t()} | {:error, Changeset.t()}
+  def handle_delete_project(project) do
+    adapter().handle_delete_project(project)
+  end
+
   defp adapter, do: adapter(:project_hook)
 end

--- a/lib/lightning/services/project_hook.ex
+++ b/lib/lightning/services/project_hook.ex
@@ -1,0 +1,19 @@
+defmodule Lightning.Services.ProjectHook do
+  @moduledoc """
+  Allows handling project creation atomically without relying on async events.
+  """
+  @behaviour Lightning.Extensions.ProjectHooking
+
+  import Lightning.Services.AdapterHelper
+
+  alias Ecto.Changeset
+  alias Lightning.Projects.Project
+
+  @spec handle_create_project(map()) ::
+          {:ok, Project.t()} | {:error, Changeset.t()}
+  def handle_create_project(attrs) do
+    adapter().handle_create_project(attrs)
+  end
+
+  defp adapter, do: adapter(:project_hook)
+end

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -833,14 +833,16 @@ defmodule Lightning.RunsTest do
       refute dataclip.wiped_at
 
       :ok = Runs.wipe_dataclips(run)
+      wiped_at = DateTime.utc_now() |> DateTime.truncate(:second)
 
       # dataclip body is cleared
       query = from(Invocation.Dataclip, select: [:wiped_at, :body, :request])
 
       updated_dataclip = Lightning.Repo.get(query, dataclip.id)
 
-      assert updated_dataclip.wiped_at ==
-               DateTime.utc_now() |> DateTime.truncate(:second)
+      assert updated_dataclip.wiped_at == wiped_at or
+               1 ==
+                 abs(DateTime.diff(updated_dataclip.wiped_at, wiped_at, :second))
 
       refute updated_dataclip.body
       refute updated_dataclip.request

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -42,5 +42,7 @@ Application.put_env(:lightning, Lightning, LightningMock)
 Application.put_env(:lightning, Lightning.Extensions,
   rate_limiter: Lightning.Extensions.MockRateLimiter,
   usage_limiter: Lightning.Extensions.MockUsageLimiter,
-  run_queue: Lightning.Extensions.FifoRunQueue
+  run_queue: Lightning.Extensions.FifoRunQueue,
+  account_hook: Lightning.Extensions.AccountHook,
+  project_hook: Lightning.Extensions.ProjectHook
 )


### PR DESCRIPTION
## Validation Steps

1. Register a new user (Lightning form)
2. Login as super user and create another super user
3. Still as a super user, create a regular user
4. Still as a super user, create a project

## Notes for the reviewer

These hooks (`ProjectHook` and `AccountHook`) inside Project and Account contexts allow umbrella apps to handle project and user creation on the same DB which means that all set of operations that need to be atomic can be handled without relying on async events.

As `ProjectHook.handle_create_project/1`, `AccountHook.handle_create_user/1` and so on are called in the context of a DB transaction can be reused by an umbrella app to override and/or extend these hooks.

## Related issue

Resolves #2029
Refs https://github.com/OpenFn/thunderbolt/issues/146

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
