### PR TITLE
2589 retention period events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to
   Arcade videos [#2563](https://github.com/OpenFn/lightning/issues/2563)
 - Store user preferences in database
   [#2564](https://github.com/OpenFn/lightning/issues/2564)
+- Create audit events when the retention periods for a project's dataclips
+  and history are modified.
+  [#2589](https://github.com/OpenFn/lightning/issues/2589)
 
 ### Changed
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -7,6 +7,14 @@ defmodule Lightning.Projects do
     queue: :background,
     max_attempts: 1
 
+  use Lightning.Auditing.Audit,
+    repo: Lightning.Repo,
+    item: "project",
+    events: [
+      "dataclip_retention_period_updated",
+      "history_retention_period_updated"
+    ]
+
   import Ecto.Query, warn: false
 
   alias Ecto.Multi
@@ -16,6 +24,7 @@ defmodule Lightning.Projects do
   alias Lightning.ExportUtils
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Step
+  alias Lightning.Projects.Audit
   alias Lightning.Projects.Events
   alias Lightning.Projects.File
   alias Lightning.Projects.Project
@@ -242,13 +251,18 @@ defmodule Lightning.Projects do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_project(%Project{} = project, attrs) do
+  def update_project(%Project{} = project, attrs, user \\ nil) do
     changeset = Project.changeset(project, attrs)
 
     case Repo.update(changeset) do
       {:ok, updated_project} ->
         if retention_setting_updated?(changeset) do
           send_data_retention_change_email(updated_project)
+        end
+
+        if user do
+          Audit.audit_history_retention_period_updated(project, changeset, user)
+          Audit.audit_dataclip_retention_period_updated(project, changeset, user)
         end
 
         {:ok, updated_project}

--- a/lib/lightning/projects/audit.ex
+++ b/lib/lightning/projects/audit.ex
@@ -1,0 +1,90 @@
+defmodule Lightning.Projects.Audit do
+  @moduledoc """
+  Creates Audit entries for selected changes to project settings.
+  """
+  use Lightning.Auditing.Audit,
+    repo: Lightning.Repo,
+    item: "project",
+    events: [
+      "dataclip_retention_period_updated",
+      "history_retention_period_updated"
+    ]
+
+  alias Lightning.Repo
+
+  require Logger
+
+  def audit_history_retention_period_updated(project, changeset, user) do
+    event_changeset = filter_changes(changeset, :history_retention_period)
+
+    "history_retention_period_updated"
+    |> save_event(project, user, event_changeset)
+    |> tap(fn
+      {:error, changeset} ->
+        {before_value, after_value} =
+          extract_before_after(changeset, :history_retention_period)
+
+        %{
+          project_id: project.id,
+          user_id: user.id,
+          event: "history_retention_period_updated",
+          before_value: before_value,
+          after_value: after_value
+        }
+        |> report_error()
+
+      _ok_response ->
+        nil
+    end)
+  end
+
+  def audit_dataclip_retention_period_updated(project, changeset, user) do
+    event_changeset = filter_changes(changeset, :dataclip_retention_period)
+
+    "dataclip_retention_period_updated"
+    |> save_event(project, user, event_changeset)
+    |> tap(fn
+      {:error, changeset} ->
+        {before_value, after_value} =
+          extract_before_after(changeset, :dataclip_retention_period)
+
+        %{
+          project_id: project.id,
+          user_id: user.id,
+          event: "dataclip_retention_period_updated",
+          before_value: before_value,
+          after_value: after_value
+        }
+        |> report_error()
+
+      _ok_response ->
+        nil
+    end)
+  end
+
+  defp filter_changes(%{changes: changes} = changeset, field) do
+    changeset |> Map.merge(%{changes: changes |> Map.take([field])})
+  end
+
+  defp save_event(event_name, project, user, changeset) do
+    event_name
+    |> event(project.id, user.id, changeset)
+    |> Lightning.Auditing.Audit.save(Repo)
+  end
+
+  defp report_error(error_data) do
+    Logger.error(%{error: "Saving audit event"} |> Map.merge(error_data))
+
+    Sentry.capture_message(
+      "Error saving audit event",
+      extra: error_data
+    )
+  end
+
+  defp extract_before_after(%{data: data, changes: changes}, field) do
+    before_value = data |> Map.get(field)
+    after_value = changes |> Map.get(field)
+
+    {before_value, after_value}
+  end
+end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -590,7 +590,9 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   defp save_project(socket, project_params) do
-    case Projects.update_project(socket.assigns.project, project_params) do
+    socket.assigns.project
+    |> Projects.update_project(project_params, socket.assigns.current_user)
+    |> case do
       {:ok, project} ->
         {:noreply,
          socket

--- a/test/lightning/projects/audit_test.exs
+++ b/test/lightning/projects/audit_test.exs
@@ -1,0 +1,443 @@
+defmodule Lightning.Projects.AuditTest do
+  use Lightning.DataCase
+
+  import ExUnit.CaptureLog
+  import Mock
+
+  alias Lightning.Auditing
+  alias Lightning.Auditing.Audit.Changes
+  alias Lightning.Projects.Audit
+  alias Lightning.Projects.Project
+
+  describe "./audit_history_retention_period_updated/3" do
+    setup do
+      project =
+        insert(
+          :project,
+          dataclip_retention_period: 14,
+          history_retention_period: 90,
+          retention_policy: :retain_all
+        )
+
+      user = insert(:user)
+
+      %{
+        project: project,
+        user: user
+      }
+    end
+
+    test "creates an event if the history retention period is updated", %{
+      project: %{id: project_id} = project,
+      user: %{id: user_id} = user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      project
+      |> Audit.audit_history_retention_period_updated(changeset, user)
+
+      audit_event = Auditing.Audit |> Repo.one!()
+
+      assert %{
+               event: "history_retention_period_updated",
+               item_type: "project",
+               item_id: ^project_id,
+               actor_id: ^user_id,
+               changes: changes
+             } = audit_event
+
+      assert changes == %Changes{
+               before: %{"history_retention_period" => 90},
+               after: %{"history_retention_period" => 30}
+             }
+    end
+
+    test "creates an event if the history retention period is set to nil", %{
+      project: %{id: project_id} = project,
+      user: %{id: user_id} = user
+    } do
+      attrs = %{
+        dataclip_retention_period: nil,
+        history_retention_period: nil,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      project
+      |> Audit.audit_history_retention_period_updated(changeset, user)
+
+      audit_event = Auditing.Audit |> Repo.one!()
+
+      assert %{
+               event: "history_retention_period_updated",
+               item_type: "project",
+               item_id: ^project_id,
+               actor_id: ^user_id,
+               changes: changes
+             } = audit_event
+
+      assert changes == %Changes{
+               before: %{"history_retention_period" => 90},
+               after: %{"history_retention_period" => nil}
+             }
+    end
+
+    test "does not create event if history retention period is not updated", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 90,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      project
+      |> Audit.audit_history_retention_period_updated(changeset, user)
+
+      assert Auditing.Audit |> Repo.one() == nil
+    end
+
+    test "returns the result of saving the event", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 90,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      response =
+        project
+        |> Audit.audit_history_retention_period_updated(changeset, user)
+
+      assert {:ok, :no_changes} = response
+
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      response =
+        project
+        |> Audit.audit_history_retention_period_updated(changeset, user)
+
+      assert {:ok, %Auditing.Audit{}} = response
+    end
+
+    test "logs if there is an error saving the event", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      with_mocks([
+        {
+          Lightning.Auditing.Audit,
+          [:passthrough],
+          [
+            save: fn _event, _repo ->
+              {
+                :error,
+                %{data: project, changes: %{history_retention_period: 30}}
+              }
+            end
+          ]
+        }
+      ]) do
+        fun = fn ->
+          project
+          |> Audit.audit_history_retention_period_updated(changeset, user)
+        end
+
+        assert capture_log(fun) =~ "Saving audit event"
+        assert capture_log(fun) =~ "project_id: \"#{project.id}\""
+        assert capture_log(fun) =~ "user_id: \"#{user.id}\""
+        assert capture_log(fun) =~ "event: \"history_retention_period_updated\""
+        assert capture_log(fun) =~ "before_value: 90"
+        assert capture_log(fun) =~ "after_value: 30"
+      end
+    end
+
+    test "it notifies Sentry if there is an error saving the event", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      message = "Error saving audit event"
+
+      extra = %{
+        project_id: project.id,
+        user_id: user.id,
+        event: "history_retention_period_updated",
+        before_value: 90,
+        after_value: 30
+      }
+
+      with_mocks([
+        {
+          Lightning.Auditing.Audit,
+          [:passthrough],
+          [
+            save: fn _event, _repo ->
+              {
+                :error,
+                %{data: project, changes: %{history_retention_period: 30}}
+              }
+            end
+          ]
+        },
+        {Sentry, [], [capture_message: fn _data, _extra -> :ok end]}
+      ]) do
+        project
+        |> Audit.audit_history_retention_period_updated(changeset, user)
+
+        assert_called(Sentry.capture_message(message, extra: extra))
+      end
+    end
+  end
+
+  describe "./audit_dataclip_retention_period_updated/3" do
+    setup do
+      project =
+        insert(
+          :project,
+          dataclip_retention_period: 14,
+          history_retention_period: 90,
+          retention_policy: :retain_all
+        )
+
+      user = insert(:user)
+
+      %{
+        project: project,
+        user: user
+      }
+    end
+
+    test "creates an event if the dataclip retention period is updated", %{
+      project: %{id: project_id} = project,
+      user: %{id: user_id} = user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      project
+      |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+
+      audit_event = Auditing.Audit |> Repo.one!()
+
+      assert %{
+               event: "dataclip_retention_period_updated",
+               item_type: "project",
+               item_id: ^project_id,
+               actor_id: ^user_id,
+               changes: changes
+             } = audit_event
+
+      assert changes == %Changes{
+               before: %{"dataclip_retention_period" => 14},
+               after: %{"dataclip_retention_period" => 7}
+             }
+    end
+
+    test "creates an event if the dataclip retention period is set to nil", %{
+      project: %{id: project_id} = project,
+      user: %{id: user_id} = user
+    } do
+      attrs = %{
+        dataclip_retention_period: nil,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      project
+      |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+
+      audit_event = Auditing.Audit |> Repo.one!()
+
+      assert %{
+               event: "dataclip_retention_period_updated",
+               item_type: "project",
+               item_id: ^project_id,
+               actor_id: ^user_id,
+               changes: changes
+             } = audit_event
+
+      assert changes == %Changes{
+               before: %{"dataclip_retention_period" => 14},
+               after: %{"dataclip_retention_period" => nil}
+             }
+    end
+
+    test "does not create event if dataclip retention period is not updated", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 14,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      project
+      |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+
+      assert Auditing.Audit |> Repo.one() == nil
+    end
+
+    test "returns the result of saving the event", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 14,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      response =
+        project
+        |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+
+      assert {:ok, :no_changes} = response
+
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      response =
+        project
+        |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+
+      assert {:ok, %Auditing.Audit{}} = response
+    end
+
+    test "logs if there is an error saving the event", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      with_mocks([
+        {
+          Lightning.Auditing.Audit,
+          [:passthrough],
+          [
+            save: fn _event, _repo ->
+              {
+                :error,
+                %{data: project, changes: %{dataclip_retention_period: 7}}
+              }
+            end
+          ]
+        }
+      ]) do
+        fun = fn ->
+          project
+          |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+        end
+
+        assert capture_log(fun) =~ "Saving audit event"
+        assert capture_log(fun) =~ "project_id: \"#{project.id}\""
+        assert capture_log(fun) =~ "user_id: \"#{user.id}\""
+        assert capture_log(fun) =~ "event: \"dataclip_retention_period_updated\""
+        assert capture_log(fun) =~ "before_value: 14"
+        assert capture_log(fun) =~ "after_value: 7"
+      end
+    end
+
+    test "it notifies Sentry if there is an error saving the event", %{
+      project: project,
+      user: user
+    } do
+      attrs = %{
+        dataclip_retention_period: 7,
+        history_retention_period: 30,
+        retention_policy: :retain_with_errors
+      }
+
+      changeset = project |> Project.changeset(attrs)
+
+      message = "Error saving audit event"
+
+      extra = %{
+        project_id: project.id,
+        user_id: user.id,
+        event: "dataclip_retention_period_updated",
+        before_value: 14,
+        after_value: 7
+      }
+
+      with_mocks([
+        {
+          Lightning.Auditing.Audit,
+          [:passthrough],
+          [
+            save: fn _event, _repo ->
+              {
+                :error,
+                %{data: project, changes: %{dataclip_retention_period: 7}}
+              }
+            end
+          ]
+        },
+        {Sentry, [], [capture_message: fn _data, _extra -> :ok end]}
+      ]) do
+        project
+        |> Audit.audit_dataclip_retention_period_updated(changeset, user)
+
+        assert_called(Sentry.capture_message(message, extra: extra))
+      end
+    end
+  end
+end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -3,6 +3,7 @@ defmodule Lightning.ProjectsTest do
   alias Swoosh.Email
   use Lightning.DataCase, async: true
 
+  alias Lightning.Auditing.Audit
   alias Lightning.Invocation.Dataclip
   alias Lightning.Projects.ProjectUser
   alias Lightning.Projects
@@ -1561,8 +1562,12 @@ defmodule Lightning.ProjectsTest do
     end
   end
 
-  describe ".update_project/2" do
-    test "update_project/2 with valid data updates the project" do
+  describe ".update_project/3" do
+    setup do
+      %{user: insert(:user)}
+    end
+
+    test "update_project/3 with valid data updates the project" do
       project = project_fixture()
       update_attrs = %{name: "some-updated-name"}
 
@@ -1677,13 +1682,110 @@ defmodule Lightning.ProjectsTest do
       end
     end
 
-    test "update_project/2 with invalid data returns error changeset" do
+    test "update_project/3 with invalid data returns error changeset" do
       project = project_fixture() |> unload_relation(:project_users)
 
       assert {:error, %Ecto.Changeset{}} =
                Projects.update_project(project, @invalid_attrs)
 
       assert project == Projects.get_project!(project.id)
+    end
+
+    test "creates audit events if retnetion periods are updated", %{
+      user: %{id: user_id} = user
+    } do
+      %{id: project_id} =
+        project =
+        insert(
+          :project,
+          dataclip_retention_period: 7,
+          history_retention_period: 30,
+          retention_policy: :retain_all
+        )
+
+      update_attrs = %{
+        dataclip_retention_period: 14,
+        history_retention_period: 90,
+        retention_policy: :retain_with_errors
+      }
+
+      Projects.update_project(project, update_attrs, user)
+
+      query =
+        from a in Audit, where: a.event == "history_retention_period_updated"
+
+      history_audit_event = Repo.one!(query)
+
+      assert %{
+               item_type: "project",
+               item_id: ^project_id,
+               actor_id: ^user_id,
+               changes: changes
+             } = history_audit_event
+
+      assert changes == %Audit.Changes{
+               before: %{"history_retention_period" => 30},
+               after: %{"history_retention_period" => 90}
+             }
+
+      query =
+        from a in Audit, where: a.event == "dataclip_retention_period_updated"
+
+      dataclip_audit_event = Repo.one!(query)
+
+      assert %{
+               item_type: "project",
+               item_id: ^project_id,
+               actor_id: ^user_id,
+               changes: changes
+             } = dataclip_audit_event
+
+      assert changes == %Audit.Changes{
+               before: %{"dataclip_retention_period" => 7},
+               after: %{"dataclip_retention_period" => 14}
+             }
+    end
+
+    test "does not create events if no user was provided" do
+      project =
+        insert(
+          :project,
+          dataclip_retention_period: 7,
+          history_retention_period: 30,
+          retention_policy: :retain_all
+        )
+
+      update_attrs = %{
+        dataclip_retention_period: 14,
+        history_retention_period: 90,
+        retention_policy: :retain_with_errors
+      }
+
+      Projects.update_project(project, update_attrs)
+
+      assert Audit |> Repo.all() |> Enum.empty?()
+    end
+
+    test "does not create events if the project change fails", %{
+      user: user
+    } do
+      project =
+        insert(
+          :project,
+          dataclip_retention_period: 7,
+          history_retention_period: 30,
+          retention_policy: :retain_all
+        )
+
+      update_attrs = %{
+        dataclip_retention_period: 14,
+        history_retention_period: 90,
+        retention_policy: :no_such_value
+      }
+
+      Projects.update_project(project, update_attrs, user)
+
+      assert Audit |> Repo.all() |> Enum.empty?()
     end
   end
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -176,130 +176,6 @@ defmodule Lightning.ProjectsTest do
                Projects.create_project(%{"name" => "Can't have spaces!"})
     end
 
-    test "update_project/2 with valid data updates the project" do
-      project = project_fixture()
-      update_attrs = %{name: "some-updated-name"}
-
-      assert {:ok, %Project{} = project} =
-               Projects.update_project(project, update_attrs)
-
-      assert project.name == "some-updated-name"
-    end
-
-    test "update_project/2 updates the MFA requirement" do
-      project = insert(:project)
-
-      refute project.requires_mfa
-      update_attrs = %{requires_mfa: true}
-
-      assert {:ok, %Project{} = project} =
-               Projects.update_project(project, update_attrs)
-
-      assert project.requires_mfa
-    end
-
-    test "update_project/2 updates the data retention periods" do
-      project =
-        insert(:project,
-          project_users:
-            Enum.map(
-              [
-                :viewer,
-                :editor,
-                :admin,
-                :owner
-              ],
-              fn role -> build(:project_user, user: build(:user), role: role) end
-            )
-        )
-
-      update_attrs = %{
-        history_retention_period: 14,
-        dataclip_retention_period: 7
-      }
-
-      assert {:ok, %Project{} = updated_project} =
-               Projects.update_project(project, update_attrs)
-
-      # admins and owners receives an email
-      admins =
-        Enum.filter(project.project_users, fn %{role: role} ->
-          role in [:admin, :owner]
-        end)
-
-      assert Enum.count(admins) == 2
-
-      %{subject: subject, body: body} = data_retention_email(updated_project)
-
-      for %{user: user} <- admins do
-        email = Swoosh.Email.Recipient.format(user)
-
-        assert_receive {:email,
-                        %Swoosh.Email{
-                          subject: ^subject,
-                          to: [^email],
-                          text_body: ^body
-                        }}
-      end
-
-      # editors and viewers do not receive any email
-      non_admins =
-        Enum.filter(project.project_users, fn %{role: role} ->
-          role in [:editor, :viewer]
-        end)
-
-      assert Enum.count(non_admins) == 2
-
-      for %{user: %{email: email}} <- non_admins do
-        refute_receive {:email,
-                        %Swoosh.Email{
-                          subject: ^subject,
-                          to: [{"", ^email}],
-                          text_body: ^body
-                        }}
-
-        # data_retention_email(user, updated_project) |> assert_email_not_sent()
-      end
-
-      # no email is sent when there's no change
-      assert {:ok, updated_project} =
-               Projects.update_project(updated_project, update_attrs)
-
-      for %{user: %{email: email}} <- project.project_users do
-        refute_receive {:email,
-                        %Swoosh.Email{
-                          subject: ^subject,
-                          to: [{"", ^email}],
-                          text_body: ^body
-                        }}
-      end
-
-      # no email is sent when there's an error in the changeset
-      assert {:error, _changeset} =
-               Projects.update_project(updated_project, %{
-                 history_retention_period: "xyz",
-                 dataclip_retention_period: 7
-               })
-
-      for %{user: %{email: email}} <- project.project_users do
-        refute_receive {:email,
-                        %Swoosh.Email{
-                          subject: ^subject,
-                          to: [{"", ^email}],
-                          text_body: ^body
-                        }}
-      end
-    end
-
-    test "update_project/2 with invalid data returns error changeset" do
-      project = project_fixture() |> unload_relation(:project_users)
-
-      assert {:error, %Ecto.Changeset{}} =
-               Projects.update_project(project, @invalid_attrs)
-
-      assert project == Projects.get_project!(project.id)
-    end
-
     test "update_project_user/2 with valid data updates the project_user" do
       project =
         project_fixture(
@@ -1682,6 +1558,132 @@ defmodule Lightning.ProjectsTest do
         |> Enum.sort()
 
       assert actual_emails == expected_emails
+    end
+  end
+
+  describe ".update_project/2" do
+    test "update_project/2 with valid data updates the project" do
+      project = project_fixture()
+      update_attrs = %{name: "some-updated-name"}
+
+      assert {:ok, %Project{} = project} =
+               Projects.update_project(project, update_attrs)
+
+      assert project.name == "some-updated-name"
+    end
+
+    test "update_project/2 updates the MFA requirement" do
+      project = insert(:project)
+
+      refute project.requires_mfa
+      update_attrs = %{requires_mfa: true}
+
+      assert {:ok, %Project{} = project} =
+               Projects.update_project(project, update_attrs)
+
+      assert project.requires_mfa
+    end
+
+    test "update_project/2 updates the data retention periods" do
+      project =
+        insert(:project,
+          project_users:
+            Enum.map(
+              [
+                :viewer,
+                :editor,
+                :admin,
+                :owner
+              ],
+              fn role -> build(:project_user, user: build(:user), role: role) end
+            )
+        )
+
+      update_attrs = %{
+        history_retention_period: 14,
+        dataclip_retention_period: 7
+      }
+
+      assert {:ok, %Project{} = updated_project} =
+               Projects.update_project(project, update_attrs)
+
+      # admins and owners receives an email
+      admins =
+        Enum.filter(project.project_users, fn %{role: role} ->
+          role in [:admin, :owner]
+        end)
+
+      assert Enum.count(admins) == 2
+
+      %{subject: subject, body: body} = data_retention_email(updated_project)
+
+      for %{user: user} <- admins do
+        email = Swoosh.Email.Recipient.format(user)
+
+        assert_receive {:email,
+                        %Swoosh.Email{
+                          subject: ^subject,
+                          to: [^email],
+                          text_body: ^body
+                        }}
+      end
+
+      # editors and viewers do not receive any email
+      non_admins =
+        Enum.filter(project.project_users, fn %{role: role} ->
+          role in [:editor, :viewer]
+        end)
+
+      assert Enum.count(non_admins) == 2
+
+      for %{user: %{email: email}} <- non_admins do
+        refute_receive {:email,
+                        %Swoosh.Email{
+                          subject: ^subject,
+                          to: [{"", ^email}],
+                          text_body: ^body
+                        }}
+
+        # data_retention_email(user, updated_project) |> assert_email_not_sent()
+      end
+
+      # no email is sent when there's no change
+      assert {:ok, updated_project} =
+               Projects.update_project(updated_project, update_attrs)
+
+      for %{user: %{email: email}} <- project.project_users do
+        refute_receive {:email,
+                        %Swoosh.Email{
+                          subject: ^subject,
+                          to: [{"", ^email}],
+                          text_body: ^body
+                        }}
+      end
+
+      # no email is sent when there's an error in the changeset
+      assert {:error, _changeset} =
+               Projects.update_project(updated_project, %{
+                 history_retention_period: "xyz",
+                 dataclip_retention_period: 7
+               })
+
+      for %{user: %{email: email}} <- project.project_users do
+        refute_receive {:email,
+                        %Swoosh.Email{
+                          subject: ^subject,
+                          to: [{"", ^email}],
+                          text_body: ^body
+                        }}
+      end
+    end
+
+    test "update_project/2 with invalid data returns error changeset" do
+      project = project_fixture() |> unload_relation(:project_users)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Projects.update_project(project, @invalid_attrs)
+
+      assert project == Projects.get_project!(project.id)
     end
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -16,6 +16,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
   import Mox
 
+  alias Lightning.Auditing.Audit
   alias Lightning.Name
   alias Lightning.Projects
   alias Lightning.Repo
@@ -1935,6 +1936,29 @@ defmodule LightningWeb.ProjectLiveTest do
         |> render_submit()
 
       assert html =~ "Project updated successfully"
+    end
+
+    @tag role: :admin
+    test "creates event linked to user when retention period is updated", %{
+      conn: conn,
+      project: project,
+      user: %{id: user_id}
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#data-storage"
+        )
+
+      view
+      |> form("#retention-settings-form",
+        project: %{
+          history_retention_period: 7
+        }
+      )
+      |> render_submit()
+
+      assert %{actor_id: ^user_id} = Audit |> Repo.one!()
     end
   end
 


### PR DESCRIPTION
### Description

Functionality to track when a project's history and dataclip retention settings have been changed. Per Stu's suggestion, this serves as a warm up for the main event - tracking the creation of snapshots.

Closes #2589

### Validation steps

In Lightning, navigate to the data storage settings for a project of your choice:

![image](https://github.com/user-attachments/assets/79eb4ee0-a50f-4281-94b2-330b3f968618)





## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
