### PR TITLE
Make root layout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 ### Added
 
 ### Changed
+- Make root layout configurable
+  [#2310](https://github.com/OpenFn/lightning/pull/2310)
 
 ### Fixed
 - Fix an intermittent bug when trying to intern Kafka offset reset policy.

--- a/lib/lightning_web/components/layouts.ex
+++ b/lib/lightning_web/components/layouts.ex
@@ -4,4 +4,7 @@ defmodule LightningWeb.Layouts do
   use LightningWeb, :html
 
   embed_templates "layouts/*"
+
+  slot :header_tags
+  def root(assigns)
 end

--- a/lib/lightning_web/components/layouts/root.html.heex
+++ b/lib/lightning_web/components/layouts/root.html.heex
@@ -39,6 +39,7 @@
       src={Routes.static_path(@conn, "/assets/js/app.js")}
     >
     </script>
+    <%= render_slot(@header_tags) %>
   </head>
   <body class="h-full">
     <div class="min-h-full">

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1366,6 +1366,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
            |> assign_workflow(workflow, snapshot)
            |> put_flash(:info, "Workflow saved")
            |> push_patches_applied(initial_params)
+           |> then(fn socket ->
+             if socket.assigns.live_action == :new do
+               push_event(socket, "workflow_created", %{id: workflow.id})
+             else
+               socket
+             end
+           end)
            |> push_patch(
              to: ~p"/projects/#{project.id}/w/#{workflow.id}?#{query_params}",
              replace: true

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1366,13 +1366,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
            |> assign_workflow(workflow, snapshot)
            |> put_flash(:info, "Workflow saved")
            |> push_patches_applied(initial_params)
-           |> then(fn socket ->
-             if socket.assigns.live_action == :new do
-               push_event(socket, "workflow_created", %{id: workflow.id})
-             else
-               socket
-             end
-           end)
+           |> maybe_push_workflow_created(workflow)
            |> push_patch(
              to: ~p"/projects/#{project.id}/w/#{workflow.id}?#{query_params}",
              replace: true
@@ -2021,6 +2015,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     socket
     |> push_event("patches-applied", %{patches: patches})
+  end
+
+  defp maybe_push_workflow_created(socket, workflow) do
+    if socket.assigns.live_action == :new do
+      push_event(socket, "workflow_created", %{id: workflow.id})
+    else
+      socket
+    end
   end
 
   # In situations where a new job is added, specifically by the WorkflowDiagram

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -13,11 +13,17 @@ defmodule LightningWeb.Router do
   alias ProjectLive
   alias UserLive
 
+  @root_layout Application.compile_env(
+                 :lightning,
+                 :root_layout,
+                 {LightningWeb.Layouts, :root}
+               )
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_live_flash
-    plug :put_root_layout, {LightningWeb.Layouts, :root}
+    plug :put_root_layout, @root_layout
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_user


### PR DESCRIPTION
### Description

- This PR makes the root layout configurable. This way we can use another root layout in thunderbolt.
- It also introduces a slot for additional header tags to be injected
- Pushes a workflow created event which is handled in js land


### Validation steps

Check https://github.com/OpenFn/thunderbolt/pull/265 in order to test these changes.
At a minimum, everything should be working in `Lightning` as it was. The layout and workflow creation is not affected in any way


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
