### PR TITLE
Simulate Kafka persistence failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   [#2531] (https://github.com/OpenFn/lightning/issues/2531)
 - Always use the `initial_offset_reset_policy` when enabling a Kafka pipeline.
   [#2531] (https://github.com/OpenFn/lightning/issues/2531)
+- Add plumbing to simulate a persistence failure in a Kafka trigger pipeline.
+  [#2386] (https://github.com/OpenFn/lightning/issues/2386)
 
 ### Fixed
 

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -678,6 +678,11 @@ defmodule LightningWeb.WorkOrderLiveTest do
       |> render_submit()
 
       refute view |> has_element?("#workorder-#{failed_work_order.id}")
+
+      dynamically_absorb_delay(fn ->
+        view |> has_element?("#workorder-#{rejected_work_order.id}")
+      end)
+
       assert view |> has_element?("#workorder-#{rejected_work_order.id}")
 
       view

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2,7 +2,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
   use LightningWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
-  import Lightning.ApplicationHelpers, only: [dynamically_absorb_delay: 1]
+  import Lightning.ApplicationHelpers, only: [dynamically_absorb_delay: 2]
   import Lightning.WorkflowLive.Helpers
   import Lightning.WorkflowsFixtures
   import Lightning.JobsFixtures
@@ -2110,10 +2110,13 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert high_priority_view
              |> has_element?("#inspector-workflow-version", "latest")
 
-      dynamically_absorb_delay(fn ->
-        !(low_priority_view
-          |> has_element?("#inspector-workflow-version", "latest"))
-      end)
+      dynamically_absorb_delay(
+        fn ->
+          !(low_priority_view
+            |> has_element?("#inspector-workflow-version", "latest"))
+        end,
+        sleep: 2
+      )
 
       assert low_priority_view
              |> has_element?(


### PR DESCRIPTION
### Description

This PR adds functionality that allows the KafkaTriggers::Pipeline to simulate the occurrence of a persistence failure. This allows the testing of as much of the 'persistence failure' handling code as possible without having to wait for a persistence failure to occur :).

This is achieved by setting a 'testing flag' key/value pair using `:persistent_term`. When the pipeline sees that the flag is set, it will mark the message it is processing as 'failed' and will then unset the flag and process any other messages as it normally would.

This functionality is currently being used to develop the pipeline's failure handling code. It will also be useful to test behaviour in the staging environment (for example).

Note: The last commit contains fixes to unrelated flickering tests.

 #2386 

### Validation steps

- Setup a local Kafka cluster based on these [instructions](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster)
- Setup an enabled Kafka trigger as follows:

![image](https://github.com/user-attachments/assets/30dc2f5e-cb73-4401-9158-e44fc657fb03)

In an IEx session:

```
import Ecto.Query
alias Lightning.Repo
alias Lightning.Workflows.Trigger
alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord

TriggerKafkaMessageRecord |> Repo.delete_all()
%{id: trigger_id} = (from t in Trigger, where: t.enabled == true and t.type == :kafka, order_by: [desc: t.inserted_at]) |> Repo.one()
:persistent_term.put({:kafka_trigger_test_failure, trigger_id}, true)
```

In the terminal, add 5 messages to the cluster:

```
kafka_testing/lots_of_messages_sans_headers.sh 5
```

In the server logs, you should an error similar to the below:

```
[error] Kafka Pipeline Error: Type `persistence` Trigger_id `3da10211-5c74-4494-82c8-4490f7e7e125` Topic `baz_topic` Partition `0` Offset `99` Key ``
```

In your IEx session, you should see that only 4 of the 5 messages were processed:

```
TriggerKafkaMessageRecord |> Repo.all() |> Enum.count() == 4
```

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
