### PR TITLE
Fix editor panel overlays output panel when scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix editor panel overlays output panel when scrolled
+  [#2291](https://github.com/OpenFn/lightning/issues/2291)
+
 ## [v2.9.9] - 2024-10-09
 
 ### Changed

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -585,7 +585,7 @@ defmodule LightningWeb.WorkflowLive.Components do
     >
       <div
         id={"#{@id}-panel-header"}
-        class="flex justify-between items-center p-2 px-4 panel-header"
+        class="flex justify-between items-center p-2 px-4 panel-header z-50"
       >
         <div
           id={"#{@id}-panel-header-title"}


### PR DESCRIPTION
### Description

This PR stops the editor from overlaying the output panel when scrolled.
The solution here just adds  higher `z-index` to the panel headers.

Closes #2291 

### Validation steps

As shown in the issue report, you just need to scroll half way on the editor and try to hover over the `Run` or `Log` tabs. You'll notice that now they are hover-able and clickable


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
