### PR TITLE
Added workflow concurrency queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 ### Added
 
+- Workflows can now specify concurrency, allowing runs to be executed
+  syncronously or to a maximum concurrency level. Note that this applies to the
+  default FifoRunQueue only.
+  [#2022](https://github.com/OpenFn/lightning/issues/2022)
+
 ### Changed
 
 - Make modal close events configurable

--- a/lib/lightning/extensions/fifo_run_queue.ex
+++ b/lib/lightning/extensions/fifo_run_queue.ex
@@ -9,8 +9,8 @@ defmodule Lightning.Extensions.FifoRunQueue do
 
   alias Ecto.Multi
   alias Lightning.Repo
-  alias Lightning.Runs.Queue
   alias Lightning.Runs.Query
+  alias Lightning.Runs.Queue
 
   @impl true
   def enqueue(%Multi{} = multi), do: Repo.transaction(multi)

--- a/lib/lightning/extensions/fifo_run_queue.ex
+++ b/lib/lightning/extensions/fifo_run_queue.ex
@@ -10,6 +10,7 @@ defmodule Lightning.Extensions.FifoRunQueue do
   alias Ecto.Multi
   alias Lightning.Repo
   alias Lightning.Runs.Queue
+  alias Lightning.Runs.Query
 
   @impl true
   def enqueue(%Multi{} = multi), do: Repo.transaction(multi)
@@ -17,8 +18,8 @@ defmodule Lightning.Extensions.FifoRunQueue do
   @impl true
   def claim(demand) do
     fifo_runs_query =
-      Lightning.Run
-      |> order_by([:priority, :inserted_at])
+      Query.eligible_for_claim()
+      |> prepend_order_by([:priority])
 
     Queue.claim(demand, fifo_runs_query)
   end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -79,7 +79,7 @@ defmodule Lightning.Runs.Query do
         # does the subsequent query's limit clause get applied to the row_number
         # calculated here?
         row_number: row_number() |> over(:row_number),
-        project_name: p.name,
+        project_id: p.id,
         concurrency: w.concurrency
       }
     )

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -105,7 +105,8 @@ defmodule Lightning.Runs.Query do
     Run
     |> with_cte("in_progress_window", as: ^in_progress_window())
     |> join(:inner, [r], w in fragment(~s("in_progress_window")),
-      on: r.id == w.id
+      on: r.id == w.id,
+      as: :in_progress_window
     )
     |> where(
       [r, w],

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -110,7 +110,7 @@ defmodule Lightning.Runs.Query do
     )
     |> where(
       [r, w],
-      (w.row_number <= w.concurrency or is_nil(w.concurrency)) and
+      (is_nil(w.concurrency) or w.row_number <= w.concurrency) and
         r.state == :available
     )
     |> order_by([r, w], asc: r.inserted_at, asc: w.row_number)

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -112,6 +112,6 @@ defmodule Lightning.Runs.Query do
       (w.row_number <= w.concurrency or is_nil(w.concurrency)) and
         r.state == :available
     )
-    |> order_by([r, w], asc: w.row_number, asc: r.inserted_at)
+    |> order_by([r, w], asc: r.inserted_at, asc: w.row_number)
   end
 end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -11,7 +11,9 @@ defmodule Lightning.Runs.Query do
   @doc """
   Return all runs that have been claimed by a worker before the earliest
   acceptable start time (determined by the run options and grace period) but are
-  still incomplete. This indicates that we may have lost contact with the worker
+  still incomplete.
+
+  This indicates that we may have lost contact with the worker
   that was responsible for executing the run.
   """
   @spec lost :: Ecto.Queryable.t()
@@ -44,5 +46,72 @@ defmodule Lightning.Runs.Query do
           ^now
         ) or (is_nil(r.options) and r.claimed_at < ^fallback_oldest_claim)
     )
+  end
+
+  @doc """
+  Query to return a list of runs that are either in progress (started or claimed)
+  or available.
+
+  The select clause includes:
+  - `id`, the id of the run
+  - `state`, the state of the run
+  - `row_number`, the number of the row in the window, per workflow
+  - `limit`, the maximum number of runs that can be claimed for the workflow
+  """
+  @spec in_progress_window() :: Ecto.Queryable.t()
+  def in_progress_window do
+    from(r in Run,
+      where: r.state in [:available, :claimed, :started],
+      join: wo in assoc(r, :work_order),
+      join: w in assoc(wo, :workflow),
+      join: p in assoc(w, :project),
+      windows: [
+        row_number: [
+          partition_by: w.id,
+          order_by: [asc: r.inserted_at]
+        ]
+      ],
+      order_by: [asc: r.inserted_at],
+      select: %{
+        id: r.id,
+        state: r.state,
+        # need to check what performance implications are of using row_number
+        # does the subsequent query's limit clause get applied to the row_number
+        # calculated here?
+        row_number: row_number() |> over(:row_number),
+        project_name: p.name,
+        concurrency: w.concurrency
+      }
+    )
+  end
+
+  @doc """
+  Query to return runs that are eligible for claiming.
+
+  Uses `in_progress_window/0` and filters for runs that are either in the
+  available state and have not reached the concurrency limit for their workflow.
+
+  > ### Note {: .info}
+  > This query does not currently take into account the priority of the run.
+  > To allow for prioritization, the query should be updated to order by
+  > priority.
+  >
+  > ```elixir
+  > eligible_for_claim() |> prepend_order_by([:priority])
+  > ```
+  """
+  @spec eligible_for_claim() :: Ecto.Queryable.t()
+  def eligible_for_claim do
+    Run
+    |> with_cte("in_progress_window", as: ^in_progress_window())
+    |> join(:inner, [r], w in fragment(~s("in_progress_window")),
+      on: r.id == w.id
+    )
+    |> where(
+      [r, w],
+      (w.row_number <= w.concurrency or is_nil(w.concurrency)) and
+        r.state == :available
+    )
+    |> order_by([r, w], asc: w.row_number, asc: r.inserted_at)
   end
 end

