### PR TITLE
make Credentials unique by user by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Changed
 
+- Enforced uniqueness on credential names _by user_.
+  [#2371](https://github.com/OpenFn/lightning/pull/2371)
+
 ### Fixed
 
 ## [v2.7.16] - 2024-08-07

--- a/lib/lightning/credentials/credential.ex
+++ b/lib/lightning/credentials/credential.ex
@@ -44,6 +44,9 @@ defmodule Lightning.Credentials.Credential do
     ])
     |> cast_assoc(:project_credentials)
     |> validate_required([:name, :body, :user_id])
+    |> unique_constraint([:name, :user_id],
+      message: "you have another credential with the same name"
+    )
     |> assoc_constraint(:user)
     |> assoc_constraint(:oauth_client)
     |> validate_oauth()

--- a/priv/repo/migrations/20240810082050_add_uniqueness_to_credential_name_per_user.exs
+++ b/priv/repo/migrations/20240810082050_add_uniqueness_to_credential_name_per_user.exs
@@ -1,0 +1,33 @@
+defmodule Lightning.Repo.Migrations.AddUniquenessToCredentialNamePerUser do
+  use Ecto.Migration
+
+  def up do
+    # Identify duplicates and update them to ensure uniqueness
+    execute """
+    WITH duplicates AS (
+      SELECT
+        id,
+        name,
+        user_id,
+        ROW_NUMBER() OVER (PARTITION BY LOWER(REPLACE(name, '-', ' ')), user_id ORDER BY id) AS row_num
+      FROM
+        credentials
+    )
+    UPDATE credentials
+    SET name = credentials.name || '-' || duplicates.row_num
+    FROM duplicates
+    WHERE credentials.id = duplicates.id
+    AND duplicates.row_num > 1;
+    """
+
+    execute """
+    CREATE UNIQUE INDEX credentials_name_user_id_index ON credentials (LOWER(REPLACE(name, '-', ' ')), user_id);
+    """
+  end
+
+  def down do
+    execute """
+    DROP INDEX credentials_name_user_id_index;
+    """
+  end
+end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -576,8 +576,8 @@ defmodule Lightning.AccountsTest do
     test "purging user deletes all project credentials that involve this user's credentials" do
       user = insert(:user)
 
-      CredentialsFixtures.project_credential_fixture(user_id: user.id)
-      CredentialsFixtures.project_credential_fixture(user_id: user.id)
+      CredentialsFixtures.project_credential_fixture(user_id: user.id, name: "1")
+      CredentialsFixtures.project_credential_fixture(user_id: user.id, name: "2")
       CredentialsFixtures.project_credential_fixture()
 
       assert count_project_credentials_for_user(user) == 2
@@ -591,9 +591,9 @@ defmodule Lightning.AccountsTest do
       user_1 = insert(:user)
       user_2 = insert(:user)
 
-      CredentialsFixtures.credential_fixture(user_id: user_1.id)
-      CredentialsFixtures.credential_fixture(user_id: user_1.id)
-      CredentialsFixtures.credential_fixture(user_id: user_2.id)
+      CredentialsFixtures.credential_fixture(user_id: user_1.id, name: "1")
+      CredentialsFixtures.credential_fixture(user_id: user_1.id, name: "2")
+      CredentialsFixtures.credential_fixture(user_id: user_2.id, name: "3")
 
       assert count_for(Credentials.Credential) == 3
 

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -303,6 +303,31 @@ defmodule Lightning.CredentialsTest do
   end
 
   describe "create_credential/1" do
+    test "fails if another cred exists with the same name for the same user" do
+      valid_attrs = %{
+        body: %{"a" => "test"},
+        name: "simple name",
+        user_id: insert(:user).id,
+        schema: "raw"
+      }
+
+      assert {:ok, %Credential{}} = Credentials.create_credential(valid_attrs)
+
+      assert {
+               :error,
+               %Ecto.Changeset{
+                 errors: [
+                   name:
+                     {"you have another credential with the same name",
+                      [
+                        constraint: :unique,
+                        constraint_name: "credentials_name_user_id_index"
+                      ]}
+                 ]
+               }
+             } = Credentials.create_credential(valid_attrs)
+    end
+
     test "suceeds with raw schema" do
       valid_attrs = %{
         body: %{"username" => "user", "password" => "pass", "port" => 5000},

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -648,7 +648,7 @@ defmodule LightningWeb.ProjectLiveTest do
               "#credentials"
           )
 
-        credential_name = "My Credential"
+        credential_name = Lightning.Name.generate()
 
         refute html =~ credential_name
 


### PR DESCRIPTION
### Description

This PR makes credentials unique by `user_id` and `name`. Right now, we allow duplicate credential names. This creates 2 problems:
1. it's hard to know which credential to select from a picklist (only partially solved now... we may consider extending the uniqueness to `project_id` via `project_credentials` if we want more collision avoidance, but that's doesn't seem necessary at the moment—will speak with @midigofrank on Monday to decide)
2. it's hard to generate credential slugs and associate jobs with credentials via `cli deploy` unless we have some sort of uniqueness here.

References #2367 

### Validation steps

1. Create several credentials with the same name for the same user
2. Run the migrations
3. Note that the credential names have been updated with `duplicatename-2`, `duplicatename-3`, etc.
4. Try to create a new credential with a duplicate name for the same user
5. Note the validation error

### Additional notes for the reviewer

Only the note above on whether we should extend this to include unqiueness by `project_id` via the `project_credentials` relationship. 

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
