### PR TITLE
Refactor Projects Dashboard & Fix Last Activity Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Refactor projects dashboard page and fix bug on last activity column
+  [#2593](https://github.com/OpenFn/lightning/issues/2593)
+
 ## [v2.9.11] - 2024-10-23
 
 ### Added

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -309,8 +309,6 @@ export const ModalHook = {
   mounted() {
     this.handleEvent('close_modal', () => {
       this.liveSocket.execJS(this.el, this.el.getAttribute('phx-on-close'));
-
-      this.pushEvent('modal_closed', { id: this.el.id });
     });
   },
 } as PhoenixHook;

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -309,6 +309,8 @@ export const ModalHook = {
   mounted() {
     this.handleEvent('close_modal', () => {
       this.liveSocket.execJS(this.el, this.el.getAttribute('phx-on-close'));
+
+      this.pushEvent('modal_closed', { id: this.el.id });
     });
   },
 } as PhoenixHook;

--- a/lib/lightning_web/live/components/modal.ex
+++ b/lib/lightning_web/live/components/modal.ex
@@ -34,7 +34,7 @@ defmodule LightningWeb.Components.Modal do
     <div
       id={@id}
       phx-mounted={@show && show_modal(@id)}
-      phx-on-close={hide_modal(@id)}
+      phx-on-close={hide_modal(@on_close, @id)}
       phx-hook="ModalHook"
       class={"#{@position} z-50 hidden"}
       {@rest}
@@ -43,6 +43,10 @@ defmodule LightningWeb.Components.Modal do
         id={"#{@id}-bg"}
         class="fixed inset-0 bg-black bg-opacity-60 transition-opacity"
         aria-hidden="true"
+        phx-click={
+          @close_on_click_away &&
+            hide_modal(@on_close, @id) |> JS.push("modal_closed", value: %{id: @id})
+        }
       />
       <div
         class="fixed inset-0 overflow-y-auto sm:py-2"
@@ -57,15 +61,24 @@ defmodule LightningWeb.Components.Modal do
             <.focus_wrap
               id={"#{@id}-container"}
               phx-mounted={@show && show_modal(@on_open, @id)}
-              phx-window-keydown={@close_on_keydown && hide_modal(@on_close, @id)}
+              phx-window-keydown={
+                @close_on_keydown &&
+                  hide_modal(@on_close, @id)
+                  |> JS.push("modal_closed", value: %{id: @id})
+              }
               phx-key="escape"
-              phx-click-away={@close_on_click_away && hide_modal(@on_close, @id)}
+              phx-click-away={
+                @close_on_click_away &&
+                  hide_modal(@on_close, @id)
+                  |> JS.push("modal_closed", value: %{id: @id})
+              }
               class={[
                 "hidden relative rounded-xl transition",
                 @with_frame &&
                   "bg-white py-[24px] shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10"
               ]}
             >
+              <!-- Modal Content -->
               <header :if={@title != [] && @with_frame} class="pl-[24px] pr-[24px]">
                 <h1
                   id={"#{@id}-title"}

--- a/lib/lightning_web/live/components/modal.ex
+++ b/lib/lightning_web/live/components/modal.ex
@@ -78,7 +78,6 @@ defmodule LightningWeb.Components.Modal do
                   "bg-white py-[24px] shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10"
               ]}
             >
-              <!-- Modal Content -->
               <header :if={@title != [] && @with_frame} class="pl-[24px] pr-[24px]">
                 <h1
                   id={"#{@id}-title"}

--- a/lib/lightning_web/live/components/modal.ex
+++ b/lib/lightning_web/live/components/modal.ex
@@ -12,6 +12,7 @@ defmodule LightningWeb.Components.Modal do
   attr :id, :string, required: true
   attr :show, :boolean, default: false
   attr :with_frame, :boolean, default: true
+  attr :target, :any, default: nil
   attr :position, :string, default: "fixed inset-0"
   attr :width, :string, default: "max-w-3xl"
   attr :close_on_click_away, :boolean, default: true
@@ -45,7 +46,8 @@ defmodule LightningWeb.Components.Modal do
         aria-hidden="true"
         phx-click={
           @close_on_click_away &&
-            hide_modal(@on_close, @id) |> JS.push("modal_closed", value: %{id: @id})
+            hide_modal(@on_close, @id)
+            |> push_modal_closed(@id, @target)
         }
       />
       <div
