### PR TITLE
Rejected Work Orders: Fix Filters And Retrials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix history page filters not working for rejected work orders
+  [#2391](https://github.com/OpenFn/lightning/issues/2391)
+
 ## [v2.9.4] - 2024-09-16
 
 ### Changed

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -63,7 +63,7 @@ defmodule Lightning.WorkOrders do
           | {:project_id, Ecto.UUID.t()}
           | {:without_run, boolean()}
 
-  @run_many_chunk_size 100
+  @retry_many_chunk_size 100
 
   defdelegate subscribe(project_id), to: Events
 
@@ -447,33 +447,35 @@ defmodule Lightning.WorkOrders do
           | UsageLimiting.error()
           | {:error, :enqueue_error}
   def retry_many([%WorkOrder{} | _rest] = workorders, opts) do
-    runs_ids =
-      workorders
-      |> Enum.map(& &1.id)
-      |> get_first_runs_for_retry()
-
     with project_id <- Keyword.fetch!(opts, :project_id),
          :ok <-
            UsageLimiter.limit_action(
-             %Action{type: :new_run, amount: length(runs_ids)},
+             %Action{type: :new_run, amount: length(workorders)},
              %Context{
                project_id: project_id
              }
            ) do
       creating_user = Keyword.fetch!(opts, :created_by)
 
-      runs_ids
-      |> Enum.chunk_every(@run_many_chunk_size)
-      |> Enum.map(
+      workorders
+      |> Enum.chunk_every(@retry_many_chunk_size)
+      |> Enum.flat_map(fn chunk ->
         # TODO: Enqueue the first chunk directly with Runs.enqueue_many and schedule the rest with Oban
-        &RetryManyWorkOrdersJob.new(%{runs_ids: &1, created_by: creating_user.id})
-      )
+        workorder_ids = Enum.map(chunk, & &1.id)
+
+        [
+          RetryManyWorkOrdersJob.new(%{
+            workorders_ids: workorder_ids,
+            created_by: creating_user.id
+          })
+        ]
+      end)
       |> then(fn jobs ->
         Oban.insert_all(Lightning.Oban, jobs)
       end)
       |> case do
         inserted_list when is_list(inserted_list) ->
-          enqueued_count = length(runs_ids)
+          enqueued_count = length(workorders)
           discarded_count = length(workorders) - enqueued_count
 
           {:ok, enqueued_count, discarded_count}
@@ -510,27 +512,27 @@ defmodule Lightning.WorkOrders do
   @doc """
   Enqueue multiple runs for retry in the same transaction.
   """
-  def enqueue_many_for_retry(runs_ids, creating_user_id) do
-    runs = preload_runs_for_retry(runs_ids)
+  def enqueue_many_for_retry(workorders_ids, creating_user_id) do
+    workorders = workorders_with_first_runs(workorders_ids)
     creating_user = Repo.get!(User, creating_user_id)
 
-    runs
+    workorders
     |> Enum.with_index()
-    |> Enum.reduce(Multi.new(), fn {run, index}, multi ->
+    |> Enum.reduce(Multi.new(), fn {workorder, index}, multi ->
+      %{workflow: workflow, dataclip_id: dataclip_id} = workorder
+
       run_op = "run-#{index}"
-      snapshot_op = "snapshot-#{run.work_order.workflow.id}"
+      snapshot_op = "snapshot-#{workflow.id}"
 
       multi
-      |> get_or_create_snapshot(run.work_order.workflow, snapshot_op)
+      |> get_or_create_snapshot(workflow, snapshot_op)
       |> Multi.insert(run_op, fn %{^snapshot_op => snapshot} ->
-        starting_job =
-          run.starting_job ||
-            hd(run.starting_trigger.edges).target_job
+        starting_job = determine_starting_job(workorder)
 
         new_retry_run(
           snapshot,
-          run.work_order,
-          run.dataclip_id,
+          workorder,
+          dataclip_id,
           starting_job,
           [],
           creating_user
@@ -545,10 +547,7 @@ defmodule Lightning.WorkOrders do
         returning: true
       )
     end)
-    |> Multi.put(
-      :workflow_runs_count,
-      Enum.frequencies_by(runs, & &1.work_order.workflow_id)
-    )
+    |> workflow_runs_count(workorders)
     |> Runs.enqueue_many()
     |> case do
       {:ok, changes} ->
@@ -630,44 +629,22 @@ defmodule Lightning.WorkOrders do
     )
   end
 
-  defp get_first_runs_for_retry(orders_ids) do
-    run_numbers_query =
-      from(r in Run,
-        where: r.work_order_id in ^orders_ids,
-        select: %{
-          id: r.id,
-          row_num:
-            row_number()
-            |> over(
-              partition_by: r.work_order_id,
-              order_by: coalesce(r.started_at, r.inserted_at)
-            )
-        }
-      )
-
-    from(r in Run,
-      join: rn in subquery(run_numbers_query),
-      on: r.id == rn.id,
-      join: wo in assoc(r, :work_order),
-      join: dc in assoc(r, :dataclip),
-      where: rn.row_num == 1 and is_nil(dc.wiped_at),
-      select: r.id,
-      order_by: [asc: wo.inserted_at]
+  def workorders_with_first_runs(workorders_ids) do
+    from(w in WorkOrder,
+      where: w.id in ^workorders_ids,
+      preload: [
+        :workflow,
+        runs: ^first_run_query()
+      ]
     )
     |> Repo.all()
   end
 
-  defp preload_runs_for_retry(runs_ids) do
-    from(r in Run,
-      where: r.id in ^runs_ids,
-      order_by: [asc: r.inserted_at],
-      preload: [
-        :starting_job,
-        starting_trigger: [edges: :target_job],
-        work_order: [:workflow]
-      ]
-    )
-    |> Repo.all()
+  defp first_run_query do
+    from r in Run,
+      order_by: [asc: coalesce(r.started_at, r.inserted_at)],
+      preload: [:starting_job, starting_trigger: [edges: :target_job]],
+      limit: 1
   end
 
   defp publish_events_for_retry_many(changes) do
@@ -697,5 +674,24 @@ defmodule Lightning.WorkOrders do
         do: [v | acc],
         else: acc
     end)
+  end
+
+  def determine_starting_job(%{runs: []} = workorder) do
+    hd(workorder.trigger.edges).target_job
+  end
+
+  def determine_starting_job(%{runs: [run]} = workorder) do
+    run.starting_job || hd(workorder.trigger.edges).target_job
+  end
+
+  def workflow_runs_count(multi, workorders) do
+    workflow_runs_count =
+      workorders
+      |> Enum.flat_map(fn workorder ->
+        List.duplicate(workorder.workflow_id, length(workorder.runs))
+      end)
+      |> Enum.frequencies()
+
+    Multi.put(multi, :workflow_runs_count, workflow_runs_count)
   end
 end

--- a/lib/lightning/workorders/retry_many_workorders_job.ex
+++ b/lib/lightning/workorders/retry_many_workorders_job.ex
@@ -12,10 +12,13 @@ defmodule Lightning.WorkOrders.RetryManyWorkOrdersJob do
 
   @impl Oban.Worker
   def perform(%{
-        args: %{"runs_ids" => runs_ids, "created_by" => creating_user_id}
+        args: %{
+          "workorders_ids" => workorders_ids,
+          "created_by" => creating_user_id
+        }
       }) do
     with {:error, changeset} <-
-           WorkOrders.enqueue_many_for_retry(runs_ids, creating_user_id) do
+           WorkOrders.enqueue_many_for_retry(workorders_ids, creating_user_id) do
       Logger.error("Error retrying workorders: #{inspect(changeset)}")
     end
 

--- a/lib/lightning/workorders/search_params.ex
+++ b/lib/lightning/workorders/search_params.ex
@@ -19,7 +19,7 @@ defmodule Lightning.WorkOrders.SearchParams do
              :wo_date_before
            ]}
 
