### PR TITLE
Fix race condition when syncing from openfn while deploy actions are running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix race condition when syncing from openfn while deploy actions are running
+  [#2179](https://github.com/OpenFn/lightning/issues/2179)
+
 ## [v2.6.2] - 2024-06-13
 
 ### Fixed

--- a/priv/github/pull.yml
+++ b/priv/github/pull.yml
@@ -16,7 +16,9 @@ on:
       commitMessage:
         description: 'Commit message for project state and spec'
         required: true
-
+concurrency:
+  group: openfn-deployment
+  cancel-in-progress: false
 jobs:
   pull-from-lightning:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Validation Steps
In order to test this properly, your github project should have more than 1 connection to openfn. Let's go with 2

- Trigger the deploy actions by committing and pushing to your branch then immediately go to Lightning then click sync to branch.
- You'll notice that your `pull job` will run `3rd`, that is after the 2 deploy  actions have ran.


## Related issue

Fixes #2179 

## Review checklist

- [x] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
