### PR TITLE
Do not expect :earliest or :latest to exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 ### Changed
 
 ### Fixed
+- Fix an intermittent bug when trying to intern Kafka offset reset policy.
+  [#2327](https://github.com/OpenFn/lightning/issues/2327)
 
 ## [v2.7.9] - 2024-07-24
 

--- a/lib/lightning/kafka_triggers.ex
+++ b/lib/lightning/kafka_triggers.ex
@@ -50,7 +50,7 @@ defmodule Lightning.KafkaTriggers do
   defp initial_policy(%{initial_offset_reset_policy: initial_policy}) do
     cond do
       initial_policy in ["earliest", "latest"] ->
-        initial_policy |> String.to_existing_atom()
+        initial_policy |> String.to_atom()
 
       String.match?(initial_policy, ~r/^\d+$/) ->
         {timestamp, _remainder} = Integer.parse(initial_policy)


### PR DESCRIPTION
### Description

This PR fixes an intermittent issue setting up Kafka triggers that occurred when it tried to intern the offset reset policy as an existing atom.

Closes #2327 

### Validation steps

Reset your Lightning DB.
Setup a local Kafka [cluster](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster).
Start Lightning and create a Kafka trigger (below assumes that you have a topic named `baz_topic`):

![image](https://github.com/user-attachments/assets/19f3acd5-1dab-4b2d-b21e-81d5cdbe7d1f)

In an IEx session, run `GenServer.whereis(:kafka_pipeline_supervisor) |> Supervisor.which_children()` - you should see something like the below:

```
[
  {"e1bc3e06-a74f-4706-b6ee-56539fe95a22", #PID<0.1054.0>, :worker,
   [Lightning.KafkaTriggers.Pipeline]}
]
```


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
