### PR TITLE
Navbar theme by scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Change navbar colors depending on scope.
+  [#2449](https://github.com/OpenFn/lightning/pull/2449)
+
 - Add support for configurable idle connection timeouts via the `IDLE_TIMEOUT`
   environment variable. [#2443](https://github.com/OpenFn/lightning/issues/2443)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to
 
 - Change navbar colors depending on scope.
   [#2449](https://github.com/OpenFn/lightning/pull/2449)
-
 - Add support for configurable idle connection timeouts via the `IDLE_TIMEOUT`
   environment variable. [#2443](https://github.com/OpenFn/lightning/issues/2443)
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -29,6 +29,17 @@
     --primary-ring-focus: theme('colors.blue.600');
   }
 
+  &.sudo-theme {
+    --primary-bg: theme('colors.slate.700');
+    --primary-text: theme('colors.white');
+    --primary-bg-lighter: theme('colors.slate.600');
+    --primary-bg-dark: theme('colors.slate.900');
+    --primary-text-light: theme('colors.slate.300');
+    --primary-text-lighter: theme('colors.slate.200');
+    --primary-ring: theme('colors.gray.300');
+    --primary-ring-focus: theme('colors.slate.600');
+  }
+
   background-color: var(--primary-bg);
   color: var(--primary-text);
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -14,126 +14,64 @@
   --primary-text-lighter: theme('colors.primary.200');
   --primary-ring: theme('colors.primary.500');
   --primary-ring-focus: theme('colors.primary.800');
-
-  --secondary-bg: theme('colors.blue.700');
-  --secondary-text: theme('colors.white');
-  --secondary-bg-dark: theme('colors.blue.900');
-  --secondary-text-light: theme('colors.blue.300');
-  --secondary-text-lighter: theme('colors.blue.200');
-  --secondary-ring: theme('colors.blue.500');
-  --secondary-ring-focus: theme('colors.blue.800');
 }
 
-.primary-theme {
-  #side-menu {
-    background-color: var(--primary-bg);
-    color: var(--primary-text);
+#side-menu {
+  &.secondary-theme {
+    --primary-bg: theme('colors.blue.700');
+    --primary-text: theme('colors.white');
+    --primary-bg-dark: theme('colors.blue.900');
+    --primary-text-light: theme('colors.blue.300');
+    --primary-text-lighter: theme('colors.blue.200');
+    --primary-ring: theme('colors.blue.500');
+    --primary-ring-focus: theme('colors.blue.800');
   }
-}
 
-.primary-theme > div > div:nth-child(1) {
-  background-color: var(--primary-bg-dark);
-}
-
-.primary-theme > div > div > .menu-item-active {
-  color: var(--primary-text-lighter);
-  background-color: var(--primary-bg-dark);
-}
-
-.primary-theme > div > div .menu-item-inactive {
-  color: var(--primary-text-light);
-}
-
-.primary-theme > div > div .menu-item-inactive:hover {
-  background-color: var(--primary-bg-dark);
-}
-
-.primary-theme > div > div > input#combobox {
-  background-color: white;
-  color: theme('colors.gray.900');
-  --tw-ring-color: var(--primary-ring);
-}
-
-.primary-theme > div > div > input#combobox:focus {
-  --tw-ring-color: var(--primary-ring-focus);
-}
-
-.primary-theme > div > div > input#combobox ~ ul {
-  background-color: white;
-  --tw-ring-color: var(--primary-ring-focus);
-}
-
-.primary-theme > div > div > input#combobox ~ ul > li {
-  color: theme('colors.gray.900');
-}
-
-.primary-theme > div > div > input#combobox ~ ul > li > span > .hero-check {
-  color: var(--primary-bg-dark);
-}
-
-.primary-theme > div > div > input#combobox ~ ul > li[data-highlighted='true'] {
-  background-color: var(--primary-bg-dark);
+  background-color: var(--primary-bg);
   color: var(--primary-text);
