### PR TITLE
Fix Projects Table Sorting Directions Icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix sorting directions icons in projects table in the project dashboard page
+  [#2631](https://github.com/OpenFn/lightning/pull/2631)
 - Fixed an issue where code-completion prompts don't load properly in the
   inspector [#2629](https://github.com/OpenFn/lightning/pull/2629)
 - Fixed an issue where namespaces (like http.) don't appear in code assist

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -123,7 +123,7 @@ defmodule LightningWeb.DashboardLive.Components do
   end
 
   def user_projects_table(assigns) do
-    next_sort_icon = %{asc: "hero-chevron-down", desc: "hero-chevron-up"}
+    next_sort_icon = %{asc: "hero-chevron-up", desc: "hero-chevron-down"}
 
     assigns =
       assign(assigns,
@@ -210,7 +210,7 @@ defmodule LightningWeb.DashboardLive.Components do
             <%= if project.last_activity do %>
               <%= Lightning.Helpers.format_date(
                 project.last_activity,
-                "%d/%b/%Y %H:%M:%S"
+                "%d/%m/%Y %H:%M:%S"
               ) %>
             <% else %>
               No activity

--- a/test/lightning_web/live/dashboard_live_test.exs
+++ b/test/lightning_web/live/dashboard_live_test.exs
@@ -344,7 +344,7 @@ defmodule LightningWeb.DashboardLiveTest do
            )
 
     formatted_date =
-      Lightning.Helpers.format_date(max_updated_at, "%d/%b/%Y %H:%M:%S")
+      Lightning.Helpers.format_date(max_updated_at, "%d/%m/%Y %H:%M:%S")
 
     assert has_element?(
              view,
@@ -374,7 +374,7 @@ defmodule LightningWeb.DashboardLiveTest do
         |> Enum.max(fn -> nil end)
 
       if last_activity do
-        Lightning.Helpers.format_date(last_activity, "%d/%b/%Y %H:%M:%S")
+        Lightning.Helpers.format_date(last_activity, "%d/%m/%Y %H:%M:%S")
       else
         "No activity"
       end


### PR DESCRIPTION
### Description

This PR fixes the sorting directions icons in the projects table. The icons now represent the current sorting direction.

### Validation steps

1. Go to the projects dashboard page
2. Sort by name or by last activity
3. Notice that the sorting direction icon is up when the elements are sorted in ascending order and down when they are sorted in descending order

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
