### PR TITLE
msf 1, allow setup_user to build super

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 
 ### Changed
 
+- Allow `Setup_utils.setup_user` to be used for the initial superuser creation.
+
 ### Fixed
 
 ## [v2.7.19] - 2024-08-19

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -904,26 +904,36 @@ defmodule Lightning.SetupUtils do
     :ok
 
   """
-  @spec setup_user(map(), String.t(), list(map())) :: :ok | {:error, any()}
-  def setup_user(user, token, credentials) do
+  @spec setup_user(map(), String.t() | nil, list(map()) | nil) ::
+          :ok | {:error, any()}
+  def setup_user(user, token \\ nil, credentials \\ nil) do
+    {role, user} = Map.pop(user, :role)
+
     # create user
-    {:ok, user} = Accounts.create_user(user)
+    {:ok, user} =
+      if role == :superuser,
+        do: Accounts.register_superuser(user),
+        else: Accounts.create_user(user)
 
     # create token
-    Repo.insert!(%Lightning.Accounts.UserToken{
-      user_id: user.id,
-      context: "api",
-      token: token
-    })
+    if token,
+      do:
+        Repo.insert!(%Lightning.Accounts.UserToken{
+          user_id: user.id,
+          context: "api",
+          token: token
+        })
 
     # create credentials
-    Enum.each(credentials, fn credential ->
-      {:ok, _credential} =
-        Credentials.create_credential(
-          credential
-          |> Map.put(:user_id, user.id)
-        )
-    end)
+    if credentials,
+      do:
+        Enum.each(credentials, fn credential ->
+          {:ok, _credential} =
+            Credentials.create_credential(
+              credential
+              |> Map.put(:user_id, user.id)
+            )
+        end)
 
     :ok
   end

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -687,6 +687,24 @@ defmodule Lightning.SetupUtilsTest do
                %Credential{name: "dhis2", user_id: ^user_id}
              ] = Repo.all(Credential)
     end
+
+    test "can be used to set up a superuser" do
+      assert :ok ==
+               Lightning.SetupUtils.setup_user(
+                 %{
+                   role: :superuser,
+                   first_name: "Super",
+                   last_name: "Hero",
+                   email: "super@openfn.org",
+                   password: "easyAsCake123!"
+                 },
+                 "abc"
+               )
+
+      # check that the user has been created
+      assert %User{id: _user_id, role: :superuser} =
+               Repo.get_by(User, email: "super@openfn.org")
+    end
   end
 
   defp get_dataclip_body(dataclip_id) do


### PR DESCRIPTION
### Description

This PR changes `setup_user`, allowing it to generate a `superuser` user.

### Validation steps

1. launch lightning
2. run the following command from iex:
```ex
Lightning.SetupUtils.setup_user(%{role: :superuser, first_name: "Taylor", last_name: "Downs", email: "contact@openfn.org", password: "shh12345678!"}, "abc123", [%{name: "openmrs", schema: "raw", body: %{"a" => "secret"}}, %{ name: "dhis2", schema: "raw", body: %{"b" => "safe"}}])
```
3. Check to see that the user has been created, **_is a superuser_**, has an apiToken, has acess to both projects, and that the credential is associated with both projects.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
