### PR TITLE
Add Full Width Option for Select Inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to
 - Implement a combo-box to make navigating between projects easier
   [#241](https://github.com/OpenFn/lightning/pull/2424)
 
+- Fix select inputs not expanding to full width. Added a :full_width option to
+  control whether the input should expand to the full width or not
+  [#2437](https://github.com/OpenFn/lightning/pull/2437)
+
 ### Fixed
 
 ## [v2.8.1] - 2024-08-28

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -154,6 +154,10 @@ defmodule LightningWeb.Components.NewInputs do
 
   attr :display_errors, :boolean, default: true
 
+  attr :full_width, :boolean,
+    default: false,
+    doc: "allows to have select boxes expanding the full width of the container"
+
   slot :inner_block
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -217,7 +221,7 @@ defmodule LightningWeb.Components.NewInputs do
         > *</span>
       </.label>
       <div class="flex w-full">
-        <div class="relative items-center">
+        <div class={"relative items-center #{if @full_width, do: "flex-grow"}"}>
           <select
             id={@id}
             name={@name}


### PR DESCRIPTION
### Description

This PR introduces a new :full_width attribute to the input component in `LightningWeb.Components.NewInputs`. When set to true, this attribute allows the select input to expand to the full width of its container. This provides more flexibility in layout management and ensures that the select input can be displayed consistently alongside other form elements like text inputs. The default behavior remains unchanged, with the select input not expanding unless explicitly specified.

### Validation steps

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
