### PR TITLE
Fix Bug On Last Activity Column In The Projects List

### DIFF
--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -49,7 +49,7 @@ defmodule Lightning.Projects do
   end
 
   def get_projects_overview(%User{id: user_id}, opts \\ []) do
-    order_by = Keyword.get(opts, :order_by, {:name, :asc})
+    order_by = Keyword.get(opts, :order_by, {:asc, :name})
 
     from(p in Project,
       join: pu in assoc(p, :project_users),
@@ -61,8 +61,8 @@ defmodule Lightning.Projects do
         id: p.id,
         name: p.name,
         role: pu.role,
-        workflows_count: count(w.id),
-        collaborators_count: count(pu.id),
+        workflows_count: count(w.id, :distinct),
+        collaborators_count: count(pu.id, :distinct),
         last_activity: max(wo.last_activity)
       },
       order_by: ^dynamic_order_by(order_by)

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -34,7 +34,10 @@ defmodule Lightning.Projects do
 
   require Logger
 
-  defmodule ProjectTableRow do
+  defmodule ProjectOverviewRow do
+    @moduledoc """
+    Represents a summarized view of a project for a user, used in the project overview table.
+    """
     defstruct [
       :id,
       :name,
@@ -45,7 +48,7 @@ defmodule Lightning.Projects do
     ]
   end
 
