### PR TITLE
Pass Errors Occurring During Credential Refresh To The Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
 
 ### Fixed
 
+- Prevent Oauth credentials from being created if they don't have a
+  `refresh_token` [#2289](https://github.com/OpenFn/lightning/pull/2289) and
+  send more helpful error data back to the worker during token refresh failure
+  [#2135](https://github.com/OpenFn/lightning/issues/2135)
+
 ## [v2.7.6] - 2024-07-11
 
 ### Fixed
@@ -28,7 +33,7 @@ and this project adheres to
 - UsageTracking crons are enabled again (if config is enabled)
   [#2276](https://github.com/OpenFn/lightning/issues/2276)
 - UsageTracking metrics absorb the fact that a step's job_id may not currently
-  exist when counting unique jobs.
+  exist when counting unique jobs
   [#2279](https://github.com/OpenFn/lightning/issues/2279)
 - Adjusted layout and text displayed when preventing simultaneous edits to
   accommodate more screen sizes

--- a/lib/lightning/auth_providers/oauth_http_client.ex
+++ b/lib/lightning/auth_providers/oauth_http_client.ex
@@ -33,7 +33,7 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     |> post(client.token_endpoint, body)
     |> handle_resp([200])
     |> maybe_introspect(client)
-    |> validate_token()
+    |> maybe_validate_token()
   end
 
   @doc """
@@ -152,12 +152,16 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     end
   end
 
-  defp validate_token({:ok, token}) do
+  defp maybe_validate_token({:ok, token} = _response) do
     if Map.get(token, "refresh_token") do
       {:ok, token}
     else
       {:error, :no_refresh_token}
     end
+  end
+
+  defp maybe_validate_token(response) do
+    response
   end
 
   defp maybe_introspect({:error, reason}, _client) do

--- a/lib/lightning/auth_providers/oauth_http_client.ex
+++ b/lib/lightning/auth_providers/oauth_http_client.ex
@@ -33,6 +33,7 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     |> post(client.token_endpoint, body)
     |> handle_resp([200])
     |> maybe_introspect(client)
+    |> validate_token()
   end
 
   @doc """
@@ -148,6 +149,14 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
       time_remaining >= threshold
     else
       expiration_time
+    end
+  end
+
+  defp validate_token({:ok, token}) do
+    if Map.get(token, "refresh_token") do
+      {:ok, token}
+    else
+      {:error, :no_refresh_token}
     end
   end
 

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -554,7 +554,7 @@ defmodule Lightning.Credentials do
   def maybe_refresh_token(%Credential{schema: "oauth"} = credential) do
     cond do
       # TODO: Even tho the still_fresh/1 function is in the OauthHTTPClient module, it doesn't do any HTTP call.
-      #       It will be moved in another module after we deprecate salesforce and googlesheets oauth
+      # It will be moved in another module after we deprecate salesforce and googlesheets oauth
       OauthHTTPClient.still_fresh(credential.body) ->
         {:ok, credential}
 

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -102,10 +102,6 @@ defmodule LightningWeb.RunChannel do
       :not_found ->
         {:reply, {:error, %{errors: %{id: ["Credential not found!"]}}}, socket}
 
-      # TODO - would it be OK to send the actual error back to the logger?
-      # https://github.com/OpenFn/lightning/issues/1842#issuecomment-2109682877
-      # @openfn/ws-worker@1.1.9-pre will now handle this!
-      # {:error, %{body: %{"error" => "invalid_grant", "error_description" => "expired access/refresh token"}}
       {:error,
        %{
          body: %{
@@ -113,7 +109,6 @@ defmodule LightningWeb.RunChannel do
            "error_description" => error_description
          }
        }} ->
-        # TODO - how can we ensure this is safe to send back?
         {:reply,
          {
            :error,

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -102,6 +102,24 @@ defmodule LightningWeb.RunChannel do
       :not_found ->
         {:reply, {:error, %{errors: %{id: ["Credential not found!"]}}}, socket}
 
+      # TODO - would it be OK to send the actual error back to the logger?
+      # https://github.com/OpenFn/lightning/issues/1842#issuecomment-2109682877
+      # @openfn/ws-worker@1.1.9-pre will now handle this!
+      # {:error, %{body: %{"error" => "invalid_grant", "error_description" => "expired access/refresh token"}}
+      {:error,
+       %{
+         body: %{
+           "error" => error,
+           "error_description" => error_description
+         }
+       }} ->
+        # TODO - how can we ensure this is safe to send back?
+        {:reply,
+         {
+           :error,
+           %{errors: %{id: ["#{inspect(error)}: #{inspect(error_description)}"]}}
+         }, socket}
+
       {:error, error} ->
         Logger.error(fn ->
           """

--- a/lib/lightning_web/live/components/oauth.ex
+++ b/lib/lightning_web/live/components/oauth.ex
@@ -202,21 +202,20 @@ defmodule LightningWeb.Components.Oauth do
           <Heroicons.exclamation_triangle class="h-5 w-5 text-yellow-400" />
         </div>
         <div class="ml-3">
-          <h3 class="text-sm font-medium text-yellow-800">Something went wrong.</h3>
+          <h3 class="text-sm font-medium text-yellow-800">Missing refresh token</h3>
           <div class="mt-2 text-sm text-yellow-700">
             <p class="text-sm mt-2">
-              The token is missing it's
-              <code class="bg-gray-200 rounded-md p-1">refresh_token</code>
-              value. Please reauthorize <.link
+              We didn't receive a refresh token from this provider. Sometimes this happens if you have already granted access to OpenFn via another credential. If you have another credential, please use that one. If you don't, please revoke OpenFn's access to your provider via the "third party apps" section of their website. Once that is done, you can try to reauthorize
+              <.link
                 href={@authorize_url}
                 target="_blank"
                 phx-target={@myself}
                 phx-click="authorize_click"
                 class="hover:underline text-primary-900"
               >
-            here
-            <Heroicons.arrow_top_right_on_square class="h-4 w-4 text-indigo-600 inline-block" />.
-          </.link>.
+                here
+                <Heroicons.arrow_top_right_on_square class="h-4 w-4 text-indigo-600 inline-block" />.
+              </.link>
             </p>
           </div>
         </div>

--- a/test/lightning/oauth_http_client_test.exs
+++ b/test/lightning/oauth_http_client_test.exs
@@ -14,7 +14,12 @@ defmodule Lightning.AuthProviders.OauthHTTPClientTest do
       }
 
       code = "authcode123"
-      response_body = %{"access_token" => "token123", "token_type" => "bearer"}
+
+      response_body = %{
+        "access_token" => "token123",
+        "token_type" => "bearer",
+        "refresh_token" => "refresh_token123"
+      }
 
       expect(Lightning.AuthProviders.OauthHTTPClient.Mock, :call, fn
         env, _opts


### PR DESCRIPTION
- This Oauth2 PR prevents credentials (linked to new Oauth2 Clients) from being created if they don't have `refresh_token`.
- This can happen if a user tries to create multiple credentials for the same `{oauth_client, third_party_account}` combination.
- It now blocks the new credential, asks the user to use the old one if they still have it, and recommends that they "revoke Oauth access for OpenFn then click reauthorize" if they no longer have access to their old credential.
- It also sends better oauth credential error data back to the worker, as expected in the `ws-worker@1.1.9` release

## Related issue

Fixes #2135 
Fixes #2285

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [x] Product has **QA'd** this feature
