### PR TITLE
Invite Non-Registered Users to a Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Invite Non-Registered Users to a Project
+  [#2288](https://github.com/OpenFn/lightning/pull/2288)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -110,7 +110,11 @@ defmodule Lightning.Accounts do
   Returns the list of users with the given emails
   """
   def list_users_by_emails(emails) do
-    query = from u in User, where: u.email in ^emails
+    lowercase_emails = Enum.map(emails, &String.downcase/1)
+
+    query =
+      from u in User, where: fragment("LOWER(?)", u.email) in ^lowercase_emails
+
     Repo.all(query)
   end
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -350,12 +350,13 @@ defmodule Lightning.Accounts.UserNotifier do
     """)
   end
 
-  def deliver_project_invitation_email(user, project, token, inviter) do
+  def deliver_project_invitation_email(user, inviter, project, role, token) do
     deliver(user.email, "Join #{project.name} on OpenFn as a collaborator", """
     Hi #{user.first_name},
 
-    #{inviter.first_name} has invited you to join the #{project.name} project on OpenFn. Since you don't have an account yet, we've set one up for you. Please click the link below to complete your account setup:
-    #{url(LightningWeb.Endpoint, ~p"/users/reset_password/#{token}")}
+    #{inviter.first_name} has invited you to join project "#{project.name}" and granted you "#{role}" access. Since you don't have an OpenFn account yet, we've set one up for you.
+
+    Please click the link below to complete your account setup: #{url(LightningWeb.Endpoint, ~p"/users/reset_password/#{token}")}
 
     If you did not request to join this project, please ignore this email.
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -350,15 +350,15 @@ defmodule Lightning.Accounts.UserNotifier do
     """)
   end
 
-  def deliver_project_invitation_email(user, project, url) do
+  def deliver_project_invitation_email(user, project, token) do
     deliver(user.email, "Join #{project.name} on OpenFn as a collaborator", """
     Hi #{user.first_name},
 
     #{user.first_name} has invited you to join the #{project.name} project on OpenFn. Since you don't have an account yet, we've set one up for you. Please click the link below to complete your account setup:
-    #{url}
+    #{url(LightningWeb.Endpoint, ~p"/users/reset_password/#{token}")}
 
     If you did not request to join this project, please ignore this email.
-    Best regards,
+
     OpenFn
     """)
   end

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -350,6 +350,19 @@ defmodule Lightning.Accounts.UserNotifier do
     """)
   end
 
+  def deliver_project_invitation_email(user, project, url) do
+    deliver(user.email, "Join #{project.name} on OpenFn as a collaborator", """
+    Hi #{user.first_name},
+
+    #{user.first_name} has invited you to join the #{project.name} project on OpenFn. Since you don't have an account yet, we've set one up for you. Please click the link below to complete your account setup:
+    #{url}
+
+    If you did not request to join this project, please ignore this email.
+    Best regards,
+    OpenFn
+    """)
+  end
+
   defp pluralize_with_s(1, string), do: string
   defp pluralize_with_s(_integer, string), do: "#{string}s"
 end

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -350,11 +350,11 @@ defmodule Lightning.Accounts.UserNotifier do
     """)
   end
 
-  def deliver_project_invitation_email(user, project, token) do
+  def deliver_project_invitation_email(user, project, token, inviter) do
     deliver(user.email, "Join #{project.name} on OpenFn as a collaborator", """
     Hi #{user.first_name},
 
-    #{user.first_name} has invited you to join the #{project.name} project on OpenFn. Since you don't have an account yet, we've set one up for you. Please click the link below to complete your account setup:
+    #{inviter.first_name} has invited you to join the #{project.name} project on OpenFn. Since you don't have an account yet, we've set one up for you. Please click the link below to complete your account setup:
     #{url(LightningWeb.Endpoint, ~p"/users/reset_password/#{token}")}
 
     If you did not request to join this project, please ignore this email.

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -2,8 +2,6 @@ defmodule Lightning.Projects do
   @moduledoc """
   The Projects context.
   """
-  alias Lightning.Accounts.UserToken
-
   use Oban.Worker,
     queue: :background,
     max_attempts: 1
@@ -13,6 +11,7 @@ defmodule Lightning.Projects do
   alias Ecto.Multi
   alias Lightning.Accounts.User
   alias Lightning.Accounts.UserNotifier
+  alias Lightning.Accounts.UserToken
   alias Lightning.ExportUtils
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.LogLine

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -153,6 +153,8 @@ defmodule LightningWeb.Components.NewInputs do
 
   attr :class, :string, default: ""
 
+  attr :display_errors, :boolean, default: true
+
   slot :inner_block
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -201,7 +203,7 @@ defmodule LightningWeb.Components.NewInputs do
           class="text-red-500"
         > *</span>
       </label>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors} :if={@display_errors}><%= msg %></.error>
     </div>
     """
   end
@@ -238,7 +240,7 @@ defmodule LightningWeb.Components.NewInputs do
           <%= render_slot(@inner_block) %>
         </div>
       </div>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors} :if={@display_errors}><%= msg %></.error>
     </div>
     """
   end
@@ -268,7 +270,7 @@ defmodule LightningWeb.Components.NewInputs do
         ]}
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors} :if={@display_errors}><%= msg %></.error>
     </div>
     """
   end
@@ -322,7 +324,7 @@ defmodule LightningWeb.Components.NewInputs do
           />
         </div>
       </div>
-      <div :if={Enum.any?(@errors)} class="error-space h-6">
+      <div :if={Enum.any?(@errors) and @display_errors} class="error-space h-6">
         <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
     </div>
@@ -380,7 +382,7 @@ defmodule LightningWeb.Components.NewInputs do
         ]}
         {@rest}
       />
