### PR TITLE
Provide link to `/src` from Inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Link to adaptor `/src` from inspector.
+
 ### Changed
 
 - Reverted behaviour on "Rerun from here" to select the Log tab.

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import type { PackageDescription } from '@openfn/describe-package';
 import useDocs from '../hooks/useDocs';
 import Function from './render/Function';
@@ -8,27 +8,38 @@ type DocsPanelProps = {
   onInsert?: (text: string) => void;
 };
 
-const docsLink = (srcLink: string) => {
+const DocsLink = ({ specifier }: { specifier: string }) => {
+  const { name, version } = useCallback(() => {
+    const strippedName = specifier.replace(/^@openfn\/language-/, '');
+    const [name, version] = strippedName.split('@');
+    return { name, version };
+  }, [specifier])();
+
+  const srcLink = `https://github.com/OpenFn/adaptors/tree/%40openfn/language-${name}%40${version}/packages/${name}/src`;
+
   return (
-    <p>
-      You can check the external docs site at
-      <a
-        className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
-        href="https://docs.openfn.org/adaptors/#where-to-find-them"
-        target="none"
-      >
-        docs.openfn.org/adaptors
-      </a>{' '}
-      or view the source code
-      <a
-        className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
-        href={srcLink}
-        target="none"
-      >
-        here
-      </a>
-      .
-    </p>
+    <div className="mb-2 text-sm">
+      <div>
+        External docs:
+        <a
+          className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
+          href={`https://docs.openfn.org/adaptors/packages/${name}-docs`}
+          target="_blank"
+        >
+          docs.openfn.org
+        </a>
+      </div>
+      <div>
+        Source code:
+        <a
+          className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
+          href={srcLink}
+          target="_blank"
+        >
+          github.com/OpenFn/adaptors
+        </a>
+      </div>
+    </div>
   );
 };
 
@@ -44,16 +55,16 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   }
   if (pkg === false) {
     return (
-      <div className="block m-2">
-        <p>Sorry, an error occurred loading the docs for this adaptor.</p>
-        {docsLink}
-      </div>
+      <>
+        <DocsLink specifier={specifier} />
+        <div className="block m-2">
+          <p>An error occurred loading the docs for this adaptor.</p>
+        </div>
+      </>
     );
   }
 
   const { name, version, functions } = pkg as PackageDescription;
-  const strippedName = name.replace(/^@openfn\/language-/, '');
-  const srcLink = `https://github.com/OpenFn/adaptors/tree/%40openfn/language-${strippedName}%40${version}/packages/${strippedName}/src`;
 
   if (functions.length === 0) {
     return (
@@ -61,8 +72,8 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
         <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">
           {name} ({version})
         </h1>
-        <p>Sorry, docs are unavailable for this adaptor.</p>
-        {docsLink(srcLink)}
+        <DocsLink specifier={specifier} />
+        <p>Docs are unavailable for this adaptor.</p>
       </div>
     );
   }
@@ -73,14 +84,8 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
         <span>
           {name} ({version})
         </span>
-        <a
-          className="text-xs text-indigo-400 underline underline-offset-2 hover:text-indigo-500 mx-2"
-          target="none"
-          href={srcLink}
-        >
-          view src
-        </a>
       </h1>
+      <DocsLink specifier={specifier} />
       <div className="text-sm mb-4">
         These are the operations available for this adaptor:
       </div>

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -8,19 +8,29 @@ type DocsPanelProps = {
   onInsert?: (text: string) => void;
 };
 
-const docsLink = (
-  <p>
-    You can check the external docs site at
-    <a
-      className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
-      href="https://docs.openfn.org/adaptors/#where-to-find-them."
-      target="none"
-    >
-      docs.openfn.org/adaptors
-    </a>
-    .
-  </p>
-);
+const docsLink = (srcLink: string) => {
+  return (
+    <p>
+      You can check the external docs site at
+      <a
+        className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
+        href="https://docs.openfn.org/adaptors/#where-to-find-them"
+        target="none"
+      >
+        docs.openfn.org/adaptors
+      </a>{' '}
+      or view the source code
+      <a
+        className="text-indigo-400 underline underline-offset-2 hover:text-indigo-500 ml-2"
+        href={srcLink}
+        target="none"
+      >
+        here
+      </a>
+      .
+    </p>
+  );
+};
 
 const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   if (!specifier) {
@@ -42,6 +52,9 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   }
 
   const { name, version, functions } = pkg as PackageDescription;
+  const strippedName = name.replace(/^@openfn\/language-/, '');
+  const srcLink = `https://github.com/OpenFn/adaptors/tree/%40openfn/language-${strippedName}%40${version}/packages/${strippedName}/src`;
+
   if (functions.length === 0) {
     return (
       <div className="block m-2">
@@ -49,15 +62,24 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
           {name} ({version})
         </h1>
         <p>Sorry, docs are unavailable for this adaptor.</p>
-        {docsLink}
+        {docsLink(srcLink)}
       </div>
     );
   }
 
   return (
     <div className="block w-full overflow-auto ml-1">
-      <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">
-        {name} ({version})
+      <h1 className="h1 text-lg font-bold text-secondary-700 mb-2 flex justify-between items-center">
+        <span>
+          {name} ({version})
+        </span>
+        <a
+          className="text-xs text-indigo-400 underline underline-offset-2 hover:text-indigo-500 mx-2"
+          target="none"
+          href={srcLink}
+        >
+          view src
+        </a>
       </h1>
       <div className="text-sm mb-4">
         These are the operations available for this adaptor:


### PR DESCRIPTION
## Validation Steps

View adaptor docs for adaptors without any docs:
<img width="979" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/305df03c-c96d-4ee2-9fed-e25e68efe122">


View adaptor docs for adaptors with docs:
<img width="998" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/41ba4a8b-23b2-4018-a28b-9b8dc1bc1685">


## Notes for the reviewer

@josephjclark , documentation is getting better every day, but in my typically workflow I still _almost always_ go to the source. There's something nice and soothing about knowing exactly what this thing I'm about to call really is. What do you think?

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
