### PR TITLE
Fix retry many workorders when built for job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix retry many workorders when built for job
+  [#2597](https://github.com/OpenFn/lightning/issues/2597)
+
 ## [v2.9.10] - 2024-10-16
 
 ### Added

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -687,7 +687,7 @@ defmodule Lightning.WorkOrders do
     workorder_ids
     |> workorders_with_dataclips_query()
     |> preload([
-        workflow: [edges: ^first_job_query()],
+        workflow: [edges: ^first_edge_query()],
         runs: ^first_run_query()
     ])
     |> Repo.all()
@@ -700,7 +700,7 @@ defmodule Lightning.WorkOrders do
       limit: 1
   end
 
-  defp first_job_query do
+  defp first_edge_query do
     from e in Edge,
       where: not is_nil(e.source_trigger_id),
       preload: :target_job

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -686,10 +686,10 @@ defmodule Lightning.WorkOrders do
   defp workorders_with_first_runs(workorder_ids) do
     workorder_ids
     |> workorders_with_dataclips_query()
-    |> preload([
-        workflow: [edges: ^first_edge_query()],
-        runs: ^first_run_query()
-    ])
+    |> preload(
+      workflow: [edges: ^first_edge_query()],
+      runs: ^first_run_query()
+    )
     |> Repo.all()
   end
 

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -46,6 +46,7 @@ defmodule Lightning.WorkOrders do
   alias Lightning.Runs
   alias Lightning.RunStep
   alias Lightning.Services.UsageLimiter
+  alias Lightning.Workflows.Edge
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Trigger
@@ -263,7 +264,6 @@ defmodule Lightning.WorkOrders do
     |> validate_required_assoc(:snapshot)
     |> validate_required_assoc(:workflow)
     |> validate_required_assoc(:dataclip)
-    |> assoc_constraint(:trigger)
     |> assoc_constraint(:workflow)
     |> assoc_constraint(:snapshot)
   end
@@ -661,39 +661,35 @@ defmodule Lightning.WorkOrders do
     end)
   end
 
-  defp determine_starting_job(%{runs: []} = workorder) do
-    hd(workorder.trigger.edges).target_job
+  defp determine_starting_job(%{runs: [], workflow: %{edges: [edge]}}) do
+    edge.target_job
   end
 
-  defp determine_starting_job(%{runs: [run]} = workorder) do
-    run.starting_job || hd(workorder.trigger.edges).target_job
+  defp determine_starting_job(%{runs: [run]}) do
+    run.starting_job || hd(run.starting_trigger.edges).target_job
   end
 
   defp fetch_retriable_workorders(workorder_ids) do
-    from(w in WorkOrder,
-      join: d in assoc(w, :dataclip),
-      where: w.id in ^workorder_ids and is_nil(d.wiped_at),
-      order_by: [asc: w.inserted_at]
-    )
+    workorder_ids
+    |> workorders_with_dataclips_query()
     |> Repo.all()
   end
 
   defp workorders_with_dataclips_query(workorder_ids) do
     from(w in WorkOrder,
-      left_join: d in assoc(w, :dataclip),
-      where: w.id in ^workorder_ids,
-      preload: [
-        :workflow,
-        :dataclip,
-        trigger: [edges: :target_job]
-      ]
+      join: d in assoc(w, :dataclip),
+      where: w.id in ^workorder_ids and is_nil(d.wiped_at),
+      order_by: [asc: w.inserted_at]
     )
   end
 
   defp workorders_with_first_runs(workorder_ids) do
     workorder_ids
     |> workorders_with_dataclips_query()
-    |> preload(runs: ^first_run_query())
+    |> preload([
+        workflow: [edges: ^first_job_query()],
+        runs: ^first_run_query()
+    ])
     |> Repo.all()
   end
 
@@ -702,5 +698,11 @@ defmodule Lightning.WorkOrders do
       order_by: [asc: coalesce(r.started_at, r.inserted_at)],
       preload: [:starting_job, starting_trigger: [edges: :target_job]],
       limit: 1
+  end
+
+  defp first_job_query do
+    from e in Edge,
+      where: not is_nil(e.source_trigger_id),
+      preload: :target_job
   end
 end

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -1737,24 +1737,27 @@ defmodule Lightning.WorkOrdersTest do
       refute workorder.state == :rejected
     end
 
