### PR TITLE
default sender name to OpenFn

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -176,7 +176,7 @@ config :lightning, :release, release
 
 config :lightning, :emails,
   admin_email: env!("EMAIL_ADMIN", :string, "support@openfn.org"),
-  sender_name: env!("EMAIL_SENDER_NAME", :string, "Lightning")
+  sender_name: env!("EMAIL_SENDER_NAME", :string, "OpenFn")
 
 config :lightning, :adaptor_service,
   adaptors_path: env!("ADAPTORS_PATH", :string, "./priv/openfn")


### PR DESCRIPTION
I think we should default this to "OpenFn", even though "Lightning" is the codename we've been using for OpenFn v2. This was the original request, yes, @aleksa-krolls ?