### PR TITLE
Rejected Work Orders: Fix Filters And Retrials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix history page filters not working for rejected work orders
+  [#2391](https://github.com/OpenFn/lightning/issues/2391)
+
 ## [v2.9.5] - 2024-09-18
 
 ### Changed

--- a/lib/lightning/workorders/search_params.ex
+++ b/lib/lightning/workorders/search_params.ex
@@ -19,7 +19,7 @@ defmodule Lightning.WorkOrders.SearchParams do
              :wo_date_before
            ]}
 
-  @statuses ~w(pending running success failed crashed killed cancelled lost exception)
+  @statuses ~w(pending running success failed crashed killed cancelled lost exception rejected)
   @statuses_set MapSet.new(@statuses)
   @search_fields ~w(id body log)
 

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -405,7 +405,7 @@ defmodule LightningWeb.RunLive.Index do
     workorder = Enum.find(page.entries, &(&1.id == workorder_id))
 
     work_orders =
-      if selected? and nil != workorder do
+      if selected? and !is_nil(workorder) do
         selected_workorder = %Lightning.WorkOrder{
           id: workorder.id,
           workflow_id: workorder.workflow_id

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -1685,6 +1685,42 @@ defmodule Lightning.WorkOrdersTest do
       assert retry_run |> Repo.preload(:steps) |> Map.get(:steps) == []
     end
 
+    test "rejected workorders are retryable",
+         %{
+           snapshot: snapshot,
+           trigger: trigger,
+           user: user,
+           workflow: workflow
+         } do
+      input_dataclip = insert(:dataclip)
+
+      workorder =
+        insert(:workorder,
+          dataclip: input_dataclip,
+          snapshot: snapshot,
+          trigger: trigger,
+          workflow: workflow,
+          state: :rejected
+        )
+
+      runs = workorder |> Ecto.assoc(:runs) |> Repo.all()
+
+      assert Enum.empty?(runs)
+      assert workorder.state == :rejected
+
+      {:ok, 1} =
+        WorkOrders.retry_many([workorder],
+          created_by: user,
+          project_id: workflow.project_id
+        )
+
+      workorder = Repo.reload(workorder)
+      runs = workorder |> Ecto.assoc(:runs) |> Repo.all()
+
+      refute Enum.empty?(runs)
+      refute workorder.state == :rejected
+    end
+
     test "retrying a WorkOrder with a run having starting_job without steps",
          %{
            jobs: [_job_a, job_b, _job_c],


### PR DESCRIPTION
### Description

This PR addresses two issues on the history page:
- Fixes filters to properly handle the "rejected" status for work orders.
- Adds the ability to retry rejected work orders.

Fixes #2391 

### Validation steps

#### For The Filters Of Rejected Work Orders Fix
1. Make sure you have rejected work orders
2. Visit the history page
3. Filter by status and chose 'Rejected'
4. See the app displaying only the rejected work orders or nothing when no rejected work orders exist

#### For The Retrial Of Rejected Work Orders Fix
1. Make sure you have rejected work orders (maybe follow the steps described here by @aleksa-krolls)
![image](https://github.com/user-attachments/assets/c550708f-6aa1-425d-8e57-db25d1a0fa1d)
2. Go to the history page
3. Select few rejected work orders
4. Click on the bulk retry button
5. See your work orders being rerun successfully

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
