### PR TITLE
Better UX for project deletion modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   [#2629](https://github.com/OpenFn/lightning/pull/2629)
 - JSDoc annotations are removed from code assist descriptions
   [#2629](https://github.com/OpenFn/lightning/pull/2629)
+- Show project name during delete confirmation
+  [#2634](https://github.com/OpenFn/lightning/pull/2634)
 
 ### Fixed
 

--- a/lib/lightning_web/live/components/project_deletion_modal.ex
+++ b/lib/lightning_web/live/components/project_deletion_modal.ex
@@ -97,19 +97,19 @@ defmodule LightningWeb.Components.ProjectDeletionModal do
     <div id={"project-#{@id}"}>
       <PetalComponents.Modal.modal
         max_width="sm"
-        title="Delete project"
+        title={"Delete #{@project.name}"}
         close_modal_target={@myself}
       >
         <.p>
-          Enter the project name to confirm it's deletion
+          Deleting this project will disable access
+          for all users, and disable all jobs in the project. The whole project will be deleted
+          along with all workflows and work order history, <%= human_readable_grace_period() %>.
         </.p>
         <div class="hidden sm:block" aria-hidden="true">
           <div class="py-2"></div>
         </div>
         <.p>
-          Deleting this project will disable access
-          for all users, and disable all jobs in the project. The whole project will be deleted
-          along with all workflows and work order history, <%= human_readable_grace_period() %>.
+          Enter the project name to confirm deletion: <b><%= @project.name %></b>
         </.p>
         <div class="hidden sm:block" aria-hidden="true">
           <div class="py-2"></div>

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -177,7 +177,7 @@ defmodule LightningWeb.ProjectLiveTest do
       {:ok, delete_project_modal, html} =
         live(conn, ~p"/projects/#{project.id}/settings/delete")
 
-      assert html =~ "Enter the project name to confirm it&#39;s deletion"
+      assert html =~ "Enter the project name to confirm deletion"
 
       {:ok, _delete_project_modal, html} =
         delete_project_modal
@@ -258,7 +258,7 @@ defmodule LightningWeb.ProjectLiveTest do
                project: %{name_confirmation: "invalid name"}
              )
              |> render_change() =~
-               "Enter the project name to confirm it&#39;s deletion"
+               "Enter the project name to confirm deletion"
 
       {:ok, _index_live, html} =
         form_live


### PR DESCRIPTION
### Description

Before, we hid the project name while asking users to confirm deletion. This PR shows the project name so that users don't need to exit the modal, note the name, and open the modal again.

### Old - cannot see which project I'm about to delete!
<img width="695" alt="image" src="https://github.com/user-attachments/assets/455a2235-06eb-41a3-9a51-82a4bf401b60">

### New - **_can_** see which project I'm about to delete:
<img width="1085" alt="image" src="https://github.com/user-attachments/assets/55e62458-90a7-4ad6-840c-0ee1471d75aa">

### Validation steps

1. *(How can a reviewer validate your work?)*

### Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
