### PR TITLE
Enable put_all on Collections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
 #   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20210902-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.13.2-erlang-24.2.1-debian-bullseye-20210902-slim
+#   - Ex: hexpm/elixir:1.16.2-erlang-26.2.5-debian-bookworm-20240513
 #
 ARG ELIXIR_VERSION=1.16.2
 ARG OTP_VERSION=26.2.5


### PR DESCRIPTION
### Description

This PR adds the `put_all` function to the `Collections` allowing to add multiple items in the same API call between worker and backend. 

Insertion on conflicting keys have the `value` and `updated_at` updated.  

### Validation steps

`LOG_LEVEL=info RTM=false mix run priv/bench/collections.exs`

## Additional notes

Once neither the collection nor an item is fetch anymore when operating over the items, the operations over collections returns a `:not_found` error instead of `:collection_not_found`.
 
## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
