### PR TITLE
More information about anonymous public metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to
 
 ### Changed
 
+- Added a notice on application start about anonymous public impact reporting
+  and its importance for the sustainability of
+  [Digital Public Goods](https://digitalpublicgoods.net/) and
+  [Digital Public Infrastructure](https://www.codevelop.fund/insights-1/what-is-digital-public-infrastructure).
+
 ### Fixed
 
 ## [v2.6.2] - 2024-06-13

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -511,7 +511,7 @@ config :lightning, :metrics,
 
 # Digital Public Goods Anonymous Impact Tracking ===============================
 about_anonymous_public_impact_tracking =
-  "\nOpenFn is a free and open-source Digital Public Good. Even if you are unable to contribute to the movement financially or by participating in our product development community, sending these anonymous aggregate usage reports will help us ensure the long-term sustainability of the project by better demonstrating our impact and helping us secure further donor support.\n" <>
+  "\nOpenFn is a free and open-source Digital Public Good. Even if you are unable to contribute to the movement financially or by participating in our product development community, sending these anonymous aggregate usage reports will ensure the long-term sustainability of the project by allowing us to understand the needs of our users, by better demonstrating our impact, and by helping us secure further donor support.\n" <>
     "\nView the aggregated anonymous public metrics submitted by other OpenFn instance administrators like you from around the world here: https://analytics.openfn.org/public/dashboard/d4d7766e-e2fe-4673-b4e5-8bf52f0054a1\n"
 
 where_to_view_anonymous_public_impact_data =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,6 +2,8 @@ alias Lightning.Config.Utils
 import Config
 import Dotenvy
 
+require Logger
+
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
 # system starts, so it is typically used to load production configuration
@@ -507,8 +509,32 @@ config :lightning, :metrics,
   run_queue_metrics_period_seconds:
     env!("METRICS_RUN_QUEUE_METRICS_PERIOD_SECONDS", :integer, 5)
 
+# Digital Public Goods Anonymous Impact Tracking ===============================
+about_anonymous_public_impact_tracking =
+  "\nOpenFn is a free and open-source Digital Public Good. Even if you are unable to contribute to the movement financially or by participating in our product development community, sending these anonymous aggregate usage reports will help us ensure the long-term sustainability of the project by better demonstrating our impact and helping us secure further donor support.\n" <>
+    "\nView the aggregated anonymous public metrics submitted by other OpenFn instance administrators like you from around the world here: https://analytics.openfn.org/public/dashboard/d4d7766e-e2fe-4673-b4e5-8bf52f0054a1\n"
+
+where_to_view_anonymous_public_impact_data =
+  case env!("USAGE_TRACKING_ENABLED", &Utils.ensure_boolean/1, true) do
+    true ->
+      Logger.notice(
+        "Thank you for participating in anonymous public impact tracking!\n" <>
+          about_anonymous_public_impact_tracking <>
+          "\nIf you would like to opt-out of anonymous public impact tracking, you can set your `USAGE_TRACKING_ENABLED` environment variable to `false` at any time.\n"
+      )
+
+    false ->
+      Logger.notice(
+        "You have opted-out of anonymous public impact tracking.\n" <>
+          about_anonymous_public_impact_tracking <>
+          "\nIf the product is benefitting you or your organization, we hope you will consider opting-in to anonymous public impact tracking in the future. You can do so by setting your `USAGE_TRACKING_ENABLED` environment variable to `true` at any time.\n"
+      )
+  end
+
 config :lightning, :usage_tracking,
   cleartext_uuids_enabled:
     env!("USAGE_TRACKING_UUIDS", :string, nil) == "cleartext",
   enabled: env!("USAGE_TRACKING_ENABLED", &Utils.ensure_boolean/1, true),
   host: env!("USAGE_TRACKER_HOST", :string, "https://impact.openfn.org")
+
+# ==============================================================================

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -518,16 +518,16 @@ where_to_view_anonymous_public_impact_data =
   case env!("USAGE_TRACKING_ENABLED", &Utils.ensure_boolean/1, true) do
     true ->
       Logger.notice(
-        "Thank you for participating in anonymous public impact tracking!\n" <>
+        "❤️ Thank you for participating in anonymous public impact reporting!\n" <>
           about_anonymous_public_impact_tracking <>
-          "\nIf you would like to opt-out of anonymous public impact tracking, you can set your `USAGE_TRACKING_ENABLED` environment variable to `false` at any time.\n"
+          "\nYou are reporting to #{env!("USAGE_TRACKER_HOST", :string, "https://impact.openfn.org")}. If you would like to opt-out of anonymous public impact reporting, you can set your `USAGE_TRACKING_ENABLED` environment variable to `false` at any time.\n"
       )
 
     false ->
       Logger.notice(
-        "You have opted-out of anonymous public impact tracking.\n" <>
+        "You have opted-out of anonymous public impact reporting.\n" <>
           about_anonymous_public_impact_tracking <>
-          "\nIf the product is benefitting you or your organization, we hope you will consider opting-in to anonymous public impact tracking in the future. You can do so by setting your `USAGE_TRACKING_ENABLED` environment variable to `true` at any time.\n"
+          "\nIf the product is benefitting you or your organization, we hope you will consider opting-in to anonymous public impact reporting in the future. You can do so by setting your `USAGE_TRACKING_ENABLED` environment variable to `true` at any time.\n"
       )
   end
 

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -2,9 +2,10 @@ defmodule Lightning.Application do
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
   @moduledoc false
-
   use Application
   import Cachex.Spec
+
+  require Logger
 
   @impl true
   def start(_type, _args) do
@@ -143,6 +144,67 @@ defmodule Lightning.Application do
   end
 
   def oban_opts do
-    Application.get_env(:lightning, Oban)
+    opts = Application.get_env(:lightning, Oban)
+
+    opts[:plugins]
+    |> List.keyfind(Oban.Plugins.Cron, 0)
+    |> then(fn {mod, cron_opts} ->
+      {mod, put_usage_tracking_cron_opts(cron_opts)}
+    end)
+
+    opts
+  end
+
+  defp put_usage_tracking_cron_opts(cron_opts) do
+    usage_tracking_opts = Lightning.Config.usage_tracking()
+
+    if usage_tracking_opts[:enabled] do
+      print_tracking_thanks_message()
+    else
+      print_tracking_opt_out_message()
+    end
+
+    Keyword.merge(
+      cron_opts,
+      [crontab: Lightning.Config.usage_tracking_cron_opts()],
+      fn _key, old, new -> old ++ new end
+    )
+  end
+
+  @about_anonymous_public_impact_tracking """
+  OpenFn is a free and open-source Digital Public Good.
+  Even if you are unable to contribute to the movement financially or by participating
+  in our product development community, sending these anonymous aggregate usage reports
+  will ensure the long-term sustainability of the project by allowing us
+  to understand the needs of our users, by better demonstrating our impact,
+  and by helping us secure further donor support.
+
+  View the aggregated anonymous public metrics submitted by other OpenFn
+  instance administrators like you from around the world here:
+
+  https://analytics.openfn.org/public/dashboard/d4d7766e-e2fe-4673-b4e5-8bf52f0054a1
+  """
+
+  defp print_tracking_thanks_message do
+    Logger.notice("""
+    ️❤️ Thank you for participating in anonymous public impact reporting!
+
+    #{@about_anonymous_public_impact_tracking}
+    You are reporting to #{Lightning.Config.usage_tracking()[:host]}.
+    If you would like to opt-out of anonymous public impact reporting,
+    you can set your `USAGE_TRACKING_ENABLED` environment variable to `false` at any time.
+    """)
+  end
+
+  defp print_tracking_opt_out_message do
+    Logger.notice("""
+    You have opted-out of anonymous public impact reporting.
+
+    #{@about_anonymous_public_impact_tracking}
+    If the product is benefitting you or your organization, we hope you
+    will consider opting-in to anonymous public impact reporting in the future.
+
+    You can do so by setting your `USAGE_TRACKING_ENABLED` environment variable to `true` at any time.
+    """)
   end
 end


### PR DESCRIPTION
I'd like to start making some more noise about the anonymous public metrics system. It's looking really good and we've already got a number of instances around the world reporting. This PR introduces a notice that explains why it's so important for the project and provides instructions for seeing the anonymous, public, aggregate data as well as how to turn participation on or off.

Two questions:
1. **Technical:** Is it OK to use `Logger` in `runtime.exs`?
2. **Communications:** Do you like the language here? Anything we should add or remove?

## The notices themselves:

### If enabled (default)

_12:35:23.502 [notice] ❤️ Thank you for participating in anonymous public impact tracking!_

_OpenFn is a free and open-source Digital Public Good. Even if you are unable to contribute to the movement financially or by participating in our product development community, sending these anonymous aggregate usage reports will help us ensure the long-term sustainability of the project by better demonstrating our impact and helping us secure further donor support._

_View the aggregated anonymous public metrics submitted by other OpenFn instance administrators like you from around the world here: https://analytics.openfn.org/public/dashboard/d4d7766e-e2fe-4673-b4e5-8bf52f0054a1_

_You are reporting to https://impact.openfn.org. If you would like to opt-out of anonymous public impact reporting, you can set your `USAGE_TRACKING_ENABLED` environment variable to `false` at any time._


### If disabled

_12:35:15.138 [notice] You have opted-out of anonymous public impact tracking._

_OpenFn is a free and open-source Digital Public Good. Even if you are unable to contribute to the movement financially or by participating in our product development community, sending these anonymous aggregate usage reports will help us ensure the long-term sustainability of the project by better demonstrating our impact and helping us secure further donor support._

_View the aggregated anonymous public metrics submitted by other OpenFn instance administrators like you from around the world here: https://analytics.openfn.org/public/dashboard/d4d7766e-e2fe-4673-b4e5-8bf52f0054a1_

_If the product is benefitting you or your organization, we hope you will consider opting-in to anonymous public impact tracking in the future. You can do so by setting your `USAGE_TRACKING_ENABLED` environment variable to `true` at any time._