### PR TITLE
line up default worker run timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@
 # in seconds. Combined, these should be lower than the pod termination grace
 # period if you are using Kubernetes.
 # RUN_GRACE_PERIOD_SECONDS=10
-# WORKER_MAX_RUN_DURATION_SECONDS=60
+# WORKER_MAX_RUN_DURATION_SECONDS=300
 
 # TODO: these aren't specified in Runtime, do they belong to the worker process?
 # WORKER_MAX_RUN_MEMORY_MB=500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- Increase default WORKER*MAX_RUN_DURATION_SECONDS to 300 to match the
+  [ws-worker default](https://github.com/OpenFn/kit/blob/main/packages/ws-worker/src/util/cli.ts#L149-L153)
+  so if people don't set their timeout via ENV, at least the two match up.
+
 ### Fixed
 
 ## [v2.6.2] - 2024-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to
 
 ### Changed
 
-- Increase default WORKER*MAX_RUN_DURATION_SECONDS to 300 to match the
+- Increase default `WORKER_MAX_RUN_DURATION_SECONDS` to 300 to match the
   [ws-worker default](https://github.com/OpenFn/kit/blob/main/packages/ws-worker/src/util/cli.ts#L149-L153)
   so if people don't set their timeout via ENV, at least the two match up.
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -277,7 +277,7 @@ config :lightning,
 
 config :lightning,
        :max_run_duration_seconds,
-       env!("WORKER_MAX_RUN_DURATION_SECONDS", :integer, 60)
+       env!("WORKER_MAX_RUN_DURATION_SECONDS", :integer, 300)
 
 config :lightning,
        :max_dataclip_size_bytes,

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -302,7 +302,7 @@ defmodule Lightning.RunsTest do
 
       assert %Lightning.Runs.RunOptions{
                save_dataclips: false,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              } = run.options
 
       step =

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -302,7 +302,7 @@ defmodule Lightning.RunsTest do
 
       assert %Lightning.Runs.RunOptions{
                save_dataclips: false,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              } = run.options
 
       step =

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -62,7 +62,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.options == %Lightning.Runs.RunOptions{
                save_dataclips: false,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              }
 
       workorder_id = workorder.id
@@ -130,7 +130,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              }
 
       workorder_id = workorder.id
@@ -178,7 +178,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              }
 
       assert_received %Events.RunCreated{
@@ -278,7 +278,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              }
 
       assert retry_run.snapshot_id == snapshot2.id,
@@ -340,7 +340,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              }
 
       steps = Ecto.assoc(retry_run, :steps) |> Repo.all()
@@ -619,7 +619,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 300000
+               run_timeout_ms: 300_000
              }
 
       assert retry_run |> Repo.preload(:steps) |> Map.get(:steps) == [],

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -62,7 +62,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.options == %Lightning.Runs.RunOptions{
                save_dataclips: false,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              }
 
       workorder_id = workorder.id
@@ -130,7 +130,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              }
 
       workorder_id = workorder.id
@@ -178,7 +178,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              }
 
       assert_received %Events.RunCreated{
@@ -278,7 +278,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              }
 
       assert retry_run.snapshot_id == snapshot2.id,
@@ -340,7 +340,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              }
 
       steps = Ecto.assoc(retry_run, :steps) |> Repo.all()
@@ -619,7 +619,7 @@ defmodule Lightning.WorkOrdersTest do
 
       assert retry_run.options == %Lightning.Runs.RunOptions{
                save_dataclips: true,
-               run_timeout_ms: 60000
+               run_timeout_ms: 300000
              }
 
       assert retry_run |> Repo.preload(:steps) |> Map.get(:steps) == [],

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -47,7 +47,7 @@ defmodule LightningWeb.RunWithOptionsTest do
           ],
           "starting_node_id" => trigger.id,
           "triggers" => [%{"id" => trigger.id}],
-          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 60000}
+          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 300000}
         }
 
       run = Runs.get_for_worker(run.id)
@@ -96,7 +96,7 @@ defmodule LightningWeb.RunWithOptionsTest do
           ],
           "starting_node_id" => trigger.id,
           "triggers" => [%{"id" => trigger.id}],
-          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 60000}
+          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 300000}
         }
 
       assert RunWithOptions.render(run)

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -47,7 +47,7 @@ defmodule LightningWeb.RunWithOptionsTest do
           ],
           "starting_node_id" => trigger.id,
           "triggers" => [%{"id" => trigger.id}],
-          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 300000}
+          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 300_000}
         }
 
       run = Runs.get_for_worker(run.id)
@@ -96,7 +96,7 @@ defmodule LightningWeb.RunWithOptionsTest do
           ],
           "starting_node_id" => trigger.id,
           "triggers" => [%{"id" => trigger.id}],
-          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 300000}
+          "options" => %{"output_dataclips" => true, "run_timeout_ms" => 300_000}
         }
 
       assert RunWithOptions.render(run)


### PR DESCRIPTION
lots of `LOST` runs during jembi workshop. sounds like the people deploying lightning never set their ENVs, and the defaults don't match right now! this fixes this.