### PR TITLE
Handle credential schema email format error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Support dynamic json schema email format validation.
+  [#2664](https://github.com/OpenFn/lightning/issues/2664)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -92,12 +92,19 @@ defmodule Lightning.Credentials.Schema do
     |> error_to_changeset(changeset)
   end
 
+  @error_messages %{
+    "uri" => "expected to be a URI",
+    "email" => "expected to be an email"
+  }
+  @expected_formats Map.keys(@error_messages)
+
   defp error_to_changeset(%{path: path, error: error}, changeset) do
     field = String.slice(path, 2..-1//1) |> String.to_existing_atom()
 
     case error do
-      %{expected: "uri"} ->
-        Changeset.add_error(changeset, field, "expected to be a URI")
+      %{expected: format} when format in @expected_formats ->
+        error_msg = Map.fetch!(@error_messages, format)
+        Changeset.add_error(changeset, field, error_msg)
 
       %{any_of: formats} ->
         formats =

--- a/test/fixtures/schemas/godata.json
+++ b/test/fixtures/schemas/godata.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "apiUrl": {
+            "title": "API URL",
+            "type": "string",
+            "description": "Godata API URL",
+            "default": "https://www.who-godata.com/api",
+            "format": "uri",
+            "minLength": 1,
+            "examples": [
+                "https://www.who-godata.com/api"
+            ]
+        },
+        "email": {
+            "title": "Email",
+            "type": "string",
+            "description": "Your Godata login email",
+            "format": "email",
+            "minLength": 1,
+            "examples": [
+                "test@openfn.org"
+            ]
+        },
+        "password": {
+            "title": "Password",
+            "type": "string",
+            "description": "Your Godata login password",
+            "writeOnly": true,
+            "minLength": 1,
+            "examples": [
+                "@some(!)Strongpassword"
+            ]
+        }
+    },
+    "type": "object",
+    "additionalProperties": true,
+    "required": [
+        "apiUrl",
+        "email",
+        "password"
+    ]
+}

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -69,6 +69,23 @@ defmodule Lightning.Credentials.SchemaTest do
   end
 
   describe "validate/2" do
+    test "successfully validates field with json schema email format" do
+      schema = Credentials.get_schema("godata")
+
+      changeset =
+        Ecto.Changeset.put_change(
+          %Ecto.Changeset{
+            data: %{password: "1234", apiUrl: "http://addr"},
+            types: schema.types
+          },
+          :email,
+          "some@email.com"
+        )
+
+      assert %Ecto.Changeset{errors: [], changes: %{email: "some@email.com"}} =
+               Schema.validate(changeset, schema)
+    end
+
     test "returns a changeset with 2 expected formats" do
       schema = Credentials.get_schema("postgresql")
 
@@ -102,6 +119,24 @@ defmodule Lightning.Credentials.SchemaTest do
       assert Enum.any?(
                errors,
                &(&1 == {:baseUrl, {"expected to be a URI", []}})
+             )
+    end
+
+    test "returns a changeset with expected email format" do
+      schema = Credentials.get_schema("godata")
+
+      changeset =
+        Ecto.Changeset.put_change(
+          %Ecto.Changeset{data: %{}, types: schema.types},
+          :email,
+          "not-an-email@"
+        )
+
+      assert %Ecto.Changeset{errors: errors} = Schema.validate(changeset, schema)
+
+      assert Enum.any?(
+               errors,
+               &(&1 == {:email, {"expected to be an email", []}})
              )
     end
 

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -516,6 +516,54 @@ defmodule LightningWeb.CredentialLiveTest do
       {_path, flash} = assert_redirect(index_live)
       assert flash == %{"info" => "Credential created successfully"}
     end
+
+    test "allows the user to define and save a credential with email (godata)",
+         %{
+           conn: conn
+         } do
+      {:ok, view, _html} = live(conn, ~p"/credentials")
+
+      select_credential_type(view, "godata")
+      click_continue(view)
+
+      assert fill_credential(view, %{body: %{email: ""}}) =~ "can&#39;t be blank"
+
+      assert submit_disabled(view, "#save-credential-button-new")
+
+      assert click_save(view) =~ "can&#39;t be blank"
+
+      refute_redirected(view, ~p"/credentials")
+
+      assert fill_credential(view, %{
+               name: "Godata Credential",
+               body: %{
+                 apiUrl: "http://url",
+                 password: "baz1234",
+                 email: "incomplete-email"
+               }
+             }) =~ "expected to be an email"
+
+      assert submit_disabled(view, "#save-credential-button-new")
+
+      refute fill_credential(view, %{
+               name: "Godata Credential",
+               body: %{
+                 apiUrl: "http://url",
+                 password: "baz1234",
+                 email: "good@email.com"
+               }
+             }) =~ "expected to be an email"
+
+      refute submit_disabled(view, "#save-credential-button-new")
+
+      {:ok, _view, _html} =
+        view
+        |> click_save()
+        |> follow_redirect(conn, ~p"/credentials")
+
+      {_path, flash} = assert_redirect(view)
+      assert flash == %{"info" => "Credential created successfully"}
+    end
   end
 
   describe "Edit" do


### PR DESCRIPTION
### Description

This PR adds support for dynamic json schemas validation of fields declared with email format.  

Refs #2664 

### Validation steps

1. Go to a project settings.
2. Click on new credential -> Credential
3. Select Godata
4. Fill an email and as you type the an error message "expected to be an email" is shown until the value is correct.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
