### PR TITLE
Disable actions for deleted workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Disable save and run actions on deleted workflows
+  [#2170](https://github.com/OpenFn/lightning/issues/2170)
+
 ## [v2.10.3] - 2024-11-13
 
 ### Added
@@ -58,8 +61,6 @@ and this project adheres to
 
 - Error when the logger receives a boolean
   [#2666](https://github.com/OpenFn/lightning/issues/2666)
-- Disable save and run actions on deleted workflows
-  [#2170](https://github.com/OpenFn/lightning/issues/2170)
 
 ## [v2.10.1] - 2024-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Error when the logger receives a boolean
   [#2666](https://github.com/OpenFn/lightning/issues/2666)
+- Disable save and run actions on deleted workflows
+  [#2170](https://github.com/OpenFn/lightning/issues/2170)
 
 ## [v2.10.1] - 2024-11-13
 

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -283,7 +283,7 @@ defmodule Lightning.WorkOrders do
           Step.t() | Ecto.UUID.t(),
           [work_order_option(), ...]
         ) ::
-          {:ok, Run.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Run.t()} | {:error, Ecto.Changeset.t() | :workflow_deleted}
   def retry(%Run{id: run_id}, %Step{id: step_id}, opts) do
     retry(run_id, step_id, opts)
   end
@@ -508,7 +508,10 @@ defmodule Lightning.WorkOrders do
           retry(run_step.run_id, run_step.step_id, opts)
         end)
 
-      {:ok, Enum.count(results, fn result -> match?({:ok, _}, result) end), 0}
+      success_count =
+        Enum.count(results, fn result -> match?({:ok, _}, result) end)
+
+      {:ok, success_count, Enum.count(results) - success_count}
     end
   end
 

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -679,7 +679,7 @@ defmodule Lightning.WorkOrders do
   defp fetch_retriable_workorders(workorder_ids) do
     workorder_ids
     |> workorders_with_dataclips_query()
-    |> join([wo], :inner, wf in assoc(wo, :workflow), as: :workflow)
+    |> join(:inner, [wo], wf in assoc(wo, :workflow), as: :workflow)
     |> where([workflow: wf], is_nil(wf.deleted_at))
     |> Repo.all()
   end

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -56,14 +56,14 @@ defmodule Lightning.Workflows do
   @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map()) ::
           {:ok, Workflow.t()}
           | {:error, Ecto.Changeset.t(Workflow.t())}
-          | {:error, :deleted}
+          | {:error, :workflow_deleted}
   def save_workflow(%Ecto.Changeset{data: %Workflow{}} = changeset) do
     Multi.new()
     |> Multi.run(:validate, fn _repo, _changes ->
       if is_nil(changeset.data.deleted_at) do
         {:ok, true}
       else
-        {:error, :deleted}
+        {:error, :workflow_deleted}
       end
     end)
     |> Multi.insert_or_update(:workflow, changeset)

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -340,6 +340,11 @@ defmodule LightningWeb.RunLive.Index do
            socket
            |> put_flash(:error, error_text)}
 
+        {:error, :workflow_deleted} ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "Runs for deleted workflows cannot be retried")}
+
         {:error, _changeset} ->
           {:noreply,
            socket
@@ -362,7 +367,8 @@ defmodule LightningWeb.RunLive.Index do
          "New run#{if count > 1, do: "s", else: ""} enqueued for #{count} workorder#{if count > 1, do: "s", else: ""}"
          |> then(fn msg ->
            if discarded_count > 0 do
-             msg <> " (#{discarded_count} were discarded due to wiped dataclip)"
+             msg <>
+               " (#{discarded_count} were discarded due to wiped dataclip/workflow being deleted)"
            else
              msg
            end

--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -361,11 +361,10 @@ defmodule LightningWeb.RunLive.Index do
        socket
        |> put_flash(
          :info,
-         "New run#{if count > 1, do: "s", else: ""} enqueued for #{count} workorder#{if count > 1, do: "s", else: ""}"
+         "New run#{if count > 1, do: "s"} enqueued for #{count} workorder#{if count > 1, do: "s"}"
          |> then(fn msg ->
            if discarded_count > 0 do
-             msg <>
-               " (#{discarded_count} were discarded due to wiped dataclip/workflow being deleted)"
+             "#{msg} (#{discarded_count} were discarded due to wiped dataclip/workflow being deleted)"
            else
              msg
            end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1789,7 +1789,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
       _snapshot_not_latest ->
         {:noreply,
          socket
-         |> put_flash(:error, "Cannot save in snapshot mode, switch to latest.")}
+         |> put_flash(
+           :error,
+           "Cannot save in snapshot mode, switch to the latest version."
+         )}
     end
   end
 
@@ -1946,8 +1949,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
       %{manual_run_form: nil} ->
         true
 
-      %{workflow: workflow} ->
-        !is_nil(workflow.deleted_at)
+      %{workflow: %{deleted_at: deleted_at}} when is_struct(deleted_at) ->
+        true
 
       %{
         manual_run_form: manual_run_form,

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1464,6 +1464,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
         {:error, %{text: message}} ->
           {:noreply, put_flash(socket, :error, message)}
 
+        {:error, :deleted} ->
+          {:noreply,
+           put_flash(
+             socket,
+             :error,
+             "Oops! You cannot modify a deleted workflow"
+           )}
+
         {:error, %Ecto.Changeset{} = changeset} ->
           {:noreply,
            socket
@@ -1666,6 +1674,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
       {:error, %{text: message}} ->
         {:noreply, put_flash(socket, :error, message)}
+
+      {:error, :deleted} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Oops! You cannot modify a deleted workflow"
+         )}
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -52,7 +52,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
           | {:error, Ecto.Changeset.t(Workflows.Workflow.t())}
           | {:error, Ecto.Changeset.t(WorkOrders.Manual.t())}
           | {:error, UsageLimiting.message()}
-          | {:error, :deleted}
+          | {:error, :workflow_deleted}
   def run_workflow(workflow_or_changeset, params, opts) do
     Lightning.Repo.transact(fn ->
       %{id: project_id} = Keyword.fetch!(opts, :project)

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -25,7 +25,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
 
   @spec save_workflow(Ecto.Changeset.t()) ::
           {:ok, Workflows.Workflow.t()}
-          | {:error, Ecto.Changeset.t() | UsageLimiting.message()}
+          | {:error, Ecto.Changeset.t() | UsageLimiting.message() | :deleted}
   def save_workflow(changeset) do
     case WorkflowUsageLimiter.limit_workflow_activation(changeset) do
       :ok ->
@@ -52,6 +52,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
           | {:error, Ecto.Changeset.t(Workflows.Workflow.t())}
           | {:error, Ecto.Changeset.t(WorkOrders.Manual.t())}
           | {:error, UsageLimiting.message()}
+          | {:error, :deleted}
   def run_workflow(workflow_or_changeset, params, opts) do
     Lightning.Repo.transact(fn ->
       %{id: project_id} = Keyword.fetch!(opts, :project)

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -25,7 +25,8 @@ defmodule LightningWeb.WorkflowLive.Helpers do
 
   @spec save_workflow(Ecto.Changeset.t()) ::
           {:ok, Workflows.Workflow.t()}
-          | {:error, Ecto.Changeset.t() | UsageLimiting.message() | :deleted}
+          | {:error,
+             Ecto.Changeset.t() | UsageLimiting.message() | :workflow_deleted}
   def save_workflow(changeset) do
     case WorkflowUsageLimiter.limit_workflow_activation(changeset) do
       :ok ->

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -573,6 +573,45 @@ defmodule Lightning.WorkOrdersTest do
         work_order: %{id: ^workorder_id}
       }
     end
+
+    test "returns error in case the workflow is deleted", %{
+      workflow: workflow,
+      snapshot: snapshot,
+      trigger: trigger,
+      jobs: [job | _rest]
+    } do
+      user = insert(:user)
+      dataclip = insert(:dataclip)
+      # create existing complete run
+      %{runs: [run]} =
+        insert(:workorder,
+          workflow: workflow,
+          snapshot: snapshot,
+          trigger: trigger,
+          dataclip: dataclip,
+          runs: [
+            %{
+              state: :failed,
+              dataclip: dataclip,
+              snapshot: snapshot,
+              starting_trigger: trigger,
+              steps: [
+                step = insert(:step, job: job, input_dataclip: dataclip)
+              ]
+            }
+          ]
+        )
+
+      # delete workflow
+      workflow
+      |> Ecto.Changeset.change(%{
+        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+      |> Repo.update!()
+
+      assert {:error, :workflow_deleted} =
+               WorkOrders.retry(run, step, created_by: user)
+    end
   end
 
   describe "retry_many/3" do
@@ -2036,6 +2075,98 @@ defmodule Lightning.WorkOrdersTest do
                )
       end)
     end
+
+    test "retrying multiple workorders only retries workorders with workflows that havent been deleted",
+         %{
+           jobs: [job_a | _rest],
+           snapshot: snapshot,
+           trigger: trigger,
+           user: user,
+           workflow: workflow
+         } do
+      workorder_1 =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: build(:dataclip),
+          snapshot: snapshot,
+          runs: [
+            %{
+              state: :failed,
+              dataclip: build(:dataclip),
+              starting_trigger: trigger,
+              snapshot: snapshot,
+              steps: [
+                insert(:step,
+                  job: job_a,
+                  input_dataclip: build(:dataclip),
+                  output_dataclip: build(:dataclip)
+                )
+              ]
+            }
+          ]
+        )
+
+      deleted_workflow =
+        insert(:simple_workflow,
+          project: workflow.project,
+          deleted_at: DateTime.utc_now()
+        )
+
+      deleted_workflow_job = hd(deleted_workflow.jobs)
+
+      snapshot_2 =
+        Lightning.Workflows.Snapshot.build(deleted_workflow) |> Repo.insert!()
+
+      workorder_2 =
+        insert(:workorder,
+          workflow: deleted_workflow,
+          trigger: hd(deleted_workflow.triggers),
+          dataclip: build(:dataclip),
+          snapshot: snapshot_2,
+          runs: [
+            %{
+              state: :failed,
+              dataclip: build(:dataclip),
+              starting_trigger: hd(deleted_workflow.triggers),
+              snapshot: snapshot_2,
+              steps: [
+                insert(:step,
+                  job: deleted_workflow_job,
+                  input_dataclip: build(:dataclip),
+                  output_dataclip: build(:dataclip)
+                )
+              ]
+            }
+          ]
+        )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_1.id,
+               starting_job_id: job_a.id
+             )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_2.id,
+               starting_job_id: deleted_workflow_job.id
+             )
+
+      {:ok, 1, 1} =
+        WorkOrders.retry_many([workorder_2, workorder_1],
+          created_by: user,
+          project_id: workflow.project_id
+        )
+
+      assert Repo.get_by(Lightning.Run,
+               work_order_id: workorder_1.id,
+               starting_job_id: job_a.id
+             )
+
+      refute Repo.get_by(Lightning.Run,
+               work_order_id: workorder_2.id,
+               starting_job_id: deleted_workflow_job.id
+             )
+    end
   end
 
   describe "retry_many/2 for RunSteps" do
@@ -2406,7 +2537,7 @@ defmodule Lightning.WorkOrdersTest do
                starting_job_id: job_a.id
              )
 
