### PR TITLE
Limit MFA Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Enforcing MFA for a project can be enforced by the usage limiter
+  [#2607](https://github.com/OpenFn/lightning/pull/2607)
+
 ### Fixed
 
 ## [v2.9.11] - 2024-10-23

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -38,15 +38,55 @@ defmodule Lightning.Extensions.UsageLimiting do
     defstruct [:project_id, :user_id]
   end
 
+  @doc """
+  Checks the usage limits for a given project and user context, returning an error
+  message if the limits are exceeded.
+
+  Requires a `Context` struct containing the `project_id` and `user_id`.
+
+  ## Returns
+
+    - `{:ok}` if the limits are within bounds.
+    - `{:error, reason, message}` if the limits are exceeded.
+  """
   @callback check_limits(context :: Context.t()) ::
               :ok | error()
 
+  @doc """
+  Limits specific actions based on an `Action` and `Context`.
+
+  ## Returns
+
+    - `:ok` if the action is allowed.
+    - `{:error, reason, message}` if the action is not allowed.
+  """
   @callback limit_action(action :: Action.t(), context :: Context.t()) ::
               :ok | error()
 
+  @doc """
+  Increments the AI query count for a given chat session.
+
+  Requires a `Lightning.AiAssistant.ChatSession` struct.
+
+  ## Returns
+
+    - An Ecto.Multi struct representing the transaction to increment AI queries.
+  """
   @callback increment_ai_queries(Lightning.AiAssistant.ChatSession.t()) ::
               Ecto.Multi.t()
 
+  @doc """
+  Returns run options based on the given project context. The run options include
+  a timeout value and a flag for saving dataclips.
+
+  Requires a `Context` struct containing the `project_id`.
+
+  ## Returns
+
+    - A keyword list of run options including:
+      - `:run_timeout_ms`: The run timeout in milliseconds.
+      - `:save_dataclips`: A boolean indicating whether to save dataclips.
+  """
   @callback get_run_options(context :: Context.t()) ::
               Lightning.Runs.RunOptions.keyword_list()
 end

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -19,7 +19,8 @@ defmodule Lightning.Extensions.UsageLimiting do
               | :ai_query
               | :alert_failure
               | :github_sync
-              | :new_user,
+              | :new_user
+              | :require_mfa,
             amount: pos_integer()
           }
 

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -98,7 +98,7 @@ defmodule LightningWeb.Hooks do
       :ok ->
         {:cont, assign(socket, can_require_mfa: true)}
 
-      {:error, %{function: func} = component} when is_function(func) ->
+      {:error, _reason, %{function: func} = component} when is_function(func) ->
         {:cont, assign(socket, mfa_banner: component, can_require_mfa: false)}
     end
   end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -27,6 +27,7 @@ defmodule LightningWeb.ProjectLive.Settings do
 
   on_mount {LightningWeb.Hooks, :project_scope}
   on_mount {LightningWeb.Hooks, :limit_github_sync}
+  on_mount {LightningWeb.Hooks, :limit_mfa}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -195,6 +196,7 @@ defmodule LightningWeb.ProjectLive.Settings do
          |> Permissions.can?(:edit_failure_alerts, current_user, project_user)
 
   defp can_edit_project(assigns), do: assigns.can_edit_project
+  defp can_require_mfa(assigns), do: assigns.can_require_mfa
 
   @impl true
   def handle_params(params, _url, socket) do
@@ -284,7 +286,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event("toggle-mfa", _params, socket) do
-    if can_edit_project(socket.assigns) do
+    if can_edit_project(socket.assigns) && can_require_mfa(socket.assigns) do
       project = socket.assigns.project
 
       {:ok, project} =

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -195,9 +195,6 @@ defmodule LightningWeb.ProjectLive.Settings do
          ProjectUsers
          |> Permissions.can?(:edit_failure_alerts, current_user, project_user)
 
-  defp can_edit_project(assigns), do: assigns.can_edit_project
-  defp can_require_mfa(assigns), do: assigns.can_require_mfa
-
   @impl true
   def handle_params(params, _url, socket) do
     %{project: %{id: project_id}, live_action: live_action} = socket.assigns
