### PR TITLE
2351 nil key optimisation final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to
 ### Added
 
 ### Changed
+- Kafka messages without keys are synchronously converted into a
+  Workorder, Dataclip and Run. Messages with keys are stored as
+  TriggerKafkaMessage records, however the code needed to process them has been
+  disabled, pending removal.
+  [#2351] (https://github.com/OpenFn/lightning/issues/2351)
 
 ### Fixed
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -118,30 +118,6 @@ be able to edit any triggers created before the feature was disabled.
 
 #### Performance Tuning
 
-Kafka triggers currently rely on the existence of Message Candidate Sets. These
-are a temporary measure to ensure that message sequence for messages with
-identical keys are preserved. As part of this mechanism, Lightning uses
-a MessageCandidateSetWorker to convert messages into WorkOrders.
-
-By default, there is only one worker process, but the number of workers can be
-increased by setting the `KAFKA_NUMBER_OF_MESSAGE_CANDIDATE_SET_WORKERS`
-environment variable. Increasing this may increase the rate at which messages
-received by Kafka are converted to WorkOrders. If you find that you have a
-large number of records in the `trigger_kafka_messages` table, then increasing
-the number of workers may help to reduce this backlog.
-
-The MessageCandidateSetWorker has two configurable processing delays:
-
-- The delay before the worker requests the next Message Candidate Set for
-  consideration after it has finished processing the current Message Candidate
-  Set. This can be set by configuring the
-  `KAFKA_NEXT_MESSAGE_CANDIDATE_SET_DELAY_MILLISECONDS` environment variable. The
-  default value is currently 250ms.
-- The delay before the worker requests the next Message Candidate Set for
-  consideration when there are no Message Candidate Sets available. This can be
-  set by configuring the `KAFKA_NO_MESSAGE_CANDIDATE_SET_DELAY_MILLISECONDS`
-  environment variable. The default value is currently 10000ms.
-
 The number of Kafka consumers in the consumer group can be modified by setting
 the `KAFKA_NUMBER_OF_CONSUMERS` environment variable. The default value is
 currently 1. The optimal setting is one consumer per topic partition. NOTE:
@@ -156,8 +132,16 @@ message every 10 seconds). The default value is 1.
 Processing concurrency within the Kafka Broadway pipeline is controlled by the
 `KAFKA_NUMBER_OF_PROCESSORS` environment variable. Modifying this, modifies the
 number of processors that are downstream of the Kafka consumer, so an increase
