### PR TITLE
Update Promex Oban config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 ### Changed
 
 - Standardize `link-uuid` style for uuid chips
+- Updated PromEx configuration to align with custom Oban naming.
+  [#2488](https://github.com/OpenFn/lightning/issues/2488)
 
 ### Fixed
 

--- a/lib/lightning/prom_ex.ex
+++ b/lib/lightning/prom_ex.ex
@@ -80,7 +80,7 @@ defmodule Lightning.PromEx do
       {Plugins.Phoenix,
        router: LightningWeb.Router, endpoint: LightningWeb.Endpoint},
       Plugins.Ecto,
-      Plugins.Oban,
+      {Plugins.Oban, oban_supervisors: [Lightning.Oban]},
       Plugins.PhoenixLiveView,
       # Add your own PromEx metrics plugins
       {

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -44,7 +44,7 @@ defmodule Lightning.PromExTest do
       {PromEx.Plugins.Phoenix,
        router: LightningWeb.Router, endpoint: LightningWeb.Endpoint},
       PromEx.Plugins.Ecto,
-      PromEx.Plugins.Oban,
+      {PromEx.Plugins.Oban, [oban_supervisors: [Lightning.Oban]]},
       PromEx.Plugins.PhoenixLiveView,
       {
         Lightning.Runs.PromExPlugin,


### PR DESCRIPTION
### Description

This PR updates the PromEx config - it was not reporting Oban metrics due to the Oban supervisor having a custom name.

Closes #2488 

### Validation steps

- Configure Lightning to expose PromeEx metrics:

```
PROMEX_ENABLED=true                                                                  
PROMEX_GRAFANA_HOST=http://localhost:3000                                            
PROMEX_GRAFANA_USER=admin                                                            
PROMEX_GRAFANA_PASSWORD=admin                                                        
PROMEX_UPLOAD_GRAFANA_DASHBOARDS_ON_START=false                                       
PROMEX_DATASOURCE_ID=promex                                                          
PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=no                                    
PROMEX_METRICS_ENDPOINT_TOKEN=foobar                                                 
PROMEX_ENDPOINT_SCHEME=http 
```

- Start Lightning and let it run for a few minutes (i.e long enough for Oban to do some work)
- Browse to the metrics [endpoint](http://localhost:4000/metrics)
- Search for `lightning_prom_ex_oban_queue_length_count`. It should be present with non-zero values in the metrics output.

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
