### PR TITLE
When loading a step based on a run and a job, use the first one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 
 - Fix issue when selecting different steps in RunViewer and the parent liveview
   not being informed [#2253](https://github.com/OpenFn/lightning/issues/2253)
+- Stopped inspector from crashing when looking for a step by a run/job
+  combination [#2201](https://github.com/OpenFn/lightning/issues/2201)
 - Workflow activation only considers new and changed workflows
   [#2237](https://github.com/OpenFn/lightning/pull/2237)
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -68,12 +68,12 @@ defmodule Lightning.Invocation do
     Repo.one(query)
   end
 
-  @spec get_dataclip_for_run_and_job(
+  @spec get_first_dataclip_for_run_and_job(
           run_id :: Ecto.UUID.t(),
           job_id :: Ecto.UUID.t()
         ) ::
           Dataclip.t() | nil
-  def get_dataclip_for_run_and_job(run_id, job_id) do
+  def get_first_dataclip_for_run_and_job(run_id, job_id) do
     query =
       from d in Dataclip,
         join: s in Lightning.Invocation.Step,
@@ -81,15 +81,17 @@ defmodule Lightning.Invocation do
         join: a in assoc(s, :runs),
         on: a.id == ^run_id
 
-    Repo.one(query)
+    query
+    |> first(:inserted_at)
+    |> Repo.one()
   end
 
-  @spec get_step_for_run_and_job(
+  @spec get_first_step_for_run_and_job(
           run_id :: Ecto.UUID.t(),
           job_id :: Ecto.UUID.t()
         ) ::
           Lightning.Invocation.Step.t() | nil
-  def get_step_for_run_and_job(run_id, job_id) do
+  def get_first_step_for_run_and_job(run_id, job_id) do
     query =
       from s in Lightning.Invocation.Step,
         join: a in assoc(s, :runs),
@@ -97,7 +99,9 @@ defmodule Lightning.Invocation do
         where: s.job_id == ^job_id,
         preload: [snapshot: [triggers: :webhook_auth_methods]]
 
-    Repo.one(query)
+    query
+    |> first(:inserted_at)
+    |> Repo.one()
   end
 
   @spec get_step_count_for_run(run_id :: Ecto.UUID.t()) :: non_neg_integer()

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -154,7 +154,7 @@ defmodule LightningWeb.RunLive.Components do
       class={[
         "relative flex space-x-3 border-r-4 items-center",
         if(@selected,
-          do: "border-primary-500 text-indigo-500 font-semibold",
+          do: "border-primary-500 text-indigo-500",
           else: "border-transparent hover:border-gray-300"
         ),
         @class

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -154,7 +154,7 @@ defmodule LightningWeb.RunLive.Components do
       class={[
         "relative flex space-x-3 border-r-4 items-center",
         if(@selected,
-          do: "border-primary-500",
+          do: "border-primary-500 text-indigo-500 font-semibold",
           else: "border-transparent hover:border-gray-300"
         ),
         @class
@@ -186,7 +186,7 @@ defmodule LightningWeb.RunLive.Components do
             </span>
           </div>
         <% end %>
-        <div class="flex text-sm space-x-1 text-gray-900 items-center">
+        <div class="flex text-sm space-x-1 items-center">
           <span><%= @job.name %></span>
           <%= unless @job_id == @job.id do %>
             <.link

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1468,7 +1468,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
         step =
           assigns[:follow_run] &&
-            Invocation.get_step_for_run_and_job(
+            Invocation.get_first_step_for_run_and_job(
               assigns[:follow_run].id,
               job.id
             )
@@ -1493,7 +1493,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   defp get_selected_dataclip(run, job_id) do
-    dataclip = Invocation.get_dataclip_for_run_and_job(run.id, job_id)
+    dataclip = Invocation.get_first_dataclip_for_run_and_job(run.id, job_id)
 
     if is_nil(dataclip) and
          (run.starting_job_id == job_id ||
@@ -1814,7 +1814,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   defp assign_follow_run(%{assigns: %{selected_job: job}} = socket, run_id)
        when is_binary(run_id) do
     run = Runs.get(run_id)
-    step = Invocation.get_step_for_run_and_job(run_id, job.id)
+    step = Invocation.get_first_step_for_run_and_job(run_id, job.id)
 
     Runs.subscribe(run)
 


### PR DESCRIPTION
Fixes #2201 
<img width="940" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/be2cc08c-22c2-4336-8af0-f39963abfd65">


## Validation Steps

- set up a workflow like this
<img width="850" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/cf6e7a8e-e9a9-4f17-b045-429c040d835f">

- run it
- reload the inspector after switching to inspect the JOB that has multiple steps in this run
- it should pick the first step for that job
- it should not crash

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
