### PR TITLE
allow injection after <body>

### DIFF
--- a/lib/lightning_web/components/layouts.ex
+++ b/lib/lightning_web/components/layouts.ex
@@ -6,5 +6,6 @@ defmodule LightningWeb.Layouts do
   embed_templates "layouts/*"
 
   slot :header_tags
+  slot :body_tags
   def root(assigns)
 end

--- a/lib/lightning_web/components/layouts/root.html.heex
+++ b/lib/lightning_web/components/layouts/root.html.heex
@@ -42,6 +42,7 @@
     <%= render_slot(@header_tags) %>
   </head>
   <body class="h-full">
+    <%= render_slot(@body_tags) %>
     <div class="min-h-full">
       <%= @inner_content %>
     </div>


### PR DESCRIPTION
### Description

This PR allows for tags to be injected just after the `<body>` element, extending the functionality introduced in https://github.com/OpenFn/lightning/pull/2310

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
