### PR TITLE
2279 usage tracker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to
 ### Changed
 
 ### Fixed
+- UsageTracking crons are enabled again (if config is enabled)
+  [#2276](https://github.com/OpenFn/lightning/issues/2276)
+- UsageTracking metrics absorb the fact that a step's job\_id may not currently
+  exist when counting unique jobs.
+  [#2279](https://github.com/OpenFn/lightning/issues/2279)
 
 ## [v2.7.5] - 2024-07-10
 

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -148,13 +148,18 @@ defmodule Lightning.Application do
   def oban_opts do
     opts = Application.get_env(:lightning, Oban)
 
-    opts[:plugins]
-    |> List.keyfind(Oban.Plugins.Cron, 0)
-    |> then(fn {mod, cron_opts} ->
-      {mod, put_usage_tracking_cron_opts(cron_opts)}
-    end)
+    {_keyword, new_opts} =
+      opts[:plugins]
+      |> List.keyfind(Oban.Plugins.Cron, 0)
+      |> then(fn {mod, cron_opts} ->
+        {mod, put_usage_tracking_cron_opts(cron_opts)}
+      end)
 
-    opts
+    updated_plugins =
+      opts[:plugins]
+      |> Keyword.merge([{Oban.Plugins.Cron, new_opts}])
+
+    opts |> Keyword.put(:plugins, updated_plugins)
   end
 
   defp put_usage_tracking_cron_opts(cron_opts) do

--- a/lib/lightning/usage_tracking/run_service.ex
+++ b/lib/lightning/usage_tracking/run_service.ex
@@ -15,11 +15,11 @@ defmodule Lightning.UsageTracking.RunService do
     |> finished_on(date)
   end
 
-  def unique_jobs(steps, date) do
+  def unique_job_ids(steps, date) do
     steps
     |> finished_on(date)
-    |> Enum.map(& &1.job)
-    |> Enum.uniq_by(& &1.id)
+    |> Enum.map(& &1.job.id)
+    |> Enum.uniq_by(& &1)
   end
 
   defp finished_on(collection, date) do

--- a/lib/lightning/usage_tracking/run_service.ex
+++ b/lib/lightning/usage_tracking/run_service.ex
@@ -18,7 +18,7 @@ defmodule Lightning.UsageTracking.RunService do
   def unique_job_ids(steps, date) do
     steps
     |> finished_on(date)
-    |> Enum.map(& &1.job.id)
+    |> Enum.map(& &1.job_id)
     |> Enum.uniq_by(& &1)
   end
 

--- a/lib/lightning/usage_tracking/workflow_metrics_service.ex
+++ b/lib/lightning/usage_tracking/workflow_metrics_service.ex
@@ -14,7 +14,7 @@ defmodule Lightning.UsageTracking.WorkflowMetricsService do
   def generate_metrics(workflow, cleartext_enabled, date) do
     runs = RunService.finished_runs(workflow.runs, date)
     steps = RunService.finished_steps(workflow.runs, date)
-    active_jobs = RunService.unique_jobs(steps, date)
+    active_jobs = RunService.unique_job_ids(steps, date)
 
     %{
       no_of_active_jobs: Enum.count(active_jobs),

--- a/test/lightning/application_test.exs
+++ b/test/lightning/application_test.exs
@@ -1,0 +1,38 @@
+defmodule Lightning.ApplicationTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Config
+
+  import Lightning.ApplicationHelpers, only: [put_temporary_env: 3]
+
+  describe ".oban_opts/0" do
+    test "returns the Oban configuration with usage tracking cron options" do
+      put_temporary_env(
+        :lightning,
+        :usage_tracking,
+        enabled: true,
+        daily_batch_size: 100,
+        resubmission_batch_size: 100
+      )
+
+      before_config = Application.get_env(:lightning, Oban)
+      plugins = before_config |> Keyword.fetch!(:plugins)
+      before_cron_plugin = plugins |> Keyword.fetch!(Oban.Plugins.Cron)
+      before_crontab = before_cron_plugin |> Keyword.fetch!(:crontab)
+
+      expected_crontab = before_crontab ++ Config.usage_tracking_cron_opts()
+
+      expected_plugins =
+        Keyword.put(
+          plugins,
+          Oban.Plugins.Cron,
+          crontab: expected_crontab
+        )
+
+      after_config = Lightning.Application.oban_opts()
+      after_plugins = after_config |> Keyword.fetch!(:plugins)
+
+      assert after_plugins == expected_plugins
+    end
+  end
+end

--- a/test/lightning/usage_tracking/run_service_test.exs
+++ b/test/lightning/usage_tracking/run_service_test.exs
@@ -128,7 +128,7 @@ defmodule Lightning.UsageTracking.RunServiceTest do
     end
   end
 
-  describe "unique_jobs/2" do
+  describe "unique_job_ids/2" do
     test "returns unique jobs across all steps finished on report date" do
       job_1 = insert(:job)
       job_2 = insert(:job)
@@ -149,7 +149,7 @@ defmodule Lightning.UsageTracking.RunServiceTest do
         unfinished
       ]
 
-      assert RunService.unique_jobs(steps, @date) == [job_1, job_2]
+      assert RunService.unique_job_ids(steps, @date) == [job_1.id, job_2.id]
     end
 
     defp insert_step(job, finished_at) do


### PR DESCRIPTION
## Validation Steps

Set USAGE_TRACKING_ENABLED to true
Change the [DayWorker cron](https://github.com/OpenFn/lightning/blob/main/lib/lightning/config.ex#L114) to run every minute.
Start up Lightning locally and then, after a minute or two, check that both Dayworker and ResubmissionCandidatesWorker appear in the logs.

## Notes for the reviewer

Two changes, grouped by commit.

For the change to `.oban_opts` I am not happy with the code I added, it could probably do with a cleanup. In addition, the test is both brittle and lacks coverage. I am opening the PR now given the urgency for fixes to the issues.

Once I have capacity I would like to circle back to the tests.

## Related issue

Fixes #2276
Fixes #2279 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
