### PR TITLE
workflow-diagram: Reduce min zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 
 - Reverted behaviour on "Rerun from here" to select the Log tab.
   [#2202](https://github.com/OpenFn/lightning/issues/2202)
+- Reduce the minimum zoom in the workflow diagram
+  [#2214](https://github.com/OpenFn/lightning/issues/2214)
 
 ### Fixed
 

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -211,6 +211,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           deleteKeyCode={null}
           fitView
           fitViewOptions={{ padding: FIT_PADDING }}
+          minZoom={0.2}
           {...connectHandlers}
         >
           <Controls showInteractive={false} position="bottom-left">


### PR DESCRIPTION
This PR simply reduces the min-zoom level, letting you zoom further out on big diagrams

This is a simple fix and won't work in all cases. It probably also zooms too far out so maybe is annoying?

I've raised this as a better solution: https://github.com/OpenFn/lightning/issues/2221

Closes #2214