-  def project_table_data_for_user(%User{id: user_id}, opts \\ []) do
+  def get_projects_overview(%User{id: user_id}, opts \\ []) do
     order_by = Keyword.get(opts, :order_by, {:name, :asc})
 
     from(p in Project,
@@ -54,7 +57,7 @@ defmodule Lightning.Projects do
       left_join: w in assoc(p, :workflows),
       left_join: wo in assoc(w, :work_orders),
       group_by: [p.id, pu.role],
-      select: %ProjectTableRow{
+      select: %ProjectOverviewRow{
         id: p.id,
         name: p.name,
         role: pu.role,

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -25,7 +25,7 @@ defmodule LightningWeb.DashboardLive.Components do
         projects_count: assigns.projects |> Enum.count(),
         empty?: assigns.projects |> Enum.empty?(),
         name_sort_icon: next_sort_icon[assigns.name_direction],
-        activity_sort_icon: next_sort_icon[assigns.activity_direction]
+        last_activity_sort_icon: next_sort_icon[assigns.last_activity_direction]
       )
 
     ~H"""
@@ -60,10 +60,10 @@ defmodule LightningWeb.DashboardLive.Components do
               Last Activity
               <span
                 phx-click="sort"
-                phx-value-by="activity"
+                phx-value-by="last_activity"
                 class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
               >
-                <.icon name={@activity_sort_icon} />
+                <.icon name={@last_activity_sort_icon} />
               </span>
             </div>
           </.th>

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -3,19 +3,8 @@ defmodule LightningWeb.DashboardLive.Components do
 
   import PetalComponents.Table
 
-  alias Lightning.Accounts.User
-  alias Lightning.Projects.Project
-
-  defp project_role(
-         %User{id: user_id} = _user,
-         %Project{project_users: project_users} = _project
-       ) do
-    project_users
-    |> Enum.find(fn pu -> pu.user_id == user_id end)
-    |> Map.get(:role)
-    |> Atom.to_string()
-    |> String.capitalize()
-  end
+  # alias Lightning.Accounts.User
+  # alias Lightning.Projects.Project
 
   defp table_title(assigns) do
     ~H"""
@@ -95,24 +84,30 @@ defmodule LightningWeb.DashboardLive.Components do
             </.link>
           </.td>
           <.td class="break-words max-w-[25rem]">
-            <%= project_role(@user, project) %>
+            <%= project.role
+            |> Atom.to_string()
+            |> String.capitalize() %>
           </.td>
           <.td class="break-words max-w-[10rem]">
-            <%= length(project.workflows) %>
+            <%= project.workflows_count %>
           </.td>
           <.td class="break-words max-w-[5rem]">
             <.link
               class="link"
               href={~p"/projects/#{project.id}/settings#collaboration"}
             >
-              <%= length(project.project_users) %>
+              <%= project.collaborators_count %>
             </.link>
           </.td>
           <.td>
-            <%= Lightning.Helpers.format_date(
-              project.updated_at,
-              "%d/%b/%Y %H:%M:%S"
-            ) %>
+            <%= if project.last_activity do %>
+              <%= Lightning.Helpers.format_date(
+                project.last_activity,
+                "%d/%m/%Y at %H:%M:%S"
+              ) %>
+            <% else %>
+              No activity
+            <% end %>
           </.td>
           <.td class="text-right">
             <.link

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -103,7 +103,7 @@ defmodule LightningWeb.DashboardLive.Components do
             <%= if project.last_activity do %>
               <%= Lightning.Helpers.format_date(
                 project.last_activity,
-                "%d/%m/%Y at %H:%M:%S"
+                "%d/%m/%Y %H:%M:%S"
               ) %>
             <% else %>
               No activity

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -122,10 +122,9 @@ defmodule LightningWeb.DashboardLive.Index do
   defp map_sort_field_to_column("activity"), do: :updated_at
 
   defp projects_for_user(%User{} = user, opts \\ []) do
-    include = Keyword.get(opts, :include, [:project_users, :workflows])
-    order_by = Keyword.get(opts, :order_by, asc: :name)
+    order_by = Keyword.get(opts, :order_by, {:asc, :name})
 
-    Projects.get_projects_for_user(user, include: include, order_by: order_by)
+    Projects.project_table_data_for_user(user, order_by: order_by)
   end
 
   @impl true

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1,20 +1,22 @@
 defmodule Lightning.ProjectsTest do
-  require Phoenix.VerifiedRoutes
-  alias Swoosh.Email
   use Lightning.DataCase, async: true
 
   alias Lightning.Invocation.Dataclip
+  alias Lightning.Projects.ProjectOverviewRow
   alias Lightning.Projects.ProjectUser
   alias Lightning.Projects
   alias Lightning.Projects.Project
   alias Lightning.Accounts.User
+  alias Swoosh.Email
 
   import Lightning.ProjectsFixtures
   import Lightning.AccountsFixtures
   import Lightning.CredentialsFixtures
   import Lightning.Factories
-  import Swoosh.TestAssertions
   import Mox
+  import Swoosh.TestAssertions
+
+  require Phoenix.VerifiedRoutes
 
   describe "projects" do
     @invalid_attrs %{name: nil}
@@ -1682,6 +1684,115 @@ defmodule Lightning.ProjectsTest do
         |> Enum.sort()
 
       assert actual_emails == expected_emails
+    end
+  end
+
+  describe "get_projects_overview/2" do
+    test "returns an empty list when the user has no projects" do
+      user = insert(:user)
+
+      assert Projects.get_projects_overview(user) == []
+    end
+
+    test "returns projects overview with workflows and collaborators count" do
+      user = insert(:user)
+      other_user = insert(:user)
+
+      project =
+        %{id: project_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      insert(:simple_workflow, project: project)
+      insert(:simple_workflow, project: project)
+
+      insert(:project,
+        name: "Project B",
+        project_users: [%{user_id: other_user.id}]
+      )
+
+      result = Projects.get_projects_overview(user)
+
+      assert length(result) == 1
+
+      [
+        %ProjectOverviewRow{
+          id: ^project_id,
+          name: "Project A",
+          workflows_count: 2,
+          collaborators_count: 1
+        }
+      ] = result
+    end
+
+    test "orders projects by name ascending by default" do
+      user = insert(:user)
+
+      %{id: project_a_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      %{id: project_b_id} =
+        insert(:project, name: "Project B", project_users: [%{user_id: user.id}])
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{id: ^project_a_id, name: "Project A"},
+               %ProjectOverviewRow{id: ^project_b_id, name: "Project B"}
+             ] = result
+    end
+
+    test "orders projects by last_activity descending when specified" do
+      user = insert(:user)
+
+      project_a =
+        %{id: project_a_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      project_b =
+        %{id: project_b_id} =
+        insert(:project, name: "Project B", project_users: [%{user_id: user.id}])
+
+      workflow_a = insert(:simple_workflow, project: project_a)
+      workflow_b = insert(:simple_workflow, project: project_b)
+
+      insert(:workorder,
+        workflow: workflow_b,
+        last_activity: ~N[2023-10-10 00:00:00]
+      )
+
+      insert(:workorder,
+        workflow: workflow_a,
+        last_activity: ~N[2023-10-05 00:00:00]
+      )
+
+      result =
+        Projects.get_projects_overview(user, order_by: {:desc, :last_activity})
+
+      assert [
+               %ProjectOverviewRow{id: ^project_b_id, name: "Project B"},
+               %ProjectOverviewRow{id: ^project_a_id, name: "Project A"}
+             ] = result
+    end
+
+    test "returns project with no workflows or last activity" do
+      user = insert(:user)
+
+      %{id: project_id} =
+        insert(:project,
+          name: "Project No Workflow",
+          project_users: [%{user_id: user.id}]
+        )
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{
+                 id: ^project_id,
+                 name: "Project No Workflow",
+                 workflows_count: 0,
+                 last_activity: nil
+               }
+             ] = result
     end
   end
 


### PR DESCRIPTION
### Description

This PR fixes a bug identified on the last activity column in the projects dashboard. The bug were due to the fact that the last activity column was displaying the value of the updated_at column of the projects table. I updated the query to fetch the last_activity value of the last executed work order in that project.

Closes #2593 

### Validation steps

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