-      <div :if={Enum.any?(@errors)} class="error-space h-6">
+      <div :if={Enum.any?(@errors) and @display_errors} class="error-space h-6">
         <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
     </div>

--- a/lib/lightning_web/live/project_live/collaborators.ex
+++ b/lib/lightning_web/live/project_live/collaborators.ex
@@ -33,7 +33,7 @@ defmodule LightningWeb.ProjectLive.Collaborators do
   end
 
   @spec prepare_for_insertion(%__MODULE__{}, map(), [map(), ...]) ::
-          {:ok, [map(), ...], [map(), ...]} | {:error, Ecto.Changeset.t()}
+          {:ok, [map(), ...]} | {:error, Ecto.Changeset.t()}
   def prepare_for_insertion(schema, attrs, current_project_users) do
     changeset = changeset(schema, attrs)
 
@@ -70,11 +70,6 @@ defmodule LightningWeb.ProjectLive.Collaborators do
 
     with {:ok, %{collaborators: collaborators}} <-
            apply_action(changeset, :insert) do
-      # collaborators =
-      #   Enum.map(collaborators, fn c ->
-      #     Map.take(c, [:user_id, :role])
-      #   end)
-
       {:ok, collaborators}
     end
   end

--- a/lib/lightning_web/live/project_live/collaborators.ex
+++ b/lib/lightning_web/live/project_live/collaborators.ex
@@ -43,13 +43,18 @@ defmodule LightningWeb.ProjectLive.Collaborators do
 
         emails = Enum.map(collaborators, &get_field(&1, :email))
 
-        existing_users = Lightning.Accounts.list_users_by_emails(emails)
+        existing_users =
+          Lightning.Accounts.list_users_by_emails(emails)
 
-        existing_emails = Enum.map(existing_users, & &1.email)
+        existing_emails =
+          Enum.map(existing_users, fn user -> String.downcase(user.email) end)
 
         {existing_collaborators, new_collaborators} =
           Enum.split_with(collaborators, fn collaborator ->
-            Enum.member?(existing_emails, get_field(collaborator, :email))
+            Enum.member?(
+              existing_emails,
+              get_field(collaborator, :email) |> String.downcase()
+            )
           end)
 
         updated_collaborators =