@@ -262,7 +259,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event("save", %{"project" => project_params}, socket) do
-    if can_edit_project(socket.assigns) do
+    if socket.assigns.can_edit_project do
       save_project(socket, project_params)
     else
       {:noreply,
@@ -286,7 +283,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event("toggle-mfa", _params, socket) do
-    if can_edit_project(socket.assigns) && can_require_mfa(socket.assigns) do
+    if socket.assigns.can_edit_project && socket.assigns.can_require_mfa do
       project = socket.assigns.project
 
       {:ok, project} =

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -688,7 +688,15 @@
         <div class="hidden sm:block" aria-hidden="true">
           <div class="py-2"></div>
         </div>
-
+        <div>
+          <%= if assigns[:mfa_banner] do %>
+            <%= Phoenix.LiveView.TagEngine.component(
+              @mfa_banner.function,
+              @mfa_banner.attrs,
+              {__ENV__.module, __ENV__.function, __ENV__.file, __ENV__.line}
+            ) %>
+          <% end %>
+        </div>
         <div class="bg-white p-4 rounded-md">
           <div class="flex items-center justify-between">
             <span class="flex flex-grow flex-col">
@@ -718,6 +726,7 @@
                 type="button"
                 class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !can_edit_project(assigns), do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
                 role="switch"
+                disabled={!@can_require_mfa}
                 phx-click="toggle-mfa"
                 aria-checked={@project.requires_mfa}
                 aria-labelledby="require-mfa-label"

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -59,7 +59,7 @@
             Projects are isolated workspaces that contain workflows, accessible to certain users.
           </small>
           <.permissions_message
-            :if={!can_edit_project(assigns)}
+            :if={!@can_edit_project}
             section="basic settings, but you can export a copy."
           />
         </div>
@@ -87,7 +87,7 @@
               <div class="md:col-span-2">
                 <Form.text_field
                   form={f}
-                  disabled={!can_edit_project(assigns)}
+                  disabled={!@can_edit_project}
                   label="Project name"
                   field={:name}
                 />
@@ -101,7 +101,7 @@
                 <Form.text_area
                   class="mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-secondary-300 rounded-md"
                   form={f}
-                  disabled={!can_edit_project(assigns)}
+                  disabled={!@can_edit_project}
                   label="Project description"
                   field={:description}
                 />
@@ -116,10 +116,7 @@
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
                 <Form.submit_button
-                  disabled={
-                    !(@project_changeset.valid? and can_edit_project(assigns) and
-                        can_edit_project(assigns))
-                  }
+                  disabled={!(@project_changeset.valid? and @can_edit_project)}
                   phx-disable-with="Saving"
                 >
                   Save
@@ -552,7 +549,7 @@
             View collaborators and manage alert settings for this project.
           </small>
           <.permissions_message
-            :if={!can_edit_project(assigns)}
+            :if={!@can_edit_project}
             section="collaboration settings, but you can change your notification preferences."
           />
         </div>
@@ -681,7 +678,7 @@
             View and manage security settings for this project.
           </small>
           <.permissions_message
-            :if={!can_edit_project(assigns)}
+            :if={!@can_edit_project}
             section="multi-factor authentication settings."
           />
         </div>
@@ -724,14 +721,14 @@
               <button
                 id="toggle-mfa-switch"
                 type="button"
-                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !can_edit_project(assigns), do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !@can_edit_project, do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
                 role="switch"
                 disabled={!@can_require_mfa}
                 phx-click="toggle-mfa"
                 aria-checked={@project.requires_mfa}
                 aria-labelledby="require-mfa-label"
                 aria-describedby="require-mfa-description"
-                {if !can_edit_project(assigns), do: ["phx-hook": "Tooltip", "data-placement": "bottom", "aria-label": "You do not have permission to perform this action"], else: []}
+                {if !@can_edit_project, do: ["phx-hook": "Tooltip", "data-placement": "bottom", "aria-label": "You do not have permission to perform this action"], else: []}
               >
                 <span
                   aria-hidden="true"

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2108,7 +2108,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert high_priority_view
              |> has_element?("#inspector-workflow-version", "latest")
 
-      retry with: exponential_backoff() |> expiry(4_000),
+      retry with: linear_backoff(50, 2) |> expiry(4_000),
             rescue_only: [ExUnit.AssertionError] do
         refute low_priority_view
                |> has_element?("#inspector-workflow-version", "latest")


### PR DESCRIPTION
### Description

This PR implements an extension for limiting the MFA feature.

Re [#387](https://github.com/OpenFn/thunderbolt/issues/387)

### Validation steps

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
