### PR TITLE
Reset Kafka trigger offset on persistence failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Allow the Kafka trigger to reset the offset and try again when a message can
+  not be persisted.[#2386](https://github.com/OpenFn/lightning/issues/2386)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/kafka_triggers.ex
+++ b/lib/lightning/kafka_triggers.ex
@@ -133,6 +133,7 @@ defmodule Lightning.KafkaTriggers do
         :start_link,
         [
           [
+            begin_offset: :assigned,
             connect_timeout: connect_timeout * 1000,
             group_id: group_id,
             hosts: hosts,
@@ -215,6 +216,11 @@ defmodule Lightning.KafkaTriggers do
   end
 
   def rollback_pipeline(_supervisor, _trigger_id, _timestamp) do
+    # If no trigger, do nothing
+    # If trigger is disabled, do nothing (this will be different for when we do not want to restart)
+    # Stop the pipeline and delete it
+    # Generate new child spec
+    # Start the pipeline
 
   end
 end

--- a/lib/lightning/kafka_triggers.ex
+++ b/lib/lightning/kafka_triggers.ex
@@ -213,4 +213,8 @@ defmodule Lightning.KafkaTriggers do
 
     %{interval: 10_000, messages_per_interval: messages_per_interval}
   end
+
+  def rollback_pipeline(_supervisor, _trigger_id, _timestamp) do
+
+  end
 end

--- a/lib/lightning/kafka_triggers.ex
+++ b/lib/lightning/kafka_triggers.ex
@@ -162,7 +162,7 @@ defmodule Lightning.KafkaTriggers do
   end
 
   defp determine_begin_offset(opts) do
-    if opts |> Keyword.get(:rollback_timestamp, nil), do: :reset, else: :assigned
+    if Keyword.get(opts, :rollback_timestamp, nil), do: :reset, else: :assigned
   end
 
   def get_kafka_triggers_being_updated(changeset) do

--- a/lib/lightning/kafka_triggers/event_listener.ex
+++ b/lib/lightning/kafka_triggers/event_listener.ex
@@ -33,7 +33,7 @@ defmodule Lightning.KafkaTriggers.EventListener do
     %{trigger_id: trigger_id, timestamp: timestamp} = event
 
     if supervisor = GenServer.whereis(:kafka_pipeline_supervisor) do
-      supervisor |> KafkaTriggers.rollback_pipeline(trigger_id, timestamp)
+      supervisor |> KafkaTriggers.reset_pipeline(trigger_id, timestamp)
     end
 
     {:noreply, state}

--- a/lib/lightning/kafka_triggers/event_listener.ex
+++ b/lib/lightning/kafka_triggers/event_listener.ex
@@ -14,8 +14,7 @@ defmodule Lightning.KafkaTriggers.EventListener do
 
   @impl true
   def init(_opts) do
-    Events.subscribe_to_kafka_trigger_updated()
-    Events.subscribe_to_kafka_trigger_persistence_failure()
+    Events.subscribe_to_kafka_trigger_events()
 
     {:ok, %{}}
   end

--- a/lib/lightning/kafka_triggers/pipeline.ex
+++ b/lib/lightning/kafka_triggers/pipeline.ex
@@ -137,6 +137,8 @@ defmodule Lightning.KafkaTriggers.Pipeline do
       create_log_entry(message, context)
     end)
 
+    stop_self_if_required(messages)
+
     messages
   end
 
@@ -257,6 +259,12 @@ defmodule Lightning.KafkaTriggers.Pipeline do
 
       sasl ->
         [{:sasl, sasl} | base_config]
+    end
+  end
+
+  def stop_self_if_required(messages) do
+    if Enum.any?(messages, &(&1.status == {:failed, :persistence})) do
+      exit(:killed)
     end
   end
 end

--- a/lib/lightning/kafka_triggers/pipeline.ex
+++ b/lib/lightning/kafka_triggers/pipeline.ex
@@ -216,12 +216,14 @@ defmodule Lightning.KafkaTriggers.Pipeline do
   end
 
   defp build_producer_opts(opts) do
+    begin_offset = opts |> Keyword.get(:begin_offset)
     hosts = opts |> Keyword.get(:hosts)
     group_id = opts |> Keyword.get(:group_id)
     offset_reset_policy = opts |> Keyword.get(:offset_reset_policy)
     topics = opts |> Keyword.get(:topics)
 
     [
+      begin_offset: begin_offset,
       client_config: client_config(opts),
       hosts: hosts,
       group_id: group_id,

--- a/lib/lightning/kafka_triggers/pipeline.ex
+++ b/lib/lightning/kafka_triggers/pipeline.ex
@@ -216,20 +216,15 @@ defmodule Lightning.KafkaTriggers.Pipeline do
   end
 
   defp build_producer_opts(opts) do
-    begin_offset = opts |> Keyword.get(:begin_offset)
-    hosts = opts |> Keyword.get(:hosts)
-    group_id = opts |> Keyword.get(:group_id)
-    offset_reset_policy = opts |> Keyword.get(:offset_reset_policy)
-    topics = opts |> Keyword.get(:topics)
-
-    [
-      begin_offset: begin_offset,
-      client_config: client_config(opts),
-      hosts: hosts,
-      group_id: group_id,
-      topics: topics,
-      offset_reset_policy: offset_reset_policy
-    ]
+    opts
+    |> Keyword.take([
+      :begin_offset,
+      :group_id,
+      :hosts,
+      :topics,
+      :offset_reset_policy
+    ])
+    |> Keyword.put(:client_config, client_config(opts))
   end
 
   defp client_config(opts) do

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -164,4 +164,8 @@ defmodule Lightning.Workflows.Trigger do
   def kafka_partitions_changeset(trigger, _partition, _timestamp) do
     change(trigger, %{})
   end
+
+  def kafka_reset_request_changeset(trigger, _reset_to, _requested_at) do
+    change(trigger, %{})
+  end
 end

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -165,6 +165,23 @@ defmodule Lightning.Workflows.Trigger do
     change(trigger, %{})
   end
 
+  def kafka_reset_request_changeset(
+        %{type: :kafka, kafka_configuration: kafka_configuration} = trigger,
+        reset_to,
+        requested_at
+      ) do
+    config_changes =
+      kafka_configuration
+      |> KafkaConfiguration.changeset(%{
+        reset_request: %{
+          requested_at: requested_at,
+          reset_to: reset_to
+        }
+      })
+
+    change(trigger, %{kafka_configuration: config_changes})
+  end
+
   def kafka_reset_request_changeset(trigger, _reset_to, _requested_at) do
     change(trigger, %{})
   end

--- a/lib/lightning/workflows/triggers/events.ex
+++ b/lib/lightning/workflows/triggers/events.ex
@@ -7,6 +7,21 @@ defmodule Lightning.Workflows.Triggers.Events do
     defstruct trigger_id: nil
   end
 
+  defmodule KafkaTriggerPersistenceFailure do
+    @moduledoc false
+    defstruct trigger_id: nil, timestamp: nil
+  end
+
+  def kafka_trigger_persistence_failure(trigger_id, timestamp) do
+    Lightning.broadcast(
+      kafka_trigger_persistence_failure_topic(),
+      %KafkaTriggerPersistenceFailure{
+        trigger_id: trigger_id,
+        timestamp: timestamp
+      }
+    )
+  end
+
   def kafka_trigger_updated(trigger_id) do
     Lightning.broadcast(
       kafka_trigger_updated_topic(),
@@ -14,8 +29,16 @@ defmodule Lightning.Workflows.Triggers.Events do
     )
   end
 
+  def subscribe_to_kafka_trigger_persistence_failure do
+    Lightning.subscribe(kafka_trigger_persistence_failure_topic())
+  end
+
   def subscribe_to_kafka_trigger_updated do
     Lightning.subscribe(kafka_trigger_updated_topic())
+  end
+
+  def kafka_trigger_persistence_failure_topic do
+    "kafka_trigger_persistence_failure"
   end
 
   def kafka_trigger_updated_topic, do: "kafka_trigger_updated"

--- a/lib/lightning/workflows/triggers/events.ex
+++ b/lib/lightning/workflows/triggers/events.ex
@@ -14,7 +14,7 @@ defmodule Lightning.Workflows.Triggers.Events do
 
   def kafka_trigger_persistence_failure(trigger_id, timestamp) do
     Lightning.broadcast(
-      kafka_trigger_persistence_failure_topic(),
+      kafka_trigger_events_topic(),
       %KafkaTriggerPersistenceFailure{
         trigger_id: trigger_id,
         timestamp: timestamp
@@ -24,22 +24,14 @@ defmodule Lightning.Workflows.Triggers.Events do
 
   def kafka_trigger_updated(trigger_id) do
     Lightning.broadcast(
-      kafka_trigger_updated_topic(),
+      kafka_trigger_events_topic(),
       %KafkaTriggerUpdated{trigger_id: trigger_id}
     )
   end
 
-  def subscribe_to_kafka_trigger_persistence_failure do
-    Lightning.subscribe(kafka_trigger_persistence_failure_topic())
+  def subscribe_to_kafka_trigger_events do
+    Lightning.subscribe(kafka_trigger_events_topic())
   end
 
-  def subscribe_to_kafka_trigger_updated do
-    Lightning.subscribe(kafka_trigger_updated_topic())
-  end
-
-  def kafka_trigger_persistence_failure_topic do
-    "kafka_trigger_persistence_failure"
-  end
-
-  def kafka_trigger_updated_topic, do: "kafka_trigger_updated"
+  defp kafka_trigger_events_topic, do: "kafka_trigger_events"
 end

--- a/lib/lightning/workflows/triggers/kafka_configuration.ex
+++ b/lib/lightning/workflows/triggers/kafka_configuration.ex
@@ -329,18 +329,26 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
 
   def validate_reset_request(changeset) do
     error_message =
-      "must be a map with both `requested_at` and `reset_to` elements" <>
-        "populated or both set to nil"
+      "must be a map with both `requested_at` and `reset_to` elements " <>
+        "set to nil or `requested_at` a valid DateTime and " <>
+        "`reset_to` a positive integer"
 
     changeset
     |> get_change(:reset_request)
-    |> IO.inspect()
     |> case do
+      nil ->
+        changeset
+
       %{requested_at: nil, reset_to: nil} ->
         changeset
+
+      %{requested_at: %DateTime{}, reset_to: reset_to}
+      when is_integer(reset_to) and reset_to > 0 ->
+        changeset
+
       _ ->
-      changeset
-      |> add_error(:reset_request, error_message)
+        changeset
+        |> add_error(:reset_request, error_message)
     end
   end
 

--- a/lib/lightning/workflows/triggers/kafka_configuration.ex
+++ b/lib/lightning/workflows/triggers/kafka_configuration.ex
@@ -13,6 +13,7 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
              :hosts,
              :initial_offset_reset_policy,
              :partition_timestamps,
+             :reset_request,
              :password,
              :sasl,
              :ssl,
@@ -28,6 +29,7 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
     field :initial_offset_reset_policy, :string
     field :partition_timestamps, :map, default: %{}
     field :password, Lightning.Encrypted.EmbeddedBinary
+    field :reset_request, :map, default: %{requested_at: nil, reset_to: nil}
     field :sasl, Ecto.Enum, values: @sasl_types, default: nil
     field :ssl, :boolean
     field :topics, {:array, :string}
@@ -44,6 +46,7 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
       :initial_offset_reset_policy,
       :partition_timestamps,
       :password,
+      :reset_request,
       :sasl,
       :ssl,
       :topics,
@@ -64,6 +67,7 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
     |> set_group_id_if_required()
     |> validate_sasl_credentials()
     |> validate_number(:connect_timeout, greater_than: 0)
+    |> validate_reset_request()
   end
 
   def generate_hosts_string(changeset) do
@@ -320,6 +324,23 @@ defmodule Lightning.Workflows.Triggers.KafkaConfiguration do
 
       set ->
         set
+    end
+  end
+
+  def validate_reset_request(changeset) do
+    error_message =
+      "must be a map with both `requested_at` and `reset_to` elements" <>
+        "populated or both set to nil"
+
+    changeset
+    |> get_change(:reset_request)
+    |> IO.inspect()
+    |> case do
+      %{requested_at: nil, reset_to: nil} ->
+        changeset
+      _ ->
+      changeset
+      |> add_error(:reset_request, error_message)
     end
   end
 

--- a/test/lightning/kafka_triggers/event_listener_test.exs
+++ b/test/lightning/kafka_triggers/event_listener_test.exs
@@ -33,7 +33,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
     assert {:ok, _pid} = EventListener.start_link([])
   end
 
-  test "init/1 subscribes to the Kafka trigger updated topic", %{
+  test "init/1 subscribes to kafka trigger updated events", %{
     trigger: trigger
   } do
     trigger_id = trigger.id
@@ -45,7 +45,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
     assert_receive %KafkaTriggerUpdated{trigger_id: ^trigger_id}
   end
 
-  test "init/1 subscribes to the Kafka trigger persistence failure topic", %{
+  test "init/1 subscribes to the Kafka trigger persistence failure events", %{
     timestamp: timestamp,
     trigger: trigger
   } do

--- a/test/lightning/kafka_triggers/event_listener_test.exs
+++ b/test/lightning/kafka_triggers/event_listener_test.exs
@@ -42,62 +42,64 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
     assert_receive %KafkaTriggerUpdated{trigger_id: ^trigger_id}
   end
 
-  test "handle_info/1 updates the trigger's pipeline", %{
-    supervisor_pid: pid,
-    state: state,
-    trigger: trigger
-  } do
-    with_mock KafkaTriggers,
-      update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
-      EventListener.handle_info(
-        %KafkaTriggerUpdated{trigger_id: trigger.id},
-        state
-      )
+  describe "handle_info/1 - KafkaTriggerUpdated" do
+    test "handle_info/1 updates the trigger's pipeline", %{
+      supervisor_pid: pid,
+      state: state,
+      trigger: trigger
+    } do
+      with_mock KafkaTriggers,
+        update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
+        EventListener.handle_info(
+          %KafkaTriggerUpdated{trigger_id: trigger.id},
+          state
+        )
 
-      assert_called(KafkaTriggers.update_pipeline(pid, trigger.id))
+        assert_called(KafkaTriggers.update_pipeline(pid, trigger.id))
+      end
     end
-  end
 
-  test "handle_info/1 returns appropriate response", %{
-    state: state,
-    trigger: trigger
-  } do
-    with_mock KafkaTriggers,
-      update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
-      assert {:noreply, ^state} =
-               EventListener.handle_info(
-                 %KafkaTriggerUpdated{trigger_id: trigger.id},
-                 state
-               )
+    test "handle_info/1 returns appropriate response", %{
+      state: state,
+      trigger: trigger
+    } do
+      with_mock KafkaTriggers,
+        update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
+        assert {:noreply, ^state} =
+                 EventListener.handle_info(
+                   %KafkaTriggerUpdated{trigger_id: trigger.id},
+                   state
+                 )
+      end
     end
-  end
 
-  test "handle_info/1 ignores non-KafkaTriggerUpdated events", %{
-    state: state
-  } do
-    with_mock KafkaTriggers,
-      update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
-      assert {:noreply, ^state} = EventListener.handle_info("huh?", state)
+    test "handle_info/1 ignores non-KafkaTriggerUpdated events", %{
+      state: state
+    } do
+      with_mock KafkaTriggers,
+        update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
+        assert {:noreply, ^state} = EventListener.handle_info("huh?", state)
 
-      assert_not_called(KafkaTriggers.update_pipeline(:_, :_))
+        assert_not_called(KafkaTriggers.update_pipeline(:_, :_))
+      end
     end
-  end
 
-  test "handle_info/1 does nothing if PipelineSupervisor is not running", %{
-    state: state,
-    trigger: trigger
-  } do
-    stop_supervised!(PipelineSupervisor)
+    test "handle_info/1 does nothing if PipelineSupervisor is not running", %{
+      state: state,
+      trigger: trigger
+    } do
+      stop_supervised!(PipelineSupervisor)
 
-    with_mock KafkaTriggers,
-      update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
-      assert {:noreply, ^state} =
-               EventListener.handle_info(
-                 %KafkaTriggerUpdated{trigger_id: trigger.id},
-                 state
-               )
+      with_mock KafkaTriggers,
+        update_pipeline: fn _supervisor, _trigger -> {:ok, "fake-pid"} end do
+        assert {:noreply, ^state} =
+                 EventListener.handle_info(
+                   %KafkaTriggerUpdated{trigger_id: trigger.id},
+                   state
+                 )
 
-      assert_not_called(KafkaTriggers.update_pipeline(:_, :_))
+        assert_not_called(KafkaTriggers.update_pipeline(:_, :_))
+      end
     end
   end
 end

--- a/test/lightning/kafka_triggers/event_listener_test.exs
+++ b/test/lightning/kafka_triggers/event_listener_test.exs
@@ -130,7 +130,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
       trigger: trigger
     } do
       with_mock KafkaTriggers,
-        rollback_pipeline: fn _supervisor, _trigger, _timestamp ->
+        reset_pipeline: fn _supervisor, _trigger, _timestamp ->
           {:ok, "fake-pid"}
         end do
         EventListener.handle_info(
@@ -141,9 +141,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
           state
         )
 
-        assert_called(
-          KafkaTriggers.rollback_pipeline(pid, trigger.id, timestamp)
-        )
+        assert_called(KafkaTriggers.reset_pipeline(pid, trigger.id, timestamp))
       end
     end
 
@@ -153,7 +151,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
       trigger: trigger
     } do
       with_mock KafkaTriggers,
-        rollback_pipeline: fn _supervisor, _trigger, _timestamp ->
+        reset_pipeline: fn _supervisor, _trigger, _timestamp ->
           {:ok, "fake-pid"}
         end do
         response =
@@ -173,12 +171,12 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
       state: state
     } do
       with_mock KafkaTriggers,
-        rollback_pipeline: fn _supervisor, _trigger, _timestamp ->
+        reset_pipeline: fn _supervisor, _trigger, _timestamp ->
           {:ok, "fake-pid"}
         end do
         assert {:noreply, ^state} = EventListener.handle_info("huh?", state)
 
-        assert_not_called(KafkaTriggers.rollback_pipeline(:_, :_, :_))
+        assert_not_called(KafkaTriggers.reset_pipeline(:_, :_, :_))
       end
     end
 
@@ -190,7 +188,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
       stop_supervised!(PipelineSupervisor)
 
       with_mock KafkaTriggers,
-        rollback_pipeline: fn _supervisor, _trigger, _timestamp ->
+        reset_pipeline: fn _supervisor, _trigger, _timestamp ->
           {:ok, "fake-pid"}
         end do
         EventListener.handle_info(
@@ -201,7 +199,7 @@ defmodule Lightning.KafkaTriggers.EventListenerTest do
           state
         )
 
-        assert_not_called(KafkaTriggers.rollback_pipeline(:_, :_, :_))
+        assert_not_called(KafkaTriggers.reset_pipeline(:_, :_, :_))
       end
     end
   end

--- a/test/lightning/kafka_triggers/pipeline_test.exs
+++ b/test/lightning/kafka_triggers/pipeline_test.exs
@@ -457,7 +457,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
 
       messages = [message_1, persistence_failed_message, message_2]
 
-      Events.subscribe_to_kafka_trigger_persistence_failure()
+      Events.subscribe_to_kafka_trigger_events()
 
       Pipeline.handle_failed(messages, context)
 

--- a/test/lightning/kafka_triggers/pipeline_test.exs
+++ b/test/lightning/kafka_triggers/pipeline_test.exs
@@ -66,16 +66,16 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
                      module: {
                        BroadwayKafka.Producer,
                        [
-                         begin_offset: begin_offset,
                          client_config: [
                            sasl: sasl_expected,
                            ssl: ssl,
                            connect_timeout: connect_timeout
                          ],
-                         hosts: hosts,
+                         begin_offset: begin_offset,
                          group_id: group_id,
-                         topics: topics,
-                         offset_reset_policy: offset_reset_policy
+                         hosts: hosts,
+                         offset_reset_policy: offset_reset_policy,
+                         topics: topics
                        ]
                      },
                      concurrency: number_of_consumers,
@@ -140,15 +140,15 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
                      module: {
                        BroadwayKafka.Producer,
                        [
-                         begin_offset: begin_offset,
                          client_config: [
                            ssl: ssl,
                            connect_timeout: connect_timeout
                          ],
-                         hosts: hosts,
+                         begin_offset: begin_offset,
                          group_id: group_id,
-                         topics: topics,
-                         offset_reset_policy: offset_reset_policy
+                         hosts: hosts,
+                         offset_reset_policy: offset_reset_policy,
+                         topics: topics
                        ]
                      },
                      concurrency: number_of_consumers,

--- a/test/lightning/kafka_triggers/pipeline_test.exs
+++ b/test/lightning/kafka_triggers/pipeline_test.exs
@@ -21,6 +21,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
 
   describe ".start_link/1" do
     test "starts a Broadway GenServer process with SASL credentials" do
+      begin_offset = :assigned
       connect_timeout = 15_000
       group_id = "my_group"
       hosts = [{"localhost", 9092}]
@@ -40,6 +41,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
       with_mock Broadway,
         start_link: fn _module, _opts -> {:ok, "fake-pid"} end do
         Pipeline.start_link(
+          begin_offset: begin_offset,
           connect_timeout: connect_timeout,
           group_id: group_id,
           hosts: hosts,
@@ -64,6 +66,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
                      module: {
                        BroadwayKafka.Producer,
                        [
+                         begin_offset: begin_offset,
                          client_config: [
                            sasl: sasl_expected,
                            ssl: ssl,
@@ -93,6 +96,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
     end
 
     test "starts a Broadway GenServer process without SASL credentials" do
+      begin_offset = :reset
       connect_timeout = 15_000
       group_id = "my_group"
       hosts = [{"localhost", 9092}]
@@ -111,6 +115,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
       with_mock Broadway,
         start_link: fn _module, _opts -> {:ok, "fake-pid"} end do
         Pipeline.start_link(
+          begin_offset: begin_offset,
           connect_timeout: connect_timeout,
           group_id: group_id,
           hosts: hosts,
@@ -135,6 +140,7 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
                      module: {
                        BroadwayKafka.Producer,
                        [
+                         begin_offset: begin_offset,
                          client_config: [
                            ssl: ssl,
                            connect_timeout: connect_timeout

--- a/test/lightning/workflows/trigger_test.exs
+++ b/test/lightning/workflows/trigger_test.exs
@@ -224,10 +224,17 @@ defmodule Lightning.Workflows.TriggerTest do
   end
 
   describe ".reset_request_changeset" do
-    test "returns changeset with changes to kafka configuration" do
+    setup do
       reset_to = 1_723_633_665_366
-      requested_at = ~U[2024-09-12 12:00:00]
+      requested_at = ~U[2024-09-12 12:00:00Z]
 
+      %{reset_to: reset_to, requested_at: requested_at}
+    end
+
+    test "returns changeset with changes to kafka configuration", %{
+      reset_to: reset_to,
+      requested_at: requested_at
+    } do
       trigger =
         insert(
           :trigger,
@@ -237,7 +244,7 @@ defmodule Lightning.Workflows.TriggerTest do
 
       changeset =
         trigger
-        |> Trigger.reset_request_changeset(reset_to, requested_at)
+        |> Trigger.kafka_reset_request_changeset(reset_to, requested_at)
 
       expected_request_reset = %{
         requested_at: requested_at,
@@ -251,6 +258,36 @@ defmodule Lightning.Workflows.TriggerTest do
                  changes: %{reset_request: ^expected_request_reset}
                }
              } = changes
+    end
+
+    test "returns an empty changeset if type is :webhook", %{
+      reset_to: reset_to,
+      requested_at: requested_at
+    } do
+      trigger = insert(:trigger, type: :webhook)
+
+      changeset =
+        trigger
+        |> Trigger.kafka_reset_request_changeset(reset_to, requested_at)
+
+      assert %Changeset{valid?: true, changes: changes} = changeset
+
+      assert changes == %{}
+    end
+
+    test "returns an empty changeset if type is :cron", %{
+      reset_to: reset_to,
+      requested_at: requested_at
+    } do
+      trigger = insert(:trigger, type: :webhook)
+
+      changeset =
+        trigger
+        |> Trigger.kafka_reset_request_changeset(reset_to, requested_at)
+
+      assert %Changeset{valid?: true, changes: changes} = changeset
+
+      assert changes == %{}
     end
   end
 end

--- a/test/lightning/workflows/trigger_test.exs
+++ b/test/lightning/workflows/trigger_test.exs
@@ -222,4 +222,35 @@ defmodule Lightning.Workflows.TriggerTest do
       assert changes == %{}
     end
   end
+
+  describe ".reset_request_changeset" do
+    test "returns changeset with changes to kafka configuration" do
+      reset_to = 1_723_633_665_366
+      requested_at = ~U[2024-09-12 12:00:00]
+
+      trigger =
+        insert(
+          :trigger,
+          type: :kafka,
+          kafka_configuration: build(:triggers_kafka_configuration)
+        )
+
+      changeset =
+        trigger
+        |> Trigger.reset_request_changeset(reset_to, requested_at)
+
+      expected_request_reset = %{
+        requested_at: requested_at,
+        reset_to: reset_to
+      }
+
+      assert %Changeset{valid?: true, changes: changes} = changeset
+
+      assert %{
+               kafka_configuration: %{
+                 changes: %{reset_request: ^expected_request_reset}
+               }
+             } = changes
+    end
+  end
 end

--- a/test/lightning/workflows/triggers/events_test.exs
+++ b/test/lightning/workflows/triggers/events_test.exs
@@ -8,10 +8,10 @@ defmodule Lightning.Workflows.Triggers.EventsTest do
   test "can subscribe to events relating to a Kafka trigger being updated" do
     trigger_id = "a-b-c-1-2-3"
 
-    Events.subscribe_to_kafka_trigger_updated()
+    Events.subscribe_to_kafka_trigger_events()
 
     Lightning.broadcast(
-      "kafka_trigger_updated",
+      "kafka_trigger_events",
       %KafkaTriggerUpdated{trigger_id: trigger_id}
     )
 
@@ -21,7 +21,7 @@ defmodule Lightning.Workflows.Triggers.EventsTest do
   test "can broadcast a kafka trigger updated event" do
     trigger_id = Ecto.UUID.generate()
 
-    Events.subscribe_to_kafka_trigger_updated()
+    Events.subscribe_to_kafka_trigger_events()
 
     Events.kafka_trigger_updated(trigger_id)
 
@@ -32,10 +32,10 @@ defmodule Lightning.Workflows.Triggers.EventsTest do
     trigger_id = "a-b-c-1-2-3"
     timestamp = 1_723_633_665_366
 
-    Events.subscribe_to_kafka_trigger_persistence_failure()
+    Events.subscribe_to_kafka_trigger_events()
 
     Lightning.broadcast(
-      "kafka_trigger_persistence_failure",
+      "kafka_trigger_events",
       %KafkaTriggerPersistenceFailure{
         trigger_id: trigger_id,
         timestamp: timestamp
@@ -52,7 +52,7 @@ defmodule Lightning.Workflows.Triggers.EventsTest do
     trigger_id = "a-b-c-1-2-3"
     timestamp = 1_723_633_665_366
 
-    Events.subscribe_to_kafka_trigger_persistence_failure()
+    Events.subscribe_to_kafka_trigger_events()
 
     Events.kafka_trigger_persistence_failure(trigger_id, timestamp)
 

--- a/test/lightning/workflows/triggers/events_test.exs
+++ b/test/lightning/workflows/triggers/events_test.exs
@@ -3,6 +3,7 @@ defmodule Lightning.Workflows.Triggers.EventsTest do
 
   alias Lightning.Workflows.Triggers.Events
   alias Lightning.Workflows.Triggers.Events.KafkaTriggerUpdated
+  alias Lightning.Workflows.Triggers.Events.KafkaTriggerPersistenceFailure
 
   test "can subscribe to events relating to a Kafka trigger being updated" do
     trigger_id = "a-b-c-1-2-3"
@@ -25,5 +26,39 @@ defmodule Lightning.Workflows.Triggers.EventsTest do
     Events.kafka_trigger_updated(trigger_id)
 
     assert_receive %KafkaTriggerUpdated{trigger_id: ^trigger_id}
+  end
+
+  test "subscribes to events relating to Kakfa trigger persistence failures" do
+    trigger_id = "a-b-c-1-2-3"
+    timestamp = 1_723_633_665_366
+
+    Events.subscribe_to_kafka_trigger_persistence_failure()
+
+    Lightning.broadcast(
+      "kafka_trigger_persistence_failure",
+      %KafkaTriggerPersistenceFailure{
+        trigger_id: trigger_id,
+        timestamp: timestamp
+      }
+    )
+
+    assert_receive %KafkaTriggerPersistenceFailure{
+      trigger_id: ^trigger_id,
+      timestamp: ^timestamp
+    }
+  end
+
+  test "publishes events relating to Kafka trigger persistence failures" do
+    trigger_id = "a-b-c-1-2-3"
+    timestamp = 1_723_633_665_366
+
+    Events.subscribe_to_kafka_trigger_persistence_failure()
+
+    Events.kafka_trigger_persistence_failure(trigger_id, timestamp)
+
+    assert_receive %KafkaTriggerPersistenceFailure{
+      trigger_id: ^trigger_id,
+      timestamp: ^timestamp
+    }
   end
 end

--- a/test/lightning/workflows/triggers/kafka_configuration_test.exs
+++ b/test/lightning/workflows/triggers/kafka_configuration_test.exs
@@ -653,16 +653,17 @@ defmodule Lightning.Workflows.Triggers.KafkaConfigurationTest do
 
       assert %Changeset{errors: errors, valid?: false} = changeset
 
-      assert errors == [
-               connect_timeout: {
-                 "must be greater than %{number}",
-                 [
-                   {:validation, :number},
-                   {:kind, :greater_than},
-                   {:number, 0}
-                 ]
-               }
-             ]
+      assert [reset_request: {_message, []}] = errors
+      # assert errors == [
+      #          connect_timeout: {
+      #            "must be greater than %{number}",
+      #            [
+      #              {:validation, :number},
+      #              {:kind, :greater_than},
+      #              {:number, 0}
+      #            ]
+      #          }
+      #        ]
     end
   end
 

--- a/test/lightning/workflows/triggers/kafka_configuration_test.exs
+++ b/test/lightning/workflows/triggers/kafka_configuration_test.exs
@@ -654,16 +654,6 @@ defmodule Lightning.Workflows.Triggers.KafkaConfigurationTest do
       assert %Changeset{errors: errors, valid?: false} = changeset
 
       assert [reset_request: {_message, []}] = errors
-      # assert errors == [
-      #          connect_timeout: {
-      #            "must be greater than %{number}",
-      #            [
-      #              {:validation, :number},
-      #              {:kind, :greater_than},
-      #              {:number, 0}
-      #            ]
-      #          }
-      #        ]
     end
   end
 

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -109,7 +109,7 @@ defmodule Lightning.WorkflowsTest do
 
       changeset = workflow |> build_changeset(triggers)
 
-      Events.subscribe_to_kafka_trigger_updated()
+      Events.subscribe_to_kafka_trigger_events()
 
       changeset |> Workflows.save_workflow()
 
@@ -161,7 +161,7 @@ defmodule Lightning.WorkflowsTest do
 
       changeset = workflow |> build_changeset(triggers)
 
-      Events.subscribe_to_kafka_trigger_updated()
+      Events.subscribe_to_kafka_trigger_events()
 
       changeset |> Workflows.save_workflow()
 
@@ -585,7 +585,7 @@ defmodule Lightning.WorkflowsTest do
       %{id: kafka_trigger_2_id} =
         insert(:trigger, workflow: w1, enabled: true, type: :kafka)
 
-      Events.subscribe_to_kafka_trigger_updated()
+      Events.subscribe_to_kafka_trigger_events()
 
       assert {:ok, _workflow} = Workflows.mark_for_deletion(w1)
 


### PR DESCRIPTION
### Description

BroadwayKafka will always notify a Kafka cluster of a processed offset, regardless whether the pipeline completed successfully or not. To cater for this behaviour we need to implement error-handling that will allow us to safely deal with messages that have experienced certain errors during processing.

This PR covers the first use case: When there is a transient error in the persisting of a message that means we could not store an incoming message in the database. Under these circumstances , the Kafka trigger will reset the offset to before the message and then reconnect to the Kafka cluster.

Caveats:

- This PR dos not cover the use case where there is a  prolonged failure affecting database insertions. For now, my hypothesis is that such an error will affect Lightning so badly that it may be entirely unusable.
- This PR does not cover the case where a trigger can not create WorkOrders due to hitting  a hard limit. In such cases, restarting the pipeline does not make sense as it will only exacerbate the issue. In addition, there will need to be a way to communicate this to users. As a result, this work is left for a future PR.
As the PR included some housekeeping and a few moving parts, I have tried to group the changes into distinct commits in the hopes it will make the changes easier to follow.

Closes #2386 

### Validation steps

- Setup a local Kafka cluster based on these [instructions](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster).
- Ensure that `KAFKA_TRIGGERS_ENABLED` is set to 'yes'
- Set up a Kafka trigger similar to the screenshot below (assuming you have  a topic named `baz_topic`) - note that the `Initial offset reset policy` is set to `latest` :

![Screenshot from 2024-08-19 12-23-47](https://github.com/user-attachments/assets/f528c6ba-dea3-460b-ace4-45fd704ac565)

- Ensure that Lightning is running.
- Publish a message to the Kafka cluster, using kcat: `cat message.json | kcat -P -b 127.0.0.1:9094 -t baz_topic`.
- Wait a few seconds and then publish another message using kacat:  `cat other_message.json | kcat -P -b 127.0.0.1:9094 -t baz_topic`.
- Wait until you see both messages show up in the workflow's history, then open an IEx session.
- Create the `Rollbackarino` module in IEx:

```
defmodule Rollbackarino do

  alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord                
  alias Lightning.Repo                    
  alias Lightning.Workflows.Trigger
  alias Lightning.Workflows.Triggers.Events
  import Ecto.Query

  def rollback() do
    find_latest_kafka_trigger = from t in Trigger, where: t.type == :kafka, order_by: [desc: :inserted_at], limit: 1

    trigger = find_latest_kafka_trigger |> Repo.one()

    # trigger = Trigger |> Repo.get(trigger_id)

    rollback_timestamp = trigger.kafka_configuration.partition_timestamps |> Map.values() |> Enum.max()

    %{topic_partition_offset: deleted_topic_partition_offset} = find_latest_tkmr() |> Repo.one()

    trigger_id = trigger.id

    delete_tkmr = from t in TriggerKafkaMessageRecord, where: t.trigger_id == ^trigger_id and t.topic_partition_offset == ^deleted_topic_partition_offset

    delete_tkmr |> Repo.delete_all()

    Events.kafka_trigger_persistence_failure(trigger_id, rollback_timestamp)

    deleted_topic_partition_offset
  end

  def validate_roll_forward(deleted_topic_partition_offset) do
    %{topic_partition_offset: most_recent_topic_partition_offset} = find_latest_tkmr() |> Repo.one()

    most_recent_topic_partition_offset == deleted_topic_partition_offset
  end

  defp find_latest_tkmr do
    from t in TriggerKafkaMessageRecord, order_by: [desc: :inserted_at], limit: 1
  end
end

```

Next, rollback the pipeline:

```
deleted_tpo = Rollbackarino.rollback()
```

It may take a a short while before the consumer group reconnects to the cluster - you should see your second message reappear in the Workflow history.  For additional validation, you can confirm that the same message has been reprocessed by confirming that we have captured a new message with the same topic, partition and offset as the message that is 'after' the rollback point:

```
Rollbackarino.validate_roll_forward(deleted_tpo) # Should return true
```

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
