### PR TITLE
pretty print raw JSON in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to
 
 ### Changed
 
+- When the entire log string is a valid JSON object, pretty print it with a
+  standard `JSON.stringify(str, null, 2)` but if it's something else then let
+  the user do whatever they want (e.g., if you write
+  `console.log('some', 'cool', state.data)` we won't mess with it.)
+  [#2260](https://github.com/OpenFn/lightning/pull/2260)
+
 ### Fixed
 
 - Fix issue when selecting different steps in RunViewer and the parent liveview

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -65,13 +65,26 @@ function coerceLogs(logs: LogLine[]): LogLine[] {
   }));
 }
 
+function isProbablyJSON(str: string) {
+  // Check if the string starts with '{' or '[' and ends with '}' or ']'
+  return (
+    (str.trim().startsWith('{') && str.trim().endsWith('}')) ||
+    (str.trim().startsWith('[') && str.trim().endsWith(']'))
+  );
+}
+
 function formatLogLine(log: LogLine) {
-  try {
-    const jsonObj = JSON.parse(log.message);
-    return `${log.source} ${JSON.stringify(jsonObj, null, 2)}`;
-  } catch {
-    return `${log.source} ${log.message}`;
+  const { source, message } = log;
+  if (isProbablyJSON(message)) {
+    try {
+      const jsonObj = JSON.parse(message);
+      return `${source} ${JSON.stringify(jsonObj, null, 2)}`;
+    } catch {
+      return `${source} ${message}`;
+    }
   }
+
+  return `${source} ${message}`;
 }
 
 export const createLogStore = () => {

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -28,7 +28,9 @@ function findSelectedRanges(logs: LogLine[], stepId: string | undefined) {
   }>(
     ({ ranges, marker }, log) => {
       // Get the number of newlines in the message, used to determine the end index.
-      const newLineCount = [...log.message.matchAll(/\n/g)].length;
+      const newLineCount = [...possiblyPrettify(log.message).matchAll(/\n/g)]
+        .length;
+
       const nextMarker = marker + 1 + newLineCount;
 
       if (log.step_id !== stepId) {
@@ -73,18 +75,25 @@ function isProbablyJSON(str: string) {
   );
 }
 
+function tryPrettyJSON(str: string) {
+  try {
+    const jsonObj = JSON.parse(str);
+    return JSON.stringify(jsonObj, null, 2);
+  } catch {
+    return str;
+  }
+}
+
+function possiblyPrettify(str: string | string) {
+  if (isProbablyJSON(str)) {
+    return tryPrettyJSON(str);
+  }
+  return str;
+}
+
 function formatLogLine(log: LogLine) {
   const { source, message } = log;
-  if (isProbablyJSON(message)) {
-    try {
-      const jsonObj = JSON.parse(message);
-      return `${source} ${JSON.stringify(jsonObj, null, 2)}`;
-    } catch {
-      return `${source} ${message}`;
-    }
-  }
-
-  return `${source} ${message}`;
+  return `${source} ${possiblyPrettify(message)}`;
 }
 
 export const createLogStore = () => {

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -68,8 +68,8 @@ function coerceLogs(logs: LogLine[]): LogLine[] {
 function isProbablyJSON(str: string) {
   // Check if the string starts with '{' or '[' and ends with '}' or ']'
   return (
-    (str.trim().startsWith('{') && str.trim().endsWith('}')) ||
-    (str.trim().startsWith('[') && str.trim().endsWith(']'))
+    (str.startsWith('{') && str.endsWith('}')) ||
+    (str.startsWith('[') && str.endsWith(']'))
   );
 }
 

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -66,7 +66,12 @@ function coerceLogs(logs: LogLine[]): LogLine[] {
 }
 
 function formatLogLine(log: LogLine) {
-  return `${log.source} ${log.message}`;
+  try {
+    const jsonObj = JSON.parse(log.message);
+    return `${log.source} ${JSON.stringify(jsonObj, null, 2)}`;
+  } catch {
+    return `${log.source} ${log.message}`;
+  }
 }
 
 export const createLogStore = () => {


### PR DESCRIPTION
## Two questions:
1. Do you like this more than single-line JSON?
2. If yes, will it destroy our performance to `try/catch` JSON stringify on every log line?

### Pretty Print JSON in log viewer:
<img width="1705" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/08bbab4a-6d8a-4a8d-b3b1-58ad7aa706cc">

### Keep it as a single line (currently on production):
<img width="1700" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/695da741-ec27-4e8c-9743-7fa0540c55c4">

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [ ] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