@@ -82,7 +87,8 @@ defmodule LightningWeb.ProjectLive.Collaborators do
     Enum.map(collaborators, fn collaborator ->
       existing_user =
         Enum.find(existing_users, fn u ->
-          u.email == get_field(collaborator, :email)
+          String.downcase(u.email) ==
+            get_field(collaborator, :email) |> String.downcase()
         end)
 
       collaborator

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.ex
@@ -1,6 +1,7 @@
 defmodule LightningWeb.ProjectLive.InviteCollaboratorComponent do
   @moduledoc false
 
+  require Logger
   use LightningWeb, :live_component
 
   alias Lightning.Projects
@@ -43,18 +44,74 @@ defmodule LightningWeb.ProjectLive.InviteCollaboratorComponent do
 
   def handle_event("add_collaborators", %{"project" => params}, socket) do
     with :ok <- limit_adding_users(socket, params) do
-      {:ok, %{invited_collaborators: collaborators}} =
-        InvitedCollaborators.changeset(socket.assigns.collaborators, params)
-        |> Ecto.Changeset.apply_action(:insert)
+      case validate_collaborators(socket.assigns.collaborators, params) do
+        {:ok, collaborators} ->
+          case Projects.invite_collaborators(
+                 socket.assigns.project,
+                 collaborators,
+                 socket.assigns.current_user
+               ) do
+            {:ok, _result} ->
+              {:noreply,
+               socket
+               |> put_flash(:info, "Invites sent successfully")
+               |> push_navigate(
+                 to:
+                   ~p"/projects/#{socket.assigns.project}/settings#collaboration"
+               )}
 
-      Projects.invite_collaborators(socket.assigns.project, collaborators)
+            {:error, changeset} ->
+              Logger.info(
+                "Error when inviting users to the project #{socket.assigns.project.name}: #{inspect(changeset)}"
+              )
 
-      {:noreply,
-       socket
-       |> put_flash(:info, "Invites sent successfully")
-       |> push_navigate(
-         to: ~p"/projects/#{socket.assigns.project}/settings#collaboration"
-       )}
+              {:noreply, socket}
+          end
+
+        {:error, changeset} ->
+          {:noreply, socket |> assign(:changeset, changeset)}
+      end
+    end
+  end
+
+  defp validate_collaborators(schema, params) do
+    changeset = InvitedCollaborators.changeset(schema, params)
+
+    changeset =
+      if changeset.valid? do
+        collaborators =
+          Ecto.Changeset.get_embed(changeset, :invited_collaborators)
+
+        existing_emails =
+          collaborators
+          |> Enum.map(&Ecto.Changeset.get_field(&1, :email))
+          |> Lightning.Accounts.list_users_by_emails()
+          |> Enum.map(& &1.email)
+
+        collaborators =
+          Enum.map(collaborators, fn collaborator ->
+            collaborator
+            |> Ecto.Changeset.validate_change(:email, fn :email, _email ->
+              if Ecto.Changeset.get_field(collaborator, :email) in existing_emails do
+                [email: "This email is already taken"]
+              else
+                []
+              end
+            end)
+          end)
+
+        Ecto.Changeset.put_embed(
+          changeset,
+          :invited_collaborators,
+          collaborators
+        )
+      else
+        changeset
+      end
+
+    case Ecto.Changeset.apply_action(changeset, :insert) do
+      {:ok, %{invited_collaborators: collaborators}} -> {:ok, collaborators}
+      {:error, changeset} -> {:error, changeset}
     end
   end
 

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.ex
@@ -74,6 +74,20 @@ defmodule LightningWeb.ProjectLive.InviteCollaboratorComponent do
     end
   end
 
+  defp error_field(assigns) do
+    ~H"""
+    <.error :for={
+      msg <-
+        Enum.map(
+          @field.errors,
+          &LightningWeb.CoreComponents.translate_error(&1)
+        )
+    }>
+      <%= msg %>
+    </.error>
+    """
+  end
+
   defp validate_collaborators(schema, params) do
     changeset = InvitedCollaborators.changeset(schema, params)
 

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.ex
@@ -10,9 +10,17 @@ defmodule LightningWeb.ProjectLive.InviteCollaboratorComponent do
 
   @impl true
   def update(assigns, socket) do
+    collaborators_data =
+      Enum.map(assigns.collaborators, fn %{role: role, email: email} ->
+        %{role: role, email: email}
+      end)
+
     collaborators = %InvitedCollaborators{}
 
-    changeset = InvitedCollaborators.changeset(collaborators, %{})
+    changeset =
+      InvitedCollaborators.changeset(collaborators, %{
+        invited_collaborators: collaborators_data
+      })
 
     {:ok,
      socket
@@ -39,11 +47,11 @@ defmodule LightningWeb.ProjectLive.InviteCollaboratorComponent do
         InvitedCollaborators.changeset(socket.assigns.collaborators, params)
         |> Ecto.Changeset.apply_action(:insert)
 
-      Projects.invite_user(socket.assigns.project, collaborators)
+      Projects.invite_collaborators(socket.assigns.project, collaborators)
 
       {:noreply,
        socket
-       |> put_flash(:info, "Collaborators updated successfully!")
+       |> put_flash(:info, "Invites sent successfully")
        |> push_navigate(
          to: ~p"/projects/#{socket.assigns.project}/settings#collaboration"
        )}

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.ex
@@ -1,0 +1,90 @@
+defmodule LightningWeb.ProjectLive.InviteCollaboratorComponent do
+  @moduledoc false
+
+  use LightningWeb, :live_component
+
+  alias Lightning.Projects
+  alias Lightning.Projects.ProjectUsersLimiter
+  alias LightningWeb.ProjectLive.InvitedCollaborators
+  alias Phoenix.LiveView.JS
+
+  @impl true
+  def update(assigns, socket) do
+    collaborators = %InvitedCollaborators{}
+
+    changeset = InvitedCollaborators.changeset(collaborators, %{})
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(collaborators: collaborators, changeset: changeset, error: nil)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"project" => params}, socket) do
+    socket =
+      assign(socket,
+        changeset:
+          InvitedCollaborators.changeset(socket.assigns.collaborators, params)
+      )
+
+    with :ok <- limit_adding_users(socket, params) do
+      {:noreply, assign(socket, error: nil)}
+    end
+  end
+
+  def handle_event("add_collaborators", %{"project" => params}, socket) do
+    with :ok <- limit_adding_users(socket, params),
+         {:ok, project_users} <- prepare_for_insertion(socket, params),
+         {:ok, _project} <- add_project_users(socket, project_users) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Collaborators updated successfully!")
+       |> push_navigate(
+         to: ~p"/projects/#{socket.assigns.project}/settings#collaboration"
+       )}
+    end
+  end
+
+  defp prepare_for_insertion(%{assigns: assigns} = socket, params) do
+    case InvitedCollaborators.prepare_for_insertion(
+           assigns.collaborators,
+           params,
+           assigns.project_users
+         ) do
+      {:ok, project_users} ->
+        {:ok, project_users}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+
+  defp add_project_users(socket, project_users) do
+    case Projects.add_project_users(socket.assigns.project, project_users) do
+      {:ok, project} ->
+        {:ok, project}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+
+  defp limit_adding_users(socket, params) do
+    changeset =
+      InvitedCollaborators.changeset(socket.assigns.collaborators, params)
+
+    project_users = Ecto.Changeset.get_embed(changeset, :invited_collaborators)
+
+    case ProjectUsersLimiter.request_new(
+           socket.assigns.project.id,
+           Enum.count(project_users)
+         ) do
+      :ok ->
+        :ok
+
+      {:error, _reason, %{text: error_text}} ->
+        {:noreply, assign(socket, error: error_text)}
+    end
+  end
+end

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
@@ -2,17 +2,17 @@
   <.modal
     id={@id}
     show={true}
-    on_close={JS.push("toggle_collaborators_modal")}
+    on_close={JS.push("toggle_invite_collaborators_modal")}
     width="min-w-1/2 max-w-xl"
   >
     <:title>
       <div class="flex justify-between">
         <span class="font-bold">
-          Invite new collaborator(s)
+          Invite new user(s) to join OpenFn
         </span>
 
         <button
-          phx-click="toggle_collaborators_modal"
+          phx-click="toggle_invite_collaborators_modal"
           type="button"
           class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
           aria-label={gettext("close")}
@@ -24,7 +24,7 @@
     </:title>
     <:subtitle>
       <span class="text-xs">
-        Enter the email address and role of new collaborator(s) to invite them to this project
+        The following users don't have OpenFn accounts, you can invite them to join and grant access to this project
       </span>
     </:subtitle>
 
@@ -60,7 +60,7 @@
               <.input
                 type="text"
                 field={cf[:first_name]}
-                placeholder="Ayodele"
+                placeholder="First Name"
                 required="true"
               />
             </div>
@@ -68,17 +68,12 @@
               <.input
                 type="text"
                 field={cf[:last_name]}
-                placeholder="Adeyemo"
+                placeholder="Last Name"
                 required="true"
               />
             </div>
             <div class="min-w-1/5">
-              <.input
-                type="text"
-                field={cf[:email]}
-                placeholder="ayodele@openfn.org"
-                required="true"
-              />
+              <.input type="email" field={cf[:email]} required="true" />
             </div>
             <div class="min-w-1/4">
               <.input
