### PR TITLE
Persist AI messages

### DIFF
--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -77,8 +77,7 @@ defmodule Lightning.AiAssistant do
     )
     |> case do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
-        assist_resp = body["history"] |> Enum.reverse() |> hd()
-        message = Map.merge(assist_resp, %{"sender" => "assistant"})
+        message = body["history"] |> Enum.reverse() |> hd()
         {:ok, save_message!(session, message)}
 
       _ ->
@@ -88,17 +87,13 @@ defmodule Lightning.AiAssistant do
 
   defp build_history(session) do
     case Enum.reverse(session.messages) do
-      [%{sender: :user} | other] ->
+      [%{role: :user} | other] ->
         other
         |> Enum.reverse()
-        |> Enum.map(fn message ->
-          %{role: message.sender, content: message.content}
-        end)
+        |> Enum.map(&Map.take(&1, [:role, :content]))
 
       messages ->
-        Enum.map(messages, fn message ->
-          %{role: message.sender, content: message.content}
-        end)
+        Enum.map(messages, &Map.take(&1, [:role, :content]))
     end
   end
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -49,7 +49,7 @@ defmodule Lightning.AiAssistant do
     }
   end
 
-  @spec save_message!(ChatSession.t(), %{String.t() => any()}) :: Session.t()
+  @spec save_message!(ChatSession.t(), %{String.t() => any()}) :: ChatSession.t()
   def save_message!(session, message) do
     messages = Enum.map(session.messages, &Map.take(&1, [:id]))
 

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -6,7 +6,7 @@ defmodule Lightning.AiAssistant.ChatMessage do
 
   schema "ai_chat_messages" do
     field :content, :string
-    field :sender, Ecto.Enum, values: [:user, :assistant]
+    field :role, Ecto.Enum, values: [:user, :assistant]
     field :is_deleted, :boolean, default: false
     field :is_public, :boolean, default: true
 
@@ -20,12 +20,12 @@ defmodule Lightning.AiAssistant.ChatMessage do
     chat_message
     |> cast(attrs, [
       :content,
-      :sender,
+      :role,
       :is_deleted,
       :is_public,
       :chat_session_id,
       :user_id
     ])
-    |> validate_required([:content, :sender])
+    |> validate_required([:content, :role])
   end
 end

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -1,0 +1,31 @@
+defmodule Lightning.AiAssistant.ChatMessage do
+  use Lightning.Schema
+  import Ecto.Changeset
+
+  @type t() :: %__MODULE__{}
+
+  schema "ai_chat_messages" do
+    field :content, :string
+    field :sender, Ecto.Enum, values: [:user, :assistant]
+    field :is_deleted, :boolean, default: false
+    field :is_public, :boolean, default: true
+
+    belongs_to :chat_session, Lightning.AiAssistant.ChatSession
+    belongs_to :user, Lightning.Accounts.User
+
+    timestamps()
+  end
+
+  def changeset(chat_message, attrs) do
+    chat_message
+    |> cast(attrs, [
+      :content,
+      :sender,
+      :is_deleted,
+      :is_public,
+      :chat_session_id,
+      :user_id
+    ])
+    |> validate_required([:content, :sender])
+  end
+end

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -2,7 +2,8 @@ defmodule Lightning.AiAssistant.ChatMessage do
   use Lightning.Schema
   import Ecto.Changeset
 
-  @type t() :: %__MODULE__{}
+  @type role() :: :user | :assistant
+  @type t() :: %__MODULE__{id: Ecto.UUID.t(), content: String.t(), role: role()}
 
   schema "ai_chat_messages" do
     field :content, :string

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -3,7 +3,13 @@ defmodule Lightning.AiAssistant.ChatMessage do
   import Ecto.Changeset
 
   @type role() :: :user | :assistant
-  @type t() :: %__MODULE__{id: Ecto.UUID.t(), content: String.t(), role: role()}
+  @type t() :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          content: String.t() | nil,
+          role: role(),
+          is_deleted: boolean(),
+          is_public: boolean()
+        }
 
   schema "ai_chat_messages" do
     field :content, :string

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -1,4 +1,6 @@
 defmodule Lightning.AiAssistant.ChatMessage do
+  @moduledoc false
+
   use Lightning.Schema
   import Ecto.Changeset
 

--- a/lib/lightning/ai_assistant/chat_session.ex
+++ b/lib/lightning/ai_assistant/chat_session.ex
@@ -1,4 +1,6 @@
 defmodule Lightning.AiAssistant.ChatSession do
+  @moduledoc false
+
   use Lightning.Schema
   import Ecto.Changeset
 

--- a/lib/lightning/ai_assistant/chat_session.ex
+++ b/lib/lightning/ai_assistant/chat_session.ex
@@ -2,11 +2,17 @@ defmodule Lightning.AiAssistant.ChatSession do
   use Lightning.Schema
   import Ecto.Changeset
 
-  alias Lightning.Workflows.Job
   alias Lightning.Accounts.User
   alias Lightning.AiAssistant.ChatMessage
+  alias Lightning.Workflows.Job
 
-  @type t() :: %__MODULE__{}
+  @type t() :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          job_id: Ecto.UUID.t(),
+          expression: String.t(),
+          adaptor: String.t(),
+          messages: [ChatMessage.t()]
+        }
 
   schema "ai_chat_sessions" do
     field :expression, :string, virtual: true

