### PR TITLE
Add support for booleans to LogMessage ecto type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Error when the logger receives a boolean
+  [#2666](https://github.com/OpenFn/lightning/issues/2666)
+
 ## [v2.10.1] - 2024-11-13
 
 ### Fixed

--- a/lib/lightning/ecto_types.ex
+++ b/lib/lightning/ecto_types.ex
@@ -85,6 +85,9 @@ defmodule Lightning.LogMessage do
   def cast(d) when is_integer(d),
     do: Ecto.Type.cast(:string, d |> Integer.to_string())
 
+  def cast(d) when is_boolean(d),
+    do: Ecto.Type.cast(:string, d |> to_string())
+
   def cast(d) when is_float(d),
     do: Ecto.Type.cast(:string, d |> Float.to_string())
 

--- a/test/lightning/ecto_types_test.exs
+++ b/test/lightning/ecto_types_test.exs
@@ -31,6 +31,14 @@ defmodule Lightning.EctoTypesTest do
       assert {:ok, ~s<5.893>} =
                LogMessage.cast(5.893)
     end
+
+    test "can be cast from a boolean" do
+      assert {:ok, ~s<true>} =
+               LogMessage.cast(true)
+
+      assert {:ok, ~s<false>} =
+               LogMessage.cast(false)
+    end
   end
 
   describe "UnixDateTime" do


### PR DESCRIPTION
### Description

Certain jobs can log booleans, `console.log(false)`. Which caused the LogMessage Ecto type to throw an error.

This adds a clause to cast booleans to strings.

Fixes #2666

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
