### PR TITLE
Reject unsupported content-types on webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   [#2182](https://github.com/OpenFn/lightning/pull/2182)
 - Update email notification for changing retention period
   [#2066](https://github.com/OpenFn/lightning/issues/2066)
+- Return 415s when Webhooks are sent Content-Types what are not supported.
+  [#2180](https://github.com/OpenFn/lightning/issues/2180)
 
 ### Fixed
 

--- a/lib/lightning_web.ex
+++ b/lib/lightning_web.ex
@@ -22,7 +22,6 @@ defmodule LightningWeb do
 
   def router do
     quote do
-      # , helpers: false
       use Phoenix.Router
 
       import Plug.Conn

--- a/test/lightning_web/controllers/webhooks_controller_test.exs
+++ b/test/lightning_web/controllers/webhooks_controller_test.exs
@@ -179,6 +179,19 @@ defmodule LightningWeb.WebhooksControllerTest do
       assert Runs.get_dataclip_request(run) ==
                ~s({\"path\": [\"i\", \"#{trigger_id}\"], \"method\": \"POST\", \"headers\": {\"content-type\": \"multipart/mixed; boundary=plug_conn_test\"}, \"query_params\": {\"moar\": \"things\", \"extra\": \"stuff\"}})
     end
+
+    test "returns 415 when client sends xml", %{conn: conn} do
+      %{triggers: [%{id: trigger_id}]} =
+        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "text/xml")
+        |> put_req_header("accepts", "*/*")
+        |> post("/i/#{trigger_id}", "{}")
+
+      assert response(conn, 415) == ~s({"error":"Unsupported Media Type"})
+    end
   end
 
   describe "a disabled message" do


### PR DESCRIPTION
## Validation Steps

1. Run your local server
2. Get a web hook url for any workflow
3. Run a curl command:

```sh
curl \
 -X POST \
 -H "Accept: */*" \
 -H "Accept-Encoding: gzip, deflate" \
 -H "Content-Length: 4834" \
 -H "Content-Type: text/xml" \
 $WEBHOOK_URL
```

You should see: `{"error":"Unsupported Media Type"}` as the response.

## Notes for the reviewer

Users that send data without a supported mime type cause exceptions to be raised because the controller tries to encode the request body (which is `Unfetched`).

Instead of throwing an exception, we should return a 415 error.

## Related issue

Fixes #2180

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
