### PR TITLE
Change Inspector layout when preventing simultaneous edits to a workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,15 @@ and this project adheres to
 ### Changed
 
 ### Fixed
+
 - UsageTracking crons are enabled again (if config is enabled)
   [#2276](https://github.com/OpenFn/lightning/issues/2276)
-- UsageTracking metrics absorb the fact that a step's job\_id may not currently
+- UsageTracking metrics absorb the fact that a step's job_id may not currently
   exist when counting unique jobs.
   [#2279](https://github.com/OpenFn/lightning/issues/2279)
+- Adjusted layout and text displayed when preventing simultaneous edits to
+  accommodate more screen sizes
+  [#2277](https://github.com/OpenFn/lightning/issues/2277)
 
 ## [v2.7.5] - 2024-07-10
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -251,10 +251,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     :if={display_switcher(@snapshot, @workflow)}
                     id={@selected_job.id}
                     label="Latest Version"
-                    disabled={
-                      job_deleted?(@selected_job, @workflow) ||
-                        !@has_presence_edit_priority
-                    }
+                    disabled={job_deleted?(@selected_job, @workflow)}
                     version={@snapshot_version_tag}
                   />
 
@@ -730,6 +727,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
         phx-value-type="toggle"
         data-version={@version}
         type="button"
+        disabled={@disabled}
         class={"#{if @version == "latest", do: "bg-indigo-600", else: "bg-gray-200"} relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
         role="switch"
         aria-checked="false"

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -238,6 +238,15 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   <% {is_empty, error_message} =
                     editor_is_empty(@workflow_form, @selected_job) %>
 
+                  <div
+                    :if={@snapshot_version_tag == "latest" && @display_banner}
+                    id={"inspector-banner-#{@current_user.id}"}
+                    class="flex items-center text-sm font-medium mr-1 text-gray-700"
+                  >
+                    <Heroicons.lock_closed solid class="h-4 w-4 mr-1" />
+                    <%= @banner_message %>
+                  </div>
+
                   <.version_switcher_toggle
                     :if={display_switcher(@snapshot, @workflow)}
                     id={@selected_job.id}
@@ -612,10 +621,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     cond do
       current_user_presence.active_sessions > 1 ->
-        "You can't edit this workflow because you have #{current_user_presence.active_sessions} active sessions. Close your other sessions to enable editing."
+        "You have this workflow open in #{current_user_presence.active_sessions} tabs and can't edit until you close the other#{if current_user_presence.active_sessions > 2, do: "s", else: ""}."
 
       current_user_presence.user.id != prior_user_presence.user.id ->
-        "This workflow is currently locked for editing because a collaborator (#{prior_user_name}) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+        "#{prior_user_name} is currently active and you can't edit this workflow until they close the editor and canvas."
 
       true ->
         nil
@@ -721,7 +730,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
         phx-value-type="toggle"
         data-version={@version}
         type="button"
-        disabled={@disabled}
         class={"#{if @version == "latest", do: "bg-indigo-600", else: "bg-gray-200"} relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
         role="switch"
         aria-checked="false"

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -141,12 +141,6 @@ defmodule LightningWeb.WorkflowLive.JobView do
             </.link>
           </div>
         </div>
-        <LightningWeb.WorkflowLive.Components.workflow_info_banner
-          :if={@display_banner}
-          id={"inspector-banner-#{@current_user.id}"}
-          position="relative"
-          message={@banner_message}
-        />
       </:top>
       <%= for slot <- @collapsible_panel do %>
         <.collapsible_panel
@@ -226,11 +220,12 @@ defmodule LightningWeb.WorkflowLive.JobView do
   defp editor_disabled?(params) do
     cond do
       is_struct(params.form.source.data, Lightning.Workflows.Snapshot.Job) ->
-        {true, "Cannot edit in snapshot mode, switch to the latest version.",
+        {true,
+         "You can't edit while viewing a snapshot, switch to the latest version.",
          "Editor (read-only)"}
 
       params.display_banner ->
-        {true, "Cannot edit in low priority access.", "Editor (read-only)"}
+        {true, params.banner_message, "Editor (read-only)"}
 
       true ->
         {false, "", "Editor"}

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -568,7 +568,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert view
              |> has_element?(
-               "[id='job-editor-#{job_1.id}'][data-disabled='true'][data-source='#{job_1.body}']"
+               "[id='job-editor-#{job_1.id}'][data-disabled='true'][data-source='#{job_1.body}'][data-disabled-message=\"You can't edit while viewing a snapshot, switch to the latest version.\"]"
              )
 
       assert view |> has_element?("[id='manual_run_form_dataclip_id'][disabled]")

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -298,7 +298,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
         refute view
                |> has_element?(
-                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message='You can&#39;t edit while viewing a snapshot, switch to the latest version.']"
+                 "[id='job-editor-#{job.id}'][data-disabled='true']"
                )
 
         refute view
@@ -413,7 +413,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
         assert view
                |> has_element?(
-                 "[id='job-editor-#{job.id}'][data-disabled='true']"
+                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message=\"You can't edit while viewing a snapshot, switch to the latest version.\""
                )
 
         assert view

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -413,7 +413,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
         assert view
                |> has_element?(
-                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message='Cannot edit in snapshot mode, switch to the latest version.']"
+                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message='You cannot edit or run an old snapshot of a workflow.']"
                )
 
         assert view
@@ -502,7 +502,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert view |> element("[type='submit']", "Save") |> has_element?()
     end
 
-    test "Inspector renders run thru their snapshots and allows switching to the latest versions for edition",
+    test "Inspector renders run thru their snapshots and allows switching to the latest versions for editing",
          %{conn: conn, project: project, workflow: workflow} do
       {:ok, earliest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
 
@@ -568,7 +568,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert view
              |> has_element?(
-               "[id='job-editor-#{job_1.id}'][data-disabled-message='Cannot edit in snapshot mode, switch to the latest version.'][data-disabled='true'][data-source='#{job_1.body}']"
+               "[id='job-editor-#{job_1.id}'][data-disabled-message='You can't edit while viewing a snapshot, switch to the latest version.'][data-disabled='true'][data-source='#{job_1.body}']"
              )
 
       assert view |> has_element?("[id='manual_run_form_dataclip_id'][disabled]")

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -298,7 +298,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
         refute view
                |> has_element?(
-                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message='Cannot edit in snapshot mode, switch to the latest version.']"
+                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message='You can&#39;t edit while viewing a snapshot, switch to the latest version.']"
                )
 
         refute view
@@ -408,12 +408,12 @@ defmodule LightningWeb.WorkflowLive.EditTest do
                  version
                )
 
-        assert view
-               |> has_element?("[id='manual_run_form_dataclip_id'][disabled]")
+        view
+        |> has_element?("[id='manual_run_form_dataclip_id'][disabled]")
 
         assert view
                |> has_element?(
-                 "[id='job-editor-#{job.id}'][data-disabled='true'][data-disabled-message='You cannot edit or run an old snapshot of a workflow.']"
+                 "[id='job-editor-#{job.id}'][data-disabled='true']"
                )
 
         assert view
@@ -568,7 +568,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert view
              |> has_element?(
-               "[id='job-editor-#{job_1.id}'][data-disabled-message='You can't edit while viewing a snapshot, switch to the latest version.'][data-disabled='true'][data-source='#{job_1.body}']"
+               "[id='job-editor-#{job_1.id}'][data-disabled='true'][data-source='#{job_1.body}']"
              )
 
       assert view |> has_element?("[id='manual_run_form_dataclip_id'][disabled]")

--- a/test/lightning_web/live/workflow_live/user_presences_test.exs
+++ b/test/lightning_web/live/workflow_live/user_presences_test.exs
@@ -144,7 +144,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert ana_view |> has_element?("#canvas-banner-#{ana.id}")
 
       assert ana_view |> element("#canvas-banner-#{ana.id}") |> render() =~
-               "This workflow is currently locked for editing because a collaborator (Amy Ly) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+               "Amy Ly is currently active and you can&#39;t edit this workflow until they close the editor and canvas."
 
       refute render(amy_view) =~ amy.first_name
       assert render(amy_view) =~ ana.first_name
@@ -170,7 +170,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert ana_view |> has_element?("#canvas-banner-#{ana.id}")
 
       assert ana_view |> element("#canvas-banner-#{ana.id}") |> render() =~
-               "This workflow is currently locked for editing because a collaborator (Amy Ly) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+               "Amy Ly is currently active and you can&#39;t edit this workflow until they close the editor and canvas."
 
       wait_for_canvas_disabled_state(aly_view, false)
 
@@ -180,7 +180,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert aly_view |> has_element?("#canvas-banner-#{aly.id}")
 
       assert aly_view |> element("#canvas-banner-#{aly.id}") |> render() =~
-               "This workflow is currently locked for editing because a collaborator (Amy Ly) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+               "Amy Ly is currently active and you can&#39;t edit this workflow until they close the editor and canvas."
 
       refute render(amy_view) =~ amy.first_name
       assert render(amy_view) =~ ana.first_name
@@ -291,7 +291,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert ana_view |> has_element?("#inspector-banner-#{ana.id}")
 
       assert ana_view |> element("#canvas-banner-#{ana.id}") |> render() =~
-               "This workflow is currently locked for editing because a collaborator (Amy Ly) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+               "Amy Ly is currently active and you can&#39;t edit this workflow until they close the editor and canvas."
 
       refute render(amy_view) =~ amy.first_name
       assert render(amy_view) =~ ana.first_name
@@ -319,7 +319,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert ana_view |> has_element?("#inspector-banner-#{ana.id}")
 
       assert ana_view |> element("#canvas-banner-#{ana.id}") |> render() =~
-               "This workflow is currently locked for editing because a collaborator (Amy Ly) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+               "Amy Ly is currently active and you can&#39;t edit this workflow until they close the editor and canvas."
 
       refute aly_view |> has_element?("#inspector-online-users-#{aly.id}")
       assert aly_view |> has_element?("#inspector-online-users-#{amy.id}")
@@ -327,7 +327,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert aly_view |> has_element?("#inspector-banner-#{aly.id}")
 
       assert aly_view |> element("#canvas-banner-#{aly.id}") |> render() =~
-               "This workflow is currently locked for editing because a collaborator (Amy Ly) is currently working on it. You can inspect this workflow and its associated steps but cannot make edits."
+               "Amy Ly is currently active and you can&#39;t edit this workflow until they close the editor and canvas."
 
       refute render(amy_view) =~ amy.first_name
       assert render(amy_view) =~ ana.first_name
@@ -384,10 +384,10 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert another_amy_view |> has_element?("#canvas-banner-#{amy.id}")
 
       assert amy_view |> element("#canvas-banner-#{amy.id}") |> render() =~
-               "You can&#39;t edit this workflow because you have 2 active sessions. Close your other sessions to enable editing."
+               "You have this workflow open in 2 tabs and can&#39;t edit until you close the other."
 
       assert another_amy_view |> element("#canvas-banner-#{amy.id}") |> render() =~
-               "You can&#39;t edit this workflow because you have 2 active sessions. Close your other sessions to enable editing."
+               "You have this workflow open in 2 tabs and can&#39;t edit until you close the other."
     end
 
     test "in inspector", %{conn: conn} do
@@ -431,12 +431,12 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
       assert another_amy_view |> has_element?("#inspector-banner-#{amy.id}")
 
       assert amy_view |> element("#inspector-banner-#{amy.id}") |> render() =~
-               "You can&#39;t edit this workflow because you have 2 active sessions. Close your other sessions to enable editing."
+               "You have this workflow open in 2 tabs and can&#39;t edit until you close the other."
 
       assert another_amy_view
              |> element("#inspector-banner-#{amy.id}")
              |> render() =~
-               "You can&#39;t edit this workflow because you have 2 active sessions. Close your other sessions to enable editing."
+               "You have this workflow open in 2 tabs and can&#39;t edit until you close the other."
     end
   end
 


### PR DESCRIPTION
Implemented @christad92 's changes here - the previous implementation was taking up too much screen space. This does two things:
1. shortens the text
2. moves the message from a banner on the inspector into the bottom bar