### PR TITLE
Enhance YAML Export: Make Project Description Multiline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- Make project description multiline in project.yaml
+  [#2534](https://github.com/OpenFn/lightning/issues/2534)
 - Do not track partition timestamps when ingesting Kafka messages.
-  [#2531] (https://github.com/OpenFn/lightning/issues/2531)
+  [#2531](https://github.com/OpenFn/lightning/issues/2531)
 - Always use the `initial_offset_reset_policy` when enabling a Kafka pipeline.
   [#2531] (https://github.com/OpenFn/lightning/issues/2531)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to
 - Do not track partition timestamps when ingesting Kafka messages.
   [#2531](https://github.com/OpenFn/lightning/issues/2531)
 - Always use the `initial_offset_reset_policy` when enabling a Kafka pipeline.
-  [#2531] (https://github.com/OpenFn/lightning/issues/2531)
+  [#2531](https://github.com/OpenFn/lightning/issues/2531)
 
 ### Fixed
 
@@ -336,7 +336,7 @@ and this project adheres to
 - Kafka messages without keys are synchronously converted into a Workorder,
   Dataclip and Run. Messages with keys are stored as TriggerKafkaMessage
   records, however the code needed to process them has been disabled, pending
-  removal. [#2351] (https://github.com/OpenFn/lightning/issues/2351)
+  removal. [#2351](https://github.com/OpenFn/lightning/issues/2351)
 
 ## [v2.7.14] - 2024-08-05
 

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -143,6 +143,9 @@ defmodule Lightning.ExportUtils do
       :body ->
         "body: |\n#{indent_multiline_value(v, i)}"
 
+      :description ->
+        "description: |\n#{indent_multiline_value(v, i)}"
+
       :adaptor ->
         "#{k}: '#{v}'"
 

--- a/test/fixtures/canonical_project.yaml
+++ b/test/fixtures/canonical_project.yaml
@@ -1,5 +1,6 @@
 name: a-test-project
-description: This is only a test
+description: |
+  This is only a test
 credentials:
   cannonical-user@lightning.com-new-credential:
     name: new credential

--- a/test/integration/cli_deploy_test.exs
+++ b/test/integration/cli_deploy_test.exs
@@ -156,7 +156,7 @@ defmodule Lightning.CliDeployTest do
                |> Lightning.Repo.preload(workflows: [:jobs, :triggers, :edges])
 
       assert project.name == "a-test-project"
-      assert project.description == "This is only a test"
+      assert project.description == "This is only a test\n"
 
       assert Enum.count(project.workflows) == 2
 


### PR DESCRIPTION
### Description

This PR updates the project export functionality to format project descriptions as multiline strings in the YAML file using the pipe operator (|). By doing so, it preserves line breaks and special characters in project descriptions without the need for escaping, enhancing the readability and integrity of the exported YAML data.

Closes #2534 

### Validation steps

1. Create a project that has a description.
2. Export it.
3. Note that the project description in the YAML file is formatted as a multiline string using the pipe operator (|), preserving line breaks and special characters.
4. Import the project YAML file using the CLI deploy command
5. Note that the import is successful and that your project is created with the description

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
