### PR TITLE
Change `Lightning.LogMessage` module to add support for casting floats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Correctly handle floats in LogMessage
+  [#2348](https://github.com/OpenFn/lightning/issues/2348)
+
 ## [v2.7.12] - 2024-07-31
 
 ### Changed

--- a/lib/lightning/ecto_types.ex
+++ b/lib/lightning/ecto_types.ex
@@ -85,6 +85,9 @@ defmodule Lightning.LogMessage do
   def cast(d) when is_integer(d),
     do: Ecto.Type.cast(:string, d |> Integer.to_string())
 
+  def cast(d) when is_float(d),
+    do: Ecto.Type.cast(:string, d |> Float.to_string())
+
   def cast(d) when is_list(d) do
     {:ok,
      d

--- a/test/lightning/ecto_types_test.exs
+++ b/test/lightning/ecto_types_test.exs
@@ -21,6 +21,16 @@ defmodule Lightning.EctoTypesTest do
       assert {:ok, ~s<{"baz":null,"foo":"bar"}>} =
                LogMessage.cast(%{"foo" => "bar", "baz" => nil})
     end
+
+    test "can be cast from an integer" do
+      assert {:ok, ~s<12345>} =
+               LogMessage.cast(12345)
+    end
+
+    test "can be cast from a float" do
+      assert {:ok, ~s<5.893>} =
+               LogMessage.cast(5.893)
+    end
   end
 
   describe "UnixDateTime" do


### PR DESCRIPTION
Logging a float number in a job causes an exception in the LogMessage casting module.
Added a pattern match to support this.

Fixes #2348

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
