### PR TITLE
Rename the Last Activity Column to Last Updated in the Projects List

### DIFF
--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -45,12 +45,12 @@ defmodule Lightning.Projects do
       :role,
       :workflows_count,
       :collaborators_count,
-      :last_activity
+      :last_updated_at
     ]
   end
 
   def get_projects_overview(%User{id: user_id}, opts \\ []) do
-    order_by = Keyword.get(opts, :order_by, {:asc, :name})
+    order_by = Keyword.get(opts, :order_by, {:asc_nulls_last, :name})
 
     from(p in Project,
       join: pu in assoc(p, :project_users),
@@ -64,7 +64,7 @@ defmodule Lightning.Projects do
         role: pu.role,
         workflows_count: count(w.id, :distinct),
         collaborators_count: count(pu_all.user_id, :distinct),
-        last_activity: max(w.updated_at)
+        last_updated_at: max(w.updated_at)
       },
       order_by: ^dynamic_order_by(order_by)
     )
@@ -75,7 +75,7 @@ defmodule Lightning.Projects do
     {direction, dynamic([p, _pu, _w, _pu_all], field(p, :name))}
   end
 
-  defp dynamic_order_by({direction, :last_activity}) do
+  defp dynamic_order_by({direction, :last_updated_at}) do
     {direction, dynamic([_p, _pu, w, _pu_all], max(w.updated_at))}
   end
 

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -123,14 +123,18 @@ defmodule LightningWeb.DashboardLive.Components do
   end
 
   def user_projects_table(assigns) do