-  @statuses ~w(pending running success failed crashed killed cancelled lost exception)
+  @statuses ~w(pending running success failed crashed killed cancelled lost exception rejected)
   @statuses_set MapSet.new(@statuses)
   @search_fields ~w(id body log)
 

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -412,7 +412,7 @@ defmodule LightningWeb.RunLive.Index do
     workorder = Enum.find(page.entries, &(&1.id == workorder_id))
 
     work_orders =
-      if selected? and nil != workorder do
+      if selected? and !is_nil(workorder) do
         selected_workorder = %Lightning.WorkOrder{
           id: workorder.id,
           workflow_id: workorder.workflow_id


### PR DESCRIPTION
### Description

This PR addresses two issues on the history page:
- Fixes filters to properly handle the "rejected" status for work orders.
- Adds the ability to retry rejected work orders.

Fixes #2391 

### Validation steps

#### For The Filters Of Rejected Work Orders Fix
1. Make sure you have rejected work orders
2. Visit the history page
3. Filter by status and chose 'Rejected'
4. See the app displaying only the rejected work orders or nothing when no rejected work orders exist

#### For The Retrial Of Rejected Work Orders Fix
1. Make sure you have rejected work orders (maybe follow the steps described here by @aleksa-krolls)
![image](https://github.com/user-attachments/assets/c550708f-6aa1-425d-8e57-db25d1a0fa1d)
2. Go to the history page
3. Select few rejected work orders
4. Click on the bulk retry button
5. See your work orders being rerun successfully

### Additional notes for the reviewer

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
