### PR TITLE
Renaming fields and status

### DIFF
--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -172,7 +172,8 @@ defmodule Lightning.Collections do
     end)
   end
 
-  @spec put_all(Collection.t(), [{String.t(), String.t()}]) :: :ok | :error
+  @spec put_all(Collection.t(), [{String.t(), String.t()}]) ::
+          {:ok, non_neg_integer()} | :error
   def put_all(%{id: collection_id}, kv_list) do
     item_list =
       Enum.with_index(kv_list, fn %{"key" => key, "value" => value},

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -122,7 +122,7 @@ defmodule Lightning.Collections do
     end
   end
 
-  @spec get(Collection.t(), String.t()) :: Item.t()
+  @spec get(Collection.t(), String.t()) :: Item.t() | nil
   def get(%{id: collection_id}, key) do
     Repo.get_by(Item, collection_id: collection_id, key: key)
   end

--- a/test/lightning_web/collections_controller_test.exs
+++ b/test/lightning_web/collections_controller_test.exs
@@ -21,9 +21,6 @@ defmodule LightningWeb.API.CollectionsControllerTest do
   end
 
   describe "authenticating with a run token" do
-    # test "for a project they don't have access to"
-    # test "with a token that has expired"
-
     test "with a token that is invalid", %{conn: conn} do
       workflow = insert(:simple_workflow)
       workorder = insert(:workorder, dataclip: insert(:dataclip))
@@ -39,8 +36,11 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       token = Lightning.Workers.generate_run_token(run)
 
-      conn = conn |> assign_bearer(token)
-      conn = get(conn, ~p"/collections/#{collection.name}")
+      conn =
+        conn
+        |> assign_bearer(token)
+        |> get(~p"/collections/#{collection.name}")
+
       assert json_response(conn, 401) == %{"error" => "Unauthorized"}
     end
   end
@@ -56,13 +56,16 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       token = Lightning.Accounts.generate_api_token(user)
 
-      conn = conn |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
-      conn = get(conn, ~p"/collections/#{collection.name}")
+      conn =
+        conn
+        |> assign_bearer(token)
+        |> get(~p"/collections/#{collection.name}")
+
       assert json_response(conn, 401) == %{"error" => "Unauthorized"}
     end
   end
 
-  describe "get" do
+  describe "GET /collections/:name/:key" do
     test "returns the item", %{conn: conn} do
       user = insert(:user)
 
@@ -79,7 +82,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> get(~p"/collections/#{collection.name}/foo")
 
       item = hd(collection.items)
@@ -102,7 +105,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> get(~p"/collections/misspelled-collection/foo")
 
       assert json_response(conn, 404) == %{"error" => "Not Found"}
@@ -120,14 +123,14 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> get(~p"/collections/#{collection.name}/some-unexisting-key")
 
       assert json_response(conn, 204) == nil
     end
   end
 
-  describe "put" do
+  describe "PUT /collections/:name/:key" do
     test "inserts an item", %{conn: conn} do
       user = insert(:user)
 
@@ -144,7 +147,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> put(~p"/collections/#{collection.name}/baz", value: "qux")
 
       assert json_response(conn, 200) == %{
@@ -169,7 +172,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> put(~p"/collections/#{collection.name}/foo", %{value: "qux2"})
 
       assert json_response(conn, 200) == %{
@@ -190,14 +193,14 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> post(~p"/collections/misspelled-collection/baz", value: "qux")
 
       assert json_response(conn, 404) == %{"error" => "Not Found"}
     end
   end
 
-  describe "put_all" do
+  describe "POST /collections/:name" do
     test "upserted multiple items", %{conn: conn} do
       user = insert(:user)
 
@@ -214,7 +217,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> post(~p"/collections/#{collection.name}", %{
           items: Enum.map(1..10, &%{key: "foo#{&1}", value: "bar#{&1}"})
         })
@@ -237,7 +240,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> post(~p"/collections/misspelled-collection", %{
           items: [%{key: "baz", value: "qux"}]
         })
@@ -246,7 +249,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
     end
   end
 
-  describe "delete" do
+  describe "DELETE" do
     test "deletes an item", %{conn: conn} do
       user = insert(:user)
 
@@ -263,7 +266,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> delete(~p"/collections/#{collection.name}/foo")
 
       assert json_response(conn, 200) == %{
@@ -285,14 +288,14 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> delete(~p"/collections/misspelled-collection/foo")
 
       assert json_response(conn, 404) == %{"error" => "Not Found"}
     end
   end
 
-  describe "stream_all" do
+  describe "GET /collections/:name" do
     test "with no results", %{conn: conn} do
       user = insert(:user)
 
@@ -305,10 +308,48 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> get(~p"/collections/#{collection.name}")
 
       assert json_response(conn, 200) == %{"items" => [], "cursor" => nil}
+    end
+
+    test "using a key pattern", %{conn: conn} do
+      user = insert(:user)
+
+      project =
+        insert(:project, project_users: [%{user: user}])
+
+      collection = insert(:collection, project: project)
+
+      insert(:collection_item, collection: collection, key: "foo:bar:baz")
+      insert(:collection_item, collection: collection, key: "foo:bar:baz:quux")
+
+      token = Lightning.Accounts.generate_api_token(user)
+
+      conn =
+        conn
+        |> assign_bearer(token)
+        |> get(~p"/collections/#{collection.name}?#{%{key: "foo:bar:*"}}")
+
+      assert conn.state == :chunked
+
+      assert %{
+               "items" => [
+                 %{"key" => "foo:bar:baz", "value" => _},
+                 %{"key" => "foo:bar:baz:quux", "value" => _}
+               ],
+               "cursor" => nil
+             } = json_response(conn, 200)
+
+      conn =
+        conn
+        |> get(~p"/collections/#{collection.name}?#{%{key: "foo:*:baz"}}")
+
+      assert %{
+               "items" => [%{"key" => "foo:bar:baz", "value" => _}],
+               "cursor" => nil
+             } = json_response(conn, 200)
     end
 
     test "up exactly to the limit", %{conn: conn} do
@@ -325,7 +366,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> get(~p"/collections/#{collection.name}")
 
       assert conn.state == :chunked
@@ -355,7 +396,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
 
       conn =
         conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+        |> assign_bearer(token)
         |> get(~p"/collections/#{collection.name}?limit=10")
 
       assert conn.state == :chunked
@@ -375,109 +416,110 @@ defmodule LightningWeb.API.CollectionsControllerTest do
     end
   end
 
-  test "up to the limit and returning a cursor", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project, project_users: [%{user: user}])
-    collection = insert(:collection, project: project)
-    begin = DateTime.utc_now()
+  describe "GET /collections/:name with cursors" do
+    test "up to the limit and returning a cursor", %{conn: conn} do
+      user = insert(:user)
+      project = insert(:project, project_users: [%{user: user}])
+      collection = insert(:collection, project: project)
 
-    items =
-      Enum.map(1..(@stream_limit + 1), fn i ->
-        updated_at = DateTime.add(begin, i, :microsecond)
-        insert(:collection_item, updated_at: updated_at, collection: collection)
-      end)
+      items =
+        insert_list(@stream_limit + 1, :collection_item,
+          collection: collection,
+          updated_at: fn -> build(:timestamp, from: {-300, :microsecond}) end
+        )
 
-    token = Lightning.Accounts.generate_api_token(user)
+      token = Lightning.Accounts.generate_api_token(user)
 
-    conn =
-      conn
-      |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
-      |> get(~p"/collections/#{collection.name}")
+      conn =
+        conn
+        |> assign_bearer(token)
+        |> get(~p"/collections/#{collection.name}")
 
-    assert conn.state == :chunked
+      assert conn.state == :chunked
 
-    items = Enum.take(items, @stream_limit)
-    last_item = List.last(items)
+      items = Enum.take(items, @stream_limit)
+      last_item = List.last(items)
 
-    assert json_response(conn, 200) == %{
-             "items" =>
-               Enum.map(items, &%{"key" => &1.key, "value" => &1.value}),
-             "cursor" => Base.encode64(DateTime.to_iso8601(last_item.updated_at))
-           }
-  end
+      assert json_response(conn, 200) == %{
+               "items" =>
+                 Enum.map(items, &%{"key" => &1.key, "value" => &1.value}),
+               "cursor" =>
+                 Base.encode64(DateTime.to_iso8601(last_item.updated_at))
+             }
+    end
 
-  test "up exactly to the limit from a cursor", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project, project_users: [%{user: user}])
-    collection = insert(:collection, project: project)
-    begin = DateTime.utc_now()
+    test "up exactly to the limit from a cursor", %{conn: conn} do
+      user = insert(:user)
+      project = insert(:project, project_users: [%{user: user}])
+      collection = insert(:collection, project: project)
 
-    items =
-      Enum.map(1..100, fn i ->
-        updated_at = DateTime.add(begin, i, :microsecond)
-        insert(:collection_item, updated_at: updated_at, collection: collection)
-      end)
+      items =
+        insert_list(100, :collection_item,
+          collection: collection,
+          updated_at: fn -> build(:timestamp, from: {-300, :microsecond}) end
+        )
 
-    token = Lightning.Accounts.generate_api_token(user)
+      token = Lightning.Accounts.generate_api_token(user)
 
-    cursor =
-      items
-      |> Enum.at(@stream_limit - 1)
-      |> Map.get(:updated_at)
-      |> DateTime.to_iso8601()
-      |> Base.encode64()
+      cursor =
+        items
+        |> Enum.at(@stream_limit - 1)
+        |> Map.get(:updated_at)
+        |> DateTime.to_iso8601()
+        |> Base.encode64()
 
-    conn =
-      conn
-      |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
-      |> get(~p"/collections/#{collection.name}", cursor: cursor)
+      conn =
+        conn
+        |> assign_bearer(token)
+        |> get(~p"/collections/#{collection.name}", cursor: cursor)
 
-    assert conn.state == :chunked
+      assert conn.state == :chunked
 
-    items = Enum.drop(items, @stream_limit)
+      items = Enum.drop(items, @stream_limit)
 
-    assert json_response(conn, 200) == %{
-             "items" =>
-               Enum.map(items, &%{"key" => &1.key, "value" => &1.value}),
-             "cursor" => nil
-           }
-  end
+      assert json_response(conn, 200) == %{
+               "items" =>
+                 Enum.map(items, &%{"key" => &1.key, "value" => &1.value}),
+               "cursor" => nil
+             }
+    end
 
-  test "up to the limit from a cursor", %{conn: conn} do
-    user = insert(:user)
-    project = insert(:project, project_users: [%{user: user}])
-    collection = insert(:collection, project: project)
-    begin = DateTime.utc_now()
+    test "up to the limit from a cursor", %{conn: conn} do
+      user = insert(:user)
+      project = insert(:project, project_users: [%{user: user}])
+      collection = insert(:collection, project: project)
 
-    items =
-      Enum.map(1..101, fn i ->
-        updated_at = DateTime.add(begin, i, :microsecond)
-        insert(:collection_item, updated_at: updated_at, collection: collection)
-      end)
+      items =
+        insert_list(101, :collection_item,
+          collection: collection,
+          updated_at: fn -> build(:timestamp, from: {-300, :microsecond}) end
+        )
 
-    token = Lightning.Accounts.generate_api_token(user)
+      token = Lightning.Accounts.generate_api_token(user)
 
-    cursor =
-      items
-      |> Enum.at(@stream_limit - 1)
-      |> Map.get(:updated_at)
-      |> DateTime.to_iso8601()
-      |> Base.encode64()
+      cursor =
+        items
+        |> Enum.at(@stream_limit - 1)
+        |> Map.get(:updated_at)
+        |> DateTime.to_iso8601()
+        |> Base.encode64()
 
-    conn =
-      conn
-      |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
-      |> get(~p"/collections/#{collection.name}", cursor: cursor)
+      conn =
+        conn
+        |> assign_bearer(token)
+        |> get(~p"/collections/#{collection.name}", cursor: cursor)
 
-    assert conn.state == :chunked
+      assert conn.state == :chunked
 
-    items = items |> Enum.drop(@stream_limit) |> Enum.take(@stream_limit)
-    last_item = Enum.at(items, @stream_limit - 1)
+      items = items |> Enum.drop(@stream_limit) |> Enum.take(@stream_limit)
+      last_item = Enum.at(items, @stream_limit - 1)
 
-    assert json_response(conn, 200) == %{
-             "items" =>
-               Enum.map(items, &%{"key" => &1.key, "value" => &1.value}),
-             "cursor" => Base.encode64(DateTime.to_iso8601(last_item.updated_at))
-           }
+      assert json_response(conn, 200) == %{
+               "items" =>
+                 Enum.map(items, &%{"key" => &1.key, "value" => &1.value}),
+               "cursor" =>
+                 Base.encode64(DateTime.to_iso8601(last_item.updated_at))
+             }
+    end
   end
 end

--- a/test/lightning_web/collections_controller_test.exs
+++ b/test/lightning_web/collections_controller_test.exs
@@ -123,7 +123,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
         |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
         |> get(~p"/collections/#{collection.name}/some-unexisting-key")
 
-      assert json_response(conn, 200) == nil
+      assert json_response(conn, 204) == nil
     end
   end
 
@@ -148,7 +148,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
         |> put(~p"/collections/#{collection.name}/baz", value: "qux")
 
       assert json_response(conn, 200) == %{
-               "upserts" => 1,
+               "upserted" => 1,
                "error" => nil
              }
     end
@@ -173,7 +173,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
         |> put(~p"/collections/#{collection.name}/foo", %{value: "qux2"})
 
       assert json_response(conn, 200) == %{
-               "upserts" => 1,
+               "upserted" => 1,
                "error" => nil
              }
     end
@@ -198,7 +198,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
   end
 
   describe "put_all" do
-    test "upserts multiple items", %{conn: conn} do
+    test "upserted multiple items", %{conn: conn} do
       user = insert(:user)
 
       project =
@@ -220,7 +220,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
         })
 
       assert json_response(conn, 200) == %{
-               "upserts" => 10,
+               "upserted" => 10,
                "error" => nil
              }
     end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -360,7 +360,7 @@ defmodule Lightning.Factories do
     sequence(:timestamp, fn i ->
       DateTime.utc_now()
       |> DateTime.add(ago, scale)
-      |> DateTime.add(i * gap, :second)
+      |> DateTime.add(i * gap, scale)
     end)
   end
 


### PR DESCRIPTION
### Description

This PR does some chore on:
- Renaming `upserts` to `upserted` on PUT and POST response.
- Returning 204 for a GET on unexisting key from an existing collection
- Fix some type specs

### Validation steps

1. GET /collections/existing-col/unexisting-key
returns 204 status code
2. PUT /collections/existing-col/some-key with {"value": "some-new-value"} as a body
3. POST /collections/existing-col with {"items": [{"key": "key1", "value": "value1"}]} as a body 
returns `upserted` on the response

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