@@ -113,19 +108,6 @@
             </div>
           </div>
         </.inputs_for>
-
-        <div class="mt-5">
-          <input type="hidden" name={"#{f.name}[collaborators_drop][]"} />
-          <button
-            type="button"
-            name={"#{f.name}[collaborators_sort][]"}
-            value="new"
-            phx-click={JS.dispatch("change")}
-            class="inline-flex items-center gap-x-2 rounded-md bg-white px-3.5 py-2.5 text-sm  text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-          >
-            <Heroicons.plus_circle class="w-5 h-5" /> Add Additonal Collaborator
-          </button>
-        </div>
       </div>
       <.modal_footer class="mx-6 mt-6">
         <div class="flex flex-row-reverse gap-4">
@@ -135,13 +117,14 @@
             phx-disable-with="Adding..."
             disabled={!@changeset.valid? || !is_nil(@error)}
           >
-            Invite Collaborator<%= if(Enum.count(f[:invited_collaborators].value) > 1,
+            Invite new user<%= if(
+              Enum.count(f[:invited_collaborators].value) > 1,
               do: "s"
             ) %>
           </.button>
           <button
             type="button"
-            phx-click="toggle_collaborators_modal"
+            phx-click="toggle_invite_collaborators_modal"
             class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
           >
             Cancel

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
@@ -55,13 +55,14 @@
           field={f[:invited_collaborators]}
           prepend={[%InvitedCollaborators.InvitedCollaborator{}]}
         >
-          <div class="flex space-x-4">
+          <div class="flex flex-wrap space-x-4">
             <div class="flex-1">
               <.input
                 type="text"
                 field={cf[:first_name]}
                 placeholder="First Name"
                 required="true"
+                class="w-full"
               />
             </div>
             <div class="flex-1">
@@ -70,12 +71,19 @@
                 field={cf[:last_name]}
                 placeholder="Last Name"
                 required="true"
+                class="w-full"
               />
             </div>
             <div class="flex-1">
-              <.input type="email" field={cf[:email]} required="true" />
+              <.input
+                type="email"
+                field={cf[:email]}
+                required="true"
+                class="w-full"
+                display_errors={false}
+              />
             </div>
-            <div class="flex-1">
+            <div>
               <.input
                 type="select"
                 prompt="Select Role"
@@ -87,6 +95,7 @@
                   )
                 }
                 required="true"
+                class="w-full"
               />
             </div>
             <div class="flex items-center">
@@ -107,6 +116,7 @@
               </button>
             </div>
           </div>
+          <.error_field field={cf[:email]} />
         </.inputs_for>
       </div>
       <.modal_footer class="mx-6 mt-6">

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
@@ -55,8 +55,8 @@
           field={f[:invited_collaborators]}
           prepend={[%InvitedCollaborators.InvitedCollaborator{}]}
         >
-          <div class="flex justify-between">
-            <div class="min-w-1/5">
+          <div class="flex space-x-4">
+            <div class="flex-1">
               <.input
                 type="text"
                 field={cf[:first_name]}
@@ -64,7 +64,7 @@
                 required="true"
               />
             </div>
-            <div class="min-w-1/5">
+            <div class="flex-1">
               <.input
                 type="text"
                 field={cf[:last_name]}
@@ -72,10 +72,10 @@
                 required="true"
               />
             </div>
-            <div class="min-w-1/5">
+            <div class="flex-1">
               <.input type="email" field={cf[:email]} required="true" />
             </div>
-            <div class="min-w-1/4">
+            <div class="flex-1">
               <.input
                 type="select"
                 prompt="Select Role"
@@ -89,7 +89,7 @@
                 required="true"
               />
             </div>
-            <div class="">
+            <div class="flex items-center">
               <input
                 type="hidden"
                 name={"#{f.name}[collaborators_sort][]"}