--- a/lib/lightning/workflows/workflow.ex
+++ b/lib/lightning/workflows/workflow.ex
@@ -25,6 +25,7 @@ defmodule Lightning.Workflows.Workflow do
 
   schema "workflows" do
     field :name, :string
+    field :concurrency, :integer, default: nil
 
     has_many :edges, Edge, on_replace: :delete_if_exists
 

--- a/lib/lightning/workflows/workflow.ex
+++ b/lib/lightning/workflows/workflow.ex
@@ -49,7 +49,7 @@ defmodule Lightning.Workflows.Workflow do
   @doc false
   def changeset(workflow, attrs) do
     workflow
-    |> cast(attrs, [:name, :project_id])
+    |> cast(attrs, [:name, :project_id, :concurrency])
     |> optimistic_lock(:lock_version)
     |> cast_assoc(:edges, with: &Edge.changeset/2)
     |> cast_assoc(:jobs, with: &Job.changeset/2)
@@ -60,6 +60,7 @@ defmodule Lightning.Workflows.Workflow do
   def validate(changeset) do
     changeset
     |> assoc_constraint(:project)
+    |> validate_number(:concurrency, greater_than_or_equal_to: 1)
     |> validate_required([:name])
     |> unique_constraint([:name, :project_id],
       message: "a workflow with this name already exists in this project."

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -300,7 +300,8 @@ defmodule LightningWeb.Components.NewInputs do
           {@rest}
         />
         <div class="absolute inset-y-0 right-0 flex items-center pr-3">
-          <Heroicons.eye_slash
+          <.icon
+            name="hero-eye-slash"
             class="h-5 w-5 cursor-pointer"
             id={"show_password_#{@id}"}
             phx-hook="TogglePassword"
@@ -310,7 +311,8 @@ defmodule LightningWeb.Components.NewInputs do
               |> JS.toggle(to: "#show_password_#{@id}")
             }
           />
-          <Heroicons.eye
+          <.icon
+            name="hero-eye"
             class="h-5 w-5 cursor-pointer hidden"
             phx-hook="TogglePassword"
             data-target={@id}
@@ -359,31 +361,60 @@ defmodule LightningWeb.Components.NewInputs do
     ~H"""
     <div phx-feedback-for={@name}>
       <.label :if={@label} for={@id} class="mb-2">
-        <%= @label %><span
-          :if={Map.get(@rest, :required, false)}
-          class="text-red-500"
-        > *</span>
+        <%= @label %>
+        <span :if={Map.get(@rest, :required, false)} class="text-red-500"> *</span>
       </.label>
-      <input
+      <.input_element
         type={@type}
         name={@name}
         id={@id}
+        class={@class}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-        class={[
-          "focus:outline focus:outline-2 focus:outline-offset-1 block w-full rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
-          "phx-no-feedback:border-slate-300 phx-no-feedback:focus:border-slate-400 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500",
-          @errors == [] &&
-            "border-slate-300 focus:border-slate-400 focus:outline-indigo-600",
-          @errors != [] &&
-            "border-danger-400 focus:border-danger-400 focus:outline-danger-400",
-          @class
-        ]}
         {@rest}
       />
       <div :if={Enum.any?(@errors)} class="error-space h-6">
         <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
     </div>
+    """
+  end
+
+  @doc """
+  Renders an input element.
+
+  This function is used internally by `input/1` and generally should not
+  be used directly.
+
+  In the case of inputs that are different enough to warrant a new function,
+  this component can be used to maintain style consistency.
+  """
+
+  attr :id, :string, default: nil
+  attr :name, :string, required: true
+  attr :type, :string, required: true
+  attr :value, :any
+  attr :errors, :list, default: []
+  attr :class, :string, default: ""
+  attr :rest, :global
+
+  def input_element(assigns) do
+    ~H"""
+    <input
+      type={@type}
+      name={@name}
+      id={@id}
+      value={@value}
+      class={[
+        "focus:outline focus:outline-2 focus:outline-offset-1 block w-full rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
+        "phx-no-feedback:border-slate-300 phx-no-feedback:focus:border-slate-400 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500",
+        @errors == [] &&
+          "border-slate-300 focus:border-slate-400 focus:outline-indigo-600",
+        @errors != [] &&
+          "border-danger-400 focus:border-danger-400 focus:outline-danger-400",
+        @class
+      ]}
+      {@rest}
+    />
     """
   end
 
@@ -402,6 +433,29 @@ defmodule LightningWeb.Components.NewInputs do
     >
       <%= render_slot(@inner_block) %>
     </label>
