### PR TITLE
Collections CRUD UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 ### Added
 
+- Adds a UI for managing collections
+  [#2567](https://github.com/OpenFn/lightning/issues/2567)
+- Introduces collections, a programatic workflow data sharing resource.
+  [#2551](https://github.com/OpenFn/lightning/issues/2551)
+
 ### Changed
 
 ### Fixed
@@ -45,8 +50,6 @@ and this project adheres to
   Arcade videos [#2563](https://github.com/OpenFn/lightning/issues/2563)
 - Store user preferences in database
   [#2564](https://github.com/OpenFn/lightning/issues/2564)
-- Introduces collections, a programatic workflow data sharing resource.
-  [#2551](https://github.com/OpenFn/lightning/issues/2551)
 
 ### Changed
 

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -12,15 +12,6 @@ defmodule Lightning.Collections do
                      :query_all_limit
                    ]
 
-  def url_safe_name(nil), do: ""
-
-  def url_safe_name(name) when is_binary(name) do
-    name
-    |> String.downcase()
-    |> String.replace(~r/[^a-z-_\.\d]+/, "-")
-    |> String.replace(~r/^\-+|\-+$/, "")
-  end
-
   @doc """
   Returns the list of collections with optional ordering and preloading.
 

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -22,16 +22,23 @@ defmodule Lightning.Collections do
   end
 
   @doc """
-  Returns the list of collections.
+  Returns the list of collections with optional ordering and preloading.
 
   ## Examples
 
       iex> list_collections()
       [%Collection{}, ...]
 
+      iex> list_collections(order_by: [asc: :inserted_at], preload: [:project, :user])
+      [%Collection{}, ...]
+
   """
-  def list_collections do
-    Repo.all(from(c in Collection, order_by: c.name, preload: :project))
+  @spec list_collections(keyword()) :: [Collection.t()]
+  def list_collections(opts \\ []) do
+    order_by = Keyword.get(opts, :order_by, asc: :name)
+    preload = Keyword.get(opts, :preload, [:project])
+
+    Repo.all(from(c in Collection, order_by: ^order_by, preload: ^preload))
   end
 
   @spec get_collection(String.t()) ::

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -15,6 +15,12 @@ defmodule Lightning.Collections do
   @doc """
   Returns the list of collections with optional ordering and preloading.
 
+  ## Parameters
+
+    - `opts`: A keyword list of options.
+      - `:order_by` (optional): The field by which to order the results. Default is `[asc: :name]`.
+      - `:preload` (optional): A list of associations to preload. Default is `[:project]`.
+
   ## Examples
 
       iex> list_collections()
@@ -23,6 +29,9 @@ defmodule Lightning.Collections do
       iex> list_collections(order_by: [asc: :inserted_at], preload: [:project, :user])
       [%Collection{}, ...]
 
+  ## Returns
+
+    - A list of `%Collection{}` structs, preloaded and ordered as specified.
   """
   @spec list_collections(keyword()) :: [Collection.t()]
   def list_collections(opts \\ []) do
@@ -41,12 +50,57 @@ defmodule Lightning.Collections do
     end
   end
 
+  @doc """
+  Creates a new collection with the given attributes.
+
+  ## Parameters
+
+    - `attrs`: A map of attributes to create the collection.
+
+  ## Examples
+
+      iex> create_collection(%{name: "New Collection", description: "Description here"})
+      {:ok, %Collection{}}
+
+      iex> create_collection(%{name: nil})
+      {:error, %Ecto.Changeset{}}
+
+  ## Returns
+
+    - `{:ok, %Collection{}}` on success.
+    - `{:error, %Ecto.Changeset{}}` on failure due to validation errors.
+  """
+  @spec create_collection(map()) ::
+          {:ok, Collection.t()} | {:error, Ecto.Changeset.t()}
   def create_collection(attrs) do
     %Collection{}
     |> Collection.changeset(attrs)
     |> Repo.insert()
   end
 
+  @doc """
+  Updates an existing collection with the given attributes.
+
+  ## Parameters
+
+    - `collection`: The existing `%Collection{}` struct to update.
+    - `attrs`: A map of attributes to update the collection.
+
+  ## Examples
+
+      iex> update_collection(collection, %{name: "Updated Name"})
+      {:ok, %Collection{}}
+
+      iex> update_collection(collection, %{name: nil})
+      {:error, %Ecto.Changeset{}}
+
+  ## Returns
+
+    - `{:ok, %Collection{}}` on success.
+    - `{:error, %Ecto.Changeset{}}` on failure due to validation errors.
+  """
+  @spec update_collection(Collection.t(), map()) ::
+          {:ok, Collection.t()} | {:error, Ecto.Changeset.t()}
   def update_collection(collection, attrs) do
     collection
     |> Collection.changeset(attrs)

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -12,6 +12,28 @@ defmodule Lightning.Collections do
                      :query_all_limit
                    ]
 
+  def url_safe_name(nil), do: ""
+
+  def url_safe_name(name) when is_binary(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z-_\.\d]+/, "-")
+    |> String.replace(~r/^\-+|\-+$/, "")
+  end
+
+  @doc """
+  Returns the list of collections.
+
+  ## Examples
+
+      iex> list_collections()
+      [%Collection{}, ...]
+
+  """
+  def list_collections do
+    Repo.all(from(c in Collection, order_by: c.name, preload: :project))
+  end
+
   @spec get_collection(String.t()) ::
           {:ok, Collection.t()} | {:error, :not_found}
   def get_collection(name) do
@@ -19,6 +41,18 @@ defmodule Lightning.Collections do
       nil -> {:error, :not_found}
       collection -> {:ok, collection}
     end
+  end
+
+  def create_collection(attrs) do
+    %Collection{}
+    |> Collection.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_collection(collection, attrs) do
+    collection
+    |> Collection.changeset(attrs)
+    |> Repo.update()
   end
 
   @spec create_collection(Ecto.UUID.t(), String.t()) ::

--- a/lib/lightning/collections/collection.ex
+++ b/lib/lightning/collections/collection.ex
@@ -26,6 +26,11 @@ defmodule Lightning.Collections.Collection do
     entry
     |> cast(attrs, [:project_id, :name])
     |> validate_required([:project_id, :name])
-    |> unique_constraint([:name])
+    |> validate_format(:name, ~r/^[a-z0-9]+([\-_.][a-z0-9]+)*$/,
+      message: "Collection name must be URL safe"
+    )
+    |> unique_constraint([:name],
+      message: "A collection with this name already exists"
+    )
   end
 end

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -124,4 +124,33 @@ defmodule Lightning.Helpers do
       changeset
     end
   end
+
+  @doc """
+  Converts a string into a URL-safe format by converting it to lowercase,
+  replacing unwanted characters with hyphens, and trimming leading/trailing hyphens.
+
+  This function allows international characters, which will be automatically
+  percent-encoded in URLs by browsers.
+
+  ## Parameters
+
+    - `name`: The string to convert. If `nil` is passed, it returns an empty string.
+
+  ## Examples
+
+      iex> url_safe_name("My Project!!")
+      "my-project"
+
+      iex> url_safe_name(nil)
+      ""
+  """
+  @spec url_safe_name(String.t() | nil) :: String.t()
+  def url_safe_name(nil), do: ""
+
+  def url_safe_name(name) when is_binary(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^\p{L}0-9_\.\-]+/u, "-")
+    |> String.trim("-")
+  end
 end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -606,15 +606,6 @@ defmodule Lightning.Projects do
     |> Repo.one()
   end
 
-  def url_safe_project_name(nil), do: ""
-
-  def url_safe_project_name(name) when is_binary(name) do
-    name
-    |> String.downcase()
-    |> String.replace(~r/[^a-z-_\.\d]+/, "-")
-    |> String.replace(~r/^\-+|\-+$/, "")
-  end
-
   def member_of?(%Project{id: project_id}, %User{id: user_id}) do
     from(p in Project,
       join: pu in assoc(p, :project_users),

--- a/lib/lightning_web/components/layouts/settings.html.heex
+++ b/lib/lightning_web/components/layouts/settings.html.heex
@@ -19,35 +19,42 @@
         </div>
         <div class="mt-4"></div>
         <Menu.menu_item
-          to={Routes.project_index_path(@socket, :index)}
+          to={~p"/settings/projects"}
           active={@active_menu_item == :projects}
         >
           <Heroicons.building_library class="h-5 w-5 inline-block mr-2" />
           <span class="inline-block align-middle">Projects</span>
         </Menu.menu_item>
         <Menu.menu_item
-          to={Routes.user_index_path(@socket, :index)}
+          to={~p"/settings/users"}
           active={@active_menu_item == :users}
         >
           <Heroicons.user_group class="h-5 w-5 inline-block mr-2" />
           <span class="inline-block align-middle">Users</span>
         </Menu.menu_item>
         <Menu.menu_item
-          to={Routes.auth_providers_index_path(@socket, :edit)}
+          to={~p"/settings/authentication/new"}
           active={@active_menu_item == :authentication}
         >
           <Heroicons.key class="h-5 w-5 inline-block mr-2" />
           <span class="inline-block align-middle">Authentication</span>
         </Menu.menu_item>
         <Menu.menu_item
-          to={Routes.audit_index_path(@socket, :index)}
+          to={~p"/settings/audit"}
           active={@active_menu_item == :audit}
         >
           <Heroicons.archive_box class="h-5 w-5 inline-block mr-2" />
           <span class="inline-block align-middle">Audit</span>
         </Menu.menu_item>
+        <Menu.menu_item
+          to={~p"/settings/collections"}
+          active={@active_menu_item == :collections}
+        >
+          <Heroicons.circle_stack class="h-5 w-5 inline-block mr-2" />
+          <span class="inline-block align-middle">Collections</span>
+        </Menu.menu_item>
         <div class="grow"></div>
-        <Menu.menu_item to={Routes.dashboard_index_path(@socket, :index)}>
+        <Menu.menu_item to={~p"/projects"}>
           <Icon.left class="h-5 w-5 inline-block mr-2" />
           <span class="inline-block align-middle">Back</span>
         </Menu.menu_item>

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -1,9 +1,9 @@
 defmodule LightningWeb.CollectionLive.CollectionCreationModal do
-  alias Lightning.Projects
-  alias Lightning.Collections
   use LightningWeb, :live_component
 
+  alias Lightning.Collections
   alias Lightning.Collections.Collection
+  alias Lightning.Projects
 
   @impl true
   def update(assigns, socket) do
@@ -60,7 +60,6 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
             collection_params
           )
       end
-      |> IO.inspect()
 
     case result do
       {:ok, _collection} ->

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -1,0 +1,174 @@
+defmodule LightningWeb.CollectionLive.CollectionCreationModal do
+  alias Lightning.Projects
+  alias Lightning.Collections
+  use LightningWeb, :live_component
+
+  alias Lightning.Collections.Collection
+
+  @impl true
+  def update(assigns, socket) do
+    changeset = Collection.changeset(assigns.collection, %{})
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:changeset, changeset)
+     |> assign(:name, get_collection_name(changeset))
+     |> assign(:projects_options, list_project_options())
+     |> assign_new(:mode, fn -> :create end)}
+  end
+
+  defp list_project_options do
+    Projects.list_projects() |> Enum.map(&{&1.name, &1.id})
+  end
+
+  defp get_collection_name(changeset) do
+    Ecto.Changeset.fetch_field!(changeset, :name)
+  end
+
+  @impl true
+  def handle_event("close_modal", _, socket) do
+    {:noreply, socket |> push_navigate(to: socket.assigns.return_to)}
+  end
+
+  def handle_event("validate", %{"collection" => collection_params}, socket) do
+    changeset =
+      socket.assigns.collection
+      |> Collection.changeset(
+        collection_params
+        |> coerce_raw_name_to_safe_name
+      )
+      |> Map.put(:action, :validate)
+
+    {:noreply,
+     socket
+     |> assign(:changeset, changeset)
+     |> assign(:name, Ecto.Changeset.fetch_field!(changeset, :name))}
+  end
+
+  def handle_event("save", %{"collection" => collection_params}, socket) do
+    %{mode: mode, return_to: return_to} = socket.assigns
+
+    result =
+      case mode do
+        :create ->
+          Collections.create_collection(collection_params)
+
+        :update ->
+          Collections.update_collection(
+            socket.assigns.collection,
+            collection_params
+          )
+      end
+      |> IO.inspect()
+
+    case result do
+      {:ok, _collection} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Collection #{mode}d successfully")
+         |> push_navigate(to: return_to)}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :changeset, changeset)}
+    end
+  end
+
+  defp coerce_raw_name_to_safe_name(%{"raw_name" => raw_name} = params) do
+    new_name = Collections.url_safe_name(raw_name)
+
+    params |> Map.put("name", new_name)
+  end
+
+  defp coerce_raw_name_to_safe_name(%{} = params) do
+    params
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="text-xs">
+      <.modal id={@id} width="xl:min-w-1/3 min-w-1/2 max-w-full">
+        <:title>
+          <div class="flex justify-between">
+            <span class="font-bold">
+              <%= if @mode == :create,
+                do: "Create Collection",
+                else: "Edit Collection" %>
+            </span>
+            <button
+              id={"close-collection-#{@collection.id || "new"}-creation-modal"}
+              phx-click="close_modal"
+              phx-target={@myself}
+              type="button"
+              class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+              aria-label={gettext("close")}
+            >
+              <span class="sr-only">Close</span>
+              <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+            </button>
+          </div>
+        </:title>
+        <.form
+          :let={f}
+          for={@changeset}
+          id={"collection-form-#{@collection.id || "new"}"}
+          phx-target={@myself}
+          phx-change="validate"
+          phx-submit="save"
+        >
+          <div class="container mx-auto px-6 space-y-6 bg-white">
+            <div class="space-y-4">
+              <.input
+                type="text"
+                field={f[:raw_name]}
+                value={@name}
+                label="Name"
+                required="true"
+              />
+              <.input type="hidden" field={f[:name]} />
+              <small class="mt-2 block text-xs text-gray-600">
+                <%= if to_string(f[:name].value) != "" do %>
+                  Your collection will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
+      <%= @name %></span>.
+                <% end %>
+              </small>
+            </div>
+            <div class="space-y-4">
+              <.input
+                type="select"
+                field={f[:project_id]}
+                label="Project"
+                options={@projects_options}
+                required="true"
+              />
+            </div>
+          </div>
+          <.modal_footer class="mt-6 mx-6">
+            <div class="sm:flex sm:flex-row-reverse">
+              <button
+                id={"save-collection-#{@collection.id || "new"}"}
+                type="submit"
+                disabled={!@changeset.valid?}
+                phx-target={@myself}
+                class="inline-flex w-full justify-center rounded-md disabled:bg-primary-300 bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-500 sm:ml-3 sm:w-auto"
+              >
+                Save
+              </button>
+              <button
+                id={"cancel-collection-creation-#{@collection.id || "new"}"}
+                type="button"
+                phx-click="close_modal"
+                phx-target={@myself}
+                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+              >
+                Cancel
+              </button>
+            </div>
+          </.modal_footer>
+        </.form>
+      </.modal>
+    </div>
+    """
+  end
+end

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -1,9 +1,9 @@
 defmodule LightningWeb.CollectionLive.CollectionCreationModal do
-  alias Lightning.Helpers
   use LightningWeb, :live_component
 
   alias Lightning.Collections
   alias Lightning.Collections.Collection
+  alias Lightning.Helpers
   alias Lightning.Projects
 
   @impl true

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -1,4 +1,5 @@
 defmodule LightningWeb.CollectionLive.CollectionCreationModal do
+  alias Lightning.Helpers
   use LightningWeb, :live_component
 
   alias Lightning.Collections
@@ -82,7 +83,7 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
   end
 
   defp coerce_raw_name_to_safe_name(%{"raw_name" => raw_name} = params) do
-    new_name = Collections.url_safe_name(raw_name)
+    new_name = Helpers.url_safe_name(raw_name)
 
     params |> Map.put("name", new_name)
   end

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -42,7 +42,10 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
 
     {:noreply,
      socket
-     |> assign(:changeset, changeset)
+     |> assign(
+       :changeset,
+       Lightning.Helpers.copy_error(changeset, :name, :raw_name)
+     )
      |> assign(:name, Ecto.Changeset.fetch_field!(changeset, :name))}
   end
 
@@ -69,7 +72,12 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
          |> push_navigate(to: return_to)}
 
       {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+        {:noreply,
+         assign(
+           socket,
+           :changeset,
+           Lightning.Helpers.copy_error(changeset, :name, :raw_name)
+         )}
     end
   end
 

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -91,7 +91,8 @@ defmodule LightningWeb.CollectionLive.Components do
             <div class="group inline-flex items-center">
               Name
               <span
-                phx-click="sort_by_name"
+                phx-click="sort"
+                phx-value-by="name"
                 class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
               >
                 <.icon name={@name_sort_icon} />

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -1,0 +1,151 @@
+defmodule LightningWeb.CollectionLive.Components do
+  use LightningWeb, :component
+
+  import PetalComponents.Table
+
+  defp confirm_collection_deletion_modal(assigns) do
+    ~H"""
+    <.modal id={@id} width="max-w-md">
+      <:title>
+        <div class="flex justify-between">
+          <span class="font-bold">
+            Delete collection
+          </span>
+
+          <button
+            phx-click={hide_modal(@id)}
+            type="button"
+            class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+            aria-label={gettext("close")}
+          >
+            <span class="sr-only">Close</span>
+            <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+          </button>
+        </div>
+      </:title>
+      <div class="px-6">
+        <p class="text-sm text-gray-500">
+          Are you sure you want to delete the collection
+          <span class="font-medium"><%= @collection.name %></span>
+          ?
+          If you wish to proceed with this action, click on the delete button. To cancel click on the cancel button.<br /><br />
+        </p>
+      </div>
+      <div class="flex flex-row-reverse gap-4 mx-6 mt-2">
+        <.button
+          id={"#{@id}_confirm_button"}
+          type="button"
+          phx-click="delete_collection"
+          phx-value-collection={@collection.id}
+          color_class="bg-red-600 hover:bg-red-700 text-white"
+          phx-disable-with="Deleting..."
+        >
+          Delete
+        </.button>
+        <button
+          type="button"
+          phx-click={hide_modal(@id)}
+          class="inline-flex items-center rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </.modal>
+    """
+  end
+
+  defp table_title(assigns) do
+    ~H"""
+    <h3 class="text-3xl font-bold">
+      Collections
+      <span class="text-base font-normal">
+        (<%= @count %>)
+      </span>
+    </h3>
+    """
+  end
+
+  def collections_table(assigns) do
+    next_sort_icon = %{asc: "hero-chevron-down", desc: "hero-chevron-up"}
+
+    assigns =
+      assign(assigns,
+        collections_count: Enum.count(assigns.collections),
+        empty?: Enum.empty?(assigns.collections),
+        name_sort_icon: next_sort_icon[assigns.name_direction]
+      )
+
+    ~H"""
+    <%= if @empty? do %>
+      <%= render_slot(@empty_state) %>
+    <% else %>
+      <div class="mt-5 flex justify-between mb-3">
+        <.table_title count={@collections_count} />
+        <div>
+          <%= render_slot(@create_collection_button) %>
+        </div>
+      </div>
+      <.table id="collections-table">
+        <.tr>
+          <.th>
+            <div class="group inline-flex items-center">
+              Name
+              <span
+                phx-click="sort_by_name"
+                class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
+              >
+                <.icon name={@name_sort_icon} />
+              </span>
+            </div>
+          </.th>
+          <.th>Project</.th>
+          <.th></.th>
+        </.tr>
+
+        <.tr
+          :for={collection <- @collections}
+          id={"collections-table-row-#{collection.id}"}
+          class="hover:bg-gray-100 transition-colors duration-200"
+        >
+          <.td class="break-words max-w-[15rem] text-gray-800">
+            <%= collection.name %>
+          </.td>
+          <.td class="break-words max-w-[25rem]">
+            <%= collection.project.name %>
+          </.td>
+
+          <.td>
+            <div class="text-right">
+              <button
+                id={"edit-collection-#{collection.id}-button"}
+                phx-click={show_modal("update-collection-#{collection.id}-modal")}
+                class="table-action"
+              >
+                Edit
+              </button>
+              <button
+                id={"delete-collection-#{collection.id}-button"}
+                phx-click={show_modal("delete-collection-#{collection.id}-modal")}
+                class="table-action"
+              >
+                Delete
+              </button>
+            </div>
+            <.live_component
+              id={"update-collection-#{collection.id}-modal"}
+              module={LightningWeb.CollectionLive.CollectionCreationModal}
+              collection={collection}
+              mode={:update}
+              return_to={~p"/settings/collections"}
+            />
+            <.confirm_collection_deletion_modal
+              id={"delete-collection-#{collection.id}-modal"}
+              collection={collection}
+            />
+          </.td>
+        </.tr>
+      </.table>
+    <% end %>
+    """
+  end
+end

--- a/lib/lightning_web/live/collection_live/index.ex
+++ b/lib/lightning_web/live/collection_live/index.ex
@@ -1,0 +1,102 @@
+defmodule LightningWeb.CollectionLive.Index do
+  require Logger
+  alias Lightning.Collections.Collection
+  use LightningWeb, :live_view
+
+  import LightningWeb.CollectionLive.Components
+
+  alias Lightning.Collections
+  alias Lightning.Policies.Users
+  alias Lightning.Policies.Permissions
+
+  def mount(_params, _session, socket) do
+    can_access_admin_space =
+      Users
+      |> Permissions.can?(:access_admin_space, socket.assigns.current_user, {})
+
+    if can_access_admin_space do
+      {:ok,
+       socket
+       |> assign(
+         page_title: "Collections",
+         active_menu_item: :collections,
+         collections: Collections.list_collections(),
+         name_sort_direction: :asc
+       ), layout: {LightningWeb.Layouts, :settings}}
+    else
+      {:ok,
+       socket
+       |> put_flash(:nav, :no_access)
+       |> push_redirect(to: "/projects")}
+    end
+  end
+
+  def handle_event("delete_collection", %{"collection" => collection_id}, socket) do
+    case Collections.delete_collection(collection_id) do
+      {:ok, _collection} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Collection deleted successfully!")
+         |> push_navigate(to: ~p"/settings/collections")}
+
+      {:error, reason} ->
+        Logger.error("Error during collection deletion: #{inspect(reason)}")
+
+        {:noreply,
+         socket
+         |> put_flash(:error, "Couldn't delete collection!")
+         |> push_navigate(to: ~p"/settings/collections")}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <LayoutComponents.page_content>
+      <:header>
+        <LayoutComponents.header current_user={@current_user}>
+          <:title><%= @page_title %></:title>
+        </LayoutComponents.header>
+      </:header>
+      <LayoutComponents.centered>
+        <div class="w-full">
+          <.collections_table
+            collections={@collections}
+            user={@current_user}
+            name_direction={@name_sort_direction}
+          >
+            <:empty_state>
+              <button
+                type="button"
+                id="open-create-collection-modal-big-buttton"
+                phx-click={show_modal("create-collection-modal")}
+                class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-4 text-center hover:border-gray-400 focus:outline-none"
+              >
+                <Heroicons.plus_circle class="mx-auto w-12 h-12 text-secondary-400" />
+                <span class="mt-2 block text-xs font-semibold text-secondary-600">
+                  No collection found. Create a new one.
+                </span>
+              </button>
+            </:empty_state>
+            <:create_collection_button>
+              <.button
+                role="button"
+                id="open-create-collection-modal-button"
+                phx-click={show_modal("create-collection-modal")}
+                class="col-span-1 w-full rounded-md"
+              >
+                Create collection
+              </.button>
+            </:create_collection_button>
+          </.collections_table>
+          <.live_component
+            id="create-collection-modal"
+            module={LightningWeb.CollectionLive.CollectionCreationModal}
+            collection={%Collection{}}
+            return_to={~p"/settings/collections"}
+          />
+        </div>
+      </LayoutComponents.centered>
+    </LayoutComponents.page_content>
+    """
+  end
+end

--- a/lib/lightning_web/live/collection_live/index.ex
+++ b/lib/lightning_web/live/collection_live/index.ex
@@ -1,13 +1,14 @@
 defmodule LightningWeb.CollectionLive.Index do
-  require Logger
-  alias Lightning.Collections.Collection
   use LightningWeb, :live_view
 
   import LightningWeb.CollectionLive.Components
 
   alias Lightning.Collections
+  alias Lightning.Collections.Collection
   alias Lightning.Policies.Users
   alias Lightning.Policies.Permissions
+
+  require Logger
 
   def mount(_params, _session, socket) do
     can_access_admin_space =

--- a/lib/lightning_web/live/collection_live/index.ex
+++ b/lib/lightning_web/live/collection_live/index.ex
@@ -5,8 +5,8 @@ defmodule LightningWeb.CollectionLive.Index do
 
   alias Lightning.Collections
   alias Lightning.Collections.Collection
-  alias Lightning.Policies.Users
   alias Lightning.Policies.Permissions
+  alias Lightning.Policies.Users
 
   require Logger
 

--- a/lib/lightning_web/live/dashboard_live/project_creation_modal.ex
+++ b/lib/lightning_web/live/dashboard_live/project_creation_modal.ex
@@ -1,7 +1,7 @@
 defmodule LightningWeb.DashboardLive.ProjectCreationModal do
-  alias Lightning.Helpers
   use LightningWeb, :live_component
 
+  alias Lightning.Helpers
   alias Lightning.Projects
   alias Lightning.Projects.Project
 

--- a/lib/lightning_web/live/dashboard_live/project_creation_modal.ex
+++ b/lib/lightning_web/live/dashboard_live/project_creation_modal.ex
@@ -1,4 +1,5 @@
 defmodule LightningWeb.DashboardLive.ProjectCreationModal do
+  alias Lightning.Helpers
   use LightningWeb, :live_component
 
   alias Lightning.Projects
@@ -61,7 +62,7 @@ defmodule LightningWeb.DashboardLive.ProjectCreationModal do
   end
 
   defp coerce_raw_name_to_safe_name(%{"raw_name" => raw_name} = params) do
-    new_name = Projects.url_safe_project_name(raw_name)
+    new_name = Helpers.url_safe_name(raw_name)
 
     params |> Map.put("name", new_name)
   end

--- a/lib/lightning_web/live/project_live/form_component.ex
+++ b/lib/lightning_web/live/project_live/form_component.ex
@@ -15,6 +15,7 @@ defmodule LightningWeb.ProjectLive.FormComponent do
   import Ecto.Changeset, only: [fetch_field!: 2]
   import LightningWeb.Components.Form
 
+  alias Lightning.Helpers
   alias Lightning.Projects
   alias Lightning.Projects.Project
 
@@ -49,7 +50,7 @@ defmodule LightningWeb.ProjectLive.FormComponent do
      |> assign(:changeset, changeset)
      |> assign(
        :name,
-       Projects.url_safe_project_name(fetch_field!(changeset, :name))
+       Helpers.url_safe_name(fetch_field!(changeset, :name))
      )}
   end
 
@@ -125,7 +126,7 @@ defmodule LightningWeb.ProjectLive.FormComponent do
   end
 
   defp coerce_raw_name_to_safe_name(%{"raw_name" => raw_name} = params) do
-    new_name = Projects.url_safe_project_name(raw_name)
+    new_name = Helpers.url_safe_name(raw_name)
 
     params |> Map.put("name", new_name)
   end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -632,31 +632,33 @@
                     project_user={project_user}
                   />
                 </.td>
-                <.td class="text-right">
-                  <.button
-                    id={"remove_project_user_#{project_user.id}_button"}
-                    type="button"
-                    phx-click={show_modal("remove_#{project_user.id}_modal")}
-                    color_class="bg-white text-gray-900 hover:bg-gray-50 disabled:bg-gray-100"
-                    class="gap-x-2 rounded-md  px-3.5 py-2.5 text-sm shadow-sm ring-1 ring-inset ring-gray-300 disabled:cursor-not-allowed"
-                    tooltip={
-                      remove_user_tooltip(
-                        project_user,
-                        @current_user,
-                        @can_remove_project_user
-                      )
-                    }
-                    disabled={
-                      !user_removable?(
-                        project_user,
-                        @current_user,
-                        @can_remove_project_user
-                      )
-                    }
-                  >
-                    <.icon name="hero-minus-circle" class="w-5 h-5" />
-                    Remove Collaborator
-                  </.button>
+                <.td>
+                  <div class="text-right">
+                    <.button
+                      id={"remove_project_user_#{project_user.id}_button"}
+                      type="button"
+                      phx-click={show_modal("remove_#{project_user.id}_modal")}
+                      color_class="bg-white text-gray-900 hover:bg-gray-50 disabled:bg-gray-100"
+                      class="gap-x-2 rounded-md  px-3.5 py-2.5 text-sm shadow-sm ring-1 ring-inset ring-gray-300 disabled:cursor-not-allowed"
+                      tooltip={
+                        remove_user_tooltip(
+                          project_user,
+                          @current_user,
+                          @can_remove_project_user
+                        )
+                      }
+                      disabled={
+                        !user_removable?(
+                          project_user,
+                          @current_user,
+                          @can_remove_project_user
+                        )
+                      }
+                    >
+                      <.icon name="hero-minus-circle" class="w-5 h-5" />
+                      Remove Collaborator
+                    </.button>
+                  </div>
                   <.confirm_user_removal_modal
                     :if={
                       user_removable?(

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -154,6 +154,8 @@ defmodule LightningWeb.Router do
 
       live "/settings/authentication", AuthProvidersLive.Index, :edit
       live "/settings/authentication/new", AuthProvidersLive.Index, :new
+
+      live "/settings/collections", CollectionLive.Index, :index
     end
 
     live_session :default, on_mount: LightningWeb.InitAssigns do

--- a/test/lightning/collection_test.exs
+++ b/test/lightning/collection_test.exs
@@ -1,0 +1,85 @@
+defmodule Lightning.CollectionTest do
+  use Lightning.DataCase, async: true
+
+  import Lightning.Factories
+
+  alias Lightning.Collections.Collection
+
+  setup do
+    project = insert(:project, name: "Test Project")
+    {:ok, project: project}
+  end
+
+  @valid_name "valid-name"
+
+  describe "changeset/2" do
+    test "valid attributes create a valid changeset", %{project: project} do
+      valid_attrs = %{
+        "project_id" => project.id,
+        "name" => @valid_name
+      }
+
+      changeset = Collection.changeset(%Collection{}, valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "missing required fields result in errors" do
+      invalid_attrs = %{"project_id" => nil, "name" => nil}
+
+      changeset = Collection.changeset(%Collection{}, invalid_attrs)
+      refute changeset.valid?
+
+      assert %{
+               project_id: ["can't be blank"],
+               name: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "name must be URL-safe (valid format)", %{project: project} do
+      valid_names = [
+        "valid-name",
+        "collection_123",
+        "my.collection",
+        "valid-collection-name"
+      ]
+
+      for name <- valid_names do
+        attrs = %{"project_id" => project.id, "name" => name}
+        changeset = Collection.changeset(%Collection{}, attrs)
+        assert changeset.valid?, "Expected #{name} to be valid"
+      end
+    end
+
+    test "name with invalid characters fails validation", %{project: project} do
+      invalid_names = [
+        "invalid name",
+        "invalid_name!",
+        "invalid/name",
+        "-invalid",
+        "invalid-",
+        "invalid--name"
+      ]
+
+      for name <- invalid_names do
+        attrs = %{"project_id" => project.id, "name" => name}
+        changeset = Collection.changeset(%Collection{}, attrs)
+        refute changeset.valid?, "Expected #{name} to be invalid"
+
+        assert %{name: ["Collection name must be URL safe"]} =
+                 errors_on(changeset)
+      end
+    end
+
+    test "name uniqueness constraint adds error", %{project: project} do
+      insert(:collection, project: project, name: "existing-name")
+
+      attrs = %{"project_id" => project.id, "name" => "existing-name"}
+      changeset = Collection.changeset(%Collection{}, attrs)
+
+      assert {:error, changeset} = Lightning.Repo.insert(changeset)
+
+      assert %{name: ["A collection with this name already exists"]} =
+               errors_on(changeset)
+    end
+  end
+end

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -40,7 +40,7 @@ defmodule Lightning.CollectionsTest do
               %{
                 errors: [
                   name:
-                    {"has already been taken",
+                    {"A collection with this name already exists",
                      [
                        constraint: :unique,
                        constraint_name: "collections_name_index"
@@ -473,9 +473,9 @@ defmodule Lightning.CollectionsTest do
   describe "create_collection/1" do
     test "creates a new collection with valid attributes" do
       %{id: project_id} = insert(:project)
-      attrs = %{name: "New Collection", project_id: project_id}
+      attrs = %{name: "new-collection", project_id: project_id}
 
-      assert {:ok, %Collection{name: "New Collection"}} =
+      assert {:ok, %Collection{name: "new-collection"}} =
                Collections.create_collection(attrs)
     end
 
@@ -492,9 +492,9 @@ defmodule Lightning.CollectionsTest do
   describe "update_collection/2" do
     test "updates an existing collection with valid attributes" do
       collection = insert(:collection, name: "Old Name")
-      attrs = %{name: "Updated Name"}
+      attrs = %{name: "updated-name"}
 
-      assert {:ok, %Collection{name: "Updated Name"}} =
+      assert {:ok, %Collection{name: "updated-name"}} =
                Collections.update_collection(collection, attrs)
     end
 

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -440,4 +440,72 @@ defmodule Lightning.CollectionsTest do
                Collections.delete(collection, "nonexistent")
     end
   end
+
+  describe "list_collections/1" do
+    test "returns a list of collections with default ordering and preloading" do
+      collection1 = insert(:collection, name: "B Collection")
+      collection2 = insert(:collection, name: "A Collection")
+
+      result = Collections.list_collections()
+
+      assert Enum.map(result, & &1.id) == [collection2.id, collection1.id]
+    end
+
+    test "returns collections ordered by specified field" do
+      collection1 = insert(:collection, inserted_at: ~N[2024-01-01 00:00:00])
+      collection2 = insert(:collection, inserted_at: ~N[2024-02-01 00:00:00])
+
+      result = Collections.list_collections(order_by: [asc: :inserted_at])
+
+      assert Enum.map(result, & &1.id) == [collection1.id, collection2.id]
+    end
+
+    test "preloads specified associations" do
+      project = insert(:project)
+      insert(:collection, project: project)
+
+      result = Collections.list_collections(preload: [:project])
+
+      assert Enum.map(result, & &1.project.id) == [project.id]
+    end
+  end
+
+  describe "create_collection/1" do
+    test "creates a new collection with valid attributes" do
+      %{id: project_id} = insert(:project)
+      attrs = %{name: "New Collection", project_id: project_id}
+
+      assert {:ok, %Collection{name: "New Collection"}} =
+               Collections.create_collection(attrs)
+    end
+
+    test "returns an error if invalid attributes are provided" do
+      attrs = %{name: nil}
+
+      assert {:error, changeset} = Collections.create_collection(attrs)
+
+      assert %{name: ["can't be blank"], project_id: ["can't be blank"]} ==
+               errors_on(changeset)
+    end
+  end
+
+  describe "update_collection/2" do
+    test "updates an existing collection with valid attributes" do
+      collection = insert(:collection, name: "Old Name")
+      attrs = %{name: "Updated Name"}
+
+      assert {:ok, %Collection{name: "Updated Name"}} =
+               Collections.update_collection(collection, attrs)
+    end
+
+    test "returns an error if invalid attributes are provided" do
+      collection = insert(:collection)
+      attrs = %{name: nil}
+
+      assert {:error, changeset} =
+               Collections.update_collection(collection, attrs)
+
+      assert %{name: ["can't be blank"]} == errors_on(changeset)
+    end
+  end
 end

--- a/test/lightning/helpers_test.exs
+++ b/test/lightning/helpers_test.exs
@@ -3,6 +3,9 @@ defmodule Lightning.HelpersTest do
 
   import Lightning.Helpers, only: [coerce_json_field: 2]
 
+  alias Ecto.Changeset
+  alias Lightning.Helpers
+
   test "coerce_json_field/2 will transform a json string inside a map by it's key" do
     input = %{
       "body" =>
@@ -53,5 +56,67 @@ defmodule Lightning.HelpersTest do
              name: "Sadio Mane",
              goals: 123
            }
+  end
+
+  describe "copy_error/4" do
+    test "copies an error from one key to another" do
+      changeset = %Changeset{errors: [name: {"has already been taken", []}]}
+      updated_changeset = Helpers.copy_error(changeset, :name, :raw_name)
+
+      assert updated_changeset.errors[:name] == {"has already been taken", []}
+
+      assert updated_changeset.errors[:raw_name] ==
+               {"has already been taken", []}
+    end
+
+    test "returns the changeset unchanged if original_key does not exist" do
+      changeset = %Changeset{errors: [email: {"is invalid", []}]}
+      updated_changeset = Helpers.copy_error(changeset, :name, :raw_name)
+
+      assert updated_changeset == changeset
+      refute Keyword.has_key?(updated_changeset.errors, :raw_name)
+    end
+
+    test "overwrites the new_key error if it exists and overwrite is true" do
+      changeset = %Changeset{
+        errors: [
+          name: {"has already been taken", []},
+          raw_name: {"is invalid", []}
+        ]
+      }
+
+      updated_changeset = Helpers.copy_error(changeset, :name, :raw_name)
+
+      assert updated_changeset.errors[:raw_name] ==
+               {"has already been taken", []}
+    end
+
+    test "does not overwrite the new_key error if overwrite is false" do
+      changeset = %Changeset{
+        errors: [
+          name: {"has already been taken", []},
+          raw_name: {"is invalid", []}
+        ]
+      }
+
+      updated_changeset =
+        Helpers.copy_error(changeset, :name, :raw_name, overwrite: false)
+
+      assert updated_changeset.errors[:raw_name] == {"is invalid", []}
+    end
+
+    test "returns the changeset unchanged if new_key already exists and overwrite is false" do
+      changeset = %Changeset{
+        errors: [
+          name: {"has already been taken", []},
+          raw_name: {"is invalid", []}
+        ]
+      }
+
+      updated_changeset =
+        Helpers.copy_error(changeset, :name, :raw_name, overwrite: false)
+
+      assert updated_changeset.errors[:raw_name] == {"is invalid", []}
+    end
   end
 end

--- a/test/lightning/helpers_test.exs
+++ b/test/lightning/helpers_test.exs
@@ -119,4 +119,48 @@ defmodule Lightning.HelpersTest do
       assert updated_changeset.errors[:raw_name] == {"is invalid", []}
     end
   end
+
+  describe "url_safe_name/1" do
+    test "returns an empty string when given nil" do
+      assert Helpers.url_safe_name(nil) == ""
+    end
+
+    test "converts a simple string to lowercase and replaces spaces" do
+      assert Helpers.url_safe_name("My Project") == "my-project"
+    end
+
+    test "removes special characters and replaces them with hyphens" do
+      assert Helpers.url_safe_name("My@#Project!!") == "my-project"
+    end
+
+    test "trims leading and trailing hyphens" do
+      assert Helpers.url_safe_name("--My Project--") == "my-project"
+    end
+
+    test "preserves international characters" do
+      assert Helpers.url_safe_name("Éléphant") == "éléphant"
+    end
+
+    test "handles a string with multiple special characters" do
+      assert Helpers.url_safe_name("Hello, World! 123") == "hello-world-123"
+    end
+
+    test "handles a string with underscores and periods" do
+      assert Helpers.url_safe_name("file_name.version_1.0") ==
+               "file_name.version_1.0"
+    end
+
+    test "replaces multiple spaces or special characters with a single hyphen" do
+      assert Helpers.url_safe_name("My   Project") == "my-project"
+      assert Helpers.url_safe_name("My--Project!!") == "my--project"
+    end
+
+    test "handles a string with only special characters and removes them" do
+      assert Helpers.url_safe_name("###!!!") == ""
+    end
+
+    test "keeps numbers intact in the string" do
+      assert Helpers.url_safe_name("Project 2023") == "project-2023"
+    end
+  end
 end

--- a/test/lightning_web/live/collection_live_test.exs
+++ b/test/lightning_web/live/collection_live_test.exs
@@ -1,0 +1,122 @@
+defmodule LightningWeb.CollectionLiveTest do
+  use LightningWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Lightning.Factories
+
+  describe "Index as a regular user" do
+    setup :register_and_log_in_user
+
+    test "Regular user cannot access the collections page", %{conn: conn} do
+      {:ok, _view, html} =
+        live(conn, ~p"/settings/collections")
+        |> follow_redirect(conn, ~p"/projects")
+
+      assert html =~ "No Access"
+    end
+  end
+
+  describe "Index as a superuser" do
+    setup :register_and_log_in_superuser
+
+    test "Superuser can access the collections page", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/settings/collections")
+
+      assert html =~ "Collections"
+      assert html =~ "No collection found. Create a new one."
+    end
+
+    test "Collections are listed for superuser", %{conn: conn} do
+      collection_1 =
+        insert(:collection,
+          name: "Collection A",
+          project: build(:project, name: "Project A")
+        )
+
+      collection_2 =
+        insert(:collection,
+          name: "Collection B",
+          project: build(:project, name: "Project B")
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/settings/collections")
+
+      assert has_element?(view, "tr#collections-table-row-#{collection_1.id}")
+      assert has_element?(view, "tr#collections-table-row-#{collection_2.id}")
+    end
+
+    test "Collections can be sorted by name for superuser", %{conn: conn} do
+      insert(:collection, name: "B Collection")
+      insert(:collection, name: "A Collection")
+
+      {:ok, view, _html} = live(conn, ~p"/settings/collections")
+
+      sorted_names = get_sorted_collection_names(view)
+      assert sorted_names == ["A Collection", "B Collection"]
+
+      view |> element("span[phx-click='sort']") |> render_click()
+      sorted_names = get_sorted_collection_names(view)
+      assert sorted_names == ["B Collection", "A Collection"]
+    end
+
+    test "Superuser can delete a collection", %{conn: conn} do
+      collection = insert(:collection, name: "Delete Me")
+
+      {:ok, view, _html} = live(conn, ~p"/settings/collections")
+
+      assert has_element?(view, "tr#collections-table-row-#{collection.id}")
+
+      {:ok, view, html} =
+        view
+        |> element("#delete-collection-#{collection.id}-modal_confirm_button")
+        |> render_click()
+        |> follow_redirect(conn, ~p"/settings/collections")
+
+      assert html =~ "Collection deleted successfully"
+
+      refute has_element?(view, "tr#collections-table-row-#{collection.id}")
+    end
+
+    test "Superuser can create a collection via the modal", %{
+      conn: conn,
+      user: user
+    } do
+      project = insert(:project, project_users: [%{user: user}])
+      {:ok, view, _html} = live(conn, ~p"/settings/collections")
+
+      assert has_element?(view, "#collection-form-new")
+
+      view
+      |> form("#collection-form-new", collection: %{raw_name: "New Collection"})
+      |> render_change()
+
+      assert has_element?(view, "input[type='text'][value='new-collection']")
+
+      {:ok, _view, html} =
+        view
+        |> form("#collection-form-new",
+          collection: %{raw_name: "New Collection", project_id: project.id}
+        )
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/settings/collections")
+
+      assert html =~ "Collection created successfully"
+      assert html =~ "new-collection"
+      assert html =~ project.name
+    end
+  end
+
+  defp get_sorted_collection_names(view) do
+    html = render(view)
+
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("#collections-table tr")
+    |> Enum.map(fn tr ->
+      Floki.find(tr, "td:nth-child(1)")
+      |> Floki.text()
+      |> String.trim()
+    end)
+    |> Enum.filter(fn name -> String.length(name) > 0 end)
+  end
+end

--- a/test/lightning_web/live/collection_live_test.exs
+++ b/test/lightning_web/live/collection_live_test.exs
@@ -104,6 +104,24 @@ defmodule LightningWeb.CollectionLiveTest do
       assert html =~ "new-collection"
       assert html =~ project.name
     end
+
+    test "Canceling collection creation modal closes the modal", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/settings/collections")
+
+      assert has_element?(view, "#collection-form-new")
+
+      view
+      |> form("#collection-form-new", collection: %{raw_name: "New Collection"})
+      |> render_change()
+
+      {:ok, _view, html} =
+        view
+        |> element("#cancel-collection-creation-new")
+        |> render_click()
+        |> follow_redirect(conn, ~p"/settings/collections")
+
+      refute html =~ "new-collection"
+    end
   end
 
   defp get_sorted_collection_names(view) do


### PR DESCRIPTION
### Description

This PR introduces the **Collections CRUD UI** to the system management module, providing a streamlined interface to manage collections. The new UI includes functionalities to **create**, **view**, **edit**, and **delete** collections, improving user control and management of data within the app.

#### Features Added  
1. **List View of Collections:**  
   - Displays all collections available in the system.
   - Includes sorting capabilities (e.g., by name).

2. **Create New Collections:**  
   - Provides a modal for adding new collections with project assignments.

3. **Edit Existing Collections:**  
   - Allows editing collection details (name, project) via the same modal.

4. **Delete Collections:**  
   - Enables users to delete collections with a confirmation prompt to prevent accidental deletion.

Closes #2567 

https://www.loom.com/share/95563390b47644d0846292df1905ec9d?sid=94a56967-a7e3-45ed-a9f7-b474755d2611

### Validation steps

1. **Navigate to the Collections Page:**  
   - Ensure all collections are listed properly.
   
2. **Create a New Collection:**  
   - Check if the new collection appears immediately after creation.
   
3. **Edit a Collection:**  
   - Verify the updated details reflect without reloading the page.

4. **Delete a Collection:**  
   - Confirm that the collection is removed only after accepting the confirmation prompt.

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR