### PR TITLE
Setup user, apiToken, project, creds via iex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 ### Added
 
+- Added an `iex` command to setup a user, apiToken, project, and credential so
+  that it's possible to get a fully running lightning instance via external
+  shell script. (This is a tricky requirement for a distributed set of local
+  deployments) [#2369](https://github.com/OpenFn/lightning/issues/2369)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -882,7 +882,7 @@ defmodule Lightning.SetupUtils do
   def setup_user(user, token, project_names, credentials) do
     IO.inspect("Doing a lot here!")
     IO.inpsect(user)
-    IO.inpsect(projects)
+    IO.inpsect(project_names)
     IO.inpsect(credentials)
 
     # create user

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -868,4 +868,18 @@ defmodule Lightning.SetupUtils do
     |> limit(1)
     |> Repo.one!()
   end
+
+  @doc """
+  In some (mostly remote-controlled) deployments, it's necessary to create a
+  user, empty projects that they can access, and credentials (shared with those
+  projects) that they own so that later `openfn deploy` calls can make use of
+  these artifacts.
+
+  When run _before_ `openfn deploy`, this function makes it possible to set up
+  an entire lightning instance with a working project (including secrets)
+  without using the web UI.
+  """
+  def setup_user(user, projects, credentials) do
+    IO.inspect("Doing a lot here!")
+  end
 end

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -880,11 +880,6 @@ defmodule Lightning.SetupUtils do
   without using the web UI.
   """
   def setup_user(user, token, project_names, credentials) do
-    IO.inspect("Doing a lot here!")
-    IO.inpsect(user)
-    IO.inpsect(project_names)
-    IO.inpsect(credentials)
-
     # create user
     {:ok, user} = Accounts.create_user(user)
 
@@ -897,7 +892,8 @@ defmodule Lightning.SetupUtils do
 
     # create projects
     projects =
-      Enum.map(project_names, fn name ->
+      project_names
+      |> Enum.map(fn name ->
         {:ok, project} =
           Projects.create_project(
             %{
@@ -913,5 +909,20 @@ defmodule Lightning.SetupUtils do
       end)
 
     # create credentials
+    Enum.each(credentials, fn credential ->
+      {:ok, _credential} =
+        Credentials.create_credential(
+          credential
+          |> Map.put(:user_id, user.id)
+          |> Map.put(
+            :project_credentials,
+            Enum.map(projects, fn project ->
+              %{project_id: project.id}
+            end)
+          )
+        )
+    end)
+
+    :ok
   end
 end

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -4,7 +4,9 @@ defmodule Lightning.SetupUtilsTest do
   import Swoosh.TestAssertions
 
   alias Lightning.{Accounts, Projects, Workflows, Jobs, SetupUtils}
-  alias Lightning.Accounts.User
+  alias Lightning.Projects.{Project, ProjectUser, ProjectCredential}
+  alias Lightning.Accounts.{User, UserToken}
+  alias Lightning.Credentials.{Credential}
 
   describe "Setup demo site seed data" do
     setup do
@@ -34,7 +36,7 @@ defmodule Lightning.SetupUtilsTest do
       User.valid_password?(super_user, "welcome123")
 
       user_token =
-        Lightning.Repo.all(Lightning.Accounts.UserToken)
+        Lightning.Repo.all(UserToken)
         |> List.first()
 
       assert user_token.user_id == super_user.id
@@ -645,6 +647,68 @@ defmodule Lightning.SetupUtilsTest do
 
       assert Repo.all(Lightning.Invocation.LogLine)
              |> Enum.count() == 0
+    end
+  end
+
+  describe "setup_user/4" do
+    test "creates a user, an api token, projects, and credentials" do
+      assert :ok ==
+               Lightning.SetupUtils.setup_user(
+                 %{
+                   first_name: "Taylor",
+                   last_name: "Downs",
+                   email: "contact@openfn.org",
+                   password: "shh12345678!"
+                 },
+                 "abc123",
+                 ["project-a", "project-b"],
+                 [
+                   %{
+                     name: "openmrs",
+                     schema: "raw",
+                     body: %{"a" => "secret"}
+                   },
+                   %{
+                     name: "dhis2",
+                     schema: "raw",
+                     body: %{"b" => "safe"}
+                   }
+                 ]
+               )
+
+      # check that the user and the API token has been created
+      assert %User{id: user_id} = Repo.get_by(User, email: "contact@openfn.org")
+      assert %UserToken{} = Repo.get_by(UserToken, token: "abc123")
+
+      # check that both projects are there
+      assert [%Project{id: p1_id}, %Project{id: p2_id}] = Repo.all(Project)
+
+      # check that the user has owner access to both
+      assert [
+               %ProjectUser{project_id: ^p1_id, user_id: ^user_id, role: :owner},
+               %ProjectUser{project_id: ^p2_id, user_id: ^user_id, role: :owner}
+             ] =
+               Repo.all(ProjectUser)
+
+      credentials =
+        Repo.all(Credential) |> Repo.preload(:project_credentials)
+
+      assert [
+               %Credential{
+                 name: "openmrs",
+                 project_credentials: [
+                   %ProjectCredential{project_id: ^p1_id},
+                   %ProjectCredential{project_id: ^p2_id}
+                 ]
+               },
+               %Credential{
+                 name: "dhis2",
+                 project_credentials: [
+                   %ProjectCredential{project_id: ^p1_id},
+                   %ProjectCredential{project_id: ^p2_id}
+                 ]
+               }
+             ] = credentials
     end
   end
 


### PR DESCRIPTION
This PR makes it possible to setup a lightning user, apiToken, projects, and credentials via `iex`, and therefore via a shell script. 

Closes #2369 

References #2367 

### Validation steps

1. launch lightning
2. run the following command from `iex`:

    `Lightning.SetupUtils.setup_user(%{first_name: "Taylor", last_name: "Downs", email: "contact@openfn.org", password: "shh12345678!"}, "abc123", ["project-a", "project-b"], [%{name: "openmrs", schema: "raw", body: %{"a" => "secret"}}, %{
name: "dhis2", schema: "raw", body: %{"b" => "safe"}}])`

3. Check to see that the user has been created, has an apiToken, has acess to both projects, and that the credential is associated with both projects.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