+    """
+  end
+
+  @doc """
+  Generic wrapper for rendering error messages in custom input components.
+  """
+  attr :field, Phoenix.HTML.FormField, required: true
+
+  def errors(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        :errors,
+        Enum.map(
+          assigns.field.errors,
+          &LightningWeb.CoreComponents.translate_error(&1)
+        )
+      )
+
+    ~H"""
+    <div :if={Enum.any?(@errors)} class="error-space h-6">
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
     """
   end
 

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -117,24 +117,27 @@ defmodule LightningWeb.WorkflowLive.Components do
       <div class="col-span-6 @md:col-span-4">
         <div class="flex grid-cols-3">
           <div class="mt-2">
-          <.label for={@form[:concurrency].id}>
-            Maximum Concurrency
-          </.label>
+            <.label for={@form[:concurrency].id}>
+              Maximum Concurrency
+            </.label>
           </div>
           <div class="flex-grow">
-            <Common.tooltip id="max-concurrency-tooltip" title="The maximum number of concurrent runs." />
+            <Common.tooltip
+              id="max-concurrency-tooltip"
+              title="The maximum number of concurrent runs."
+            />
           </div>
           <div class="w-24 flex-center">
             <.input_element
-                type="number"
-                  name={@form[:concurrency].name}
-                  value={
-                    Phoenix.HTML.Form.normalize_value(
-                      "number",
-                      @form[:concurrency].value
-                    )
-                  }
-                  class="w-4 text-right"
+              type="number"
+              name={@form[:concurrency].name}
+              value={
+                Phoenix.HTML.Form.normalize_value(
+                  "number",
+                  @form[:concurrency].value
+                )
+              }
+              class="w-4 text-right"
             />
           </div>
         </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -147,8 +147,11 @@ defmodule LightningWeb.WorkflowLive.Components do
             :if={Enum.empty?(@form[:concurrency].errors)}
             class="text-xs text-slate-500 italic"
           >
-            <%= if @form[:concurrency].value do
-              "No more than #{@form[:concurrency].value} run#{if @form[:concurrency].value == 1, do: "", else: "s"} at a time"
+            <%= case @form[:concurrency].value do
+              nil -> "Unlimited (up to max available)"
+              "" -> "Unlimited (up to max available)"
+              1 -> "No more than one run at a time"
+              value -> "No more than #{value} runs at a time"
             end %>
           </div>
         </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -54,6 +54,8 @@ defmodule LightningWeb.WorkflowLive.Components do
   attr :id, :string, required: true
   attr :title, :string, required: true
   attr :cancel_url, :string, required: true
+  attr :class, :string, default: ""
+  attr :rest, :global
   slot :inner_block, required: true
   slot :header
   slot :footer
@@ -61,8 +63,12 @@ defmodule LightningWeb.WorkflowLive.Components do
   def panel(assigns) do
     ~H"""
     <div
-      class="absolute right-0 sm:m-4 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 max-h-content"
+      class={[
+        "absolute right-0 sm:m-4 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 max-h-content",
+        @class
+      ]}
       id={@id}
+      {@rest}
     >
       <div class="divide-y divide-gray-200 rounded-lg bg-white shadow">
         <div class="flex px-4 py-5 sm:px-6">
@@ -76,7 +82,7 @@ defmodule LightningWeb.WorkflowLive.Components do
               patch={@cancel_url}
               class="justify-center hover:text-gray-500"
             >
-              <Heroicons.x_mark solid class="h-4 w-4 inline-block" />
+              <.icon name="hero-x-mark" class="h-4 w-4 inline-block" />
             </.link>
           </div>
         </div>
@@ -92,6 +98,67 @@ defmodule LightningWeb.WorkflowLive.Components do
                 <%= render_slot(item) %>
               <% end %>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+
+  def workflow_settings(assigns) do
+    ~H"""
+    <div class="md:grid md:grid-cols-6 md:gap-4 p-2 @container">
+      <div class="col-span-6 @md:col-span-4">
+        <.input type="text" label="Name" field={@form[:name]} />
+      </div>
+
+      <div class="col-span-6 @md:col-span-4">
+        <.label for={@form[:concurrency].id}>
+          Concurrency
+        </.label>
+        <p class="text-xs text-slate-500 pb-2">
+          The maximum number of concurrent runs.
+        </p>
+        <div class="flex place-content-between items-center space-x-2">
+          <span class="text-sm">Limit</span>
+          <div class="w-24">
+            <.input_element
+              type="number"
+              name={@form[:concurrency].name}
+              value={
+                Phoenix.HTML.Form.normalize_value(
+                  "number",
+                  @form[:concurrency].value
+                )
+              }
+              class="w-4 text-right"
+            />
+          </div>
+        </div>
+        <div class="flex place-content-between items-center space-x-2 pt-1">
+          <div
+            :if={!is_nil(@form[:concurrency].value)}
+            class="hover:cursor-pointer hover:text-slate-400"
+            phx-click={
+              JS.dispatch("change", to: "input[name='workflow\[concurrency\]']")
+            }
+          >
+            <.icon name="hero-lock-closed" class="h4 w-4" />
+          </div>
+          <div :if={is_nil(@form[:concurrency].value)}>
+            <.icon name="hero-lock-open" class="h4 w-4" />
+          </div>
+          <.errors field={@form[:concurrency]} />
+          <div
+            :if={Enum.empty?(@form[:concurrency].errors)}
+            class="text-xs text-slate-500 italic"
+          >
+            <%= case @form[:concurrency].value do
+              nil -> "Unlimited"
+              value -> "Maximum of #{value} run(s) at a time"
+            end %>
           </div>
         </div>
       </div>
@@ -583,7 +650,10 @@ defmodule LightningWeb.WorkflowLive.Components do
               href="#"
               phx-click={JS.dispatch("collapse", to: "##{@id}")}
             >
-              <Heroicons.minus_circle class="w-5 h-5 hover:bg-gray-200 text-gray-600 rounded-lg" />
+              <.icon
+                name="hero-minus-circle"
+                class="w-5 h-5 hover:bg-slate-400 text-slate-500"
+              />
             </a>
             <a
               id={"#{@id}-panel-expand-icon"}
@@ -591,7 +661,10 @@ defmodule LightningWeb.WorkflowLive.Components do
               class="hidden panel-expand-icon"
               phx-click={JS.dispatch("expand-panel", to: "##{@id}")}
             >
-              <Heroicons.plus_circle class="w-5 h-5 hover:bg-gray-200 text-gray-600 rounded-lg" />
+              <.icon
+                name="hero-plus-circle"
+                class="w-5 h-5 hover:bg-slate-400 text-slate-500"
+              />
             </a>
           </div>
         </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -122,7 +122,7 @@ defmodule LightningWeb.WorkflowLive.Components do
               <Common.tooltip
                 class="inline-block ml-1"
                 id="max-concurrency-tooltip"
-                title="The maximum number of concurrent runs."
+                title="Even if your project supports concurrency, you may LIMIT the number of runs that occur simultaneously for this particular workflow by setting a value here. (Leaving it blank will allow runs to be processed as fast as your resources allow.)"
               />
             </.label>
           </div>
@@ -148,7 +148,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             class="text-xs text-slate-500 italic"
           >
             <%= if @form[:concurrency].value do
-              "Maximum of #{@form[:concurrency].value} run(s) at a time"
+              "No more than #{@form[:concurrency].value} run#{if @form[:concurrency].value == 1, do: "", else: "s"} at a time"
             end %>
           </div>
         </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -109,7 +109,7 @@ defmodule LightningWeb.WorkflowLive.Components do
 
   def workflow_settings(assigns) do
     ~H"""
