### PR TITLE
Do not send empty strings in credential body to the worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Do not send empty strings in credential body to the worker
+  [#2585](https://github.com/OpenFn/lightning/issues/2585)
+
 ## [v2.9.11] - 2024-10-23
 
 ### Added

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -92,7 +92,9 @@ defmodule LightningWeb.RunChannel do
          samples <- Credentials.sensitive_values_for(credential),
          basic_auth <- Credentials.basic_auth_for(credential),
          {:ok, scrubber} <- update_scrubber(scrubber, samples, basic_auth) do
-      socket |> assign(scrubber: scrubber) |> reply_with({:ok, credential.body})
+      socket
+      |> assign(scrubber: scrubber)
+      |> reply_with({:ok, remove_empty_values(credential.body)})
     else
       :not_found ->
         reply_with(socket, {:error, %{errors: %{id: ["Credential not found!"]}}})
@@ -212,5 +214,9 @@ defmodule LightningWeb.RunChannel do
   defp update_scrubber(scrubber, samples, basic_auth) do
     :ok = Scrubber.add_samples(scrubber, samples, basic_auth)
     {:ok, scrubber}
+  end
+
+  defp remove_empty_values(credential_body) do
+    Map.reject(credential_body, fn {_key, val} -> val == "" end)
   end
 end

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -431,6 +431,40 @@ defmodule LightningWeb.RunChannelTest do
                      "user" => "user1"
                    }
     end
+
+    test "does not send keys with empty strings" do
+      user = insert(:user)
+
+      credential =
+        insert(:credential,
+          name: "Test Commcare",
+          body: %{
+            "apiKey" => "",
+            "appId" => "12345",
+            "domain" => "localhost",
+            "hostUrl" => "http://localhost:2500",
+            "password" => "test",
+            "username" => "test"
+          },
+          schema: "commcare",
+          user: user
+        )
+
+      %{socket: socket} =
+        create_socket_and_run(%{credential: credential, user: user})
+
+      ref = push(socket, "fetch:credential", %{"id" => credential.id})
+
+      assert_reply ref,
+                   :ok,
+                   %{
+                     "appId" => "12345",
+                     "domain" => "localhost",
+                     "hostUrl" => "http://localhost:2500",
+                     "password" => "test",
+                     "username" => "test"
+                   }
+    end
   end
 
   describe "marking steps as started and finished" do


### PR DESCRIPTION
### Description

This PR fixes an issue where the adaptor was preferring an `apiKey` value even when the user did not submit it.
On checking with @christad92, we noticed that the credential body that gets saved includes all keys defined by the adaptor schema, and so if the user doesn't submit it, it gets saved with a value of an empty string, i.e. `""`.

We could strip down the params getting saved not to include empty strings, but **I FEAR** it might get us into trouble. We might lose some data, maybe for Oauth, or something else.

Closes #2585

### Validation steps

1. You can test this with the Commcare adaptor. 
2. Create a credential for the `commcare` adpator, but don't fill in the API Key field.
3. Use this credential with a job in your workflow and log the state in the job body, i.e. `console.log(state)
4. Create a manual workorder and monitor the logs
5. You'll see that only the fields you filled in are logged in there. Initially, you could have spotted the the `apiKey` as well


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
