### PR TITLE
Allow configuring of run memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 - Additional documentation and notification text relating to the importance of
   alternate storage for Kafka triggers.
   [#2614](https://github.com/OpenFn/lightning/issues/2614)
+- Add support for run memory limit option
+  [#2623](https://github.com/OpenFn/lightning/pull/2623)
 
 ### Changed
 

--- a/lib/lightning/runs/run_options.ex
+++ b/lib/lightning/runs/run_options.ex
@@ -7,23 +7,29 @@ defmodule Lightning.Runs.RunOptions do
 
   @type t :: %__MODULE__{
           save_dataclips: boolean(),
-          run_timeout_ms: integer()
+          run_timeout_ms: integer(),
+          run_memory_limit_mb: integer() | nil
         }
 
   @type keyword_list :: [
           save_dataclips: boolean(),
-          run_timeout_ms: integer()
+          run_timeout_ms: integer(),
+          run_memory_limit_mb: integer() | nil
         ]
 
   @primary_key false
   embedded_schema do
     field :save_dataclips, :boolean, default: true
     field :run_timeout_ms, :integer, default: 60_000
+    field :run_memory_limit_mb, :integer
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(value, opts) do
-      Jason.Encode.map(Map.take(value, [:save_dataclips, :run_timeout_ms]), opts)
+      value
+      |> Map.take([:save_dataclips, :run_timeout_ms, :run_memory_limit_mb])
+      |> Map.reject(fn {_key, val} -> is_nil(val) end)
+      |> Jason.Encode.map(opts)
     end
   end
 end

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -86,7 +86,9 @@ defmodule LightningWeb.RunWithOptions do
   def options_for_worker(%Lightning.Runs.RunOptions{} = options) do
     %{
       output_dataclips: options.save_dataclips,
-      run_timeout_ms: options.run_timeout_ms
+      run_timeout_ms: options.run_timeout_ms,
+      run_memory_limit_mb: options.run_memory_limit_mb
     }
+    |> Map.reject(fn {_key, val} -> is_nil(val) end)
   end
 end


### PR DESCRIPTION
### Description

This PR accepts a `run_memory_limit_mb` from the usage limiter as a `RunOption`

This option is already supported by the worker: https://github.com/OpenFn/kit/blob/591bcc8a430285f1a8bb413b57fc996678085df5/packages/lexicon/lightning.d.ts#L45

Because the option can be `nil`, this PR ignores all `nil` options before sending them to the worker.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