-    <div class="md:grid md:grid-cols-6 md:gap-4 p-2 @container">
+    <div class="md:grid md:grid-cols-4 md:gap-4 p-2 @container">
       <div class="col-span-6 @md:col-span-4">
         <.input type="text" label="Workflow Name" field={@form[:name]} />
       </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -141,8 +141,12 @@ defmodule LightningWeb.WorkflowLive.Components do
           <div
             :if={!is_nil(@form[:concurrency].value)}
             class="hover:cursor-pointer hover:text-slate-400"
+            id="unlock-concurrency"
             phx-click={
-              JS.dispatch("change", to: "input[name='workflow\[concurrency\]']")
+              JS.set_attribute({"value", ""},
+                to: "input[name='workflow\[concurrency\]']"
+              )
+              |> JS.dispatch("change", to: "input[name='workflow\[concurrency\]']")
             }
           >
             <.icon name="hero-lock-closed" class="h4 w-4" />

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -119,14 +119,14 @@ defmodule LightningWeb.WorkflowLive.Components do
           <div class="mt-2">
             <.label for={@form[:concurrency].id}>
               Maximum Concurrency
+              <Common.tooltip
+                class="inline-block ml-1"
+                id="max-concurrency-tooltip"
+                title="The maximum number of concurrent runs."
+              />
             </.label>
           </div>
