### PR TITLE
use snapshots when initiating github sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Use snapshots when initiating Github Sync
+  [#1827](https://github.com/OpenFn/lightning/issues/1827)
+
 ### Fixed
 
 ## [v2.7.11] - 2024-07-26

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -235,11 +235,11 @@ defmodule Lightning.ExportUtils do
     |> to_workflow_yaml_tree(workflow)
   end
 
-  def generate_new_yaml(project_id, snapshots \\ nil)
+  @spec generate_new_yaml(Projects.Project.t(), [Snapshot.t()] | nil) ::
+          {:ok, binary()}
+  def generate_new_yaml(project, snapshots \\ nil)
 
-  def generate_new_yaml(project_id, nil) do
-    project = Projects.get_project!(project_id)
-
+  def generate_new_yaml(project, nil) do
     yaml =
       project
       |> Workflows.get_workflows_for()
@@ -249,13 +249,10 @@ defmodule Lightning.ExportUtils do
     {:ok, yaml}
   end
 
-  def generate_new_yaml(project_id, snapshots) when is_list(snapshots) do
-    project = Projects.get_project!(project_id)
-
+  def generate_new_yaml(project, snapshots) when is_list(snapshots) do
     yaml =
       snapshots
-      |> Snapshot.get_all_by_ids()
-      |> Enum.sort_by(fn s -> s.name end)
+      |> Enum.sort_by(& &1.name)
       |> build_yaml_tree(project)
       |> to_new_yaml()
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -27,6 +27,7 @@ defmodule Lightning.Projects do
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
+  alias Lightning.Workflows.Snapshot
   alias Lightning.WorkOrder
 
   require Logger
@@ -558,12 +559,15 @@ defmodule Lightning.Projects do
       {:ok, string}
 
   """
-  @spec export_project(:yaml, Ecto.UUID.t(), [Ecto.UUID.t(), ...] | nil) ::
+  @spec export_project(atom(), Ecto.UUID.t(), [Ecto.UUID.t()] | nil) ::
           {:ok, binary}
-  def export_project(:yaml, project_id, snapshots \\ nil) do
-    {:ok, yaml} = ExportUtils.generate_new_yaml(project_id, snapshots)
+  def export_project(:yaml, project_id, snapshot_ids \\ nil) do
+    project = get_project!(project_id)
 
-    {:ok, yaml}
+    snapshots =
+      if snapshot_ids, do: Snapshot.get_all_by_ids(snapshot_ids), else: nil
+
+    {:ok, _yaml} = ExportUtils.generate_new_yaml(project, snapshots)
   end
 
   @doc """

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -25,9 +25,9 @@ defmodule Lightning.Projects do
   alias Lightning.RunStep
   alias Lightning.Services.ProjectHook
   alias Lightning.Workflows.Job
+  alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
-  alias Lightning.Workflows.Snapshot
   alias Lightning.WorkOrder
 
   require Logger

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -558,9 +558,10 @@ defmodule Lightning.Projects do
       {:ok, string}
 
   """
-  @spec export_project(:yaml, any) :: {:ok, binary}
-  def export_project(:yaml, project_id) do
-    {:ok, yaml} = ExportUtils.generate_new_yaml(project_id)
+  @spec export_project(:yaml, Ecto.UUID.t(), [Ecto.UUID.t(), ...] | nil) ::
+          {:ok, binary}
+  def export_project(:yaml, project_id, snapshots \\ nil) do
+    {:ok, yaml} = ExportUtils.generate_new_yaml(project_id, snapshots)
 
     {:ok, yaml}
   end

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -132,8 +132,11 @@ defmodule Lightning.Projects.Provisioner do
 
   Exclude deleted workflows.
   """
-  @spec preload_dependencies(Project.t()) :: Project.t()
-  def preload_dependencies(project) do
+  @spec preload_dependencies(Project.t(), nil | [Ecto.UUID.t(), ...]) ::
+          Project.t()
+  def preload_dependencies(project, snapshots \\ nil)
+
+  def preload_dependencies(project, nil) do
     w = from(w in Workflow, where: is_nil(w.deleted_at))
 
     Repo.preload(
@@ -144,6 +147,10 @@ defmodule Lightning.Projects.Provisioner do
       ],
       force: true
     )
+  end
+
+  def preload_dependencies(project, snapshots) when is_list(snapshots) do
+    %{project | workflows: Snapshot.get_all_by_ids(snapshots)}
   end
 
   defp project_changeset(project, attrs) do

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -157,6 +157,13 @@ defmodule Lightning.Workflows.Snapshot do
     |> Repo.all()
   end
 
+  def get_all_by_ids(ids) do
+    from(s in __MODULE__,
+      where: s.id in ^ids
+    )
+    |> Repo.all()
+  end
+
   @doc """
   Get the latest snapshot for a workflow, based on the lock_version.
 

--- a/lib/lightning_web/controllers/api/provisioning_controller.ex
+++ b/lib/lightning_web/controllers/api/provisioning_controller.ex
@@ -67,7 +67,8 @@ defmodule LightningWeb.API.ProvisioningController do
              conn.assigns.current_resource,
              project
            ),
-         project <- Provisioner.preload_dependencies(project) do
+         project <-
+           Provisioner.preload_dependencies(project, params["snapshots"]) do
       conn
       |> put_status(:ok)
       |> render("create.json", project: project)
@@ -78,7 +79,7 @@ defmodule LightningWeb.API.ProvisioningController do
   Returns a description of the project as yaml. Same as the export project to
   yaml button (see Downloads Controller) but made for the API.
   """
