### PR TITLE
Allow users to to preview password fields in credential forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to
 
 ### Changed
 
+- Allow users to to preview password fields in credential forms
+  [#2584](https://github.com/OpenFn/lightning/issues/2584)
+
 ### Fixed
 
 - Fix retry many workorders when built for job

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -83,12 +83,12 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
 
     type =
       case properties do
-        %{"format" => "uri"} -> :url_input
-        %{"type" => "string", "writeOnly" => true} -> :password_input
-        %{"type" => "string"} -> :text_input
-        %{"type" => "integer"} -> :text_input
-        %{"type" => "boolean"} -> :checkbox
-        %{"anyOf" => [%{"type" => "string"}, %{"type" => "null"}]} -> :text_input
+        %{"format" => "uri"} -> "url"
+        %{"type" => "string", "writeOnly" => true} -> "password"
+        %{"type" => "string"} -> "text"
+        %{"type" => "integer"} -> "text"
+        %{"type" => "boolean"} -> "checkbox"
+        %{"anyOf" => [%{"type" => "string"}, %{"type" => "null"}]} -> "text"
       end
 
     required = Credentials.Schema.required?(schema, field)
@@ -103,7 +103,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         type: type
       )
 
-    if type == :checkbox do
+    if type == "checkbox" do
       ~H"""
       <LightningWeb.Components.Form.check_box
         form={@form}
@@ -123,18 +123,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         Required
       </span>
       <div class="col-span-2">
-        <%= apply(Phoenix.HTML.Form, @type, [
-          @form,
-          @field,
-          [
-            value: @value || "",
-            class: ~w(mt-1 focus:ring-primary-500 focus:border-primary-500 block
-               w-full shadow-sm sm:text-sm border-secondary-300 rounded-md)
-          ]
-        ]) %>
-      </div>
-      <div class="error-space h-6">
-        <LightningWeb.CoreComponents.old_error errors={@errors} />
+        <.input type={@type} field={@form[@field]} value={@value || ""} />
       </div>
       """
     end

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -125,6 +125,9 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
       <div class="col-span-2">
         <.input type={@type} field={@form[@field]} value={@value || ""} />
       </div>
+      <div class="error-space h-6">
+        <LightningWeb.CoreComponents.old_error errors={@errors} />
+      </div>
       """
     end
   end

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2108,7 +2108,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert high_priority_view
              |> has_element?("#inspector-workflow-version", "latest")
 
-      wait constant_backoff(100) |> expiry(4_000) do
+      wait exponential_backoff() |> expiry(4_000) do
         refute low_priority_view
                |> has_element?("#inspector-workflow-version", "latest")
 


### PR DESCRIPTION
### Description

This PR allows users to to preview password fields in credential forms. This feature already existed in the `NewInputs.input/1` function component. 

Closes #2584 

### Validation steps

1. Try creating/updating a credential having a password field, like the `http` adaptor credential.
2. You'll see that it now have the button to preview the password 

### Additional notes for the reviewer

There is slight problem with the existing implementation for preview. All is does is change the input type to `text`. 
For liveview forms with `phx-change`, the input gets restored back to a password type. It can be a bit annoying to the user

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
