### PR TITLE
Super User Can Update Users Passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 
 ### Fixed
 
+- Superusers can't update users passwords
+  [#2621](https://github.com/OpenFn/lightning/issues/2621)
 - Error when the logger receives a boolean
   [#2666](https://github.com/OpenFn/lightning/issues/2666)
 

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -210,6 +210,7 @@ defmodule Lightning.Accounts.User do
     user
     |> cast(attrs, [
       :email,
+      :password,
       :first_name,
       :last_name,
       :role,
@@ -217,6 +218,7 @@ defmodule Lightning.Accounts.User do
       :scheduled_deletion
     ])
     |> validate_email()
+    |> validate_password([])
     |> validate_name()
     |> trim_name()
     |> validate_role()

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -75,6 +75,8 @@ defmodule LightningWeb.UserLiveTest do
              |> form("#user-form", user: @invalid_attrs)
              |> render_change() =~ "can&#39;t be blank"
 
+      refute user_attrs_match?(user, @update_attrs)
+
       {:ok, _, html} =
         form_live
         |> form("#user-form", user: @update_attrs)
@@ -82,6 +84,8 @@ defmodule LightningWeb.UserLiveTest do
         |> follow_redirect(conn, Routes.user_index_path(conn, :index))
 
       assert html =~ "User updated successfully"
+
+      assert Repo.reload!(user) |> user_attrs_match?(@update_attrs)
     end
 
     test "stops a superuser from deleting themselves", %{
@@ -295,5 +299,15 @@ defmodule LightningWeb.UserLiveTest do
 
       assert html =~ "Sorry, you don&#39;t have access to that."
     end
+  end
+
+  def user_attrs_match?(user, attrs) do
+    Enum.all?(attrs, fn
+      {:password, password} ->
+        Bcrypt.verify_pass(password, user.hashed_password)
+
+      {key, value} ->
+        Map.get(user, key) == value
+    end)
   end
 end

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -1,11 +1,12 @@
 defmodule LightningWeb.UserLiveTest do
-  alias Lightning.AccountsFixtures
   use LightningWeb.ConnCase, async: true
 
-  import Lightning.{AccountsFixtures}
+  alias Lightning.AccountsFixtures
+
+  import Lightning.AccountsFixtures
+  import Lightning.Factories
   import Phoenix.LiveViewTest
   import Swoosh.TestAssertions
-  import Lightning.Factories
 
   @create_attrs %{
     email: "test@example.com",
@@ -304,7 +305,7 @@ defmodule LightningWeb.UserLiveTest do
   def user_attrs_match?(user, attrs) do
     Enum.all?(attrs, fn
       {:password, password} ->
-        Bcrypt.verify_pass(password, user.hashed_password)
+        Lightning.Accounts.User.valid_password?(user, password)
 
       {key, value} ->
         Map.get(user, key) == value


### PR DESCRIPTION
### Description

This PR fixes a bug where the super user was unable to update user passwords.

Closes #2621 

### Validation steps

1. Login as super user
2. Go to the `/settings/users` page
3. Pick a user and click on edit
4. Change their password
5. Log out and login as that user
6. Notice that you can no longer login with the old password
7. Notice that you can now login with the new password

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
