### PR TITLE
limit the scope of setup_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ and this project adheres to
 
 ### Added
 
-- Added an `iex` command to setup a user, apiToken, project, and credential so
-  that it's possible to get a fully running lightning instance via external
-  shell script. (This is a tricky requirement for a distributed set of local
-  deployments) [#2369](https://github.com/OpenFn/lightning/issues/2369)
+- Added an `iex` command to setup a user, an apiToken, and credentials so that
+  it's possible to get a fully running lightning instance via external shell
+  script. (This is a tricky requirement for a distributed set of local
+  deployments) [#2369](https://github.com/OpenFn/lightning/issues/2369) and
+  [#2373](https://github.com/OpenFn/lightning/pull/2373)
 
 ### Changed
 

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -576,8 +576,8 @@ defmodule Lightning.AccountsTest do
     test "purging user deletes all project credentials that involve this user's credentials" do
       user = insert(:user)
 
-      CredentialsFixtures.project_credential_fixture(user_id: user.id)
-      CredentialsFixtures.project_credential_fixture(user_id: user.id)
+      CredentialsFixtures.project_credential_fixture(user_id: user.id, name: "a")
+      CredentialsFixtures.project_credential_fixture(user_id: user.id, name: "b")
       CredentialsFixtures.project_credential_fixture()
 
       assert count_project_credentials_for_user(user) == 2
@@ -591,9 +591,9 @@ defmodule Lightning.AccountsTest do
       user_1 = insert(:user)
       user_2 = insert(:user)
 
-      CredentialsFixtures.credential_fixture(user_id: user_1.id)
-      CredentialsFixtures.credential_fixture(user_id: user_1.id)
-      CredentialsFixtures.credential_fixture(user_id: user_2.id)
+      CredentialsFixtures.credential_fixture(user_id: user_1.id, name: "a")
+      CredentialsFixtures.credential_fixture(user_id: user_1.id, name: "b")
+      CredentialsFixtures.credential_fixture(user_id: user_2.id, name: "a")
 
       assert count_for(Credentials.Credential) == 3
 


### PR DESCRIPTION
### Description

This PR changes `setup_user/4` to be `setup_user/3`, limiting its scope so that you can only use it to create a user, apiToken, and credentials.

Creating projects and project_credentials will be the domain of `cli deploy`.

### Validation steps

1. launch lightning
2. run the following command from iex:
    ```
    Lightning.SetupUtils.setup_user(%{first_name: "Taylor", last_name: "Downs", email: "contact@openfn.org", password: "shh12345678!"}, "abc123", [%{name: "openmrs", schema: "raw", body: %{"a" => "secret"}}, %{ name: "dhis2", schema: "raw", body: %{"b" => "safe"}}])
    ```
3. Check to see that the user has been created, has an apiToken, has acess to both projects, and that the credential is associated with both projects.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
