### PR TITLE
skip flaky, references #2311

### DIFF
--- a/test/lightning_web/live/workflow_live/user_presences_test.exs
+++ b/test/lightning_web/live/workflow_live/user_presences_test.exs
@@ -83,6 +83,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
     end
   end
 
+  @tag skip: "Flaky, to be fixed in #2311"
   describe "When workflow has many visitors, presences is detected and edit is disabled" do
     test "in canvas", %{conn: conn} do
       amy =
@@ -476,6 +477,7 @@ defmodule LightningWeb.WorkflowLive.UserPresencesTest do
     end
   end
 
+  @tag skip: "Flaky, to be fixed in #2311"
   describe "When workflow has many visits from same user, multiple sessions are detected and edit is disabled" do
     test "in canvas", %{conn: conn} do
       amy =


### PR DESCRIPTION
### Description

This PR skips 4 notoriously flaky tests. The proposal is that we're losing too much time and getting numb to test failures, that puts other stuff at risk.

References #2311 

### Validation steps

Run `mix test`

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