--- a/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/invite_collaborator_component.html.heex
@@ -1,0 +1,153 @@
+<div>
+  <.modal
+    id={@id}
+    show={true}
+    on_close={JS.push("toggle_collaborators_modal")}
+    width="min-w-1/2 max-w-xl"
+  >
+    <:title>
+      <div class="flex justify-between">
+        <span class="font-bold">
+          Invite new collaborator(s)
+        </span>
+
+        <button
+          phx-click="toggle_collaborators_modal"
+          type="button"
+          class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+          aria-label={gettext("close")}
+        >
+          <span class="sr-only">Close</span>
+          <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+        </button>
+      </div>
+    </:title>
+    <:subtitle>
+      <span class="text-xs">
+        Enter the email address and role of new collaborator(s) to invite them to this project
+      </span>
+    </:subtitle>
+
+    <.form
+      :let={f}
+      id={"#{@id}_form"}
+      as={:project}
+      for={@changeset}
+      phx-target={@myself}
+      phx-change="validate"
+      phx-submit="add_collaborators"
+    >
+      <div class="px-6 space-y-5">
+        <div :if={@error} class="bg-red-50 p-4">
+          <div class="flex">
+            <div class="flex-shrink-0">
+              <Heroicons.exclamation_triangle class="h-5 w-5 text-red-400" />
+            </div>
+            <div class="ml-3">
+              <p class="text-sm text-red-700">
+                <%= @error %>
+              </p>
+            </div>
+          </div>
+        </div>
+        <.inputs_for
+          :let={cf}
+          field={f[:invited_collaborators]}
+          prepend={[%InvitedCollaborators.InvitedCollaborator{}]}
+        >
+          <div class="flex justify-between">
+            <div class="min-w-1/5">
+              <.input
+                type="text"
+                field={cf[:first_name]}
+                placeholder="Ayodele"
+                required="true"
+              />
+            </div>
+            <div class="min-w-1/5">
+              <.input
+                type="text"
+                field={cf[:last_name]}
+                placeholder="Adeyemo"
+                required="true"
+              />
+            </div>
+            <div class="min-w-1/5">
+              <.input
+                type="text"
+                field={cf[:email]}
+                placeholder="ayodele@openfn.org"
+                required="true"
+              />
+            </div>
+            <div class="min-w-1/4">
+              <.input
+                type="select"
+                prompt="Select Role"
+                field={cf[:role]}
+                options={
+                  Enum.map(
+                    ["viewer", "editor", "admin"],
+                    &{String.capitalize(&1), &1}
+                  )
+                }
+                required="true"
+              />
+            </div>
+            <div class="">
+              <input
+                type="hidden"
+                name={"#{f.name}[collaborators_sort][]"}
+                value={cf.index}
+              />
+              <button
+                :if={Enum.count(f[:invited_collaborators].value) > 1}
+                type="button"
+                name={"#{f.name}[collaborators_drop][]"}
+                value={cf.index}
+                phx-click={JS.dispatch("change")}
+                class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+              >
+                <Heroicons.minus_circle class="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+        </.inputs_for>
+
+        <div class="mt-5">
+          <input type="hidden" name={"#{f.name}[collaborators_drop][]"} />
+          <button
+            type="button"
+            name={"#{f.name}[collaborators_sort][]"}
+            value="new"
+            phx-click={JS.dispatch("change")}
+            class="inline-flex items-center gap-x-2 rounded-md bg-white px-3.5 py-2.5 text-sm  text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          >
+            <Heroicons.plus_circle class="w-5 h-5" /> Add Additonal Collaborator
+          </button>
+        </div>
+      </div>
+      <.modal_footer class="mx-6 mt-6">
+        <div class="flex flex-row-reverse gap-4">
+          <.button
+            id="save_collaborators_button"
+            type="submit"
+            phx-disable-with="Adding..."
+            disabled={!@changeset.valid? || !is_nil(@error)}
+          >
+            Invite Collaborator<%= if(Enum.count(f[:invited_collaborators].value) > 1,
+              do: "s"
+            ) %>
+          </.button>
+          <button
+            type="button"
+            phx-click="toggle_collaborators_modal"
+            class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </.modal_footer>
+    </.form>
+  </.modal>
+</div>

--- a/lib/lightning_web/live/project_live/invited_collaborators.ex
+++ b/lib/lightning_web/live/project_live/invited_collaborators.ex
@@ -1,0 +1,47 @@
+defmodule LightningWeb.ProjectLive.InvitedCollaborators do
+  @moduledoc """
+  This schema is used for building the changeset for adding new collaborators to a project.
+  It is mirroring the `Project -> ProjectUser` relationship.
+  """
+
+  use Lightning.Schema
+
+  embedded_schema do
+    embeds_many :invited_collaborators, InvitedCollaborator, on_replace: :delete do
+      field :first_name, :string
+      field :last_name, :string
+      field :email, :string
+      field :user_id, :binary_id
+      field :role, Ecto.Enum, values: [:viewer, :editor, :admin]
+    end
+  end
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [])
+    |> cast_embed(:invited_collaborators,
+      with: &collaborators_changeset/2,
+      required: true,
+      drop_param: :collaborators_drop,
+      sort_param: :collaborators_sort
+    )
+  end
+
+  defp collaborators_changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:first_name, :last_name, :email, :role])
+    |> validate_required([:first_name, :last_name, :email, :role])
+    |> validate_format(:email, ~r/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/)
+  end
+
+  @spec prepare_for_insertion(%__MODULE__{}, map(), [map(), ...]) ::
+          {:ok, [map(), ...]} | {:error, Ecto.Changeset.t()}
+  def prepare_for_insertion(schema, attrs, _current_project_users) do
+    changeset = changeset(schema, attrs)
+
+    with {:ok, %{collaborators: collaborators}} <-
+           apply_action(changeset, :insert) do
+      {:ok, collaborators}
+    end
+  end
+end

--- a/lib/lightning_web/live/project_live/invited_collaborators.ex
+++ b/lib/lightning_web/live/project_live/invited_collaborators.ex
@@ -33,4 +33,57 @@ defmodule LightningWeb.ProjectLive.InvitedCollaborators do
     |> validate_required([:first_name, :last_name, :email, :role])
     |> validate_format(:email, ~r/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/)
   end
+
+  def validate_collaborators(schema, params) do
+    changeset = changeset(schema, params)
+
+    changeset =
+      if changeset.valid? do
+        validate_collaborator_emails(changeset)
+      else
+        changeset
+      end
+
+    apply_changeset_action(changeset)
+  end
+
+  defp validate_collaborator_emails(changeset) do
+    collaborators = Ecto.Changeset.get_embed(changeset, :invited_collaborators)
+    existing_emails = fetch_existing_emails(collaborators)
+
+    updated_collaborators =
+      Enum.map(collaborators, fn collaborator ->
+        validate_collaborator_email(collaborator, existing_emails)
+      end)
+
+    Ecto.Changeset.put_embed(
+      changeset,
+      :invited_collaborators,
+      updated_collaborators
+    )
+  end
+
+  defp fetch_existing_emails(collaborators) do
+    collaborators
+    |> Enum.map(&Ecto.Changeset.get_field(&1, :email))
+    |> Lightning.Accounts.list_users_by_emails()
+    |> Enum.map(& &1.email)
+  end
+
+  defp validate_collaborator_email(collaborator, existing_emails) do
+    Ecto.Changeset.validate_change(collaborator, :email, fn :email, email ->
+      if email in existing_emails do
+        [email: "This email is already taken"]
+      else
+        []
+      end
+    end)
+  end
+
+  defp apply_changeset_action(changeset) do
+    case Ecto.Changeset.apply_action(changeset, :insert) do
+      {:ok, %{invited_collaborators: collaborators}} -> {:ok, collaborators}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
 end