-      {:ok, 1, 0} =
+      {:ok, 1, 1} =
         WorkOrders.retry_many([run_step_2_a, run_step_1_a],
           created_by: user,
           project_id: workflow.project_id

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -70,7 +70,7 @@ defmodule Lightning.WorkflowsTest do
       workflow = insert(:workflow, deleted_at: DateTime.utc_now())
       update_attrs = %{name: "some-updated-name"}
 
-      assert {:error, :deleted} =
+      assert {:error, :workflow_deleted} =
                Workflows.change_workflow(workflow, update_attrs)
                |> Workflows.save_workflow()
     end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -66,6 +66,15 @@ defmodule Lightning.WorkflowsTest do
       assert workflow.name == "some-updated-name"
     end
 
+    test "save_workflow/1 for a deleted workflow returns an error" do
+      workflow = insert(:workflow, deleted_at: DateTime.utc_now())
+      update_attrs = %{name: "some-updated-name"}
+
+      assert {:error, :deleted} =
+               Workflows.change_workflow(workflow, update_attrs)
+               |> Workflows.save_workflow()
+    end
+
     test "save_workflow/1 publishes event for updated Kafka triggers" do
       kafka_configuration = build(:triggers_kafka_configuration)
 


### PR DESCRIPTION
### Description

This PR disables the workflow edit form whenever a deleted workflow is opened. The save and run form for manual runs is also disabled.

It also adds the restriction on the retry logic. Only un-deleted workflows can be retried. 

Closes #2170

### Validation steps

In order to test this, you'll need an existing workflow with some `workorders` and `runs`.

1. Delete the workflow
2. Go to the runs page. Try retrying a run/workorder for the deleted workorder. 
     - When you try retrying individually, you'll get an error saying `Runs for deleted workflows cannot be retried`.  
     - When you retry in bulk, you'll see that a certain number was discarded because the workflow was disabled/deleted
3. Click to inspect one of the steps for that run. You'll see that the job inspector has the action buttons (save/retry) disabled. The whole workflow form is disabled, you cannot even modify the job name


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
