### PR TITLE
allow configurable targets for menu link

### DIFF
--- a/lib/lightning_web/live/components/menu.ex
+++ b/lib/lightning_web/live/components/menu.ex
@@ -150,7 +150,7 @@ defmodule LightningWeb.Components.Menu do
     ~H"""
     <div class="h-12 mx-2">
       <%= if assigns[:href] do %>
-          <.link href={@href} target={@target} class={@class}>
+        <.link href={@href} target={@target} class={@class}>
           <%= if assigns[:inner_block] do %>
             <%= render_slot(@inner_block) %>
           <% else %>

--- a/lib/lightning_web/live/components/menu.ex
+++ b/lib/lightning_web/live/components/menu.ex
@@ -145,11 +145,12 @@ defmodule LightningWeb.Components.Menu do
             inactive_classes
           end
       )
+      |> assign_new(:target, fn -> "_blank" end)
 
     ~H"""
     <div class="h-12 mx-2">
       <%= if assigns[:href] do %>
-        <.link href={@href} target="_blank" class={@class}>
+          <.link href={@href} target={@target} class={@class}>
           <%= if assigns[:inner_block] do %>
             <%= render_slot(@inner_block) %>
           <% else %>


### PR DESCRIPTION
## Notes for the reviewer

- Allows `menu_link` to have a configurable `target` for links with `href`


## Related issue

Needed in https://github.com/OpenFn/thunderbolt/pull/207 to help load a liveview page afresh

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
