### PR TITLE
Show common functions in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Show common functions in the Docs panel
+  [#1733](https://github.com/OpenFn/lightning/issues/1733)
+
 ## [v2.7.0] - 2024-06-26
 
 ### Added

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.1.1",
         "@monaco-editor/react": "^4.4.5",
-        "@openfn/describe-package": "^0.0.20",
+        "@openfn/describe-package": "^0.1.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/forms": "^0.5.6",
         "classcat": "^5.0.4",
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@openfn/describe-package": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.0.20.tgz",
-      "integrity": "sha512-NM7B4rX58BMml+COm9g4GcvrZXqujnWEHOFqHmNTEBH+Pk7ouAbmBDB+39IaM/nL7yjtkF63gKBjVV1maMPUGw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@openfn/describe-package/-/describe-package-0.1.0.tgz",
+      "integrity": "sha512-5a6ErhfetFc19pMWVGyO0lFgOvskl5Vw6jJArB9Xw5msOintPPVnRVVfbuI1uXg208R7j1NTg0KooOwk3agi4w==",
       "dependencies": {
         "@typescript/vfs": "^1.3.5",
         "cross-fetch": "^3.1.5",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.1",
     "@monaco-editor/react": "^4.4.5",
-    "@openfn/describe-package": "^0.0.20",
+    "@openfn/describe-package": "^0.1.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.6",
     "classcat": "^5.0.4",


### PR DESCRIPTION
Bump the version of `describe-package` so that that Docs panel shows the common functions exported from an adaptor.

The actual fix is in https://github.com/OpenFn/kit/pull/724

![image](https://github.com/OpenFn/lightning/assets/7052509/cc689241-3bc1-4125-bdbd-7f5b13baa02c)

## Validation Steps

* Open the inspector on a HTTP step
* Check the listed functions in the Docs pabel
* Common functions like `fn` and `dataValue` should be included (in production they are not)

## Notes for the reviewer

Two `describe-package` releases in a week. Who saw that coming?

## Related issue

Fixes #1733

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