--- a/lib/lightning_web/live/project_live/invited_collaborators.ex
+++ b/lib/lightning_web/live/project_live/invited_collaborators.ex
@@ -33,15 +33,4 @@ defmodule LightningWeb.ProjectLive.InvitedCollaborators do
     |> validate_required([:first_name, :last_name, :email, :role])
     |> validate_format(:email, ~r/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/)
   end
-
-  @spec prepare_for_insertion(%__MODULE__{}, map(), [map(), ...]) ::
-          {:ok, [map(), ...]} | {:error, Ecto.Changeset.t()}
-  def prepare_for_insertion(schema, attrs, _current_project_users) do
-    changeset = changeset(schema, attrs)
-
-    with {:ok, %{collaborators: collaborators}} <-
-           apply_action(changeset, :insert) do
-      {:ok, collaborators}
-    end
-  end
 end

--- a/lib/lightning_web/live/project_live/invited_collaborators.ex
+++ b/lib/lightning_web/live/project_live/invited_collaborators.ex
@@ -67,12 +67,12 @@ defmodule LightningWeb.ProjectLive.InvitedCollaborators do
     collaborators
     |> Enum.map(&Ecto.Changeset.get_field(&1, :email))
     |> Lightning.Accounts.list_users_by_emails()
-    |> Enum.map(& &1.email)
+    |> Enum.map(fn user -> String.downcase(user.email) end)
   end
 
   defp validate_collaborator_email(collaborator, existing_emails) do
     Ecto.Changeset.validate_change(collaborator, :email, fn :email, email ->
-      if email in existing_emails do
+      if String.downcase(email) in existing_emails do
         [email: "This email is already taken"]
       else
         []

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -34,19 +34,11 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
 
   def handle_event("add_collaborators", %{"project" => params}, socket) do
     with :ok <- limit_adding_users(socket, params),
-         {:ok, %{collaborators: project_users, to_invite: users_to_invite}} <-
-           prepare_for_insertion(socket, params),
+         {:ok, project_users} <- prepare_for_insertion(socket, params),
          {:ok, _project} <- add_project_users(socket, project_users) do
-      n_project_users = length(project_users)
-      n_to_invite = length(users_to_invite)
-      total = n_project_users + n_to_invite
-
-      message =
-        "#{n_project_users} out of #{total} collaborators have OpenFn accounts and have been added to your project. You can invite others to join OpenFn and grant them access to this project."
-
       {:noreply,
        socket
-       |> put_flash(:info, message)
+       |> put_flash(:info, "Collaborators updated successfully!")
        |> push_navigate(
          to: ~p"/projects/#{socket.assigns.project}/settings#collaboration"
        )}
@@ -59,8 +51,8 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
            params,
            assigns.project_users
          ) do
-      {:ok, %{collaborators: project_users, to_invite: non_project_users}} ->
-        {:ok, %{collaborators: project_users, to_invite: non_project_users}}
+      {:ok, project_users} ->
+        {:ok, project_users}
 
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -73,6 +73,20 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
     end
   end
 
+  defp error_field(assigns) do
+    ~H"""
+    <.error :for={
+      msg <-
+        Enum.map(
+          @field.errors,
+          &LightningWeb.CoreComponents.translate_error(&1)
+        )
+    }>
+      <%= msg %>
+    </.error>
+    """
+  end
+
   defp prepare_for_insertion(%{assigns: assigns} = socket, params) do
     case Collaborators.prepare_for_insertion(
            assigns.collaborators,

--- a/lib/lightning_web/live/project_live/new_collaborator_component.ex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.ex
@@ -34,14 +34,42 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
 
   def handle_event("add_collaborators", %{"project" => params}, socket) do
     with :ok <- limit_adding_users(socket, params),
-         {:ok, project_users} <- prepare_for_insertion(socket, params),
+         {:ok, project_users, new_project_users} <-
+           prepare_for_insertion(socket, params),
          {:ok, _project} <- add_project_users(socket, project_users) do
-      {:noreply,
-       socket
-       |> put_flash(:info, "Collaborators updated successfully!")
-       |> push_navigate(
-         to: ~p"/projects/#{socket.assigns.project}/settings#collaboration"
-       )}
+      flash_message = generate_flash_message(project_users, new_project_users)
+
+      return_to = ~p"/projects/#{socket.assigns.project}/settings#collaboration"
+
+      socket = put_flash(socket, :info, flash_message)
+
+      socket =
+        if length(new_project_users) > 0 do
+          send(self(), {:show_invite_collaborators_modal, new_project_users})
+          push_patch(socket, to: return_to)
+        else
+          push_navigate(socket, to: return_to)
+        end
+
+      {:noreply, socket}
+    end
+  end
+
+  defp generate_flash_message(existing, new) do
+    case {length(existing), length(new)} do
+      {_, 0} ->
+        "Collaborator#{if length(existing) == 1, do: "", else: "s"} added successfully"
+
+      {0, 1} ->
+        "This collaborator does not have an OpenFn account. Invite them to join OpenFn and grant access to the project."
+
+      {0, _} ->
+        "These collaborators do not have OpenFn accounts. Invite them to join OpenFn and grant them access to the project."
+
+      {existing_count, new_count} ->
+        total = existing_count + new_count
+
+        "#{existing_count} out of #{total} collaborator#{if total == 1, do: "", else: "s"} have OpenFn accounts and have been added to your project. You can invite others to join OpenFn and grant them access to this project."
     end
   end
 
@@ -52,15 +80,28 @@ defmodule LightningWeb.ProjectLive.NewCollaboratorComponent do
            assigns.project_users
          ) do
       {:ok, project_users} ->