-}
-
-.primary-theme
-  > div
-  > div
-  > input#combobox
-  ~ ul
-  > li[data-highlighted='true']
-  > span
-  > .hero-check {
-  color: var(--primary-text);
-}
-
-/* Secondary theme */
-.secondary-theme#side-menu {
-  background-color: var(--secondary-bg);
-  color: var(--secondary-text);
 
   div > div {
     &:first-child {
-      background-color: var(--secondary-bg-dark);
+      background-color: var(--primary-bg-dark);
     }
   }
 
   .menu-item-active {
-    color: var(--secondary-text-lighter);
-    background-color: var(--secondary-bg-dark);
+    color: var(--primary-text-lighter);
+    background-color: var(--primary-bg-dark);
   }
   .menu-item-inactive {
-    color: var(--secondary-text-light);
+    color: var(--primary-text-light);
   }
   .menu-item-inactive:hover {
-    background-color: var(--secondary-bg-dark);
+    background-color: var(--primary-bg-dark);
   }
 
   input#combobox {
     background-color: white;
     color: theme('colors.gray.900');
-    --tw-ring-color: var(--secondary-ring);
+    --tw-ring-color: var(--primary-ring);
 
     &:focus {
-      --tw-ring-color: var(--secondary-ring-focus);
+      --tw-ring-color: var(--primary-ring-focus);
     }
 
     ~ ul {
       background-color: white;
-      --tw-ring-color: var(--secondary-ring-focus);
+      --tw-ring-color: var(--primary-ring-focus);
 
       > li {
         color: theme('colors.gray.900');
         .hero-check {
-          color: var(--secondary-bg-dark);
+          color: var(--primary-bg-dark);
         }
 
         &[data-highlighted='true'] {
-          background-color: var(--secondary-bg-dark);
-          color: var(--secondary-text);
+          background-color: var(--primary-bg-dark);
+          color: var(--primary-text);
 
           .hero-check {
-            color: var(--secondary-text);
+            color: var(--primary-text);
           }
         }
       }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,13 +7,13 @@
 /* This file is for your main application CSS */
 
 :root {
-  --primary-bg: theme('colors.indigo.800');
+  --primary-bg: theme('colors.primary.800');
   --primary-text: theme('colors.white');
-  --primary-bg-dark: theme('colors.indigo.900');
-  --primary-text-light: theme('colors.indigo.300');
-  --primary-text-lighter: theme('colors.indigo.200');
-  --primary-ring: theme('colors.indigo.500');
-  --primary-ring-focus: theme('colors.indigo.800');
+  --primary-bg-dark: theme('colors.primary.900');
+  --primary-text-light: theme('colors.primary.300');
+  --primary-text-lighter: theme('colors.primary.200');
+  --primary-ring: theme('colors.primary.500');
+  --primary-ring-focus: theme('colors.primary.800');
 
   --secondary-bg: #1d4ed8;
   --secondary-text: theme('colors.white');

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,6 +6,152 @@
 @import '../../deps/petal_components/assets/default.css';
 /* This file is for your main application CSS */
 
+:root {
+  --primary-bg: theme('colors.indigo.800');
+  --primary-text: theme('colors.white');
+  --primary-bg-dark: theme('colors.indigo.900');
+  --primary-text-light: theme('colors.indigo.300');
+  --primary-text-lighter: theme('colors.indigo.200');
+  --primary-ring: theme('colors.indigo.500');
+  --primary-ring-focus: theme('colors.indigo.800');
+
+  --secondary-bg: #1d4ed8;
+  --secondary-text: theme('colors.white');
+  --secondary-bg-dark: #163b8d;
+  --secondary-text-light: #93c5fd;
+  --secondary-text-lighter: #dbeafe;
+  --secondary-ring: #60a5fa;
+  --secondary-ring-focus: #3b82f6;
+}
+
+.primary-theme {
+  background-color: var(--primary-bg);
+  color: var(--primary-text);
+}
+
+.primary-theme > div > div:nth-child(1) {
+  background-color: var(--primary-bg-dark);
+}
+
+.primary-theme > div > div > .menu-item-active {
+  color: var(--primary-text-lighter);
+  background-color: var(--primary-bg-dark);
+}
+
+.primary-theme > div > div .menu-item-inactive {
+  color: var(--primary-text-light);
+}
+
+.primary-theme > div > div .menu-item-inactive:hover {
+  background-color: var(--primary-bg-dark);
+}
+
+.primary-theme > div > div > input#combobox {
+  background-color: white;
+  color: theme('colors.gray.900');
+  --tw-ring-color: var(--primary-ring);
+}
+
+.primary-theme > div > div > input#combobox:focus {
+  --tw-ring-color: var(--primary-ring-focus);
+}
+
+.primary-theme > div > div > input#combobox ~ ul {
+  background-color: white;
+  --tw-ring-color: var(--primary-ring-focus);
+}
+
+.primary-theme > div > div > input#combobox ~ ul > li {
+  color: theme('colors.gray.900');
+}
+
+.primary-theme > div > div > input#combobox ~ ul > li > span > .hero-check {
+  color: var(--primary-bg-dark);
+}
+
+.primary-theme > div > div > input#combobox ~ ul > li[data-highlighted='true'] {
+  background-color: var(--primary-bg-dark);
+  color: var(--primary-text);
+}
+
+.primary-theme
+  > div
+  > div
+  > input#combobox
+  ~ ul
+  > li[data-highlighted='true']
+  > span
+  > .hero-check {
+  color: var(--primary-text);
+}
+
+/* Secondary theme */
+.secondary-theme {
+  background-color: var(--secondary-bg);
+  color: var(--secondary-text);
+}
+
+.secondary-theme > div > div:nth-child(1) {
+  background-color: var(--secondary-bg-dark);
+}
+
+.secondary-theme > div > div > .menu-item-active {
+  color: var(--secondary-text-lighter);
+  background-color: var(--secondary-bg-dark);
+}
+
+.secondary-theme > div > div .menu-item-inactive {
+  color: var(--secondary-text-light);
+}
+
+.secondary-theme > div > div .menu-item-inactive:hover {
+  background-color: var(--secondary-bg-dark);
+}
+
+.secondary-theme > div > div > input#combobox {
+  background-color: white;
+  color: theme('colors.gray.900');
+  --tw-ring-color: var(--secondary-ring);
+}
+
+.secondary-theme > div > div > input#combobox:focus {
+  --tw-ring-color: var(--secondary-ring-focus);
+}
+
+.secondary-theme > div > div > input#combobox ~ ul {
+  background-color: white;
+  --tw-ring-color: var(--secondary-ring-focus);
+}
+
+.secondary-theme > div > div > input#combobox ~ ul > li {
+  color: theme('colors.gray.900');
+}
+
+.secondary-theme > div > div > input#combobox ~ ul > li > span > .hero-check {
+  color: var(--secondary-bg-dark);
+}
+
+.secondary-theme
+  > div
+  > div
+  > input#combobox
+  ~ ul
+  > li[data-highlighted='true'] {
+  background-color: var(--secondary-bg-dark);
+  color: var(--secondary-text);
+}
+
+.secondary-theme
+  > div
+  > div
+  > input#combobox
+  ~ ul
+  > li[data-highlighted='true']
+  > span
+  > .hero-check {
+  color: var(--secondary-text);
+}
+
 /* Alerts and form errors used by phx.new */
 .alert {
   padding: 15px;
@@ -19,14 +165,14 @@
   border-color: #bce8f1;
 }
 .alert-warning {
-  color: #8B5F0D;
+  color: #8b5f0d;
   background-color: #fcf8e3;
   border-color: #faebcc;
 }
 .alert-danger {
-  color: #DC2626;
-  background-color: #FDEBEB;
-  border-color: #FDEBEB;
+  color: #dc2626;
+  background-color: #fdebeb;
+  border-color: #fdebeb;
 }
 .alert p {
   margin-bottom: 0;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -9,6 +9,7 @@
 :root {
   --primary-bg: theme('colors.primary.800');
   --primary-text: theme('colors.white');
+  --primary-bg-lighter: theme('colors.primary.600');
   --primary-bg-dark: theme('colors.primary.900');
   --primary-text-light: theme('colors.primary.300');
   --primary-text-lighter: theme('colors.primary.200');
@@ -20,6 +21,7 @@
   &.secondary-theme {
     --primary-bg: theme('colors.blue.700');
     --primary-text: theme('colors.white');
+    --primary-bg-lighter: theme('colors.blue.600');
     --primary-bg-dark: theme('colors.blue.900');
     --primary-text-light: theme('colors.blue.300');
     --primary-text-lighter: theme('colors.blue.200');
@@ -44,7 +46,7 @@
     color: var(--primary-text-light);
   }
   .menu-item-inactive:hover {
-    background-color: var(--primary-bg-dark);
+    background-color: var(--primary-bg-lighter);
   }
 
   input#combobox {
@@ -63,11 +65,11 @@
       > li {
         color: theme('colors.gray.900');
         .hero-check {
-          color: var(--primary-bg-dark);
+          color: var(--primary-bg-lighter);
         }
 
         &[data-highlighted='true'] {
-          background-color: var(--primary-bg-dark);
+          background-color: var(--primary-bg-lighter);
           color: var(--primary-text);
 
           .hero-check {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -46,7 +46,7 @@
     color: var(--primary-text-light);
   }
   .menu-item-inactive:hover {
-    background-color: var(--primary-bg-lighter);
+    background-color: var(--primary-bg-dark);
   }
 
   input#combobox {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -15,18 +15,20 @@
   --primary-ring: theme('colors.primary.500');
   --primary-ring-focus: theme('colors.primary.800');
 
-  --secondary-bg: #1d4ed8;
+  --secondary-bg: theme('colors.blue.700');
   --secondary-text: theme('colors.white');
-  --secondary-bg-dark: #163b8d;
-  --secondary-text-light: #93c5fd;
-  --secondary-text-lighter: #dbeafe;
-  --secondary-ring: #60a5fa;
-  --secondary-ring-focus: #3b82f6;
+  --secondary-bg-dark: theme('colors.blue.900');
+  --secondary-text-light: theme('colors.blue.300');
+  --secondary-text-lighter: theme('colors.blue.200');
+  --secondary-ring: theme('colors.blue.500');
+  --secondary-ring-focus: theme('colors.blue.800');
 }
 
 .primary-theme {
-  background-color: var(--primary-bg);
-  color: var(--primary-text);
+  #side-menu {
+    background-color: var(--primary-bg);
+    color: var(--primary-text);
+  }
 }
 
 .primary-theme > div > div:nth-child(1) {
@@ -86,70 +88,57 @@
 }
 
 /* Secondary theme */
-.secondary-theme {
+.secondary-theme#side-menu {
   background-color: var(--secondary-bg);
   color: var(--secondary-text);
-}
 
-.secondary-theme > div > div:nth-child(1) {
-  background-color: var(--secondary-bg-dark);
-}
+  div > div {
+    &:first-child {
+      background-color: var(--secondary-bg-dark);
+    }
+  }
 
-.secondary-theme > div > div > .menu-item-active {
-  color: var(--secondary-text-lighter);
-  background-color: var(--secondary-bg-dark);
-}
+  .menu-item-active {
+    color: var(--secondary-text-lighter);
+    background-color: var(--secondary-bg-dark);
+  }
+  .menu-item-inactive {
+    color: var(--secondary-text-light);
+  }
+  .menu-item-inactive:hover {
+    background-color: var(--secondary-bg-dark);
+  }
 
-.secondary-theme > div > div .menu-item-inactive {
-  color: var(--secondary-text-light);
-}
+  input#combobox {
+    background-color: white;
+    color: theme('colors.gray.900');
+    --tw-ring-color: var(--secondary-ring);
 
-.secondary-theme > div > div .menu-item-inactive:hover {
-  background-color: var(--secondary-bg-dark);
-}
+    &:focus {
+      --tw-ring-color: var(--secondary-ring-focus);
+    }
 
-.secondary-theme > div > div > input#combobox {
-  background-color: white;
-  color: theme('colors.gray.900');
-  --tw-ring-color: var(--secondary-ring);
-}
+    ~ ul {
+      background-color: white;
+      --tw-ring-color: var(--secondary-ring-focus);
 
-.secondary-theme > div > div > input#combobox:focus {
-  --tw-ring-color: var(--secondary-ring-focus);
-}
+      > li {
+        color: theme('colors.gray.900');
+        .hero-check {
+          color: var(--secondary-bg-dark);
+        }
 
-.secondary-theme > div > div > input#combobox ~ ul {
-  background-color: white;
-  --tw-ring-color: var(--secondary-ring-focus);
-}
+        &[data-highlighted='true'] {
+          background-color: var(--secondary-bg-dark);
+          color: var(--secondary-text);
 
-.secondary-theme > div > div > input#combobox ~ ul > li {
-  color: theme('colors.gray.900');
-}
-
-.secondary-theme > div > div > input#combobox ~ ul > li > span > .hero-check {
-  color: var(--secondary-bg-dark);
-}
-
-.secondary-theme
-  > div
-  > div
-  > input#combobox
-  ~ ul
-  > li[data-highlighted='true'] {
-  background-color: var(--secondary-bg-dark);
-  color: var(--secondary-text);
-}
-
-.secondary-theme
-  > div
-  > div
-  > input#combobox
-  ~ ul
-  > li[data-highlighted='true']
-  > span
-  > .hero-check {
-  color: var(--secondary-text);
+          .hero-check {
+            color: var(--secondary-text);
+          }
+        }
+      }
+    }
+  }
 }
 
 /* Alerts and form errors used by phx.new */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -13,8 +13,8 @@
   --primary-bg-dark: theme('colors.primary.900');
   --primary-text-light: theme('colors.primary.300');
   --primary-text-lighter: theme('colors.primary.200');
