### PR TITLE
Add quotes when special YAML characters are present in the exported project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Add quotes when special YAML characters are present in the exported project
+  [#2446](https://github.com/OpenFn/lightning/issues/2446)
+
 ## [v2.9.4] - 2024-09-16
 
 ### Changed

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -163,9 +163,9 @@ defmodule Lightning.ExportUtils do
 
   defp yaml_safe_string(value) do
     # starts with alphanumeric
-    # followed by alphanumeric or hyphen or underscore or @ or . or space
+    # followed by alphanumeric or hyphen or underscore or @ or . or > or space
     # ends with alphanumeric
-    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\. ]*[a-zA-Z0-9]$/, value) do
+    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.> ]*[a-zA-Z0-9]$/, value) do
       value
     else
       ~s('#{value}')
@@ -182,9 +182,9 @@ defmodule Lightning.ExportUtils do
 
   defp maybe_escape_key(key) do
     # starts with alphanumeric
-    # followed by alphanumeric or hyphen or underscore or @ or .
+    # followed by alphanumeric or hyphen or underscore or @ or . or >
     # ends with alphanumeric
-    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.]*[a-zA-Z0-9]$/, key) do
+    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.>]*[a-zA-Z0-9]$/, key) do
       key
     else
       ~s("#{key}")

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -165,18 +165,18 @@ defmodule Lightning.ExportUtils do
     # starts with alphanumeric
     # followed by alphanumeric or hyphen or underscore or @ or . or space
     # ends with alphanumeric
-    if !Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\. ]*[a-zA-Z0-9]$/, value) do
-      ~s('#{value}')
-    else
+    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\. ]*[a-zA-Z0-9]$/, value) do
       value
+    else
+      ~s('#{value}')
     end
   end
 
   defp yaml_safe_key(key) do
-    if key not in @special_keys do
-      key |> to_string() |> hyphenate() |> maybe_escape_key()
-    else
+    if key in @special_keys do
       key
+    else
+      key |> to_string() |> hyphenate() |> maybe_escape_key()
     end
   end
 
@@ -184,10 +184,10 @@ defmodule Lightning.ExportUtils do
     # starts with alphanumeric
     # followed by alphanumeric or hyphen or underscore or @ or .
     # ends with alphanumeric
-    if !Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.]*[a-zA-Z0-9]$/, key) do
-      ~s("#{key}")
-    else
+    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.]*[a-zA-Z0-9]$/, key) do
       key
+    else
+      ~s("#{key}")
     end
   end
 

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -8,6 +8,27 @@ defmodule Lightning.ExportUtils do
   alias Lightning.Workflows
   alias Lightning.Workflows.Snapshot
 
+  @ordering_map %{
+    project: [:name, :description, :credentials, :globals, :workflows],
+    credential: [:name, :owner],
+    workflow: [:name, :jobs, :triggers, :edges],
+    job: [:name, :adaptor, :credential, :globals, :body],
+    trigger: [:type, :cron_expression, :enabled],
+    edge: [
+      :source_trigger,
+      :source_job,
+      :target_job,
+      :condition_type,
+      :condition_label,
+      :condition_expression,
+      :enabled
+    ]
+  }
+
+  @special_keys Enum.flat_map(@ordering_map, fn {node_key, child_keys} ->
+                  [node_key | child_keys]
+                end)
+
   defp hyphenate(string) when is_binary(string) do
     string |> String.replace(" ", "-")
   end
@@ -95,27 +116,10 @@ defmodule Lightning.ExportUtils do
   end
 
   defp pick_and_sort(map) do
