### PR TITLE
Fix Empty Webhook URL When Switching Workflow Trigger Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix empty webhook URL when switching workflow trigger type
+  [#2050](https://github.com/OpenFn/lightning/issues/2050)
+
 ## [v2.9.4] - 2024-09-16
 
 ### Changed

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -221,7 +221,6 @@ defmodule LightningWeb.WorkflowLive.Components do
   attr :cancel_url, :string, required: true
   attr :disabled, :boolean, required: true
   attr :can_write_webhook_auth_method, :boolean, required: true
-  attr :webhook_url, :string, required: true
   attr :on_change, :any, required: true
   attr :selected_trigger, :any, required: true
   attr :action, :any, required: true
@@ -292,7 +291,7 @@ defmodule LightningWeb.WorkflowLive.Components do
                 type="text"
                 id="webhookUrlInput"
                 class="block w-full flex-1 rounded-l-lg text-slate-900 disabled:bg-gray-50 disabled:text-gray-500 border border-r-0 border-secondary-300 sm:text-sm sm:leading-6"
-                value={@webhook_url}
+                value={url(~p"/i/#{@form[:id].value}")}
                 disabled="disabled"
               />
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1939,8 +1939,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
-  defp webhook_url(%{id: id}),
-    do: Routes.webhooks_url(LightningWeb.Endpoint, :create, [id])
+  defp webhook_url(%{id: id}), do: url(LightningWeb.Endpoint, ~p"/i/#{id}")
 
   defp send_form_changed(params) do
     send(self(), {"form_changed", params})

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -607,7 +607,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       !@has_presence_edit_priority
                   }
                   can_write_webhook_auth_method={@can_write_webhook_auth_method}
-                  webhook_url={webhook_url(@selected_trigger)}
                   selected_trigger={@selected_trigger}
                   action={@live_action}
                   cancel_url={close_url(assigns, :selected_trigger, :unselect)}
@@ -1938,8 +1937,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
       |> put_flash(:error, "You are not authorized to perform this action.")
     end
   end
-
-  defp webhook_url(%{id: id}), do: url(LightningWeb.Endpoint, ~p"/i/#{id}")
 
   defp send_form_changed(params) do
     send(self(), {"form_changed", params})

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1939,16 +1939,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
-  defp webhook_url(trigger) do
-    trigger
-    |> case do
-      %{type: :webhook, id: id} ->
-        Routes.webhooks_url(LightningWeb.Endpoint, :create, [id])
-
-      _ ->
-        nil
-    end
-  end
+  defp webhook_url(%{id: id}),
+    do: Routes.webhooks_url(LightningWeb.Endpoint, :create, [id])
 
   defp send_form_changed(params) do
     send(self(), {"form_changed", params})


### PR DESCRIPTION
### Description

This PR fixes the empty webhook URL input when one switches a workflow trigger type.

Closes #2050 

### Validation steps

1. Open a workflow
2. Switch it's trigger from CRON to Webhook and vice versa
3. Note that the Webhook URL input is not empty

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
