### PR TITLE
Fix Broken Input Dataclip UI

### DIFF
--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -170,6 +170,10 @@ defmodule LightningWeb.Components.NewInputs do
 
   attr :class, :string, default: ""
 
+  attr :wrapper_class, :string,
+    default: "h-full",
+    doc: "control the wrapping div classes of some components like the textarea"
+
   attr :display_errors, :boolean, default: true
 
   attr :tooltip, :any, default: nil
@@ -248,7 +252,7 @@ defmodule LightningWeb.Components.NewInputs do
 
   def input(%{type: "textarea"} = assigns) do
     ~H"""
-    <div phx-feedback-for={@name}>
+    <div phx-feedback-for={@name} class={@wrapper_class}>
       <.label :if={@label} for={@id}>
         <%= @label %><span
           :if={Map.get(@rest, :required, false)}

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -170,8 +170,8 @@ defmodule LightningWeb.Components.NewInputs do
 
   attr :class, :string, default: ""
 
-  attr :wrapper_class, :string,
-    default: "h-full",
+  attr :stretch, :boolean,
+    default: false,
     doc: "control the wrapping div classes of some components like the textarea"
 
   attr :display_errors, :boolean, default: true
@@ -252,7 +252,7 @@ defmodule LightningWeb.Components.NewInputs do
 
   def input(%{type: "textarea"} = assigns) do
     ~H"""
-    <div phx-feedback-for={@name} class={@wrapper_class}>
+    <div phx-feedback-for={@name} class={@stretch && "h-full"}>
       <.label :if={@label} for={@id}>
         <%= @label %><span
           :if={Map.get(@rest, :required, false)}

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -125,7 +125,8 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
         type="textarea"
         field={@form[:body]}
         disabled={@disabled}
-        class="h-full font-mono proportional-nums text-slate-200 bg-slate-700 "
+        class="h-full font-mono proportional-nums text-slate-200 bg-slate-700"
+        stretch={true}
         phx-debounce="300"
         phx-hook="BlurDataclipEditor"
       />

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -125,7 +125,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
         type="textarea"
         field={@form[:body]}
         disabled={@disabled}
-        class="h-full pb-2 font-mono proportional-nums"
+        class="h-full font-mono proportional-nums text-slate-200 bg-slate-700 "
         phx-debounce="300"
         phx-hook="BlurDataclipEditor"
       />


### PR DESCRIPTION
### Description

This PR propose code that is most likely a temporarily fix for the broken data-clip viewer UI in the inspector page.

### Validation steps

1. Go to the inspector page
2. Make sure no dataclip is selected
3. See that the input dataclip is looking quite normal now (it was looking weird - all white and unstyled textarea)

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
