### PR TITLE
Drop Workflow Id From Snapshot When Pulling With CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to
 - Updated vulnerable version of micromatch.
   [#2454](https://github.com/OpenFn/lightning/issues/2454)
 
+- Fix `workflow_id` presence in state.json during Github sync
+  [#2445](https://github.com/OpenFn/lightning/issues/2445)
+
 ## [v2.8.1] - 2024-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix `workflow_id` presence in state.json during Github sync
+  [#2445](https://github.com/OpenFn/lightning/issues/2445)
+
 ## [v2.8.2] - 2024-09-04
 
 ### Added
@@ -38,9 +41,6 @@ and this project adheres to
   [#241](https://github.com/OpenFn/lightning/pull/2424)
 - Updated vulnerable version of micromatch.
   [#2454](https://github.com/OpenFn/lightning/issues/2454)
-
-- Fix `workflow_id` presence in state.json during Github sync
-  [#2445](https://github.com/OpenFn/lightning/issues/2445)
 
 ## [v2.8.1] - 2024-08-28
 

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -47,7 +47,7 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
     workflow_or_snapshot
     |> Ecto.embedded_dump(:json)
-    |> Map.take(~w(id name inserted_at lock_version concurrency)a)
+    |> Map.take(~w(id name inserted_at updated_at deleted_at lock_version concurrency)a)
     |> Map.put(:id, workflow_id)
     |> Map.put(
       :jobs,

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -47,7 +47,9 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
     workflow_or_snapshot
     |> Ecto.embedded_dump(:json)
-    |> Map.take(~w(id name inserted_at updated_at deleted_at lock_version concurrency)a)
+    |> Map.take(
+      ~w(id name inserted_at updated_at deleted_at lock_version concurrency)a
+    )
     |> Map.put(:id, workflow_id)
     |> Map.put(
       :jobs,

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -47,8 +47,8 @@ defmodule LightningWeb.API.ProvisioningJSON do
 
     workflow_or_snapshot
     |> Ecto.embedded_dump(:json)
+    |> Map.take(~w(id name inserted_at lock_version concurrency)a)
     |> Map.put(:id, workflow_id)
-    |> Map.delete(:workflow_id)
     |> Map.put(
       :jobs,
       workflow_or_snapshot.jobs

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -48,6 +48,7 @@ defmodule LightningWeb.API.ProvisioningJSON do
     workflow_or_snapshot
     |> Ecto.embedded_dump(:json)
     |> Map.put(:id, workflow_id)
+    |> Map.delete(:workflow_id)
     |> Map.put(
       :jobs,
       workflow_or_snapshot.jobs

--- a/test/integration/cli_deploy_test.exs
+++ b/test/integration/cli_deploy_test.exs
@@ -300,7 +300,15 @@ defmodule Lightning.CliDeployTest do
   defp expected_workflow_state(workflow) do
     state =
       workflow
-      |> Map.take([:id, :name, :inserted_at, :lock_version, :concurrency])
+      |> Map.take([
+        :id,
+        :name,
+        :inserted_at,
+        :updated_at,
+        :deleted_at,
+        :lock_version,
+        :concurrency
+      ])
 
     jobs =
       Map.new(workflow.jobs, fn job ->

--- a/test/integration/cli_deploy_test.exs
+++ b/test/integration/cli_deploy_test.exs
@@ -298,7 +298,9 @@ defmodule Lightning.CliDeployTest do
   end
 
   defp expected_workflow_state(workflow) do
-    state = Map.take(workflow, Lightning.Workflows.Workflow.__schema__(:fields))
+    state =
+      workflow
+      |> Map.take([:id, :name, :inserted_at, :lock_version, :concurrency])
 
     jobs =
       Map.new(workflow.jobs, fn job ->

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -795,7 +795,16 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
 
       assert project.name == "test-project"
 
-      assert workflows |> Enum.all?(&match?(%{"project_id" => ^project_id}, &1)),
+      workflow_ids = Enum.map(workflows, fn w -> w["id"] end)
+
+      parent_project_ids =
+        from(w in Workflow,
+          where: w.id in ^workflow_ids
+        )
+        |> Repo.all()
+        |> Enum.map(fn w -> w.project_id end)
+
+      assert parent_project_ids |> Enum.all?(&match?(^project_id, &1)),
              "All workflows should belong to the same project"
 
       workflow =


### PR DESCRIPTION
### Description

This PR removes `workflow_id` from the snapshot when doing CLI pull.

Closes #2445 

### Validation steps

1. Initiate Github sync from the project
2. Check state.json to see that there is no `workflow_id`

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