-    test "enqueues a workorder that was originally built for manual/job", %{workflow: workflow, jobs: [job | _jobs]} do
+    test "enqueues a workorder that was originally built for manual/job", %{
+      workflow: workflow,
+      jobs: [job | _jobs]
+    } do
       user = insert(:user)
 
       assert {:ok, manual} =
-                Lightning.WorkOrders.Manual.new(
-                  %{
-                    "body" =>
-                      Jason.encode!(%{
-                        "key_left" => "value_left",
-                        "configuration" => %{"password" => "secret"}
-                      })
-                  },
-                  workflow: workflow,
-                  project: workflow.project,
-                  job: job,
-                  created_by: user
-                )
-                |> Ecto.Changeset.apply_action(:validate)
+               Lightning.WorkOrders.Manual.new(
+                 %{
+                   "body" =>
+                     Jason.encode!(%{
+                       "key_left" => "value_left",
+                       "configuration" => %{"password" => "secret"}
+                     })
+                 },
+                 workflow: workflow,
+                 project: workflow.project,
+                 job: job,
+                 created_by: user
+               )
+               |> Ecto.Changeset.apply_action(:validate)
 
       assert {:ok, %{runs: old_runs} = workorder} = WorkOrders.create_for(manual)
 

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -1699,6 +1699,7 @@ defmodule Lightning.WorkOrdersTest do
            workflow: workflow
          } do
       input_dataclip = insert(:dataclip)
+      wiped_dataclip = insert(:dataclip, wiped_at: DateTime.utc_now())
 
       workorder =
         insert(:workorder,
@@ -1709,13 +1710,22 @@ defmodule Lightning.WorkOrdersTest do
           state: :rejected
         )
 
+      discarded_workorder =
+        insert(:workorder,
+          dataclip: wiped_dataclip,
+          snapshot: snapshot,
+          trigger: trigger,
+          workflow: workflow,
+          state: :success
+        )
+
       runs = workorder |> Ecto.assoc(:runs) |> Repo.all()
 
       assert Enum.empty?(runs)
       assert workorder.state == :rejected
 
-      {:ok, 1, 0} =
-        WorkOrders.retry_many([workorder],
+      {:ok, 1, 1} =
+        WorkOrders.retry_many([workorder, discarded_workorder],
           created_by: user,
           project_id: workflow.project_id
         )
@@ -1725,6 +1735,38 @@ defmodule Lightning.WorkOrdersTest do
 
       refute Enum.empty?(runs)
       refute workorder.state == :rejected
+    end
+
+    test "enqueues a workorder that was originally built for manual/job", %{workflow: workflow, jobs: [job | _jobs]} do
+      user = insert(:user)
+
+      assert {:ok, manual} =
+                Lightning.WorkOrders.Manual.new(
+                  %{
+                    "body" =>
+                      Jason.encode!(%{
+                        "key_left" => "value_left",
+                        "configuration" => %{"password" => "secret"}
+                      })
+                  },
+                  workflow: workflow,
+                  project: workflow.project,
+                  job: job,
+                  created_by: user
+                )
+                |> Ecto.Changeset.apply_action(:validate)
+
+      assert {:ok, %{runs: old_runs} = workorder} = WorkOrders.create_for(manual)
+
+      {:ok, 1, 0} =
+        WorkOrders.retry_many([workorder],
+          created_by: user,
+          project_id: workflow.project_id
+        )
+
+      %{runs: runs} = Repo.reload(workorder) |> Repo.preload(:runs)
+
+      assert runs -- old_runs != []
     end
 
     test "retrying a WorkOrder with a run having starting_job without steps",


### PR DESCRIPTION
### Description

This PR fixes the enqueue work on retry many work orders when the work order was originally built for manual job (without a trigger).

Closes #2591 

### Validation steps

1. Create work order for job (a manual one)
2. Go to history page
3. Select the work order along with another one and click on retry
4. Check that it has run 

### Additional notes for the reviewer

This change affects the scenario when the work order doesn't have a run (on rejected work orders for example). When there is a run, it gets the job from the starting trigger.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
