### PR TITLE
2601 allow non user audit actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+- Make provision for non-User actors when creating Audit entries.
+  [#2601](https://github.com/OpenFn/lightning/issues/2601)
 
 - Audit history exports events
   [#2367](https://github.com/OpenFn/lightning/issues/2367)
@@ -65,8 +67,6 @@ and this project adheres to
   [#2648](https://github.com/OpenFn/lightning/issues/2648)
 - Change column name for "Last Activity" to "Last Modified" on Projects list
   [#2593](https://github.com/OpenFn/lightning/issues/2593)
-- Make provision for non-User actors when creating Audit entries.
-  [#2601](https://github.com/OpenFn/lightning/issues/2601)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+
 - Make provision for non-User actors when creating Audit entries.
   [#2601](https://github.com/OpenFn/lightning/issues/2601)
-
 - Audit history exports events
-  [#2367](https://github.com/OpenFn/lightning/issues/2367)
+  [#2637](https://github.com/OpenFn/lightning/issues/2637)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to
   [#2648](https://github.com/OpenFn/lightning/issues/2648)
 - Change column name for "Last Activity" to "Last Modified" on Projects list
   [#2593](https://github.com/OpenFn/lightning/issues/2593)
+- Make provision for non-User actors when creating Audit entries.
+  [#2601](https://github.com/OpenFn/lightning/issues/2601)
 
 ### Fixed
 

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -12,7 +12,16 @@ defmodule Lightning.Auditing do
     from(a in Audit,
       left_join: u in User,
       on: [id: a.actor_id],
-      select_merge: %{actor: u},
+      select_merge: %{
+        actor_display_identifier: u.email,
+        actor_display_label:
+          fragment(
+            "CASE WHEN ? IS NOT NULL THEN CONCAT(?, ' ', ?) ELSE '(User deleted)' END",
+            u.id,
+            u.first_name,
+            u.last_name
+          )
+      },
       order_by: [desc: a.inserted_at]
     )
     |> Repo.paginate(params)

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -24,74 +24,51 @@ defmodule Lightning.Auditing do
     )
     |> Repo.paginate(params)
     |> then(fn %{entries: entries} = result ->
-      Map.put(result, :entries, Enum.map(entries, &extended_audit/1))
+      Map.put(result, :entries, Enum.map(entries, &assign_actor_display/1))
     end)
   end
 
-  defp extended_audit(%{
-         audit: %{actor_type: :project_repo_connection} = audit,
-         project_repo_connection: actor
-       }) do
-    merge(audit, actor, :project_repo_connection)
+  defp assign_actor_display(%{audit: %{actor_type: actor_type} = audit} = entry) do
+    %{audit | actor_display: actor_display_for(entry[actor_type], actor_type)}
   end
 
-  defp extended_audit(%{
-         audit: %{actor_type: :trigger} = audit,
-         trigger: actor
-       }) do
-    merge(audit, actor, :trigger)
-  end
+  defp actor_display_for(actor, actor_type) do
+    case {actor, actor_type} do
+      {nil, :project_repo_connection} ->
+        %{
+          identifier: nil,
+          label: "(Project Repo Connection Deleted)"
+        }
 
-  defp extended_audit(%{
-         audit: %{actor_type: :user} = audit,
-         user: actor
-       }) do
-    merge(audit, actor, :user)
-  end
+      {%ProjectRepoConnection{}, :project_repo_connection} ->
+        %{
+          identifier: nil,
+          label: "GitHub"
+        }
 
-  defp actor_display_for(nil, :project_repo_connection) do
-    %{
-      identifier: nil,
-      label: "(Project Repo Connection Deleted)"
-    }
-  end
+      {nil, :trigger} ->
+        %{
+          identifier: nil,
+          label: "(Trigger Deleted)"
+        }
 
-  defp actor_display_for(%ProjectRepoConnection{}, :project_repo_connection) do
-    %{
-      identifier: nil,
-      label: "GitHub"
-    }
-  end
+      {%Trigger{type: type}, :trigger} ->
+        %{
+          identifier: nil,
+          label: Atom.to_string(type) |> String.capitalize()
+        }
 
-  defp actor_display_for(nil, :trigger) do
-    %{
-      identifier: nil,
-      label: "(Trigger Deleted)"
-    }
-  end
+      {nil, :user} ->
+        %{
+          identifier: nil,
+          label: "(User deleted)"
+        }
 
-  defp actor_display_for(%Trigger{type: type}, :trigger) do
-    %{
-      identifier: nil,
-      label: Atom.to_string(type) |> String.capitalize()
-    }
-  end
-
-  defp actor_display_for(nil, :user) do
-    %{
-      identifier: nil,
-      label: "(User deleted)"
-    }
-  end
-
-  defp actor_display_for(%User{} = actor, :user) do
-    %{
-      identifier: actor.email,
-      label: "#{actor.first_name} #{actor.last_name}"
-    }
-  end
-
-  defp merge(audit, actor, actor_type) do
-    %{audit | actor_display: actor_display_for(actor, actor_type)}
+      {%User{} = actor, :user} ->
+        %{
+          identifier: actor.email,
+          label: "#{actor.first_name} #{actor.last_name}"
+        }
+    end
   end
 end

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -4,26 +4,83 @@ defmodule Lightning.Auditing do
   """
 
   import Ecto.Query
+
   alias Lightning.Accounts.User
   alias Lightning.Auditing.Audit
   alias Lightning.Repo
+  alias Lightning.VersionControl.ProjectRepoConnection
+  alias Lightning.Workflows.Trigger
 
   def list_all(params \\ %{}) do
     from(a in Audit,
+      left_join: p in ProjectRepoConnection,
+      on: p.id == a.actor_id and a.actor_type == :project_repo_connection,
+      left_join: t in Trigger,
+      on: t.id == a.actor_id and a.actor_type == :trigger,
       left_join: u in User,
-      on: [id: a.actor_id],
+      on: u.id == a.actor_id and a.actor_type == :user,
       select_merge: %{
-        actor_display_identifier: u.email,
-        actor_display_label:
-          fragment(
-            "CASE WHEN ? IS NOT NULL THEN CONCAT(?, ' ', ?) ELSE '(User deleted)' END",
-            u.id,
-            u.first_name,
-            u.last_name
-          )
+        project_repo_connection: p,
+        trigger: t,
+        user: u
       },
       order_by: [desc: a.inserted_at]
     )
     |> Repo.paginate(params)
+    |> then(fn %{entries: entries} = result ->
+      Map.put(
+        result,
+        :entries,
+        Enum.map(entries, &Map.put(&1, :actor_display, actor_display_for(&1)))
+      )
+    end)
+  end
+
+  defp actor_display_for(%{
+         project_repo_connection: nil,
+         actor_type: :project_repo_connection
+       }) do
+    %{
+      identifier: nil,
+      label: "(Project Repo Connection Deleted)"
+    }
+  end
+
+  defp actor_display_for(%{actor_type: :project_repo_connection}) do
+    %{
+      identifier: nil,
+      label: "GitHub"
+    }
+  end
+
+  defp actor_display_for(%{trigger: nil, actor_type: :trigger}) do
+    %{
+      identifier: nil,
+      label: "(Trigger Deleted)"
+    }
+  end
+
+  defp actor_display_for(%{
+         trigger: %Trigger{type: type} = _actor,
+         actor_type: :trigger
+       }) do
+    %{
+      identifier: nil,
+      label: Atom.to_string(type) |> String.capitalize()
+    }
+  end
+
+  defp actor_display_for(%{user: nil, actor_type: :user}) do
+    %{
+      identifier: nil,
+      label: "(User deleted)"
+    }
+  end
+
+  defp actor_display_for(%{user: %User{} = actor, actor_type: :user}) do
+    %{
+      identifier: actor.email,
+      label: "#{actor.first_name} #{actor.last_name}"
+    }
   end
 end

--- a/lib/lightning/auditing.ex
+++ b/lib/lightning/auditing.ex
@@ -19,68 +19,79 @@ defmodule Lightning.Auditing do
       on: t.id == a.actor_id and a.actor_type == :trigger,
       left_join: u in User,
       on: u.id == a.actor_id and a.actor_type == :user,
-      select_merge: %{
-        project_repo_connection: p,
-        trigger: t,
-        user: u
-      },
+      select: %{audit: a, user: u, trigger: t, project_repo_connection: p},
       order_by: [desc: a.inserted_at]
     )
     |> Repo.paginate(params)
     |> then(fn %{entries: entries} = result ->
-      Map.put(
-        result,
-        :entries,
-        Enum.map(entries, &Map.put(&1, :actor_display, actor_display_for(&1)))
-      )
+      Map.put(result, :entries, Enum.map(entries, &extended_audit/1))
     end)
   end
 
-  defp actor_display_for(%{
-         project_repo_connection: nil,
-         actor_type: :project_repo_connection
+  defp extended_audit(%{
+         audit: %{actor_type: :project_repo_connection} = audit,
+         project_repo_connection: actor
        }) do
+    merge(audit, actor, :project_repo_connection)
+  end
+
+  defp extended_audit(%{
+         audit: %{actor_type: :trigger} = audit,
+         trigger: actor
+       }) do
+    merge(audit, actor, :trigger)
+  end
+
+  defp extended_audit(%{
+         audit: %{actor_type: :user} = audit,
+         user: actor
+       }) do
+    merge(audit, actor, :user)
+  end
+
+  defp actor_display_for(nil, :project_repo_connection) do
     %{
       identifier: nil,
       label: "(Project Repo Connection Deleted)"
     }
   end
 
-  defp actor_display_for(%{actor_type: :project_repo_connection}) do
+  defp actor_display_for(%ProjectRepoConnection{}, :project_repo_connection) do
     %{
       identifier: nil,
       label: "GitHub"
     }
   end
 
-  defp actor_display_for(%{trigger: nil, actor_type: :trigger}) do
+  defp actor_display_for(nil, :trigger) do
     %{
       identifier: nil,
       label: "(Trigger Deleted)"
     }
   end
 
-  defp actor_display_for(%{
-         trigger: %Trigger{type: type} = _actor,
-         actor_type: :trigger
-       }) do
+  defp actor_display_for(%Trigger{type: type}, :trigger) do
     %{
       identifier: nil,
       label: Atom.to_string(type) |> String.capitalize()
     }
   end
 
-  defp actor_display_for(%{user: nil, actor_type: :user}) do
+  defp actor_display_for(nil, :user) do
     %{
       identifier: nil,
       label: "(User deleted)"
     }
   end
 
-  defp actor_display_for(%{user: %User{} = actor, actor_type: :user}) do
+  defp actor_display_for(%User{} = actor, :user) do
     %{
       identifier: actor.email,
       label: "#{actor.first_name} #{actor.last_name}"
     }
+  end
+
+  defp merge(audit, actor, actor_type) do
+    %{audit | actor_display: actor_display_for(actor, actor_type)}
   end
 end

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -129,7 +129,8 @@ defmodule Lightning.Auditing.Audit do
     field :actor_type, Ecto.Enum,
       values: [:project_repo_connection, :trigger, :user]
 
-    field :actor, :map, virtual: true
+    field :actor_display_identifier, :string, virtual: true
+    field :actor_display_label, :string, virtual: true
     field :metadata, :map, default: %{}
 
     timestamps(updated_at: false)

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -196,7 +196,9 @@ defmodule Lightning.Auditing.Audit do
           String.t(),
           String.t(),
           Ecto.UUID.t(),
-          struct(),
+          Lightning.Accounts.User.t()
+          | Lightning.VersionControl.ProjectRepoConnection.t()
+          | Lightning.Workflows.Trigger.t(),
           Ecto.Changeset.t() | map() | nil,
           map(),
           update_changes_fun :: (map() -> map())
@@ -293,7 +295,7 @@ defmodule Lightning.Auditing.Audit do
         event: event,
         item_id: item_id,
         actor_id: actor_id,
-        actor_type: actor_struct |> extract_actor_type(),
+        actor_type: extract_actor_type(actor_struct),
         changes: changes,
         metadata: metadata
       },
@@ -302,8 +304,7 @@ defmodule Lightning.Auditing.Audit do
   end
 
   defp extract_actor_type(struct_name) do
-    struct_name
-    |> case do
+    case struct_name do
       Lightning.VersionControl.ProjectRepoConnection -> :project_repo_connection
       Lightning.Workflows.Trigger -> :trigger
       Lightning.Accounts.User -> :user

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -129,10 +129,6 @@ defmodule Lightning.Auditing.Audit do
     field :actor_type, Ecto.Enum,
       values: [:project_repo_connection, :trigger, :user]
 
-    field :project_repo_connection, :map, virtual: true
-    field :trigger, :map, virtual: true
-    field :user, :map, virtual: true
-
     field :actor_display, :string, virtual: true
     field :metadata, :map, default: %{}
 

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -303,10 +303,6 @@ defmodule Lightning.Auditing.Audit do
   end
 
   defp extract_actor_type(struct_name) do
-    case struct_name do
-      Lightning.VersionControl.ProjectRepoConnection -> :project_repo_connection
-      Lightning.Workflows.Trigger -> :trigger
-      Lightning.Accounts.User -> :user
-    end
+    struct_name |> Module.split() |> List.last() |> Macro.underscore()
   end
 end

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -46,7 +46,7 @@ defmodule Lightning.Auditing.Audit do
 
     event_signature =
       quote do
-        def event(event, item_id, actor_id, changes \\ %{}, metadata \\ %{})
+        def event(event, item_id, actor, changes \\ %{}, metadata \\ %{})
       end
 
     event_log_functions =
@@ -54,13 +54,13 @@ defmodule Lightning.Auditing.Audit do
         quote do
           # Output:
           #
-          # def event(item_type, "foo_event", item_id, actor_id, changes) do
-          #   Lightning.Audit.event(item_type, "foo_event", item_id, actor_id, changes)
+          # def event(item_type, "foo_event", item_id, actor, changes, metadata) do
+          #   Lightning.Audit.event(item_type, "foo_event", item_id, actor, changes, metadata)
           # end
           def event(
                 unquote(event_name),
                 item_id,
-                actor_id,
+                actor,
                 changes,
                 metadata
               ) do
@@ -68,7 +68,7 @@ defmodule Lightning.Auditing.Audit do
               unquote(item),
               unquote(event_name),
               item_id,
-              actor_id,
+              actor,
               changes,
               metadata,
               &update_changes/1
@@ -125,6 +125,10 @@ defmodule Lightning.Auditing.Audit do
     field :item_id, Ecto.UUID
     embeds_one :changes, Changes
     field :actor_id, Ecto.UUID
+
+    field :actor_type, Ecto.Enum,
+      values: [:project_repo_connection, :trigger, :user]
+
     field :actor, :map, virtual: true
     field :metadata, :map, default: %{}
 
@@ -138,13 +142,23 @@ defmodule Lightning.Auditing.Audit do
         update_changes_fun \\ fn x -> x end
       ) do
     audit
-    |> cast(attrs, [:event, :item_id, :actor_id, :item_type, :metadata])
+    |> cast(
+      attrs,
+      [
+        :event,
+        :item_id,
+        :actor_id,
+        :actor_type,
+        :item_type,
+        :metadata
+      ]
+    )
     |> cast_embed(:changes,
       with: fn schema, changes ->
         Changes.changeset(schema, changes, update_changes_fun)
       end
     )
-    |> validate_required([:event, :actor_id])
+    |> validate_required([:event, :actor_id, :actor_type])
   end
 
   @doc """
@@ -170,7 +184,7 @@ defmodule Lightning.Auditing.Audit do
 
   @doc """
   Creates a `changeset` for the `event` identified by `item_id` and caused
-  by `actor_id`.
+  by `actor`.
 
   The given `changes` can be either `nil`, `Ecto.Changeset`, struct or map.
 
@@ -181,7 +195,7 @@ defmodule Lightning.Auditing.Audit do
           String.t(),
           String.t(),
           Ecto.UUID.t(),
-          Ecto.UUID.t(),
+          %{id: Ecto.UUID.t()},
           Ecto.Changeset.t() | map() | nil,
           map(),
           update_changes_fun :: (map() -> map())
@@ -192,7 +206,7 @@ defmodule Lightning.Auditing.Audit do
         item_type,
         event,
         item_id,
-        actor_id,
+        actor,
         changes \\ %{},
         metadata \\ %{},
         update_fun \\ fn x -> x end
@@ -215,7 +229,7 @@ defmodule Lightning.Auditing.Audit do
         item_type,
         event,
         item_id,
-        actor_id,
+        actor,
         %Ecto.Changeset{data: %subject_schema{} = data, changes: changes},
         metadata,
         update_fun
@@ -242,20 +256,20 @@ defmodule Lightning.Auditing.Audit do
       item_type,
       event,
       item_id,
-      actor_id,
+      actor,
       changes,
       metadata,
       update_fun
     )
   end
 
-  def event(item_type, event, item_id, actor_id, changes, metadata, update_fun)
+  def event(item_type, event, item_id, actor, changes, metadata, update_fun)
       when is_map(changes) do
     audit_changeset(
       item_type,
       event,
       item_id,
-      actor_id,
+      actor,
       changes,
       metadata,
       update_fun
@@ -266,7 +280,7 @@ defmodule Lightning.Auditing.Audit do
          item_type,
          event,
          item_id,
-         actor_id,
+         %actor_struct{id: actor_id},
          changes,
          metadata,
          update_fun
@@ -278,10 +292,20 @@ defmodule Lightning.Auditing.Audit do
         event: event,
         item_id: item_id,
         actor_id: actor_id,
+        actor_type: actor_struct |> extract_actor_type(),
         changes: changes,
         metadata: metadata
       },
       update_fun
     )
+  end
+
+  defp extract_actor_type(struct_name) do
+    struct_name
+    |> case do
+      Lightning.VersionControl.ProjectRepoConnection -> :project_repo_connection
+      Lightning.Workflows.Trigger -> :trigger
+      Lightning.Accounts.User -> :user
+    end
   end
 end

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -195,7 +195,7 @@ defmodule Lightning.Auditing.Audit do
           String.t(),
           String.t(),
           Ecto.UUID.t(),
-          %{id: Ecto.UUID.t()},
+          struct(),
           Ecto.Changeset.t() | map() | nil,
           map(),
           update_changes_fun :: (map() -> map())

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -129,8 +129,11 @@ defmodule Lightning.Auditing.Audit do
     field :actor_type, Ecto.Enum,
       values: [:project_repo_connection, :trigger, :user]
 
-    field :actor_display_identifier, :string, virtual: true
-    field :actor_display_label, :string, virtual: true
+    field :project_repo_connection, :map, virtual: true
+    field :trigger, :map, virtual: true
+    field :user, :map, virtual: true
+
+    field :actor_display, :string, virtual: true
     field :metadata, :map, default: %{}
 
     timestamps(updated_at: false)

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -269,10 +269,9 @@ defmodule Lightning.Credentials do
         |> Multi.insert(
           :audit,
           fn %{credential: credential} ->
-            Audit.event(
+            Audit.user_initiated_event(
               if(state == :built, do: "created", else: "updated"),
-              credential.id,
-              credential.user_id,
+              credential,
               changeset
             )
           end
@@ -292,10 +291,9 @@ defmodule Lightning.Credentials do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
-        Audit.event(
+        Audit.user_initiated_event(
           "removed_from_project",
-          credential.id,
-          credential.user_id,
+          credential,
           %{
             before: %{
               project_id: Ecto.Changeset.get_field(changeset, :project_id)
@@ -318,7 +316,7 @@ defmodule Lightning.Credentials do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{credential: credential} ->
-        Audit.event("added_to_project", credential.id, credential.user_id, %{
+        Audit.user_initiated_event("added_to_project", credential, %{
           before: %{project_id: nil},
           after: %{
             project_id: Ecto.Changeset.get_field(changeset, :project_id)
@@ -351,7 +349,7 @@ defmodule Lightning.Credentials do
     Multi.new()
     |> Multi.delete(:credential, credential)
     |> Multi.insert(:audit, fn _ ->
-      Audit.event("deleted", credential.id, credential.user_id)
+      Audit.user_initiated_event("deleted", credential)
     end)
     |> Repo.transaction()
   end

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -24,4 +24,10 @@ defmodule Lightning.Credentials.Audit do
       changes
     end
   end
+
+  def user_initiated_event(event, credential, changes \\ %{}) do
+    %{id: id, user: user} = credential |> Lightning.Repo.preload(:user)
+
+    event(event, id, user, changes)
+  end
 end

--- a/lib/lightning/credentials/audit.ex
+++ b/lib/lightning/credentials/audit.ex
@@ -26,7 +26,7 @@ defmodule Lightning.Credentials.Audit do
   end
 
   def user_initiated_event(event, credential, changes \\ %{}) do
-    %{id: id, user: user} = credential |> Lightning.Repo.preload(:user)
+    %{id: id, user: user} = Lightning.Repo.preload(credential, :user)
 
     event(event, id, user, changes)
   end

--- a/lib/lightning/credentials/oauth_client_audit.ex
+++ b/lib/lightning/credentials/oauth_client_audit.ex
@@ -26,4 +26,10 @@ defmodule Lightning.Credentials.OauthClientAudit do
       changes
     end
   end
+
+  def user_initiated_event(event, client, changes \\ %{}) do
+    %{id: id, user: user} = client |> Lightning.Repo.preload(:user)
+
+    event(event, id, user, changes)
+  end
 end

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -684,7 +684,7 @@ defmodule Lightning.Invocation do
       ExportAudit.event(
         "requested",
         project.id,
-        user.id,
+        user,
         %{},
         %{search_params: search_params}
       )

--- a/lib/lightning/oauth_clients.ex
+++ b/lib/lightning/oauth_clients.ex
@@ -195,10 +195,9 @@ defmodule Lightning.OauthClients do
         |> Multi.insert(
           :audit,
           fn %{client: client} ->
-            OauthClientAudit.event(
+            OauthClientAudit.user_initiated_event(
               if(state == :built, do: "created", else: "updated"),
-              client.id,
-              client.user_id,
+              client,
               changeset
             )
           end
@@ -218,10 +217,9 @@ defmodule Lightning.OauthClients do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{client: client} ->
-        OauthClientAudit.event(
+        OauthClientAudit.user_initiated_event(
           "removed_from_project",
-          client.id,
-          client.user_id,
+          client,
           %{
             before: %{
               project_id: Ecto.Changeset.get_field(changeset, :project_id)
@@ -244,7 +242,7 @@ defmodule Lightning.OauthClients do
       multi,
       {:audit, Ecto.Changeset.get_field(changeset, :project_id)},
       fn %{client: client} ->
-        OauthClientAudit.event("added_to_project", client.id, client.user_id, %{
+        OauthClientAudit.user_initiated_event("added_to_project", client, %{
           before: %{project_id: nil},
           after: %{
             project_id: Ecto.Changeset.get_field(changeset, :project_id)
@@ -288,7 +286,7 @@ defmodule Lightning.OauthClients do
     end)
     |> Multi.delete(:client, client)
     |> Multi.insert(:audit, fn _ ->
-      OauthClientAudit.event("deleted", client.id, client.user_id)
+      OauthClientAudit.user_initiated_event("deleted", client)
     end)
     |> Repo.transaction()
   end

--- a/lib/lightning/projects/audit.ex
+++ b/lib/lightning/projects/audit.ex
@@ -31,8 +31,7 @@ defmodule Lightning.Projects.Audit do
   defp event_changeset(%Ecto.Changeset{} = changeset, field, user) do
     project_id = Ecto.Changeset.get_field(changeset, :id)
 
-    "#{field}_updated"
-    |> event(project_id, user.id, changeset)
+    "#{field}_updated" |> event(project_id, user, changeset)
   end
 
   defp operation_name(:dataclip_retention_period), do: :audit_dataclip_retention

--- a/lib/lightning/projects/audit.ex
+++ b/lib/lightning/projects/audit.ex
@@ -31,7 +31,7 @@ defmodule Lightning.Projects.Audit do
   defp event_changeset(%Ecto.Changeset{} = changeset, field, user) do
     project_id = Ecto.Changeset.get_field(changeset, :id)
 
-    "#{field}_updated" |> event(project_id, user, changeset)
+    event("#{field}_updated", project_id, user, changeset)
   end
 
   defp operation_name(:dataclip_retention_period), do: :audit_dataclip_retention

--- a/lib/lightning/usage_tracking/day_worker.ex
+++ b/lib/lightning/usage_tracking/day_worker.ex
@@ -12,8 +12,8 @@ defmodule Lightning.UsageTracking.DayWorker do
   @impl Oban.Worker
   def perform(%{args: %{"batch_size" => batch_size}}) do
     UsageTracking.enqueue_reports(
-      Application.get_env(:lightning, :usage_tracking)[:enabled],
-      DateTime.utc_now(),
+      Lightning.Config.usage_tracking_enabled?(),
+      Lightning.current_time(),
       batch_size
     )
 

--- a/lib/lightning/webhook_auth_methods.ex
+++ b/lib/lightning/webhook_auth_methods.ex
@@ -162,7 +162,7 @@ defmodule Lightning.WebhookAuthMethods do
     Multi.new()
     |> Multi.insert(:auth_method, changeset)
     |> Multi.insert(:audit, fn %{auth_method: auth_method} ->
-      WebhookAuthMethodAudit.event("created", auth_method.id, user.id, changeset)
+      WebhookAuthMethodAudit.event("created", auth_method.id, user, changeset)
     end)
     |> Repo.transaction()
     |> case do
@@ -185,13 +185,13 @@ defmodule Lightning.WebhookAuthMethods do
     Multi.new()
     |> Multi.insert(:auth_method, changeset)
     |> Multi.insert(:created_audit, fn %{auth_method: auth_method} ->
-      WebhookAuthMethodAudit.event("created", auth_method.id, user.id, changeset)
+      WebhookAuthMethodAudit.event("created", auth_method.id, user, changeset)
     end)
     |> Multi.insert(:add_to_trigger_audit, fn %{auth_method: auth_method} ->
       WebhookAuthMethodAudit.event(
         "added_to_trigger",
         auth_method.id,
-        user.id,
+        user,
         %{before: %{trigger_id: nil}, after: %{trigger_id: trigger.id}}
       )
     end)
@@ -260,7 +260,7 @@ defmodule Lightning.WebhookAuthMethods do
         WebhookAuthMethodAudit.event(
           "updated",
           auth_method.id,
-          user.id,
+          user,
           changeset
         )
       end
@@ -350,7 +350,7 @@ defmodule Lightning.WebhookAuthMethods do
             WebhookAuthMethodAudit.event(
               "added_to_trigger",
               auth_id,
-              user.id,
+              user,
               %{before: %{trigger_id: nil}, after: %{trigger_id: trigger.id}}
             )
 
@@ -362,7 +362,7 @@ defmodule Lightning.WebhookAuthMethods do
           WebhookAuthMethodAudit.event(
             "removed_from_trigger",
             auth_id,
-            user.id,
+            user,
             %{before: %{trigger_id: trigger.id}, after: %{trigger_id: nil}}
           )
 
@@ -660,7 +660,7 @@ defmodule Lightning.WebhookAuthMethods do
   @spec schedule_for_deletion(WebhookAuthMethod.t(), actor: User.t()) ::
           {:ok, WebhookAuthMethod.t()} | {:error, Ecto.Changeset.t()}
   def schedule_for_deletion(%WebhookAuthMethod{} = webhook_auth_method,
-        actor: %User{id: user_id}
+        actor: %User{} = user
       ) do
     if webhook_auth_method.scheduled_deletion do
       changeset =
@@ -685,7 +685,7 @@ defmodule Lightning.WebhookAuthMethods do
         WebhookAuthMethodAudit.event(
           "deleted",
           auth_method.id,
-          user_id,
+          user,
           %{
             before: %{scheduled_deletion: nil},
             after: %{scheduled_deletion: deletion_date}

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -23,13 +23,11 @@
           <.td>
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
-                <%= if audit.actor,
-                  do: "#{audit.actor.first_name} #{audit.actor.last_name}",
-                  else: "(User deleted)" %>
+                <%= audit.actor_display_label %>
               </div>
               <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">
-                <%= if audit.actor,
-                  do: audit.actor.email,
+                <%= if audit.actor_display_identifier,
+                  do: audit.actor_display_identifier,
                   else: display_short_uuid(audit.actor_id) %>
               </div>
             </div>

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -23,11 +23,11 @@
           <.td>
             <div class="flex flex-col overflow-hidden">
               <div class="overflow-hidden font-normal text-gray-900 whitespace-nowrap text-ellipsis dark:text-gray-300">
-                <%= audit.actor_display_label %>
+                <%= audit.actor_display.label %>
               </div>
               <div class="overflow-hidden font-normal text-gray-500 text-xs whitespace-nowrap text-ellipsis">
-                <%= if audit.actor_display_identifier,
-                  do: audit.actor_display_identifier,
+                <%= if audit.actor_display.identifier,
+                  do: audit.actor_display.identifier,
                   else: display_short_uuid(audit.actor_id) %>
               </div>
             </div>

--- a/priv/repo/migrations/20241022125816_add_actor_type_to_audit_events.exs
+++ b/priv/repo/migrations/20241022125816_add_actor_type_to_audit_events.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddActorTypeToAuditEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_events) do
+      add :actor_type, :string, null: false, default: "user"
+    end
+  end
+end

--- a/test/lightning/auditing_test.exs
+++ b/test/lightning/auditing_test.exs
@@ -16,7 +16,11 @@ defmodule Lightning.AuditingTest do
   end
 
   describe "Audit.event/6" do
-    test "returns no_changes when there are no changes" do
+    setup do
+      %{actor: insert(:project_repo_connection)}
+    end
+
+    test "returns no_changes when there are no changes", %{actor: actor} do
       changeset =
         Ecto.Changeset.change(%Lightning.Credentials.Credential{}, %{})
 
@@ -25,14 +29,15 @@ defmodule Lightning.AuditingTest do
                  "credential",
                  "updated",
                  Ecto.UUID.generate(),
-                 Ecto.UUID.generate(),
+                 actor,
                  changeset
                )
     end
 
-    test "returns a changeset when there are changes" do
+    test "returns a changeset when there are changes", %{
+      actor: %{id: actor_id} = actor
+    } do
       item_id = Ecto.UUID.generate()
-      actor_id = Ecto.UUID.generate()
 
       changeset =
         Ecto.Changeset.change(
@@ -45,7 +50,7 @@ defmodule Lightning.AuditingTest do
           "credential",
           "updated",
           item_id,
-          actor_id,
+          actor,
           changeset
         )
 
@@ -54,8 +59,10 @@ defmodule Lightning.AuditingTest do
                  item_type: "credential",
                  event: "updated",
                  item_id: ^item_id,
-                 actor_id: ^actor_id
-               }
+                 actor_id: ^actor_id,
+                 actor_type: :project_repo_connection
+               },
+               valid?: true
              } = audit_changeset
 
       changes = Ecto.Changeset.get_embed(audit_changeset, :changes)
@@ -63,7 +70,71 @@ defmodule Lightning.AuditingTest do
       assert Ecto.Changeset.get_change(changes, :after) == %{name: "test two"}
     end
 
-    test "'created' event sets before changes to nil" do
+    test "returns a changeset when the changes are a map", %{
+      actor: %{id: actor_id} = actor
+    } do
+      item_id = Ecto.UUID.generate()
+
+      changes = %{before: %{foo: "bar"}, after: %{foo: "baz"}}
+
+      audit_changeset =
+        Audit.event(
+          "credential",
+          "updated",
+          item_id,
+          actor,
+          changes
+        )
+
+      assert %{
+               changes: %{
+                 item_type: "credential",
+                 event: "updated",
+                 item_id: ^item_id,
+                 actor_id: ^actor_id,
+                 actor_type: :project_repo_connection
+               },
+               valid?: true
+             } = audit_changeset
+
+      changes = Ecto.Changeset.get_embed(audit_changeset, :changes)
+      assert Ecto.Changeset.get_change(changes, :before) == %{foo: "bar"}
+      assert Ecto.Changeset.get_change(changes, :after) == %{foo: "baz"}
+    end
+
+    test "maps actor structs to actor types" do
+      item_id = Ecto.UUID.generate()
+      changes = %{before: %{foo: "bar"}, after: %{foo: "baz"}}
+
+      assert %{changes: %{actor_type: :user}} =
+               Audit.event(
+                 "credential",
+                 "updated",
+                 item_id,
+                 insert(:user),
+                 changes
+               )
+
+      assert %{changes: %{actor_type: :project_repo_connection}} =
+               Audit.event(
+                 "credential",
+                 "updated",
+                 item_id,
+                 insert(:project_repo_connection),
+                 changes
+               )
+
+      assert %{changes: %{actor_type: :trigger}} =
+               Audit.event(
+                 "credential",
+                 "updated",
+                 item_id,
+                 insert(:trigger),
+                 changes
+               )
+    end
+
+    test "'created' event sets before changes to nil", %{actor: actor} do
       changeset =
         Ecto.Changeset.change(%Lightning.Credentials.Credential{}, %{
           name: "test"
@@ -74,7 +145,7 @@ defmodule Lightning.AuditingTest do
           "credential",
           "created",
           Ecto.UUID.generate(),
-          Ecto.UUID.generate(),
+          actor,
           changeset
         )
 
@@ -87,7 +158,7 @@ defmodule Lightning.AuditingTest do
           "credential",
           "updated",
           Ecto.UUID.generate(),
-          Ecto.UUID.generate(),
+          actor,
           changeset
         )
 
@@ -96,7 +167,7 @@ defmodule Lightning.AuditingTest do
       assert Ecto.Changeset.get_change(changes, :after) == %{name: "test"}
     end
 
-    test "changes can be updated using the callback function" do
+    test "changes can be updated using the callback function", %{actor: actor} do
       changeset =
         Ecto.Changeset.change(%Lightning.Credentials.Credential{}, %{
           name: "test"
@@ -111,7 +182,7 @@ defmodule Lightning.AuditingTest do
           "credential",
           "created",
           Ecto.UUID.generate(),
-          Ecto.UUID.generate(),
+          actor,
           changeset,
           %{},
           update_fun
@@ -119,6 +190,100 @@ defmodule Lightning.AuditingTest do
 
       changes = Ecto.Changeset.get_embed(audit_changeset, :changes)
       assert Ecto.Changeset.get_change(changes, :after) == %{name: "TEST"}
+    end
+  end
+
+  describe "Audit.changeset" do
+    setup do
+      actor_id = Ecto.UUID.generate()
+      item_id = Ecto.UUID.generate()
+
+      attrs = %{
+        item_type: "credential",
+        event: "updated",
+        item_id: item_id,
+        actor_id: actor_id,
+        actor_type: :project_repo_connection,
+        changes: %{
+          before: %{name: "test"},
+          after: %{name: "test two"}
+        }
+      }
+
+      %{
+        actor_id: actor_id,
+        item_id: item_id,
+        attrs: attrs
+      }
+    end
+
+    test "returns a valid changeset", %{
+      actor_id: actor_id,
+      item_id: item_id,
+      attrs: attrs
+    } do
+      changeset = %Audit{} |> Audit.changeset(attrs)
+
+      assert %{
+               changes: %{
+                 item_type: "credential",
+                 event: "updated",
+                 item_id: ^item_id,
+                 actor_id: ^actor_id,
+                 actor_type: :project_repo_connection,
+                 changes: changes
+               },
+               valid?: true
+             } = changeset
+
+      assert %{
+               changes: %{
+                 before: %{name: "test"},
+                 after: %{name: "test two"}
+               },
+               valid?: true
+             } = changes
+    end
+
+    test "is invalid if the event is absent", %{
+      attrs: attrs
+    } do
+      changeset = %Audit{} |> Audit.changeset(attrs |> Map.delete(:event))
+
+      assert %{
+               errors: errors,
+               valid?: false
+             } = changeset
+
+      assert errors == [{:event, {"can't be blank", [validation: :required]}}]
+    end
+
+    test "is invalid if the actor_id is absent", %{
+      attrs: attrs
+    } do
+      changeset = %Audit{} |> Audit.changeset(attrs |> Map.delete(:actor_id))
+
+      assert %{
+               errors: errors,
+               valid?: false
+             } = changeset
+
+      assert errors == [{:actor_id, {"can't be blank", [validation: :required]}}]
+    end
+
+    test "is invalid if the actor_type is absent", %{
+      attrs: attrs
+    } do
+      changeset = %Audit{} |> Audit.changeset(attrs |> Map.delete(:actor_type))
+
+      assert %{
+               errors: errors,
+               valid?: false
+             } = changeset
+
+      assert errors == [
+               {:actor_type, {"can't be blank", [validation: :required]}}
+             ]
     end
   end
 end

--- a/test/lightning/auditing_test.exs
+++ b/test/lightning/auditing_test.exs
@@ -73,12 +73,7 @@ defmodule Lightning.AuditingTest do
     end
 
     test "full audit entry for an user event", %{
-      user:
-        %{
-          first_name: first_name,
-          last_name: last_name,
-          email: email
-        } = user,
+      user: %{first_name: first_name, last_name: last_name, email: email},
       user_event_3: user_event_3
     } do
       %{
@@ -91,8 +86,6 @@ defmodule Lightning.AuditingTest do
         changes: changes
       } = user_event_3
 
-      user = Repo.reload!(user)
-
       actor_display_label = "#{first_name} #{last_name}"
 
       %{entries: [entry | _other_entries]} =
@@ -100,9 +93,6 @@ defmodule Lightning.AuditingTest do
 
       assert %{
                id: ^id,
-               project_repo_connection: nil,
-               trigger: nil,
-               user: ^user,
                actor_display: %{
                  identifier: ^email,
                  label: ^actor_display_label
@@ -137,9 +127,6 @@ defmodule Lightning.AuditingTest do
 
       assert %{
                id: ^id,
-               project_repo_connection: nil,
-               trigger: nil,
-               user: nil,
                actor_display: %{
                  identifier: nil,
                  label: "(User deleted)"
@@ -154,7 +141,6 @@ defmodule Lightning.AuditingTest do
     end
 
     test "full audit entry for an event linked to a repo connection", %{
-      repo_connection: repo_connection,
       repo_event_3: repo_event_3
     } do
       %{
@@ -167,16 +153,11 @@ defmodule Lightning.AuditingTest do
         changes: changes
       } = repo_event_3
 
-      repo_connection = Repo.reload!(repo_connection)
-
       %{entries: [_user_entry | [entry | _other_entries]]} =
         Auditing.list_all(page: 2, page_size: 6)
 
       assert %{
                id: ^id,
-               project_repo_connection: ^repo_connection,
-               trigger: nil,
-               user: nil,
                actor_display: %{
                  identifier: nil,
                  label: "GitHub"
@@ -211,9 +192,6 @@ defmodule Lightning.AuditingTest do
 
       assert %{
                id: ^id,
-               project_repo_connection: nil,
-               trigger: nil,
-               user: nil,
                actor_display: %{
                  identifier: nil,
                  label: "(Project Repo Connection Deleted)"
@@ -228,7 +206,6 @@ defmodule Lightning.AuditingTest do
     end
 
     test "full audit entry for an event linked to a trigger", %{
-      trigger: trigger,
       trigger_event_3: trigger_event_3
     } do
       %{
@@ -241,16 +218,11 @@ defmodule Lightning.AuditingTest do
         changes: changes
       } = trigger_event_3
 
-      trigger = Repo.reload!(trigger)
-
       %{entries: [_user_entry | [_repo_entry | [entry | _other_entries]]]} =
         Auditing.list_all(page: 2, page_size: 6)
 
       assert %{
                id: ^id,
-               project_repo_connection: nil,
-               trigger: ^trigger,
-               user: nil,
                actor_display: %{
                  identifier: nil,
                  label: "Webhook"
@@ -285,9 +257,6 @@ defmodule Lightning.AuditingTest do
 
       assert %{
                id: ^id,
-               project_repo_connection: nil,
-               trigger: nil,
-               user: nil,
                actor_display: %{
                  identifier: nil,
                  label: "(Trigger Deleted)"

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -1,5 +1,5 @@
 defmodule Lightning.CollectionsTest do
-  use Lightning.DataCase
+  use Lightning.DataCase, async: true
 
   alias Lightning.Collections
   alias Lightning.Collections.Collection

--- a/test/lightning/credentials/audit_test.exs
+++ b/test/lightning/credentials/audit_test.exs
@@ -1,7 +1,9 @@
 defmodule Lightning.Credentials.AuditTest do
   use Lightning.DataCase, async: true
 
+  alias Ecto.Changeset
   alias Lightning.Credentials.{Audit, Credential}
+
   import Lightning.{AccountsFixtures, CredentialsFixtures}
 
   describe "event/4" do
@@ -12,7 +14,7 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("created", credential.id, user.id)
+        Audit.event("created", credential.id, user)
         |> Audit.save()
 
       assert audit.item_type == "credential"
@@ -20,6 +22,7 @@ defmodule Lightning.Credentials.AuditTest do
       assert %{before: nil, after: nil} = audit.changes
       assert audit.event == "created"
       assert audit.actor_id == user.id
+      assert audit.actor_type == :user
     end
 
     test "generates 'updated' audit trail entries" do
@@ -31,7 +34,7 @@ defmodule Lightning.Credentials.AuditTest do
         Credential.changeset(credential, %{body: %{"my-secret" => "value"}})
 
       {:ok, audit} =
-        Audit.event("updated", credential.id, user.id, changeset)
+        Audit.event("updated", credential.id, user, changeset)
         |> Audit.save()
 
       assert audit.item_type == "credential"
@@ -47,6 +50,7 @@ defmodule Lightning.Credentials.AuditTest do
 
       assert audit.event == "updated"
       assert audit.actor_id == user.id
+      assert audit.actor_type == :user
     end
 
     test "generates 'deleted' audit trail entries" do
@@ -56,7 +60,7 @@ defmodule Lightning.Credentials.AuditTest do
         credential_fixture(user_id: user.id, body: %{"my-secret" => "value"})
 
       {:ok, audit} =
-        Audit.event("deleted", credential.id, user.id)
+        Audit.event("deleted", credential.id, user)
         |> Audit.save()
 
       assert audit.item_type == "credential"
@@ -69,6 +73,98 @@ defmodule Lightning.Credentials.AuditTest do
 
       assert audit.event == "deleted"
       assert audit.actor_id == user.id
+      assert audit.actor_type == :user
+    end
+  end
+
+  describe ".user_initiated_event" do
+    test "generates changeset for event if user association is present" do
+      %{id: user_id} = user_fixture()
+
+      %{id: credential_id} =
+        credential =
+        credential_fixture(user_id: user_id, body: %{}) |> Repo.preload(:user)
+
+      changeset =
+        Credential.changeset(credential, %{body: %{"my-secret" => "value"}})
+
+      audit_changeset =
+        Audit.user_initiated_event("updated", credential, changeset)
+
+      assert %{
+               changes: %{
+                 event: "updated",
+                 item_id: ^credential_id,
+                 item_type: "credential",
+                 actor_id: ^user_id,
+                 actor_type: :user,
+                 changes: changes
+               }
+             } = audit_changeset
+
+      # Check that the body attribute is encrypted in audit records too.
+      # We can only test the beginning of the encrypted string as the
+      # algorithm include randomness or padding of some sort.
+      # %{}
+      assert Changeset.get_change(changes, :before).body =~ "AQpBRVMuR0NNLlYx"
+      # %{"my-secret" => "value}
+      assert Changeset.get_change(changes, :after).body =~ "AQpBRVMuR0NNLlYx"
+    end
+
+    test "generates changeset for event if user association is absent" do
+      %{id: user_id} = user_fixture()
+
+      %{id: credential_id} =
+        credential =
+        credential_fixture(user_id: user_id, body: %{})
+
+      changeset =
+        Credential.changeset(credential, %{body: %{"my-secret" => "value"}})
+
+      audit_changeset =
+        Audit.user_initiated_event("updated", credential, changeset)
+
+      assert %{
+               changes: %{
+                 event: "updated",
+                 item_id: ^credential_id,
+                 item_type: "credential",
+                 actor_id: ^user_id,
+                 actor_type: :user,
+                 changes: changes
+               }
+             } = audit_changeset
+
+      # Check that the body attribute is encrypted in audit records too.
+      # We can only test the beginning of the encrypted string as the
+      # algorithm include randomness or padding of some sort.
+      # %{}
+      assert Changeset.get_change(changes, :before).body =~ "AQpBRVMuR0NNLlYx"
+      # %{"my-secret" => "value}
+      assert Changeset.get_change(changes, :after).body =~ "AQpBRVMuR0NNLlYx"
+    end
+
+    test "generates changeset for event where changes are absent" do
+      %{id: user_id} = user_fixture()
+
+      %{id: credential_id} =
+        credential =
+        credential_fixture(user_id: user_id, body: %{})
+
+      audit_changeset = Audit.user_initiated_event("deleted", credential)
+
+      assert %{
+               changes: %{
+                 event: "deleted",
+                 item_id: ^credential_id,
+                 item_type: "credential",
+                 actor_id: ^user_id,
+                 actor_type: :user,
+                 changes: %{
+                   changes: %{}
+                 }
+               }
+             } = audit_changeset
     end
   end
 end

--- a/test/lightning/credentials/oauth_client_audit_test.exs
+++ b/test/lightning/credentials/oauth_client_audit_test.exs
@@ -1,0 +1,107 @@
+defmodule Lightning.Credentials.OauthClientAuditTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Credentials.OauthClient
+  alias Lightning.Credentials.OauthClientAudit
+
+  describe ".user_initiated_event/3" do
+    test "returns audit changeset if user association is loaded" do
+      %{id: client_id, user_id: user_id} =
+        client =
+        insert(
+          :oauth_client,
+          token_endpoint: "https://example.com/token"
+        )
+        |> Repo.preload(:user)
+
+      changes =
+        client
+        |> OauthClient.changeset(%{token_endpoint: "https://example.com/token2"})
+
+      audit_changeset =
+        OauthClientAudit.user_initiated_event("updated", client, changes)
+
+      assert %{
+               changes: %{
+                 event: "updated",
+                 item_type: "oauth_client",
+                 item_id: ^client_id,
+                 actor_id: ^user_id,
+                 actor_type: :user,
+                 changes: %{
+                   changes: %{
+                     before: %{
+                       token_endpoint: "https://example.com/token"
+                     },
+                     after: %{
+                       token_endpoint: "https://example.com/token2"
+                     }
+                   }
+                 }
+               }
+             } = audit_changeset
+    end
+
+    test "returns audit changeset if user association is not loaded" do
+      %{id: client_id, user_id: user_id} =
+        insert(
+          :oauth_client,
+          token_endpoint: "https://example.com/token"
+        )
+
+      client_without_user = Repo.get(OauthClient, client_id)
+
+      changes =
+        client_without_user
+        |> OauthClient.changeset(%{token_endpoint: "https://example.com/token2"})
+
+      audit_changeset =
+        "updated"
+        |> OauthClientAudit.user_initiated_event(client_without_user, changes)
+
+      assert %{
+               changes: %{
+                 event: "updated",
+                 item_type: "oauth_client",
+                 item_id: ^client_id,
+                 actor_id: ^user_id,
+                 actor_type: :user,
+                 changes: %{
+                   changes: %{
+                     before: %{
+                       token_endpoint: "https://example.com/token"
+                     },
+                     after: %{
+                       token_endpoint: "https://example.com/token2"
+                     }
+                   }
+                 }
+               }
+             } = audit_changeset
+    end
+
+    test "returns audit changeset if no changes are provided" do
+      %{id: client_id, user_id: user_id} =
+        client =
+        insert(
+          :oauth_client,
+          token_endpoint: "https://example.com/token"
+        )
+
+      audit_changeset = OauthClientAudit.user_initiated_event("deleted", client)
+
+      assert %{
+               changes: %{
+                 event: "deleted",
+                 item_type: "oauth_client",
+                 item_id: ^client_id,
+                 actor_id: ^user_id,
+                 actor_type: :user,
+                 changes: %{
+                   changes: %{}
+                 }
+               }
+             } = audit_changeset
+    end
+  end
+end

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -1,6 +1,5 @@
 defmodule Lightning.DashboardStatsTest do
-  @moduledoc false
-  use Lightning.DataCase
+  use Lightning.DataCase, async: true
 
   import Lightning.WorkflowsFixtures
 

--- a/test/lightning/kafka_triggers/trigger_kafka_message_record_test.exs
+++ b/test/lightning/kafka_triggers/trigger_kafka_message_record_test.exs
@@ -1,5 +1,5 @@
 defmodule Lightning.KafkaTriggers.TriggerKafkaMessageRecordTest do
-  use Lightning.DataCase
+  use Lightning.DataCase, async: true
 
   alias Ecto.Changeset
   alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord, as: TKMR

--- a/test/lightning_web/controllers/user_totp_controller_test.exs
+++ b/test/lightning_web/controllers/user_totp_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule LightningWeb.UserTOTPControllerTest do
-  use LightningWeb.ConnCase, async: false
+  use LightningWeb.ConnCase, async: true
 
   import Lightning.Factories
 

--- a/test/lightning_web/live/credential_live_helpers_test.exs
+++ b/test/lightning_web/live/credential_live_helpers_test.exs
@@ -1,5 +1,5 @@
 defmodule LightningWeb.CredentialLive.HelpersTest do
-  use Lightning.DataCase
+  use Lightning.DataCase, async: true
 
   alias Lightning.Credentials.Credential
   alias Lightning.Credentials.OauthClient

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -338,6 +338,15 @@ defmodule Lightning.Factories do
     }
   end
 
+  def audit_factory do
+    %Lightning.Auditing.Audit{
+      item_type: "item_type",
+      item_id: fn -> Ecto.UUID.generate() end,
+      event: "something_happened",
+      changes: %{before: %{"stuff" => "bad"}, after: %{"stuff" => "good"}}
+    }
+  end
+
   # ----------------------------------------------------------------------------
   # Helpers
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
### Description

This allows audit events to be created with non-user actors. This is in preparation for the auditing of snapshots, where the actor may be a `ProjectRepoConnection` or a `Trigger`.

There are a fair number of changes in this PR, but they mostly consist of:

- Adding extra test coverage
- Swapping out a user id for the user struct.

I have tried to group related changes in commits to make reviewing easier.

#2601 

### Validation steps

As the intent of this change is to have everything remain unchanged, I would suggest the following:

- On `main` make some retention period changes for a project.
- Take a screenshot of the Audit UI.
- Switch to this branch.
- Make similar changes to the changes on `main`
- Compare the audit screen to your screenshot.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