-in this value should inrcease throughput (when factoring in the rate limit set
+in this value should increase throughput (when factoring in the rate limit set
 by `KAFKA_NUMBER_OF_MESSAGES_PER_SECOND`). The default value is 1.
+
+#### Deduplication
+
+Each Kafka trigger maintains record of the topic, parition and offset for each
+message received. This to protect against the ingestion of duplicate messages
+from the cluster. These records are periodically cleaned out. The duration for
+which they are retained is controlled by
+`KAFKA_DUPLICATE_TRACKING_RETENTION_SECONDS`. The default value is 3600.
 
 ### Other config
 

--- a/lib/lightning/kafka_triggers/message_handling.ex
+++ b/lib/lightning/kafka_triggers/message_handling.ex
@@ -102,7 +102,7 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
     create_work_order(message, trigger, multi)
   end
 
-  defp create_work_order(candidate = %TriggerKafkaMessage{}) do
+  defp create_work_order(%TriggerKafkaMessage{} = candidate) do
     %{
       data: data,
       metadata: metadata,
@@ -144,7 +144,7 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
     end
   end
 
-  defp create_work_order(message = %Broadway.Message{}, trigger, multi) do
+  defp create_work_order(%Broadway.Message{} = message, trigger, multi) do
     %{data: data, metadata: request} = message
     %{workflow: workflow} = trigger
 

--- a/lib/lightning/kafka_triggers/message_handling.ex
+++ b/lib/lightning/kafka_triggers/message_handling.ex
@@ -13,6 +13,7 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
   alias Lightning.KafkaTriggers.TriggerKafkaMessage
   alias Lightning.Repo
   alias Lightning.Services.UsageLimiter
+  alias Lightning.Workflows.Trigger
   alias Lightning.WorkOrder
   alias Lightning.WorkOrders
 
@@ -92,7 +93,16 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
     :ok
   end
 
-  defp create_work_order(candidate) do
+  def persist_message(multi, trigger_id, message) do
+    trigger =
+      Trigger
+      |> Repo.get(trigger_id)
+      |> Repo.preload(:workflow)
+
+    create_work_order(message, trigger, multi)
+  end
+
+  defp create_work_order(candidate = %TriggerKafkaMessage{}) do
     %{
       data: data,
       metadata: metadata,
@@ -131,6 +141,42 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
 
       {:error, _decode_error} ->
         candidate |> update_with_error("Data is not a JSON object")
+    end
+  end
+
+  defp create_work_order(message = %Broadway.Message{}, trigger, multi) do
+    %{data: data, metadata: request} = message
+    %{workflow: workflow} = trigger
+
+    data
+    |> Jason.decode()
+    |> case do
+      {:ok, body} when is_map(body) ->
+        assess_workorder_creation(workflow.project_id)
+        |> case do
+          {:ok, without_run?} ->
+            WorkOrders.create_for(
+              trigger,
+              multi,
+              workflow: workflow,
+              dataclip: %{
+                body: body,
+                request: request,
+                type: :kafka,
+                project_id: workflow.project_id
+              },
+              without_run: without_run?
+            )
+
+          {:error, message} ->
+            {:error, :work_order_creation_blocked, message}
+        end
+
+      {:ok, _something_other_than_map} ->
+        {:error, :data_is_not_json_object}
+
+      {:error, _decode_error} ->
+        {:error, :data_is_not_json_object}
     end
   end
 

--- a/lib/lightning/kafka_triggers/pipeline.ex
+++ b/lib/lightning/kafka_triggers/pipeline.ex
@@ -186,7 +186,7 @@ defmodule Lightning.KafkaTriggers.Pipeline do
     Logger.warning(log_entry)
   end
 
-  defp create_log_entry(message, context) do
+  defp create_log_entry(%{status: {:failed, type}} = message, context) do
     %{
       metadata: %{
         key: key,
@@ -198,6 +198,7 @@ defmodule Lightning.KafkaTriggers.Pipeline do
 
     log_message =
       "Kafka Pipeline Error:" <>
+        " Type `#{type}`" <>
         " Trigger_id `#{context.trigger_id}`" <>
         " Topic `#{topic}`" <>
         " Partition `#{partition}`" <>
@@ -209,7 +210,7 @@ defmodule Lightning.KafkaTriggers.Pipeline do
 
   defp notify_sentry(%{status: {:failed, :duplicate}}, _context), do: nil
 
-  defp notify_sentry(message, context) do
+  defp notify_sentry(%{status: {:failed, type}} = message, context) do
     %{
       metadata: %{
         key: key,
@@ -226,7 +227,8 @@ defmodule Lightning.KafkaTriggers.Pipeline do
         offset: offset,
         partition: partition,
         topic: topic,
-        trigger_id: context.trigger_id
+        trigger_id: context.trigger_id,
+        type: type
       }
     )
   end

--- a/lib/lightning/kafka_triggers/pipeline.ex
+++ b/lib/lightning/kafka_triggers/pipeline.ex
@@ -132,7 +132,7 @@ defmodule Lightning.KafkaTriggers.Pipeline do
     messages
   end
 
-  defp persist(multi = %Multi{}, trigger_id, message) do
+  defp persist(%Multi{} = multi, trigger_id, message) do
     %{
       data: data,
       metadata: %{
@@ -148,7 +148,7 @@ defmodule Lightning.KafkaTriggers.Pipeline do
         multi
         |> MessageHandling.persist_message(trigger_id, message)
 
-      _ ->
+      _key ->
         message_changeset =
           %TriggerKafkaMessage{}
           |> TriggerKafkaMessage.changeset(%{

--- a/lib/lightning/kafka_triggers/supervisor.ex
+++ b/lib/lightning/kafka_triggers/supervisor.ex
@@ -13,21 +13,9 @@ defmodule Lightning.KafkaTriggers.Supervisor do
   def init(_init_arg) do
     enabled = Lightning.Config.kafka_triggers_enabled?()
 
-    number_of_workers =
-      Lightning.Config.kafka_number_of_message_candidate_set_workers()
-
     children =
       if enabled do
         [
-          %{
-            id: Lightning.KafkaTriggers.MessageCandidateSetSupervisor,
-            start: {
-              Lightning.KafkaTriggers.MessageCandidateSetSupervisor,
-              :start_link,
-              [[number_of_workers: number_of_workers]]
-            },
-            type: :supervisor
-          },
           {
             Lightning.KafkaTriggers.PipelineSupervisor,
             type: :supervisor

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -71,10 +71,12 @@ defmodule Lightning.WorkOrders do
   **For a user**
       create_for(job, workflow: workflow, dataclip: dataclip, user: user)
   """
-  @spec create_for(Trigger.t() | Job.t(), [work_order_option()]) ::
+  @spec create_for(Trigger.t() | Job.t(), Multi.t(), [work_order_option()]) ::
           {:ok, WorkOrder.t()} | {:error, Ecto.Changeset.t(WorkOrder.t())}
-  def create_for(%Trigger{} = trigger, opts) do
-    Multi.new()
+  def create_for(target, multi \\ Multi.new(), opts)
+
+  def create_for(%Trigger{} = trigger, multi, opts) do
+    multi
     |> Multi.put(:workflow, opts[:workflow])
     |> get_or_insert_dataclip(opts[:dataclip])
     |> get_or_create_snapshot(opts[:workflow])
@@ -99,8 +101,8 @@ defmodule Lightning.WorkOrders do
     |> emit_and_return_work_order()
   end
 
-  def create_for(%Job{} = job, opts) do
-    Multi.new()
+  def create_for(%Job{} = job, multi, opts) do
+    multi
     |> Multi.put(:workflow, opts[:workflow])
     |> get_or_create_snapshot()
     |> Multi.insert(:workorder, build_for(job, opts |> Map.new()))

--- a/test/lightning/kafka_triggers/message_handling_test.exs
+++ b/test/lightning/kafka_triggers/message_handling_test.exs
@@ -7,6 +7,7 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
 
   require Lightning.Run
 
+  alias Ecto.Multi
   alias Lightning.Extensions.MockUsageLimiter
   alias Lightning.Extensions.Message
   alias Lightning.Extensions.UsageLimiting.Action
@@ -15,6 +16,7 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
   alias Lightning.KafkaTriggers.MessageCandidateSet
   alias Lightning.KafkaTriggers.MessageHandling
   alias Lightning.KafkaTriggers.TriggerKafkaMessage
+  alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord
   alias Lightning.Run
   alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
@@ -959,9 +961,270 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
     end
   end
 
+  describe ".persist_message/3" do
+    setup do
+      message = build_broadway_message()
+
+      trigger = insert(:trigger, type: :kafka)
+
+      record_changeset =
+        TriggerKafkaMessageRecord.changeset(
+          %TriggerKafkaMessageRecord{},
+          %{topic_partition_offset: "foo-bar-baz", trigger_id: trigger.id}
+        )
+
+      multi =
+        Multi.new()
+        |> Multi.insert(:record, record_changeset)
+
+      %{message: message, multi: multi, trigger: trigger}
+    end
+
+    test "creates the WorkOrder", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      %{workflow: workflow} = trigger
+      MessageHandling.persist_message(multi, trigger.id, message)
+
+      created_workorder =
+        WorkOrder
+        |> Repo.one()
+        |> Repo.preload([
+          :trigger,
+          :workflow,
+          dataclip: Invocation.Query.dataclip_with_body()
+        ])
+
+      assert created_workorder.trigger_id == trigger.id
+      assert created_workorder.workflow_id == workflow.id
+      assert created_workorder.state == :pending
+
+      %{dataclip: dataclip} = created_workorder
+      assert dataclip.body["data"] == %{"interesting" => "stuff"}
+      assert dataclip.body["request"] == message.metadata |> stringify_keys()
+      assert dataclip.type == :kafka
+      assert dataclip.project_id == workflow.project_id
+    end
+
+    test "executes any other instructions in the multi", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      MessageHandling.persist_message(multi, trigger.id, message)
+
+      assert TriggerKafkaMessageRecord
+             |> Repo.get_by(trigger_id: trigger.id) != nil
+    end
+
+    test "returns the results of the insertion", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      assert {:ok, work_order} =
+               MessageHandling.persist_message(multi, trigger.id, message)
+
+      assert WorkOrder |> Repo.get(work_order.id) != nil
+    end
+
+    test "creates a rejected work order if run creation is constrained", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      %{workflow: workflow} = trigger
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :too_many_runs,
+         %Message{text: "Too many runs in the last minute"}}
+      end)
+
+      MessageHandling.persist_message(multi, trigger.id, message)
+
+      created_workorder =
+        WorkOrder
+        |> Repo.one()
+        |> Repo.preload([
+          :trigger,
+          :workflow,
+          dataclip: Invocation.Query.dataclip_with_body()
+        ])
+
+      assert created_workorder.trigger_id == trigger.id
+      assert created_workorder.workflow_id == workflow.id
+      assert created_workorder.state == :rejected
+
+      %{dataclip: dataclip} = created_workorder
+      assert dataclip.body["data"] == %{"interesting" => "stuff"}
+      assert dataclip.body["request"] == message.metadata |> stringify_keys()
+      assert dataclip.type == :kafka
+      assert dataclip.project_id == workflow.project_id
+    end
+
+    test "returns results of the insertion if run creation is constrained", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      %{workflow: workflow} = trigger
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :too_many_runs,
+         %Message{text: "Too many runs in the last minute"}}
+      end)
+
+      assert {:ok, work_order} =
+               MessageHandling.persist_message(multi, trigger.id, message)
+
+      assert WorkOrder |> Repo.get(work_order.id) != nil
+    end
+
+    test "does not create a workorder if workorder creation is constrained", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      %{workflow: workflow} = trigger
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :runs_hard_limit,
+         %Lightning.Extensions.Message{text: "Runs limit exceeded"}}
+      end)
+
+      MessageHandling.persist_message(multi, trigger.id, message)
+
+      assert WorkOrder |> Repo.all() == []
+    end
+
+    test "returns an error response if workorder creation is constrained", %{
+      message: message,
+      multi: multi,
+      trigger: trigger
+    } do
+      %{workflow: workflow} = trigger
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :runs_hard_limit,
+         %Lightning.Extensions.Message{text: "Runs limit exceeded"}}
+      end)
+
+      assert MessageHandling.persist_message(multi, trigger.id, message) ==
+               {:error, :work_order_creation_blocked, "Runs limit exceeded"}
+    end
+
+    test "does not create a work order if data is not valid JSON", %{
+      multi: multi,
+      trigger: trigger
+    } do
+      message = build_broadway_message(data_as_json: "not a JSON object")
+
+      MessageHandling.persist_message(multi, trigger.id, message)
+
+      assert WorkOrder |> Repo.all() == []
+    end
+
+    test "returns an error if data is not valid JSON", %{
+      multi: multi,
+      trigger: trigger
+    } do
+      message = build_broadway_message(data_as_json: "not a JSON object")
+
+      assert MessageHandling.persist_message(multi, trigger.id, message) ==
+               {:error, :data_is_not_json_object}
+    end
+
+    test "does not create a work order if data is not a map", %{
+      multi: multi,
+      trigger: trigger
+    } do
+      message = build_broadway_message(data_as_json: "\"not a JSON object\"")
+
+      MessageHandling.persist_message(multi, trigger.id, message)
+
+      assert WorkOrder |> Repo.all() == []
+    end
+
+    test "returns an error indicating that the data can not be parsed", %{
+      multi: multi,
+      trigger: trigger
+    } do
+      message = build_broadway_message(data_as_json: "\"not a JSON object\"")
+
+      assert MessageHandling.persist_message(multi, trigger.id, message) ==
+               {:error, :data_is_not_json_object}
+    end
+
+    defp build_broadway_message(opts \\ []) do
+      data =
+        Keyword.get(
+          opts,
+          :data_as_json,
+          %{interesting: "stuff"} |> Jason.encode!()
+        )
+
+      key = Keyword.get(opts, :key, "abc_123_def")
+      offset = Keyword.get(opts, :offset, 11)
+
+      %Broadway.Message{
+        data: data,
+        metadata: %{
+          offset: offset,
+          partition: 2,
+          key: key,
+          headers: [],
+          ts: 1_715_164_718_283,
+          topic: "bar_topic"
+        },
+        acknowledger: nil,
+        batcher: :default,
+        batch_key: {"bar_topic", 2},
+        batch_mode: :bulk,
+        status: :ok
+      }
+    end
+  end
+
   defp timestamp_from_offset(offset) do
     DateTime.utc_now()
     |> DateTime.add(offset)
     |> DateTime.to_unix(:millisecond)
+  end
+
+  # Put this in a helper
+  defp stringify_keys(map) do
+    map
+    |> Map.keys()
+    |> Enum.reduce(%{}, fn key, acc ->
+      acc |> stringify_key(key, map[key])
+    end)
+  end
+
+  defp stringify_key(acc, key, val) when is_map(val) and not is_struct(val) do
+    acc
+    |> Map.merge(%{to_string(key) => stringify_keys(val)})
+  end
+
+  defp stringify_key(acc, key, val) do
+    acc
+    |> Map.merge(%{to_string(key) => val})
   end
 end

--- a/test/lightning/kafka_triggers/pipeline_test.exs
+++ b/test/lightning/kafka_triggers/pipeline_test.exs
@@ -590,7 +590,10 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
     end
 
     defp expected_general_error_message(message, context) do
+      %{status: {:failed, type}} = message
+
       "Kafka Pipeline Error:" <>
+        " Type `#{type}`" <>
         " Trigger_id `#{context.trigger_id}`" <>
         " Topic `#{message.metadata.topic}`" <>
         " Partition `#{message.metadata.partition}`" <>
@@ -599,12 +602,15 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
     end
 
     defp expected_extra_sentry_data(message, context) do
+      %{status: {:failed, type}} = message
+
       %{
         key: message.metadata.key,
         offset: message.metadata.offset,
         partition: message.metadata.partition,
         topic: message.metadata.topic,
-        trigger_id: context.trigger_id
+        trigger_id: context.trigger_id,
+        type: type
       }
     end
   end

--- a/test/lightning/kafka_triggers/pipeline_test.exs
+++ b/test/lightning/kafka_triggers/pipeline_test.exs
@@ -5,12 +5,18 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
   import ExUnit.CaptureLog
 
   alias Ecto.Changeset
+  alias Lightning.Extensions.MockUsageLimiter
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.Invocation
   alias Lightning.KafkaTriggers
+  alias Lightning.KafkaTriggers.MessageHandling
   alias Lightning.KafkaTriggers.TriggerKafkaMessage
   alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord
   alias Lightning.KafkaTriggers.Pipeline
   alias Lightning.Repo
   alias Lightning.Workflows.Trigger
+  alias Lightning.WorkOrder
 
   describe ".start_link/1" do
     test "starts a Broadway GenServer process with SASL credentials" do
@@ -156,7 +162,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
     end
   end
 
-  describe ".handle_message" do
+  describe ".handle_message - message has key" do
     setup do
       trigger_1 =
         insert(
@@ -236,18 +242,6 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
                trigger_id: ^trigger_id,
                work_order_id: nil
              } = trigger_kafka_message
-    end
-
-    test "converts empty Kafka key to nil TriggerKafkaMessage key", %{
-      context: context
-    } do
-      message = build_broadway_message(key: "")
-
-      Pipeline.handle_message(nil, message, context)
-
-      trigger_kafka_message = Repo.one(TriggerKafkaMessage)
-
-      assert %{key: nil} = trigger_kafka_message
     end
 
     test "records the message for the purposes of future deduplication", %{
@@ -336,66 +330,199 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
         assert {:failed, :persistence} = status
       end
     end
+  end
 
-    defp configuration(opts) do
-      index = opts |> Keyword.get(:index)
-      sasl = opts |> Keyword.get(:sasl, true)
-      ssl = opts |> Keyword.get(:ssl, true)
+  describe ".handle_message - message does not have a key" do
+    setup do
+      trigger_1 =
+        insert(
+          :trigger,
+          type: :kafka,
+          kafka_configuration: configuration(index: 1),
+          enabled: true
+        )
 
-      password = if sasl, do: "secret-#{index}", else: nil
-      sasl_type = if sasl, do: :plain, else: nil
-      username = if sasl, do: "my-user-#{index}", else: nil
+      trigger_2 =
+        insert(
+          :trigger,
+          type: :kafka,
+          kafka_configuration: configuration(index: 2, ssl: false),
+          enabled: true
+        )
+
+      context = %{trigger_id: trigger_1.id |> String.to_atom()}
+
+      message = build_broadway_message(key: "")
 
       %{
-        group_id: "lightning-#{index}",
-        hosts: [["host-#{index}", "9092"], ["other-host-#{index}", "9093"]],
-        hosts_string: "host-#{index}:9092, other-host-#{index}:9093",
-        initial_offset_reset_policy: "earliest",
-        partition_timestamps: partition_timestamps(),
-        password: password,
-        sasl: sasl_type,
-        ssl: ssl,
-        topics: ["topic-#{index}-1", "topic-#{index}-2"],
-        topics_string: "topic-#{index}-1, topic-#{index}-2",
-        username: username
+        context: context,
+        message: message,
+        trigger_1: trigger_1,
+        trigger_2: trigger_2
       }
     end
 
-    defp partition_timestamps do
-      %{
-        "1" => 1_715_164_718_281,
-        "2" => 1_715_164_718_282
-      }
+    test "returns the message", %{context: context, message: message} do
+      assert Pipeline.handle_message(nil, message, context) == message
     end
 
-    defp insert_message_record(trigger_id) do
-      TriggerKafkaMessageRecord.changeset(
-        %TriggerKafkaMessageRecord{},
-        %{
-          topic_partition_offset: "bar_topic_2_11",
-          trigger_id: trigger_id
+    test "updates the partition timestamp for the trigger", %{
+      context: context,
+      message: message,
+      trigger_1: trigger_1,
+      trigger_2: trigger_2
+    } do
+      Pipeline.handle_message(nil, message, context)
+
+      %{
+        kafka_configuration: %{
+          partition_timestamps: trigger_1_timestamps
         }
-      )
-      |> Repo.insert()
+      } = Trigger |> Repo.get(trigger_1.id)
+
+      %{
+        kafka_configuration: %{
+          partition_timestamps: trigger_2_timestamps
+        }
+      } = Trigger |> Repo.get(trigger_2.id)
+
+      assert %{"1" => 1_715_164_718_281, "2" => 1_715_164_718_283} =
+               trigger_1_timestamps
+
+      assert trigger_2_timestamps == partition_timestamps()
     end
 
-    # Put this in a helper
-    defp stringify_keys(map) do
-      map
-      |> Map.keys()
-      |> Enum.reduce(%{}, fn key, acc ->
-        acc |> stringify_key(key, map[key])
+    test "persists a WorkOrder", %{
+      context: context,
+      message: message,
+      trigger_1: trigger
+    } do
+      Pipeline.handle_message(nil, message, context)
+
+      assert %WorkOrder{dataclip: dataclip} =
+               WorkOrder
+               |> Repo.get_by(trigger_id: trigger.id)
+               |> Repo.preload(dataclip: Invocation.Query.dataclip_with_body())
+
+      assert dataclip.body["data"] == message.data |> Jason.decode!()
+    end
+
+    test "records the message for the purposes of future deduplication", %{
+      context: context,
+      message: message
+    } do
+      trigger_id = context.trigger_id |> Atom.to_string()
+
+      Pipeline.handle_message(nil, message, context)
+
+      message_record = Repo.one(TriggerKafkaMessageRecord)
+
+      assert %TriggerKafkaMessageRecord{
+               trigger_id: ^trigger_id,
+               topic_partition_offset: "bar_topic_2_11"
+             } = message_record
+    end
+
+    test "does not update partition timestamps if message is duplicate", %{
+      context: context,
+      message: message,
+      trigger_1: trigger_1,
+      trigger_2: trigger_2
+    } do
+      trigger_id = context.trigger_id |> Atom.to_string()
+
+      insert_message_record(trigger_id)
+
+      Pipeline.handle_message(nil, message, context)
+
+      %{
+        kafka_configuration: %{
+          partition_timestamps: trigger_1_timestamps
+        }
+      } = Trigger |> Repo.get(trigger_1.id)
+
+      %{
+        kafka_configuration: %{
+          partition_timestamps: trigger_2_timestamps
+        }
+      } = Trigger |> Repo.get(trigger_2.id)
+
+      assert trigger_1_timestamps == partition_timestamps()
+      assert trigger_2_timestamps == partition_timestamps()
+    end
+
+    test "does not create WorkOrder if message is duplicate", %{
+      context: context,
+      message: message
+    } do
+      trigger_id = context.trigger_id |> Atom.to_string()
+
+      insert_message_record(trigger_id)
+
+      Pipeline.handle_message(nil, message, context)
+
+      assert Repo.one(WorkOrder) == nil
+    end
+
+    test "marks message as failed when duplicate", %{
+      context: context,
+      message: message
+    } do
+      trigger_id = context.trigger_id |> Atom.to_string()
+
+      insert_message_record(trigger_id)
+
+      %{status: status} = Pipeline.handle_message(nil, message, context)
+
+      assert {:failed, :duplicate} = status
+    end
+
+    test "marks message as failed for non-duplicate error", %{
+      context: context,
+      message: message
+    } do
+      persistence_error = {
+        :error,
+        %Changeset{changes: %{}, errors: [], valid?: false}
+      }
+
+      with_mock MessageHandling,
+        persist_message: fn _multi, _trigger_id, _message ->
+          persistence_error
+        end do
+        %{status: status} = Pipeline.handle_message(nil, message, context)
+
+        assert {:failed, :persistence} = status
+      end
+    end
+
+    test "marks message as failed for invalid json", %{context: context} do
+      message = build_broadway_message(data_as_json: "invalid json", key: "")
+
+      %{status: status} = Pipeline.handle_message(nil, message, context)
+
+      assert {:failed, :invalid_data} = status
+    end
+
+    test "marks messages as failed if work order creation is blocked", %{
+      context: context,
+      message: message,
+      trigger_1: trigger
+    } do
+      %{workflow: workflow} = trigger
+      project_id = workflow.project_id
+
+      action = %Action{type: :new_run}
+      usage_context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^usage_context ->
+        {:error, :runs_hard_limit,
+         %Lightning.Extensions.Message{text: "Runs limit exceeded"}}
       end)
-    end
 
-    defp stringify_key(acc, key, val) when is_map(val) and not is_struct(val) do
-      acc
-      |> Map.merge(%{to_string(key) => stringify_keys(val)})
-    end
+      %{status: status} = Pipeline.handle_message(nil, message, context)
 
-    defp stringify_key(acc, key, val) do
-      acc
-      |> Map.merge(%{to_string(key) => val})
+      assert {:failed, :work_order_creation_blocked} = status
     end
   end
 
@@ -483,11 +610,18 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
   end
 
   defp build_broadway_message(opts \\ []) do
+    data =
+      Keyword.get(
+        opts,
+        :data_as_json,
+        %{interesting: "stuff"} |> Jason.encode!()
+      )
+
     key = Keyword.get(opts, :key, "abc_123_def")
     offset = Keyword.get(opts, :offset, 11)
 
     %Broadway.Message{
-      data: %{interesting: "stuff"} |> Jason.encode!(),
+      data: data,
       metadata: %{
         offset: offset,
         partition: 2,
@@ -502,5 +636,66 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
       batch_mode: :bulk,
       status: :ok
     }
+  end
+
+  defp configuration(opts) do
+    index = opts |> Keyword.get(:index)
+    sasl = opts |> Keyword.get(:sasl, true)
+    ssl = opts |> Keyword.get(:ssl, true)
+
+    password = if sasl, do: "secret-#{index}", else: nil
+    sasl_type = if sasl, do: :plain, else: nil
+    username = if sasl, do: "my-user-#{index}", else: nil
+
+    %{
+      group_id: "lightning-#{index}",
+      hosts: [["host-#{index}", "9092"], ["other-host-#{index}", "9093"]],
+      hosts_string: "host-#{index}:9092, other-host-#{index}:9093",
+      initial_offset_reset_policy: "earliest",
+      partition_timestamps: partition_timestamps(),
+      password: password,
+      sasl: sasl_type,
+      ssl: ssl,
+      topics: ["topic-#{index}-1", "topic-#{index}-2"],
+      topics_string: "topic-#{index}-1, topic-#{index}-2",
+      username: username
+    }
+  end
+
+  defp partition_timestamps do
+    %{
+      "1" => 1_715_164_718_281,
+      "2" => 1_715_164_718_282
+    }
+  end
+
+  defp insert_message_record(trigger_id) do
+    TriggerKafkaMessageRecord.changeset(
+      %TriggerKafkaMessageRecord{},
+      %{
+        topic_partition_offset: "bar_topic_2_11",
+        trigger_id: trigger_id
+      }
+    )
+    |> Repo.insert()
+  end
+
+  # Put this in a helper
+  defp stringify_keys(map) do
+    map
+    |> Map.keys()
+    |> Enum.reduce(%{}, fn key, acc ->
+      acc |> stringify_key(key, map[key])
+    end)
+  end
+
+  defp stringify_key(acc, key, val) when is_map(val) and not is_struct(val) do
+    acc
+    |> Map.merge(%{to_string(key) => stringify_keys(val)})
+  end
+
+  defp stringify_key(acc, key, val) do
+    acc
+    |> Map.merge(%{to_string(key) => val})
   end
 end


### PR DESCRIPTION
### Description

This enables synchronous processing of Kafka messages without keys - rather than via the existing buffer table. For now, I have not removed the asynchronous processing code, but that is temporary in an attempt to keep this PR as digestible as possible. This means that there is some duplication - especially wrt handling error conditions, but that will be stripped out as part of the follow-up PR.

I had to tweak `WorkOrder.create_for` to allow for usage with an existing Multi structure.

The changes are grouped in commits to hopefully make it easier to follow, I will collapse them into a single commit before merging.

Closes #2351 

### Validation steps

- Setup a local Kafka cluster based on these [instructions](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster).
- Ensure that `KAFKA_TRIGGERS_ENABLED` is set to 'yes'
- Set up a Kafka trigger similar t the screenshot below (assuming you have  a topic named `baz_topic`) :

![image](https://github.com/user-attachments/assets/3caa53c6-c0e6-4f3d-8487-99a940d5d778)

- Publish a message using kcat: `cat message.json | kcat -P -b 127.0.0.1:9094 -t baz_topic`.
- You should see a WorkOrder being enqueued.


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
