### PR TITLE
add index to `dataclip_id` on `runs` and `work_orders` tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 - Ignore Plug.Conn.InvalidQueryError in Sentry
   [#2672](https://github.com/OpenFn/lightning/issues/2672)
+- Add Index to `dataclip_id` on `runs` and `work_orders` tables to fasten deletion
+  [PR#2677](https://github.com/OpenFn/lightning/pull/2677)
 
 ### Fixed
 

--- a/priv/repo/migrations/20241114122325_add_index_to_dataclip_id_on_runs.exs
+++ b/priv/repo/migrations/20241114122325_add_index_to_dataclip_id_on_runs.exs
@@ -1,0 +1,8 @@
+defmodule Lightning.Repo.Migrations.AddIndexToDataclipIdOnRuns do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists index("runs", [:dataclip_id])
+    create_if_not_exists index("work_orders", [:dataclip_id])
+  end
+end


### PR DESCRIPTION
### Description

This PR adds an index to `dataclip_id` on `runs` and `work_orders` tables to fasten deletion
Based on the benchmarks done locally, this makes the deletion `5 - 7x` faster.

**Before**
```sql
Planning Time: 11.198 ms
Trigger RI_ConstraintTrigger_a_195840 for constraint runs_dataclip_id_fkey: time=5277.221 calls=1000
Trigger RI_ConstraintTrigger_a_195860 for constraint steps_input_dataclip_id_fkey: time=53.755 calls=1000
Trigger RI_ConstraintTrigger_a_195865 for constraint steps_output_dataclip_id_fkey: time=17.599 calls=1000
Trigger RI_ConstraintTrigger_a_195915 for constraint work_orders_dataclip_id_fkey: time=2883.484 calls=1000
Execution Time: 9060.997 ms
```

**After**
```sql
Planning Time: 11.031 ms
Trigger RI_ConstraintTrigger_a_195840 for constraint runs_dataclip_id_fkey: time=10.258 calls=1000
Trigger RI_ConstraintTrigger_a_195860 for constraint steps_input_dataclip_id_fkey: time=8.149 calls=1000
Trigger RI_ConstraintTrigger_a_195865 for constraint steps_output_dataclip_id_fkey: time=7.807 calls=1000
Trigger RI_ConstraintTrigger_a_195915 for constraint work_orders_dataclip_id_fkey: time=13.149 calls=1000
Execution Time: 1169.497 ms
```


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
