### PR TITLE
Trim erroneous spaces on user names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to
 
 ### Fixed
 
-- Trim errant spaces on user first and last names
+- Trim erroneous spaces on user first and last names
+  [#2269](https://github.com/OpenFn/lightning/pull/2269)
 
 ## [v2.7.4] 2024-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 ### Fixed
 
+- Trim errant spaces on user first and last names
+
 ## [v2.7.4] 2024-07-06
 
 ### Changed

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -56,8 +56,8 @@ defmodule Lightning.Accounts.User do
       :password,
       :contact_preference
     ])
-    |> trim_name()
     |> validate_name()
+    |> trim_name()
     |> validate_email()
     |> validate_password([])
   end
@@ -104,8 +104,8 @@ defmodule Lightning.Accounts.User do
         ]
     )
     |> validate_email()
-    |> trim_name()
     |> validate_name()
+    |> trim_name()
     |> validate_password(opts)
     |> validate_change(:terms_accepted, fn :terms_accepted, terms_accepted ->
       if terms_accepted do
@@ -215,8 +215,8 @@ defmodule Lightning.Accounts.User do
       :scheduled_deletion
     ])
     |> validate_email()
-    |> trim_name()
     |> validate_name()
+    |> trim_name()
     |> validate_role()
   end
 

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -56,6 +56,7 @@ defmodule Lightning.Accounts.User do
       :password,
       :contact_preference
     ])
+    |> trim_name()
     |> validate_name()
     |> validate_email()
     |> validate_password([])
@@ -103,6 +104,7 @@ defmodule Lightning.Accounts.User do
         ]
     )
     |> validate_email()
+    |> trim_name()
     |> validate_name()
     |> validate_password(opts)
     |> validate_change(:terms_accepted, fn :terms_accepted, terms_accepted ->
@@ -213,8 +215,7 @@ defmodule Lightning.Accounts.User do
       :scheduled_deletion
     ])
     |> validate_email()
-    |> update_change(:first_name, &String.trim/1)
-    |> update_change(:last_name, &String.trim/1)
+    |> trim_name()
     |> validate_name()
     |> validate_role()
   end
@@ -329,5 +330,11 @@ defmodule Lightning.Accounts.User do
         "This email doesn't match your current email"
       )
     end
+  end
+
+  defp trim_name(changeset) do
+    changeset
+    |> update_change(:first_name, &String.trim/1)
+    |> update_change(:last_name, &String.trim/1)
   end
 end

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -213,6 +213,8 @@ defmodule Lightning.Accounts.User do
       :scheduled_deletion
     ])
     |> validate_email()
+    |> update_change(:first_name, &String.trim/1)
+    |> update_change(:last_name, &String.trim/1)
     |> validate_name()
     |> validate_role()
   end

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -75,7 +75,6 @@ defmodule LightningWeb.UserRegistrationControllerTest do
             )
         )
         |> get("/")
-        |> IO.inspect()
 
       assert conn.assigns.current_user.first_name == "Emory H"
       assert conn.assigns.current_user.last_name == "McLasterson"

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -68,9 +68,17 @@ defmodule LightningWeb.UserRegistrationControllerTest do
       conn =
         conn
         |> post(~p"/users/register",
-          user: valid_user_attributes(first_name: "Emory")
+          user:
+            valid_user_attributes(
+              first_name: " Emory H   ",
+              last_name: " McLasterson "
+            )
         )
         |> get("/")
+        |> IO.inspect()
+
+      assert conn.assigns.current_user.first_name == "Emory H"
+      assert conn.assigns.current_user.last_name == "McLasterson"
 
       project =
         conn.assigns.current_user
@@ -78,7 +86,7 @@ defmodule LightningWeb.UserRegistrationControllerTest do
         |> Lightning.Repo.one!()
 
       assert project
-             |> Map.get(:name) == "emory-demo"
+             |> Map.get(:name) == "emory-h-demo"
 
       assert project
              |> Lightning.Projects.project_workorders_query()


### PR DESCRIPTION
This (untrimmed strings being concatenated and resulting in lots of `---`) is no good
<img width="182" alt="image" src="https://github.com/OpenFn/lightning/assets/8732845/ea83912d-7e78-46bf-9c4e-71414d125da6">


## Validation Steps

- Create a new user with a space after their first or last name, such as `"Taylor "`
- Notice that the name is now trimmed before the user record is generated, fixing
  1. the user itself,
  2. the starter project name, and
  3. the associated personal billing account name.

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
