### PR TITLE
Update vulnerable version of micromatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   `/app/bin/lightning eval Lightning.Setup.setup_user/3`
 - Implement a combo-box to make navigating between projects easier
   [#241](https://github.com/OpenFn/lightning/pull/2424)
+- Updated vulnerable version of micromatch.
+  [#2454](https://github.com/OpenFn/lightning/issues/2454)
 
 ### Fixed
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -4108,11 +4108,11 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
### Description

This PR updates `micromatch` in response to a Dependabot alert.

Closes #2454

### Validation steps

I am really not sure, tbh :). it is a patch-version change to a dependency of `tailwindcss` and `fast-glob` and `fast-glob` is itself a dependency of `globby` which is a dependency of `ava` and some other stuff - so it is really a very interesting philosophical question :).

I started up Lightning locally, browsed around a little bit and looked for any JS errors that seemed related.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
