### PR TITLE
Ignore Plug.Conn.InvalidQueryError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Ignore Plug.Conn.InvalidQueryError in Sentry
+  [#2672](https://github.com/OpenFn/lightning/issues/2672)
+
 ### Fixed
 
 ## [v2.10.1] - 2024-11-13

--- a/lib/lightning/sentry_event_filter.ex
+++ b/lib/lightning/sentry_event_filter.ex
@@ -4,12 +4,13 @@ defmodule Lightning.SentryEventFilter do
   @behaviour Sentry.EventFilter
 
   @ignored_exceptions [
+    Phoenix.NotAcceptableError,
     Phoenix.Router.NoRouteError,
-    Plug.Parsers.RequestTooLargeError,
+    Plug.Conn.InvalidQueryError,
     Plug.Parsers.BadEncodingError,
     Plug.Parsers.ParseError,
-    Plug.Parsers.UnsupportedMediaTypeError,
-    Phoenix.NotAcceptableError
+    Plug.Parsers.RequestTooLargeError,
+    Plug.Parsers.UnsupportedMediaTypeError
   ]
 
   def exclude_exception?(%x{}, :plug) when x in @ignored_exceptions do


### PR DESCRIPTION
### Description

This error occurs when someone sends a bad UTF-8 encoded query param. There is nothing that we can do but send back a 400 error, which is what happens in both dev and production environments

So there is no need to register this error in Sentry either, as these kinds of errors are usually associated with bots.

Closes #2672

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
