### PR TITLE
ASVS: password length to 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 ### Changed
 
+- Increase minimum password length to 12 in accordance with ASVS 4.0.3 "V2.1.2"
+
 ### Fixed
 
 ## [v2.9.5] - 2024-09-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to
 
 ### Changed
 
-- Increase minimum password length to 12 in accordance with ASVS 4.0.3 "V2.1.2"
+- Increase minimum password length to 12 in accordance with ASVS 4.0.3
+  recommendation V2.1.2 [#2507](https://github.com/OpenFn/lightning/pull/2507)
+- Changed the public sandbox (https://demo.openfn.org) setup script to use
+  `welcome12345` passwords to comply with a 12-character minimum
 
 ### Fixed
 
@@ -48,7 +51,7 @@ and this project adheres to
 - Improve history export page UI
   [#2442](https://github.com/OpenFn/lightning/issues/2442)
 - When selecting a node in the workflow diagram, connected edges will also be
-  highlighted [2396](https://github.com/OpenFn/lightning/issues/2358)
+  highlighted [#2396](https://github.com/OpenFn/lightning/issues/2358)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ keep private!_**
 
 ```
 username: demo@openfn.org
-password: welcome123
+password: welcome12345
 ```
 
 ## Features

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -168,7 +168,7 @@ defmodule Lightning.Accounts.User do
   defp validate_password(changeset, opts) do
     changeset
     |> validate_required(:password, message: "can't be blank")
-    |> validate_length(:password, min: 8, max: 72)
+    |> validate_length(:password, min: 12, max: 72)
     |> maybe_hash_password(opts)
   end
 

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -123,7 +123,7 @@ defmodule Lightning.SetupUtils do
             first_name: "Sizwe",
             last_name: "Super",
             email: "super@openfn.org",
-            password: "welcome123"
+            password: "welcome12345"
           })
 
         Repo.insert!(%Lightning.Accounts.UserToken{
@@ -143,7 +143,7 @@ defmodule Lightning.SetupUtils do
         first_name: "Amy",
         last_name: "Admin",
         email: "demo@openfn.org",
-        password: "welcome123"
+        password: "welcome12345"
       })
 
     {:ok, editor} =
@@ -151,7 +151,7 @@ defmodule Lightning.SetupUtils do
         first_name: "Esther",
         last_name: "Editor",
         email: "EditOr@openfn.org",
-        password: "welcome123"
+        password: "welcome12345"
       })
 
     {:ok, viewer} =
@@ -159,7 +159,7 @@ defmodule Lightning.SetupUtils do
         first_name: "Vikram",
         last_name: "Viewer",
         email: "viewer@openfn.org",
-        password: "welcome123"
+        password: "welcome12345"
       })
 
     %{super_user: super_user, admin: admin, editor: editor, viewer: viewer}

--- a/test/lightning/accounts/user_test.exs
+++ b/test/lightning/accounts/user_test.exs
@@ -3,6 +3,35 @@ defmodule Lightning.Accounts.UserTest do
 
   alias Lightning.Accounts.User
 
+  describe "password validation" do
+    test "it allows passwords between 12 and 72 characters" do
+      changeset =
+        User.password_changeset(%User{}, %{password: "12345678"})
+
+      refute changeset.valid?
+
+      assert {:password,
+              {"should be at least %{count} character(s)",
+               [count: 12, validation: :length, kind: :min, type: :string]}} in changeset.errors
+
+      changeset =
+        User.password_changeset(%User{}, %{password: "123456789abc"})
+
+      assert changeset.valid?
+
+      changeset =
+        User.password_changeset(%User{}, %{
+          password: String.duplicate(".", 72) <> "💣"
+        })
+
+      refute changeset.valid?
+
+      assert {:password,
+              {"should be at most %{count} character(s)",
+               [count: 72, validation: :length, kind: :max, type: :string]}} in changeset.errors
+    end
+  end
+
   describe "scheduled deletion changeset" do
     test "email doesn't match current users email" do
       errors =

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -33,7 +33,7 @@ defmodule Lightning.SetupUtilsTest do
       assert jobs |> Enum.count() == 6
 
       assert super_user.email == "super@openfn.org"
-      User.valid_password?(super_user, "welcome123")
+      User.valid_password?(super_user, "welcome12345")
 
       user_token =
         Lightning.Repo.all(UserToken)
@@ -46,13 +46,13 @@ defmodule Lightning.SetupUtilsTest do
       assert openhie_project.id == "4adf2644-ed4e-4f97-a24c-ab35b3cb1efa"
 
       assert admin.email == "demo@openfn.org"
-      User.valid_password?(admin, "welcome123")
+      User.valid_password?(admin, "welcome12345")
 
       assert editor.email == "editor@openfn.org"
-      User.valid_password?(editor, "welcome123")
+      User.valid_password?(editor, "welcome12345")
 
       assert viewer.email == "viewer@openfn.org"
-      User.valid_password?(viewer, "welcome123")
+      User.valid_password?(viewer, "welcome12345")
 
       assert Enum.map(
                openhie_project.project_users,

--- a/test/lightning_web/live/first_setup_live_test.exs
+++ b/test/lightning_web/live/first_setup_live_test.exs
@@ -30,8 +30,8 @@ defmodule LightningWeb.FirstSetupLiveTest do
         show_live
         |> form("#superuser-registration-form",
           superuser_registration: %{
-            password: "aaaaaaaa",
-            password_confirmation: "aaaaaaaa",
+            password: "1234567890ab",
+            password_confirmation: "1234567890ab",
             first_name: "Test",
             last_name: "McTest",
             email: "foo@example.com"

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -8,8 +8,8 @@ defmodule LightningWeb.ProfileLiveTest do
 
   @update_password_attrs %{
     current_password: valid_user_password(),
-    password: "password1",
-    password_confirmation: "password1"
+    password: "password1234",
+    password_confirmation: "password1234"
   }
 
   @invalid_empty_password_attrs %{
@@ -30,8 +30,8 @@ defmodule LightningWeb.ProfileLiveTest do
 
   @invalid_dont_match_password_attrs %{
     current_password: "",
-    password: "password1",
-    password_confirmation: "password2"
+    password: "password1234",
+    password_confirmation: "password4567"
   }
 
   @invalid_email_update_attrs %{
@@ -113,7 +113,7 @@ defmodule LightningWeb.ProfileLiveTest do
 
       assert profile_live
              |> form("#password-form", user: @invalid_too_short_password_attrs)
-             |> render_change() =~ "Password minimum length is 8 characters"
+             |> render_change() =~ "Password minimum length is 12 characters"
 
       assert profile_live
              |> form("#password-form", user: @invalid_empty_password_attrs)
@@ -125,7 +125,7 @@ defmodule LightningWeb.ProfileLiveTest do
 
       assert profile_live
              |> form("#password-form", user: @invalid_too_short_password_attrs)
-             |> render_submit() =~ "Password minimum length is 8 characters"
+             |> render_submit() =~ "Password minimum length is 12 characters"
 
       {:ok, conn} =
         profile_live


### PR DESCRIPTION
Note that after this gets shipped to demo in a release, we must merge this: https://github.com/OpenFn/docs/pull/571 

### Description

This PR changes the minimum required password length to 12 in alignment with https://github.com/OWASP/ASVS/blob/master/4.0/en/0x11-V2-Authentication.md?plain=1#L43

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
