### PR TITLE
update default step text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
   [#2066](https://github.com/OpenFn/lightning/issues/2066)
 - Return 415s when Webhooks are sent Content-Types what are not supported.
   [#2180](https://github.com/OpenFn/lightning/issues/2180)
+- Updated the default step text
 
 ### Fixed
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -10,7 +10,7 @@ import { initiateSaveAndRun } from '../common';
 import dts_es5 from './lib/es5.min.dts';
 
 export const DEFAULT_TEXT = `
-// Check out the Job Writing guide for help getting started:
+// Check out the Job Writing Guide for help getting started:
 // https://docs.openfn.org/documentation/jobs/job-writing-guide
 `;
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -9,10 +9,10 @@ import { initiateSaveAndRun } from '../common';
 // static imports for core lib
 import dts_es5 from './lib/es5.min.dts';
 
-export const DEFAULT_TEXT = `// Use pure JavaScript to add operations to your
-// step. Click Docs to see list of operations or visit
-// https://bit.ly/OFNJWG for our job writing guide
-// and example job codes.\n`;
+export const DEFAULT_TEXT = `
+// Check out the Job Writing guide for help getting started:
+// https://docs.openfn.org/documentation/jobs/job-writing-guide
+`;
 
 type EditorProps = {
   source?: string;


### PR DESCRIPTION
## Overview

## Details

This is another attempt to address #2014 - but that issue doesn't even scratch the surface of the problems users face getting started.

## What was wrong with the last fix?

* It wrongly claimed that jobs are written in "pure" JS (the pure bit in particular I have issues with)
* It used a URL shortener to link to our own docs. But URL shorteners are poor UX and bad security practice
* It had bad english eg "job codes"
* It had some weird stuff about the Docs panel
* Also its full of jargon

I'm sorry but basically it just hadn't been thought through with care and rigour.

Also, doing any of this stuff in a comment only lasts as long as the comment. Once the user deletes it, it's gone forever.

## Why is this fix so much better

* First of all this "fix" is terrible and doesn't address the issue in question
* It removes the URL shortener and is honest about the content it links to
* It is good english
* It is accurate

## What next?

Onboarding the user into something as complex as openfn job writing is really hard and won't be solved by a comment If there is to be any attempt to address this problem it needs coordinated, thoughtful effort.

Here are some brief thoughts about things we might look at:

* Having a Help or Getting Started tab, with a short and friendly onboarding guide
* Don't show four large, complex and intimidating panels when the user first opens the inspector
* Putting a leading example in the Docs panel, one per adaptor
* Similarly, put a default example in each adaptor and insert that into the template (doesn't work when the adaptor changes)
* Show a permanent banner with a link to the job writing guide
