### PR TITLE
editor: fix namespaces in code assist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 - Show Github Error messages as they are to help troubleshooting
   [#2156](https://github.com/OpenFn/lightning/issues/2156)
 - Allow `Setup_utils.setup_user` to be used for the initial superuser creation.
+- Update to code assist in the Job Editor.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to
 - Show Github Error messages as they are to help troubleshooting
   [#2156](https://github.com/OpenFn/lightning/issues/2156)
 - Allow `Setup_utils.setup_user` to be used for the initial superuser creation.
-- Update to code assist in the Job Editor.
+- Update to code assist in the Job Editor to import namespaces from adaptors.
+  [#2432](https://github.com/OpenFn/lightning/issues/2432)
 
 ### Fixed
 

--- a/assets/js/adaptor-docs/hooks/useDocs.tsx
+++ b/assets/js/adaptor-docs/hooks/useDocs.tsx
@@ -3,7 +3,7 @@ import { describePackage, PackageDescription } from '@openfn/describe-package';
 
 // Describe package is slow right now even if data is available
 // This in-mamory cache will help when switching tabs etc
-const cache: Record<string, PackageDescription | null | false> = {}
+const cache: Record<string, PackageDescription | null | false> = {};
 
 const useDocs = (specifier: string) => {
   const [docs, setDocs] = useState<PackageDescription | null | false>(null);
@@ -15,15 +15,17 @@ const useDocs = (specifier: string) => {
       setDocs(cache[specifier]);
     } else {
       cache[specifier] = null;
-      describePackage(specifier, {}).then((result) => {
-        cache[specifier] = result;
-        setDocs(result);
-      }).catch((err) => {
-        cache[specifier] = false;
-        setDocs(false)
-      });  
+      describePackage(specifier, {})
+        .then(result => {
+          cache[specifier] = result;
+          setDocs(result);
+        })
+        .catch(err => {
+          cache[specifier] = false;
+          setDocs(false);
+        });
     }
-  }, [specifier])
+  }, [specifier]);
 
   return docs;
 };


### PR DESCRIPTION
This PR fixes (kinda) an issue in the editor where code assist is not provided for namespaces (like `http.get`). See #2432

This how it looks on this branch:

![image](https://github.com/user-attachments/assets/b811a143-8a09-4c97-aff6-16f77eda600b)

Playing with this stuff in Monaco is like pulling teeth. Some things work, some don't, the results always seem a bit random. FWIW the best example I've found for how to load typescript libraries is [this playground demo](). But that only deals with a single file.

For some reason, when we load index.d.ts, the namespaces and stuff exported from there don't get properly loaded into the environment. There's some strange voodoo needed to get the TS environment to load the right context.

In VSC this stuff just works, so I know that the actual typescript is correct. It's just our Monaco setup.

Anyway: this PR changers the way we load stuff so that namespaces kinda work.

I don't like it, but it's an improvement. It also takes a bunch of stuff out the environment that shouldn't be there.

One issue on this branch is that the options are not properly tracked `http.get` . Strange because the interface _IS_ is inside the namespace. Monaco just doesn't  find it.

It does track on other adaptors though -  I've got good namespaced trackign working on this experimental adaptor

![image](https://github.com/user-attachments/assets/cac84e0a-f6d6-4422-9a14-1ce216a7781f)


