### PR TITLE
Fix code editor cursor resetting it's position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix jumpy cursor in the Job editor.
+  [#2229](https://github.com/OpenFn/lightning/issues/2229)
+
 ## [v2.7.0] - 2024-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 
 - Fix jumpy cursor in the Job editor.
   [#2229](https://github.com/OpenFn/lightning/issues/2229)
+- Rework syncing behaviour to prevent changes getting thrown out on a socket
+  reconnect. [#2007](https://github.com/OpenFn/lightning/issues/2007)
 
 ## [v2.7.0] - 2024-06-26
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -100,3 +100,9 @@ liveSocket.connect();
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket;
+
+// Testing helper to simulate a reconnect
+window.triggerReconnect = function triggerReconnect(timeout = 5000) {
+  liveSocket.disconnect();
+  setTimeout(liveSocket.connect.bind(liveSocket), timeout);
+};

--- a/assets/js/hooks/PhoenixHook.ts
+++ b/assets/js/hooks/PhoenixHook.ts
@@ -14,6 +14,7 @@ export type PhoenixHook<T = {}, Dataset = {}, El = HTMLElement> = {
   reconnected(): void;
   disconnected(): void;
   handleEvent<T = {}>(eventName: string, callback: (payload: T) => void): void;
+  removeHandleEvent(callbackRef: unknown): void;
   pushEventTo<P = {}, R = any>(
     selectorOrTarget: string | HTMLElement,
     event: string,

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -2,23 +2,37 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import type JobEditor from './JobEditor';
 import { sortMetadata } from '../metadata-loader/metadata';
-import { PhoenixHook } from '../hooks/PhoenixHook';
+import { LiveSocket, PhoenixHook } from '../hooks/PhoenixHook';
+import type WorkflowEditorEntrypoint from '../workflow-editor';
+import pRetry from 'p-retry';
+import pDebounce from 'p-debounce';
+import { WorkflowStore } from '../workflow-editor/store';
+import { Lightning } from '../workflow-diagram/types';
 
 type JobEditorEntrypoint = PhoenixHook<
   {
     componentRoot: ReturnType<typeof createRoot> | null;
     changeEvent: string;
     field?: HTMLTextAreaElement | null;
-    handleContentChange(content: string): void;
+    findWorkflowEditorStore(): Promise<WorkflowStore>;
+    workflowEditorStore: WorkflowStore;
+    handleContentChange(content: string): Promise<void>;
     metadata?: true | object;
     observer: MutationObserver | null;
     render(): void;
     requestMetadata(): Promise<{}>;
     setupObserver(): void;
-    removeHandleEvent(callbackRef: unknown): void;
-    _timeout: number | null;
+    pushChange(content: string): Promise<void>;
+    _debouncedPushChange(content: string): Promise<void>;
+    currentContent: string;
   },
-  { adaptor: string; source: string; disabled: string; disabledMessage: string }
+  {
+    adaptor: string;
+    source: string;
+    disabled: string;
+    disabledMessage: string;
+    jobID: string;
+  }
 >;
 
 type AttributeMutationRecord = MutationRecord & {
@@ -31,13 +45,31 @@ let JobEditorComponent: typeof JobEditor | undefined;
 const EDITOR_DEBOUNCE_MS = 300;
 
 export default {
+  findWorkflowEditorStore() {
+    return pRetry(
+      () => {
+        console.debug('Looking up WorkflowEditorHook');
+        return lookupWorkflowEditorHook(this.liveSocket, this.el);
+      },
+      { retries: 5 }
+    ).then(hook => {
+      return hook.workflowStore;
+    });
+  },
+  reconnected() {
+    console.debug('Reconnected JobEditor');
+    // this.handleContentChange(this.currentContent);
+  },
   mounted(this: JobEditorEntrypoint) {
+    window.jobEditor = this;
+
     console.group('JobEditor');
     console.debug('Mounted');
+    this._debouncedPushChange = pDebounce(this.pushChange, EDITOR_DEBOUNCE_MS);
+
     import('./JobEditor').then(module => {
       console.group('JobEditor');
       console.debug('loaded module');
-      console.groupEnd();
       JobEditorComponent = module.default as typeof JobEditor;
       this.componentRoot = createRoot(this.el);
 
@@ -50,43 +82,54 @@ export default {
       this.setupObserver();
       this.render();
       this.requestMetadata().then(() => this.render());
+      console.groupEnd();
     });
 
     console.groupEnd();
   },
   handleContentChange(content: string) {
-    if (this._timeout) {
-      clearTimeout(this._timeout);
-      this._timeout = window.setTimeout(() => {
-        this.pushEventTo(this.el, this.changeEvent, { source: content });
-        this._timeout = null;
-      }, EDITOR_DEBOUNCE_MS);
-    } else {
-      this.pushEventTo(this.el, this.changeEvent, { source: content });
-      this._timeout = window.setTimeout(() => {
-        this._timeout = null;
-      }, EDITOR_DEBOUNCE_MS);
+    this._debouncedPushChange(content);
+  },
+  async pushChange(content: string) {
+    console.debug('pushChange', content);
+    const jobId = this.el.dataset.jobId;
+
+    if (!jobId) {
+      throw new Error(
+        'No jobId found on JobEditor element, refusing to push change'
+      );
     }
+
+    await this.findWorkflowEditorStore().then(workflowStore => {
+      workflowStore.getState().change({ jobs: [{ id: jobId, body: content }] });
+    });
   },
   render() {
-    const { adaptor, source, disabled, disabledMessage } = this.el.dataset;
-    if (adaptor.split('@').at(-1) === 'latest') {
-      console.warn(
-        "job-editor hook received an adaptor with @latest as it's version - to load docs a specific version must be provided"
-      );
-    }
-    if (JobEditorComponent) {
-      this.componentRoot?.render(
-        <JobEditorComponent
-          adaptor={adaptor}
-          source={source}
-          metadata={this.metadata}
-          disabled={disabled === 'true'}
-          disabledMessage={disabledMessage}
-          onSourceChanged={src => this.handleContentChange(src)}
-        />
-      );
-    }
+    const { adaptor, disabled, disabledMessage, jobId } = this.el.dataset;
+
+    checkAdaptorVersion(adaptor);
+
+    this.findWorkflowEditorStore().then(workflowStore => {
+      const job = workflowStore.getState().getById<Lightning.Job>(jobId);
+
+      if (!job) {
+        console.error('Job not found', jobId);
+        return;
+      }
+
+      if (JobEditorComponent) {
+        this.componentRoot?.render(
+          <JobEditorComponent
+            adaptor={adaptor}
+            source={job.body}
+            metadata={this.metadata}
+            disabled={disabled === 'true'}
+            disabledMessage={disabledMessage}
+            onSourceChanged={src => this.handleContentChange(src)}
+          />
+        );
+      }
+    });
   },
   requestMetadata() {
     this.metadata = true; // indicate we're loading
@@ -118,7 +161,7 @@ export default {
         'data-adaptor',
         'data-change-event',
         'data-disabled',
-        'data-disabled-message'
+        'data-disabled-message',
       ],
       attributeOldValue: true,
     });
@@ -128,3 +171,29 @@ export default {
     this.observer?.disconnect();
   },
 } as JobEditorEntrypoint;
+
+function lookupWorkflowEditorHook(liveSocket: LiveSocket, el: HTMLElement) {
+  let found: typeof WorkflowEditorEntrypoint | undefined;
+  liveSocket.withinOwners(el, view => {
+    for (let hook of Object.values(view.viewHooks)) {
+      if (hook.el.getAttribute('phx-hook') === 'WorkflowEditor') {
+        found = hook as typeof WorkflowEditorEntrypoint;
+        break;
+      }
+    }
+  });
+
+  if (!found) {
+    throw new Error('WorkflowEditor hook not found');
+  }
+
+  return found;
+}
+
+function checkAdaptorVersion(adaptor: string) {
+  if (adaptor.split('@').at(-1) === 'latest') {
+    console.warn(
+      "job-editor hook received an adaptor with @latest as it's version - to load docs a specific version must be provided"
+    );
+  }
+}

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -118,8 +118,7 @@ export default {
         'data-adaptor',
         'data-change-event',
         'data-disabled',
-        'data-disabled-message',
-        'data-source',
+        'data-disabled-message'
       ],
       attributeOldValue: true,
     });

--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -1,4 +1,4 @@
-import Dagre from '../../vendor/dagre';
+import Dagre from '../../vendor/dagre.js';
 import { timer } from 'd3-timer';
 import { getRectOfNodes, ReactFlowInstance } from 'reactflow';
 

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -12,6 +12,11 @@ export namespace Lightning {
     placeholder?: boolean;
   }
 
+  export interface Job extends Node {
+    adaptor: string | null;
+    body: string;
+  }
+
   export interface CronTrigger extends Node {
     type: 'cron';
     enabled: boolean;

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -10,7 +10,7 @@ import {
   createWorkflowStore,
 } from './store';
 
-type WorkflowEditorEntrypoint = PhoenixHook<
+export type WorkflowEditorEntrypoint = PhoenixHook<
   {
     _isMounting: boolean;
     _pendingWorker: Promise<void>;
@@ -121,6 +121,11 @@ export default {
     // TODO: request the workflow params, but this time create a diff
     // between the current state and the server state and send those diffs
     // to the server.
+    console.log('reconnected', this.workflowStore.getState());
+    this.pushEventTo(this.el, 'get-current-state', {}, response => {
+      console.log('get-current-state response', response);
+      this.workflowStore.getState().rebase(response['workflow_params']);
+    });
   },
   getItem(id?: string) {
     if (id) {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -22,6 +22,8 @@
         "jsonpath": "^1.1.1",
         "marked": "^4.2.4",
         "monaco-editor": "^0.34.0",
+        "p-debounce": "^4.0.0",
+        "p-retry": "^6.2.0",
         "postcss": "^8.4.23",
         "rc-resize-observer": "^1.4.0",
         "react": "^18.1.0",
@@ -1171,6 +1173,11 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.5",
@@ -3082,6 +3089,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4333,6 +4351,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-debounce/-/p-debounce-4.0.0.tgz",
+      "integrity": "sha512-4Ispi9I9qYGO4lueiLDhe4q4iK5ERK8reLsuzH6BPaXn53EGaua8H66PXIFGrW897hwjXp+pVLrm/DLxN0RF0A==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -4397,6 +4423,22 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+      "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5043,6 +5085,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -23,6 +23,8 @@
     "jsonpath": "^1.1.1",
     "marked": "^4.2.4",
     "monaco-editor": "^0.34.0",
+    "p-debounce": "^4.0.0",
+    "p-retry": "^6.2.0",
     "postcss": "^8.4.23",
     "rc-resize-observer": "^1.4.0",
     "react": "^18.1.0",

--- a/lib/lightning_web.ex
+++ b/lib/lightning_web.ex
@@ -133,6 +133,7 @@ defmodule LightningWeb do
 
       import LightningWeb.Components.Pills
       import LightningWeb.Components.Loaders
+      import LightningWeb.Components.Icons
 
       unquote(verified_routes())
     end

--- a/lib/lightning_web/components/icons.ex
+++ b/lib/lightning_web/components/icons.ex
@@ -1,0 +1,37 @@
+defmodule LightningWeb.Components.Icons do
+  @moduledoc false
+
+  use Phoenix.Component
+
+  @doc """
+  Renders a [Heroicon](https://heroicons.com).
+
+  Heroicons come in three styles – outline, solid, and mini.
+  By default, the outline style is used, but solid and mini may
+  be applied by using the `-solid` and `-mini` suffix.
+
+  You can customize the size and colors of the icons by setting
+  width, height, and background color classes.
+
+  Icons are extracted from your `assets/vendor/heroicons` directory and bundled
+  within your compiled app.css by the plugin in your `assets/tailwind.config.js`.
+
+  ## Examples
+
+      <.icon name="hero-x-mark-solid" />
+      <.icon name="hero-play-circle" class="ml-1 w-3 h-3 animate-spin" />
+  """
+  attr :name, :string, required: true
+  attr :class, :string, default: nil
+  attr :naked, :boolean, default: false
+  attr :rest, :global
+
+  def icon(%{name: "hero-" <> _} = assigns) do
+    ~H"""
+    <span
+      class={[@naked && "text-gray-500 hover:text-primary-400", @name, @class]}
+      {@rest}
+    />
+    """
+  end
+end

--- a/lib/lightning_web/components/loaders.ex
+++ b/lib/lightning_web/components/loaders.ex
@@ -4,6 +4,10 @@ defmodule LightningWeb.Components.Loaders do
   """
   use Phoenix.Component
 
+  import LightningWeb.Components.Icons
+
+  alias Phoenix.LiveView.JS
+
   slot :inner_block, required: true
 
   def text_ping_loader(assigns) do
@@ -44,6 +48,18 @@ defmodule LightningWeb.Components.Loaders do
         </span>
       </span>
     </span>
+    """
+  end
+
+  def offline_indicator(assigns) do
+    ~H"""
+    <div
+      class="hidden"
+      phx-disconnected={JS.show(transition: "fade-in")}
+      phx-connected={JS.hide(transition: "fade-out")}
+    >
+      <.icon name="hero-signal-slash" class="w-6 h-6 mr-2 text-red-500" />
+    </div>
     """
   end
 end

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -5,6 +5,8 @@ defmodule LightningWeb.Components.NewInputs do
   """
   use Phoenix.Component
 
+  import LightningWeb.Components.Icons
+
   alias Phoenix.LiveView.JS
 
   @doc """
@@ -417,38 +419,6 @@ defmodule LightningWeb.Components.NewInputs do
       <.icon name="hero-exclamation-circle" class="h-4 w-4" />
       <%= render_slot(@inner_block) %>
     </p>
-    """
-  end
-
-  @doc """
-  Renders a [Heroicon](https://heroicons.com).
-
-  Heroicons come in three styles – outline, solid, and mini.
-  By default, the outline style is used, but solid and mini may
-  be applied by using the `-solid` and `-mini` suffix.
-
-  You can customize the size and colors of the icons by setting
-  width, height, and background color classes.
-
-  Icons are extracted from your `assets/vendor/heroicons` directory and bundled
-  within your compiled app.css by the plugin in your `assets/tailwind.config.js`.
-
-  ## Examples
-
-      <.icon name="hero-x-mark-solid" />
-      <.icon name="hero-play-circle" class="ml-1 w-3 h-3 animate-spin" />
-  """
-  attr :name, :string, required: true
-  attr :class, :string, default: nil
-  attr :naked, :boolean, default: false
-  attr :rest, :global
-
-  def icon(%{name: "hero-" <> _} = assigns) do
-    ~H"""
-    <span
-      class={[@naked && "text-gray-500 hover:text-primary-400", @name, @class]}
-      {@rest}
-    />
     """
   end
 end

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -12,6 +12,8 @@ defmodule LightningWeb.Components.Viewers do
 
   use LightningWeb, :component
 
+  import LightningWeb.Components.Icons
+
   alias Lightning.Invocation.Dataclip
   alias LightningWeb.Components.Icon
 

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -2,6 +2,8 @@ defmodule LightningWeb.Components.Common do
   @moduledoc false
   use LightningWeb, :component
 
+  import LightningWeb.Components.Icons
+
   alias Phoenix.LiveView.JS
 
   attr :id, :string, required: true

--- a/lib/lightning_web/live/components/form.ex
+++ b/lib/lightning_web/live/components/form.ex
@@ -24,28 +24,14 @@ defmodule LightningWeb.Components.Form do
       focus:ring-2
       focus:ring-offset-2
       focus:ring-primary-500
+      enabled:bg-primary-600
+      enabled:hover:bg-primary-700
+      disabled:bg-primary-300
     ]
-
-    inactive_classes = ~w[
-      bg-primary-300
-    ] ++ base_classes
-
-    active_classes = ~w[
-      bg-primary-600
-      hover:bg-primary-700
-    ] ++ base_classes
 
     assigns =
       assigns
-      |> assign_new(:class, fn -> "" end)
-      |> update(:class, fn class, %{rest: rest} ->
-        if rest[:disabled] do
-          inactive_classes
-        else
-          active_classes
-        end
-        |> Enum.concat(List.wrap(class))
-      end)
+      |> assign_new(:class, fn -> base_classes end)
 
     ~H"""
     <button type="submit" class={@class} {@rest}>

--- a/lib/lightning_web/live/job_live/job_builder_components.ex
+++ b/lib/lightning_web/live/job_live/job_builder_components.ex
@@ -2,10 +2,11 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
   use LightningWeb, :component
 
   attr :adaptor, :string, required: true
+  attr :change_event, :string, default: "job_body_changed"
   attr :disabled, :boolean, default: false
   attr :disabled_message, :string, required: true
+  attr :job_id, :string, required: true
   attr :source, :string, required: true
-  attr :change_event, :string, default: "job_body_changed"
   attr :rest, :global
 
   def job_editor_component(assigns) do
@@ -13,6 +14,7 @@ defmodule LightningWeb.JobLive.JobBuilderComponents do
 
     ~H"""
     <div
+      data-job-id={@job_id}
       data-adaptor={@adaptor}
       data-source={@source}
       data-disabled={@disabled}

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -5,6 +5,7 @@ defmodule LightningWeb.RunLive.Index do
   use LightningWeb, :live_view
 
   import Ecto.Changeset, only: [get_change: 2]
+  import LightningWeb.Components.Icons
 
   alias Lightning.Extensions.UsageLimiting.Action
   alias Lightning.Extensions.UsageLimiting.Context

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -3,6 +3,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
   use LightningWeb.RunLive.Streaming, chunk_size: 100
 
   import LightningWeb.RunLive.Components
+  import LightningWeb.Components.Icons
 
   alias Lightning.Accounts.User
   alias Lightning.Policies.Permissions

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -2,6 +2,7 @@ defmodule LightningWeb.RunLive.Show do
   use LightningWeb, :live_view
   use LightningWeb.RunLive.Streaming, chunk_size: 100
 
+  import LightningWeb.Components.Icons
   import LightningWeb.RunLive.Components
 
   alias Lightning.Policies.Permissions

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1816,10 +1816,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end)
   end
 
-  # defp find_item(%Snapshot{} = snapshot, id) do
-  #   find_item_helper(snapshot, id, &Map.get/2)
-  # end
-
   defp find_item_helper(data, id, accessor) do
     [:jobs, :triggers, :edges]
     |> Enum.reduce_while(nil, fn field, _ ->

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -3,6 +3,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   use LightningWeb, {:live_view, container: {:div, []}}
 
   import LightningWeb.Components.NewInputs
+  import LightningWeb.Components.Icons
   import LightningWeb.WorkflowLive.Components
 
   alias Lightning.Extensions.UsageLimiting.Action
@@ -102,16 +103,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 name="hero-lock-closed"
                 class="w-5 h-5 place-self-center text-gray-300"
               />
-              <Form.submit_button
-                phx-disable-with="Saving..."
-                disabled={
-                  !@can_edit_workflow or !@changeset.valid? or
-                    @snapshot_version_tag != "latest"
-                }
-                form="workflow-form"
-              >
-                Save
-              </Form.submit_button>
+              <div class="m-auto">
+                <.offline_indicator />
+              </div>
+              <.save_workflow_button
+                changeset={@changeset}
+                can_edit_workflow={@can_edit_workflow}
+                snapshot_version_tag={@snapshot_version_tag}
+              />
             </div>
           </.with_changes_indicator>
         </LayoutComponents.header>
@@ -326,16 +325,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     </div>
                   </div>
                   <.with_changes_indicator changeset={@changeset}>
-                    <Form.submit_button
-                      phx-disable-with="Saving..."
-                      disabled={
-                        !@can_edit_workflow or !@changeset.valid? or
-                          @snapshot_version_tag != "latest"
-                      }
-                      form="workflow-form"
-                    >
-                      Save
-                    </Form.submit_button>
+                    <.save_workflow_button
+                      changeset={@changeset}
+                      can_edit_workflow={@can_edit_workflow}
+                      snapshot_version_tag={@snapshot_version_tag}
+                    />
                   </.with_changes_indicator>
                 </div>
               </:footer>
@@ -1013,6 +1007,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
      |> push_event("current-workflow-params", %{
        workflow_params: socket.assigns.workflow_params
      })}
+  end
+
+  def handle_event("get-current-state", _params, socket) do
+    {:reply, %{workflow_params: socket.assigns.workflow_params}, socket}
   end
 
   def handle_event("switch-version", %{"type" => type}, socket) do
@@ -1862,6 +1860,40 @@ defmodule LightningWeb.WorkflowLive.Edit do
       </div>
       <%= render_slot(@inner_block) %>
     </div>
+    """
+  end
+
+  attr :can_edit_workflow, :boolean, required: true
+  attr :changeset, Ecto.Changeset, required: true
+  attr :snapshot_version_tag, :string, required: true
+
+  defp save_workflow_button(assigns) do
+    alias Phoenix.LiveView.JS
+
+    %{
+      can_edit_workflow: can_edit_workflow,
+      changeset: changeset,
+      snapshot_version_tag: snapshot_version_tag
+    } = assigns
+
+    assigns =
+      assigns
+      |> assign(
+        disabled:
+          !can_edit_workflow or !changeset.valid? or
+            snapshot_version_tag != "latest"
+      )
+
+    ~H"""
+    <Form.submit_button
+      phx-disable-with="Saving..."
+      disabled={@disabled}
+      form="workflow-form"
+      phx-disconnected={JS.set_attribute({"disabled", ""})}
+      phx-connected={!@disabled && JS.remove_attribute("disabled")}
+    >
+      Save
+    </Form.submit_button>
     """
   end
 end

--- a/lib/lightning_web/live/workflow_live/editor_pane.ex
+++ b/lib/lightning_web/live/workflow_live/editor_pane.ex
@@ -1,5 +1,6 @@
 defmodule LightningWeb.WorkflowLive.EditorPane do
   use LightningWeb, :live_component
+
   alias Lightning.Credentials
   alias LightningWeb.JobLive.JobBuilderComponents
 
@@ -20,6 +21,7 @@ defmodule LightningWeb.WorkflowLive.EditorPane do
         adaptor={@adaptor}
         source={@source}
         id={"job-editor-#{@job_id}"}
+        job_id={@job_id}
         disabled={@disabled}
         disabled_message={@disabled_message}
         phx-target={@myself}
@@ -40,8 +42,7 @@ defmodule LightningWeb.WorkflowLive.EditorPane do
         adaptor:
           form[:adaptor].value
           |> Lightning.AdaptorRegistry.resolve_adaptor(),
-        source: form[:body].value,
-        credential: fetch_credential(form[:project_credential_id].value),
+        source: form.source.data.body,
         job_id: form[:id].value
       )
 
@@ -52,7 +53,9 @@ defmodule LightningWeb.WorkflowLive.EditorPane do
   def handle_event("request_metadata", _params, socket) do
     pid = self()
 
-    %{adaptor: adaptor, credential: credential, id: id} = socket.assigns
+    %{adaptor: adaptor, id: id, form: form} = socket.assigns
+
+    credential = fetch_credential(form[:project_credential_id].value)
 
     Task.start(fn ->
       metadata =

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -113,8 +113,16 @@ defmodule LightningWeb.WorkflowLive.JobView do
             }
           />
           <div class="flex flex-grow items-center justify-end">
+            <.offline_indicator />
             <.link
               id={"close-job-edit-view-#{@job.id}"}
+              phx-disconnected={
+                Phoenix.LiveView.JS.set_attribute(
+                  {"data-confirm",
+                   "You're currently disconnected.\nBy closing you will lose any unsaved changes.\nAre you sure you want to close this job?"}
+                )
+              }
+              phx-connected={Phoenix.LiveView.JS.remove_attribute("data-confirm")}
               patch={@close_url}
               phx-hook="ClosePanelViaEscape"
             >
@@ -181,7 +189,8 @@ defmodule LightningWeb.WorkflowLive.JobView do
               "project_id" => @project.id,
               "user_id" => @current_user.id
             },
-            container: {:div, class: "h-full p-2"}
+            container: {:div, class: "h-full p-2"},
+            sticky: true
           ) %>
         <% else %>
           <div class="w-1/2 h-16 text-center m-auto p-4">

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -5,11 +5,14 @@ defmodule Lightning.AiAssistantTest do
   alias Lightning.AiAssistant
   alias Lightning.AiAssistant.Session
 
+  import Lightning.Factories
+
   setup :verify_on_exit!
 
   describe "Session" do
     test "creation" do
-      session = Session.new("fn()", "@openfn/language-common@latest")
+      job = build(:job, body: "fn()", adaptor: "@openfn/language-common@latest")
+      session = Session.new(job)
 
       assert session.adaptor == "@openfn/language-common@1.6.2"
       assert session.expression == "fn()"
@@ -17,16 +20,20 @@ defmodule Lightning.AiAssistantTest do
     end
 
     test "put_history" do
+      job = build(:job, body: "fn()", adaptor: "@openfn/language-common@latest")
+
       session =
-        Session.new("fn()", "@openfn/language-common@latest")
+        Session.new(job)
         |> Session.put_history([%{role: :user, content: "fn()"}])
 
       assert session.history == [%{role: :user, content: "fn()"}]
     end
 
     test "put_expression" do
+      job = build(:job, body: "fn()", adaptor: "@openfn/language-common@latest")
+
       session =
-        Session.new("fn()", "@openfn/language-common@latest")
+        Session.new(job)
         |> Session.put_expression("fn(state => state)")
 
       assert session.expression == "fn(state => state)"


### PR DESCRIPTION
## Validation Steps

- Edit any job and start typing relatively quickly.
- The cursor should no jump to the end of the document.

> To further emphasis the issue, create a Network profile in the browser debug tools, bandwidth doesn't matter that much, but go for 200+ ms of latency.

https://github.com/OpenFn/lightning/assets/144796/0cf61bd3-5829-4c10-a0e7-f8a6eed8ba68

This PR also includes significant changes in how data is sync'd with the server.

Special attention should be paid to editing jobs, and combinations of saving and not saving while moving around different jobs.

Also attention should be paid to the recent snapshot UI changes, as the editors body/text is not getting its data directly via the html data attributes anymore.

I have added a function onto the `window` object for testing the behaviour of socket reconnects. To use it open the browser devtools and call the `triggerReconnect()` function which closes the socket and reconnects after 5 seconds, which appears to reproduce the same behaviour when you're online.

## Details

Rework of editor state syncing

- The editor now gets it's text body from the WorkflowEditorHook's store.
- It also sends it's changes to LiveView via the `proposeChanges` API which sends diffs.
- Added an online/offline indicator to the WorkflowEdit page.
- Disabled and reenable Save buttons when the socket is reconnecting.
- Added a warning that closing the JobEditor during a reconnect will lose changes (since a live patch link behaves like a regular link when disconnected)
- added a `reconnected` callback to WorkflowEditor that does a diff against the new (outdated) state from the server and sends back diffs to update the server, maintaining the users changes across socket reconnects

## Related issue

Fixes #2229 
Fixes #2007

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
