### PR TITLE
Disable Monaco Command Palette in Input and Log Viewer

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -15,5 +15,32 @@ export function initiateSaveAndRun(buttonElement) {
 }
 
 export function randomUUID() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => (c === 'x' ? (Math.random() * 16 | 0) : ('r&0x3'| '0x8')).toString(16))
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c =>
+    (c === 'x' ? (Math.random() * 16) | 0 : 'r&0x3' | '0x8').toString(16)
+  );
+}
+
+/**
+ * Creates a context key and adds a command to the Monaco editor.
+ * @param {import('monaco-editor').editor.IStandaloneCodeEditor} editor - The Monaco editor instance.
+ * @param {number} keyCode - The key code to trigger the command (e.g., `monaco.KeyCode.F1`).
+ * @param {string} contextKeyName - The unique name for the context key, enabling command scoping.
+ * @param {() => void} commandCallback - The callback function to execute when the command is triggered.
+ * @returns {string | null} The command ID if successfully created, or `null` if creation fails.
+ */
+export function addContextualCommand(
+  editor,
+  keyCode,
+  contextKeyName,
+  commandCallback
+) {
+  const contextKey = editor.createContextKey(contextKeyName, true);
+
+  const command = editor.addCommand(keyCode, commandCallback, contextKeyName);
+
+  editor.onDidDispose(() => {
+    contextKey.reset();
+  });
+
+  return command;
 }

--- a/assets/js/dataclip-viewer/component.tsx
+++ b/assets/js/dataclip-viewer/component.tsx
@@ -1,6 +1,8 @@
+import type { editor as __MonacoEditor } from 'monaco-editor/esm/vs/editor/editor.api';
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { MonacoEditor } from '../monaco';
+import { Monaco, MonacoEditor } from '../monaco';
+import { addContextualCommand } from '../common';
 
 export function mount(el: HTMLElement, dataclipId: string) {
   const componentRoot = createRoot(el);
@@ -37,6 +39,21 @@ async function fetchDataclipContent(dataclipId: string) {
 const DataclipViewer = ({ dataclipId }: { dataclipId: string }) => {
   const [content, setContent] = useState<string>('');
 
+  const [monaco, setMonaco] = useState<Monaco | null>(null);
+  const [editor, setEditor] =
+    useState<__MonacoEditor.IStandaloneCodeEditor | null>(null);
+
+  useEffect(() => {
+    if (monaco && editor) {
+      addContextualCommand(
+        editor,
+        monaco.KeyCode.F1,
+        'DataclipViewerContext',
+        () => {}
+      );
+    }
+  }, [editor, monaco]);
+
   useEffect(() => {
     fetchDataclipContent(dataclipId).then(setContent);
   }, [dataclipId]);
@@ -46,6 +63,8 @@ const DataclipViewer = ({ dataclipId }: { dataclipId: string }) => {
       defaultLanguage="json"
       theme="default"
       value={content}
+      beforeMount={setMonaco}
+      onMount={setEditor}
       loading={<div>Loading...</div>}
       options={{
         readOnly: true,

--- a/assets/js/log-viewer/component.tsx
+++ b/assets/js/log-viewer/component.tsx
@@ -3,21 +3,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useShallow } from 'zustand/react/shallow';
 import { Monaco, MonacoEditor } from '../monaco';
-import { LogLine, createLogStore } from './store';
-
-function findLogIndicesByStepId(
-  logs: LogLine[],
-  stepId: string
-): { first: number | null; last: number | null } {
-  let firstIndex = logs.findIndex(log => log.step_id === stepId);
-  let lastIndex = logs.findLastIndex(log => log.step_id === stepId);
-
-  if (firstIndex === -1) {
-    return { first: null, last: null };
-  } else {
-    return { first: firstIndex, last: lastIndex + 1 };
-  }
-}
+import { createLogStore } from './store';
+import { addContextualCommand } from '../common';
 
 export function mount(
   el: HTMLElement,
@@ -53,6 +40,17 @@ const LogViewer = ({
 
   const decorationsCollection =
     useRef<__MonacoEditor.IEditorDecorationsCollection | null>(null);
+
+  useEffect(() => {
+    if (monaco && editor) {
+      addContextualCommand(
+        editor,
+        monaco.KeyCode.F1,
+        'LogViewerContext',
+        () => {}
+      );
+    }
+  }, [editor, monaco]);
 
   useEffect(() => {
     if (stepId && highlightedRanges.length > 0) {


### PR DESCRIPTION
### Description

This PR proposes changes that will disable the command palette (the menu that appears when you press `F1`) in the input data clip viewer and the log viewer. 

Closes #2643 

### Validation steps

1. Open the inspector
2. Focus the input data clip viewer, press F1 on your keyboard, note that the Monaco command palette doesn't show up
3. Do the same for the log viewer (input and output tab also)
4. Focus the job editor, press F1, note that the command palette does show up this time; it hasn't been disabled

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
