### PR TITLE
Lock trigger when updating partition_timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Protect against race conditions when updating partition timestamps for a
+  Kafka trigger. [#2378](https://github.com/OpenFn/lightning/issues/2378)
+
 ## [v2.7.19] - 2024-08-19
 
 ### Added


### PR DESCRIPTION
### Description

This PR ensures the record for the appropriate Kafka trigger is locked before trying to update partition timestamps. This is to prevent race conditions when there is more than one concurrent processor.

Closes #2378 

### Validation steps

- Setup a local Kafka cluster based on these [instructions](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster).
- Ensure that `KAFKA_TRIGGERS_ENABLED` is set to 'yes'
- Set up a Kafka trigger similar to the screenshot below (assuming you have  a topic named `baz_topic`) :

![Screenshot from 2024-08-07 10-07-28](https://github.com/user-attachments/assets/2f8f73aa-b118-4e8b-ba70-3e4155f9bdd5)

- Publish a message using kcat: `cat message.json | kcat -P -b 127.0.0.1:9094 -t baz_topic`.

- In an IEx session, run the following:

```
alias Lightning.Workflows.Trigger
alias Lightning.Repo
import Ecto.Query

q = from t in Trigger, order_by: [desc:  :inserted_at], limit: 1

trigger = q |> Repo.one()


%{kafka_configuration: %{partition_timestamps: before_timestamps}} = q |> Repo.one()
```

- Leave the IEx session running and publish another message to the cluster (it can be the same message as before).
- Once you have seen the WorkOrder created in the history for the trigger, run the following from your IEx session:

```
%{kafka_configuration: %{partition_timestamps: after_timestamps}} = q |> Repo.one()

after_timestamps != before_timestamps # Should return true
```


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
