### PR TITLE
Fix job editor switches to the snapshot version when body is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to
 
 - Fix work order URL in failure alerts
   [#2305](https://github.com/OpenFn/lightning/pull/2305)
+- Fix job editor switches to the snapshot version when body is changed
+  [#2306](https://github.com/OpenFn/lightning/issues/2306)
+- Fix misaligned "Retry from here" button on inspector page
+  [#2308](https://github.com/OpenFn/lightning/issues/2308)
 
 ## [v2.7.7] - 2024-07-18
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -330,7 +330,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     >
                       <.button
                         type="button"
-                        class="rounded-l-none pr-1 pl-1 focus:ring-inset"
+                        class="h-full rounded-l-none pr-1 pl-1 focus:ring-inset"
                         id="option-menu-button"
                         aria-expanded="true"
                         aria-haspopup="true"
@@ -1407,14 +1407,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   def handle_event("push-change", %{"patches" => patches}, socket) do
-    %{workflow: workflow, snapshot: snapshot} = socket.assigns
     # Apply the incoming patches to the current workflow params producing a new
     # set of params.
     {:ok, params} =
       WorkflowParams.apply_patches(socket.assigns.workflow_params, patches)
 
     version_type =
-      if snapshot == nil or workflow.lock_version == snapshot.lock_version do
+      if socket.assigns.snapshot_version_tag == "latest" do
         :workflow
       else
         :snapshot
@@ -1610,11 +1609,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   @impl true
-  def handle_info({"form_changed", %{"workflow" => params}}, socket) do
+  def handle_info({"form_changed", %{"workflow" => params}} = event, socket) do
+    dbg(event)
     {:noreply, handle_new_params(socket, params, :workflow)}
   end
 
-  def handle_info({"form_changed", %{"snapshot" => params}}, socket) do
+  def handle_info({"form_changed", %{"snapshot" => params}} = event, socket) do
+    dbg(event)
     {:noreply, handle_new_params(socket, params, :snapshot)}
   end
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1609,13 +1609,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   @impl true
-  def handle_info({"form_changed", %{"workflow" => params}} = event, socket) do
-    dbg(event)
+  def handle_info({"form_changed", %{"workflow" => params}}, socket) do
     {:noreply, handle_new_params(socket, params, :workflow)}
   end
 
-  def handle_info({"form_changed", %{"snapshot" => params}} = event, socket) do
-    dbg(event)
+  def handle_info({"form_changed", %{"snapshot" => params}}, socket) do
     {:noreply, handle_new_params(socket, params, :snapshot)}
   end
 

--- a/lib/lightning_web/live/workflow_live/editor_pane.ex
+++ b/lib/lightning_web/live/workflow_live/editor_pane.ex
@@ -78,6 +78,8 @@ defmodule LightningWeb.WorkflowLive.EditorPane do
     {:noreply, socket}
   end
 
+  # NOTE: This is dead code and should probably be removed. All events are
+  # being handled by 'push-change' in the parent liveview
   def handle_event("job_body_changed", %{"source" => source}, socket) do
     params =
       {socket.assigns.form[:body].name, source}


### PR DESCRIPTION
### Description

This PR fixes the bug on the inspector that switches the job editor back to the snapshot version whenever the user types anything in. You can check the issue #2306 for a video on this

Closes #2306 
Closes #2308 

### Validation steps
In order to validate this, we'll need to have a workflow with at least one job in it. 
We'll create a manual work order using the job as it is, then later update the job body to have something else.
This way, we'll have a work order with an older version of the job body.

**These instructions assume you've done the the above**

1. Open up the inspector from the executed step of the work order in the history page
2. The inspector will open up in "snapshot mode". Now toggle to switch to the latest version
3. Notice that the job editor content gets updated to the latest job body.
4. If you try changing the job body, the content gets updated and the editor doesn't switch back to the snapshot version


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
