### PR TITLE
Auto-confirm Demo Accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to
 
 ### Changed
 
+- Ensure that all the demo accounts are confirmed by default
+  [#2395](https://github.com/OpenFn/lightning/issues/2395)
+
 ### Fixed
 
 ## [v2.7.17] - 2024-08-14

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -5,8 +5,8 @@ defmodule Lightning.SetupUtils do
   import Ecto.Query
   import Ecto.Changeset
 
-  alias Lightning.Accounts.User
   alias Lightning.Accounts
+  alias Lightning.Accounts.User
   alias Lightning.Credentials
   alias Lightning.Jobs
   alias Lightning.Projects

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -5,6 +5,7 @@ defmodule Lightning.SetupUtils do
   import Ecto.Query
   import Ecto.Changeset
 
+  alias Lightning.Accounts.User
   alias Lightning.Accounts
   alias Lightning.Credentials
   alias Lightning.Jobs
@@ -49,7 +50,7 @@ defmodule Lightning.SetupUtils do
   """
   def setup_demo(opts \\ [create_super: false]) do
     %{super_user: super_user, admin: admin, editor: editor, viewer: viewer} =
-      create_users(opts)
+      create_users(opts) |> confirm_users()
 
     %{
       project: openhie_project,
@@ -162,6 +163,25 @@ defmodule Lightning.SetupUtils do
       })
 
     %{super_user: super_user, admin: admin, editor: editor, viewer: viewer}
+  end
+
+  def confirm_users(users) do
+    confirm_user = fn user ->
+      case user do
+        nil ->
+          :ok
+
+        _ ->
+          User.confirm_changeset(user)
+          |> Repo.update!()
+      end
+    end
+
+    users
+    |> Map.values()
+    |> Enum.each(confirm_user)
+
+    users
   end
 
   def create_starter_project(name, project_users) do


### PR DESCRIPTION
### Description

This PR modifies the demo script to automatically confirm the demo accounts created.

Closes #2395 

### Validation steps

1. Setup the demo accounts
2. Login with one of them (maybe demo@openfn.org)
3. Notice that the accounts confirmation banner is no longer displayed
4. Notice also that the account confirmation modal is never displayed

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
