### PR TITLE
2614 kafka email and doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 ### Added
 
+- Additional documentation and notification text relating to the importance of
+  alternate storage for Kafka triggers.
+  [#2614](https://github.com/OpenFn/lightning/issues/2614)
+
 ### Changed
 
 ### Fixed

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -238,6 +238,10 @@ variable.
 
 #### Persisting Failed Messages
 
+**PLEASE NOTE: If alternate file storage is not enabled, messages that fail
+to be persisted will not be retained by Lightning ans this can result in data
+loss, if the Kafka cluster can not make these messages available again.**
+
 If a Kafka message files to be persisted as a WorkOrder, Run and Dataclip, the 
 option exists to write the failed message to a location on the local file system.
 If this option is enabled by setting `KAFKA_ALTERNATE_STORAGE_ENABLED`, then the

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -396,10 +396,20 @@ defmodule Lightning.Accounts.UserNotifier do
     deliver(user, "Kafka trigger failure on #{workflow.name}", """
     As of #{display_timestamp}, the Kafka trigger associated with the workflow `#{workflow.name}` (#{url(~p"/projects/#{workflow.project_id}/w/#{workflow.id}")}) has failed to persist at least one message.
 
+    #{alternate_storage_message(Lightning.Config.kafka_alternate_storage_enabled?())}
+
     If you have access to the system logs, please look for entries containing 'Kafka Pipeline Error'.
 
     OpenFn
     """)
+  end
+
+  defp alternate_storage_message(true = _alternate_storage_enabled) do
+    "This Lightning instance has alternate storage enabled. This means that any messages that failed to persist will be stored in the location referenced by the KAFKA_ALTERNATE_STORAGE_FILE_PATH environment variable. These messages can be recovered by reprocessing them."
+  end
+
+  defp alternate_storage_message(false = _alternate_storage_enabled) do
+    "THIS LIGHTNING INSTANCE DOES NOT HAVE ALTERNATE STORAGE ENABLED, SO THESE FAILED MESSAGES CANNOT BE RECOVERED WITHOUT MAKING THEM AVAILABLE ON THE KAFKA CLUSTER AGAIN."
   end
 
   defp pluralize_with_s(1, string), do: string


### PR DESCRIPTION
### Description

Small changes to email and documentation relating to Kafka persistence failures to be more explicit about the possibility of data loss. 

Closes #2614 

### Validation steps

#### Setting up trigger (common to both sets of tests)

- Setup a local Kafka cluster based on these [instructions](https://github.com/OpenFn/lightning/blob/main/kafka_testing/KAFKA_ARCHITECTURE.md#testing-locally-using-the-docker-kafka-cluster)
- Setup an enabled Kafka trigger as follows:

![image](https://github.com/user-attachments/assets/30dc2f5e-cb73-4401-9158-e44fc657fb03)

#### Generate email without alternate storage

- Before starting up Lightning locally, ensure that `KAFKA_ALTERNATE_STORAGE_ENABLED` is set to 'no'.
- Follow the steps in the 'Simulate persistence failure' section below.
- Navigate to http://localhost:4000/dev/mailbox. The body of the email should contain warning text informing the user that alternate storage is not in place.

#### Generate email with alternate storage

- Before starting up Lightning locally, ensure that `KAFKA_ALTERNATE_STORAGE_ENABLED` is set to 'yes' and that `KAFKA_ALTERNATE_STORAGE_FILE_PATH` is pointing to an existing, writable location on disk.
- Follow the steps in the 'Simulate persistence failure' section below.
- Navigate to http://localhost:4000/dev/mailbox. The body of the email should contain text telling the user that alternate storage is enabled and where they should go to find the persisted files.

#### Simulate persistence failure

In an IEx session:

```
import Ecto.Query
alias Lightning.Repo
alias Lightning.Workflows.Trigger
alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord

TriggerKafkaMessageRecord |> Repo.delete_all()
%{id: trigger_id} = (from t in Trigger, where: t.enabled == true and t.type == :kafka, order_by: [desc: t.inserted_at]) |> Repo.one()
:persistent_term.put({:kafka_trigger_test_failure, trigger_id}, true)
```

In the terminal, add 5 messages to the cluster:

```
kafka_testing/lots_of_messages_sans_headers.sh 5
```

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
