### PR TITLE
Export edge condition expressions as multiline in project spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 
 - Dataclip selector always shows that the dataclip is wiped even when the job wasn't run
   [#2303](https://github.com/OpenFn/lightning/issues/2303)
+- Export edge condition expressions as multiline in project spec
+  [#2521](https://github.com/OpenFn/lightning/issues/2521)
 
 ## [v2.9.5] - 2024-09-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Export edge condition expressions as multiline in project spec
+  [#2521](https://github.com/OpenFn/lightning/issues/2521)
+
 ## [v2.9.6] - 2024-09-23
 
 ### Added
@@ -36,8 +39,6 @@ and this project adheres to
 
 - Dataclip selector always shows that the dataclip is wiped even when the job wasn't run
   [#2303](https://github.com/OpenFn/lightning/issues/2303)
-- Export edge condition expressions as multiline in project spec
-  [#2521](https://github.com/OpenFn/lightning/issues/2521)
 - Send run channel errors to sentry
   [#2515](https://github.com/OpenFn/lightning/issues/2515)
 

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -141,11 +141,7 @@ defmodule Lightning.ExportUtils do
   defp handle_binary(k, v, i) do
     case k do
       :body ->
-        indented_expression =
-          String.split(v, "\n")
-          |> Enum.map_join("\n", fn line -> "#{i}  #{line}" end)
-
-        "body: |\n#{indented_expression}"
+        "body: |\n#{indent_multiline_value(v, i)}"
 
       :adaptor ->
         "#{k}: '#{v}'"
@@ -154,11 +150,17 @@ defmodule Lightning.ExportUtils do
         "#{k}: '#{v}'"
 
       :condition_expression ->
-        "condition_expression: #{v}"
+        "condition_expression: |\n#{indent_multiline_value(v, i)}"
 
       _ ->
         "#{yaml_safe_key(k)}: #{yaml_safe_string(v)}"
     end
+  end
+
+  defp indent_multiline_value(value, current_indent) do
+    value
+    |> String.split("\n")
+    |> Enum.map_join("\n", fn line -> "#{current_indent}  #{line}" end)
   end
 
   defp yaml_safe_string(value) do

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -724,7 +724,8 @@ defmodule Lightning.ProjectsTest do
 
       assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
 
-      assert generated_yaml =~ "condition_expression: |\n          #{js_expression}"
+      assert generated_yaml =~
+               "condition_expression: |\n          #{js_expression}"
     end
 
     test "exports canonical project" do

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -459,7 +459,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert response =~ ~S[condition_type: js_expression]
       assert response =~ ~S[condition_label: not underaged]
-      assert response =~ ~S[condition_expression: state.data.age > 18]
+      assert response =~ ~s[condition_expression: |\n          state.data.age > 18]
     end
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -459,7 +459,9 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert response =~ ~S[condition_type: js_expression]
       assert response =~ ~S[condition_label: not underaged]
-      assert response =~ ~s[condition_expression: |\n          state.data.age > 18]
+
+      assert response =~
+               ~s[condition_expression: |\n          state.data.age > 18]
     end
   end
 


### PR DESCRIPTION
### Description

This PR exports condition expressions in a multiline format to avoid crashing the cli during pull.
This is the same format used in handling job body

Closes #2521 


### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
