### PR TITLE
Enhance OAuth Credential Validation via Changeset

### DIFF
--- a/lib/lightning/auth_providers/oauth_http_client.ex
+++ b/lib/lightning/auth_providers/oauth_http_client.ex
@@ -34,6 +34,10 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     |> handle_resp([200])
     |> maybe_introspect(client)
     |> maybe_validate_token()
+    #  up here ^^^ you can't `maybe_validate_token` ALONE...
+    # you must validate after merging, since clicking "reauthorize" won't actually
+    # return a `refresh_token` unless the customer has fully revoked privs on the
+    # 3rd party system
   end
 
   @doc """

--- a/lib/lightning/auth_providers/oauth_http_client.ex
+++ b/lib/lightning/auth_providers/oauth_http_client.ex
@@ -33,11 +33,6 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     |> post(client.token_endpoint, body)
     |> handle_resp([200])
     |> maybe_introspect(client)
-    |> maybe_validate_token()
-    #  up here ^^^ you can't `maybe_validate_token` ALONE...
-    # you must validate after merging, since clicking "reauthorize" won't actually
-    # return a `refresh_token` unless the customer has fully revoked privs on the
-    # 3rd party system
   end
 
   @doc """
@@ -154,18 +149,6 @@ defmodule Lightning.AuthProviders.OauthHTTPClient do
     else
       expiration_time
     end
-  end
-
-  defp maybe_validate_token({:ok, token} = _response) do
-    if Map.get(token, "refresh_token") do
-      {:ok, token}
-    else
-      {:error, :no_refresh_token}
-    end
-  end
-
-  defp maybe_validate_token(response) do
-    response
   end
 
   defp maybe_introspect({:error, reason}, _client) do

--- a/lib/lightning/credentials/credential.ex
+++ b/lib/lightning/credentials/credential.ex
@@ -46,7 +46,26 @@ defmodule Lightning.Credentials.Credential do
     |> validate_required([:name, :body, :user_id])
     |> assoc_constraint(:user)
     |> assoc_constraint(:oauth_client)
+    |> validate_oauth()
     |> validate_transfer_ownership()
+  end
+
+  defp validate_oauth(changeset) do
+    if get_field(changeset, :schema) == "oauth" do
+      case get_field(changeset, :body) do
+        %{"refresh_token" => _any} ->
+          changeset
+
+        _else ->
+          add_error(
+            changeset,
+            :body,
+            "We can't save this credential with a refresh_token."
+          )
+      end
+    else
+      changeset
+    end
   end
 
   defp validate_transfer_ownership(changeset) do

--- a/lib/lightning/credentials/credential.ex
+++ b/lib/lightning/credentials/credential.ex
@@ -54,6 +54,8 @@ defmodule Lightning.Credentials.Credential do
     if get_field(changeset, :schema) == "oauth" do
       body = get_field(changeset, :body) || %{}
 
+      body = Enum.into(body, %{}, fn {k, v} -> {to_string(k), v} end)
+
       required_fields = ["access_token", "refresh_token"]
       expires_fields = ["expires_in", "expires_at"]
 

--- a/lib/lightning_web/live/components/oauth.ex
+++ b/lib/lightning_web/live/components/oauth.ex
@@ -194,7 +194,7 @@ defmodule LightningWeb.Components.Oauth do
     """
   end
 
-  def error_block(%{type: :no_refresh_token} = assigns) do
+  def error_block(%{type: :missing_required} = assigns) do
     ~H"""
     <div class="rounded-md bg-yellow-50 border border-yellow-200 p-4">
       <div class="flex">

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -880,7 +880,7 @@ defmodule LightningWeb.CredentialLiveTest do
             id: "generic-oauth-component-new"
           )
 
-        :no_refresh_token === assigns[:oauth_progress]
+        :missing_required === assigns[:oauth_progress]
       end)
 
       refute view |> has_element?("h3", "Test User")

