### PR TITLE
Testing out a different CI env strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
     environment:
       ERL_FLAGS: +S 4:4
       ASSERT_RECEIVE_TIMEOUT: 1000
+      MIX_ENV: test
     working_directory: /home/lightning/project
 
     steps:
@@ -74,12 +75,15 @@ jobs:
           name: "Install libsodium and sudo"
           command: |
             apt-get update && apt-get install -y libsodium-dev sudo
+      - run: |
+          echo 'Defaults env_keep += "ERL_FLAGS ASSERT_RECEIVE_TIMEOUT MIX_ENV"' | \
+            sudo EDITOR='tee -a' visudo
 
       - run: chown -R lightning /home/lightning
       - run: sudo -u lightning mix local.hex --force && mix local.rebar --force
       - run: cd assets; sudo -u lightning npm install
-      - run: sudo -u lightning env MIX_ENV=test mix do deps.get --only test, deps.compile, compile
-      - run: sudo -u lightning env MIX_ENV=test mix lightning.install_runtime
+      - run: sudo -u lightning mix do deps.get --only test, deps.compile, compile
+      - run: sudo -u lightning mix lightning.install_runtime
 
       - save_cache:
           key: v3-deps-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}
@@ -108,25 +112,25 @@ workflows:
       - build:
           name: "Check code formatting"
           execute:
-            - run: sudo -u lightning env MIX_ENV=test mix format --check-formatted
+            - run: sudo -u lightning mix format --check-formatted
       - build:
           name: "Check code style"
           execute:
-            - run: sudo -u lightning env MIX_ENV=test mix credo --strict --all
+            - run: sudo -u lightning mix credo --strict --all
       - build:
           name: "Type check"
           execute:
-            - run: sudo -u lightning env MIX_ENV=test mix dialyzer
+            - run: sudo -u lightning mix dialyzer
       - build:
           name: "Check for security vulnerabilities"
           execute:
-            - run: sudo -u lightning env MIX_ENV=test mix sobelow
+            - run: sudo -u lightning mix sobelow
       - build:
           name: "Check Elixir tests (codecov)"
           execute:
-            - run: sudo -u lightning env MIX_ENV=test mix do ecto.create, ecto.migrate
+            - run: sudo -u lightning mix do ecto.create, ecto.migrate
             - run:
-                command: sudo -u lightning env MIX_ENV=test mix coveralls.json -o ./test/reports
+                command: sudo -u lightning mix coveralls.json -o ./test/reports
             - codecov/upload:
                 file: test/reports/excoveralls.json
             - store_test_results:


### PR DESCRIPTION
### Description

We're having issues on CI right now because the custom env vars we put in like `ERL_FLAGS` etc aren't carried across via `sudo`.

And when using `sudo -E` things got even weirder.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
