### PR TITLE
Provisioner only saves modified edges/jobs/triggers in snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to
 
 - Fix `workflow_id` presence in state.json during Github sync
   [#2445](https://github.com/OpenFn/lightning/issues/2445)
+- Provioner creates invalid snapshots when doing CLI deploy
+  [#2461](https://github.com/OpenFn/lightning/issues/2461)
+  [#2460](https://github.com/OpenFn/lightning/issues/2460)
 
 ## [v2.8.2] - 2024-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
 
 ### Fixed
 
+- Provisioner creates invalid snapshots when doing CLI deploy
+  [#2461](https://github.com/OpenFn/lightning/issues/2461)
+  [#2460](https://github.com/OpenFn/lightning/issues/2460)
+
 ## [v2.9.0] - 2024-09-06
 
 ### Added
@@ -39,9 +43,6 @@ and this project adheres to
 
 - Fix `workflow_id` presence in state.json during Github sync
   [#2445](https://github.com/OpenFn/lightning/issues/2445)
-- Provioner creates invalid snapshots when doing CLI deploy
-  [#2461](https://github.com/OpenFn/lightning/issues/2461)
-  [#2460](https://github.com/OpenFn/lightning/issues/2460)
 
 ## [v2.8.2] - 2024-09-04
 

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -49,10 +49,12 @@ defmodule Lightning.Projects.Provisioner do
              build_import_changeset(project, user_or_repo_connection, data),
            {:ok, %{workflows: workflows} = project} <-
              Repo.insert_or_update(project_changeset),
-           {:ok, _changes} <- create_snapshots(project_changeset, workflows) do
+           updated_project <- preload_dependencies(project),
+           {:ok, _changes} <-
+             create_snapshots(project_changeset, updated_project.workflows) do
         Enum.each(workflows, &Lightning.Workflows.Events.workflow_updated/1)
 
-        {:ok, preload_dependencies(project)}
+        {:ok, updated_project}
       end
     end)
   end

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -94,7 +94,8 @@ defmodule Lightning.Workflows do
     |> save_workflow()
   end
 
-  defp publish_kafka_trigger_events(changeset) do
+  @spec publish_kafka_trigger_events(Ecto.Changeset.t(Workflow.t())) :: :ok
+  def publish_kafka_trigger_events(changeset) do
     changeset
     |> KafkaTriggers.get_kafka_triggers_being_updated()
     |> Enum.each(fn trigger_id ->

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -315,7 +315,13 @@ defmodule Lightning.Projects.ProvisionerTest do
 
       assert flatten_errors(changeset) == %{
                workflows: [
-                 %{jobs: [%{id: ["This email address already exists."]}]}
+                 %{
+                   jobs: [
+                     %{id: ["This email address already exists."]},
+                     %{},
+                     %{}
+                   ]
+                 }
                ]
              }
 
@@ -333,7 +339,9 @@ defmodule Lightning.Projects.ProvisionerTest do
 
       assert flatten_errors(changeset) == %{
                workflows: [
-                 %{triggers: [%{id: ["This email address already exists."]}]}
+                 %{
+                   triggers: [%{id: ["This email address already exists."]}, %{}]
+                 }
                ]
              }
 
@@ -353,7 +361,13 @@ defmodule Lightning.Projects.ProvisionerTest do
 
       assert flatten_errors(changeset) == %{
                workflows: [
-                 %{edges: [%{id: ["This email address already exists."]}]}
+                 %{
+                   edges: [
+                     %{id: ["This email address already exists."]},
+                     %{},
+                     %{}
+                   ]
+                 }
                ]
              }
     end

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -216,7 +216,18 @@ defmodule Lightning.Projects.ProvisionerTest do
           Snapshot.get_current_for(workflow)
         end)
 
-      assert [%Snapshot{lock_version: 1}] = snapshots_before
+      assert [
+               %Snapshot{
+                 lock_version: 1,
+                 jobs: jobs,
+                 triggers: triggers,
+                 edges: edges
+               }
+             ] = snapshots_before
+
+      assert Enum.count(jobs) == 2
+      assert Enum.count(triggers) == 1
+      assert Enum.count(edges) == 2
 
       third_job_id = Ecto.UUID.generate()
 
@@ -255,7 +266,18 @@ defmodule Lightning.Projects.ProvisionerTest do
           Snapshot.get_current_for(workflow)
         end)
 
-      assert [%Snapshot{lock_version: 2}] = snapshots_after
+      assert [
+               %Snapshot{
+                 lock_version: 2,
+                 jobs: jobs,
+                 triggers: triggers,
+                 edges: edges
+               }
+             ] = snapshots_after
+
+      assert Enum.count(jobs) == 3
+      assert Enum.count(triggers) == 1
+      assert Enum.count(edges) == 2
     end
 
     test "adding a record from another project or workflow", %{

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -526,7 +526,10 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
       body = %{
         "id" => project.id,
         "name" => "",
-        "workflows" => [%{"name" => "default"}]
+        "workflows" => [
+          %{"name" => "default"},
+          %{"id" => Ecto.UUID.generate(), "name" => "Valid Workflow"}
+        ]
       }
 
       conn = post(conn, ~p"/api/provision", body)
@@ -553,6 +556,12 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
                 "adaptor" => "@openfn/language-common@latest"
               },
               %{
+                "adaptor" => "@openfn/language-common@latest",
+                "body" => "console.log('hello world');"
+              },
+              %{
+                "id" => Ecto.UUID.generate(),
+                "name" => "valid job",
                 "adaptor" => "@openfn/language-common@latest",
                 "body" => "console.log('hello world');"
               }


### PR DESCRIPTION
### Description
This PR fixes an issue where only changed jobs, edges and triggers were getting saved in the db.

In the provisioner, there existed a logic in the changesets for `edges`, `jobs` and `triggers` which was ignoring unchanged data. The logic is useful because it gets rid of empty maps when there is an error in one workflow but not the others

What this PR does is it forces the preload of all the assocs before creating snapshots


Closes #2461 
Closes #2460 

### Validation steps
You can validate this using the Github Sync feature in the UI or just the plain old cli. If you're testing locally and want to use Github, head to #2273, there's a nice description on how to do that easily.
 
Here's the gist of it:

1. In your project, open a workflow in the UI. It will redirect you to the "latest" version of that workflow. In the uri, note the version number, it's something like `?v=1`. For this purpose, let's use `1` as the lates version. PS: make sure your workflow has multiple jobs
2. Pull these changes. If using Github, head to project settings and click `initiate sync to github`. If using cli, `openfn pull project_id`
3.  Identify one job in your `spec.yaml`, change the name and commit. Or if using cli, `openfn deploy`. This creates snapshot version 2 of that particular workflow
4. Now in the workflow that you opened in step 1, if you type `?v=2` or your equivalent latest snapshot version, all the jobs will exist and the page would just fine. Previously, you would have found that only the job whose name you updated in step 3 exists.

### Additional notes for the reviewer
Anyone who attempted to use `cli deploy` after snapshots were added to the Provisioner is probably affected by this.
Once deployed, we should run a script to correct the snapshots using the state in the `job`, `edges` and `triggers` tables. 

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