-  def show_yaml(conn, %{"id" => id}) do
+  def show_yaml(conn, %{"id" => id} = params) do
     with %Projects.Project{} = project <-
            Projects.get_project(id) || {:error, :not_found},
          :ok <-
@@ -88,7 +89,7 @@ defmodule LightningWeb.API.ProvisioningController do
              conn.assigns.current_resource,
              project
            ) do
-      {:ok, yaml} = Projects.export_project(:yaml, id)
+      {:ok, yaml} = Projects.export_project(:yaml, id, params["snapshots"])
 
       conn
       |> put_resp_content_type("text/yaml")

--- a/priv/github/pull.yml
+++ b/priv/github/pull.yml
@@ -28,7 +28,7 @@ jobs:
     name: A job to pull changes from Lightning
     steps:
       - name: openfn pull and commit
-        uses: midigofrank/cli-pull-action@v1.0.1-beta.2
+        uses: openfn/cli-pull-action@v1.1.0
         with:
           secret_input: ${{ secrets[inputs.apiSecretName] }}
           project_id_input: ${{ inputs.projectId }}

--- a/priv/github/pull.yml
+++ b/priv/github/pull.yml
@@ -16,6 +16,9 @@ on:
       commitMessage:
         description: 'Commit message for project state and spec'
         required: true
+      snapshots:
+        description: 'IDs of snapshots separated by spaces'
+        required: false
 
 jobs:
   pull-from-lightning:
@@ -25,10 +28,11 @@ jobs:
     name: A job to pull changes from Lightning
     steps:
       - name: openfn pull and commit
-        uses: openfn/cli-pull-action@v1.0.0
+        uses: midigofrank/cli-pull-action@v1.0.1-beta.2
         with:
           secret_input: ${{ secrets[inputs.apiSecretName] }}
           project_id_input: ${{ inputs.projectId }}
           config_path_input: ${{ inputs.pathToConfig }}
           branch_input: ${{ inputs.branch }}
           commit_message_input: ${{ inputs.commitMessage }}
+          snapshots_input: ${{ inputs.snapshots }}


### PR DESCRIPTION
## Validation Steps
You'll need these envs:
- `GITHUB_APP_ID`
- `GITHUB_APP_NAME`
- `GITHUB_APP_CLIENT_ID`
- `GITHUB_APP_CLIENT_SECRET`
- `GITHUB_CERT`

You also need a github repo. I would advise that you create an empty repo in your account with just the `README`. I have one just like that for testing these github work: https://github.com/midigofrank/openfn

If you're testing this locally, you'll need a tunnelling tool. I always use https://ngrok.com/docs/getting-started/ .
Assuming you're using `ngrok`, run the command below and copy the URL generated.
Replace call to `LightningWeb.Endpoint.url()` using that URL in this line https://github.com/OpenFn/lightning/blob/main/lib/lightning/version_control/version_control.ex#L548
Please remember to undo this change once you're done 

```bash
ngrok http 4000
```

**How to validate**
The aim is to initiate a sync and modify our workflow before the github action runs. We can achieve this by cancelling/stopping the github action and then later retry it.

1. Open the `Sync to Github` tab under project settings page
2. Click to connect your github account if you haven't already
3. Have your github repo open in another tab
4. Start the process, select your repo, branch, and chose the option to **Sync to Github** (OpenFn -> Github)
5. Click save and rush to your github repo, under the actions tab, wait for the action `.github/workflows/openfn-pull.yml` and cancel it. 
6. Now go back to lightning and update your workflow name, or any job name and save
7. Go back to your github repo actions and retry the action you cancelled in step 5
8. Once the `action` completes, we expect that the `yaml` committed in your github repo **NOT** to contain the changes you did in Step 6. It should have the original workflow and job names 

## Notes for the reviewer

- [x] Send workflow snapshot ids to github when initiating github sync.
- [x] Optimize creating snapshots for workflows without one. I need some eyes here
- [x] Update `priv/github/pull.yaml` to handle the `snapshot input` sent
- [x] Handle pulling of `state.json` and `project.yaml` with snapshots. It expects the user to hit the endpoint with `?snapshots[]=uuid1&snapshots[]=uuid2&snapshots[]=uuid3`.
The logic for getting this data in the contexts has been modified to accept `nil` or `list`
- [x] Modify the `cli-pull-action` to use the snapshots.  Here is the PR: https://github.com/OpenFn/cli-pull-action/pull/2.
Notice that it adds the `--snapshots` flag only if the `snapshots` are provided.
Also notice that `priv/github/pull.yaml` has been [modified](https://github.com/OpenFn/lightning/pull/2273/files#diff-094a7d24937d74952e4fb3795a84a777356fe78e7407061ca2cdde5afff11132R31) to use `midigofrank/cli-pull-action`. **PLEASE REMEMBER TO REMOVE IT ONCE THE PR IN THE ORIGINAL REPO HAS BEEN MERGED AND A RELEASE PUBLISHED**. The only reason I've used my fork is because I didn't want to litter the original repo with test releases
- [x]  Update the cli `pull` command to accept the `--snapshots` option: https://github.com/OpenFn/kit/issues/729

## Related issue

Fixes #1827

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature (TD approved after discussion with frank on slack. to be tested further on staging.)
