### PR TITLE
Hide Export Button When No Work Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to
   [#2442](https://github.com/OpenFn/lightning/issues/2442)
 - When selecting a node in the workflow diagram, connected edges will also be
   highlighted [2396](https://github.com/OpenFn/lightning/issues/2358)
-- Hide Export Button When No Work Order
+- Hide export history button when no workorder is rendered in the table
   [2440](https://github.com/OpenFn/lightning/issues/2440)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to
 - When selecting a node in the workflow diagram, connected edges will also be
   highlighted [2396](https://github.com/OpenFn/lightning/issues/2358)
 - Hide export history button when no workorder is rendered in the table
-  [2440](https://github.com/OpenFn/lightning/issues/2440)
+  [#2440](https://github.com/OpenFn/lightning/issues/2440)
 
 ### Fixed
 
@@ -35,6 +35,8 @@ and this project adheres to
 - Fix jumpy combobox for scope switcher
   [#2469](https://github.com/OpenFn/lightning/issues/2469)
 - Fix console errors when rending edge labels in the workflow diagram
+- Fix tooltip on export workorder button
+  [#2430](https://github.com/OpenFn/lightning/issues/2430)
 
 ## [v2.9.3] - 2024-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
   [#2442](https://github.com/OpenFn/lightning/issues/2442)
 - When selecting a node in the workflow diagram, connected edges will also be
   highlighted [2396](https://github.com/OpenFn/lightning/issues/2358)
+- Hide Export Button When No Work Order
+  [2440](https://github.com/OpenFn/lightning/issues/2440)
 
 ### Fixed
 

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -726,18 +726,13 @@
               >
                 <:action>
                   <button
+                    :if={@page.total_entries > 0}
                     id="export-history-button"
                     type="button"
                     phx-click="show-export-modal"
                     class="icon-button"
                     phx-hook="Tooltip"
-                    aria-label={
-                      if @page.total_entries > 0,
-                        do:
-                          "Export all #{@page.total_entries} results matching your query",
-                        else: ""
-                    }
-                    disabled={@page.total_entries <= 0}
+                    aria-label={"Export all #{@page.total_entries} results matching your query"}
                   >
                     <.icon name="hero-cloud-arrow-down" class="w-5 h-5" />
                   </button>


### PR DESCRIPTION
### Description

This PR hides the 'Export History' button when no work orders are displayed on the history page. The button is shown only when work orders are available for export. It also fixes the non rendering tool-tip message on the button.

Closes #2440 & #2430

### Validation steps

1. Go to the history page
2. Apply filters such that no work order will be displayed (empty table)
3. Note that the 'Export History' button is hidden
4. Remove filters to list all available work orders (table with work orders)
5. Note that the 'Export History' button is displayed
6. Click on it to start an export
7. Hover the 'Export History' button to see the tool-tip appear normally.

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