@@ -64,13 +66,13 @@ defmodule LightningWeb.Components.Modal do
               phx-window-keydown={
                 @close_on_keydown &&
                   hide_modal(@on_close, @id)
-                  |> JS.push("modal_closed", value: %{id: @id})
+                  |> push_modal_closed(@id, @target)
               }
               phx-key="escape"
               phx-click-away={
                 @close_on_click_away &&
                   hide_modal(@on_close, @id)
-                  |> JS.push("modal_closed", value: %{id: @id})
+                  |> push_modal_closed(@id, @target)
               }
               class={[
                 "hidden relative rounded-xl transition",
@@ -161,5 +163,15 @@ defmodule LightningWeb.Components.Modal do
     )
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
     |> JS.pop_focus()
+  end
+
+  defp push_modal_closed(js, modal_id, nil) do
+    js
+    |> JS.push("modal_closed", value: %{id: modal_id})
+  end
+
+  defp push_modal_closed(js, modal_id, target) do
+    js
+    |> JS.push("modal_closed", value: %{id: modal_id}, target: target)
   end
 end

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -6,6 +6,104 @@ defmodule LightningWeb.DashboardLive.Components do
   alias Lightning.Accounts.User
   alias Lightning.Projects.Project
 
+  def welcome_banner(assigns) do
+    ~H"""
+    <div class="pb-6">
+      <div class="flex justify-between items-center pt-6">
+        <h1 class="text-2xl font-medium">
+          Good day, <%= @user.first_name %>!
+        </h1>
+        <button
+          phx-click="toggle-welcome-banner"
+          phx-target={@target}
+          class="text-gray-500 focus:outline-none"
+        >
+          <span class="text-lg">
+            <.icon name={"hero-chevron-#{if @collapsed, do: "down", else: "up"}"} />
+          </span>
+        </button>
+      </div>
+
+      <div
+        id="welcome-banner-content"
+        class={[
+          "hover:overflow-visible transition-all duration-500 ease-in-out overflow-hidden",
+          banner_content_classes(@collapsed)
+        ]}
+      >
+        <p class="mb-6 mt-4">
+          Here are some resources to help you get started with OpenFn
+        </p>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <%= for resource <- @resources do %>
+            <.resource_card resource={resource} target={@target} />
+          <% end %>
+        </div>
+      </div>
+
+      <hr class="border-t border-gray-300 mt-4" />
+      <.arcade_modal
+        :if={@selected_resource}
+        resource={@selected_resource}
+        target={@id}
+      />
+    </div>
+    """
+  end
+
+  defp resource_card(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click="select-arcade-resource"
+      phx-target={@target}
+      phx-value-resource={@resource.id}
+      class="relative flex items-end h-[150px] bg-gradient-to-r from-blue-400 to-purple-500 text-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300 p-4 text-left"
+    >
+      <h2 class="text-lg font-semibold absolute bottom-4 left-4">
+        <%= @resource.title %>
+      </h2>
+    </button>
+    """
+  end
+
+  defp arcade_modal(assigns) do
+    ~H"""
+    <div class="text-xs">
+      <.modal
+        id={"arcade-modal-#{@resource.id}"}
+        target={"##{@target}"}
+        with_frame={false}
+        show={true}
+        width="w-5/6"
+      >
+        <div class="relative h-0 w-full pb-[60%]">
+          <iframe
+            src={@resource.link}
+            title={@resource.title}
+            frameborder="0"
+            loading="lazy"
+            webkitallowfullscreen
+            mozallowfullscreen
+            allowfullscreen
+            allow="clipboard-write"
+            style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; color-scheme: light;"
+          >
+          </iframe>
+        </div>
+      </.modal>
+    </div>
+    """
+  end
+
+  defp banner_content_classes(collapsed) do
+    case collapsed do
+      true -> "max-h-0"
+      false -> "max-h-[500px]"
+      nil -> "max-h-[500px]"
+    end
+  end
+
   defp project_role(
          %User{id: user_id} = _user,
          %Project{project_users: project_users} = _project

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -155,6 +155,7 @@ defmodule LightningWeb.DashboardLive.Components do
               <span
                 phx-click="sort"
                 phx-value-by="name"
+                phx-target={@target}
                 class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
               >
                 <.icon name={@name_sort_icon} />
@@ -170,6 +171,7 @@ defmodule LightningWeb.DashboardLive.Components do
               <span
                 phx-click="sort"
                 phx-value-by="activity"
+                phx-target={@target}
                 class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
               >
                 <.icon name={@activity_sort_icon} />

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -3,9 +3,6 @@ defmodule LightningWeb.DashboardLive.Components do
 
   import PetalComponents.Table
 
-  alias Lightning.Accounts.User
-  alias Lightning.Projects.Project
-
   def welcome_banner(assigns) do
     ~H"""
     <div class="pb-6">
@@ -104,17 +101,6 @@ defmodule LightningWeb.DashboardLive.Components do
     end
   end
 
-  defp project_role(
-         %User{id: user_id} = _user,
-         %Project{project_users: project_users} = _project
-       ) do
-    project_users
-    |> Enum.find(fn pu -> pu.user_id == user_id end)
-    |> Map.get(:role)
-    |> Atom.to_string()
-    |> String.capitalize()
-  end
-
   defp table_title(assigns) do
     ~H"""
     <h3 class="text-3xl font-bold">
@@ -134,7 +120,7 @@ defmodule LightningWeb.DashboardLive.Components do
         projects_count: assigns.projects |> Enum.count(),
         empty?: assigns.projects |> Enum.empty?(),
         name_sort_icon: next_sort_icon[assigns.name_direction],
-        activity_sort_icon: next_sort_icon[assigns.activity_direction]
+        last_activity_sort_icon: next_sort_icon[assigns.last_activity_direction]
       )
 
     ~H"""
@@ -170,11 +156,11 @@ defmodule LightningWeb.DashboardLive.Components do
               Last Activity
               <span
                 phx-click="sort"
-                phx-value-by="activity"
+                phx-value-by="last_activity"
                 phx-target={@target}
                 class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
               >
-                <.icon name={@activity_sort_icon} />
+                <.icon name={@last_activity_sort_icon} />
               </span>
             </div>
           </.th>
@@ -195,24 +181,30 @@ defmodule LightningWeb.DashboardLive.Components do
             </.link>
           </.td>
           <.td class="break-words max-w-[25rem]">
-            <%= project_role(@user, project) %>
+            <%= project.role
+            |> Atom.to_string()
+            |> String.capitalize() %>
           </.td>
           <.td class="break-words max-w-[10rem]">
-            <%= length(project.workflows) %>
+            <%= project.workflows_count %>
           </.td>
           <.td class="break-words max-w-[5rem]">
             <.link
               class="link"
               href={~p"/projects/#{project.id}/settings#collaboration"}
             >
-              <%= length(project.project_users) %>
+              <%= project.collaborators_count %>
             </.link>
           </.td>
           <.td>
-            <%= Lightning.Helpers.format_date(
-              project.updated_at,
-              "%d/%b/%Y %H:%M:%S"
-            ) %>
+            <%= if project.last_activity do %>
+              <%= Lightning.Helpers.format_date(
+                project.last_activity,
+                "%d/%b/%Y %H:%M:%S"
+              ) %>
+            <% else %>
+              No activity
+            <% end %>
           </.td>
           <.td class="text-right">
             <.link

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -1,111 +1,13 @@
 defmodule LightningWeb.DashboardLive.Index do
   use LightningWeb, :live_view
 
-  import LightningWeb.DashboardLive.Components
-
-  alias Lightning.Accounts
-  alias Lightning.Accounts.User
-  alias Lightning.Projects
-
   require Logger
 
   on_mount {LightningWeb.Hooks, :project_scope}
 
   @impl true
   def mount(_params, _session, socket) do
-    welcome_collapsed =
-      Accounts.get_preference(
-        socket.assigns.current_user,
-        "welcome.collapsed"
-      )
-
-    {:ok,
-     socket
-     |> assign_new(:projects, fn ->
-       projects_for_user(socket.assigns.current_user)
-     end)
-     |> assign(
-       arcade_resources: @arcade_resources,
-       selected_arcade_resource: nil,
-       welcome_collapsed: welcome_collapsed,
-       active_menu_item: :projects,
-       name_sort_direction: :asc,
-       activity_sort_direction: :asc
-     )}
-  end
-
-  @impl true
-  def handle_params(_params, _url, socket) do
-    {:noreply, assign(socket, page_title: "Projects")}
-  end
-
-  @impl true
-  def handle_event("sort", %{"by" => field}, socket) do
-    sort_key = String.to_atom("#{field}_sort_direction")
-    sort_direction = Map.get(socket.assigns, sort_key, :asc)
-    new_sort_direction = switch_sort_direction(sort_direction)
-
-    order_column = map_sort_field_to_column(field)
-
-    projects =
-      projects_for_user(socket.assigns.current_user,
-        order_by: [{new_sort_direction, order_column}]
-      )
-
-    socket =
-      socket
-      |> assign(:projects, projects)
-      |> assign(sort_key, new_sort_direction)
-
-    {:noreply, socket}
-  end
-
-  def handle_event(
-        "select-arcade-resource",
-        %{"resource" => resource_id},
-        socket
-      ) do
-    resource =
-      Enum.find(socket.assigns.arcade_resources, fn resource ->
-        resource.id == String.to_integer(resource_id)
-      end)
-
-    {:noreply, assign(socket, selected_arcade_resource: resource)}
-  end
-
-  def handle_event("toggle-welcome-banner", _params, socket) do
-    welcome_collapsed = !socket.assigns.welcome_collapsed
-
-    Accounts.update_user_preference(
-      socket.assigns.current_user,
-      "welcome.collapsed",
-      welcome_collapsed
-    )
-    |> case do
-      {:ok, _user} ->
-        {:noreply, assign(socket, welcome_collapsed: welcome_collapsed)}
-
-      {:error, reason} ->
-        Logger.error("Couldn't update user preferences: #{inspect(reason)}")
-        {:noreply, socket}
-    end
-  end
-
-  def handle_event("modal_closed", _params, socket) do
-    {:noreply, assign(socket, selected_arcade_resource: nil)}
-  end
-
-  defp switch_sort_direction(:asc), do: :desc
-  defp switch_sort_direction(:desc), do: :asc
-
-  defp map_sort_field_to_column("name"), do: :name
-  defp map_sort_field_to_column("activity"), do: :updated_at
-
-  defp projects_for_user(%User{} = user, opts \\ []) do
-    include = Keyword.get(opts, :include, [:project_users, :workflows])
-    order_by = Keyword.get(opts, :order_by, asc: :name)
-
-    Projects.get_projects_for_user(user, include: include, order_by: order_by)
+    {:ok, assign(socket, page_title: "Projects", active_menu_item: :projects)}
   end
 
   @impl true
@@ -120,42 +22,17 @@ defmodule LightningWeb.DashboardLive.Index do
 
       <LayoutComponents.centered>
         <div class="w-full">
-          <.welcome_banner
+          <.live_component
+            id="projects-dashboard-welcome-section"
+            module={LightningWeb.DashboardLive.WelcomeSection}
             current_user={@current_user}
-            resources={@arcade_resources}
-            collapsed={@welcome_collapsed}
-            selected_resource={@selected_arcade_resource}
           />
 
-          <.user_projects_table
-            projects={@projects}
-            user={@current_user}
-            name_direction={@name_sort_direction}
-            activity_direction={@activity_sort_direction}
-          >
-            <:empty_state>
-              <button
-                type="button"
-                id="open-create-project-modal-big-button"
-                phx-click={show_modal("create-project-modal")}
-                class="relative block w-full rounded-lg border-2 border-dashed p-4 text-center hover:border-gray-400"
-              >
-                <Heroicons.plus_circle class="mx-auto w-12 h-12 text-secondary-400" />
-                <span class="mt-2 block text-xs font-semibold text-secondary-600">
-                  No projects found. Create a new one.
-                </span>
-              </button>
-            </:empty_state>
-            <:create_project_button>
-              <.button
-                id="open-create-project-modal-button"
-                phx-click={show_modal("create-project-modal")}
-                class="w-full rounded-md"
-              >
-                Create project
-              </.button>
-            </:create_project_button>
-          </.user_projects_table>
+          <.live_component
+            id="user-projects-section"
+            module={LightningWeb.DashboardLive.UserProjectsSection}
+            current_user={@current_user}
+          />
 
           <.live_component
             id="create-project-modal"
@@ -166,102 +43,6 @@ defmodule LightningWeb.DashboardLive.Index do
         </div>
       </LayoutComponents.centered>
     </LayoutComponents.page_content>
-    """
-  end
-
-  def welcome_banner(assigns) do
-    ~H"""
-    <div class="rounded-lg pb-6">
-      <div class="flex justify-between items-center pt-6">
-        <h1 class="text-2xl font-medium">
-          Good day, <%= @current_user.first_name %>!
-        </h1>
-        <button
-          phx-click="toggle-welcome-banner"
-          class="text-gray-500 focus:outline-none"
-        >
-          <span class="text-lg">
-            <.icon name={"hero-chevron-#{if @collapsed, do: "down", else: "up"}"} />
-          </span>
-        </button>
-      </div>
-
-      <div
-        id="welcome-banner-content"
-        class={[
-          "transition-all duration-500 ease-in-out overflow-hidden hover:overflow-visible",
-          banner_content_classes(@collapsed)
-        ]}
-      >
-        <p class="mb-6 mt-4">
-          Here are some resources to help you get started with OpenFn
-        </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <%= for resource <- @resources do %>
-            <.resource_card resource={resource} />
-          <% end %>
-        </div>
-      </div>
-
-      <hr class="border-t border-gray-300 mt-4" />
-      <.arcade_modal :if={@selected_resource} resource={@selected_resource} />
-    </div>
-    """
-  end
-
-  defp banner_content_classes(collapsed) do
-    case collapsed do
-      true -> "max-h-0"
-      false -> "max-h-[500px]"
-      nil -> "max-h-[500px]"
-    end
-  end
-
-  def resource_card(assigns) do
-    ~H"""
-    <button
-      type="button"
-      phx-click="select-arcade-resource"
-      phx-value-resource={@resource.id}
-      class={[
-        "relative flex items-end h-[150px] p-4 text-left",
-        "bg-gradient-to-r from-blue-400 to-purple-500",
-        "text-white rounded-lg shadow-sm hover:shadow-md",
-        "transition-shadow duration-300"
-      ]}
-    >
-      <h2 class="text-lg font-semibold absolute bottom-4 left-4">
-        <%= @resource.title %>
-      </h2>
-    </button>
-    """
-  end
-
-  def arcade_modal(assigns) do
-    ~H"""
-    <div class="text-xs">
-      <.modal
-        id={"arcade-modal-#{@resource.id}"}
-        with_frame={false}
-        show={true}
-        width="w-5/6"
-      >
-        <div style="position: relative; padding-bottom: calc(54.43121693121693% + 41px); height: 0; width: 100%;">
-          <iframe
-            src={@resource.link}
-            title={@resource.title}
-            frameborder="0"
-            loading="lazy"
-            webkitallowfullscreen
-            mozallowfullscreen
-            allowfullscreen
-            allow="clipboard-write"
-            style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; color-scheme: light;"
-          >
-          </iframe>
-        </div>
-      </.modal>
-    </div>
     """
   end
 end

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -9,33 +9,6 @@ defmodule LightningWeb.DashboardLive.Index do
 
   require Logger
 
-  @arcade_resources [
-    %{
-      id: 1,
-      title: "Getting Started with OpenFn",
-      link:
-        "https://demo.arcade.software/xmGSUuZ1Ovd9WeHaTLle?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true"
-    },
-    %{
-      id: 2,
-      title: "Creating your first workflow",
-      link:
-        "https://demo.arcade.software/JzPHX0mUGTkPgAUoctHy?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true"
-    },
-    %{
-      id: 3,
-      title: "How to use the IDE",
-      link:
-        "https://demo.arcade.software/L3jtNbBEdMJHtY1Z1PFk?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true"
-    },
-    %{
-      id: 4,
-      title: "Managing project history",
-      link:
-        "https://demo.arcade.software/JLR25gjZdm3NlasAIrZ5?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true"
-    }
-  ]
-
   on_mount {LightningWeb.Hooks, :project_scope}
 
   @impl true
@@ -116,6 +89,10 @@ defmodule LightningWeb.DashboardLive.Index do
         Logger.error("Couldn't update user preferences: #{inspect(reason)}")
         {:noreply, socket}
     end
+  end
+
+  def handle_event("modal_closed", _params, socket) do
+    {:noreply, assign(socket, selected_arcade_resource: nil)}
   end
 
   defp switch_sort_direction(:asc), do: :desc

--- a/lib/lightning_web/live/dashboard_live/index.ex
+++ b/lib/lightning_web/live/dashboard_live/index.ex
@@ -4,6 +4,7 @@ defmodule LightningWeb.DashboardLive.Index do
   require Logger
 
   on_mount {LightningWeb.Hooks, :project_scope}
+  on_mount {LightningWeb.Hooks, :assign_projects}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/lightning_web/live/dashboard_live/user_projects_section.ex
+++ b/lib/lightning_web/live/dashboard_live/user_projects_section.ex
@@ -64,6 +64,7 @@ defmodule LightningWeb.DashboardLive.UserProjectsSection do
         projects={@projects}
         user={@current_user}
         name_direction={@name_sort_direction}
+        target={@myself}
         activity_direction={@activity_sort_direction}
       >
         <:empty_state>

--- a/lib/lightning_web/live/dashboard_live/user_projects_section.ex
+++ b/lib/lightning_web/live/dashboard_live/user_projects_section.ex
@@ -35,12 +35,10 @@ defmodule LightningWeb.DashboardLive.UserProjectsSection do
         order_by: [{new_sort_direction, order_column}]
       )
 
-    socket =
-      socket
-      |> assign(:projects, projects)
-      |> assign(sort_key, new_sort_direction)
-
-    {:noreply, socket}
+    {:noreply,
+     socket
+     |> assign(:projects, projects)
+     |> assign(sort_key, new_sort_direction)}
   end
 
   defp switch_sort_direction(:asc), do: :desc

--- a/lib/lightning_web/live/dashboard_live/user_projects_section.ex
+++ b/lib/lightning_web/live/dashboard_live/user_projects_section.ex
@@ -1,0 +1,95 @@
+defmodule LightningWeb.DashboardLive.UserProjectsSection do
+  use LightningWeb, :live_component
+
+  import LightningWeb.DashboardLive.Components
+
+  alias Lightning.Accounts.User
+  alias Lightning.Projects
+
+  require Logger
+
+  @impl true
+  def update(assigns, socket) do
+    projects = projects_for_user(assigns.current_user)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(
+       projects: projects,
+       name_sort_direction: :asc,
+       activity_sort_direction: :asc
+     )}
+  end
+
+  @impl true
+  def handle_event("sort", %{"by" => field}, socket) do
+    sort_key = String.to_atom("#{field}_sort_direction")
+    sort_direction = Map.get(socket.assigns, sort_key, :asc)
+    new_sort_direction = switch_sort_direction(sort_direction)
+
+    order_column = map_sort_field_to_column(field)
+
+    projects =
+      projects_for_user(socket.assigns.current_user,
+        order_by: [{new_sort_direction, order_column}]
+      )
+
+    socket =
+      socket
+      |> assign(:projects, projects)
+      |> assign(sort_key, new_sort_direction)
+
+    {:noreply, socket}
+  end
+
+  defp switch_sort_direction(:asc), do: :desc
+  defp switch_sort_direction(:desc), do: :asc
+
+  defp map_sort_field_to_column("name"), do: :name
+  defp map_sort_field_to_column("activity"), do: :updated_at
+
+  defp projects_for_user(%User{} = user, opts \\ []) do
+    include = Keyword.get(opts, :include, [:project_users, :workflows])
+    order_by = Keyword.get(opts, :order_by, asc: :name)
+
+    Projects.get_projects_for_user(user, include: include, order_by: order_by)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.user_projects_table
+        projects={@projects}
+        user={@current_user}
+        name_direction={@name_sort_direction}
+        activity_direction={@activity_sort_direction}
+      >
+        <:empty_state>
+          <button
+            type="button"
+            id="open-create-project-modal-big-button"
+            phx-click={show_modal("create-project-modal")}
+            class="relative block w-full rounded-lg border-2 border-dashed p-4 text-center hover:border-gray-400"
+          >
+            <Heroicons.plus_circle class="mx-auto w-12 h-12 text-secondary-400" />
+            <span class="mt-2 block text-xs font-semibold text-secondary-600">
+              No projects found. Create a new one.
+            </span>
+          </button>
+        </:empty_state>
+        <:create_project_button>
+          <.button
+            id="open-create-project-modal-button"
+            phx-click={show_modal("create-project-modal")}
+            class="w-full rounded-md"
+          >
+            Create project
+          </.button>
+        </:create_project_button>
+      </.user_projects_table>
+    </div>
+    """
+  end
+end

--- a/lib/lightning_web/live/dashboard_live/welcome_section.ex
+++ b/lib/lightning_web/live/dashboard_live/welcome_section.ex
@@ -1,0 +1,104 @@
+defmodule LightningWeb.DashboardLive.WelcomeSection do
+  use LightningWeb, :live_component
+
+  import LightningWeb.DashboardLive.Components
+
+  alias Lightning.Accounts
+
+  require Logger
+
+  @arcade_resources [
+    %{
+      id: 1,
+      title: "Getting Started with OpenFn",
+      link:
+        "https://demo.arcade.software/xmGSUuZ1Ovd9WeHaTLle?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+    },
+    %{
+      id: 2,
+      title: "Creating your first workflow",
+      link:
+        "https://demo.arcade.software/JzPHX0mUGTkPgAUoctHy?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+    },
+    %{
+      id: 3,
+      title: "How to use the IDE",
+      link:
+        "https://demo.arcade.software/L3jtNbBEdMJHtY1Z1PFk?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+    },
+    %{
+      id: 4,
+      title: "Managing project history",
+      link:
+        "https://demo.arcade.software/JLR25gjZdm3NlasAIrZ5?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+    }
+  ]
+
+  @impl true
+  def update(assigns, socket) do
+    welcome_collapsed =
+      Accounts.get_preference(
+        assigns.current_user,
+        "welcome.collapsed"
+      )
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(arcade_resources: @arcade_resources)
+     |> assign(selected_arcade_resource: nil)
+     |> assign(welcome_collapsed: welcome_collapsed)}
+  end
+
+  @impl true
+  def handle_event(
+        "select-arcade-resource",
+        %{"resource" => resource_id},
+        socket
+      ) do
+    resource =
+      Enum.find(socket.assigns.arcade_resources, fn resource ->
+        resource.id == String.to_integer(resource_id)
+      end)
+
+    {:noreply, assign(socket, selected_arcade_resource: resource)}
+  end
+
+  def handle_event("toggle-welcome-banner", _params, socket) do
+    welcome_collapsed = !socket.assigns.welcome_collapsed
+
+    Accounts.update_user_preference(
+      socket.assigns.current_user,
+      "welcome.collapsed",
+      welcome_collapsed
+    )
+    |> case do
+      {:ok, _user} ->
+        {:noreply, assign(socket, welcome_collapsed: welcome_collapsed)}
+
+      {:error, reason} ->
+        Logger.error("Couldn't update user preferences: #{inspect(reason)}")
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("modal_closed", _params, socket) do
+    {:noreply, assign(socket, selected_arcade_resource: nil)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.welcome_banner
+        id={@id}
+        user={@current_user}
+        resources={@arcade_resources}
+        target={@myself}
+        collapsed={@welcome_collapsed}
+        selected_resource={@selected_arcade_resource}
+      />
+    </div>
+    """
+  end
+end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -12,6 +12,7 @@ defmodule Lightning.ProjectsTest do
   alias Lightning.Invocation.Dataclip
   alias Lightning.Projects
   alias Lightning.Projects.Project
+  alias Lightning.Projects.ProjectOverviewRow
   alias Lightning.Projects.ProjectUser
   alias Swoosh.Email
 
@@ -1683,6 +1684,200 @@ defmodule Lightning.ProjectsTest do
         |> Enum.sort()
 
       assert actual_emails == expected_emails
+    end
+  end
+
+  describe "get_projects_overview/2" do
+    test "returns an empty list when the user has no projects" do
+      user = insert(:user)
+
+      assert Projects.get_projects_overview(user) == []
+    end
+
+    test "returns projects overview with workflows and collaborators count" do
+      user = insert(:user)
+      other_user = insert(:user)
+
+      project =
+        %{id: project_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      insert(:simple_workflow, project: project)
+      insert(:simple_workflow, project: project)
+
+      insert(:project,
+        name: "Project B",
+        project_users: [%{user_id: other_user.id}]
+      )
+
+      result = Projects.get_projects_overview(user)
+
+      assert length(result) == 1
+
+      [
+        %ProjectOverviewRow{
+          id: ^project_id,
+          name: "Project A",
+          workflows_count: 2,
+          collaborators_count: 1
+        }
+      ] = result
+    end
+
+    test "orders projects by name ascending by default" do
+      user = insert(:user)
+
+      %{id: project_a_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      %{id: project_b_id} =
+        insert(:project, name: "Project B", project_users: [%{user_id: user.id}])
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{id: ^project_a_id, name: "Project A"},
+               %ProjectOverviewRow{id: ^project_b_id, name: "Project B"}
+             ] = result
+    end
+
+    test "orders projects by last_activity (updated_at of workflows) descending when specified" do
+      user = insert(:user)
+
+      project_a =
+        %{id: project_a_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      project_b =
+        %{id: project_b_id} =
+        insert(:project, name: "Project B", project_users: [%{user_id: user.id}])
+
+      insert(:simple_workflow,
+        project: project_a,
+        updated_at: ~N[2023-10-05 00:00:00]
+      )
+
+      insert(:simple_workflow,
+        project: project_b,
+        updated_at: ~N[2023-10-10 00:00:00]
+      )
+
+      result =
+        Projects.get_projects_overview(user, order_by: {:desc, :last_activity})
+
+      assert [
+               %ProjectOverviewRow{id: ^project_b_id, name: "Project B"},
+               %ProjectOverviewRow{id: ^project_a_id, name: "Project A"}
+             ] = result
+    end
+
+    test "orders projects by last_activity ascending when specified" do
+      user = insert(:user)
+
+      project_a =
+        %{id: project_a_id} =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      project_b =
+        %{id: project_b_id} =
+        insert(:project, name: "Project B", project_users: [%{user_id: user.id}])
+
+      insert(:simple_workflow,
+        project: project_a,
+        updated_at: ~N[2023-10-05 00:00:00]
+      )
+
+      insert(:simple_workflow,
+        project: project_b,
+        updated_at: ~N[2023-10-10 00:00:00]
+      )
+
+      result =
+        Projects.get_projects_overview(user, order_by: {:asc, :last_activity})
+
+      assert [
+               %ProjectOverviewRow{id: ^project_a_id, name: "Project A"},
+               %ProjectOverviewRow{id: ^project_b_id, name: "Project B"}
+             ] = result
+    end
+
+    test "returns project with no workflows or last activity" do
+      user = insert(:user)
+
+      %{id: project_id} =
+        insert(:project,
+          name: "Project No Workflow",
+          project_users: [%{user_id: user.id}]
+        )
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{
+                 id: ^project_id,
+                 name: "Project No Workflow",
+                 workflows_count: 0,
+                 last_activity: nil
+               }
+             ] = result
+    end
+
+    test "returns correct collaborators count with multiple collaborators" do
+      user = insert(:user)
+      other_user = insert(:user)
+      third_user = insert(:user)
+
+      project =
+        insert(:project, name: "Project A", project_users: [%{user_id: user.id}])
+
+      insert(:project_user, project: project, user: other_user)
+      insert(:project_user, project: project, user: third_user)
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{
+                 collaborators_count: 3
+               }
+             ] = result
+    end
+
+    test "returns correct role for the user" do
+      user = insert(:user)
+      other_user = insert(:user)
+
+      project =
+        insert(:project,
+          name: "Project A",
+          project_users: [%{user_id: user.id, role: :owner}]
+        )
+
+      insert(:project_user, project: project, user: other_user, role: :admin)
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{
+                 role: :owner
+               }
+             ] = result
+    end
+
+    test "returns correct collaborators count with only one collaborator" do
+      user = insert(:user)
+
+      insert(:project,
+        name: "Solo Project",
+        project_users: [%{user_id: user.id}]
+      )
+
+      result = Projects.get_projects_overview(user)
+
+      assert [
+               %ProjectOverviewRow{
+                 collaborators_count: 1
+               }
+             ] = result
     end
   end
 


### PR DESCRIPTION
### Description

This PR refactors the projects dashboard page by encapsulating the three different components of the page into separate live components. This change makes the page more reusable, improves separation of concerns, and ensures the page itself doesn't handle state and events for these components. Additionally, this PR also fixes a bug identified in the last activity column of the projects list. The bug was due to the last activity column displaying the value of the updated_at column from the projects table. The query has been updated to fetch the most recent updated_at value of the workflows for each project.

Fixes #2593 

### Validation steps

1. Log in to the app.
2. Navigate to the projects dashboard page and confirm that both the welcome section and the projects table load correctly.
3. Expand/Collapse the welcome section to ensure it functions as expected.
4. Verify that clicking on the welcome cards loads the associated arcade videos properly.
5. Test that creating a new project successfully adds it to the projects list.
6. Confirm that the last activity column now correctly reflects the most recent updated_at date of the workflows for each project.

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
