### PR TITLE
Fix step selection issue/order of phx-click and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix issue when selecting different steps in RunViewer and the parent liveview
+  not being informed [#2253](https://github.com/OpenFn/lightning/issues/2253)
 - Workflow activation only considers new and changed workflows
   [#2237](https://github.com/OpenFn/lightning/pull/2237)
 

--- a/assets/js/hooks/TabbedContainer.ts
+++ b/assets/js/hooks/TabbedContainer.ts
@@ -111,6 +111,7 @@ const TabbedSelector: PhoenixHook<{
     };
 
     window.addEventListener('hashchange', this._onHashChange);
+    window.addEventListener('phx:page-loading-stop', this._onHashChange);
 
     this.syncSelectedTab();
     this.updateTabs();
@@ -147,6 +148,7 @@ const TabbedSelector: PhoenixHook<{
   },
   destroyed() {
     window.removeEventListener('hashchange', this._onHashChange);
+    window.removeEventListener('phx:page-loading-stop', this._onHashChange);
   },
 } as typeof TabbedSelector;
 
@@ -171,6 +173,7 @@ const TabbedPanels: PhoenixHook<{
     };
 
     window.addEventListener('hashchange', this._onHashChange);
+    window.addEventListener('phx:page-loading-stop', this._onHashChange);
 
     this.syncSelectedPanel();
     this.updatePanels();
@@ -208,6 +211,7 @@ const TabbedPanels: PhoenixHook<{
   },
   destroyed() {
     window.removeEventListener('hashchange', this._onHashChange);
+    window.removeEventListener('phx:page-loading-stop', this._onHashChange);
   },
 } as typeof TabbedPanels;
 

--- a/lib/lightning.ex
+++ b/lib/lightning.ex
@@ -27,6 +27,11 @@ defmodule Lightning do
     end
 
     @impl true
+    def local_broadcast(topic, msg) do
+      Phoenix.PubSub.local_broadcast(@pubsub, topic, msg)
+    end
+
+    @impl true
     def subscribe(topic) do
       Phoenix.PubSub.subscribe(@pubsub, topic)
     end
@@ -55,6 +60,7 @@ defmodule Lightning do
   # credo:disable-for-next-line
   @callback current_time() :: DateTime.t()
   @callback broadcast(binary(), {atom(), any()}) :: :ok | {:error, term()}
+  @callback local_broadcast(binary(), {atom(), any()}) :: :ok | {:error, term()}
   @callback subscribe(binary()) :: :ok | {:error, term()}
   @callback release() :: release_info()
 
@@ -64,6 +70,8 @@ defmodule Lightning do
   def current_time, do: impl().current_time()
 
   def broadcast(topic, msg), do: impl().broadcast(topic, msg)
+
+  def local_broadcast(topic, msg), do: impl().local_broadcast(topic, msg)
 
   def subscribe(topic), do: impl().subscribe(topic)
 

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -206,7 +206,7 @@ defmodule LightningWeb.Components.Viewers do
         <%= if @can_edit_data_retention do %>
           You can’t rerun this work order, but you can change
           <.link
-            href={~p"/projects/#{@project_id}/settings#data-storage"}
+            navigate={~p"/projects/#{@project_id}/settings#data-storage"}
             class="underline inline-block text-blue-400 hover:text-blue-600"
           >
             this policy

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -191,7 +191,7 @@ defmodule LightningWeb.RunLive.Components do
           <%= unless @job_id == @job.id do %>
             <.link
               class="pl-1"
-              navigate={
+              patch={
                 ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}?#{%{v: @step.snapshot.lock_version, a: @run_id, m: "expand", s: @job.id}}" <> "#log"
               }
             >

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -192,8 +192,7 @@ defmodule LightningWeb.RunLive.Components do
             <.link
               class="pl-1"
               navigate={
-                ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}"
-                  <> "?v=#{@step.snapshot.lock_version}&a=#{@run_id}&m=expand&s=#{@step.job_id}#log"
+                ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}?#{%{v: @step.snapshot.lock_version, a: @run_id, m: "expand", s: @job.id}}" <> "#log"
               }
             >
               <.icon

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -864,7 +864,20 @@ defmodule LightningWeb.WorkflowLive.Edit do
     {:noreply,
      apply_action(socket, socket.assigns.live_action, params)
      |> apply_query_params(params)
-     |> maybe_show_manual_run()}
+     |> maybe_show_manual_run()
+     |> tap(fn socket ->
+       if connected?(socket) do
+         if changed?(socket, :selected_job) do
+           Helpers.broadcast_updated_params(socket, %{
+             job_id:
+               case socket.assigns.selected_job do
+                 nil -> nil
+                 job -> job.id
+               end
+           })
+         end
+       end
+     end)}
   end
 
   def apply_action(socket, :new, params) do

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -14,6 +14,14 @@ defmodule LightningWeb.WorkflowLive.Helpers do
   alias Lightning.WorkOrder
   alias Lightning.WorkOrders
 
+  def subscribe_to_params_update(socket_id) do
+    Lightning.subscribe(socket_id)
+  end
+
+  def broadcast_updated_params(socket, params) do
+    Lightning.local_broadcast(socket.id, {:updated_params, params})
+  end
+
   @spec save_workflow(Ecto.Changeset.t()) ::
           {:ok, Workflows.Workflow.t()}
           | {:error, Ecto.Changeset.t() | UsageLimiting.message()}

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -187,10 +187,11 @@ defmodule LightningWeb.WorkflowLive.JobView do
               "run_id" => @follow_run_id,
               "job_id" => @job.id,
               "project_id" => @project.id,
-              "user_id" => @current_user.id
+              "user_id" => @current_user.id,
+              "socket_id" => @socket.id
             },
-            container: {:div, class: "h-full p-2"},
-            sticky: true
+            sticky: true,
+            container: {:div, class: "h-full p-2"}
           ) %>
         <% else %>
           <div class="w-1/2 h-16 text-center m-auto p-4">

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -190,7 +190,6 @@ defmodule LightningWeb.WorkflowLive.JobView do
               "user_id" => @current_user.id,
               "socket_id" => @socket.id
             },
-            sticky: true,
             container: {:div, class: "h-full p-2"}
           ) %>
         <% else %>

--- a/test/support/mock.ex
+++ b/test/support/mock.ex
@@ -9,6 +9,9 @@ defmodule Lightning.Stub do
   def broadcast(topic, msg), do: Lightning.API.broadcast(topic, msg)
 
   @impl true
+  def local_broadcast(topic, msg), do: Lightning.API.local_broadcast(topic, msg)
+
+  @impl true
   def subscribe(topic), do: Lightning.API.subscribe(topic)
 
   @impl true


### PR DESCRIPTION
## Validation Steps

Open a Run from the History page, select different steps on the inspector, the job editor should reflect the correct code and the run viewer should update to not have an icon next to the selected item.

See issue for more details.

## Notes for the reviewer

This was a super weird one, there could be more than one thing at play. But it appeared that the `phx-click="select_step"` was no longer being called, or called too late because the link to the next step would trigger a navigation change.

The changes here use local pubsub to communicate the changes between the Edit and RunViewer liveviews; so the params go to the Edit LiveView and then the RunViewer receives just the changed job id.

The previous way was for the RunViewer to consume the click, handle the state change and then change the page, the responsibility is reversed now. 

## Related issue

Fixes #2253

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
