### PR TITLE
Stop Kafka pipeline on Workflow deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to
 
 ### Fixed
 
+- When a Workflow is deleted, any associated Kafka trigger pipelines will be
+  stopped and deleted. [#2379](https://github.com/OpenFn/lightning/issues/2379)
+
 ## [v2.7.16] - 2024-08-07
 
 ### Fixed

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -253,9 +253,16 @@ defmodule Lightning.Workflows do
       with {:ok, _} <- result do
         workflow
         |> Repo.preload([:triggers], force: true)
+        |> tap(&notify_of_affected_kafka_triggers/1)
         |> Events.workflow_updated()
       end
     end)
+  end
+
+  defp notify_of_affected_kafka_triggers(%{triggers: triggers}) do
+    triggers
+    |> Enum.filter(&(&1.type == :kafka))
+    |> Enum.each(&Triggers.Events.kafka_trigger_updated(&1.id))
   end
 
   @doc """


### PR DESCRIPTION
### Description

When  a Kafka trigger is modified, the associated pipeline is added or removed. However, when a Workflow was deleted, an active Kafka trigger would remain running. This change corrects that.

Closes #2379 

### Validation steps

- Setup a local Kafka cluster based on these [instructions](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster).
- Ensure that `KAFKA_TRIGGERS_ENABLED` is set to 'yes'
- Set up an enabled Kafka trigger similar to the screenshot below (assuming you have  a topic named `baz_topic`) :

![Screenshot from 2024-08-07 10-07-28](https://github.com/user-attachments/assets/a4374f47-a504-4f54-be91-ecf72e1e9e74)

In an IEx session, run the following:

```
GenServer.whereis(:kafka_pipeline_supervisor) |> Supervisor.which_children()
```

The response should be similar to:

```
[
  {"e1bc3e06-a74f-4706-b6ee-56539fe95a22", #PID<0.1032.0>, :worker,
   [Lightning.KafkaTriggers.Pipeline]}
]
```

Then from the UI, delete the workflow, and run `GenServer.whereis(:kafka_pipeline_supervisor) |> Supervisor.which_children()` again. This time it should return an empty collection.




### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
