### PR TITLE
Restore metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix metadata loading as code-assist in the editor
+
 ## [v2.10.0] - 2024-11-13
 
 ### Changed

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -147,7 +147,7 @@ async function loadDTS(specifier: string): Promise<Lib[]> {
 
       // Remove js doc annotations
       // this regex means: find a * then an @ (with 1+ space in between), then match everything up to a closing comment */
-      content = content.replace(/\* +@(.+?)\*\//gs, '*/');
+      // content = content.replace(/\* +@(.+?)\*\//gs, '*/');
 
       let fileName = filePath.split('/').at(-1).replace('.d.ts', '');
 


### PR DESCRIPTION
### Description

Restores metadata to adaptors that support it.

I added a bunch of stuff to remove "unused" jsdoc attributes to tidy up the code assist display. Turns out that I'm also stripping out the magic metadata used too.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