-  --primary-ring: theme('colors.primary.500');
-  --primary-ring-focus: theme('colors.primary.800');
+  --primary-ring: theme('colors.gray.300');
+  --primary-ring-focus: theme('colors.primary.600');
 }
 
 #side-menu {
@@ -25,8 +25,8 @@
     --primary-bg-dark: theme('colors.blue.900');
     --primary-text-light: theme('colors.blue.300');
     --primary-text-lighter: theme('colors.blue.200');
-    --primary-ring: theme('colors.blue.500');
-    --primary-ring-focus: theme('colors.blue.800');
+    --primary-ring: theme('colors.gray.300');
+    --primary-ring-focus: theme('colors.blue.600');
   }
 
   background-color: var(--primary-bg);

--- a/lib/lightning_web/components/layouts.ex
+++ b/lib/lightning_web/components/layouts.ex
@@ -12,6 +12,6 @@ defmodule LightningWeb.Layouts do
   attr :side_menu_theme, :string, default: "primary-theme"
   def live(assigns)
 
-  attr :side_menu_theme, :string, default: "secondary-theme"
+  attr :side_menu_theme, :string, default: "sudo-theme"
   def settings(assigns)
 end

--- a/lib/lightning_web/components/layouts.ex
+++ b/lib/lightning_web/components/layouts.ex
@@ -8,4 +8,10 @@ defmodule LightningWeb.Layouts do
   slot :header_tags
   slot :body_tags
   def root(assigns)
