### PR TITLE
2323 better nil key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 ### Added
 
+- A rudimentary optimisation for Kafka messages that do not have a key as the
+  sequence of these messages can not be guaranteed.
+  [#2323](https://github.com/OpenFn/lightning/issues/2323)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/kafka_triggers/message_candidate_set_supervisor.ex
+++ b/lib/lightning/kafka_triggers/message_candidate_set_supervisor.ex
@@ -21,36 +21,24 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisor do
     number_of_workers = Keyword.get(opts, :number_of_workers, 1)
 
     mcs_children =
-      generate_child_specs(:message_candidate_set, number_of_workers)
+      generate_child_specs(MessageCandidateSetServer, number_of_workers)
 
     message_children =
-      generate_child_specs(:message, number_of_workers)
+      generate_child_specs(MessageServer, number_of_workers)
 
     Supervisor.init(mcs_children ++ message_children, strategy: :one_for_one)
   end
 
-  def generate_worker_specs(number_of_workers) do
-    no_set_delay =
-      Application.get_env(:lightning, :kafka_triggers)[
-        :no_message_candidate_set_delay_milliseconds
-      ]
+  def generate_child_specs(server, number_of_workers) do
+    {worker, id_prefix} =
+      case server do
+        MessageCandidateSetServer ->
+          {MessageCandidateSetWorker, "mcs_worker"}
 
-    next_set_delay =
-      Application.get_env(:lightning, :kafka_triggers)[
-        :next_message_candidate_set_delay_milliseconds
-      ]
+        MessageServer ->
+          {MessageWorker, "message_worker"}
+      end
 
-    0..(number_of_workers - 1)
-    |> Enum.map(fn index ->
-      {
-        MessageCandidateSetWorker,
-        [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
-      }
-      |> Supervisor.child_spec(id: "mcs_worker_#{index}")
-    end)
-  end
-
-  def generate_child_specs(:message_candidate_set, number_of_workers) do
     no_set_delay =
       Application.get_env(:lightning, :kafka_triggers)[
         :no_message_candidate_set_delay_milliseconds
@@ -65,36 +53,12 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisor do
       0..(number_of_workers - 1)
       |> Enum.map(fn index ->
         {
-          MessageCandidateSetWorker,
+          worker,
           [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
         }
-        |> Supervisor.child_spec(id: "mcs_worker_#{index}")
+        |> Supervisor.child_spec(id: "#{id_prefix}_#{index}")
       end)
 
-    [MessageCandidateSetServer] ++ workers
-  end
-
-  def generate_child_specs(:message, number_of_workers) do
-    no_set_delay =
-      Application.get_env(:lightning, :kafka_triggers)[
-        :no_message_candidate_set_delay_milliseconds
-      ]
-
-    next_set_delay =
-      Application.get_env(:lightning, :kafka_triggers)[
-        :next_message_candidate_set_delay_milliseconds
-      ]
-
-    workers =
-      0..(number_of_workers - 1)
-      |> Enum.map(fn index ->
-        {
-          MessageWorker,
-          [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
-        }
-        |> Supervisor.child_spec(id: "message_worker_#{index}")
-      end)
-
-    [MessageServer] ++ workers
+    [server | workers]
   end
 end

--- a/lib/lightning/kafka_triggers/message_candidate_set_supervisor.ex
+++ b/lib/lightning/kafka_triggers/message_candidate_set_supervisor.ex
@@ -1,14 +1,16 @@
 defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisor do
   @moduledoc """
   Starts the server and worker processes responsible for converting messages
-  received from Kafka clusters. The sole purpose of this is to ensure that
-  messages with the same key (for a given cluster/topic configuration) are 
-  processed in the same order they were received.
+  received from Kafka clusters. There are two sets of workers and servers. This
+  is to accommodate messages that have keys (grouped into MessageCandidateSets) 
+  ans those that do not, which are processed individually.
   """
   use Supervisor
 
   alias Lightning.KafkaTriggers.MessageCandidateSetServer
   alias Lightning.KafkaTriggers.MessageCandidateSetWorker
+  alias Lightning.KafkaTriggers.MessageServer
+  alias Lightning.KafkaTriggers.MessageWorker
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -18,10 +20,13 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisor do
   def init(opts) do
     number_of_workers = Keyword.get(opts, :number_of_workers, 1)
 
-    children =
-      [MessageCandidateSetServer] ++ generate_worker_specs(number_of_workers)
+    mcs_children =
+      generate_child_specs(:message_candidate_set, number_of_workers)
 
-    Supervisor.init(children, strategy: :one_for_one)
+    message_children =
+      generate_child_specs(:message, number_of_workers)
+
+    Supervisor.init(mcs_children ++ message_children, strategy: :one_for_one)
   end
 
   def generate_worker_specs(number_of_workers) do
@@ -43,5 +48,53 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisor do
       }
       |> Supervisor.child_spec(id: "mcs_worker_#{index}")
     end)
+  end
+
+  def generate_child_specs(:message_candidate_set, number_of_workers) do
+    no_set_delay =
+      Application.get_env(:lightning, :kafka_triggers)[
+        :no_message_candidate_set_delay_milliseconds
+      ]
+
+    next_set_delay =
+      Application.get_env(:lightning, :kafka_triggers)[
+        :next_message_candidate_set_delay_milliseconds
+      ]
+
+    workers =
+      0..(number_of_workers - 1)
+      |> Enum.map(fn index ->
+        {
+          MessageCandidateSetWorker,
+          [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
+        }
+        |> Supervisor.child_spec(id: "mcs_worker_#{index}")
+      end)
+
+    [MessageCandidateSetServer] ++ workers
+  end
+
+  def generate_child_specs(:message, number_of_workers) do
+    no_set_delay =
+      Application.get_env(:lightning, :kafka_triggers)[
+        :no_message_candidate_set_delay_milliseconds
+      ]
+
+    next_set_delay =
+      Application.get_env(:lightning, :kafka_triggers)[
+        :next_message_candidate_set_delay_milliseconds
+      ]
+
+    workers =
+      0..(number_of_workers - 1)
+      |> Enum.map(fn index ->
+        {
+          MessageWorker,
+          [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
+        }
+        |> Supervisor.child_spec(id: "message_worker_#{index}")
+      end)
+
+    [MessageServer] ++ workers
   end
 end

--- a/lib/lightning/kafka_triggers/message_handling.ex
+++ b/lib/lightning/kafka_triggers/message_handling.ex
@@ -23,6 +23,7 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
   def find_message_candidate_sets do
     query =
       from t in TriggerKafkaMessage,
+        where: not is_nil(t.key),
         select: [t.trigger_id, t.topic, t.key],
         distinct: [t.trigger_id, t.topic, t.key]
 

--- a/lib/lightning/kafka_triggers/message_server.ex
+++ b/lib/lightning/kafka_triggers/message_server.ex
@@ -1,0 +1,40 @@
+defmodule Lightning.KafkaTriggers.MessageServer do
+  @moduledoc """
+  Server responsible for maintaining a list of messages with nil keys that
+  are provided to the worker processes.
+  """
+  use GenServer
+
+  alias Lightning.KafkaTriggers.MessageHandling
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def next_message do
+    GenServer.call(__MODULE__, :next_message)
+  end
+
+  @impl true
+  def init(_opts) do
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_call(:next_message, _from, current_messages) do
+    {message, remaining_messages} = pop_message(current_messages)
+
+    {:reply, message, remaining_messages}
+  end
+
+  defp pop_message([]) do
+    case MessageHandling.find_nil_key_message_ids() do
+      [] -> {nil, []}
+      result -> pop_message(result)
+    end
+  end
+
+  defp pop_message([message | remaining_messages]) do
+    {message, remaining_messages}
+  end
+end

--- a/lib/lightning/kafka_triggers/message_worker.ex
+++ b/lib/lightning/kafka_triggers/message_worker.ex
@@ -1,0 +1,38 @@
+defmodule Lightning.KafkaTriggers.MessageWorker do
+  @moduledoc """
+  Requests a message from the MessageServer and manages the state of the
+  returned message.
+  """
+  use GenServer
+
+  alias Lightning.KafkaTriggers.MessageHandling
+  alias Lightning.KafkaTriggers.MessageServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    Process.send_after(self(), :request_message, 1000)
+
+    {:ok, opts}
+  end
+
+  @impl true
+  def handle_info(:request_message, state) do
+    next_message_delay = Keyword.fetch!(state, :next_set_delay)
+    no_message_delay = Keyword.fetch!(state, :no_set_delay)
+
+    case MessageServer.next_message() do
+      nil ->
+        Process.send_after(self(), :request_message, no_message_delay)
+
+      message_id ->
+        MessageHandling.process_message_for(message_id)
+        Process.send_after(self(), :request_message, next_message_delay)
+    end
+
+    {:noreply, state}
+  end
+end

--- a/test/lightning/kafka_triggers/message_candidate_set_supervisor_test.exs
+++ b/test/lightning/kafka_triggers/message_candidate_set_supervisor_test.exs
@@ -1,9 +1,11 @@
 defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
   use Lightning.DataCase, async: false
 
+  alias Lightning.KafkaTriggers.MessageServer
   alias Lightning.KafkaTriggers.MessageCandidateSetServer
   alias Lightning.KafkaTriggers.MessageCandidateSetSupervisor
   alias Lightning.KafkaTriggers.MessageCandidateSetWorker
+  alias Lightning.KafkaTriggers.MessageWorker
 
   describe ".start_link/1" do
     test "successfully starts the supervisor" do
@@ -18,17 +20,29 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
       %{pid: pid}
     end
 
-    test "starts server, and single worker", %{pid: pid} do
+    test "starts single server and single worker per type", %{pid: pid} do
       assert [
                {
+                 "message_worker_0",
+                 _w2_pid,
+                 :worker,
+                 [MessageWorker]
+               },
+               {
+                 MessageServer,
+                 _s2_pid,
+                 :worker,
+                 [MessageServer]
+               },
+               {
                  "mcs_worker_0",
-                 _w_pid,
+                 _w1_pid,
                  :worker,
                  [MessageCandidateSetWorker]
                },
                {
                  MessageCandidateSetServer,
-                 _s_pid,
+                 _s1_pid,
                  :worker,
                  [MessageCandidateSetServer]
                }
@@ -47,6 +61,24 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
     test "starts server, and requested number of workers", %{pid: pid} do
       assert [
                {
+                 "message_worker_1",
+                 _w4_pid,
+                 :worker,
+                 [MessageWorker]
+               },
+               {
+                 "message_worker_0",
+                 _w3_pid,
+                 :worker,
+                 [MessageWorker]
+               },
+               {
+                 MessageServer,
+                 _s2_pid,
+                 :worker,
+                 [MessageServer]
+               },
+               {
                  "mcs_worker_1",
                  _w2_pid,
                  :worker,
@@ -60,7 +92,7 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
                },
                {
                  MessageCandidateSetServer,
-                 _s_pid,
+                 _s1_pid,
                  :worker,
                  [MessageCandidateSetServer]
                }
@@ -101,6 +133,86 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
       ]
 
       assert MessageCandidateSetSupervisor.generate_worker_specs(2) == expected
+    end
+  end
+
+  describe "generate_child_specs/2 - message_candidate_set" do
+    test "generates server spec and requested number of worker specs" do
+      no_set_delay =
+        Application.get_env(:lightning, :kafka_triggers)[
+          :no_message_candidate_set_delay_milliseconds
+        ]
+
+      next_set_delay =
+        Application.get_env(:lightning, :kafka_triggers)[
+          :next_message_candidate_set_delay_milliseconds
+        ]
+
+      assert no_set_delay != nil
+      assert next_set_delay != nil
+
+      expected = [
+        MessageCandidateSetServer,
+        Supervisor.child_spec(
+          {
+            MessageCandidateSetWorker,
+            [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
+          },
+          id: "mcs_worker_0"
+        ),
+        Supervisor.child_spec(
+          {
+            MessageCandidateSetWorker,
+            [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
+          },
+          id: "mcs_worker_1"
+        )
+      ]
+
+      result =
+        :message_candidate_set
+        |> MessageCandidateSetSupervisor.generate_child_specs(2)
+
+      assert result == expected
+    end
+  end
+
+  describe "generate_child_specs/2 - message" do
+    test "generates server spec and requested number of worker specs" do
+      no_set_delay =
+        Application.get_env(:lightning, :kafka_triggers)[
+          :no_message_candidate_set_delay_milliseconds
+        ]
+
+      next_set_delay =
+        Application.get_env(:lightning, :kafka_triggers)[
+          :next_message_candidate_set_delay_milliseconds
+        ]
+
+      assert no_set_delay != nil
+      assert next_set_delay != nil
+
+      expected = [
+        MessageServer,
+        Supervisor.child_spec(
+          {
+            MessageWorker,
+            [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
+          },
+          id: "message_worker_0"
+        ),
+        Supervisor.child_spec(
+          {
+            MessageWorker,
+            [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
+          },
+          id: "message_worker_1"
+        )
+      ]
+
+      result = :message |> MessageCandidateSetSupervisor.generate_child_specs(2)
+
+      assert result == expected
     end
   end
 end

--- a/test/lightning/kafka_triggers/message_candidate_set_supervisor_test.exs
+++ b/test/lightning/kafka_triggers/message_candidate_set_supervisor_test.exs
@@ -100,43 +100,7 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
     end
   end
 
-  describe ".generate_worker_specs/1" do
-    test "generates the requested number of worker specs" do
-      no_set_delay =
-        Application.get_env(:lightning, :kafka_triggers)[
-          :no_message_candidate_set_delay_milliseconds
-        ]
-
-      next_set_delay =
-        Application.get_env(:lightning, :kafka_triggers)[
-          :next_message_candidate_set_delay_milliseconds
-        ]
-
-      assert no_set_delay != nil
-      assert next_set_delay != nil
-
-      expected = [
-        Supervisor.child_spec(
-          {
-            MessageCandidateSetWorker,
-            [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
-          },
-          id: "mcs_worker_0"
-        ),
-        Supervisor.child_spec(
-          {
-            MessageCandidateSetWorker,
-            [no_set_delay: no_set_delay, next_set_delay: next_set_delay]
-          },
-          id: "mcs_worker_1"
-        )
-      ]
-
-      assert MessageCandidateSetSupervisor.generate_worker_specs(2) == expected
-    end
-  end
-
-  describe "generate_child_specs/2 - message_candidate_set" do
+  describe "generate_child_specs/2 - MessageCandidateSetServer" do
     test "generates server spec and requested number of worker specs" do
       no_set_delay =
         Application.get_env(:lightning, :kafka_triggers)[
@@ -170,14 +134,14 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
       ]
 
       result =
-        :message_candidate_set
+        MessageCandidateSetServer
         |> MessageCandidateSetSupervisor.generate_child_specs(2)
 
       assert result == expected
     end
   end
 
-  describe "generate_child_specs/2 - message" do
+  describe "generate_child_specs/2 - MessageServer" do
     test "generates server spec and requested number of worker specs" do
       no_set_delay =
         Application.get_env(:lightning, :kafka_triggers)[
@@ -210,7 +174,9 @@ defmodule Lightning.KafkaTriggers.MessageCandidateSetSupervisorTest do
         )
       ]
 
-      result = :message |> MessageCandidateSetSupervisor.generate_child_specs(2)
+      result =
+        MessageServer
+        |> MessageCandidateSetSupervisor.generate_child_specs(2)
 
       assert result == expected
     end

--- a/test/lightning/kafka_triggers/message_handling_test.exs
+++ b/test/lightning/kafka_triggers/message_handling_test.exs
@@ -21,7 +21,7 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
   alias Lightning.WorkOrder
 
   describe ".find_message_candidate_sets" do
-    test "returns all distinct combinations of trigger, topic, key" do
+    test "returns distinct combinations of trigger, topic, non-nil key" do
       trigger_1 = insert(:trigger, type: :kafka)
       trigger_2 = insert(:trigger, type: :kafka)
 
@@ -75,13 +75,13 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
 
       sets = MessageHandling.find_message_candidate_sets()
 
-      assert sets |> Enum.count() == 5
+      assert sets |> Enum.count() == 4
 
       assert [%{trigger_id: _, topic: _, key: _} | _other] = sets
 
       assert sets |> number_of_sets_for(message) == 1
       assert sets |> number_of_sets_for(different_key) == 1
-      assert sets |> number_of_sets_for(nil_key) == 1
+      assert sets |> number_of_sets_for(nil_key) == 0
       assert sets |> number_of_sets_for(different_topic) == 1
       assert sets |> number_of_sets_for(different_trigger) == 1
     end

--- a/test/lightning/kafka_triggers/message_handling_test.exs
+++ b/test/lightning/kafka_triggers/message_handling_test.exs
@@ -98,6 +98,36 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
     end
   end
 
+  describe ".find_nil_key_message_ids/0" do
+    setup do
+      message_1 = insert(:trigger_kafka_message, topic: "topic-1", key: nil)
+      message_2 = insert(:trigger_kafka_message, topic: "topic-2", key: nil)
+
+      _not_nil_key_message =
+        insert(
+          :trigger_kafka_message,
+          topic: "topic-3",
+          key: "not-nil"
+        )
+
+      %{
+        message_1: message_1,
+        message_2: message_2
+      }
+    end
+
+    test "returns the ids of all TriggerKafkaMessage instances with nil keys", %{
+      message_1: message_1,
+      message_2: message_2
+    } do
+      expected = [message_1.id, message_2.id] |> Enum.sort()
+
+      result = MessageHandling.find_nil_key_message_ids()
+
+      assert result |> Enum.sort() == expected
+    end
+  end
+
   describe ".process_candidate_for/1" do
     setup do
       trigger = insert(:trigger, type: :kafka)
@@ -380,6 +410,7 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
       message_2: message_2,
       other_message: other_message
     } do
+      # Link a WorkOrder
       assert MessageHandling.process_candidate_for(candidate_set) == :ok
 
       assert MessageHandling.process_candidate_for(candidate_set) == :ok
@@ -647,6 +678,284 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
     def states_other_than_success do
       ([:rejected, :pending, :running] ++ Run.final_states())
       |> Enum.reject(&(&1 == :success))
+    end
+  end
+
+  describe ".process_message_for/1" do
+    setup do
+      trigger = insert(:trigger, type: :kafka)
+
+      other_message =
+        insert(
+          :trigger_kafka_message,
+          key: nil,
+          offset: 1,
+          topic: "other-test-topic",
+          work_order: nil
+        )
+
+      message =
+        insert(
+          :trigger_kafka_message,
+          data: %{triggers: :test} |> Jason.encode!(),
+          key: "test-key",
+          metadata: %{
+            offset: 1,
+            partition: 1,
+            topic: "test-topic"
+          },
+          offset: 1,
+          processing_data: %{"existing" => "data"},
+          trigger: trigger,
+          topic: "test-topic",
+          work_order: nil
+        )
+
+      %{
+        message: message,
+        other_message: other_message
+      }
+    end
+
+    setup [:stub_usage_limiter_ok, :verify_on_exit!]
+
+    test "returns :ok, does nothing if message does not exist", %{
+      message: message
+    } do
+      message |> Repo.delete!()
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+    end
+
+    test "links to a work_order if message is not already linked", %{
+      message: message
+    } do
+      %{trigger: %{workflow: workflow} = trigger} = message
+      project_id = workflow.project_id
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      %{work_order: work_order} =
+        TriggerKafkaMessage
+        |> Repo.get(message.id)
+        |> Repo.preload(
+          work_order: [
+            [dataclip: Invocation.Query.dataclip_with_body()],
+            :runs,
+            trigger: [workflow: [:project]],
+            workflow: [:project]
+          ]
+        )
+
+      expected_body = %{
+        "data" => %{
+          "triggers" => "test"
+        },
+        "request" => %{
+          "offset" => 1,
+          "partition" => 1,
+          "topic" => "test-topic"
+        }
+      }
+
+      assert %WorkOrder{
+               dataclip: %{
+                 body: ^expected_body,
+                 project_id: ^project_id,
+                 type: :kafka
+               },
+               state: :pending,
+               trigger: ^trigger,
+               workflow: ^workflow
+             } = work_order
+    end
+
+    test "creates a rejected work order if run creation is constrained", %{
+      message: message
+    } do
+      %{trigger: %{workflow: workflow} = trigger} = message
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :too_many_runs,
+         %Message{text: "Too many runs in the last minute"}}
+      end)
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      %{work_order: work_order} =
+        TriggerKafkaMessage
+        |> Repo.get(message.id)
+        |> Repo.preload(
+          work_order: [
+            [dataclip: Invocation.Query.dataclip_with_body()],
+            :runs,
+            trigger: [workflow: [:project]],
+            workflow: [:project]
+          ]
+        )
+
+      expected_body = %{
+        "data" => %{
+          "triggers" => "test"
+        },
+        "request" => %{
+          "offset" => 1,
+          "partition" => 1,
+          "topic" => "test-topic"
+        }
+      }
+
+      assert %WorkOrder{
+               dataclip: %{
+                 body: ^expected_body,
+                 project_id: ^project_id,
+                 type: :kafka
+               },
+               state: :rejected,
+               trigger: ^trigger,
+               workflow: ^workflow
+             } = work_order
+    end
+
+    test "does not create a workorder if workorder creation is constrained", %{
+      message: message
+    } do
+      %{trigger: %{workflow: workflow}} = message
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :runs_hard_limit,
+         %Lightning.Extensions.Message{text: "Runs limit exceeded"}}
+      end)
+
+      expected =
+        message.processing_data
+        |> Map.merge(%{"errors" => ["Runs limit exceeded"]})
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      %{work_order_id: nil, processing_data: processing_data} =
+        TriggerKafkaMessage
+        |> Repo.get(message.id)
+
+      assert processing_data == expected
+    end
+
+    test "message - no workorder - not JSON - error message - no creation", %{
+      message: message
+    } do
+      message
+      |> TriggerKafkaMessage.changeset(%{data: "not a JSON object"})
+      |> Repo.update!()
+
+      expected =
+        message.processing_data
+        |> Map.merge(%{"errors" => ["Data is not a JSON object"]})
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      %{work_order_id: nil, processing_data: processing_data} =
+        TriggerKafkaMessage
+        |> Repo.get(message.id)
+
+      assert processing_data == expected
+    end
+
+    test "message - no workorder - not a map - error message - no creation", %{
+      message: message
+    } do
+      message
+      |> TriggerKafkaMessage.changeset(%{data: "\"not a JSON object\""})
+      |> Repo.update!()
+
+      expected =
+        message.processing_data
+        |> Map.merge(%{"errors" => ["Data is not a JSON object"]})
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      %{work_order_id: nil, processing_data: processing_data} =
+        TriggerKafkaMessage
+        |> Repo.get(message.id)
+
+      assert processing_data == expected
+    end
+
+    test "message - no workorder - valid data - has errors - no creation", %{
+      message: message
+    } do
+      message
+      |> TriggerKafkaMessage.changeset(%{
+        processing_data: %{
+          "errors" => ["Anything"],
+          "other" => ["Stuff"]
+        }
+      })
+      |> Repo.update!()
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      assert %{work_order_id: nil} =
+               TriggerKafkaMessage |> Repo.get(message.id)
+    end
+
+    test "if message has successful work_order, deletes candidate", %{
+      message: message,
+      other_message: other_message
+    } do
+      MessageHandling.process_message_for(message.id)
+
+      updated_message_1 =
+        TriggerKafkaMessage
+        |> Repo.get(message.id)
+        |> Repo.preload(:work_order)
+
+      %{work_order: work_order} = updated_message_1
+
+      work_order
+      |> WorkOrder.changeset(%{state: :success})
+      |> Repo.update()
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      assert TriggerKafkaMessage |> Repo.get(message.id) == nil
+      assert TriggerKafkaMessage |> Repo.get(other_message.id) != nil
+    end
+
+    test "if message does not have successful work_order, does not delete", %{
+      message: message,
+      other_message: other_message
+    } do
+      # Link a WorkOrder
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      assert MessageHandling.process_message_for(message.id) == :ok
+
+      assert TriggerKafkaMessage |> Repo.get(message.id) != nil
+      assert TriggerKafkaMessage |> Repo.get(other_message.id) != nil
+    end
+
+    test "rolls back if an error occurs", %{
+      message: message
+    } do
+      with_mock(
+        TriggerKafkaMessage,
+        [:passthrough],
+        changeset: fn _message, _changes -> raise "rollback" end
+      ) do
+        assert_raise RuntimeError, ~r/rollback/, fn ->
+          MessageHandling.process_message_for(message.id)
+        end
+      end
+
+      assert WorkOrder |> Repo.all() == []
     end
   end
 

--- a/test/lightning/kafka_triggers/message_server_test.exs
+++ b/test/lightning/kafka_triggers/message_server_test.exs
@@ -1,0 +1,75 @@
+defmodule Lightning.KafkaTriggers.MessageServerTest do
+  use Lightning.DataCase
+
+  alias Lightning.KafkaTriggers.MessageServer
+
+  describe ".start_link/1" do
+    test "successfully starts the server" do
+      pid = start_supervised!(MessageServer)
+
+      assert GenServer.whereis(MessageServer) == pid
+    end
+
+    test "initialises with an empty list" do
+      assert pid = start_supervised!(MessageServer)
+
+      assert :sys.get_state(pid) == []
+    end
+  end
+
+  describe ".next_message/0" do
+    setup do
+      pid = start_supervised!(MessageServer)
+
+      message_1 = insert(:trigger_kafka_message, topic: "topic-1", key: nil)
+      message_2 = insert(:trigger_kafka_message, topic: "topic-2", key: nil)
+
+      %{message_1: message_1, message_2: message_2, pid: pid}
+    end
+
+    test "returns nil if there are no messages", %{
+      message_1: message_1,
+      message_2: message_2
+    } do
+      message_1 |> Repo.delete!()
+      message_2 |> Repo.delete!()
+
+      assert MessageServer.next_message() == nil
+    end
+
+    test "returns a message id every time when called", %{
+      message_1: message_1,
+      message_2: message_2
+    } do
+      first_id = MessageServer.next_message()
+      second_id = MessageServer.next_message()
+
+      expected = [message_1.id, message_2.id] |> Enum.sort()
+
+      assert [first_id, second_id] |> Enum.sort() == expected
+    end
+
+    test "refreshes state once all cached messages have been returned", %{
+      message_1: message_1,
+      message_2: message_2,
+      pid: pid
+    } do
+      _first_id = MessageServer.next_message()
+      _second_id = MessageServer.next_message()
+
+      assert :sys.get_state(pid) == []
+
+      message_3 = insert(:trigger_kafka_message, topic: "topic-3", key: nil)
+
+      # Now we get all the messages again, including message_3
+
+      first_id = MessageServer.next_message()
+      second_id = MessageServer.next_message()
+      third_id = MessageServer.next_message()
+
+      expected = [message_1.id, message_2.id, message_3.id] |> Enum.sort()
+
+      assert [first_id, second_id, third_id] |> Enum.sort() == expected
+    end
+  end
+end

--- a/test/lightning/kafka_triggers/message_worker_test.exs
+++ b/test/lightning/kafka_triggers/message_worker_test.exs
@@ -1,0 +1,103 @@
+defmodule Lightning.KafkaTriggers.MessageWorkerTest do
+  use Lightning.DataCase
+
+  alias Lightning.KafkaTriggers.MessageServer
+  alias Lightning.KafkaTriggers.MessageWorker
+  alias Lightning.Repo
+
+  setup do
+    start_supervised!(MessageServer)
+
+    %{state: [no_set_delay: 200, next_set_delay: 100]}
+  end
+
+  describe ".start_link/1" do
+    test "successfully starts the worker with provided state", %{state: opts} do
+      assert pid = start_supervised!({MessageWorker, opts})
+
+      assert :sys.get_state(pid) == opts
+    end
+  end
+
+  describe ".init/1" do
+    test "successfully starts the worker with requested state", %{
+      state: state
+    } do
+      assert {:ok, ^state} = MessageWorker.init(state)
+    end
+
+    test "enqueues a message to trigger a request for a message", %{
+      state: state
+    } do
+      MessageWorker.init(state)
+
+      assert_receive :request_message, 1100
+    end
+  end
+
+  describe ".handle_info :request_message - no message available" do
+    test "enqueues a request to repeat the lookup after a delay" do
+      delay = 100
+
+      state = [no_set_delay: delay, next_set_delay: delay * 10]
+
+      MessageWorker.handle_info(:request_message, state)
+
+      assert_receive :request_message, delay + 100
+    end
+
+    test "returns the passed in state", %{state: state} do
+      response =
+        MessageWorker.handle_info(:request_message, state)
+
+      assert response == {:noreply, state}
+    end
+  end
+
+  describe ".handle_info :request_message - message available" do
+    setup do
+      message =
+        insert(
+          :trigger_kafka_message,
+          topic: "topic-1",
+          key: nil,
+          work_order: nil
+        )
+
+      %{message: message}
+    end
+
+    test "returns the passed in state", %{state: state} do
+      response =
+        MessageWorker.handle_info(:request_message, state)
+
+      assert response == {:noreply, state}
+    end
+
+    test "processes the message", %{
+      message: message,
+      state: state
+    } do
+      MessageWorker.handle_info(:request_message, state)
+
+      reloaded_message =
+        Lightning.KafkaTriggers.TriggerKafkaMessage
+        |> Repo.get!(message.id)
+        |> Repo.preload(:work_order)
+
+      %{work_order: work_order} = reloaded_message
+
+      assert work_order != nil
+    end
+
+    test "enqueues a request to fetch another message after a delay" do
+      delay = 100
+
+      state = [no_set_delay: delay * 10, next_set_delay: delay]
+
+      MessageWorker.handle_info(:request_message, state)
+
+      assert_receive :request_message, delay + 100
+    end
+  end
+end


### PR DESCRIPTION
### Description

The test data that is being received as part of load testing the kafka cluster does not have message keys. This means that the existing message handling of grouping by trigger, topic and key is horribly inefficient.

This is a very crude band-aid that is being implemented to treat messages without keys differently so that load testing can continue. Once load-testing has completed, the nil-key message handling must be refactored to allow for distinct configuration in terms of processing delays as well as to remove duplication between the two code paths.

Closes #2323 

### Validation steps

Note: To run the server locally the KAFKA_TRIGGERS_ENABLED ENV var must be set to yes. However, if you want
to run the tests, you need to set this to 'no' (it defaults to 'no', so you should only need to remove/comment out the ENV var).

Setup a Kafka trigger (via the UI) pointing at either a [local](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster) or [remote](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-using-a-confluent-cloud-instance) Kafka cluster. When setting up the trigger, set the 'Initial offset reset policy' to `:earliest`.

Publish a few messages using `kcat` aka `kafkacat`. You will want to try messages with and without keys.

With a key (using the local cluster, assuming you have a topic named `baz_topic`):

```
cat message.json | kcat -P -b 127.0.0.1:9094 -t baz_topic -k 202407211
```
Without a key:
```
cat other_message.json | kcat -P -b 127.0.0.1:9094 -t baz_topic
```

Confirm that the messages with keys and without keys were received (they may take a few minutes to show up).

Full testing information can be found in kafka_testing/KAFKA_ARCHITECTURE.md.

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
