### PR TITLE
Use Anthropic (claude)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to
 
 ### Changed
 
-- Claude integration in job chat (OPENAI_API_KEY renamed to ANTHROPIC_API_KEY)
+- Claude integration in job chat (OPENAI_API_KEY renamed to
+  AI_ASSISTANT_API_KEY)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 ### Changed
 
+- Claude integration in job chat (OPENAI_API_KEY renamed to ANTHROPIC_API_KEY)
+
 ### Fixed
 
 ## [v2.9.0] - 2024-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to
 
 ### Changed
 
-- Claude integration in job chat (OPENAI_API_KEY renamed to
-  AI_ASSISTANT_API_KEY)
+- Added Claude integration in job chat
+- OPENAI_API_KEY renamed to AI_ASSISTANT_API_KEY
 
 ### Fixed
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -160,7 +160,7 @@ the Apollo AI service.
 
 The following environment variables are required:
 
-- `OPENAI_API_KEY` - your OpenAI API key.
+- `ANTHROPIC_API_KEY` - your Anthropic API key.
 - `APOLLO_ENDPOINT` - the endpoint for the OpenFn Apollo AI service.
 
 ### Kafka Triggers

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -160,7 +160,7 @@ the Apollo AI service.
 
 The following environment variables are required:
 
-- `ANTHROPIC_API_KEY` - your Anthropic API key.
+- `AI_ASSISTANT_API_KEY` - your Anthropic API key.
 - `APOLLO_ENDPOINT` - the endpoint for the OpenFn Apollo AI service.
 
 ### Kafka Triggers

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -160,7 +160,8 @@ the Apollo AI service.
 
 The following environment variables are required:
 
-- `AI_ASSISTANT_API_KEY` - your Anthropic API key.
+- `AI_ASSISTANT_API_KEY` - API key to use the assistant. This currently requires
+  an Anthropic key.
 - `APOLLO_ENDPOINT` - the endpoint for the OpenFn Apollo AI service.
 
 ### Kafka Triggers

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -137,7 +137,7 @@ defmodule Lightning.AiAssistant do
   @spec enabled?() :: boolean()
   def enabled? do
     endpoint = Lightning.Config.apollo(:endpoint)
-    api_key = Lightning.Config.apollo(:openai_api_key)
+    api_key = Lightning.Config.apollo(:ai_assistant_api_key)
 
     is_binary(endpoint) && is_binary(api_key)
   end

--- a/lib/lightning/apollo_client.ex
+++ b/lib/lightning/apollo_client.ex
@@ -12,7 +12,7 @@ defmodule Lightning.ApolloClient do
   @spec query(String.t(), context(), list()) :: Tesla.Env.result()
   def query(content, context \\ %{}, history \\ []) do
     payload = %{
-      "api_key" => Lightning.Config.apollo(:openai_api_key),
+      "api_key" => Lightning.Config.apollo(:ai_assistant_api_key),
       "content" => content,
       "context" => context,
       "history" => history

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -99,7 +99,7 @@ defmodule Lightning.Config.Bootstrap do
           :string,
           Utils.get_env([:lightning, :apollo, :endpoint])
         ),
-      openai_api_key: env!("AI_ASSISTANT_API_KEY", :string, nil)
+      ai_assistant_api_key: env!("AI_ASSISTANT_API_KEY", :string, nil)
 
     config :lightning, Lightning.Runtime.RuntimeManager,
       start:

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -99,7 +99,7 @@ defmodule Lightning.Config.Bootstrap do
           :string,
           Utils.get_env([:lightning, :apollo, :endpoint])
         ),
-      openai_api_key: env!("ANTHROPIC_API_KEY", :string, nil)
+      openai_api_key: env!("AI_ASSISTANT_API_KEY", :string, nil)
 
     config :lightning, Lightning.Runtime.RuntimeManager,
       start:

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -99,7 +99,7 @@ defmodule Lightning.Config.Bootstrap do
           :string,
           Utils.get_env([:lightning, :apollo, :endpoint])
         ),
-      openai_api_key: env!("OPENAI_API_KEY", :string, nil)
+      openai_api_key: env!("ANTHROPIC_API_KEY", :string, nil)
 
     config :lightning, Lightning.Runtime.RuntimeManager,
       start:

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -18,7 +18,7 @@ defmodule Lightning.AiAssistantTest do
       Mox.stub(Lightning.MockConfig, :apollo, fn key ->
         case key do
           :endpoint -> "http://localhost:3000"
-          :openai_api_key -> "api_key"
+          :ai_assistant_api_key -> "api_key"
         end
       end)
 
@@ -63,7 +63,7 @@ defmodule Lightning.AiAssistantTest do
       Mox.stub(Lightning.MockConfig, :apollo, fn key ->
         case key do
           :endpoint -> "http://localhost:3000"
-          :openai_api_key -> "api_key"
+          :ai_assistant_api_key -> "api_key"
         end
       end)
 

--- a/test/lightning/apollo_client_test.exs
+++ b/test/lightning/apollo_client_test.exs
@@ -11,7 +11,7 @@ defmodule Lightning.ApolloClientTest do
     Mox.stub(Lightning.MockConfig, :apollo, fn key ->
       case key do
         :endpoint -> "http://localhost:3000"
-        :openai_api_key -> "api_key"
+        :ai_assistant_api_key -> "api_key"
       end
     end)
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1384,7 +1384,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       # when not configured properly
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> nil
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       {:ok, view, _html} =
@@ -1402,7 +1402,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       # when configured properly
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> "http://localhost:4001"
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       {:ok, view, _html} =
@@ -1426,7 +1426,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
     } do
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> "http://localhost:4001"
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       # when no session exists
@@ -1480,7 +1480,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> apollo_endpoint
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       Mox.stub(
@@ -1578,7 +1578,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> apollo_endpoint
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       Mox.stub(
@@ -1650,7 +1650,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> apollo_endpoint
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       expected_question = "Can you help me with this?"
@@ -1728,7 +1728,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> apollo_endpoint
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       Mox.stub(
@@ -1779,7 +1779,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> apollo_endpoint
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       Mox.stub(
@@ -1830,7 +1830,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.MockConfig, :apollo, fn
         :endpoint -> "http://localhost:4001/health_check"
-        :openai_api_key -> "openai_api_key"
+        :ai_assistant_api_key -> "ai_assistant_api_key"
       end)
 
       error_message = "You have reached your quota of AI queries"


### PR DESCRIPTION
This PR renames `OPENAI_API_KEY` to `AI_ASSISTANT_API_KEY`, to reflect an upcoming change on the apollo backend.

⚠️ **If you are running a lightning deployment an use the AI assistant, make sure to update your secret!**

Note that this isn't technically needed to start using the new model. Setting the anthropic key values into the open AI key will work just fine.