### PR TITLE
Support `kafka` trigger type in the provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Notify users when a Kafka trigger can not persist a message to the database.
   [#2386](https://github.com/OpenFn/lightning/issues/2386)
+- Support `kafka` trigger type in the provisioner
+  [#2506](https://github.com/OpenFn/lightning/issues/2506)
 
 ### Changed
 

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -8,12 +8,19 @@ defmodule Lightning.ExportUtils do
   alias Lightning.Workflows
   alias Lightning.Workflows.Snapshot
 
+  @kafka_trigger_fields [
+    :hosts,
+    :topics,
+    :initial_offset_reset_policy,
+    :connect_timeout
+  ]
+
   @ordering_map %{
     project: [:name, :description, :credentials, :globals, :workflows],
     credential: [:name, :owner],
     workflow: [:name, :jobs, :triggers, :edges],
     job: [:name, :adaptor, :credential, :globals, :body],
-    trigger: [:type, :cron_expression, :enabled],
+    trigger: [:type, :cron_expression, :enabled, :kafka_configuration],
     edge: [
       :source_trigger,
       :source_job,
@@ -62,9 +69,28 @@ defmodule Lightning.ExportUtils do
       type: Atom.to_string(trigger.type)
     }
 
-    if trigger.type == :cron,
-      do: Map.put(base, :cron_expression, trigger.cron_expression),
-      else: base
+    case trigger.type do
+      :cron ->
+        Map.put(base, :cron_expression, trigger.cron_expression)
+
+      :kafka ->
+        kafka_config =
+          trigger.kafka_configuration
+          |> Map.take(@kafka_trigger_fields)
+          |> Map.new(fn
+            {:hosts, hosts} when is_list(hosts) ->
+              {:hosts,
+               Enum.map(hosts, fn host_port -> Enum.join(host_port, ":") end)}
+
+            other ->
+              other
+          end)
+
+        Map.put(base, :kafka_configuration, kafka_config)
+
+      _ ->
+        base
+    end
   end
 
   defp edge_to_treenode(%{source_job_id: nil} = edge, triggers, jobs) do
@@ -217,7 +243,20 @@ defmodule Lightning.ExportUtils do
   end
 
   defp handle_input(key, value, indentation) when is_list(value) do
-    "#{indentation}#{yaml_safe_key(key)}:\n#{Enum.map_join(value, "\n", fn map -> "#{indentation}  #{yaml_safe_key(map.name)}:\n#{to_new_yaml(map, "#{indentation}    ")}" end)}"
+    "#{indentation}#{yaml_safe_key(key)}:\n#{handle_list_value(value, indentation)}"
+  end
+
+  defp handle_list_value(value, indentation) do
+    Enum.map_join(value, "\n", fn
+      map when is_map(map) ->
+        "#{indentation}  #{yaml_safe_key(map.name)}:\n#{to_new_yaml(map, "#{indentation}    ")}"
+
+      val when is_binary(val) ->
+        "#{indentation}  - #{yaml_safe_string(val)}"
+
+      val ->
+        "#{indentation}  - #{val}"
+    end)
   end
 
   defp to_new_yaml(map, indentation \\ "") do

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -55,26 +55,27 @@ defmodule Lightning.Workflows.Trigger do
 
   @doc false
   def changeset(trigger, attrs) do
-    changeset =
-      trigger
-      |> cast(attrs, [
-        :id,
-        :comment,
-        :custom_path,
-        :enabled,
-        :type,
-        :workflow_id,
-        :cron_expression,
-        :has_auth_method
-      ])
-      |> cast_embed(
-        :kafka_configuration,
-        required: false,
-        with: &KafkaConfiguration.changeset/2
-      )
-
-    changeset
+    trigger
+    |> cast_changeset(attrs)
+    |> cast_embed(
+      :kafka_configuration,
+      required: false,
+      with: &KafkaConfiguration.changeset/2
+    )
     |> validate()
+  end
+
+  def cast_changeset(trigger, attrs) do
+    cast(trigger, attrs, [
+      :id,
+      :comment,
+      :custom_path,
+      :enabled,
+      :type,
+      :workflow_id,
+      :cron_expression,
+      :has_auth_method
+    ])
   end
 
   def validate(changeset) do

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -77,8 +77,18 @@ defmodule LightningWeb.API.ProvisioningJSON do
   end
 
   def as_json(%module{} = trigger) when module in [Trigger, Snapshot.Trigger] do
-    Ecto.embedded_dump(trigger, :json)
+    trigger = Ecto.embedded_dump(trigger, :json)
+
+    kafka_configuration =
+      trigger.kafka_configuration &&
+        Map.take(
+          trigger.kafka_configuration,
+          ~w(hosts topics initial_offset_reset_policy connect_timeout)a
+        )
+
+    trigger
     |> Map.take(~w(id type cron_expression enabled)a)
+    |> Map.put(:kafka_configuration, kafka_configuration)
     |> drop_keys_with_nil_value()
   end
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -814,10 +814,10 @@ defmodule Lightning.ProjectsTest do
               kafka_configuration:
                 hosts:
                   - 'localhost:9092'
-                connect_timeout: 30
                 topics:
                   - dummy
                 initial_offset_reset_policy: earliest
+                connect_timeout: 30
       """
 
       assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -782,6 +782,49 @@ defmodule Lightning.ProjectsTest do
       assert generated_yaml =~ expected_yaml
     end
 
+    test "kafka triggers are included in the export" do
+      project = insert(:project, name: "project 1")
+
+      trigger =
+        build(:trigger,
+          type: :kafka,
+          kafka_configuration: %{
+            hosts: [["localhost", "9092"]],
+            topics: ["dummy"],
+            initial_offset_reset_policy: "earliest"
+          }
+        )
+
+      job =
+        build(:job,
+          body: ~s[fn(state => { return {...state, extra: "data"} })]
+        )
+
+      build(:workflow, name: "workflow 1", project: project)
+      |> with_trigger(trigger)
+      |> with_job(job)
+      |> with_edge({trigger, job}, condition_type: :always)
+      |> insert()
+
+      expected_yaml_trigger = """
+          triggers:
+            kafka:
+              type: kafka
+              enabled: true
+              kafka_configuration:
+                hosts:
+                  - 'localhost:9092'
+                connect_timeout: 30
+                topics:
+                  - dummy
+                initial_offset_reset_policy: earliest
+      """
+
+      assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+
+      assert generated_yaml =~ expected_yaml_trigger
+    end
+
     test "exports canonical project" do
       project =
         canonical_project_fixture(


### PR DESCRIPTION
### Description

This PR adds support for `kafka` trigger type in the provisioner. 
It maintains the structure of the schema when exporting the `spec.yaml` and the `state.json` for simplicity.
i.e
```yaml
    triggers:
      kafka:
        ...
        kafka_configuration:
          hosts:
            - 'localhost:9092'
            - 'localhost:9093'
          connect_timeout: 30
          topics:
            - test
          initial_offset_reset_policy: earliest
```

`username` and `password` are not allowed in the provisioner. An error is added in case you try including them

Closes #2506 

### Validation steps

You would need to install the cli in dev using the branch https://github.com/OpenFn/kit/pull/795

### Additional notes for the reviewer

At first I flattened the `kafka_configuration` fields into the `trigger`. This forced me to write a lot of defensive logic which made it really complex. I ended up abandoning that route and just used the existing structure

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
