### PR TITLE
Temporarily limit AI Assistant to OpenFn users

### DIFF
--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -142,6 +142,10 @@ defmodule Lightning.AiAssistant do
     is_binary(endpoint) && is_binary(api_key)
   end
 
+  def available?(user) do
+    String.match?(user.email, ~r/@openfn\.org/i)
+  end
+
   @doc """
   Checks if the Apollo endpoint is available.
   """

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -197,7 +197,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     <:tab hash="manual">
                       <span class="inline-block align-middle">Input</span>
                     </:tab>
-                    <:tab hash="aichat">
+                    <:tab
+                      :if={Lightning.AiAssistant.available?(@current_user)}
+                      hash="aichat"
+                    >
                       <span class="inline-block align-middle">AI Assistant</span>
                     </:tab>
                   </LightningWeb.Components.Tabbed.tabs>
@@ -226,7 +229,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       />
                     </div>
                   </:panel>
-                  <:panel hash="aichat" class="h-full">
+                  <:panel
+                    :if={Lightning.AiAssistant.available?(@current_user)}
+                    hash="aichat"
+                    class="h-full"
+                  >
                     <%= if @ai_assistant_enabled do %>
                       <div class="grow min-h-0 h-full text-sm">
                         <.live_component

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -13,6 +13,16 @@ defmodule Lightning.AiAssistantTest do
     [user: user, project: project, workflow: workflow]
   end
 
+  describe "available?/1" do
+    test "is not available for users without openfn.org email" do
+      user = build(:user, email: "test@openFn.org")
+      assert AiAssistant.available?(user)
+
+      user = build(:user, email: "test@example.net")
+      refute AiAssistant.available?(user)
+    end
+  end
+
   describe "endpoint_available?" do
     test "availability" do
       Mox.stub(Lightning.MockConfig, :apollo, fn key ->

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -79,9 +79,15 @@ defmodule LightningWeb.ConnCase do
 
   It stores an updated connection and a registered user in the
   test context.
+
+  Optionally you may provide the current user's email address by providing
+  an `email` tag in the context.
+
+      @tag email: "my@user.com"
   """
-  def register_and_log_in_user(%{conn: conn}) do
-    user = Lightning.AccountsFixtures.user_fixture()
+  def register_and_log_in_user(%{conn: conn} = tags) do
+    attrs = Map.take(tags, [:email])
+    user = Lightning.Factories.insert(:user, attrs)
     %{conn: log_in_user(conn, user), user: user}
   end
 


### PR DESCRIPTION
### Description

Temporarily limit AI Assistant to only OpenFn users while we smooth out the rough edges.

### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
