### PR TITLE
Handle the modal_close event in WorkflowLive.edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix LiveView crash when pressing "esc" on inspector
+  [#2622](https://github.com/OpenFn/lightning/issues/2622)
+
 ## [v2.10.0-rc.1] - 2024-11-08
 
 ### Changed

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1266,7 +1266,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   def handle_event("modal_closed", _params, socket) do
-    {:noreply, assign(socket, selected_arcade_resource: nil)}
+    {:noreply, socket}
   end
 
   def handle_event("delete_node", %{"id" => id}, socket) do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1265,6 +1265,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
     {:noreply, updated_socket}
   end
 
+  def handle_event("modal_closed", _params, socket) do
+    {:noreply, assign(socket, selected_arcade_resource: nil)}
+  end
+
   def handle_event("delete_node", %{"id" => id}, socket) do
     %{
       changeset: changeset,

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1265,10 +1265,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
     {:noreply, updated_socket}
   end
 
-  def handle_event("modal_closed", _params, socket) do
-    {:noreply, socket}
-  end
-
   def handle_event("delete_node", %{"id" => id}, socket) do
     %{
       changeset: changeset,
@@ -1663,6 +1659,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
       {:error, %{text: message}} ->
         {:noreply, put_flash(socket, :error, message)}
     end
+  end
+
+  def handle_event(_unhandled_event, _params, socket) do
+    # TODO: add a warning and/or log for unhandled events
+    {:noreply, socket}
   end
 
   @impl true


### PR DESCRIPTION
### Description

This PR fixes #2622 - but I have no idea if it's the "right" way to fix it. If it's _not_ the right way, would someone please implement the proper fix and merge? Thank you 🙌 

### Validation steps

1. See steps in #2622 - note that it not longer crashes

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
