### PR TITLE
Dynamic zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- In the workflow diagram, smartly update the view when adding new nodes
+  [#2174](https://github.com/OpenFn/lightning/issues/2174)
+- In the workflow diagram, remove the "autofit" toggle in the control bar
+
 ### Fixed
 
 ## [v2.7.0] - 2024-06-26

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -244,7 +244,6 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           onEdgeClick={handleEdgeClick}
           onInit={setFlow}
           deleteKeyCode={null}
-          minZoom={0.2}
           fitView
           fitViewOptions={{ padding: FIT_PADDING }}
           minZoom={0.2}

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -102,6 +102,11 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
 
         if (layoutId) {
           chartCache.current.lastLayout = layoutId;
+
+          // ignore autofit option for now
+          // I'll remove the option later
+          const autofit = false;
+
           layout(newModel, setModel, flow, { duration: 300, autofit }).then(
             positions => {
               // Note we don't update positions until the animation has finished

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -212,6 +212,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           onEdgeClick={handleEdgeClick}
           onInit={setFlow}
           deleteKeyCode={null}
+          minZoom={0.2}
           fitView
           fitViewOptions={{ padding: FIT_PADDING }}
           minZoom={0.2}

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -43,8 +43,6 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
 
     const [model, setModel] = useState<Flow.Model>({ nodes: [], edges: [] });
 
-    const [autofit, setAutofit] = useState<boolean>(true);
-
     const updateSelection = useCallback(
       (id?: string | null) => {
         id = id || null;
@@ -103,11 +101,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
         if (layoutId) {
           chartCache.current.lastLayout = layoutId;
 
-          // ignore autofit option for now
-          // I'll remove the option later
-          const autofit = false;
-
-          layout(newModel, setModel, flow, { duration: 300, autofit }).then(
+          layout(newModel, setModel, flow, { duration: 300 }).then(
             positions => {
               // Note we don't update positions until the animation has finished
               chartCache.current.positions = positions;
@@ -219,16 +213,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
           minZoom={0.2}
           {...connectHandlers}
         >
-          <Controls showInteractive={false} position="bottom-left">
-            <ControlButton
-              onClick={() => {
-                setAutofit(!autofit);
-              }}
-              title="Automatically fit view"
-            >
-              <ViewfinderCircleIcon style={{ opacity: autofit ? 1 : 0.4 }} />
-            </ControlButton>
-          </Controls>
+          <Controls showInteractive={false} position="bottom-left" />
         </ReactFlow>
       </ReactFlowProvider>
     );

--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -100,8 +100,11 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
 
         if (layoutId) {
           chartCache.current.lastLayout = layoutId;
-
-          layout(newModel, setModel, flow, { duration: 300 }).then(
+          const viewBounds = {
+            width: ref?.clientWidth ?? 0,
+            height: ref?.clientHeight ?? 0,
+          };
+          layout(newModel, setModel, flow, viewBounds, { duration: 300 }).then(
             positions => {
               // Note we don't update positions until the animation has finished
               chartCache.current.positions = positions;
@@ -120,7 +123,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
       } else {
         chartCache.current.positions = {};
       }
-    }, [workflow, flow, placeholders]);
+    }, [workflow, flow, placeholders, ref]);
 
     useEffect(() => {
       const updatedModel = updateSelectionStyles(model, selection);
@@ -172,6 +175,7 @@ export default React.forwardRef<HTMLElement, WorkflowDiagramProps>(
         let isFirstCallback = true;
 
         const throttledResize = throttle(() => {
+          // TODO we shouldn't fit erverything here, we should just fit visible
           flow.fitView({ duration: FIT_DURATION, padding: FIT_PADDING });
         }, FIT_DURATION * 2);
 

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -65,7 +65,6 @@ const calculateLayout = async (
       obj[next.id] = next.position;
       return obj;
     }, {} as Positions);
-    console.log({ oldPositions });
 
     // When updating the layout, we should try and fit to the currently visible nodes
     // This usually just occurs when adding or removing placeholder nodes

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -62,7 +62,7 @@ const calculateLayout = async (
 
     // First work out the size of the current viewpoint in canvas coordinates
     // TODO where do I get the canvas size from?
-    const rect = getVisibleRect(flow.getViewport(), 1498, 780, 1);
+    const rect = getVisibleRect(flow.getViewport(), 1498, 780, 0.95);
 
     // Now work out which nodes are visible
     for (const id in finalPositions) {

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -101,7 +101,6 @@ const calculateLayout = async (
         }
       }
     } else {
-      // TODO this behaviour probably causes more trouble than its worth?
       // otherwise, if running a layout, fit to the currently visible nodes
       // this usually means we've removed a placeholder and lets us tidy up
       doFit = true;

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -53,12 +53,6 @@ const calculateLayout = async (
     obj[next.id] = next.position;
     return obj;
   }, {} as Positions);
-  // console.log({ finalPositions });
-
-  // for (const id in finalPositions) {
-  //   const n = newModel.nodes.find(n => n.id === id);
-  //   console.log(n?.data.name ?? 'trigger', finalPositions[id]);
-  // }
 
   const hasOldPositions = nodes.find(n => n.position);
 
@@ -77,11 +71,8 @@ const calculateLayout = async (
     // This usually just occurs when adding or removing placeholder nodes
 
     // First work out the size of the current viewpoint in canvas coordinates
-    // TODO where do I get the canvas size from?
-
     if (newPlaceholders.length) {
-      const rect = getVisibleRect(flow.getViewport(), viewBounds, 0.8);
-      console.log({ rect });
+      const rect = getVisibleRect(flow.getViewport(), viewBounds, 0.9);
       // Now work out the visible nodes, paying special attention to the placeholder
       //
       for (const id in finalPositions) {
@@ -111,11 +102,11 @@ const calculateLayout = async (
         }
       }
     } else {
+      // TODO this behaviour probably causes more trouble than its worth?
       // otherwise, if running a layout, fit to the currently visible nodes
       // this usually means we've removed a placeholder and lets us tidy up
       doFit = true;
       const rect = getVisibleRect(flow.getViewport(), viewBounds, 1.1);
-      console.log({ rect });
       for (const id in finalPositions) {
         // again, use the OLD position to work out visibility
         const pos = oldPositions[id] || finalPositions;
@@ -128,10 +119,7 @@ const calculateLayout = async (
     }
 
     // Useful debugging
-    if (doFit) {
-      console.log(fitTargets.map(n => n.data?.name ?? n.type));
-      console.log({ fitTargets });
-    }
+    //console.log(fitTargets.map(n => n.data?.name ?? n.type));
   }
 
   // If we need to run a fit, save the set of visible nodes as the fit target
@@ -202,7 +190,7 @@ export const animate = (
         if (autofit) {
           flowInstance.fitBounds(bounds, {
             duration: typeof duration === 'number' ? duration : 0,
-            // padding: FIT_PADDING,
+            padding: FIT_PADDING,
           });
         }
         isFirst = false;

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -7,20 +7,21 @@ import { Flow, Positions } from './types';
 import { getVisibleRect, isPointInRect } from './util/viewport';
 
 export type LayoutOpts = {
-  duration: number | false;
-  autofit: boolean | Flow.Node[];
+  duration?: number | false;
+  autofit?: boolean | Flow.Node[];
 };
 
 const calculateLayout = async (
   model: Flow.Model,
   update: (newModel: Flow.Model) => any,
   flow: ReactFlowInstance,
-  options: LayoutOuts = {}
+  options: Omit<LayoutOpts, 'autofit'> = {}
 ): Promise<Positions> => {
   const { nodes, edges } = model;
   const { duration } = options;
 
   // Before we layout, work out whether there are any new unpositioned placeholders
+  // @ts-ignore _default is a temporary flag added by us
   const newPlaceholders = model.nodes.filter(n => n.position?._default);
 
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));

--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -22,6 +22,8 @@ export const create = (parentNode: Flow.Node) => {
     id: targetId,
     type: 'placeholder',
     position: {
+      // mark this as as default position
+      _default: true,
       // Offset the position of the placeholder to be more pleasing during animation
       x: parentNode.position.x,
       y: parentNode.position.y + 100,

--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -22,7 +22,8 @@ export const create = (parentNode: Flow.Node) => {
     id: targetId,
     type: 'placeholder',
     position: {
-      // mark this as as default position
+      // mark this as as default positio
+      // @ts-ignore _default is a temporary flag added by us
       _default: true,
       // Offset the position of the placeholder to be more pleasing during animation
       x: parentNode.position.x,

--- a/assets/js/workflow-diagram/usePlaceholders.ts
+++ b/assets/js/workflow-diagram/usePlaceholders.ts
@@ -22,7 +22,7 @@ export const create = (parentNode: Flow.Node) => {
     id: targetId,
     type: 'placeholder',
     position: {
-      // mark this as as default positio
+      // mark this as as default position
       // @ts-ignore _default is a temporary flag added by us
       _default: true,
       // Offset the position of the placeholder to be more pleasing during animation

--- a/assets/js/workflow-diagram/util/get-viewport-bounds.ts
+++ b/assets/js/workflow-diagram/util/get-viewport-bounds.ts
@@ -1,0 +1,35 @@
+// TODO shrink the viewport by 10% each side
+// Or at least, take a scaler
+
+// Given react-flows viewport, which gives use the topleft x/y and
+// zoom, and the dimensions of the canvas,
+// work out the view bounds
+// TODO use scale to make the bounds artificially smaller
+export default (viewport, width, height, scale = 1) => {
+  // Invert the zoom so that low zooms INCREASE the bouds size
+  const zoom = 1 / viewport.zoom;
+
+  // Also invert the viewport x and y positions
+  const x = -viewport.x;
+  const y = -viewport.y;
+
+  // Return the projected visible rect
+  return {
+    x: x * zoom,
+    width: width * zoom,
+    y: y * zoom,
+    height: height * zoom,
+  };
+};
+
+// This returns true if the point at pos fits anywhere inside rect
+export const intersect = (pos, rect) => {
+  return (
+    pos.x >= rect.x &&
+    pos.x <= rect.x + rect.width &&
+    pos.y >= rect.y &&
+    pos.y <= rect.y + rect.height
+  );
+};
+
+// wha if x/y really is center?

--- a/assets/js/workflow-diagram/util/viewport.ts
+++ b/assets/js/workflow-diagram/util/viewport.ts
@@ -20,10 +20,8 @@ export const getVisibleRect = (
   const zoom = 1 / viewport.zoom;
 
   // Also invert the viewport x and y positions
-  const x = -viewport.x * (1 / scale);
-  const y = -viewport.y * (1 / scale);
-  console.log(`scale x ${scale}`, -viewport.x, x);
-  console.log(`scale y ${scale}`, -viewport.y, y);
+  const x = -viewport.x + (1 - scale) * viewport.x;
+  const y = -viewport.y + (1 - scale) * viewport.y;
 
   // Return the projected visible rect
   return {

--- a/assets/js/workflow-diagram/util/viewport.ts
+++ b/assets/js/workflow-diagram/util/viewport.ts
@@ -3,11 +3,15 @@
 // work out the view bounds
 import { Rect, XYPosition, Viewport } from 'reactflow';
 
+type ViewBounds = {
+  width: number;
+  height: number;
+};
+
 // TODO use scale to make the bounds artificially smaller
 export const getVisibleRect = (
   viewport: Viewport,
-  width: number,
-  height: number,
+  viewBounds: ViewBounds,
   scale = 1
 ) => {
   // Invert the zoom so that low zooms INCREASE the bouds size
@@ -20,9 +24,9 @@ export const getVisibleRect = (
   // Return the projected visible rect
   return {
     x: x * zoom,
-    width: width * scale * zoom,
+    width: viewBounds.width * scale * zoom,
     y: y * zoom,
-    height: height * scale * zoom,
+    height: viewBounds.height * scale * zoom,
   };
 };
 

--- a/assets/js/workflow-diagram/util/viewport.ts
+++ b/assets/js/workflow-diagram/util/viewport.ts
@@ -14,15 +14,15 @@ export const getVisibleRect = (
   const zoom = 1 / viewport.zoom;
 
   // Also invert the viewport x and y positions
-  const x = -viewport.x;
-  const y = -viewport.y;
+  const x = -viewport.x * scale;
+  const y = -viewport.y * scale;
 
   // Return the projected visible rect
   return {
     x: x * zoom,
-    width: width * zoom,
+    width: width * scale * zoom,
     y: y * zoom,
-    height: height * zoom,
+    height: height * scale * zoom,
   };
 };
 

--- a/assets/js/workflow-diagram/util/viewport.ts
+++ b/assets/js/workflow-diagram/util/viewport.ts
@@ -1,11 +1,15 @@
-// TODO shrink the viewport by 10% each side
-// Or at least, take a scaler
-
 // Given react-flows viewport, which gives use the topleft x/y and
 // zoom, and the dimensions of the canvas,
 // work out the view bounds
+import { Rect, XYPosition, Viewport } from 'reactflow';
+
 // TODO use scale to make the bounds artificially smaller
-export default (viewport, width, height, scale = 1) => {
+export const getVisibleRect = (
+  viewport: Viewport,
+  width: number,
+  height: number,
+  scale = 1
+) => {
   // Invert the zoom so that low zooms INCREASE the bouds size
   const zoom = 1 / viewport.zoom;
 
@@ -23,7 +27,7 @@ export default (viewport, width, height, scale = 1) => {
 };
 
 // This returns true if the point at pos fits anywhere inside rect
-export const intersect = (pos, rect) => {
+export const isPointInRect = (pos: XYPosition, rect: Rect) => {
   return (
     pos.x >= rect.x &&
     pos.x <= rect.x + rect.width &&
@@ -31,5 +35,3 @@ export const intersect = (pos, rect) => {
     pos.y <= rect.y + rect.height
   );
 };
-
-// wha if x/y really is center?

--- a/assets/js/workflow-diagram/util/viewport.ts
+++ b/assets/js/workflow-diagram/util/viewport.ts
@@ -8,6 +8,8 @@ type ViewBounds = {
   height: number;
 };
 
+// do the thing is d3ee
+
 // TODO use scale to make the bounds artificially smaller
 export const getVisibleRect = (
   viewport: Viewport,
@@ -18,8 +20,10 @@ export const getVisibleRect = (
   const zoom = 1 / viewport.zoom;
 
   // Also invert the viewport x and y positions
-  const x = -viewport.x * scale;
-  const y = -viewport.y * scale;
+  const x = -viewport.x * (1 / scale);
+  const y = -viewport.y * (1 / scale);
+  console.log(`scale x ${scale}`, -viewport.x, x);
+  console.log(`scale y ${scale}`, -viewport.y, y);
 
   // Return the projected visible rect
   return {

--- a/assets/js/workflow-diagram/util/viewport.ts
+++ b/assets/js/workflow-diagram/util/viewport.ts
@@ -1,6 +1,3 @@
-// Given react-flows viewport, which gives use the topleft x/y and
-// zoom, and the dimensions of the canvas,
-// work out the view bounds
 import { Rect, XYPosition, Viewport } from 'reactflow';
 
 type ViewBounds = {
@@ -8,9 +5,6 @@ type ViewBounds = {
   height: number;
 };
 
-// do the thing is d3ee
-
-// TODO use scale to make the bounds artificially smaller
 export const getVisibleRect = (
   viewport: Viewport,
   viewBounds: ViewBounds,


### PR DESCRIPTION
This PR introduces a smart auto-layout feature to the workflow diagram.

In brief, the changes are:

* When adding a placeholder node, instead of fitting the whole chart, we just fit the currently visible nodes PLUS the placeholder
* When removing a placeholder node, we automatically try to fit to the currently visible nodes (I don't think this works very well)
* The "toggle auto-fit" controller has been removed from the toolbar in the bottom left - the whole concept of this feature is to make that button redundant.
*  When the window is resized, instead of zooming to fit the whole chart, try to just fit the visible nodes (to my surprise, this works well!)

As a rule, I am trying to only move the view if I really have to.

Despite a day of sweating over this, I am not yet sold. Detailed QA is needed.

## Still To do

I think that we should NOT try to fix the view when a placeholder is removed.

In some cases it works great (it's quite good on a small new workflow), but in others its terrible (it's particularly bad on larger workflows)

## Notes for the reviewer

Before this PR, when running a layout, there is a little function that calculates the total size of the chart and zooms the view to fit those dimensions. We do this programmatically and sync it to layout, so that layout and zoom both happen at the same time. The result is pretty slick!

The problem is that users lose their context whenever adding or removing placeholder. This is a particular problem in bigger workflows - you can add a new node and bosh, you'll be zoomed out so far you can't even see.

Here, I've added a bunch of logic to the layout function to try and work out the best dimension to fit the view to. To do this, we:
* Build a list of all the currently visible nodes (with an offset/margin so that partially visible nodes can be included or dropped, depending)
* If the currently visible nodes or the placeholder are NOT going to be visible in the current view in the new layout, we prepare a new zoom-fit
* We fit to the bounds of all the nodes we think are visible (plus the placeholder)
* And basically the same thing when a placeholder is removed - we attempt to re-fit the view. The idea here is to reclaim any space that the placeholder's view created, but the results aren't great

One difficulty with this is that we'll always fit to what the chart thinks is a perfect view of the visible nodes. This often results in small and arbitrary and occasionally even quite harmful zooms.

There's also new logic added for resizing. When a resize drag starts, we take a snapshot of what nodes are currently visible, and as the user resizes we constantly zoom-fit on the chart to try and keep those nodes in view. It doesn't matter that this isn't perfect or that the canvas size changes - it just locks the view in a _similar_  place to it was before the resize started. And that's a heck  of a lot better than resetting the zoom.

Rather crudely, we reset this "resize drag" state after 3 seconds. I'm sure we could be smarter about this but this seems reasonably effective.

## QA Notes

This one needs thorough and careful QA.

We need to make sure that:
* The new behaviour is not annoying to users
* The new behaviour preserves a user's context within the workflow
* The new behaviour does not change the view unless it really has to

Here's the kind of thing I'm testing

* On a new workflow, add a bunch of nodes without touching the zoom level
  * Make the workflow deep and wide
  * The view should happily expand to fit the newly created nodes
* On an existing, large-ish workflow, zoom in to one area and add new nodes
  * The view should expand just enough to fit the new node but shouldn't blow up your  context
 * Try all this at extremely high and low zooms
 * Try creating a very very deep chain of nodes, child after child, zooming in occasionally
 * Try creating  lots of children on one node. Note that the new node often comes up on the left, which is an annoying layout problem, but more importantly note that the view will fit horizontally.
 * Try cancelling a placeholder node and observe what the view does
   * Try this at different zoom levels on small and large workflows
  * On a large workflow, zoom in, then resize the browser window. Try constantly dragging the chart around and watch it update with broadly the same context. If you zoom to a different place and resize again, the chart should try and zoom to this new position
* Try adding and removing placeholder nodes in the middle of the workflow, where they should not affect the zoom at all. Generally, adding  placeholders is quite well behaved (minimal  view changes), but removing them is quite bad (too many view changes)

## Related issue

Fixes #2174

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