-        {:ok, project_users}
+        {project_users, new_project_users} =
+          Enum.split_with(project_users, fn pu ->
+            Map.get(pu, :user_id) != nil
+          end)
+
+        {:ok, project_users, new_project_users}
 
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
     end
   end
 
-  defp add_project_users(socket, project_users) do
-    case Projects.add_project_users(socket.assigns.project, project_users) do
+  defp add_project_users(socket, collaborators) do
+    project_users =
+      Enum.map(collaborators, fn c ->
+        Map.take(c, [:user_id, :role])
+      end)
+
+    case Projects.add_project_users(
+           socket.assigns.project,
+           project_users
+         ) do
       {:ok, project} ->
         {:ok, project}
 

--- a/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
+++ b/lib/lightning_web/live/project_live/new_collaborator_component.html.heex
@@ -3,7 +3,7 @@
     id={@id}
     show={true}
     on_close={JS.push("toggle_collaborators_modal")}
-    width="min-w-1/2 max-w-xl"
+    width="min-w-1/3 max-w-xl"
   >
     <:title>
       <div class="flex justify-between">
@@ -55,16 +55,18 @@
           field={f[:collaborators]}
           prepend={[%Collaborators.Collaborator{}]}
         >
-          <div class="flex justify-between">
-            <div class="min-w-1/2">
+          <div class="flex items-center space-x-4">
+            <div class="flex-1">
               <.input
                 type="text"
                 field={cf[:email]}
                 placeholder="email@example.com"
                 required="true"
+                class="w-full"
+                display_errors={false}
               />
             </div>
-            <div class="min-w-1/4">
+            <div>
               <.input
                 type="select"
                 prompt="Select Role"
@@ -76,9 +78,10 @@
                   )
                 }
                 required="true"
+                class="w-full"
               />
             </div>
-            <div class="">
+            <div>
               <input
                 type="hidden"
                 name={"#{f.name}[collaborators_sort][]"}
@@ -96,18 +99,19 @@
               </button>
             </div>
           </div>
+          <.error_field field={cf[:email]} />
         </.inputs_for>
 
-        <div class="mt-5">
+        <div class="mt-5 flex justify-start">
           <input type="hidden" name={"#{f.name}[collaborators_drop][]"} />
           <button
             type="button"
             name={"#{f.name}[collaborators_sort][]"}
             value="new"
             phx-click={JS.dispatch("change")}
-            class="inline-flex items-center gap-x-2 rounded-md bg-white px-3.5 py-2.5 text-sm  text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+            class="inline-flex items-center gap-x-2 rounded-md bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
           >
-            <Heroicons.plus_circle class="w-5 h-5" /> Add Additonal Collaborator
+            <Heroicons.plus_circle class="w-5 h-5" /> Add Additional Collaborator
           </button>
         </div>
       </div>

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -144,6 +144,8 @@ defmodule LightningWeb.ProjectLive.Settings do
        can_receive_failure_alerts: can_receive_failure_alerts,
        selected_credential_type: nil,
        show_collaborators_modal: false,
+       show_invite_collaborators_modal: false,
+       collaborators_to_invite: [],
        projects: projects
      )}
   end
@@ -208,7 +210,8 @@ defmodule LightningWeb.ProjectLive.Settings do
     |> assign(
       page_title: "Project settings",
       project_users: project_users,
-      show_collaborators_modal: false
+      show_collaborators_modal: false,
+      show_invite_collaborators_modal: false
     )
   end
 
@@ -304,6 +307,15 @@ defmodule LightningWeb.ProjectLive.Settings do
      |> assign(
        :show_collaborators_modal,
        !socket.assigns.show_collaborators_modal
+     )}
+  end
+
+  def handle_event("toggle_invite_collaborators_modal", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       :show_invite_collaborators_modal,
+       !socket.assigns.show_invite_collaborators_modal
      )}
   end
 
@@ -443,6 +455,16 @@ defmodule LightningWeb.ProjectLive.Settings do
        :error,
        "Oops! Github account failed to link. Please try again"
      )}
+  end
+
+  def handle_info({:show_invite_collaborators_modal, new_project_users}, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       :show_invite_collaborators_modal,
+       true
+     )
+     |> assign(:collaborators_to_invite, new_project_users)}
   end
 
   # catch all callback. Needed for tests because of Swoosh emails in tests

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -581,10 +581,18 @@
               </.button>
               <.live_component
                 :if={@can_add_project_user && @show_collaborators_modal}
-                module={LightningWeb.ProjectLive.InviteCollaboratorComponent}
+                module={LightningWeb.ProjectLive.NewCollaboratorComponent}
                 id="add_collaborators_modal"
                 project={@project}
                 project_users={@project_users}
+              />
+              <.live_component
+                :if={@can_add_project_user && @show_invite_collaborators_modal}
+                module={LightningWeb.ProjectLive.InviteCollaboratorComponent}
+                id="invite_collaborators_modal"
+                project={@project}
+                project_users={@project_users}
+                collaborators={@collaborators_to_invite}
               />
             </div>
           </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -593,6 +593,7 @@
                 project={@project}
                 project_users={@project_users}
                 collaborators={@collaborators_to_invite}
+                current_user={@current_user}
               />
             </div>
           </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -581,7 +581,7 @@
               </.button>
               <.live_component
                 :if={@can_add_project_user && @show_collaborators_modal}
-                module={LightningWeb.ProjectLive.NewCollaboratorComponent}
+                module={LightningWeb.ProjectLive.InviteCollaboratorComponent}
                 id="add_collaborators_modal"
                 project={@project}
                 project_users={@project_users}

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2046,7 +2046,7 @@ defmodule LightningWeb.ProjectLiveTest do
     test "adding a non existent user triggers the invite users process", %{
       conn: conn
     } do
