### PR TITLE
msf 2 makes execution of setup user possible from outside containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 ### Changed
 
+- Allow execution of a setup_user command from outside the container.
 - Implement a combo-box to make navigating between projects easier
   [#241](https://github.com/OpenFn/lightning/pull/2424)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to
 
 ### Changed
 
-- Allow execution of a setup_user command from outside the container.
+- Allow setup_user command to be execute from outside the container with
+  `/app/bin/lightning eval Lightning.Setup.setup_user/3`
 - Implement a combo-box to make navigating between projects easier
   [#241](https://github.com/OpenFn/lightning/pull/2424)
 

--- a/lib/lightning/demo.ex
+++ b/lib/lightning/demo.ex
@@ -12,17 +12,7 @@ defmodule Lightning.Demo do
   """
   def reset_demo do
     if Application.get_env(:lightning, :is_resettable_demo) do
-      Lightning.Release.load_app()
-
-      children =
-        [
-          {Phoenix.PubSub,
-           name: Lightning.PubSub, adapter: Lightning.Demo.FakePubSub},
-          {Lightning.Vault, Application.get_env(:lightning, Lightning.Vault, [])}
-        ]
-        |> Enum.reject(fn {mod, _} -> Process.whereis(mod) end)
-
-      Supervisor.start_link(children, strategy: :one_for_one)
+      {:ok, _pid} = Lightning.Setup.ensure_minimum_setup()
 
       {:ok, _, _} =
         Ecto.Migrator.with_repo(Lightning.Repo, fn _repo ->
@@ -31,38 +21,6 @@ defmodule Lightning.Demo do
         end)
     else
       IO.puts("I'm sorry, Dave. I'm afraid I can't do that.")
-    end
-  end
-
-  defmodule FakePubSub do
-    @moduledoc false
-
-    # FakePubSub is a Phoenix.PubSub adapter that does nothing.
-    # The purpose of this adapter is to allow the demo to run without
-    # the whole application running.
-
-    @behaviour Phoenix.PubSub.Adapter
-
-    @impl true
-    def child_spec(_opts) do
-      %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
-    end
-
-    def start_link do
-      {:ok, self()}
-    end
-
-    @impl true
-    def node_name(_), do: nil
-
-    @impl true
-    def broadcast(_, _, _, _) do
-      :ok
-    end
-
-    @impl true
-    def direct_broadcast(_, _, _, _, _) do
-      :ok
     end
   end
 end

--- a/lib/lightning/setup.ex
+++ b/lib/lightning/setup.ex
@@ -17,7 +17,7 @@ defmodule Lightning.Setup do
 
   """
   @spec setup_user(map(), String.t() | nil, list(map()) | nil) ::
-          :ok | {:error, any()}
+          {:ok, any(), any()} | {:error, any()}
   def setup_user(user, token \\ nil, credentials \\ nil) do
     {:ok, _pid} = Lightning.Setup.ensure_minimum_setup()
 

--- a/lib/lightning/setup.ex
+++ b/lib/lightning/setup.ex
@@ -1,0 +1,75 @@
+defmodule Lightning.Setup do
+  @moduledoc """
+  Demo encapsulates logic for setting up a demonstration site.
+  """
+
+  alias Lightning.SetupUtils
+
+  @doc """
+  This makes it possible to run setup_user as an external command
+
+  See: Lightning.SetupUtils.setup_user() for more docs.
+
+  ## Examples
+
+    iex> kubectl exec -it deploy/demo-web -- /app/bin/lightning eval Lightning.Setup.setup_user(%{email: "td@openfn.org", first_name: "taylor", last_name: "downs", password: "shh12345!"})
+    :ok
+
+  """
+  @spec setup_user(map(), String.t() | nil, list(map()) | nil) ::
+          :ok | {:error, any()}
+  def setup_user(user, token \\ nil, credentials \\ nil) do
+    {:ok, _pid} = Lightning.Setup.ensure_minimum_setup()
+
+    :ok = Lightning.Setup.setup_user(user, token, credentials)
+  end
+
+  @doc """
+  Set up the bare minimum so that commands can be executed against the repo.
+  """
+  def ensure_minimum_setup do
+    Lightning.Release.load_app()
+
+    children =
+      [
+        {Phoenix.PubSub,
+         name: Lightning.PubSub, adapter: Lightning.Setup.FakePubSub},
+        {Lightning.Vault, Application.get_env(:lightning, Lightning.Vault, [])}
+      ]
+      |> Enum.reject(fn {mod, _} -> Process.whereis(mod) end)
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defmodule FakePubSub do
+    @moduledoc false
+
+    # FakePubSub is a Phoenix.PubSub adapter that does nothing.
+    # The purpose of this adapter is to allow the demo to run without
+    # the whole application running.
+
+    @behaviour Phoenix.PubSub.Adapter
+
+    @impl true
+    def child_spec(_opts) do
+      %{id: __MODULE__, start: {__MODULE__, :start_link, []}}
+    end
+
+    def start_link do
+      {:ok, self()}
+    end
+
+    @impl true
+    def node_name(_), do: nil
+
+    @impl true
+    def broadcast(_, _, _, _) do
+      :ok
+    end
+
+    @impl true
+    def direct_broadcast(_, _, _, _, _) do
+      :ok
+    end
+  end
+end

--- a/lib/lightning/setup.ex
+++ b/lib/lightning/setup.ex
@@ -21,7 +21,7 @@ defmodule Lightning.Setup do
   def setup_user(user, token \\ nil, credentials \\ nil) do
     {:ok, _pid} = Lightning.Setup.ensure_minimum_setup()
 
-    :ok = Lightning.Setup.setup_user(user, token, credentials)
+    :ok = SetupUtils.setup_user(user, token, credentials)
   end
 
   @doc """

--- a/lib/lightning/setup.ex
+++ b/lib/lightning/setup.ex
@@ -21,7 +21,10 @@ defmodule Lightning.Setup do
   def setup_user(user, token \\ nil, credentials \\ nil) do
     {:ok, _pid} = Lightning.Setup.ensure_minimum_setup()
 
-    :ok = SetupUtils.setup_user(user, token, credentials)
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Lightning.Repo, fn _repo ->
+        SetupUtils.setup_user(user, token, credentials)
+      end)
   end
 
   @doc """

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -652,7 +652,7 @@ defmodule Lightning.SetupUtilsTest do
 
   describe "setup_user/3" do
     test "creates a user, an api token, and credentials" do
-      assert :ok ==
+      assert {:ok, :ok} ==
                Lightning.SetupUtils.setup_user(
                  %{
                    first_name: "Taylor",
@@ -689,7 +689,7 @@ defmodule Lightning.SetupUtilsTest do
     end
 
     test "can be used to set up a superuser" do
-      assert :ok ==
+      assert {:ok, :ok} ==
                Lightning.SetupUtils.setup_user(
                  %{
                    role: :superuser,


### PR DESCRIPTION
### Description

This PR makes it possible to run `Lightning.Setup.setup_user` from outside the container.

### Validation steps

1. I'm working on validating this now 😄 

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
