### PR TITLE
Distinguish active and inactive sort arrows in projects overview table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Distinguish active and inactive sort arrows in projects overview table
+  [#2423](https://github.com/OpenFn/lightning/issues/2423)
+
 ## [v2.10.3] - 2024-11-13
 
 ### Added

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -50,7 +50,7 @@ defmodule Lightning.Projects do
   end
 
   def get_projects_overview(%User{id: user_id}, opts \\ []) do
-    order_by = Keyword.get(opts, :order_by, {:asc_nulls_last, :name})
+    order_by = Keyword.get(opts, :order_by, "name_asc")
 
     from(p in Project,
       join: pu in assoc(p, :project_users),
@@ -71,12 +71,20 @@ defmodule Lightning.Projects do
     |> Repo.all()
   end
 
-  defp dynamic_order_by({direction, :name}) do
-    {direction, dynamic([p, _pu, _w, _pu_all], field(p, :name))}
+  defp dynamic_order_by("name_asc") do
+    {:asc_nulls_last, dynamic([p, _pu, _w, _pu_all], field(p, :name))}
   end
 
-  defp dynamic_order_by({direction, :last_updated_at}) do
-    {direction, dynamic([_p, _pu, w, _pu_all], max(w.updated_at))}
+  defp dynamic_order_by("name_desc") do
+    {:desc_nulls_last, dynamic([p, _pu, _w, _pu_all], field(p, :name))}
+  end
+
+  defp dynamic_order_by("last_updated_at_asc") do
+    {:asc_nulls_last, dynamic([_p, _pu, w, _pu_all], max(w.updated_at))}
+  end
+
+  defp dynamic_order_by("last_updated_at_desc") do
+    {:desc_nulls_last, dynamic([_p, _pu, w, _pu_all], max(w.updated_at))}
   end
 
   @doc """

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -548,4 +548,33 @@ defmodule LightningWeb.Components.Common do
     </div>
     """
   end
+
+  attr :sort_direction, :string,
+    values: ["asc", "desc"],
+    default: "asc"
+
+  attr :active, :boolean, required: true
+  attr :rest, :global, include: ~w(id href patch navigate), default: %{href: "#"}
+  slot :inner_block, required: true
+
+  def sortable_table_header(assigns) do
+    ~H"""
+    <.link class="group inline-flex" {@rest}>
+      <%= render_slot(@inner_block) %>
+      <span class={[
+        "ml-2 flex-none rounded",
+        if(@active,
+          do: "bg-gray-200 text-gray-900 group-hover:bg-gray-300",
+          else: "invisible text-gray-400 group-hover:visible group-focus:visible"
+        )
+      ]}>
+        <%= if @active and @sort_direction == "desc" do %>
+          <.icon name="hero-chevron-up" class="size-5" />
+        <% else %>
+          <.icon name="hero-chevron-down" class="size-5" />
+        <% end %>
+      </span>
+    </.link>
+    """
+  end
 end

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -244,9 +244,9 @@ defmodule LightningWeb.DashboardLive.Components do
       ]}
     >
       <%= if @current_sort_key == @target_sort_key and @current_sort_direction == "desc" do %>
-        <.icon name="hero-chevron-down" class="size-5" />
-      <% else %>
         <.icon name="hero-chevron-up" class="size-5" />
+      <% else %>
+        <.icon name="hero-chevron-down" class="size-5" />
       <% end %>
     </span>
     """

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -143,29 +143,27 @@ defmodule LightningWeb.DashboardLive.Components do
         <.table>
           <.tr>
             <.th>
-              <div class="group inline-flex items-center">
+              <.sortable_table_header
+                target_sort_key="name"
+                current_sort_key={@sort_key}
+                current_sort_direction={@sort_direction}
+                target={@target}
+              >
                 Name
-                <.table_sort_icon
-                  target_sort_key="name"
-                  current_sort_key={@sort_key}
-                  current_sort_direction={@sort_direction}
-                  target={@target}
-                />
-              </div>
+              </.sortable_table_header>
             </.th>
             <.th>Role</.th>
             <.th>Workflows</.th>
             <.th>Collaborators</.th>
             <.th>
-              <div class="group inline-flex items-center">
+              <.sortable_table_header
+                target_sort_key="last_updated_at"
+                current_sort_key={@sort_key}
+                current_sort_direction={@sort_direction}
+                target={@target}
+              >
                 Last Updated
-                <.table_sort_icon
-                  target_sort_key="last_updated_at"
-                  current_sort_key={@sort_key}
-                  current_sort_direction={@sort_direction}
-                  target={@target}
-                />
-              </div>
+              </.sortable_table_header>
             </.th>
             <.th></.th>
           </.tr>
@@ -228,27 +226,32 @@ defmodule LightningWeb.DashboardLive.Components do
   attr :current_sort_direction, :string, required: true
   attr :target, :any, required: true
   attr :target_sort_key, :string, required: true
+  slot :inner_block, required: true
 
-  defp table_sort_icon(assigns) do
+  defp sortable_table_header(assigns) do
     ~H"""
