### PR TITLE
configure modal close events triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Make modal close events configurable
+  [#2298](https://github.com/OpenFn/lightning/issues/2298)
+
 ### Fixed
 
 - Prevent Oauth credentials from being created if they don't have a

--- a/lib/lightning_web/live/components/modal.ex
+++ b/lib/lightning_web/live/components/modal.ex
@@ -14,6 +14,8 @@ defmodule LightningWeb.Components.Modal do
   attr :type, :string, default: "default"
   attr :position, :string, default: "relative"
   attr :width, :string, default: "max-w-3xl"
+  attr :close_on_click_away, :boolean, default: true
+  attr :close_on_keydown, :boolean, default: true
   attr :rest, :global
 
   attr :on_close, JS, default: %JS{}
@@ -55,9 +57,9 @@ defmodule LightningWeb.Components.Modal do
             <.focus_wrap
               id={"#{@id}-container"}
               phx-mounted={@show && show_modal(@on_open, @id)}
-              phx-window-keydown={hide_modal(@on_close, @id)}
+              phx-window-keydown={@close_on_keydown && hide_modal(@on_close, @id)}
               phx-key="escape"
-              phx-click-away={hide_modal(@on_close, @id)}
+              phx-click-away={@close_on_click_away && hide_modal(@on_close, @id)}
               class="hidden relative rounded-xl bg-white py-[24px] shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10 transition"
             >
               <header :if={@title != []} class="pl-[24px] pr-[24px]">


### PR DESCRIPTION
### Description

By default, when a modal is open, you can **click away** to close it. This PR makes it such that you can configure whether you want this action or not.

This has been necessitated by: https://github.com/OpenFn/thunderbolt/pull/207

Closes #2298 

### Validation steps
This PR is a no-op. So all modals should continue working as they were.
In order to validate this:

1.  open the create new workflow modal in the workflows page. Click the 
2. Try clicking away from the modal. The modal should just close

### Additional notes for the reviewer
- The modal also closes on `phx-window-keydown` but I haven't been able to reproduce this event. 

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
