### PR TITLE
Improve help/docs for path expressions

### DIFF
--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -412,7 +412,7 @@ defmodule LightningWeb.Components.NewInputs do
     ~H"""
     <p
       data-tag="error_message"
-      class="mt-3 inline-flex items-center gap-x-1.5 text-xs text-danger-600"
+      class="mt-1 inline-flex items-center gap-x-1.5 text-xs text-danger-600"
     >
       <.icon name="hero-exclamation-circle" class="h-4 w-4" />
       <%= render_slot(@inner_block) %>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -417,15 +417,17 @@ defmodule LightningWeb.WorkflowLive.Components do
             maxlength="255"
             placeholder="eg: !state.error"
           />
-          <details class="mt-5 ml-2">
-            <summary class="text-xs cursor-pointer">Help with expressions</summary>
+          <details class="mt-5 ml-1">
+            <summary class="text-xs cursor-pointer">
+              How to write expressions
+            </summary>
             <div class="font-normal text-xs text-gray-500 ml-1 pl-2 border-l-2 border-grey-500">
               <p class="mb-2 mt-1">
-                Use the state from the previous step to decide whether this step should fire.
+                Use the state from the previous step to decide whether this step should run.
               </p>
               <p class="mb-2">
-                Must be a single JavaScript expression. <code>state</code>
-                is in scope.
+                Must be a single JavaScript expression with <code>state</code>
+                in scope.
               </p>
               <p class="">
                 Check

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -408,22 +408,43 @@ defmodule LightningWeb.WorkflowLive.Components do
         <div>
           <.label>
             JS Expression
-            <p class="font-normal text-xs text-gray-500 ">
-              To match on output of last Step
-            </p>
-            <.input
-              type="textarea"
-              field={@form[:condition_expression]}
-              class="h-24 font-mono proportional-nums"
-              phx-debounce="300"
-              maxlength="255"
-            />
           </.label>
+          <.input
+            type="textarea"
+            field={@form[:condition_expression]}
+            class="h-24 font-mono proportional-nums"
+            phx-debounce="300"
+            maxlength="255"
+            placeholder="eg: !state.error"
+          />
+          <details class="mt-5 ml-2">
+            <summary class="text-xs cursor-pointer">Help with expressions</summary>
+            <div class="font-normal text-xs text-gray-500 ml-1 pl-2 border-l-2 border-grey-500">
+              <p class="mb-2 mt-1">
+                Use the state from the previous step to decide whether this step should fire.
+              </p>
+              <p class="mb-2">
+                Must be a single JavaScript expression. <code>state</code>
+                is in scope.
+              </p>
+              <p class="">
+                Check
+                <a
+                  class="text-indigo-700 hover:underline"
+                  href="https://docs.openfn.org/documentation/build/paths#writing-javascript-expressions-for-custom-path-conditions"
+                  target="_blank"
+                >
+                  docs.openfn.org
+                </a>
+                for more details.
+              </p>
+            </div>
+          </details>
         </div>
       <% end %>
       <%= if @form[:source_trigger_id].value do %>
         <div class="max-w-xl text-sm text-gray-500 mt-3">
-          <p>This path will be active if its trigger is enabled.</p>
+          <p>This path will be active if its trigger is enabled</p>
         </div>
       <% else %>
         <div class="mt-7 border-t flex flex-col justify-between">


### PR DESCRIPTION
A simple but considered little PR which adds some help text to the Path Expressions UI.

![image](https://github.com/OpenFn/lightning/assets/7052509/d1a50571-cfcc-4a05-b9a3-50d161417175)


## Notes for the reviewer

**SUPER IMPORTANT** I have changed the top margin on the error message of the `input` component. I've had a click around and it looks OK, but there could be surprises as a result of this PR.

I've had to make the change  because otherwise the error text bleeds over the help.

Changes I've made:
* Add placeholder text to the expression
* Take the field out of the label, so that the text isn't all bolded (note that the error is no longer bold too)
* Added a collapsible help area with some immediate text and a link to docs

## QA Notes

As a general rule, the padding between error messages and the fields they relate to has been REDUCED. This looks great in the Workflow Diagram UIs, but I don't know if I've broken something else. Presumably the margin was set to a very high value for a reason.

## Related issue

Fixes #1903

## Review checklist

- [ ] I have performed a **self-review** of my code
- [ ] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
