### PR TITLE
Store User Preferences in db

### DIFF
--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -399,6 +399,21 @@ defmodule Lightning.Accounts do
     change_user_info(user, attrs) |> Repo.update()
   end
 
+  @doc """
+  Updates the user preferences.
+
+  ## Examples
+
+      iex> update_user_preferences(%User{}, %{"editor.orientaion" => "vertical"})
+  """
+  @spec update_user_preferences(User.t(), map()) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def update_user_preferences(%User{} = user, preferences) do
+    user
+    |> User.preferences_changeset(preferences)
+    |> Repo.update()
+  end
+
   ## Settings
 
   @doc """

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -35,7 +35,7 @@ defmodule Lightning.Accounts.User do
       values: [:critical, :any],
       default: :critical
 
-    field :preferences, :map
+    field :preferences, :map, default: %{}
 
     has_one :user_totp, Lightning.Accounts.UserTOTP
     has_many :credentials, Lightning.Credentials.Credential

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -35,6 +35,8 @@ defmodule Lightning.Accounts.User do
       values: [:critical, :any],
       default: :critical
 
+    field :preferences, :map
+
     has_one :user_totp, Lightning.Accounts.UserTOTP
     has_many :credentials, Lightning.Credentials.Credential
     has_many :oauth_clients, Lightning.Credentials.OauthClient
@@ -295,6 +297,11 @@ defmodule Lightning.Accounts.User do
     user
     |> cast(attrs, [:github_oauth_token])
     |> validate_required([:github_oauth_token])
+  end
+
+  def preferences_changeset(user, attrs) do
+    user
+    |> change(%{preferences: Map.merge(user.preferences, attrs)})
   end
 
   @doc """

--- a/priv/repo/migrations/20241009065244_add_preferences_to_users.exs
+++ b/priv/repo/migrations/20241009065244_add_preferences_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddPreferencesToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      add :preferences, :jsonb, default: fragment("jsonb_object('{}')"), null: false
+    end
+  end
+end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -540,6 +540,35 @@ defmodule Lightning.AccountsTest do
     end
   end
 
+  describe "update_user_preferences/2" do
+    test "updates the user with provided preferences" do
+      user = insert(:user)
+
+      assert user.preferences == %{}
+
+      {:ok, updated_user} =
+        Accounts.update_user_preferences(user, %{"hello" => "world"})
+
+      assert updated_user.preferences == %{"hello" => "world"}
+    end
+
+    test "does not replace existing prefrences" do
+      user = insert(:user, preferences: %{"hello" => "world"})
+
+      assert user.preferences == %{"hello" => "world"}
+
+      {:ok, updated_user} =
+        Accounts.update_user_preferences(user, %{"x" => 2})
+
+      assert updated_user.preferences == %{"hello" => "world", "x" => 2}
+
+      {:ok, updated_user} =
+        Accounts.update_user_preferences(updated_user, %{"x" => 12})
+
+      assert updated_user.preferences == %{"hello" => "world", "x" => 12}
+    end
+  end
+
   describe "purge user" do
     test "purging a user removes that user from projects they are members of and deletes them from the system" do
       %{project_users: [proj_user1]} =


### PR DESCRIPTION
### Description

This PR adds `preferences` to the `User` schema. It is a `jsonb` field 

Closes #2564


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