+
+  attr :side_menu_theme, :string, default: "primary-theme"
+  def live(assigns)
+
+  attr :side_menu_theme, :string, default: "primary-theme"
+  def settings(assigns)
 end

--- a/lib/lightning_web/components/layouts.ex
+++ b/lib/lightning_web/components/layouts.ex
@@ -12,6 +12,6 @@ defmodule LightningWeb.Layouts do
   attr :side_menu_theme, :string, default: "primary-theme"
   def live(assigns)
 
-  attr :side_menu_theme, :string, default: "primary-theme"
+  attr :side_menu_theme, :string, default: "secondary-theme"
   def settings(assigns)
 end

--- a/lib/lightning_web/components/layouts/live.html.heex
+++ b/lib/lightning_web/components/layouts/live.html.heex
@@ -1,12 +1,12 @@
 <main class="h-screen">
   <div class="flex flex-row h-full">
     <nav
-      class="basis-48 bg-primary-800 text-white"
+      class={"basis-48 #{@side_menu_theme}"}
       id="side-menu"
       style="width: 192px"
     >
       <div class="flex flex-col h-full">
-        <div class="w-full h-20 bg-primary-900 flex items-center justify-center">
+        <div class="w-full h-20 flex items-center justify-center">
           <.link navigate={Routes.dashboard_index_path(@socket, :index)}>
             <img
               class="h-10 w-10"

