### PR TITLE
When the selected job was not run, do not say the dataclip is wiped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Dataclip selector always shows that the dataclip is wiped even when the job wasn't run
+  [#2303](https://github.com/OpenFn/lightning/issues/2303)
+
 ## [v2.9.5] - 2024-09-18
 
 ### Changed

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -400,9 +400,11 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
     ai_limit_result != :ok
   end
 
-  defp job_is_unsaved?(selected_job) do
-    selected_job.__meta__.state == :built
+  defp job_is_unsaved?(%{__meta__: %{state: :built}} = _job) do
+    true
   end
+
+  defp job_is_unsaved?(_job), do: false
 
   defp disabled_tooltip_message(can_edit_workflow, ai_limit_result, selected_job) do
     case {can_edit_workflow, ai_limit_result, selected_job} do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -224,8 +224,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         project={@project}
                         admin_contacts={@admin_contacts}
                         can_edit_data_retention={@can_edit_data_retention}
-                        follow_run_id={@follow_run && @follow_run.id}
-                        show_wiped_dataclip_selector={@show_wiped_dataclip_selector}
+                        follow_run={@follow_run}
+                        step={@step}
+                        show_missing_dataclip_selector={
+                          @show_missing_dataclip_selector
+                        }
                       />
                     </div>
                   </:panel>
@@ -1021,7 +1024,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
        workflow_params: %{},
        selected_credential_type: nil,
        oauth_clients: OauthClients.list_clients(assigns.project),
-       show_wiped_dataclip_selector: false,
+       show_missing_dataclip_selector: false,
        admin_contacts: Projects.list_project_admin_emails(assigns.project.id)
      )
      |> assign(initial_presence_summary(socket.assigns.current_user))}
@@ -1478,8 +1481,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
      |> put_flash(:info, "Copied webhook URL to clipboard")}
   end
 
-  def handle_event("toggle_wiped_dataclip_selector", _, socket) do
-    {:noreply, update(socket, :show_wiped_dataclip_selector, fn val -> !val end)}
+  def handle_event("toggle_missing_dataclip_selector", _, socket) do
+    {:noreply,
+     update(socket, :show_missing_dataclip_selector, fn val -> !val end)}
   end
 
   def handle_event("manual_run_change", %{"manual" => params}, socket) do
@@ -1819,7 +1823,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       selectable_dataclips:
         maybe_add_selected_dataclip(selectable_dataclips, step_dataclip)
     )
-    |> assign(show_wiped_dataclip_selector: is_map(step_dataclip))
+    |> assign(show_missing_dataclip_selector: is_map(step_dataclip))
   end
 
   defp get_selected_dataclip(run, job_id) do


### PR DESCRIPTION
### Description

This PR fixes an issue on the dataclip selector viewer whenever a run is followed and the selected job isn't part of the run.

Initially, all it was saying is the dataclip is wiped, but now, it checks to see if the `step` exists or not before making the conclusion on whether it was wiped or not

Closes #2303 

### Validation steps

1. Ensure you have a workflow with multiple steps. The `openhie-project` can do
2. Make the workflow crash in the first job. A simple typo in the job code would do
3. Now get the `run id` and open any of the subsequent jobs in that workflow and add `a={run_id_here}` to the query params.
4. You'll see that on the dataclip viewer, the message says that the job wasn't run. Attached is a screenshot of the same
<img width="1440" alt="Screenshot 2024-09-19 at 15 18 55" src="https://github.com/user-attachments/assets/e3487b90-46d4-4995-8224-5a7fb4b858b7">


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