--- a/test/lightning_web/live/oauth_components_test.exs
+++ b/test/lightning_web/live/oauth_components_test.exs
@@ -41,43 +41,45 @@ defmodule LightningWeb.OauthComponentsTest do
   end
 
   test "rendering error component for various error type" do
-    render_component(
-      &LightningWeb.Components.Oauth.error_block/1,
-      type: :token_failed,
-      authorize_url: "https://www",
-      myself: nil,
-      provider: "Salesforce"
-    ) =~ "Failed retrieving the token from the provider"
+    assert render_component(
+             &LightningWeb.Components.Oauth.error_block/1,
+             type: :token_failed,
+             authorize_url: "https://www",
+             myself: nil,
+             provider: "Salesforce"
+           ) =~ "Failed retrieving the token from the provider"
 
-    render_component(
-      &LightningWeb.Components.Oauth.error_block/1,
-      type: :refresh_failed,
-      authorize_url: "https://www",
-      myself: nil,
-      provider: "Salesforce"
-    ) =~ "Failed renewing your access token"
+    assert render_component(
+             &LightningWeb.Components.Oauth.error_block/1,
+             type: :refresh_failed,
+             authorize_url: "https://www",
+             myself: nil,
+             provider: "Salesforce"
+           ) =~ "Failed renewing your access token"
 
-    render_component(
-      &LightningWeb.Components.Oauth.error_block/1,
-      type: :userinfo_failed,
-      authorize_url: "https://www",
-      myself: nil,
-      provider: "Salesforce"
-    ) =~ "Failed retrieving your information"
+    assert render_component(
+             &LightningWeb.Components.Oauth.error_block/1,
+             type: :userinfo_failed,
+             authorize_url: "https://www",
+             myself: nil,
+             provider: "Salesforce"
+           ) =~
+             "That seemed to work, but we couldn't fetch your user information. You can save your credential now or try again."
 
-    render_component(&LightningWeb.Components.Oauth.error_block/1,
-      type: :code_failed,
-      authorize_url: "https://www",
-      myself: nil,
-      provider: "Salesforce"
-    ) =~ "Failed retrieving authentication code."
+    assert render_component(&LightningWeb.Components.Oauth.error_block/1,
+             type: :code_failed,
+             authorize_url: "https://www",
+             myself: nil,
+             provider: "Salesforce"
+           ) =~ "Failed retrieving authentication code."
 
-    render_component(
-      &LightningWeb.Components.Oauth.error_block/1,
-      type: :no_refresh_token,
-      authorize_url: "https://www",
-      myself: nil,
-      provider: "Salesforce"
-    ) =~ "The token is missing it's"
+    assert render_component(
+             &LightningWeb.Components.Oauth.error_block/1,
+             type: :missing_required,
+             authorize_url: "https://www",
+             myself: nil,
+             provider: "Salesforce"
+           ) =~
+             "We didn't receive a refresh token from this provider. Sometimes this happens if you have already granted access to OpenFn via another credential. If you have another credential, please use that one. If you don't, please revoke OpenFn's access to your provider via the \"third party apps\" section of their website. Once that is done, you can try to reauthorize"
   end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -164,12 +164,28 @@ defmodule Lightning.Factories do
     }
   end
 
-  def credential_factory do
+  def credential_factory(attrs \\ %{}) do
+    schema = Map.get(attrs, :schema, "raw")
+
+    body =
+      case schema do
+        "oauth" ->
+          %{
+            "access_token" => "access_token_#{System.unique_integer()}",
+            "refresh_token" => "refresh_token_#{System.unique_integer()}",
+            "expires_in" => 3600
+          }
+
+        _ ->
+          %{}
+      end
+
     %Lightning.Credentials.Credential{
-      body: %{},
-      schema: "raw",
+      body: body,
+      schema: schema,
       name: sequence(:credential_name, &"credential#{&1}")
     }
+    |> Map.merge(attrs)
   end
 
   def project_credential_factory do


### PR DESCRIPTION
@elias-ba , for your consideration: Is there _any situation_ in which we would want to save a credential with an `oauth` schema to the DB if it does not have a `refresh_token` in the body?