-    <span
+    <a
+      href="#"
+      class="group inline-flex"
       phx-click="sort"
       phx-value-by={@target_sort_key}
       phx-target={@target}
-      class={[
-        "cursor-pointer align-middle ml-2 flex-none rounded text-gray-400",
-        if(@current_sort_key == @target_sort_key,
-          do: "bg-gray-200 text-gray-900 group-hover:bg-gray-300",
-          else: "opacity-50"
-        )
-      ]}
     >
-      <%= if @current_sort_key == @target_sort_key and @current_sort_direction == "desc" do %>
-        <.icon name="hero-chevron-up" class="size-5" />
-      <% else %>
-        <.icon name="hero-chevron-down" class="size-5" />
-      <% end %>
-    </span>
+      <%= render_slot(@inner_block) %>
+      <span class={[
+        "ml-2 flex-none rounded",
+        if(@current_sort_key == @target_sort_key,
+          do: "bg-gray-100 text-gray-900 group-hover:bg-gray-200",
+          else: "invisible text-gray-400 group-hover:visible group-focus:visible"
+        )
+      ]}>
+        <%= if @current_sort_key == @target_sort_key and @current_sort_direction == "desc" do %>
+          <.icon name="hero-chevron-up" class="size-5" />
+        <% else %>
+          <.icon name="hero-chevron-down" class="size-5" />
+        <% end %>
+      </span>
+    </a>
     """
   end
 end

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -3,6 +3,8 @@ defmodule LightningWeb.DashboardLive.Components do
 
   import PetalComponents.Table
 
+  alias LightningWeb.Components.Common
+
   def welcome_banner(assigns) do
     ~H"""
     <div class="pb-6">
@@ -230,28 +232,15 @@ defmodule LightningWeb.DashboardLive.Components do
 
   defp sortable_table_header(assigns) do
     ~H"""
-    <a
-      href="#"
-      class="group inline-flex"
+    <Common.sortable_table_header
       phx-click="sort"
       phx-value-by={@target_sort_key}
       phx-target={@target}
+      active={@current_sort_key == @target_sort_key}
+      sort_direction={@current_sort_direction}
     >
       <%= render_slot(@inner_block) %>
-      <span class={[
-        "ml-2 flex-none rounded",
-        if(@current_sort_key == @target_sort_key,
-          do: "bg-gray-100 text-gray-900 group-hover:bg-gray-200",
-          else: "invisible text-gray-400 group-hover:visible group-focus:visible"
-        )
-      ]}>
-        <%= if @current_sort_key == @target_sort_key and @current_sort_direction == "desc" do %>
-          <.icon name="hero-chevron-up" class="size-5" />
-        <% else %>
-          <.icon name="hero-chevron-down" class="size-5" />
-        <% end %>
-      </span>
-    </a>
+    </Common.sortable_table_header>
     """
   end
 end

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -123,18 +123,10 @@ defmodule LightningWeb.DashboardLive.Components do
   end
 
   def user_projects_table(assigns) do