-      project = insert(:project)
+      project = insert(:project, name: "my-project")
 
       {conn, _user} = setup_project_user(conn, project, :owner)
 
@@ -2099,21 +2099,21 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert html =~ "Invite sent successfully"
 
-      assert_email_sent(
-        to: [{"", email}],
-        subject: "You now have access to \"#{project.name}\""
+      refute_email_sent(
+        to: [{"", "nonexists@localtests.com"}],
+        subject: "You now have access to \"my-project\""
       )
 
       assert_email_sent(
-        to: [{"", email}],
-        subject: "Join #{project.name} on OpenFn as a collaborator"
+        to: [{"", "nonexists@localtests.com"}],
+        subject: "Join my-project on OpenFn as a collaborator"
       )
     end
 
     test "inviting an aleady existing user renders an error", %{
       conn: conn
     } do
-      project = insert(:project)
+      project = insert(:project, name: "my-project")
 
       {conn, user} = setup_project_user(conn, project, :owner)
 
@@ -2159,17 +2159,15 @@ defmodule LightningWeb.ProjectLiveTest do
              )
              |> render_submit() =~ "This email is already taken"
 
-      %Swoosh.Email{
-        to: [{"", email}],
-        subject: "You now have access to \"#{project.name}\""
-      }
-      |> assert_email_not_sent()
+      refute_email_sent(
+        to: [{"", "nonexists@localtests.com"}],
+        subject: "You now have access to \"my-project\""
+      )
 
-      %Swoosh.Email{
-        to: [{"", email}],
-        subject: "Join #{project.name} on OpenFn as a collaborator"
-      }
-      |> assert_email_not_sent()
+      refute_email_sent(
+        to: [{"", "nonexists@localtests.com"}],
+        subject: "Join my-project on OpenFn as a collaborator"
+      )
     end
 
     test "adding an existing project user displays an appropriate error message",

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2043,41 +2043,71 @@ defmodule LightningWeb.ProjectLiveTest do
       end
     end
 
-    test "adding a non existent user displays an appropriate error message", %{
+    test "adding a non existent user triggers the invite users process", %{
       conn: conn
     } do
       project = insert(:project)
 
-      for {conn, _user} <- setup_project_users(conn, project, [:owner, :admin]) do
-        {:ok, view, _html} =
-          live(
-            conn,
-            ~p"/projects/#{project.id}/settings#collaboration"
-          )
+      {conn, _user} = setup_project_user(conn, project, :owner)
 
-        # Open Modal
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#collaboration"
+        )
+
+      # Open Modal
+      view
+      |> element("#show_collaborators_modal_button")
+      |> render_click()
+
+      email = "nonexists@localtests.com"
+
+      refute view |> has_element?("#invite_collaborators_modal_form")
+
+      view
+      |> form("#add_collaborators_modal_form",
+        project: %{
+          "collaborators" => %{
+            "0" => %{"email" => email, "role" => "editor"}
+          }
+        }
+      )
+      |> render_submit()
+
+      assert view |> has_element?("#invite_collaborators_modal_form")
+
+      {:ok, _view, html} =
         view
-        |> element("#show_collaborators_modal_button")
-        |> render_click()
-
-        modal = element(view, "#add_collaborators_modal")
-
-        refute render(modal) =~ "There is no account connected this email"
-        email = "nonexists@localtests.com"
-        refute Lightning.Accounts.get_user_by_email(email)
-
-        # lets submit the form
-
-        view
-        |> form("#add_collaborators_modal_form",
+        |> form("#invite_collaborators_modal_form",
           project: %{
-            "collaborators" => %{"0" => %{"email" => email, "role" => "editor"}}
+            "invited_collaborators" => %{
+              "0" => %{
+                "email" => email,
+                "role" => "editor",
+                "first_name" => "Non",
+                "last_name" => "Exists"
+              }
+            }
           }
         )
         |> render_submit()
+        |> follow_redirect(
+          conn,
+          ~p"/projects/#{project.id}/settings#collaboration"
+        )
 
-        assert render(modal) =~ "There is no account connected this email"
-      end
+      assert html =~ "Invite sent successfully"
+
+      assert_email_sent(
+        to: [{"", email}],
+        subject: "You now have access to \"#{project.name}\""
+      )
+
+      assert_email_sent(
+        to: [{"", email}],
+        subject: "Join #{project.name} on OpenFn as a collaborator"
+      )
     end
 
     test "adding an existing project user displays an appropriate error message",
@@ -2204,7 +2234,7 @@ defmodule LightningWeb.ProjectLiveTest do
             ~p"/projects/#{project}/settings#collaboration"
           )
 
-        assert flash["info"] =~ "Collaborators added successfully!"
+        assert flash["info"] =~ "Collaborators added successfully"
       end
     end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2204,7 +2204,7 @@ defmodule LightningWeb.ProjectLiveTest do
             ~p"/projects/#{project}/settings#collaboration"
           )
 
-        assert flash["info"] =~ "Collaborators updated successfully!"
+        assert flash["info"] =~ "Collaborators added successfully!"
       end
     end
 


### PR DESCRIPTION
## Description

This PR introduces the functionality to invite non-existing users to join a project in OpenFn. When adding a project collaborator, you now enter their email. If the user isn't found in the database, an invitation form appears, allowing you to enter the user's name and send an invitation email. During this process, we attempt to register the user. If successful, they are added to the project, and two emails are sent: one for OpenFn registration and one for project addition. If any errors occur, the process is rolled back, and a clear error message is displayed.

## Validation Steps

1. Invite an existing user to a project and verify they receive the invitation.
2. Invite a non-registered user, ensure they receive both emails, and can join OpenFn and the project seamlessly.
3. Check that the new user appears in the collaborator list.
4. Test the rollback mechanism for any errors during the invitation process.

## Related issue

Fixes #1835 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