--- a/lib/lightning/ai_assistant/chat_session.ex
+++ b/lib/lightning/ai_assistant/chat_session.ex
@@ -1,0 +1,31 @@
+defmodule Lightning.AiAssistant.ChatSession do
+  use Lightning.Schema
+  import Ecto.Changeset
+
+  alias Lightning.Workflows.Job
+  alias Lightning.Accounts.User
+  alias Lightning.AiAssistant.ChatMessage
+
+  @type t() :: %__MODULE__{}
+
+  schema "ai_chat_sessions" do
+    field :expression, :string, virtual: true
+    field :adaptor, :string, virtual: true
+
+    field :is_public, :boolean, default: false
+    field :is_deleted, :boolean, default: false
+    belongs_to :job, Job
+    belongs_to :user, User
+
+    has_many :messages, ChatMessage, preload_order: [asc: :inserted_at]
+
+    timestamps()
+  end
+
+  def changeset(chat_session, attrs) do
+    chat_session
+    |> cast(attrs, [:is_public, :is_deleted, :job_id, :user_id])
+    |> validate_required([:job_id, :user_id])
+    |> cast_assoc(:messages)
+  end
+end

--- a/lib/lightning/ai_assistant/chat_session.ex
+++ b/lib/lightning/ai_assistant/chat_session.ex
@@ -9,9 +9,12 @@ defmodule Lightning.AiAssistant.ChatSession do
   @type t() :: %__MODULE__{
           id: Ecto.UUID.t(),
           job_id: Ecto.UUID.t(),
-          expression: String.t(),
-          adaptor: String.t(),
-          messages: [ChatMessage.t()]
+          user_id: Ecto.UUID.t(),
+          expression: String.t() | nil,
+          adaptor: String.t() | nil,
+          is_public: boolean(),
+          is_deleted: boolean(),
+          messages: [ChatMessage.t(), ...] | []
         }
 
   schema "ai_chat_sessions" do

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -43,13 +43,13 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
         <div class="row-span-full flex flex-col gap-4 p-2 overflow-y-auto">
           <%= for message <- @session.messages do %>
             <div
-              :if={message.sender == :user}
+              :if={message.role == :user}
               class="ml-auto bg-blue-500 text-white p-2 rounded-lg text-right break-words"
             >
               <%= message.content %>
             </div>
             <div
-              :if={message.sender == :assistant}
+              :if={message.role == :assistant}
               class="mr-auto p-2 rounded-lg break-words text-wrap flex flex-row gap-x-2 makeup-html"
             >
               <div class="">
@@ -108,7 +108,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
   def handle_event("send_message", %{"content" => content}, socket) do
     session =
       AiAssistant.save_message!(socket.assigns.session, %{
-        "sender" => "user",
+        "role" => "user",
         "content" => content,
         "user_id" => socket.assigns.current_user.id
       })

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -94,6 +94,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
           phx-submit="send_message"
           class="row-span-1 p-2 pt-0"
           phx-target={@myself}
+          id="ai-assistant-form"
         >
           <.chat_input
             form={@form}

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -236,6 +236,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     <div class="grow min-h-0 h-full text-sm">
                       <.live_component
                         module={LightningWeb.WorkflowLive.AiAssistantComponent}
+                        current_user={@current_user}
                         selected_job={@selected_job}
                         id={"aichat-#{@selected_job.id}"}
                       />

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -228,11 +228,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       />
                     </div>
                   </:panel>
-                  <:panel
-                    :if={Lightning.AiAssistant.authorized?(@current_user)}
-                    hash="aichat"
-                    class="h-full"
-                  >
+                  <:panel hash="aichat" class="h-full">
                     <div class="grow min-h-0 h-full text-sm">
                       <.live_component
                         module={LightningWeb.WorkflowLive.AiAssistantComponent}

--- a/priv/repo/migrations/20240823072414_create_chat_sessions_tables.exs
+++ b/priv/repo/migrations/20240823072414_create_chat_sessions_tables.exs
@@ -1,0 +1,30 @@
+defmodule Lightning.Repo.Migrations.CreateChatSessionsTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:ai_chat_sessions, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :is_public, :boolean
+      add :is_deleted, :boolean
+      add :job_id, references(:jobs, type: :binary_id, on_delete: :nilify_all)
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+
+      timestamps()
+    end
+
+    create table(:ai_chat_messages, primary_key: false) do
+      add :id, :uuid, primary_key: true
+
+      add :chat_session_id,
+          references(:ai_chat_sessions, type: :binary_id, on_delete: :delete_all)
+
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+      add :content, :text
+      add :sender, :string
+      add :is_deleted, :boolean
+      add :is_public, :boolean
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20240823072414_create_chat_sessions_tables.exs
+++ b/priv/repo/migrations/20240823072414_create_chat_sessions_tables.exs
@@ -20,7 +20,7 @@ defmodule Lightning.Repo.Migrations.CreateChatSessionsTables do
 
       add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
       add :content, :text
-      add :sender, :string
+      add :role, :string
       add :is_deleted, :boolean
       add :is_public, :boolean
 


### PR DESCRIPTION
### Description

- This PR persists chat messages to the db instead of LiveView assigns
- It also gets rid of the `AiAssistant.Session` struct in favour of the schema `ChatSession`
- It also makes the assistant available to everyone (including viewers)

Closes #2415 

### Validation steps


### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
