### PR TITLE
Remove collections and fhir-jembi from Available Adaptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Hide the collections and fhir-jembi adaptors from the available adaptors list
+  [#2648](https://github.com/OpenFn/lightning/issues/2648)
+
 ### Fixed
 
 - Fix LiveView crash when pressing "esc" on inspector

--- a/lib/lightning/adaptor_registry.ex
+++ b/lib/lightning/adaptor_registry.ex
@@ -36,7 +36,12 @@ defmodule Lightning.AdaptorRegistry do
   use GenServer
   require Logger
 
-  @excluded_adaptors ["@openfn/language-devtools", "@openfn/language-template"]
+  @excluded_adaptors [
+    "@openfn/language-devtools",
+    "@openfn/language-template",
+    "@openfn/language-fhir-jembi",
+    "@openfn/language-collections"
+  ]
   @timeout 30_000
 
   defmodule Npm do


### PR DESCRIPTION
### Description

Closes #2648 

### Validation steps

1. Create a new workflow
2. Edit a job node and attempt to change it's adaptor
3. Note that the `collections` adaptor and the `fhir-jembi` adaptor are no longer available in the options

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
