### PR TITLE
Pull timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@
 # period if you are using Kubernetes.
 # RUN_GRACE_PERIOD_SECONDS=10
 # WORKER_MAX_RUN_DURATION_SECONDS=300
+# WORKER_MAX_PULL_TIMEOUT_SECONDS=10
 
 # TODO: these aren't specified in Runtime, do they belong to the worker process?
 # WORKER_MAX_RUN_MEMORY_MB=500

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -41,6 +41,11 @@ defmodule Lightning.Config do
     end
 
     @impl true
+    def max_pull_timeout_seconds do
+      Application.get_env(:lightning, :max_pull_timeout_seconds)
+    end
+
+    @impl true
     def default_max_run_duration do
       Application.get_env(:lightning, :max_run_duration_seconds)
     end
@@ -164,6 +169,7 @@ defmodule Lightning.Config do
   @callback email_sender_name() :: String.t()
   @callback get_extension_mod(key :: atom()) :: any()
   @callback grace_period() :: integer()
+  @callback max_pull_timeout_seconds() :: integer()
   @callback instance_admin_email() :: String.t()
   @callback kafka_duplicate_tracking_retention_seconds() :: integer()
   @callback kafka_number_of_consumers() :: integer()

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -226,6 +226,10 @@ defmodule Lightning.Config.Bootstrap do
       data_domain: env!("PLAUSIBLE_DATA_DOMAIN", :string, nil)
 
     config :lightning,
+           :max_pull_timeout_seconds,
+           env!("WORKER_MAX_PULL_TIMEOUT_SECONDS", :integer, 30)
+
+    config :lightning,
            :run_grace_period_seconds,
            env!("RUN_GRACE_PERIOD_SECONDS", :integer, 10)
 

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -319,6 +319,18 @@ defmodule Lightning.Runs do
     end)
   end
 
+  @spec forfeit_claim(Lightning.Run.t()) ::
+          {:ok, any()} | {:error, any()}
+  def forfeit_claim(%Run{} = run) do
+    Logger.warning(fn ->
+      "Detected forfeit run: #{inspect(run)}"
+    end)
+
+    run
+    |> Ecto.Changeset.change(state: "available")
+    |> Repo.update()
+  end
+
   defdelegate subscribe(run), to: Events
 
   def get_project_id_for_run(run) do

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -31,6 +31,11 @@ defmodule LightningWeb.WorkerChannel do
         runs =
           runs
           |> Enum.map(fn run ->
+            # in heavy load this averages over 10 seconds and causes all runs to
+            # be marked as lost
+            # dbg("there was a run and we set it to started")
+            # :timer.sleep(11_000)
+
             opts = run_options(run)
 
             token =

--- a/test/lightning/janitor_test.exs
+++ b/test/lightning/janitor_test.exs
@@ -6,7 +6,14 @@ defmodule Lightning.JanitorTest do
   alias Lightning.Repo
   alias Lightning.Run
 
-  describe "release_claimed_but_not_started/0" do
+  describe "forfeit_expired_claims/0" do
+    test "releases runs for reclaim if they have not been started after the pull timeout plus grace" do
+      dbg("eish, i don't love this. what if there was some other reason for them getting lost?")
+      dbg("like, what if they did start, and did the work, and all that, but we never heard back from them because of network issues?")
+      dbg("i wouldn't want to re-do the work.")
+      dbg("i wish there was some way to only mark them as claimed once we know that the worker actually got the run.")
+      dbg("can we check that our reply in the websocket channel was actually received by the ws-worker?")
+    end
   end
 
   describe "find_and_update_lost/0" do

--- a/test/lightning/janitor_test.exs
+++ b/test/lightning/janitor_test.exs
@@ -6,6 +6,9 @@ defmodule Lightning.JanitorTest do
   alias Lightning.Repo
   alias Lightning.Run
 
+  describe "release_claimed_but_not_started/0" do
+  end
+
   describe "find_and_update_lost/0" do
     @tag :capture_log
     test "updates lost runs and their steps" do


### PR DESCRIPTION
this is a concept. @stuartc , we're trying to:
1. raise the timeout (make it ENV configurable) so that 11s query doesnt lead to `lost` (@josephjclark on it.)
2. make that query more efficient (and maybe look for _other things_ that might be slowing down this part of the pipeline under heavy load - you and @rorymckinley on it)
3. come up with some sort of failsafe that sweeps up false-claims (you sir must _FORFEIT YOUR CLAIM ON THAT RUN!_) and releases them for someone else to claim... but as you can see in the test placeholder, i really don't like this.