### PR TITLE
allow injecting of plugs in the router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 ### Changed
 
+- Allow endpoint plugs to be injected at compile time.
+  [#2248](https://github.com/OpenFn/lightning/pull/2248)
 - All models to use the `public` schema.
   [#2249](https://github.com/OpenFn/lightning/pull/2249)
 - In the workflow diagram, smartly update the view when adding new nodes

--- a/lib/lightning_web/endpoint.ex
+++ b/lib/lightning_web/endpoint.ex
@@ -48,6 +48,15 @@ defmodule LightningWeb.Endpoint do
     if: {LightningWeb.PromExPlugAuthorization, nil},
     do: {PromEx.Plug, prom_ex_module: Lightning.PromEx}
 
+  @plug_extensions Application.compile_env(
+                     :lightning,
+                     Lightning.Extensions.Plugs,
+                     []
+                   )
+  for {plug, mfa_opts} <- @plug_extensions do
+    plug Replug, plug: plug, opts: mfa_opts
+  end
+
   plug Replug,
     plug: Plug.Parsers,
     opts: {LightningWeb.PlugConfigs, :plug_parsers}


### PR DESCRIPTION
## Notes for the reviewer
This PR allows plugs to be injected in the router at compile time. 
It has been necessitated by https://github.com/OpenFn/thunderbolt/pull/207


## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
