### PR TITLE
Set max_frame_size to 11MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@ and this project adheres to
 ### Changed
 - Make root layout configurable
   [#2310](https://github.com/OpenFn/lightning/pull/2310)
-
 - Use snapshots when initiating Github Sync
   [#1827](https://github.com/OpenFn/lightning/issues/1827)
-
 - Move runtime logic into module
   [#2338](https://github.com/OpenFn/lightning/pull/2338)
 
 ### Fixed
+
+- Limit frame size of worker socket connections
+  [#2339](https://github.com/OpenFn/lightning/issues/2339)
 
 ## [v2.7.11] - 2024-07-26
 

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -388,12 +388,6 @@ defmodule Lightning.Config.Bootstrap do
           port: port,
           compress: true,
           protocol_options: [
-            max_frame_size:
-              Application.get_env(
-                :lightning,
-                :max_dataclip_size_bytes,
-                10_000_000
-              ),
             # Note that if a request is more than 10x the max dataclip size, we cut
             # the connection immediately to prevent memory issues via the
             # :max_skip_body_length setting.

--- a/lib/lightning_web/endpoint.ex
+++ b/lib/lightning_web/endpoint.ex
@@ -16,7 +16,11 @@ defmodule LightningWeb.Endpoint do
     websocket: [connect_info: [session: @session_options]]
 
   socket "/worker", LightningWeb.WorkerSocket,
-    websocket: [error_handler: {LightningWeb.WorkerSocket, :handle_error, []}],
+    websocket: [
+      error_handler: {LightningWeb.WorkerSocket, :handle_error, []},
+      compress: true,
+      max_frame_size: 11_000_000
+    ],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.


### PR DESCRIPTION
### Description

`max_frame_size` needs to be set at the socket in endpoint, not in the Endpoint config.

Setting it to 11MB statically for now, no easy way to make this dynamic since `socket` doesn't appear to use plug builder (i.e. can't use Replug).

What happens when a worker sends a payload that is too big it drops the connection on the floor, not exactly what we want but ok for now I guess. The worker will see a timeout error on the socket.

Fixes #2339


### Validation steps


Setting the limit to 1MB and changing the endpoint to:

```diff
diff --git a/lib/lightning_web/endpoint.ex b/lib/lightning_web/endpoint.ex
index 2c4f4f7ad..410c855ee 100644
--- a/lib/lightning_web/endpoint.ex
+++ b/lib/lightning_web/endpoint.ex
@@ -16,7 +16,11 @@ defmodule LightningWeb.Endpoint do
     websocket: [connect_info: [session: @session_options]]
 
   socket "/worker", LightningWeb.WorkerSocket,
-    websocket: [error_handler: {LightningWeb.WorkerSocket, :handle_error, []}],
+    websocket: [
+      error_handler: {LightningWeb.WorkerSocket, :handle_error, []},
+      compress: true,
+      max_frame_size: 1_000
+    ],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.
```

When a generate an output data clip thats more than a megabyte:

```js
fn(state => {
  return new Promise((resolve) => {
    setTimeout(() => {  // ignore the timeout...
      let big = new Array(1024 * 1024).fill('z').join('');
      resolve({...state, step: 1, big})
      }, 10000);
  })
});
```  

Then the socket gets dropped on the floor:

```
[info] [SRV] ✘ 5d83a439-da2f-4e40-a35e-c34b5262a848 :: step:complete :: ERR: timeout
[info] [SRV] ✘ Error: timeout
[info]     at Object.callback (file:///Users/stuart/Sourcecode/lightning/assets/node_modules/@openfn/ws-worker/dist/start.js:923:12)
...
```


### Additional notes for the reviewer

There will be complementary work on the worker side to stop big data clips _before_ they get sent. So in the long run this acts as a safety net for DoS and bugs.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
