### PR TITLE
Collections remaining pieces

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -144,7 +144,7 @@ config :lightning, :default_retention_period, nil
 
 config :lightning, Lightning.Runtime.RuntimeManager, start: false
 
-config :lightning, Lightning.CollectionsController, stream_limit: 1_000
+config :lightning, LightningWeb.CollectionsController, stream_limit: 1_000
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/test.exs
+++ b/config/test.exs
@@ -162,4 +162,4 @@ config :lightning, :github_app,
   -----END RSA PRIVATE KEY-----
   """
 
-config :lightning, Lightning.CollectionsController, stream_limit: 50
+config :lightning, LightningWeb.CollectionsController, stream_limit: 50

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -208,8 +208,7 @@ defmodule Lightning.Collections do
     end
   end
 
-  @spec delete_all(Collection.t(), String.t()) ::
-          {:ok, non_neg_integer()} | {:error, :not_found}
+  @spec delete_all(Collection.t(), String.t() | nil) :: {:ok, non_neg_integer()}
   def delete_all(%{id: collection_id}, key_pattern \\ nil) do
     query =
       from(i in Item, where: i.collection_id == ^collection_id)
@@ -220,10 +219,7 @@ defmodule Lightning.Collections do
         end
       end)
 
-    case Repo.delete_all(query) do
-      {0, nil} -> {:error, :not_found}
-      {n, nil} -> {:ok, n}
-    end
+    with {count, _nil} <- Repo.delete_all(query), do: {:ok, count}
   end
 
   defp stream_query(collection_id, cursor, limit) do

--- a/lib/lightning/collections/item.ex
+++ b/lib/lightning/collections/item.ex
@@ -37,7 +37,9 @@ defmodule Lightning.Collections.Item do
       Jason.Encode.map(
         %{
           key: item.key,
-          value: item.value
+          value: item.value,
+          created: item.inserted_at,
+          updated: item.updated_at
         },
         opts
       )

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -118,10 +118,24 @@ defmodule LightningWeb.CollectionsController do
          :ok <- authorize(conn, collection) do
       case Collections.delete(collection, key) do
         :ok ->
-          json(conn, %{keys: [key], deleted: 1, error: nil})
+          json(conn, %{key: key, deleted: 1, error: nil})
 
         {:error, :not_found} ->
-          json(conn, %{keys: [key], deleted: 0, error: "Item Not Found"})
+          json(conn, %{key: key, deleted: 0, error: "Item Not Found"})
+      end
+    end
+  end
+
+  def delete_all(conn, %{"name" => col_name} = params) do
+    with {:ok, collection} <- Collections.get_collection(col_name),
+         :ok <- authorize(conn, collection) do
+      key_param = params["key"]
+      case Collections.delete_all(collection, key_param) do
+        {:ok, n} ->
+          json(conn, %{key: key_param, deleted: n, error: nil})
+
+        {:error, :not_found} ->
+          json(conn, %{key: key_param, deleted: 0, error: "Items Not Found"})
       end
     end
   end

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -9,13 +9,17 @@ defmodule LightningWeb.CollectionsController do
 
   @max_chunk_size 50
 
-  @stream_limit Application.compile_env!(
-                  :lightning,
-                  Lightning.CollectionsController
-                )[
-                  :stream_limit
-                ]
-  @cursor_count @stream_limit + 1
+  @default_limit Application.compile_env!(:lightning, __MODULE__)[:stream_limit]
+
+  @valid_params [
+    "key",
+    "cursor",
+    "limit",
+    "created_after",
+    "created_before"
+  ]
+
+  require Logger
 
   # TODO: move this into a plug or router pipeline
   # the logic _is_ different to what UserAuth does
@@ -142,15 +146,13 @@ defmodule LightningWeb.CollectionsController do
   end
 
   def stream(conn, %{"name" => col_name, "key" => key_pattern}) do
-    with {:ok, collection, filters} <- validate_query(conn, col_name),
-         conn <- begin_chunking(conn) do
+    with {:ok, collection, filters, response_limit} <-
+           validate_query(conn, col_name) do
       case Repo.transact(fn ->
-             collection
-             |> Collections.stream_match(key_pattern, filters)
-             |> Stream.chunk_every(@max_chunk_size)
-             |> Stream.with_index()
-             |> Enum.reduce_while(start_items_chunking(conn), &send_chunk/2)
-             |> finish_chunking()
+             items_stream =
+               Collections.stream_match(collection, key_pattern, filters)
+
+             stream_chunked(conn, items_stream, response_limit)
            end) do
         {:error, conn} -> conn
         {:ok, conn} -> conn
@@ -159,15 +161,12 @@ defmodule LightningWeb.CollectionsController do
   end
 
   def stream(conn, %{"name" => col_name}) do
-    with {:ok, collection, filters} <- validate_query(conn, col_name),
-         conn <- begin_chunking(conn) do
+    with {:ok, collection, filters, response_limit} <-
+           validate_query(conn, col_name) do
       case Repo.transact(fn ->
-             collection
-             |> Collections.stream_all(filters)
-             |> Stream.chunk_every(@max_chunk_size)
-             |> Stream.with_index()
-             |> Enum.reduce_while(start_items_chunking(conn), &send_chunk/2)
-             |> finish_chunking()
+             items_stream = Collections.stream_all(collection, filters)
+
+             stream_chunked(conn, items_stream, response_limit)
            end) do
         {:error, conn} -> conn
         {:ok, conn} -> conn
@@ -175,15 +174,43 @@ defmodule LightningWeb.CollectionsController do
     end
   end
 
-  @valid_params [
-    "key",
-    "cursor",
-    "limit",
-    "created_after",
-    "created_before",
-    "updated_after",
-    "updated_before"
-  ]
+  defmodule ChunkAcc do
+    defstruct conn: nil,
+              count: 0,
+              limit: 0,
+              last: nil,
+              cursor_data: nil
+  end
+
+  defp stream_chunked(conn, items_stream, response_limit) do
+    with %{halted: false} = conn <- begin_chunking(conn) do
+      items_stream
+      |> Stream.chunk_every(@max_chunk_size)
+      |> Stream.with_index()
+      |> Enum.reduce_while(
+        %ChunkAcc{conn: conn, limit: response_limit},
+        &send_chunk/2
+      )
+      |> finish_chunking()
+    end
+  end
+
+  defp validate_query(conn, col_name) do
+    with {:ok, collection} <- Collections.get_collection(col_name),
+         :ok <- authorize(conn, collection),
+         query_params <-
+           Enum.into(conn.query_params, %{
+             "cursor" => nil,
+             "limit" => "#{@default_limit}"
+           }),
+         {:ok, filters} <- validate_query_params(query_params) do
+      # returns one more from db than the limit to determine if there are more items for the cursor
+      db_query_filters = Map.update(filters, :limit, @default_limit, &(&1 + 1))
+      response_limit = Map.fetch!(filters, :limit)
+
+      {:ok, collection, db_query_filters, response_limit}
+    end
+  end
 
   defp validate_query_params(
          %{"cursor" => cursor, "limit" => limit} = query_params
@@ -206,23 +233,12 @@ defmodule LightningWeb.CollectionsController do
     end
   end
 
-  defp validate_cursor(%{"cursor" => cursor}) do
+  defp validate_cursor(nil), do: {:ok, nil}
+
+  defp validate_cursor(cursor) do
     with {:ok, decoded} <- Base.decode64(cursor),
          {:ok, datetime, _off} <- DateTime.from_iso8601(decoded) do
       {:ok, datetime}
-    end
-  end
-
-  defp validate_query(conn, col_name) do
-    with {:ok, collection} <- Collections.get_collection(col_name),
-         :ok <- authorize(conn, collection),
-         query_params <-
-           Enum.into(
-             %{"cursor" => nil, "limit" => "#{@stream_limit + 1}"},
-             conn.query_params
-           ),
-         {:ok, filters} <- validate_query_params(query_params) do
-      {:ok, collection, filters}
     end
   end
 
@@ -230,59 +246,88 @@ defmodule LightningWeb.CollectionsController do
     conn
     |> put_resp_content_type("application/json")
     |> send_chunked(200)
+    |> Plug.Conn.chunk(~S({"items": [))
+    |> case do
+      {:ok, conn} ->
+        conn
+
+      {:error, reason} ->
+        Logger.warning("Error starting chunking: #{inspect(reason)}")
+        halt(conn)
+    end
   end
 
-  defp start_items_chunking(conn) do
-    with {:ok, conn} <- Plug.Conn.chunk(conn, ~S({"items": [)),
-         do: {conn, {%{inserted_at: nil}, 0}}
-  end
-
-  defp finish_chunking({conn, {%{inserted_at: last_inserted_at}, count}}) do
+  defp finish_chunking(%ChunkAcc{conn: conn, cursor_data: cursor_data}) do
     cursor =
-      if count > @stream_limit do
-        last_inserted_at |> DateTime.to_iso8601() |> Base.encode64()
+      if cursor_data do
+        cursor_data |> DateTime.to_iso8601() |> Base.encode64()
       end
 
     Plug.Conn.chunk(conn, ~S(], "cursor":) <> Jason.encode!(cursor) <> "}")
   end
 
-  defp finish_chunking({:error, conn}), do: {:error, conn}
+  defp finish_chunking({:error, conn}), do: conn
 
-  defp send_chunk(_chunk_items, {:error, conn}) do
-    {:halt, {:error, conn}}
-  end
+  defp send_chunk({chunk_items, 0}, acc) do
+    {taken_items, acc} = take_and_accumulate(chunk_items, acc)
 
-  defp send_chunk({chunk_items, 0}, {conn, {_last, _count}}) do
-    last = List.last(chunk_items)
-
-    chunk_items
+    taken_items
     |> Enum.map_join(",", &Jason.encode!/1)
-    |> send_chunk_and_iterate(last, length(chunk_items), conn)
+    |> send_chunk_and_iterate(acc)
   end
 
-  defp send_chunk({[_item | _chunk_items], _i}, {conn, {last, @stream_limit}}) do
-    {:halt, {conn, {last, @cursor_count}}}
+  defp send_chunk(
+         {_chunk_items, _i},
+         %ChunkAcc{count: sent_count, last: last, limit: limit} = acc
+       )
+       when sent_count == limit do
+    {:halt, %ChunkAcc{acc | cursor_data: last.inserted_at}}
   end
 
-  defp send_chunk({chunk_items, _i}, {conn, {_last, count}}) do
-    taken_items = Enum.take(chunk_items, @stream_limit - count)
-    last = List.last(taken_items)
+  defp send_chunk({chunk_items, _i}, acc) do
+    {taken_items, acc} = take_and_accumulate(chunk_items, acc)
 
     taken_items
     |> Enum.map_join(",", &Jason.encode!/1)
     |> then(fn items_chunk ->
       "," <> items_chunk
     end)
-    |> send_chunk_and_iterate(last, length(chunk_items) + count, conn)
+    |> send_chunk_and_iterate(acc)
   end
 
-  defp send_chunk_and_iterate(chunk, last, count, conn) do
+  defp take_and_accumulate(
+         chunk_items,
+         %ChunkAcc{count: sent_count, limit: limit} = acc
+       ) do
+    taken_items = Enum.take(chunk_items, limit - sent_count)
+    last = List.last(taken_items)
+    taken_count = length(taken_items)
+
+    cursor_data =
+      if taken_count > 0 and length(chunk_items) > taken_count do
+        last.inserted_at
+      end
+
+    acc =
+      struct(acc, %{
+        count: sent_count + taken_count,
+        last: last,
+        cursor_data: cursor_data
+      })
+
+    {taken_items, acc}
+  end
+
+  defp send_chunk_and_iterate(
+         chunk,
+         %ChunkAcc{conn: conn, cursor_data: cursor_data} = acc
+       ) do
     case Plug.Conn.chunk(conn, chunk) do
       {:ok, conn} ->
-        if count > @stream_limit do
-          {:halt, {conn, {last, @cursor_count}}}
+        if cursor_data do
+          {:halt, %{acc | conn: conn}}
         else
-          {:cont, {conn, {last, count}}}
+          {:cont, %{acc | conn: conn}}
         end
 
       {:error, :closed} ->

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -94,13 +94,9 @@ defmodule LightningWeb.CollectionsController do
          :ok <- authorize(conn, collection) do
       key_param = params["key"]
 
-      case Collections.delete_all(collection, key_param) do
-        {:ok, n} ->
-          json(conn, %{key: key_param, deleted: n, error: nil})
+      {:ok, n} = Collections.delete_all(collection, key_param)
 
-        {:error, :not_found} ->
-          json(conn, %{key: key_param, deleted: 0, error: "Items Not Found"})
-      end
+      json(conn, %{key: key_param, deleted: n, error: nil})
     end
   end
 

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -7,6 +7,8 @@ defmodule LightningWeb.CollectionsController do
 
   action_fallback LightningWeb.FallbackController
 
+  require Logger
+
   @max_chunk_size 50
 
   @default_limit Application.compile_env!(:lightning, __MODULE__)[:stream_limit]
@@ -18,8 +20,6 @@ defmodule LightningWeb.CollectionsController do
     "created_after",
     "created_before"
   ]
-
-  require Logger
 
   defp authorize(conn, collection) do
     Permissions.can(

--- a/lib/lightning_web/controllers/fallback_controller.ex
+++ b/lib/lightning_web/controllers/fallback_controller.ex
@@ -14,6 +14,13 @@ defmodule LightningWeb.FallbackController do
     |> render(:"404")
   end
 
+  def call(conn, {:error, :bad_request}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(LightningWeb.ErrorView)
+    |> render(:"400")
+  end
+
   def call(conn, {:error, :unauthorized}) do
     conn
     |> put_status(:unauthorized)

--- a/lib/lightning_web/plugs/api_auth.ex
+++ b/lib/lightning_web/plugs/api_auth.ex
@@ -1,0 +1,48 @@
+defmodule LightningWeb.Plugs.ApiAuth do
+  @moduledoc """
+  Authenticates api calls based on JWT bearer token.
+  """
+  use Phoenix.Controller
+  import Plug.Conn
+
+  def init(opts) do
+    opts
+  end
+
+  def call(conn, _opts) do
+    with {:ok, bearer_token} <- get_bearer_token(conn),
+         {:ok, claims} <- Lightning.Tokens.verify(bearer_token) do
+      conn
+      |> assign(:claims, claims)
+      |> put_subject()
+    else
+      {:error, _reason} ->
+        deny_access(conn)
+    end
+  end
+
+  defp get_bearer_token(conn) do
+    conn
+    |> get_req_header("authorization")
+    |> case do
+      ["Bearer " <> bearer] -> {:ok, bearer}
+      _none_or_many -> {:error, :token_not_found}
+    end
+  end
+
+  defp put_subject(conn) do
+    conn.assigns.claims
+    |> Lightning.Tokens.get_subject()
+    |> then(fn subject ->
+      conn |> assign(:subject, subject)
+    end)
+  end
+
+  defp deny_access(conn) do
+    conn
+    |> put_status(:unauthorized)
+    |> put_view(LightningWeb.ErrorView)
+    |> render(:"401")
+    |> halt()
+  end
+end

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -42,6 +42,11 @@ defmodule LightningWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :authenticated_api do
+    plug :accepts, ["json"]
+    plug LightningWeb.Plugs.ApiAuth
+  end
+
   scope "/", LightningWeb do
     pipe_through [:browser]
 
@@ -86,7 +91,7 @@ defmodule LightningWeb.Router do
 
   ## Collections
   scope "/collections", LightningWeb do
-    pipe_through [:api]
+    pipe_through [:authenticated_api]
 
     get "/:name", CollectionsController, :stream
     get "/:name/:key", CollectionsController, :get

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -93,6 +93,7 @@ defmodule LightningWeb.Router do
     put "/:name/:key", CollectionsController, :put
     post "/:name", CollectionsController, :put_all
     delete "/:name/:key", CollectionsController, :delete
+    delete "/:name", CollectionsController, :delete_all
   end
 
   ## Authentication routes

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -232,7 +232,7 @@ defmodule Lightning.CollectionsTest do
           )
         end)
 
-      %{updated_at: cursor} = Enum.at(items, 9)
+      %{inserted_at: cursor} = Enum.at(items, 9)
 
       insert(:collection_item, key: "rkeyB", collection: collection)
 

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -476,6 +476,46 @@ defmodule Lightning.CollectionsTest do
     end
   end
 
+  describe "delete_all/2" do
+    test "deletes all items of the given collection" do
+      collection = insert(:collection)
+
+      items = insert_list(3, :collection_item, collection: collection)
+
+      assert {:ok, 3} = Collections.delete_all(collection)
+
+      refute Enum.any?(items, &Collections.get(collection, &1.key))
+    end
+
+    test "deletes matching items of the given collection" do
+      collection = insert(:collection)
+
+      item1 = insert(:collection_item, collection: collection, key: "foo:123:bar1")
+      item2 = insert(:collection_item, collection: collection, key: "foo:234:bar2")
+      item3 = insert(:collection_item, collection: collection, key: "foo:345:bar3")
+      item4 = insert(:collection_item, collection: collection, key: "foo:456:zanzibar")
+
+      assert {:ok, 3} = Collections.delete_all(collection, "foo:*:bar*")
+
+      refute Collections.get(collection, item1.key)
+      refute Collections.get(collection, item2.key)
+      refute Collections.get(collection, item3.key)
+      assert Collections.get(collection, item4.key)
+    end
+
+    test "returns an :error if the collection does not exist" do
+      assert {:error, :not_found} =
+               Collections.delete(%{id: Ecto.UUID.generate()}, "key")
+    end
+
+    test "returns an :error if item does not exist" do
+      collection = insert(:collection)
+
+      assert {:error, :not_found} =
+               Collections.delete(collection, "nonexistent")
+    end
+  end
+
   describe "list_collections/1" do
     test "returns a list of collections with default ordering and preloading" do
       collection1 = insert(:collection, name: "B Collection")

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -329,7 +329,12 @@ defmodule Lightning.Factories do
     %Lightning.Collections.Item{
       collection: build(:collection),
       key: sequence(:key, &"key-#{&1}"),
-      value: sequence(:value, &"value-#{&1}")
+      value: sequence(:value, &"value-#{&1}"),
+      inserted_at:
+        sequence(
+          :inserted_at,
+          &DateTime.add(DateTime.utc_now(), &1, :microsecond)
+        )
     }
   end
 


### PR DESCRIPTION
### Description

This PR adds:
- `:delete_all` route to delete all collection items or to delete matching keys
- `created_after` and `created_before` filters for `:stream_all` and `:stream_match` routes
-  `limit` query parameter applicable also `:stream_all` and `:stream_match` routes
-  an API authentication Plug with the generic part of the JWT verification

Additionally it fixes the query and tests related to the cursor based on `inserted_at` once all streamed items are sorted by this field.
 
### Validation steps

0. `curl --X POST -H "authorization: Bearer ${token}" -H "content-type: application/json" localhost:4000/collections/openhie -d '{"items": [{"key": "key06Nov1", "value": "value1"}, {"key": "key06Nov2", "value": "value2"}]}'
1. `curl -H "authorization: Bearer ${token}" localhost:4000/collections/openhie/key06Nov1` get the created timestamp and use to test stream all and stream match queries with `created_before` and/or `created_after`

### Additional notes for the reviewer

- The reduce to send HTTP chunks was refactored to make it clear the structure of the accumulator (acc) that includes now the custom limit and the `cursor_data` to avoid relying on cursor_count concept.
- begin and finish chunking are now symetrical
- Now that a custom limit will be accepted, ideally the code to create a stream resource should be used to avoid holding the database transaction for too long (after this the database streaming won't be needed anymore) 
    
## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
