### PR TITLE
Code assist fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,14 @@ and this project adheres to
 ### Changed
 
 - The Docs panel in the inspector will now be closed by default
+- JSDoc annotations are removed from code assist descriptions
 
 ### Fixed
 
 - Fixed an issue where code-completion prompts don't load properly in the
   inspector
+- Fixed an issue where namespaces (like http.) don't appear in code assist
+  prompts
 
 ## [v2.9.14] - 2024-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,21 @@ and this project adheres to
 ### Added
 
 - Added some basic editor usage tips to the docs panel
+  [#2629](https://github.com/OpenFn/lightning/pull/2629)
 
 ### Changed
 
 - The Docs panel in the inspector will now be closed by default
+  [#2629](https://github.com/OpenFn/lightning/pull/2629)
 - JSDoc annotations are removed from code assist descriptions
+  [#2629](https://github.com/OpenFn/lightning/pull/2629)
 
 ### Fixed
 
 - Fixed an issue where code-completion prompts don't load properly in the
-  inspector
+  inspector [#2629](https://github.com/OpenFn/lightning/pull/2629)
 - Fixed an issue where namespaces (like http.) don't appear in code assist
-  prompts
+  prompts [#2629](https://github.com/OpenFn/lightning/pull/2629)
 
 ## [v2.9.14] - 2024-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed an issue where code-completion prompts don't load properly in the
+  inspector
+
 ## [v2.9.14] - 2024-10-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to
 
 ### Added
 
+- Added some basic editor usage tips to the docs panel
+
 ### Changed
+
+- The Docs panel in the inspector will now be closed by default
 
 ### Fixed
 

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -43,6 +43,20 @@ const DocsLink = ({ specifier }: { specifier: string }) => {
   );
 };
 
+const EditorHelp = () => <details className="mb-4">
+  <summary className='text-sm cursor-pointer'>
+    <h3 className="inline">Editor tips & shortcuts</h3>
+  </summary>
+  <div className="text-sm border-solid border-grey-300 border-l-4 pl-2 mt-2">
+    <p className="mb-2">Most adaptors provide intelligent code suggestions to the editor. Start typing and press TAB or ENTER to accept a suggestion, or ESC to cancel</p>
+    <ul className="list-disc ml-4">
+      <li>Press CTRL+SPACE to show suggestions</li>
+      <li>Press CTRL+SPACE again to toggle suggestion details (recommended!)</li>
+      <li>Press F1 to show the command menu (not all commands will work!)</li>
+    </ul>
+  </div>
+</details>
+
 const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   if (!specifier) {
     return <div>Nothing selected</div>;
@@ -86,6 +100,8 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
         </span>
       </h1>
       <DocsLink specifier={specifier} />
+      <EditorHelp />
+      <h3>Adaptor API</h3>
       <div className="text-sm mb-4">
         These are the operations available for this adaptor:
       </div>

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -134,6 +134,12 @@ async function loadDTS(
     if (!filePath.startsWith('node_modules')) {
       let content = await fetchFile(`${specifier}${filePath}`);
 
+      // Remove js doc annotations
+      // this regex assumes that all jsdoc annotations are together in a single block
+      // which is probably fair?
+      // this regex means: find a * then an @ (with 1+ space in between), then match everything up to a closing comment */
+      content = content.replace(/\* +@(.+?)\*\//sg, '*/')
+
       // this is a bit cheeky
       // we'll manually build namespaces from the file structure
       // I don't understand why index.d.ts doesn't just do this though.

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -77,13 +77,15 @@ const defaultOptions: MonacoProps['options'] = {
   fontLigatures: true,
 
   suggest: {
+    // https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.ISuggestOptions.html
+    showModules: true,
     showKeywords: false,
-    showModules: false, // hides global this
     showFiles: false, // This hides property names ??
     // showProperties: false, // seems to hide consts but show properties??
     showClasses: false,
     showInterfaces: false,
     showConstructors: false,
+    showDeprecated: false,
   },
 };
 

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -48,7 +48,7 @@ const spinner = (
 
 const loadingIndicator = (
   <div className="inline-block p-2">
-    <span className="mr-2">Loading</span>
+    <span className="mr-2">Loading types</span>
     {spinner}
   </div>
 );
@@ -169,7 +169,7 @@ export default function Editor({
     updateLayout?: any;
   }>({});
 
-  const monacoRef = useRef<any>(null);
+  const [monaco, setMonaco] = useState<Monaco>();
 
   const handleSourceChange = useCallback(
     (newSource: string | undefined) => {
@@ -181,7 +181,7 @@ export default function Editor({
   );
 
   const handleEditorDidMount = useCallback((editor: any, monaco: Monaco) => {
-    monacoRef.current = monaco;
+    setMonaco(monaco);
 
     editor.addCommand(
       monaco.KeyCode.Escape,
@@ -250,10 +250,9 @@ export default function Editor({
       'insert-snippet',
       listeners.current.insertSnippet
     );
-  }, []);
+  }, [lib]);
 
   useEffect(() => {
-    let monaco = monacoRef.current;
     if (monaco && metadata) {
       const p = monaco.languages.registerCompletionItemProvider(
         'javascript',
@@ -267,7 +266,7 @@ export default function Editor({
         p.dispose();
       };
     }
-  }, [monacoRef, metadata]);
+  }, [monaco, metadata]);
 
   useEffect(() => {
     // Create a node to hold overflow widgets
@@ -305,10 +304,10 @@ export default function Editor({
   }, [adaptor]);
 
   useEffect(() => {
-    monacoRef.current?.languages.typescript.javascriptDefaults.setExtraLibs(
-      lib
+    monaco?.languages.typescript.javascriptDefaults.setExtraLibs(
+      lib!
     );
-  }, [monacoRef, lib]);
+  }, [monaco, lib]);
 
   return (
     <>

--- a/assets/js/job-editor/JobEditor.tsx
+++ b/assets/js/job-editor/JobEditor.tsx
@@ -25,7 +25,7 @@ const settings = persistedSettings
   ? JSON.parse(persistedSettings)
   : {
       [SettingsKeys.ORIENTATION]: 'h',
-      [SettingsKeys.SHOW_PANEL]: true,
+      [SettingsKeys.SHOW_PANEL]: false,
     };
 
 const persistSettings = () =>

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -63,13 +63,9 @@ export default {
   mounted(this: JobEditorEntrypoint) {
     window.jobEditor = this;
 
-    console.group('JobEditor');
-    console.debug('Mounted');
     this._debouncedPushChange = pDebounce(this.pushChange, EDITOR_DEBOUNCE_MS);
 
     import('./JobEditor').then(module => {
-      console.group('JobEditor');
-      console.debug('loaded module');
       JobEditorComponent = module.default as typeof JobEditor;
       this.componentRoot = createRoot(this.el);
 
@@ -82,10 +78,7 @@ export default {
       this.setupObserver();
       this.render();
       this.requestMetadata().then(() => this.render());
-      console.groupEnd();
     });
-
-    console.groupEnd();
   },
   handleContentChange(content: string) {
     this._debouncedPushChange(content);


### PR DESCRIPTION
### Description

This PR makes a bunch of fixes and improvements to code assist:

1. Fix an issue where if the typings load before monaco is ready (which can happen if typings are cached), the typings won't be displayed
1. Remove JSDoc attributes from the docs shown in code assist
1. expose namespaces like `http.`
1. Make the docs panel closed by default for new users (otherwise the inspector  is super overwhelming)
1. Add a little bit of editor help in the docs panel (this is a bit crude but also I think super helpful)

![image](https://github.com/user-attachments/assets/526e98d5-4d83-4cd8-b9a7-16cfdb91f640)


### QA Notes

1. Load up the inspector on a job using the common adaptor
1. hit ctrl + space to open the code assist prompt
1. You should see a list of adaptor functions from common (plus some junk)
1.... Including the `http` namespace
1. Press ctrl + space again to open the details window
1. The details window should contain longer documentation - but NO JSdoc attributes

In production, the code complete menu is likely to inconsistent. For me right now on common, I just see `undefined` in the suggestions list. That should be fixed.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
