### PR TITLE
Fix Work Order URL In Failure Alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix work order URL in failure alerts
+  [#2305](https://github.com/OpenFn/lightning/pull/2305)
+
 ## [v2.7.7] - 2024-07-18
 
 ### Added

--- a/lib/lightning/pipeline/failure_alerter.ex
+++ b/lib/lightning/pipeline/failure_alerter.ex
@@ -46,7 +46,10 @@ defmodule Lightning.FailureAlerter do
       Application.fetch_env!(:lightning, __MODULE__)
 
     run_url =
-      LightningWeb.RouteHelpers.show_run_url(project_id, run_id)
+      url(
+        LightningWeb.Endpoint,
+        ~p"/projects/#{project_id}/runs/#{run_id}"
+      )
 
     work_order_url =
       url(

--- a/lib/lightning/pipeline/failure_alerter.ex
+++ b/lib/lightning/pipeline/failure_alerter.ex
@@ -49,7 +49,10 @@ defmodule Lightning.FailureAlerter do
       LightningWeb.RouteHelpers.show_run_url(project_id, run_id)
 
     work_order_url =
-      ~p"/projects/#{project_id}/history?filters[workorder_id]=#{work_order_id}"
+      url(
+        LightningWeb.Endpoint,
+        ~p"/projects/#{project_id}/history?filters[workorder_id]=#{work_order_id}"
+      )
 
     # rate limiting per workflow AND user
     bucket_key = "#{workflow_id}::#{recipient.id}"


### PR DESCRIPTION
### Description

This PR fixes the broken work order URL that is sent in the failure alert emails.

### Validation steps

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