-    ordering_map = %{
-      project: [:name, :description, :credentials, :globals, :workflows],
-      credential: [:name, :owner],
-      workflow: [:name, :jobs, :triggers, :edges],
-      job: [:name, :adaptor, :credential, :globals, :body],
-      trigger: [:type, :cron_expression, :enabled],
-      edge: [
-        :source_trigger,
-        :source_job,
-        :target_job,
-        :condition_type,
-        :condition_label,
-        :condition_expression,
-        :enabled
-      ]
-    }
-
     map
     |> Enum.filter(fn {key, _value} ->
       if Map.has_key?(map, :node_type) do
-        ordering_map[map.node_type]
+        @ordering_map[map.node_type]
         |> Enum.member?(key)
       else
         true
@@ -124,7 +128,7 @@ defmodule Lightning.ExportUtils do
     |> Enum.sort_by(
       fn {key, _value} ->
         if Map.has_key?(map, :node_type) do
-          olist = ordering_map[map.node_type]
+          olist = @ordering_map[map.node_type]
 
           olist
           |> Enum.find_index(&(&1 == key))
@@ -149,8 +153,41 @@ defmodule Lightning.ExportUtils do
       :cron_expression ->
         "#{k}: '#{v}'"
 
+      :condition_expression ->
+        "condition_expression: #{v}"
+
       _ ->
-        "#{k}: #{v}"
+        "#{yaml_safe_key(k)}: #{yaml_safe_string(v)}"
+    end
+  end
+
+  defp yaml_safe_string(value) do
+    # starts with alphanumeric
+    # followed by alphanumeric or hyphen or underscore or @ or . or space
+    # ends with alphanumeric
+    if !Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\. ]*[a-zA-Z0-9]$/, value) do
+      ~s('#{value}')
+    else
+      value
+    end
+  end
+
+  defp yaml_safe_key(key) do
+    if key not in @special_keys do
+      key |> to_string() |> hyphenate() |> maybe_escape_key()
+    else
+      key
+    end
+  end
+
+  defp maybe_escape_key(key) do
+    # starts with alphanumeric
+    # followed by alphanumeric or hyphen or underscore or @ or .
+    # ends with alphanumeric
+    if !Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.]*[a-zA-Z0-9]$/, key) do
+      ~s("#{key}")
+    else
+      key
     end
   end
 
@@ -159,23 +196,23 @@ defmodule Lightning.ExportUtils do
   end
 
   defp handle_input(key, value, indentation) when is_number(value) do
-    "#{indentation}#{key}: #{value}"
+    "#{indentation}#{yaml_safe_key(key)}: #{value}"
   end
 
   defp handle_input(key, value, indentation) when is_boolean(value) do
-    "#{indentation}#{key}: #{Atom.to_string(value)}"
+    "#{indentation}#{yaml_safe_key(key)}: #{value}"
   end
 
   defp handle_input(key, value, indentation) when value in [%{}, [], nil] do
-    "#{indentation}#{key}: null"
+    "#{indentation}#{yaml_safe_key(key)}: null"
   end
 
   defp handle_input(key, value, indentation) when is_map(value) do
-    "#{indentation}#{hyphenate(key)}:\n#{to_new_yaml(value, "#{indentation}  ")}"
+    "#{indentation}#{yaml_safe_key(key)}:\n#{to_new_yaml(value, "#{indentation}  ")}"
   end
 
   defp handle_input(key, value, indentation) when is_list(value) do
-    "#{indentation}#{hyphenate(key)}:\n#{Enum.map_join(value, "\n", fn map -> "#{indentation}  #{hyphenate(map.name)}:\n#{to_new_yaml(map, "#{indentation}    ")}" end)}"
+    "#{indentation}#{yaml_safe_key(key)}:\n#{Enum.map_join(value, "\n", fn map -> "#{indentation}  #{yaml_safe_key(map.name)}:\n#{to_new_yaml(map, "#{indentation}    ")}" end)}"
   end
 
   defp to_new_yaml(map, indentation \\ "") do


### PR DESCRIPTION
### Description

This PR adds quotes to special YAML characters when exporting the project into YAML.

It uses a regex to do the validation.

A valid YAML key:
- starts with alphanumeric
- followed by alphanumeric or hyphen or underscore or @ or .
- ends with alphanumeric

A valid YAML value:
- starts with alphanumeric
- followed by alphanumeric or hyphen or underscore or @  or . or space
- ends with alphanumeric

This means if a job name / workflow name begins with a space, it will get quoted in the exported YAML

Closes #2446

### Validation steps

1. In your project, try renaming the project/workflow/job/edge condition names  to contain a character like `:`. Or maybe you append/prepend a space to the name and save
2. Head to the project settings and click `export project`.
3. You'll see that names with special characters have been quoted.
4. Try using the `cli` to pull that particular project, i.e. `openfn pull <project id>`
5. You should get the same result as step 3

Initially, `cli pull` would fail with this error:
```sh
[CLI] ♦ Downloading the project spec (as YAML) from the server.

[CLI] ✘ Command failed!
[CLI] ✘ Error: Document with errors cannot be stringified
    at Document.toString (/opt/hostedtoolcache/node/18.20.4/x64/lib/node_modules/@openfn/cli/node_modules/yaml/dist/doc/Document.js:321:19)
    at extractJobsToDisk (file:///opt/hostedtoolcache/node/18.20.4/x64/lib/node_modules/@openfn/cli/node_modules/@openfn/deploy/dist/index.js:626:14)
    at async pullHandler (file:///opt/hostedtoolcache/node/18.20.4/x64/lib/node_modules/@openfn/cli/dist/process/runner.js:1587:25)
    at async parse (file:///opt/hostedtoolcache/node/18.20.4/x64/lib/node_modules/@openfn/cli/dist/process/runner.js:1764:12)
```
  


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