-    next_sort_icon = %{
-      asc_nulls_last: "hero-chevron-up",
-      desc_nulls_last: "hero-chevron-down"
-    }
-
     assigns =
       assign(assigns,
         projects_count: assigns.projects |> Enum.count(),
-        empty?: assigns.projects |> Enum.empty?(),
-        name_sort_icon: next_sort_icon[assigns.name_direction],
-        last_updated_at_sort_icon:
-          next_sort_icon[assigns.last_updated_at_direction]
+        empty?: assigns.projects |> Enum.empty?()
       )
 
     ~H"""
@@ -153,14 +145,12 @@ defmodule LightningWeb.DashboardLive.Components do
             <.th>
               <div class="group inline-flex items-center">
                 Name
-                <span
-                  phx-click="sort"
-                  phx-value-by="name"
-                  phx-target={@target}
-                  class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
-                >
-                  <.icon name={@name_sort_icon} />
-                </span>
+                <.table_sort_icon
+                  target_sort_key="name"
+                  current_sort_key={@sort_key}
+                  current_sort_direction={@sort_direction}
+                  target={@target}
+                />
               </div>
             </.th>
             <.th>Role</.th>
@@ -169,14 +159,12 @@ defmodule LightningWeb.DashboardLive.Components do
             <.th>
               <div class="group inline-flex items-center">
                 Last Updated
-                <span
-                  phx-click="sort"
-                  phx-value-by="last_updated_at"
-                  phx-target={@target}
-                  class="cursor-pointer align-middle ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible"
-                >
-                  <.icon name={@last_updated_at_sort_icon} />
-                </span>
+                <.table_sort_icon
+                  target_sort_key="last_updated_at"
+                  current_sort_key={@sort_key}
+                  current_sort_direction={@sort_direction}
+                  target={@target}
+                />
               </div>
             </.th>
             <.th></.th>
@@ -233,6 +221,34 @@ defmodule LightningWeb.DashboardLive.Components do
         </.table>
       </div>
     <% end %>
+    """
+  end
+
+  attr :current_sort_key, :string, required: true
+  attr :current_sort_direction, :string, required: true
+  attr :target, :any, required: true
+  attr :target_sort_key, :string, required: true
+
+  defp table_sort_icon(assigns) do
+    ~H"""
+    <span
+      phx-click="sort"
+      phx-value-by={@target_sort_key}
+      phx-target={@target}
+      class={[
+        "cursor-pointer align-middle ml-2 flex-none rounded text-gray-400",
+        if(@current_sort_key == @target_sort_key,
+          do: "bg-gray-200 text-gray-900 group-hover:bg-gray-300",
+          else: "opacity-50"
+        )
+      ]}
+    >
+      <%= if @current_sort_key == @target_sort_key and @current_sort_direction == "desc" do %>
+        <.icon name="hero-chevron-down" class="size-5" />
+      <% else %>
+        <.icon name="hero-chevron-up" class="size-5" />
+      <% end %>
+    </span>
     """
   end
 end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1640,7 +1640,7 @@ defmodule Lightning.ProjectsTest do
 
       result =
         Projects.get_projects_overview(user,
-          order_by: {:desc_nulls_last, :last_updated_at}
+          order_by: "last_updated_at_desc"
         )
 
       assert [
@@ -1672,7 +1672,7 @@ defmodule Lightning.ProjectsTest do
 
       result =
         Projects.get_projects_overview(user,
-          order_by: {:asc_nulls_last, :last_updated_at}
+          order_by: "last_updated_at_asc"
         )
 
       assert [

--- a/test/lightning_web/live/dashboard_live_test.exs
+++ b/test/lightning_web/live/dashboard_live_test.exs
@@ -189,7 +189,7 @@ defmodule LightningWeb.DashboardLiveTest do
       assert project_names_from_html == projects_sorted_by_name
 
       view
-      |> element("span[phx-click='sort'][phx-value-by='name']")
+      |> element("a[phx-click='sort'][phx-value-by='name']")
       |> render_click()
 
       projects_sorted_by_name_desc = get_sorted_projects_by_name(projects, :desc)
@@ -198,7 +198,7 @@ defmodule LightningWeb.DashboardLiveTest do
       assert project_names_from_html == projects_sorted_by_name_desc
 
       view
-      |> element("span[phx-click='sort'][phx-value-by='name']")
+      |> element("a[phx-click='sort'][phx-value-by='name']")
       |> render_click()
 
       projects_sorted_by_name_asc = get_sorted_projects_by_name(projects, :asc)
@@ -230,7 +230,7 @@ defmodule LightningWeb.DashboardLiveTest do
                projects_sorted_by_last_updated_at
 
       view
-      |> element("span[phx-click='sort'][phx-value-by='last_updated_at']")
+      |> element("a[phx-click='sort'][phx-value-by='last_updated_at']")
       |> render_click()
 
       projects_sorted_by_last_updated_at_desc =


### PR DESCRIPTION
### Description

This PR makes the active and inactive sort arrows in projects overview table distinguishable.

When the column is actively being sorted, the icon has a `bg`. If it's inactive, the opacity falls to 50% 

I have also moved handling of the sort params to the context. It felt weird having to handle `nulls last` in the liveview code

Closes #2423

### Validation steps

<img width="1440" alt="Screenshot 2024-11-18 at 10 21 24" src="https://github.com/user-attachments/assets/a256eb0d-53e0-439d-aaa7-221656559c63">


### Additional notes for the reviewer

I'm kinda not sure if I have the correct direction for the `chevron-icon`. Might need a keen eye there

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
