### PR TITLE
Reverted behaviour on "Rerun from here" to select the Log tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Reverted behaviour on "Rerun from here" to select the Log tab.
+  [#2202](https://github.com/OpenFn/lightning/issues/2202)
+
 ### Fixed
 
 ## [v2.6.3] - 2024-06-19

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -360,7 +360,7 @@ defmodule LightningWeb.RunLive.Components do
               class="cursor-pointer"
               navigate={
                 ~p"/projects/#{@project_id}/w/#{@step.job.workflow_id}"
-                  <> "?a=#{@run.id}&m=expand&s=#{@step.job_id}"
+                  <> "?a=#{@run.id}&m=expand&s=#{@step.job_id}#log"
               }
             >
               <.icon

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -977,7 +977,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
              WorkOrders.retry(run_id, step_id, created_by: current_user) do
         Runs.subscribe(run)
 
-        {:noreply, socket |> assign_workflow(workflow) |> follow_run(run)}
+        {:noreply,
+         socket
+         |> assign_workflow(workflow)
+         |> follow_run(run)
+         |> push_event("push-hash", %{"hash" => "log"})}
       else
         {:error, _reason, %{text: error_text}} ->
           {:noreply, put_flash(socket, :error, error_text)}


### PR DESCRIPTION
## Validation Steps

- When inspecting an existing Run, ensure you have any tab other than 'Logs' selected.
- Click "Retry from here"
- The Logs tab should be selected

## Related issue

Fixes #2202

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
