### PR TITLE
Mark unfinished steps having finished runs `lost`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   [#2542](https://github.com/OpenFn/lightning/issues/2542)
 - Perform data retention purging in batches to avoid timeouts
   [#2528](https://github.com/OpenFn/lightning/issues/2528)
+- Mark unfinished steps having finished runs as `lost`
+  [#2416](https://github.com/OpenFn/lightning/issues/2416)
 
 ## [v2.9.8] - 2024-10-03
 

--- a/lib/lightning/janitor.ex
+++ b/lib/lightning/janitor.ex
@@ -42,6 +42,8 @@ defmodule Lightning.Janitor do
         Runs.mark_run_lost(run)
       end)
       |> Stream.run()
+
+      Runs.Query.lost_steps() |> Runs.mark_steps_lost()
     end)
   end
 end

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -309,10 +309,20 @@ defmodule Lightning.Runs do
 
       Ecto.assoc(run, :steps)
       |> where([r], is_nil(r.exit_reason))
-      |> Repo.update_all(
-        set: [exit_reason: "lost", finished_at: DateTime.utc_now()]
-      )
+      |> mark_steps_lost()
     end)
+  end
+
+  @spec mark_steps_lost(Ecto.Queryable.t()) :: {:ok, non_neg_integer()}
+  def mark_steps_lost(steps_query) do
+    {updated_count, nil} =
+      Repo.update_all(
+        steps_query,
+        [set: [exit_reason: "lost", finished_at: DateTime.utc_now()]],
+        returning: false
+      )
+
+    {:ok, updated_count}
   end
 
   defdelegate subscribe(run), to: Events

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -4,6 +4,7 @@ defmodule Lightning.Runs.Query do
   """
   import Ecto.Query
 
+  alias Lightning.Invocation.Step
   alias Lightning.Run
 
   require Lightning.Run
@@ -46,6 +47,16 @@ defmodule Lightning.Runs.Query do
           ^now
         ) or (is_nil(r.options) and r.claimed_at < ^fallback_oldest_claim)
     )
+  end
+
+  @spec lost_steps() :: Ecto.Queryable.t()
+  def lost_steps do
+    final_states = Run.final_states()
+
+    from s in Step,
+      join: r in assoc(s, :runs),
+      on: r.state in ^final_states,
+      where: is_nil(s.exit_reason) and is_nil(s.finished_at)
   end
 
   @doc """


### PR DESCRIPTION
### Description

This PR marks unfinished steps having finished runs `lost`

Closes #2416 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