--- a/lib/lightning_web/components/layouts/settings.html.heex
+++ b/lib/lightning_web/components/layouts/settings.html.heex
@@ -1,14 +1,23 @@
-<main class="h-screen w-screen">
+<main class="h-screen">
   <div class="flex flex-row h-full">
-    <div class={"flex-none w-48 #{@side_menu_theme} h-full"}>
+    <nav
+      class={"basis-48 #{@side_menu_theme}"}
+      id="side-menu"
+      style="width: 192px"
+    >
       <div class="flex flex-col h-full">
-        <div class="w-full h-20 bg-primary-900 flex items-center justify-center mb-4">
-          <img
-            class="h-10 w-10"
-            src={Routes.static_path(@socket || @conn, "/images/logo-white.svg")}
-            alt="OpenFn"
-          />
+        <div class="w-full h-20 flex items-center justify-center">
+          <.link navigate={Routes.dashboard_index_path(@socket, :index)}>
+            <img
+              class="h-10 w-10"
+              src={
+                Routes.static_path(@socket || @conn, "/images/logo-white.svg")
+              }
+              alt="OpenFn"
+            />
+          </.link>
         </div>
+        <div class="mt-2"></div>
         <Menu.menu_item
           to={Routes.project_index_path(@socket, :index)}
           active={@active_menu_item == :projects}
