### PR TITLE
Fix adaptor docs contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix some adaptor docs not displaying
+  [#2019](https://github.com/OpenFn/lightning/issues/2019)
+
 ## [v2.6.3] - 2024-06-19
 
 ### Changed

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.1.1",
         "@monaco-editor/react": "^4.4.5",
-        "@openfn/describe-package": "^0.0.18",
+        "@openfn/describe-package": "^0.0.20",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/forms": "^0.5.6",
         "classcat": "^5.0.4",
@@ -487,31 +487,18 @@
       }
     },
     "node_modules/@openfn/describe-package": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.18.tgz",
-      "integrity": "sha512-WIvWJ9w6XlZ3YtY5hlxV6QbaJRkHfyBpeBBvXGyQiFiCWllKyTu8RfPia7h+8j9X2/INS6Alszg2cXciWCWbxg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.20.tgz",
+      "integrity": "sha512-NM7B4rX58BMml+COm9g4GcvrZXqujnWEHOFqHmNTEBH+Pk7ouAbmBDB+39IaM/nL7yjtkF63gKBjVV1maMPUGw==",
       "dependencies": {
         "@typescript/vfs": "^1.3.5",
         "cross-fetch": "^3.1.5",
-        "node-localstorage": "^2.2.1",
-        "typescript": "^4.7.4",
+        "typescript": "^5.1.6",
         "url-join": "^5.0.0"
       },
       "engines": {
         "node": ">=16",
         "pnpm": ">=7"
-      }
-    },
-    "node_modules/@openfn/describe-package/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@openfn/engine-multi": {
@@ -2943,6 +2930,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4259,27 +4247,6 @@
         }
       }
     },
-    "node_modules/node-localstorage": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
-      "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
-      "dependencies": {
-        "write-file-atomic": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/node-localstorage/node_modules/write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
-    },
     "node_modules/nofilter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
@@ -5254,14 +5221,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5778,7 +5737,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.1",
     "@monaco-editor/react": "^4.4.5",
-    "@openfn/describe-package": "^0.0.18",
+    "@openfn/describe-package": "^0.0.20",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.6",
     "classcat": "^5.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "lightning",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "lightning",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Bump the `describe-package` dependency which fixes the issue here: https://github.com/OpenFn/kit/pull/723

Functions documented in the adaptor-docs panel should now be exactly the same as documented on docs.openfn.org

## Validation Steps

See the issue for affected docs.

## Related issue

Fixes #2019

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
