### PR TITLE
Do Not Count Deleted Workflows in the Projects Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
 
 - Fix retry many workorders when built for job
   [#2597](https://github.com/OpenFn/lightning/issues/2597)
+- Do not count deleted workflows in the projects table
+  [#2540](https://github.com/OpenFn/lightning/issues/2540)
 
 ## [v2.9.10] - 2024-10-16
 

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -37,7 +37,7 @@ defmodule Lightning.Projects.Project do
     has_many :project_oauth_clients, ProjectOauthClient
     has_many :oauth_clients, through: [:project_oauth_clients, :oauth_client]
 
-    has_many :workflows, Workflow
+    has_many :workflows, Workflow, where: [deleted_at: nil]
     has_many :jobs, through: [:workflows, :jobs]
 
     has_many :project_credentials, ProjectCredential

--- a/lib/lightning/version_control/project_repo_connection.ex
+++ b/lib/lightning/version_control/project_repo_connection.ex
@@ -42,6 +42,16 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     @impl true
     def token_config do
       default_claims(skip: [:exp, :aud], iss: "Lightning")
+      |> add_claim(
+        "iat",
+        fn -> Lightning.current_time() |> DateTime.to_unix() end,
+        &(Lightning.current_time() |> DateTime.to_unix() >= &1)
+      )
+      |> add_claim(
+        "nbf",
+        fn -> Lightning.current_time() |> DateTime.to_unix() end,
+        &(Lightning.current_time() |> DateTime.to_unix() >= &1)
+      )
     end
   end
 

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -40,8 +40,6 @@ defmodule LightningWeb.DashboardLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    projects = projects_for_user(socket.assigns.current_user)
-
     welcome_collapsed =
       Accounts.get_preference(
         socket.assigns.current_user,
@@ -49,13 +47,18 @@ defmodule LightningWeb.DashboardLive.Index do
       )
 
     {:ok,
-     assign_new(socket, :projects, fn -> projects end)
-     |> assign(:arcade_resources, @arcade_resources)
-     |> assign(:selected_arcade_resource, nil)
-     |> assign(:welcome_collapsed, welcome_collapsed)
-     |> assign(:active_menu_item, :projects)
-     |> assign(:name_sort_direction, :asc)
-     |> assign(:activity_sort_direction, :asc)}
+     socket
+     |> assign_new(:projects, fn ->
+       projects_for_user(socket.assigns.current_user)
+     end)
+     |> assign(
+       arcade_resources: @arcade_resources,
+       selected_arcade_resource: nil,
+       welcome_collapsed: welcome_collapsed,
+       active_menu_item: :projects,
+       name_sort_direction: :asc,
+       activity_sort_direction: :asc
+     )}
   end
 
   @impl true

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -35,7 +35,7 @@ defmodule LightningWeb.ChannelCase do
   setup tags do
     Mox.stub_with(Lightning.MockConfig, Lightning.Config.API)
 
-    Mox.stub_with(LightningMock, Lightning.Stub)
+    Mox.stub_with(LightningMock, Lightning.API)
 
     # Default to Hackney adapter so that Bypass dependent tests continue working
     Mox.stub_with(Lightning.Tesla.Mock, Tesla.Adapter.Hackney)


### PR DESCRIPTION
### Description

This PR make sure we do not include deleted workflows in the workflows count per project in projects table.

Closes #2540 

### Validation steps

1. Create a project
2. Add two workflows in it
3. Go to the projects table
4. Note that the workflows count for that project is two
5. Delete one of the workflows
6. Go back to the projects table again
7. Note that the workflows count for that project is now 1

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