@@ -44,7 +53,7 @@
         </Menu.menu_item>
         <LightningWeb.Components.Common.version_chip />
       </div>
-    </div>
+    </nav>
     <div class="flex-auto">
       <.live_info_block flash={@flash} />
       <.live_error_block flash={@flash} />

--- a/lib/lightning_web/components/layouts/settings.html.heex
+++ b/lib/lightning_web/components/layouts/settings.html.heex
@@ -17,7 +17,7 @@
             />
           </.link>
         </div>
-        <div class="mt-2"></div>
+        <div class="mt-4"></div>
         <Menu.menu_item
           to={Routes.project_index_path(@socket, :index)}
           active={@active_menu_item == :projects}

--- a/lib/lightning_web/components/layouts/settings.html.heex
+++ b/lib/lightning_web/components/layouts/settings.html.heex
@@ -1,6 +1,6 @@
 <main class="h-screen w-screen">
   <div class="flex flex-row h-full">
-    <div class="flex-none w-48 bg-primary-800 text-white h-full">
+    <div class={"flex-none w-48 #{@side_menu_theme} h-full"}>
       <div class="flex flex-col h-full">
         <div class="w-full h-20 bg-primary-900 flex items-center justify-center mb-4">
           <img

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -51,6 +51,7 @@ defmodule LightningWeb.Hooks do
       can_access_project ->
         {:cont,
          socket
+         |> assign(:side_menu_theme, "primary-theme")
          |> assign_new(:project_user, fn -> project_user end)
          |> assign_new(:project, fn -> project end)
          |> assign_new(:projects, fn -> projects end)}

--- a/lib/lightning_web/init_assigns.ex
+++ b/lib/lightning_web/init_assigns.ex
@@ -16,6 +16,7 @@ defmodule LightningWeb.InitAssigns do
      end)
      |> assign_new(:account_confirmation_required?, fn ->
        confirmation_required?
-     end)}
+     end)
+     |> assign(:side_menu_theme, "primary-theme")}
   end
 end

--- a/lib/lightning_web/init_assigns.ex
+++ b/lib/lightning_web/init_assigns.ex
@@ -16,7 +16,6 @@ defmodule LightningWeb.InitAssigns do
      end)
      |> assign_new(:account_confirmation_required?, fn ->
        confirmation_required?
-     end)
-     |> assign(:side_menu_theme, "primary-theme")}
+     end)}
   end
 end

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -483,7 +483,7 @@ defmodule LightningWeb.Components.Common do
         spellcheck="false"
         placeholder={@placeholder || "Search..."}
         value={@selected_item && @selected_item.name}
-        class="w-full rounded-md border-0 py-1.5 pl-3 pr-12 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6"
+        class="w-full rounded-md border-0 py-1.5 pl-3 pr-12 shadow-sm ring-1 ring-inset focus:ring-2 sm:text-sm sm:leading-6"
         role="combobox"
         aria-controls="options"
         aria-expanded="false"

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -483,7 +483,7 @@ defmodule LightningWeb.Components.Common do
         spellcheck="false"
         placeholder={@placeholder || "Search..."}
         value={@selected_item && @selected_item.name}
-        class="w-full rounded-md border-0 bg-white py-1.5 pl-3 pr-12 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+        class="w-full rounded-md border-0 py-1.5 pl-3 pr-12 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6"
         role="combobox"
         aria-controls="options"
         aria-expanded="false"
@@ -500,7 +500,7 @@ defmodule LightningWeb.Components.Common do
       <ul
         class={[
           "absolute z-10 mt-1 max-h-60 py-1 w-full overflow-auto rounded-md",
-          "bg-white shadow-lg ring-1 ring-black ring-opacity-5",
+          "shadow-lg ring-1 ring-opacity-5",
           "text-base sm:text-sm hidden focus:outline-none"
         ]}
         id="options"
@@ -509,7 +509,7 @@ defmodule LightningWeb.Components.Common do
       >
         <li
           :for={item <- @items}
-          class="group text-gray-900 relative cursor-pointer select-none py-2 px-3 text-sm data-[highlighted=true]:bg-indigo-600 data-[highlighted=true]:text-white"
+          class="group relative cursor-pointer select-none py-2 px-3 text-sm"
           id={"option-#{item.id}"}
           role="option"
           tabindex="0"
@@ -527,10 +527,7 @@ defmodule LightningWeb.Components.Common do
             "absolute inset-y-0 right-0 items-center pr-4",
             "flex group-[&:not([data-item-selected])]:hidden"
           ]}>
-            <.icon
-              name="hero-check"
-              class="text-indigo-600 group-data-[highlighted=true]:text-white"
-            />
+            <.icon name="hero-check" />
           </span>
         </li>
       </ul>

--- a/lib/lightning_web/live/components/menu.ex
+++ b/lib/lightning_web/live/components/menu.ex
@@ -59,11 +59,12 @@ defmodule LightningWeb.Components.Menu do
   end
 
   def menu_item(assigns) do
-    base_classes = ~w[px-3 py-2 rounded-md text-sm font-medium rounded-md block]
+    base_classes =
+      ~w[menu-item px-3 py-2 rounded-md text-sm font-medium rounded-md block]
 
-    active_classes = ~w[text-primary-200 bg-primary-900] ++ base_classes
+    active_classes = ~w[menu-item-active] ++ base_classes
 
-    inactive_classes = ~w[text-primary-300 hover:bg-primary-900] ++ base_classes
+    inactive_classes = ~w[menu-item-inactive] ++ base_classes
 
     assigns =
       assigns

--- a/test/lightning_web/components/layout_components_test.exs
+++ b/test/lightning_web/components/layout_components_test.exs
@@ -30,6 +30,6 @@ defmodule LightningWeb.LayoutComponentsTest do
     assert Floki.text(element) == "Settings"
 
     assert element |> Floki.attribute("class") |> hd =~
-             "text-primary-200 bg-primary-900"
+             "menu-item-active"
   end
 end

--- a/test/lightning_web/components/menu_test.exs
+++ b/test/lightning_web/components/menu_test.exs
@@ -24,7 +24,7 @@ defmodule LightningWeb.Components.MenuTest do
       assert Floki.text(element) == "Workflows"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-300 hover:bg-primary-900"
+               "menu-item-inactive"
     end
   end
 
@@ -47,21 +47,21 @@ defmodule LightningWeb.Components.MenuTest do
       assert Floki.text(element) == "Workflows"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-300 hover:bg-primary-900"
+               "menu-item-inactive"
 
       element = Floki.find(menu, "a[href='/projects/#{project_id}/history']")
 
       assert Floki.text(element) == "History"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-300 hover:bg-primary-900"
+               "menu-item-inactive"
 
       element = Floki.find(menu, "a[href='/projects/#{project_id}/settings']")
 
       assert Floki.text(element) == "Settings"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-200 bg-primary-900"
+               "menu-item-active"
     end
   end
 
@@ -80,14 +80,14 @@ defmodule LightningWeb.Components.MenuTest do
       assert Floki.text(element) =~ "User Profile"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-300 hover:bg-primary-900"
+               "menu-item-inactive"
 
       element = Floki.find(menu, "a[href='/credentials']")
 
       assert Floki.text(element) =~ "Credentials"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-200 bg-primary-900"
+               "menu-item-active"
 
       element =
         Floki.find(menu, "a[href='/profile/tokens']")
@@ -95,7 +95,7 @@ defmodule LightningWeb.Components.MenuTest do
       assert Floki.text(element) =~ "API Tokens"
 
       assert element |> Floki.attribute("class") |> hd =~
-               "text-primary-300 hover:bg-primary-900"
+               "menu-item-inactive"
     end
   end
 end


### PR DESCRIPTION
### Description

This PR introduces some kind of theming for the application navbar. It implements two themes, `primary-theme` which is the set of colors to apply when the user is on a user scope or project scope, `secondary-theme` which is the set of colors to apply when the user is on another scope. The idea of this PR is to layout what we would improve later on to implement a much more robust way of switching themes. Why not even introduce light / dark mode one day ?

Re [#241](https://github.com/OpenFn/thunderbolt/issues/241)

### Validation steps

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
