### PR TITLE
Use Swoosh to format User models into recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Changed
 
+- Use Swoosh to format User models into recipients
+  [#2374](https://github.com/OpenFn/lightning/pull/2374)
+
 ### Fixed
 
 ## [v2.7.16] - 2024-08-07

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -57,7 +57,7 @@ defmodule Lightning.Accounts.UserNotifier do
   Deliver instructions to confirm account.
   """
   def deliver_confirmation_instructions(user, token) do
-    deliver(user.email, "Confirm your OpenFn account", """
+    deliver(user, "Confirm your OpenFn account", """
     Hi #{user.first_name},
 
     Welcome to OpenFn. Please confirm your account by visiting the URL below:
@@ -74,7 +74,7 @@ defmodule Lightning.Accounts.UserNotifier do
   Deliver instructions to confirm account.
   """
   def deliver_confirmation_instructions(enroller, user, token) do
-    deliver(user.email, "Confirm your OpenFn account", """
+    deliver(user, "Confirm your OpenFn account", """
     Hi #{user.first_name},
 
     #{enroller.first_name} has just created an OpenFn account for you. You can complete your registration by visiting the URL below:
@@ -94,7 +94,7 @@ defmodule Lightning.Accounts.UserNotifier do
     role = Projects.get_project_user_role(user, project) |> Atom.to_string()
     url = LightningWeb.RouteHelpers.project_dashboard_url(project.id)
 
-    deliver(user.email, "You now have access to \"#{project.name}\"", """
+    deliver(user, "You now have access to \"#{project.name}\"", """
     Hi #{user.first_name},
 
     You've been granted "#{role}" access to the "#{project.name}" project on OpenFn.
@@ -137,7 +137,7 @@ defmodule Lightning.Accounts.UserNotifier do
       )
 
     deliver(
-      user.email,
+      user,
       "The data retention policy for #{updated_project.name} has been modified",
       """
       Hi #{user.first_name},
@@ -166,7 +166,7 @@ defmodule Lightning.Accounts.UserNotifier do
       |> Lightning.Helpers.actual_deletion_date()
       |> Lightning.Helpers.format_date()
 
-    deliver(user.email, "Your account has been scheduled for deletion", """
+    deliver(user, "Your account has been scheduled for deletion", """
      Hi #{user.first_name},
 
     Your OpenFn account has been scheduled for deletion. It has been disabled and you'll no longer be able to log in.
@@ -183,7 +183,7 @@ defmodule Lightning.Accounts.UserNotifier do
 
   def send_credential_deletion_notification_email(user, credential) do
     deliver(
-      user.email,
+      user,
       "Your \"#{credential.name}\" credential will be deleted",
       """
       Hi #{user.first_name},
@@ -207,10 +207,12 @@ defmodule Lightning.Accounts.UserNotifier do
   Deliver instructions to reset a user password.
   """
   def deliver_reset_password_instructions(user, url) do
-    deliver(user.email, "Finish resetting your password", """
+    deliver(user, "Finish resetting your password", """
     Hi #{user.first_name},
 
-    We have received a request to reset your OpenFn password. To proceed, please visit the URL below:
+    We have received a request to reset your OpenFn password.
+
+    To proceed, please visit the URL below:
 
     #{url}
 
@@ -221,13 +223,15 @@ defmodule Lightning.Accounts.UserNotifier do
   end
 
   @doc """
-  Deliver instructions to update a user email.
+  Deliver instructions to update a user.
   """
   def deliver_update_email_instructions(user, url) do
-    deliver(user.email, "Please confirm your new email", """
+    deliver(user, "Please confirm your new email", """
     Hi #{user.first_name},
 
-    We have received a request to change the email associated with your OpenFn account. To proceed, please visit the URL below:
+    We have received a request to change the email associated with your OpenFn account.
+
+    To proceed, please visit the URL below:
 
     #{url}
 
@@ -238,11 +242,11 @@ defmodule Lightning.Accounts.UserNotifier do
   end
 
   @doc """
-  Deliver warning to update a user email.
+  Deliver warning to update a user.
   """
   def deliver_update_email_warning(user, new_email) do
-    deliver(user.email, "Your OpenFn email was changed", """
-    Hi #{user.email},
+    deliver(user, "Your OpenFn email was changed", """
+    Hi #{user.first_name},
 
     We have received a request to change the email address associated with your OpenFn account from #{user.email} to #{new_email}.
 
@@ -325,7 +329,7 @@ defmodule Lightning.Accounts.UserNotifier do
     OpenFn
     """
 
-    deliver(user.email, title, body)
+    deliver(user, title, body)
   end
 
   def notify_project_deletion(
@@ -337,7 +341,7 @@ defmodule Lightning.Accounts.UserNotifier do
       |> Lightning.Helpers.actual_deletion_date()
       |> Lightning.Helpers.format_date()
 
-    deliver(user.email, "Project scheduled for deletion", """
+    deliver(user, "Project scheduled for deletion", """
     Hi #{user.first_name},
 
     Your OpenFn project "#{project.name}" has been scheduled for deletion.
@@ -351,7 +355,7 @@ defmodule Lightning.Accounts.UserNotifier do
   end
 
   def deliver_project_invitation_email(user, inviter, project, role, token) do
-    deliver(user.email, "Join #{project.name} on OpenFn as a collaborator", """
+    deliver(user, "Join #{project.name} on OpenFn as a collaborator", """
     Hi #{user.first_name},
 
     #{inviter.first_name} has invited you to join project "#{project.name}" and granted you "#{role}" access. Since you don't have an OpenFn account yet, we've set one up for you.

--- a/lib/lightning/mailer.ex
+++ b/lib/lightning/mailer.ex
@@ -4,7 +4,8 @@ defmodule Lightning.Mailer do
 
   defimpl Swoosh.Email.Recipient, for: Lightning.Accounts.User do
     def format(%Lightning.Accounts.User{} = user) do
-      {user.email, "#{user.first_name} #{user.last_name}"}
+      {[user.first_name, user.last_name] |> Enum.join(" ") |> String.trim(),
+       user.email}
     end
   end
 end

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -30,7 +30,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "Project scheduled for deletion",
-        to: "user@openfn.org",
+        to: Swoosh.Email.Recipient.format(user),
         text_body: """
         Hi User,\n\nYour OpenFn project "project-a" has been scheduled for deletion.\n\nAll of the workflows in this project have been disabled, and it's associated resources will be deleted on #{actual_deletion_date}.\n\nIf you don't want this project deleted, please email #{admin_email} as soon as possible.\n\nOpenFn
         """
@@ -54,7 +54,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "You now have access to \"#{project.name}\"",
-        to: "user@openfn.org",
+        to: Swoosh.Email.Recipient.format(user),
         text_body: """
         Hi Anna,\n\nYou've been granted "editor" access to the "a-test-project" project on OpenFn.\n\nVisit the URL below to check it out:\n\n#{url}\n\nOpenFn
         """
@@ -91,7 +91,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       UserNotifier.deliver_confirmation_instructions(
         %User{first_name: "Sizwe", email: "super@email.com"},
-        %User{
+        to_user = %User{
           first_name: "Joe",
           email: "real@email.com"
         },
@@ -107,7 +107,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "Confirm your OpenFn account",
-        to: "real@email.com",
+        to: Swoosh.Email.Recipient.format(to_user),
         text_body: """
         Hi Joe,
 
@@ -123,19 +123,21 @@ defmodule Lightning.Accounts.UserNotifierTest do
     end
 
     test "send_deletion_notification_email/1" do
-      UserNotifier.send_deletion_notification_email(%User{
-        email: "real@email.com"
-      })
+      UserNotifier.send_deletion_notification_email(
+        to_user = %User{
+          email: "real@email.com"
+        }
+      )
 
       assert_email_sent(
         subject: "Your account has been scheduled for deletion",
-        to: "real@email.com"
+        to: Swoosh.Email.Recipient.format(to_user)
       )
     end
 
     test "send_credential_deletion_notification_email/2" do
       UserNotifier.send_credential_deletion_notification_email(
-        %User{
+        to_user = %User{
           email: "real@email.com"
         },
         %Credential{name: "Test"}
@@ -143,7 +145,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "Your \"Test\" credential will be deleted",
-        to: "real@email.com"
+        to: Swoosh.Email.Recipient.format(to_user)
       )
     end
 
@@ -219,7 +221,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "Daily digest for project Real Project",
-        to: "real@email.com",
+        to: Swoosh.Email.Recipient.format(user),
         text_body: """
         Hi Elias,
 
@@ -297,7 +299,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "Weekly digest for project Real Project",
-        to: "real@email.com",
+        to: Swoosh.Email.Recipient.format(user),
         text_body: """
         Hi Elias,
 
@@ -377,7 +379,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
 
       assert_email_sent(
         subject: "Monthly digest for project Real Project",
-        to: "real@email.com",
+        to: Swoosh.Email.Recipient.format(user),
         text_body: """
         Hi Elias,
 

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -192,7 +192,7 @@ defmodule Lightning.CredentialsTest do
 
       assert_email_sent(
         subject: "Your \"#{credential.name}\" credential will be deleted",
-        to: user.email
+        to: Swoosh.Email.Recipient.format(user)
       )
     end
 

--- a/test/lightning/mailer_test.exs
+++ b/test/lightning/mailer_test.exs
@@ -1,0 +1,12 @@
+defmodule Lightning.MailerTest do
+  use ExUnit.Case, async: true
+
+  alias Lightning.Accounts.User
+
+  test "correctly formats User models" do
+    user = %User{email: "test@example.com", first_name: "John", last_name: "Doe"}
+
+    assert Swoosh.Email.Recipient.format(user) ==
+             {"John Doe", "test@example.com"}
+  end
+end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -231,11 +231,13 @@ defmodule Lightning.ProjectsTest do
 
       %{subject: subject, body: body} = data_retention_email(updated_project)
 
-      for %{user: %{email: email}} <- admins do
+      for %{user: user} <- admins do
+        email = Swoosh.Email.Recipient.format(user)
+
         assert_receive {:email,
                         %Swoosh.Email{
                           subject: ^subject,
-                          to: [{"", ^email}],
+                          to: [^email],
                           text_body: ^body
                         }}
       end
@@ -601,7 +603,7 @@ defmodule Lightning.ProjectsTest do
       for user <- [user_1, user_2] do
         email = %Email{
           subject: "Project scheduled for deletion",
-          to: [{"", user.email}],
+          to: [Swoosh.Email.Recipient.format(user)],
           from:
             {Lightning.Config.email_sender_name(),
              Lightning.Config.instance_admin_email()},

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -171,7 +171,7 @@ defmodule LightningWeb.ProfileLiveTest do
 
       assert_email_sent(
         subject: "Your account has been scheduled for deletion",
-        to: user.email
+        to: Swoosh.Email.Recipient.format(user)
       )
     end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -152,12 +152,12 @@ defmodule LightningWeb.ProjectLiveTest do
       project_name = String.replace(@create_attrs.raw_name, " ", "-")
 
       assert_email_sent(
-        to: [{"", user_1.email}],
+        to: [Swoosh.Email.Recipient.format(user_1)],
         subject: "You now have access to \"#{project_name}\""
       )
 
       assert_email_sent(
-        to: [{"", user_2.email}],
+        to: [Swoosh.Email.Recipient.format(user_2)],
         subject: "You now have access to \"#{project_name}\""
       )
     end
@@ -2101,12 +2101,12 @@ defmodule LightningWeb.ProjectLiveTest do
       assert html =~ "Invite sent successfully"
 
       refute_email_sent(
-        to: [{"", "nonexists@localtests.com"}],
+        to: [{"Non Exists", "nonexists@localtests.com"}],
         subject: "You now have access to \"my-project\""
       )
 
       assert_email_sent(
-        to: [{"", "nonexists@localtests.com"}],
+        to: [{"Non Exists", "nonexists@localtests.com"}],
         subject: "Join my-project on OpenFn as a collaborator"
       )
     end

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -157,7 +157,7 @@ defmodule LightningWeb.UserLiveTest do
 
       assert_email_sent(
         subject: "Your account has been scheduled for deletion",
-        to: user.email
+        to: Swoosh.Email.Recipient.format(user)
       )
 
       assert html =~


### PR DESCRIPTION
### Description

This PR makes changes to how we set the recipients on emails, previously we were just setting the email address.

This changes that to send the email with their first and last name as the recipient name and uses their email address.

Leveraging the Recipient protocol on Swoosh.

### Validation steps

Emails sent from Lightning should have `User Name (email@address.com)` instead of `email@address.com` as the `to:` field.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
