### PR TITLE
Replace DB transaction with on demand stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to
 
 ### Changed
 
-- Make Lightning resilient to long collection fetch
+- Reduce transaction time when fetching collection items by fetching upfront
   [#2645](https://github.com/OpenFn/lightning/issues/2645)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Make Lightning resilient to long collection fetch
+  [#2645](https://github.com/OpenFn/lightning/issues/2645)
+
 ### Fixed
 
 ## [v2.10.0-rc.0] - 2024-11-07

--- a/config/config.exs
+++ b/config/config.exs
@@ -144,7 +144,9 @@ config :lightning, :default_retention_period, nil
 
 config :lightning, Lightning.Runtime.RuntimeManager, start: false
 
-config :lightning, LightningWeb.CollectionsController, stream_limit: 1_000
+config :lightning, LightningWeb.CollectionsController,
+  default_stream_limit: 1_000,
+  max_database_limit: 5_000
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/test.exs
+++ b/config/test.exs
@@ -163,5 +163,5 @@ config :lightning, :github_app,
   """
 
 config :lightning, LightningWeb.CollectionsController,
-  default_stream_limit: 50,
-  max_database_limit: 500
+  default_stream_limit: 25,
+  max_database_limit: 75

--- a/config/test.exs
+++ b/config/test.exs
@@ -162,4 +162,6 @@ config :lightning, :github_app,
   -----END RSA PRIVATE KEY-----
   """
 
-config :lightning, LightningWeb.CollectionsController, stream_limit: 50
+config :lightning, LightningWeb.CollectionsController,
+  default_stream_limit: 50,
+  max_database_limit: 500

--- a/lib/lightning/runs/handlers.ex
+++ b/lib/lightning/runs/handlers.ex
@@ -36,7 +36,7 @@ defmodule Lightning.Runs.Handlers do
     def new(params) do
       %__MODULE__{}
       |> cast(params, [:timestamp])
-      |> put_new_change(:timestamp, DateTime.utc_now())
+      |> put_new_change(:timestamp, Lightning.current_time())
       |> validate_required([:timestamp])
     end
 
@@ -92,7 +92,7 @@ defmodule Lightning.Runs.Handlers do
     def new(params) do
       %__MODULE__{}
       |> cast(params, [:state, :reason, :error_type, :timestamp])
-      |> put_new_change(:timestamp, DateTime.utc_now())
+      |> put_new_change(:timestamp, Lightning.current_time())
       |> then(fn changeset ->
         if reason = get_change(changeset, :reason) do
           put_new_change(changeset, :state, reason_to_state(reason))
@@ -366,7 +366,7 @@ defmodule Lightning.Runs.Handlers do
           id: dataclip_id,
           project_id: project_id,
           body: nil,
-          wiped_at: DateTime.utc_now() |> DateTime.truncate(:second),
+          wiped_at: Lightning.current_time() |> DateTime.truncate(:second),
           type: :step_result
         })
         |> Repo.insert()

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -3,7 +3,6 @@ defmodule LightningWeb.CollectionsController do
 
   alias Lightning.Collections
   alias Lightning.Policies.Permissions
-  alias Lightning.Repo
 
   action_fallback LightningWeb.FallbackController
 
@@ -12,6 +11,7 @@ defmodule LightningWeb.CollectionsController do
   @max_chunk_size 50
 
   @default_limit Application.compile_env!(:lightning, __MODULE__)[:stream_limit]
+  @max_database_limit 5_000
 
   @valid_params [
     "key",
@@ -103,12 +103,10 @@ defmodule LightningWeb.CollectionsController do
   def stream(conn, %{"name" => col_name, "key" => key_pattern}) do
     with {:ok, collection, filters, response_limit} <-
            validate_query(conn, col_name) do
-      case Repo.transact(fn ->
-             items_stream =
-               Collections.stream_match(collection, key_pattern, filters)
+      items_stream =
+        safe_stream_from_db(collection, filters, key_pattern)
 
-             stream_chunked(conn, items_stream, response_limit)
-           end) do
+      case stream_chunked(conn, items_stream, response_limit) do
         {:error, conn} -> conn
         {:ok, conn} -> conn
       end
@@ -118,15 +116,31 @@ defmodule LightningWeb.CollectionsController do
   def stream(conn, %{"name" => col_name}) do
     with {:ok, collection, filters, response_limit} <-
            validate_query(conn, col_name) do
-      case Repo.transact(fn ->
-             items_stream = Collections.stream_all(collection, filters)
+      items_stream = safe_stream_from_db(collection, filters)
 
-             stream_chunked(conn, items_stream, response_limit)
-           end) do
+      case stream_chunked(conn, items_stream, response_limit) do
         {:error, conn} -> conn
         {:ok, conn} -> conn
       end
     end
+  end
+
+  defp safe_stream_from_db(
+         collection,
+         %{cursor: initial_cursor, limit: limit} = filters,
+         key_pattern \\ nil
+       ) do
+    filters = Map.put(filters, :limit, Enum.max([limit, @max_database_limit]))
+
+    Stream.unfold(initial_cursor, fn cursor ->
+      filters = Map.put(filters, :cursor, cursor)
+
+      case Collections.get_all(collection, filters, key_pattern) do
+        [] -> nil
+        list -> {list, List.last(list).inserted_at}
+      end
+    end)
+    |> Stream.flat_map(& &1)
   end
 
   defmodule ChunkAcc do

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -10,8 +10,13 @@ defmodule LightningWeb.CollectionsController do
 
   @max_chunk_size 50
 
-  @default_limit Application.compile_env!(:lightning, __MODULE__)[:stream_limit]
-  @max_database_limit 5_000
+  @limits Application.compile_env!(
+            :lightning,
+            LightningWeb.CollectionsController
+          )
+
+  @default_limit @limits[:default_stream_limit]
+  @max_database_limit @limits[:max_database_limit]
 
   @valid_params [
     "key",

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -130,7 +130,7 @@ defmodule LightningWeb.CollectionsController do
          %{cursor: initial_cursor, limit: limit} = filters,
          key_pattern \\ nil
        ) do
-    filters = Map.put(filters, :limit, Enum.max([limit, @max_database_limit]))
+    filters = Map.put(filters, :limit, min(limit, @max_database_limit))
 
     Stream.unfold(initial_cursor, fn cursor ->
       filters = Map.put(filters, :cursor, cursor)

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -121,7 +121,7 @@ defmodule Lightning.CollectionsTest do
 
       %{inserted_at: cursor} = Enum.at(items, 4)
 
-      assert Collections.get_all(collections, cursor: cursor, limit: 50)
+      assert Collections.get_all(collection, cursor: cursor, limit: 50)
              |> Enum.count() == 30 - (4 + 1)
 
       assert Collections.get_all(collection, cursor: cursor, limit: 10)
@@ -203,7 +203,7 @@ defmodule Lightning.CollectionsTest do
                %{cursor: cursor, limit: 16},
                "rkeyA*"
              )
-             |> Enum.count(get_items) == 16
+             |> Enum.count() == 16
     end
 
     test "returns empty list when collection is empty" do

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1,8 +1,8 @@
 defmodule LightningWeb.WorkflowLive.EditTest do
   use LightningWeb.ConnCase, async: true
-  use Retry
 
   import Ecto.Query
+  import Eventually
   import Lightning.Factories
   import Lightning.JobsFixtures
   import Lightning.WorkflowLive.Helpers
@@ -2099,23 +2099,22 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       high_priority_view |> form("#workflow-form") |> render_submit()
 
-      retry with: exponential_backoff() |> cap(1_000) |> expiry(6_000),
-            rescue_only: [ExUnit.AssertionError] do
-        assert high_priority_view
-               |> has_element?("#inspector-workflow-version", "latest")
+      assert high_priority_view
+             |> has_element?("#inspector-workflow-version", "latest")
 
-        refute low_priority_view
-               |> has_element?("#inspector-workflow-version", "latest")
+      refute_eventually(
+        low_priority_view
+        |> has_element?("#inspector-workflow-version", "latest")
+      )
 
-        assert low_priority_view
-               |> has_element?(
-                 "#inspector-workflow-version",
-                 "#{String.slice(snapshot.id, 0..6)}"
-               )
+      assert low_priority_view
+             |> has_element?(
+               "#inspector-workflow-version",
+               "#{String.slice(snapshot.id, 0..6)}"
+             )
 
-        assert low_priority_view |> render() =~
-                 "This workflow has been updated. You&#39;re no longer on the latest version."
-      end
+      assert low_priority_view |> render() =~
+               "This workflow has been updated. You&#39;re no longer on the latest version."
 
       workflow = Repo.reload(workflow)
 


### PR DESCRIPTION
### Description

This PR changes the way that the items are streamed to the reducer. Instead of relying on the database streaming, which blocks a transaction or a connection, now that it accepts a custom limit it's safer to do iterations that might block only on the final part of response processing. 

The iterations are now composed by:
1. Fetching some database data (up to a max limit of 5k items)
2. Right after the fetching the database connection is released back to the pool
3. Stream to network in chunks up to user limit
4. If the user limit is higher than 5k, it continues from the step 1, otherwise it finishes the chunking.

Closes #2645

### Validation steps

- Repeat same requests with cursor and limits as before.

### Additional notes

The database streaming is replaced by regular fetching once the data is streamed on chunks.
 
## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
