### PR TITLE
Restore Encrypted.Binary behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Fix work order URL in failure alerts
   [#2305](https://github.com/OpenFn/lightning/pull/2305)
+- Fix error when handling existing encrypted credentials
+  [#2316](https://github.com/OpenFn/lightning/issues/2316)
 
 ## [v2.7.7] - 2024-07-18
 

--- a/lib/lightning/encrypted/binary.ex
+++ b/lib/lightning/encrypted/binary.ex
@@ -1,19 +1,4 @@
 defmodule Lightning.Encrypted.Binary do
   @moduledoc false
   use Cloak.Ecto.Binary, vault: Lightning.Vault
-
-  # From https://github.com/danielberkompas/cloak/issues/84
-  def embed_as(_format), do: :dump
-
-  def dump(nil), do: super(nil)
-
-  def dump(value) do
-    with {:ok, encrypted} <- super(value) do
-      {:ok, Base.encode64(encrypted)}
-    end
-  end
-
-  def load(nil), do: super(nil)
-
-  def load(value), do: super(Base.decode64!(value))
 end

--- a/lib/lightning/encrypted/embedded_binary.ex
+++ b/lib/lightning/encrypted/embedded_binary.ex
@@ -1,0 +1,19 @@
+defmodule Lightning.Encrypted.EmbeddedBinary do
+  @moduledoc false
+  use Cloak.Ecto.Binary, vault: Lightning.Vault
+
+  # From https://github.com/danielberkompas/cloak/issues/84
+  def embed_as(_format), do: :dump
+
+  def dump(nil), do: super(nil)
+
+  def dump(value) do
+    with {:ok, encrypted} <- super(value) do
+      {:ok, Base.encode64(encrypted)}
+    end
+  end
+
+  def load(nil), do: super(nil)
+
+  def load(value), do: super(Base.decode64!(value))
+end

--- a/lib/lightning/workflows/triggers/kafka_configuration.ex
+++ b/lib/lightning/workflows/triggers/kafka_configuration.ex
@@ -27,12 +27,12 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
     field :hosts_string, :string, virtual: true
     field :initial_offset_reset_policy, :string
     field :partition_timestamps, :map, default: %{}
-    field :password, Lightning.Encrypted.Binary
+    field :password, Lightning.Encrypted.EmbeddedBinary
     field :sasl, Ecto.Enum, values: @sasl_types, default: nil
     field :ssl, :boolean
     field :topics, {:array, :string}
     field :topics_string, :string, virtual: true
-    field :username, Lightning.Encrypted.Binary
+    field :username, Lightning.Encrypted.EmbeddedBinary
   end
 
   def changeset(kafka_configuration, attrs) do

--- a/test/lightning/encrypted/embedded_binary_test.exs
+++ b/test/lightning/encrypted/embedded_binary_test.exs
@@ -1,14 +1,14 @@
-defmodule Lightning.Encrypted.BinaryTest do
+defmodule Lightning.Encrypted.EmbeddedBinaryTest do
   use Lightning.DataCase, async: true
 
-  alias Lightning.Encrypted.Binary
+  alias Lightning.Encrypted.EmbeddedBinary
 
   test "dump/1 with nil input" do
-    assert {:ok, nil} = Binary.dump(nil)
+    assert {:ok, nil} = EmbeddedBinary.dump(nil)
   end
 
   test "load/1 with nil input" do
-    assert {:ok, nil} = Binary.load(nil)
+    assert {:ok, nil} = EmbeddedBinary.load(nil)
   end
 
   test "dump/1 and load/1 round-trip with non-trivial input" do
@@ -16,13 +16,13 @@ defmodule Lightning.Encrypted.BinaryTest do
       %{foo: "bar"}
       |> Jason.encode!()
 
-    assert {:ok, encoded} = Binary.dump(input)
+    assert {:ok, encoded} = EmbeddedBinary.dump(input)
 
     refute encoded == input
 
     assert {:ok, _encrypted} = Base.decode64(encoded)
 
-    assert {:ok, decrypted} = Binary.load(encoded)
+    assert {:ok, decrypted} = EmbeddedBinary.load(encoded)
 
     assert decrypted == input
   end


### PR DESCRIPTION
### Description

This PR fixes an issue caused when interacting with existing data encrypted using Ecto.Cloak

Closes #2316 

### Validation steps

drop your local DB.

```
git checkout 68958bbefdf102dccf6a6ebababe1f7711d8c7d9
mix ecto.migrate
```

Start Lightning locally.
Create a Webhook trigger with authentication.

From an IEx session confirm that `Lightning.Workflows.WebhookAuthMethod |> Lightning.Repo.all()` returns a result.

```
git checkout 1dd5450bfafacc746ad16d5ac0befce83c0a68b5
mix ecto.migrate
```

From an IEx session confirm that `Lightning.Workflows.WebhookAuthMethod |> Lightning.Repo.all()` produces  an '(ArgumentError) non-alphabet character found: "\x01" (byte 1)' error,

```
git checkout 2316-correct-encrypted-binary-behaviour
mix ecto.migrate
```

From an IEx session confirm that `Lightning.Workflows.WebhookAuthMethod |> Lightning.Repo.all()` returns a result and not an error.

### Additional notes for the reviewer

I have confirmed that I the encrypted credentials for a Kafka trigger still work after this change, but please let me know if you would like to confirm this for yourself.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
