### PR TITLE
Use `AccountHook Extension` to register new users invited in a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Move runtime logic into module
   [#2338](https://github.com/OpenFn/lightning/pull/2338)
+- Use `AccountHook Extension` to register new users invited in a project
+  [#2341](https://github.com/OpenFn/lightning/pull/2341)
 
 ### Fixed
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -23,6 +23,7 @@ defmodule Lightning.Projects do
   alias Lightning.Repo
   alias Lightning.Run
   alias Lightning.RunStep
+  alias Lightning.Services.AccountHook
   alias Lightning.Services.ProjectHook
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Snapshot
@@ -749,22 +750,15 @@ defmodule Lightning.Projects do
         |> Map.take([:first_name, :last_name, :email])
         |> Map.put(:password, generate_random_password())
 
-      case User.user_registration_changeset(user_params)
-           |> Ecto.Changeset.apply_action(:insert) do
-        {:ok, user_data} ->
-          Multi.insert(
-            multi,
-            {:new_user, collaborator.email},
-            struct!(User, user_data)
-          )
-
-        {:error, _changeset} ->
-          Multi.error(
-            multi,
-            {:new_user, collaborator.email},
-            :user_registration_failed
-          )
-      end
+      Multi.run(
+        multi,
+        {:new_user, collaborator.email},
+        fn _repo, _changes ->
+          with {:error, _reason} <- AccountHook.handle_register_user(user_params) do
+            {:error, :user_registration_failed}
+          end
+        end
+      )
     end)
   end
 

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -45,6 +45,11 @@ defmodule LightningWeb.ChannelCase do
       Lightning.Extensions.UsageLimiter
     )
 
+    Mox.stub_with(
+      Lightning.Extensions.MockAccountHook,
+      Lightning.Extensions.AccountHook
+    )
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -52,6 +52,11 @@ defmodule LightningWeb.ConnCase do
       Lightning.Extensions.UsageLimiter
     )
 
+    Mox.stub_with(
+      Lightning.Extensions.MockAccountHook,
+      Lightning.Extensions.AccountHook
+    )
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -46,6 +46,11 @@ defmodule Lightning.DataCase do
       Lightning.Extensions.UsageLimiter
     )
 
+    Mox.stub_with(
+      Lightning.Extensions.MockAccountHook,
+      Lightning.Extensions.AccountHook
+    )
+
     pid =
       Ecto.Adapters.SQL.Sandbox.start_owner!(Lightning.Repo,
         shared: not tags[:async]

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,6 +26,10 @@ Mox.defmock(Lightning.Extensions.MockUsageLimiter,
   for: Lightning.Extensions.UsageLimiting
 )
 
+Mox.defmock(Lightning.Extensions.MockAccountHook,
+  for: Lightning.Extensions.AccountHooking
+)
+
 Mox.defmock(Lightning.MockConfig, for: Lightning.Config)
 Application.put_env(:lightning, Lightning.Config, Lightning.MockConfig)
 
@@ -36,7 +40,7 @@ Application.put_env(:lightning, Lightning.Extensions,
   rate_limiter: Lightning.Extensions.MockRateLimiter,
   usage_limiter: Lightning.Extensions.MockUsageLimiter,
   run_queue: Lightning.Extensions.FifoRunQueue,
-  account_hook: Lightning.Extensions.AccountHook,
+  account_hook: Lightning.Extensions.MockAccountHook,
   project_hook: Lightning.Extensions.ProjectHook
 )
 


### PR DESCRIPTION
### Description

This PR uses the `AccountHook Extension` for registering invited users instead of the generic user registration flow.
The current user signup also uses the `AccountHook Extension` for registration. 

Closes OpenFn/thunderbolt#278

### Validation steps

This can be validated in thunderbolt. 
There is a a test that has been added which validates that the `AccountHook` is called


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
