### PR TITLE
Pass user_id param on check usage limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Pass the user_id param on check usage limits.
+  [#2387](https://github.com/OpenFn/lightning/issues/2387)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -28,7 +28,8 @@ defmodule Lightning.Extensions.UsageLimiting do
     @moduledoc false
 
     @type t :: %Context{
-            project_id: Ecto.UUID.t()
+            project_id: Ecto.UUID.t(),
+            user_id: Ecto.UUID.t()
           }
 
     defstruct [:project_id, :user_id]

--- a/lib/lightning_web/live/live_helpers.ex
+++ b/lib/lightning_web/live/live_helpers.ex
@@ -172,9 +172,10 @@ defmodule LightningWeb.LiveHelpers do
     %{socket | assigns: check_limits(assigns, project_id)}
   end
 
-  def check_limits(assigns, project_id) do
+  def check_limits(%{current_user: user} = assigns, project_id) do
     case UsageLimiter.check_limits(%Context{
-           project_id: project_id
+           project_id: project_id,
+           user_id: user.id
          }) do
       :ok ->
         assigns


### PR DESCRIPTION
### Description

This PR adds the user when passing params to check usage limits.

Closes https://github.com/OpenFn/lightning/issues/2387

### Validation steps

1. Navigate to a project and see that no banner is shown.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