-    next_sort_icon = %{asc: "hero-chevron-up", desc: "hero-chevron-down"}
+    next_sort_icon = %{
+      asc_nulls_last: "hero-chevron-up",
+      desc_nulls_last: "hero-chevron-down"
+    }
 
     assigns =
       assign(assigns,
         projects_count: assigns.projects |> Enum.count(),
         empty?: assigns.projects |> Enum.empty?(),
         name_sort_icon: next_sort_icon[assigns.name_direction],
-        last_activity_sort_icon: next_sort_icon[assigns.last_activity_direction]
+        last_updated_at_sort_icon:
+          next_sort_icon[assigns.last_updated_at_direction]
       )
 
     ~H"""
@@ -163,14 +167,14 @@ defmodule LightningWeb.DashboardLive.Components do
           <.th>Collaborators</.th>
           <.th>
             <div class="group inline-flex items-center">
-              Last Activity
+              Last Updated
               <span
                 phx-click="sort"
-                phx-value-by="last_activity"
+                phx-value-by="last_updated_at"
                 phx-target={@target}
                 class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
               >
-                <.icon name={@last_activity_sort_icon} />
+                <.icon name={@last_updated_at_sort_icon} />
               </span>
             </div>
           </.th>
@@ -207,13 +211,13 @@ defmodule LightningWeb.DashboardLive.Components do
             </.link>
           </.td>
           <.td>
-            <%= if project.last_activity do %>
+            <%= if project.last_updated_at do %>
               <%= Lightning.Helpers.format_date(
-                project.last_activity,
+                project.last_updated_at,
                 "%d/%m/%Y %H:%M:%S"
               ) %>
             <% else %>
-              No activity
+              N/A
             <% end %>
           </.td>
           <.td class="text-right">

--- a/lib/lightning_web/live/dashboard_live/user_projects_section.ex
+++ b/lib/lightning_web/live/dashboard_live/user_projects_section.ex
@@ -16,8 +16,8 @@ defmodule LightningWeb.DashboardLive.UserProjectsSection do
      socket
      |> assign(assigns)
      |> assign(:projects, projects)
-     |> assign(:name_sort_direction, :asc)
-     |> assign(:last_activity_sort_direction, :asc)}
+     |> assign(:name_sort_direction, :asc_nulls_last)
+     |> assign(:last_updated_at_sort_direction, :asc_nulls_last)}
   end
 
   @impl true
@@ -27,7 +27,7 @@ defmodule LightningWeb.DashboardLive.UserProjectsSection do
 
     sort_direction =
       socket.assigns
-      |> Map.get(sort_key, :asc)
+      |> Map.get(sort_key, :asc_nulls_last)
       |> switch_sort_direction()
 
     projects =
@@ -41,11 +41,11 @@ defmodule LightningWeb.DashboardLive.UserProjectsSection do
      |> assign(sort_key, sort_direction)}
   end
 
-  defp switch_sort_direction(:asc), do: :desc
-  defp switch_sort_direction(:desc), do: :asc
+  defp switch_sort_direction(:asc_nulls_last), do: :desc_nulls_last
+  defp switch_sort_direction(:desc_nulls_last), do: :asc_nulls_last
 
   defp projects_for_user(%User{} = user, opts \\ []) do
-    order_by = Keyword.get(opts, :order_by, {:asc, :name})
+    order_by = Keyword.get(opts, :order_by, {:asc_nulls_last, :name})
 
     Projects.get_projects_overview(user, order_by: order_by)
   end
@@ -59,7 +59,7 @@ defmodule LightningWeb.DashboardLive.UserProjectsSection do
         user={@current_user}
         target={@myself}
         name_direction={@name_sort_direction}
-        last_activity_direction={@last_activity_sort_direction}
+        last_updated_at_direction={@last_updated_at_sort_direction}
       >
         <:empty_state>
           <button

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1618,7 +1618,7 @@ defmodule Lightning.ProjectsTest do
              ] = result
     end
 
-    test "orders projects by last_activity (updated_at of workflows) descending when specified" do
+    test "orders projects by last_updated_at (updated_at of workflows) descending when specified" do
       user = insert(:user)
 
       project_a =
@@ -1640,7 +1640,9 @@ defmodule Lightning.ProjectsTest do
       )
 
       result =
-        Projects.get_projects_overview(user, order_by: {:desc, :last_activity})
+        Projects.get_projects_overview(user,
+          order_by: {:desc_nulls_last, :last_updated_at}
+        )
 
       assert [
                %ProjectOverviewRow{id: ^project_b_id, name: "Project B"},
@@ -1648,7 +1650,7 @@ defmodule Lightning.ProjectsTest do
              ] = result
     end
 
-    test "orders projects by last_activity ascending when specified" do
+    test "orders projects by last_updated_at ascending when specified" do
       user = insert(:user)
 
       project_a =
@@ -1670,7 +1672,9 @@ defmodule Lightning.ProjectsTest do
       )
 
       result =
-        Projects.get_projects_overview(user, order_by: {:asc, :last_activity})
+        Projects.get_projects_overview(user,
+          order_by: {:asc_nulls_last, :last_updated_at}
+        )
 
       assert [
                %ProjectOverviewRow{id: ^project_a_id, name: "Project A"},
@@ -1694,7 +1698,7 @@ defmodule Lightning.ProjectsTest do
                  id: ^project_id,
                  name: "Project No Workflow",
                  workflows_count: 0,
-                 last_activity: nil
+                 last_updated_at: nil
                }
              ] = result
     end

--- a/test/lightning_web/live/dashboard_live_test.exs
+++ b/test/lightning_web/live/dashboard_live_test.exs
@@ -218,8 +218,8 @@ defmodule LightningWeb.DashboardLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/projects")
 
-      projects_sorted_by_last_activity =
-        get_sorted_projects_by_last_activity(projects)
+      projects_sorted_by_last_updated_at =
+        get_sorted_projects_by_last_updated_at(projects)
 
       html = render(view)
 
@@ -227,14 +227,14 @@ defmodule LightningWeb.DashboardLiveTest do
         extract_project_last_activities_from_html(html)
 
       assert project_last_activities_from_html ==
-               projects_sorted_by_last_activity
+               projects_sorted_by_last_updated_at
 
       view
-      |> element("span[phx-click='sort'][phx-value-by='last_activity']")
+      |> element("span[phx-click='sort'][phx-value-by='last_updated_at']")
       |> render_click()
 
-      projects_sorted_by_last_activity_desc =
-        get_sorted_projects_by_last_activity(projects, :desc)
+      projects_sorted_by_last_updated_at_desc =
+        get_sorted_projects_by_last_updated_at(projects, :desc)
 
       html = render(view)
 
@@ -242,7 +242,7 @@ defmodule LightningWeb.DashboardLiveTest do
         extract_project_last_activities_from_html(html)
 
       assert project_last_activities_from_html ==
-               projects_sorted_by_last_activity_desc
+               projects_sorted_by_last_updated_at_desc
     end
 
     test "Toggles the welcome banner", %{conn: conn, user: user} do
@@ -353,7 +353,7 @@ defmodule LightningWeb.DashboardLiveTest do
            )
   end
 
-  defp get_sorted_projects_by_last_activity(projects, order \\ :asc) do
+  defp get_sorted_projects_by_last_updated_at(projects, order \\ :asc) do
     projects_with_workflows = Repo.preload(projects, :workflows)
 
     projects_with_workflows
@@ -367,16 +367,16 @@ defmodule LightningWeb.DashboardLiveTest do
       order
     )
     |> Enum.map(fn project ->
-      last_activity =
+      last_updated_at =
         project
         |> Map.get(:workflows)
         |> Enum.map(& &1.updated_at)
         |> Enum.max(fn -> nil end)
 
-      if last_activity do
-        Lightning.Helpers.format_date(last_activity, "%d/%m/%Y %H:%M:%S")
+      if last_updated_at do
+        Lightning.Helpers.format_date(last_updated_at, "%d/%m/%Y %H:%M:%S")
       else
-        "No activity"
+        "N/A"
       end
     end)
   end


### PR DESCRIPTION
### Description

This PR renames the last activity column in the projects list table in the projects dashboard page to last updated at. It also fixes the sorting order of the null values. Now nulls values always come last in the sorting order.

Closes #

### Validation steps

1. Go to the project dashboard page (`/projects`)
2. Note that the presence of the `Last Modified` column instead of the `Last Activity` column
3. Note that when you sort by name or last modified, the null values always come last

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