-          <div class="flex-grow">
-            <Common.tooltip
-              id="max-concurrency-tooltip"
-              title="The maximum number of concurrent runs."
-            />
-          </div>
+          <div class="flex-grow" />
           <div class="w-24 flex-center">
             <.input_element
               type="number"

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -111,57 +111,41 @@ defmodule LightningWeb.WorkflowLive.Components do
     ~H"""
     <div class="md:grid md:grid-cols-6 md:gap-4 p-2 @container">
       <div class="col-span-6 @md:col-span-4">
-        <.input type="text" label="Name" field={@form[:name]} />
+        <.input type="text" label="Workflow Name" field={@form[:name]} />
       </div>
 
       <div class="col-span-6 @md:col-span-4">
-        <.label for={@form[:concurrency].id}>
-          Concurrency
-        </.label>
-        <p class="text-xs text-slate-500 pb-2">
-          The maximum number of concurrent runs.
-        </p>
-        <div class="flex place-content-between items-center space-x-2">
-          <span class="text-sm">Limit</span>
-          <div class="w-24">
+        <div class="flex grid-cols-3">
+          <div class="mt-2">
+          <.label for={@form[:concurrency].id}>
+            Maximum Concurrency
+          </.label>
+          </div>
+          <div class="flex-grow">
+            <Common.tooltip id="max-concurrency-tooltip" title="The maximum number of concurrent runs." />
+          </div>
+          <div class="w-24 flex-center">
             <.input_element
-              type="number"
-              name={@form[:concurrency].name}
-              value={
-                Phoenix.HTML.Form.normalize_value(
-                  "number",
-                  @form[:concurrency].value
-                )
-              }
-              class="w-4 text-right"
+                type="number"
+                  name={@form[:concurrency].name}
+                  value={
+                    Phoenix.HTML.Form.normalize_value(
+                      "number",
+                      @form[:concurrency].value
+                    )
+                  }
+                  class="w-4 text-right"
             />
           </div>
         </div>
         <div class="flex place-content-between items-center space-x-2 pt-1">
-          <div
-            :if={!is_nil(@form[:concurrency].value)}
-            class="hover:cursor-pointer hover:text-slate-400"
-            id="unlock-concurrency"
-            phx-click={
-              JS.set_attribute({"value", ""},
-                to: "input[name='workflow\[concurrency\]']"
-              )
-              |> JS.dispatch("change", to: "input[name='workflow\[concurrency\]']")
-            }
-          >
-            <.icon name="hero-lock-closed" class="h4 w-4" />
-          </div>
-          <div :if={is_nil(@form[:concurrency].value)}>
-            <.icon name="hero-lock-open" class="h4 w-4" />
-          </div>
           <.errors field={@form[:concurrency]} />
           <div
             :if={Enum.empty?(@form[:concurrency].errors)}
             class="text-xs text-slate-500 italic"
           >
-            <%= case @form[:concurrency].value do
-              nil -> "Unlimited"
-              value -> "Maximum of #{value} run(s) at a time"
+            <%= if @form[:concurrency].value do
+              "Maximum of #{@form[:concurrency].value} run(s) at a time"
             end %>
           </div>
         </div>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -131,19 +131,21 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 name="hero-lock-closed"
                 class="w-5 h-5 place-self-center text-gray-300"
               />
-              <div class="m-auto">
+              <div class="flex flex-row m-auto gap-2">
+                <div>
+                  <.link
+                    patch={
+                      if @selection_mode == "settings",
+                        do: @base_url,
+                        else: "#{@base_url}?m=settings"
+                    }
+                    class="w-5 h-5 place-self-center text-slate-500 hover:text-slate-400 cursor-pointer"
+                    id="toggle-settings"
+                  >
+                    <.icon name="hero-adjustments-vertical" />
+                  </.link>
+                </div>
                 <.offline_indicator />
-                <.link
-                  patch={
-                    if @selection_mode == "settings",
-                      do: @base_url,
-                      else: "#{@base_url}?m=settings"
-                  }
-                  class="w-5 h-5 place-self-center text-slate-500 hover:text-slate-400 cursor-pointer"
-                  id="toggle-settings"
-                >
-                  <.icon name="hero-adjustments-vertical" />
-                </.link>
               </div>
               <.save_workflow_button
                 changeset={@changeset}

--- a/priv/repo/migrations/20240711075538_add_concurency_to_workflows.exs
+++ b/priv/repo/migrations/20240711075538_add_concurency_to_workflows.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddConcurencyToWorkflows do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workflows) do
+      add :concurrency, :integer, default: nil
+    end
+  end
+end

--- a/test/lightning/extensions/fifo_run_queue_test.exs
+++ b/test/lightning/extensions/fifo_run_queue_test.exs
@@ -39,11 +39,26 @@ defmodule Lightning.Extensions.FifoRunQueueTest do
           dataclip: params_with_assocs(:dataclip)
         )
 
-      assert {:ok, [%{id: ^run1_id, state: :claimed}]} =
-               FifoRunQueue.claim(1)
+      actual = FifoRunQueue.claim(1)
 
-      assert {:ok, [%{id: ^run2_id, state: :claimed}]} =
-               FifoRunQueue.claim(1)
+      assert match?(
+               {:ok, [%{id: ^run1_id, state: :claimed}]},
+               actual
+             ),
+             """
+             Expected #{run1_id} to be claimed first
+             """
+
+      actual = FifoRunQueue.claim(1)
+
+      assert match?(
+               {:ok, [%{id: ^run2_id, state: :claimed}]},
+               actual
+             ),
+             """
+             Expected #{run2_id} to be claimed second
+             Got: #{inspect(actual)}
+             """
 
       assert {:ok,
               [

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -3,8 +3,6 @@ defmodule Lightning.Runs.QueryTest do
 
   alias Lightning.Runs.Query
 
-  import Lightning.Factories
-
   describe "lost/1" do
     test "returns only those runs which were claimed before the earliest
     allowable claim date and remain unfinished" do
@@ -135,5 +133,411 @@ defmodule Lightning.Runs.QueryTest do
 
       assert lost_runs == [should_be_lost.id]
     end
+  end
+
+  describe "concurrency" do
+    test "base case" do
+      [red, green, blue, yellow, magenta, cyan] =
+        [
+          "red",
+          "green",
+          "blue",
+          "yellow",
+          "magenta",
+          "cyan"
+        ]
+        |> Enum.map(fn name ->
+          project = insert(:project, name: name)
+          workflow = insert(:simple_workflow, project: project)
+
+          %{project: project, workflow: workflow}
+        end)
+
+      projects = [red, green, blue, yellow, magenta, cyan]
+
+      projects
+      |> Stream.cycle()
+      |> Stream.take(60)
+      |> Enum.map(fn color ->
+        insert_run(color, :available)
+      end)
+
+      # distribute_run_inserted_at(projects)
+      # set the first runs to claimed for projects red and blue
+      first_runs_query = get_first_run_for_projects([red, blue])
+
+      from(r in Lightning.Run,
+        where: r.id in subquery(first_runs_query),
+        update: [set: [state: :claimed, claimed_at: ^DateTime.utc_now()]]
+      )
+      |> Repo.update_all([])
+
+      first_runs_query = get_first_run_for_projects([blue])
+
+      from(r in Lightning.Run,
+        where: r.id in subquery(first_runs_query),
+        update: [set: [state: :claimed, claimed_at: ^DateTime.utc_now()]]
+      )
+      |> Repo.update_all([])
+
+      first_runs_query = get_first_run_for_projects([blue])
+
+      from(r in Lightning.Run,
+        where: r.id in subquery(first_runs_query),
+        update: [set: [state: :claimed, claimed_at: ^DateTime.utc_now()]]
+      )
+      |> Repo.update_all([])
+
+      assert number_of_runs_for_project(red, :available) == 9
+      assert number_of_runs_for_project(blue, :available) == 7
+      # there should be three claimed runs for projects red and blue
+
+      from(r in subquery(Query.in_progress_window()),
+        select: [r.id, r.project_name, r.state, r.row_number, r.concurrency]
+      )
+      |> Repo.all()
+
+      demand = 1
+
+      # claim items in the order of the in_progress_window query
+      Query.in_progress_window()
+      |> Repo.all()
+      |> tap(fn ip ->
+        assert length(ip) == 60
+
+        assert Enum.count(
+                 ip,
+                 &match?(%{state: :claimed, project_name: "blue"}, &1)
+               ) == 3
+
+        assert Enum.count(
+                 ip,
+                 &match?(%{state: :claimed, project_name: "red"}, &1)
+               ) == 1
+      end)
+      |> Enum.with_index()
+      |> Enum.each(fn {window_item, i} ->
+        eligible_snapshot =
+          from([run, ipw] in Query.eligible_for_claim(),
+            select: [
+              type(ipw.id, :string),
+              run.state,
+              ipw.row_number,
+              ipw.project_name,
+              ipw.concurrency
+            ]
+          )
+          |> Repo.all()
+
+        if window_item.state == "available" do
+          {:ok, [run]} =
+            Lightning.Runs.Queue.claim(demand, Query.eligible_for_claim())
+
+          assert run.id == window_item.id,
+                 """
+                 Expected run id to be #{window_item.id}, got #{run.id} at index #{i}.
+                 #{eligible_snapshot |> inspect(pretty: true)}
+                 """
+        end
+      end)
+    end
+
+    test "in_progress_window/0" do
+      [red, _green, blue, cyan, _magenta] =
+        [
+          {"red", 1},
+          {"green", 2},
+          {"blue", 3},
+          {"cyan", nil},
+          {"magenta", 5}
+        ]
+        |> Enum.map(fn {name, concurrency} ->
+          project = insert(:project, name: name)
+
+          workflow =
+            insert(:simple_workflow, project: project, concurrency: concurrency)
+
+          %{project: project, workflow: workflow}
+        end)
+
+      runs_in_order =
+        [
+          insert_run(red, :available),
+          for _ <- 1..10 do
+            insert_run(cyan, :available)
+          end,
+          insert_run(blue, :claimed),
+          insert_run(blue, :claimed),
+          insert_run(blue, :available)
+        ]
+        |> List.flatten()
+        |> Enum.zip_with(
+          [
+            %{project_name: "red", row_number: 1, concurrency: 1},
+            %{project_name: "cyan", row_number: 1, concurrency: nil},
+            %{project_name: "cyan", row_number: 2, concurrency: nil},
+            %{project_name: "cyan", row_number: 3, concurrency: nil},
+            %{project_name: "cyan", row_number: 4, concurrency: nil},
+            %{project_name: "cyan", row_number: 5, concurrency: nil},
+            %{project_name: "cyan", row_number: 6, concurrency: nil},
+            %{project_name: "cyan", row_number: 7, concurrency: nil},
+            %{project_name: "cyan", row_number: 8, concurrency: nil},
+            %{project_name: "cyan", row_number: 9, concurrency: nil},
+            %{project_name: "cyan", row_number: 10, concurrency: nil},
+            %{project_name: "blue", row_number: 1, concurrency: 3},
+            %{project_name: "blue", row_number: 2, concurrency: 3},
+            %{project_name: "blue", row_number: 3, concurrency: 3}
+          ],
+          fn run, extra ->
+            Map.take(run, [:id, :state]) |> Map.merge(extra)
+          end
+        )
+
+      window = Query.in_progress_window() |> Repo.all()
+
+      assert match?(^runs_in_order, window)
+
+      # mark the first run for project red as claimed
+      # mark 6 runs for project cyan as claimed
+      now = build(:timestamp)
+
+      Repo.update_all(
+        from(r in Lightning.Run,
+          join:
+            s in subquery(
+              from(r in Lightning.Run,
+                join: wo in assoc(r, :work_order),
+                join: wf in assoc(wo, :workflow),
+                where:
+                  r.state == :available and
+                    wf.project_id in ^[red.project.id, cyan.project.id],
+                limit: 7,
+                select: r,
+                update: []
+              )
+            ),
+          on: r.id == s.id
+        ),
+        set: [state: :claimed, claimed_at: now]
+      )
+
+      window = Query.in_progress_window() |> Repo.all()
+
+      assert Enum.count(
+               window,
+               &match?(%{state: :claimed, project_name: "red"}, &1)
+             ) == 1,
+             "there should be one claimed run for project red"
+
+      assert Enum.count(
+               window,
+               &match?(%{state: :claimed, project_name: "cyan"}, &1)
+             ) == 6,
+             "there should be 6 claimed runs for project cyan"
+
+      runs_in_order =
+        Enum.zip_with(
+          runs_in_order,
+          List.duplicate(%{state: :claimed}, 7) ++ List.duplicate(%{}, 8),
+          &Map.merge(&1, &2)
+        )
+
+      assert match?(^runs_in_order, window), """
+      Expected the first 7 to be claimed.
+      Being one red and 6 cyan.
+      #{inspect(window, pretty: true)}
+      """
+    end
+
+    test "eligible_for_claim/0 with claim" do
+      # we need 3 projects, each with one workflow, called: red, green, blue
+      # red should have a limit of 1
+      # green should have a limit of 2
+      # blue should have a limit of 3
+
+      [red, green, blue] =
+        [
+          {"red", 1},
+          {"green", 2},
+          {"blue", 3}
+        ]
+        |> Enum.map(fn {name, concurrency} ->
+          project = insert(:project, name: name)
+
+          workflow =
+            insert(:simple_workflow, project: project, concurrency: concurrency)
+
+          %{project: project, workflow: workflow}
+        end)
+
+      for _ <- 1..2 do
+        insert_run(red, :available)
+      end
+
+      insert_run(green, :available)
+
+      insert_run(blue, :available)
+
+      {:ok, [%{id: run_id} = red_run_1]} =
+        Lightning.Runs.Queue.claim(1, Query.eligible_for_claim())
+
+      Query.in_progress_window()
+      |> Repo.all()
+      |> then(fn in_progress ->
+        assert match?(
+                 [
+                   %{
+                     id: ^run_id,
+                     project_name: "red",
+                     state: :claimed,
+                     row_number: 1,
+                     concurrency: 1
+                   },
+                   %{
+                     id: _,
+                     project_name: "red",
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 1
+                   },
+                   %{
+                     id: _,
+                     project_name: "green",
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 2
+                   },
+                   _
+                 ],
+                 in_progress
+               )
+      end)
+
+      {:ok, [%{id: claimed_run_id}]} =
+        Lightning.Runs.Queue.claim(1, Query.eligible_for_claim())
+
+      Query.in_progress_window()
+      |> Repo.all()
+      |> then(fn in_progress ->
+        assert match?(
+                 [
+                   _,
+                   %{
+                     id: _,
+                     project_name: "red",
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 1
+                   },
+                   %{
+                     id: ^claimed_run_id,
+                     project_name: "green",
+                     state: :claimed,
+                     row_number: 1,
+                     concurrency: 2
+                   },
+                   %{
+                     project_name: "blue",
+                     state: :available
+                   }
+                 ],
+                 in_progress
+               ),
+               """
+               red should still be available because of concurrency 1
+               #{inspect(in_progress, pretty: true)}
+               """
+      end)
+
+      # Mark the first red run as finished
+      Ecto.Changeset.change(red_run_1,
+        state: :success,
+        finished_at: build(:timestamp)
+      )
+      |> Repo.update()
+
+      {:ok, [%{id: run_id}]} =
+        Lightning.Runs.Queue.claim(1, Query.eligible_for_claim())
+
+      Query.in_progress_window()
+      |> Repo.all()
+      |> then(fn in_progress ->
+        assert match?(
+                 [
+                   %{
+                     id: ^run_id,
+                     project_name: "red",
+                     state: :claimed,
+                     row_number: 1,
+                     concurrency: 1
+                   },
+                   %{
+                     id: _,
+                     project_name: "green",
+                     state: :claimed,
+                     row_number: 1,
+                     concurrency: 2
+                   },
+                   %{
+                     id: _,
+                     project_name: "blue",
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 3
+                   }
+                 ],
+                 in_progress
+               ),
+               """
+               the next red should be claimed because the first one is finished
+               #{inspect(in_progress, pretty: true)}
+               """
+      end)
+    end
+  end
+
+  def number_of_runs_for_project(color, state \\ :available) do
+    project = color.project
+
+    from(r in Lightning.Run,
+      join: wo in assoc(r, :work_order),
+      join: w in assoc(wo, :workflow),
+      join: p in assoc(w, :project),
+      where: p.id == ^project.id and r.state == ^state,
+      select: count(r.id)
+    )
+    |> Repo.one()
+  end
+
+  defp get_first_run_for_projects(colors) do
+    project_names = colors |> Enum.map(& &1.project.name)
+
+    from(r in Lightning.Run,
+      join: wo in assoc(r, :work_order),
+      join: w in assoc(wo, :workflow),
+      join: p in assoc(w, :project),
+      where: p.name in ^project_names,
+      where: r.state == :available,
+      distinct: p.id,
+      order_by: [asc: r.inserted_at],
+      select: r.id
+    )
+  end
+
+  defp insert_run(project_workflow_pair, state) do
+    case state do
+      :available ->
+        [state: state]
+
+      :claimed ->
+        [state: state, claimed_at: fn -> build(:timestamp) end]
+    end
+    |> Keyword.merge(
+      work_order: insert(:workorder, workflow: project_workflow_pair.workflow),
+      inserted_at: build(:timestamp),
+      starting_job: project_workflow_pair.workflow.jobs |> hd(),
+      dataclip: params_with_assocs(:dataclip)
+    )
+    |> then(fn params -> insert(:run, params) end)
   end
 end

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -153,9 +153,12 @@ defmodule Lightning.Runs.QueryTest do
           %{project: project, workflow: workflow}
         end)
 
-      projects = [red, green, blue, yellow, magenta, cyan]
-
-      projects
+      # We cycle through a list of colors to insert runs for each project
+      # The contiguous runs for the same project are added so that we
+      # can ensure the sorting order for eligible_for_claim is reliable,
+      # i.e. items are processed in order of insertion, not by their
+      # position in a given project (i.e. `row_number`)
+      [red, green, green, green, blue, yellow, magenta, cyan, red, blue, blue]
       |> Stream.cycle()
       |> Stream.take(60)
       |> Enum.map(fn color ->
@@ -188,14 +191,8 @@ defmodule Lightning.Runs.QueryTest do
       )
       |> Repo.update_all([])
 
-      assert number_of_runs_for_project(red, :available) == 9
-      assert number_of_runs_for_project(blue, :available) == 7
-      # there should be three claimed runs for projects red and blue
-
-      from(r in subquery(Query.in_progress_window()),
-        select: [r.id, r.project_name, r.state, r.row_number, r.concurrency]
-      )
-      |> Repo.all()
+      assert number_of_runs_for_project(red, :available) == 10
+      assert number_of_runs_for_project(blue, :available) == 13
 
       demand = 1
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -732,7 +732,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert view
              |> form("#workflow-form", %{"workflow" => %{"concurrency" => "5"}})
-             |> render_change() =~ "Maximum of 5 run(s) at a time"
+             |> render_change() =~ "No more than 5 runs at a time"
 
       assert view |> element("#workflow-form") |> render_submit() =~
                "Workflow saved"

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -213,9 +213,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
                Lightning.Repo.one(
                  from w in Workflow,
                    where:
-                     w.project_id == ^project.id and
-                       w.name ==
-                         ^workflow_name
+                     w.project_id == ^project.id and w.name == ^workflow_name
                )
 
       assert_patched(
@@ -700,6 +698,98 @@ defmodule LightningWeb.WorkflowLive.EditTest do
                "workflow" => %{"name" => "some new name"}
              })
              |> render_submit() =~ "Workflow saved"
+    end
+
+    test "using the settings panel", %{
+      conn: conn,
+      project: project,
+      workflow: workflow
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}"
+        )
+
+      refute has_element?(view, "#workflow-settings-#{workflow.id}")
+
+      view
+      |> element("#toggle-settings")
+      |> render_click()
+
+      path = assert_patch(view)
+      assert path == ~p"/projects/#{project.id}/w/#{workflow.id}?m=settings"
+
+      assert has_element?(view, "#workflow-settings-#{workflow.id}")
+      assert render(view) =~ "Workflow settings"
+
+      assert view
+             |> form("#workflow-form", %{"workflow" => %{"concurrency" => "0"}})
+             |> render_change() =~ "must be greater than or equal to 1"
+
+      assert view |> element("#workflow-form") |> render_submit() =~
+               "Workflow could not be saved"
+
+      assert view
+             |> form("#workflow-form", %{"workflow" => %{"concurrency" => "5"}})
+             |> render_change() =~ "Maximum of 5 run(s) at a time"
+
+      assert view |> element("#workflow-form") |> render_submit() =~
+               "Workflow saved"
+
+      assert assert_patch(view) =~
+               ~p"/projects/#{project.id}/w/#{workflow.id}?m=settings"
+
+      assert view
+             |> form("#workflow-form", %{"workflow" => %{"concurrency" => ""}})
+             |> render_change() =~ "Unlimited"
+
+      view |> element("#toggle-settings") |> render()
+
+      view
+      |> element("#toggle-settings")
+      |> render_click()
+
+      refute has_element?(view, "#workflow-settings-#{workflow.id}")
+
+      assert assert_patch(view) == ~p"/projects/#{project.id}/w/#{workflow.id}"
+
+      # bring the settings panel back, so we can test that selecting something
+      # else will close it
+      view
+      |> element("#toggle-settings")
+      |> render_click()
+
+      assert_patch(view)
+
+      job = workflow.jobs |> Enum.at(1)
+
+      view |> select_node(job)
+
+      assert assert_patch(view) ==
+               ~p"/projects/#{project.id}/w/#{workflow.id}?s=#{job.id}"
+
+      refute has_element?(view, "#workflow-settings-#{workflow.id}"),
+             "should not have settings panel present"
+
+      # bring it back again to test the close button
+      view
+      |> element("#toggle-settings")
+      |> render_click()
+
+      refute has_element?(view, "#job-pane-#{job.id}"),
+             "should not have job pane anymore"
+
+      assert assert_patch(view) ==
+               ~p"/projects/#{project.id}/w/#{workflow.id}?m=settings"
+
+      view
+      |> element("#close-panel")
+      |> render_click()
+
+      refute has_element?(view, "#workflow-settings-#{workflow.id}")
+
+      assert assert_patch(view) == ~p"/projects/#{project.id}/w/#{workflow.id}"
     end
 
     test "renders error message when a job has an empty body", %{


### PR DESCRIPTION
There are two new queries `in_progress_window` and `eligible_for_claim`. Both can be found in the `Lightning.Runs.Query` module.

The effect of these queries in practice is that once a workflow has it's `concurrency` field set, once that number of runs is claimed or started has been reached (even though they arrived first) will not be considered for the next run to be claimed.

The `FifoRunQueue` (the default) queue, now uses the `eligible_for_claim` query to determine which runs to claim next.

## Validation Steps

This PR only adds the queries and uses them on the Fifo queue, so the current expectation for these changes are: on the demo server, or locally - the queue functionality should not result in errors.

Head to a workflow and click the new 'settings' icon on the top bar:
<img width="615" alt="Screenshot 2024-07-16 at 11 57 13" src="https://github.com/user-attachments/assets/601ff604-cf5e-4bf9-9940-7c2f592f5a11">

Then change the limit from blank, to something 1 or greater.

Add some runs to the queue for the same workflow, the observed start times should be non-overlapping (at least in the case of a concurrency value of 1)

## Notes for the reviewer

There is a migration that needs to be run that adds a `concurrency` column to `workflows`.

## Related issue

Re: #2022 

## Review checklist

- [x] I have performed a **self-review** of my code
- [x] I have verified that all appropriate **authorization policies** (`:owner`, `:admin`, `:editor`, `:viewer`) have been implemented and tested
- [x] If needed, I have updated the **changelog**
- [ ] Product has **QA'd** this feature
