### PR TITLE
Sort stream all and stream match items by upsert timestamp

### DIFF
--- a/lib/lightning/collections/item.ex
+++ b/lib/lightning/collections/item.ex
@@ -21,7 +21,7 @@ defmodule Lightning.Collections.Item do
 
     belongs_to :collection, Lightning.Collections.Collection
 
-    timestamps()
+    timestamps(type: :naive_datetime_usec)
   end
 
   @doc false

--- a/lib/lightning/collections/item.ex
+++ b/lib/lightning/collections/item.ex
@@ -7,21 +7,20 @@ defmodule Lightning.Collections.Item do
   import Ecto.Changeset
 
   @type t :: %__MODULE__{
-          id: Ecto.UUID.t(),
           collection_id: Ecto.UUID.t(),
           key: String.t(),
           value: String.t(),
-          inserted_at: NaiveDateTime.t(),
-          updated_at: NaiveDateTime.t()
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
         }
 
+  @primary_key false
   schema "collections_items" do
+    belongs_to :collection, Lightning.Collections.Collection
     field :key, :string
     field :value, :string
 
-    belongs_to :collection, Lightning.Collections.Collection
-
-    timestamps(type: :naive_datetime_usec)
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/priv/repo/migrations/20241009021209_create_collections.exs
+++ b/priv/repo/migrations/20241009021209_create_collections.exs
@@ -15,12 +15,11 @@ defmodule Lightning.Repo.Migrations.CreateCollections do
     create unique_index(:collections, [:name])
 
     create table(:collections_items, primary_key: false) do
-      add :id, :binary_id, primary_key: true
-      add :key, :string
-      add :value, :string
-
       add :collection_id,
           references(:collections, type: :binary_id, on_delete: :delete_all, null: false)
+
+      add :key, :string
+      add :value, :string
 
       timestamps(type: :naive_datetime_usec)
     end

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -212,15 +212,15 @@ defmodule Lightning.CollectionsTest do
           )
         end)
 
-        orig_first = List.first(items)
-        :ok = Collections.put(collection, orig_first.key, "new value for last")
+      orig_first = List.first(items)
+      :ok = Collections.put(collection, orig_first.key, "new value for last")
 
-        new_last =
-          Repo.get_by!(Item,
-            collection_id: collection.id,
-            key: orig_first.key
-          )
-          |> Repo.preload(collection: :project)
+      new_last =
+        Repo.get_by!(Item,
+          collection_id: collection.id,
+          key: orig_first.key
+        )
+        |> Repo.preload(collection: :project)
 
       for _i <- 1..5,
           do:
@@ -231,15 +231,18 @@ defmodule Lightning.CollectionsTest do
 
       Repo.transaction(fn ->
         assert stream = Collections.stream_match(collection, "rkeyA*")
-        assert stream_items = Stream.take(stream, 12)
-        |> Enum.to_list()
-        |> Repo.preload(collection: :project)
+
+        assert stream_items =
+                 Stream.take(stream, 12)
+                 |> Enum.to_list()
+                 |> Repo.preload(collection: :project)
 
         assert List.last(stream_items) == new_last
+
         assert MapSet.new(Enum.reject(items, &(&1.key == orig_first.key))) ==
-          MapSet.new(
-            Enum.reject(stream_items, &(&1.key == orig_first.key))
-          )
+                 MapSet.new(
+                   Enum.reject(stream_items, &(&1.key == orig_first.key))
+                 )
       end)
     end
 
@@ -356,17 +359,23 @@ defmodule Lightning.CollectionsTest do
       collection = insert(:collection)
 
       assert :ok = Collections.put(collection, "some-key", "some-value")
-      assert %{key: "some-key", value: "some-value"} = Repo.get_by!(Item, key: "some-key")
+
+      assert %{key: "some-key", value: "some-value"} =
+               Repo.get_by!(Item, key: "some-key")
     end
 
     test "updates the value of an item when key exists" do
       collection = insert(:collection)
 
       assert :ok = Collections.put(collection, "some-key", "some-value1")
-      assert %{key: "some-key", value: "some-value1"} = Repo.get_by!(Item, key: "some-key")
+
+      assert %{key: "some-key", value: "some-value1"} =
+               Repo.get_by!(Item, key: "some-key")
 
       assert :ok = Collections.put(collection, "some-key", "some-value2")
-      assert %{key: "some-key", value: "some-value2"} = Repo.get_by!(Item, key: "some-key")
+
+      assert %{key: "some-key", value: "some-value2"} =
+               Repo.get_by!(Item, key: "some-key")
     end
 
     test "returns an :error if the collection does not exist" do
@@ -389,9 +398,9 @@ defmodule Lightning.CollectionsTest do
       collection = insert(:collection)
 
       %{key: key} =
-        insert(:collection_item, collection: collection) |> Repo.reload()
+        insert(:collection_item, collection: collection)
 
-      assert {:ok, %{key: ^key}} = Collections.delete(collection, key)
+      assert :ok = Collections.delete(collection, key)
 
       refute Collections.get(collection, key)
     end


### PR DESCRIPTION
### Description

This PR changes the order of streamed items. Now it's by ascending upsert (updated_at) timestamp. 

### Validation steps

Via two strict test cases. 

### Additional notes for the reviewer

The put operation is now thread-safe, protected against conflicting parallel operations made by two workflows.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
