### PR TITLE
2601 audit snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Support dynamic json schema email format validation.
   [#2664](https://github.com/OpenFn/lightning/issues/2664)
+- Audit snapshot creation
+  [#2601](https://github.com/OpenFn/lightning/issues/2601)
 
 ### Changed
 

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -132,7 +132,7 @@ defmodule Lightning.Auditing.Audit do
     field :actor_display, :string, virtual: true
     field :metadata, :map, default: %{}
 
-    timestamps(updated_at: false)
+    timestamps(updated_at: false, type: :utc_datetime_usec)
   end
 
   @doc false

--- a/lib/lightning/auditing/audit.ex
+++ b/lib/lightning/auditing/audit.ex
@@ -132,7 +132,7 @@ defmodule Lightning.Auditing.Audit do
     field :actor_display, :string, virtual: true
     field :metadata, :map, default: %{}
 
-    timestamps(updated_at: false, type: :utc_datetime_usec)
+    timestamps(updated_at: false)
   end
 
   @doc false

--- a/lib/lightning/jobs.ex
+++ b/lib/lightning/jobs.ex
@@ -135,12 +135,13 @@ defmodule Lightning.Jobs do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_job(attrs \\ %{}) do
+  def create_job(attrs \\ %{}, actor) do
     changeset =
       Job.changeset(%Job{}, attrs)
 
     Multi.new()
     |> Multi.insert(:job, changeset)
+    |> Multi.put(:actor, actor)
     |> Workflows.capture_snapshot()
     |> Repo.transaction()
     |> case do

--- a/lib/lightning/kafka_triggers/message_handling.ex
+++ b/lib/lightning/kafka_triggers/message_handling.ex
@@ -41,7 +41,8 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
                type: :kafka,
                project_id: workflow.project_id
              },
-             without_run: without_run?
+             without_run: without_run?,
+             actor: trigger
            ) do
       {:ok, work_order}
     else

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -83,7 +83,7 @@ defmodule Lightning.Runs do
           Multi.new()
           |> Multi.one(:workflow, Ecto.assoc(run, :workflow))
           |> Multi.run(:snapshot, fn _repo, %{workflow: workflow} ->
-            Workflows.Snapshot.get_or_create_latest_for(workflow)
+            Workflows.Snapshot.get_or_create_latest_for(workflow, nil)
           end)
           |> Multi.update(:run_with_snapshot, fn %{snapshot: snapshot} ->
             Ecto.Changeset.change(run, snapshot_id: snapshot.id)

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -14,7 +14,6 @@ defmodule Lightning.Runs do
   alias Lightning.Runs.Events
   alias Lightning.Runs.Handlers
   alias Lightning.Services.RunQueue
-  alias Lightning.Workflows
 
   require Logger
 
@@ -75,27 +74,7 @@ defmodule Lightning.Runs do
       get_query(id, include: [snapshot: [jobs: :credential]])
     )
     |> Multi.merge(fn %{__pre_check_run__: run} ->
-      case run do
-        %{snapshot_id: nil} ->
-          # TODO: remove this after the next minor release, all runs created after
-          # this point will have a snapshot associated.
-
-          Multi.new()
-          |> Multi.one(:workflow, Ecto.assoc(run, :workflow))
-          |> Multi.run(:snapshot, fn _repo, %{workflow: workflow} ->
-            Workflows.Snapshot.get_or_create_latest_for(workflow, nil)
-          end)
-          |> Multi.update(:run_with_snapshot, fn %{snapshot: snapshot} ->
-            Ecto.Changeset.change(run, snapshot_id: snapshot.id)
-          end)
-          |> Multi.one(
-            :run,
-            get_query(id, include: [snapshot: [jobs: :credential]])
-          )
-
-        run ->
-          Multi.new() |> Multi.put(:run, run)
-      end
+      Multi.new() |> Multi.put(:run, run)
     end)
     |> Repo.transaction()
     |> case do

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -202,7 +202,7 @@ defmodule Lightning.SetupUtils do
       Workflows.save_workflow(%{
         name: "Sample Workflow",
         project_id: project.id
-      }, nil)
+      }, user)
 
     {:ok, source_trigger} =
       Workflows.build_trigger(%{
@@ -224,7 +224,7 @@ defmodule Lightning.SetupUtils do
         """,
         adaptor: "@openfn/language-common@latest",
         workflow_id: workflow.id
-      })
+      }, user)
 
     {:ok, _root_edge} =
       Workflows.create_edge(%{
@@ -246,7 +246,7 @@ defmodule Lightning.SetupUtils do
         """,
         adaptor: "@openfn/language-common@latest",
         workflow_id: workflow.id
-      })
+      }, user)
 
     {:ok, _job_2_edge} =
       Workflows.create_edge(%{
@@ -314,11 +314,13 @@ defmodule Lightning.SetupUtils do
         false
       )
 
+    user = get_most_privileged_user!(openhie_project)
+
     {:ok, openhie_workflow} =
       Workflows.save_workflow(%{
         name: "OpenHIE Workflow",
         project_id: openhie_project.id
-      }, nil)
+      }, user)
 
     {:ok, openhie_trigger} =
       Workflows.build_trigger(%{
@@ -338,9 +340,7 @@ defmodule Lightning.SetupUtils do
         """,
         adaptor: "@openfn/language-http@latest",
         workflow_id: openhie_workflow.id
-      })
-
-    user = get_most_privileged_user!(openhie_project)
+      }, user)
 
     {:ok, _openhie_root_edge} =
       Workflows.create_edge(%{
@@ -362,7 +362,7 @@ defmodule Lightning.SetupUtils do
         adaptor: "@openfn/language-http@latest",
         # enabled: true,
         workflow_id: openhie_workflow.id
-      })
+      }, user)
 
     {:ok, notify_upload_successful} =
       Jobs.create_job(%{
@@ -375,7 +375,7 @@ defmodule Lightning.SetupUtils do
         adaptor: "@openfn/language-http@latest",
         # enabled: true,
         workflow_id: openhie_workflow.id
-      })
+      }, user)
 
     {:ok, notify_upload_failed} =
       Jobs.create_job(%{
@@ -388,7 +388,7 @@ defmodule Lightning.SetupUtils do
         adaptor: "@openfn/language-http@latest",
         # enabled: true,
         workflow_id: openhie_workflow.id
-      })
+      }, user)
 
     {:ok, _send_to_openhim_edge} =
       Workflows.create_edge(%{
@@ -538,13 +538,13 @@ defmodule Lightning.SetupUtils do
         false
       )
 
+    user = get_most_privileged_user!(project)
+
     {:ok, dhis2_workflow} =
       Workflows.save_workflow(%{
         name: "DHIS2 to Sheets",
         project_id: project.id
-      }, nil)
-
-    user = get_most_privileged_user!(project)
+      }, user)
 
     dhis2_credential = create_dhis2_credential(user)
 
@@ -593,7 +593,7 @@ defmodule Lightning.SetupUtils do
         adaptor: "@openfn/language-http@latest",
         # enabled: true,
         workflow_id: dhis2_workflow.id
-      })
+      }, user)
 
     {:ok, _success_upload} =
       Workflows.create_edge(%{

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -196,11 +196,13 @@ defmodule Lightning.SetupUtils do
         false
       )
 
+    user = get_most_privileged_user!(project)
+
     {:ok, workflow} =
       Workflows.save_workflow(%{
         name: "Sample Workflow",
         project_id: project.id
-      })
+      }, nil)
 
     {:ok, source_trigger} =
       Workflows.build_trigger(%{
@@ -231,7 +233,7 @@ defmodule Lightning.SetupUtils do
         source_trigger: source_trigger,
         target_job: job_1,
         enabled: true
-      })
+      }, user)
 
     {:ok, job_2} =
       Jobs.create_job(%{
@@ -253,9 +255,7 @@ defmodule Lightning.SetupUtils do
         condition_type: :on_job_success,
         target_job: job_2,
         enabled: true
-      })
-
-    user = get_most_privileged_user!(project)
+      }, user)
 
     dhis2_credential = create_dhis2_credential(user)
 
@@ -294,7 +294,7 @@ defmodule Lightning.SetupUtils do
         condition_type: :on_job_success,
         target_job: job_3,
         enabled: true
-      })
+      }, user)
 
     %{
       project: project,
@@ -318,7 +318,7 @@ defmodule Lightning.SetupUtils do
       Workflows.save_workflow(%{
         name: "OpenHIE Workflow",
         project_id: openhie_project.id
-      })
+      }, nil)
 
     {:ok, openhie_trigger} =
       Workflows.build_trigger(%{
@@ -340,6 +340,8 @@ defmodule Lightning.SetupUtils do
         workflow_id: openhie_workflow.id
       })
 
+    user = get_most_privileged_user!(openhie_project)
+
     {:ok, _openhie_root_edge} =
       Workflows.create_edge(%{
         workflow_id: openhie_workflow.id,
@@ -347,7 +349,7 @@ defmodule Lightning.SetupUtils do
         source_trigger: openhie_trigger,
         target_job: fhir_standard_data,
         enabled: true
-      })
+      }, user)
 
     {:ok, send_to_openhim} =
       Jobs.create_job(%{
@@ -395,7 +397,7 @@ defmodule Lightning.SetupUtils do
         target_job_id: send_to_openhim.id,
         source_job_id: fhir_standard_data.id,
         enabled: true
-      })
+      }, user)
 
     {:ok, _success_upload} =
       Workflows.create_edge(%{
@@ -404,7 +406,7 @@ defmodule Lightning.SetupUtils do
         target_job_id: notify_upload_successful.id,
         source_job_id: send_to_openhim.id,
         enabled: true
-      })
+      }, user)
 
     {:ok, _failed_upload} =
       Workflows.create_edge(%{
@@ -413,7 +415,7 @@ defmodule Lightning.SetupUtils do
         target_job_id: notify_upload_failed.id,
         source_job_id: send_to_openhim.id,
         enabled: true
-      })
+      }, user)
 
     http_body = %{
       "formId" => "early_enrollment",
@@ -540,7 +542,7 @@ defmodule Lightning.SetupUtils do
       Workflows.save_workflow(%{
         name: "DHIS2 to Sheets",
         project_id: project.id
-      })
+      }, nil)
 
     user = get_most_privileged_user!(project)
 
@@ -578,7 +580,7 @@ defmodule Lightning.SetupUtils do
         source_trigger: dhis_trigger,
         target_job: get_dhis2_data,
         enabled: true
-      })
+      }, user)
 
     {:ok, upload_to_google_sheet} =
       Jobs.create_job(%{
@@ -600,7 +602,7 @@ defmodule Lightning.SetupUtils do
         target_job_id: upload_to_google_sheet.id,
         source_job_id: get_dhis2_data.id,
         enabled: true
-      })
+      }, user)
 
     input_dataclip =
       create_dataclip(%{

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -166,8 +166,8 @@ defmodule Lightning.VersionControl do
   end
 
   defp list_or_create_snapshots_for_project(
-       %{project_id: project_id} = repo_connection
-  ) do
+         %{project_id: project_id} = repo_connection
+       ) do
     current_query =
       from w in Workflow,
         left_join: s in assoc(w, :snapshots),
@@ -181,6 +181,7 @@ defmodule Lightning.VersionControl do
       if is_nil(snapshot_id) do
         {:ok, snapshot} =
           Snapshot.get_or_create_latest_for(workflow, repo_connection)
+
         [snapshot.id | acc]
       else
         [snapshot_id | acc]

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -110,7 +110,6 @@ defmodule Lightning.WorkOrders do
   def create_for(%Job{} = job, multi, opts) do
     multi
     |> Multi.put(:workflow, opts[:workflow])
-    # get_or_create_snapshot unnecessary due to build_for?
     |> get_or_create_snapshot(opts[:actor])
     |> Multi.insert(:workorder, build_for(job, opts |> Map.new()))
     |> Runs.enqueue()

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -10,6 +10,7 @@ defmodule Lightning.Workflows do
   alias Lightning.KafkaTriggers
   alias Lightning.Projects.Project
   alias Lightning.Repo
+  alias Lightning.Workflows.Audit
   alias Lightning.Workflows.Edge
   alias Lightning.Workflows.Events
   alias Lightning.Workflows.Job
@@ -53,10 +54,12 @@ defmodule Lightning.Workflows do
 
   def get_workflow(id), do: Repo.get(Workflow, id)
 
-  @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map()) ::
+  # TODO Change typespec from any() to struct() when done
+  @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map(), any()) ::
           {:ok, Workflow.t()} | {:error, Ecto.Changeset.t(Workflow.t())}
-  def save_workflow(%Ecto.Changeset{data: %Workflow{}} = changeset) do
+  def save_workflow(%Ecto.Changeset{data: %Workflow{}} = changeset, actor) do
     Multi.new()
+    |> Multi.put(:actor, actor)
     |> Multi.insert_or_update(:workflow, changeset)
     |> then(fn multi ->
       if changeset.changes == %{} do
@@ -89,9 +92,9 @@ defmodule Lightning.Workflows do
     end
   end
 
-  def save_workflow(%{} = attrs) do
+  def save_workflow(%{} = attrs, actor) do
     Workflow.changeset(%Workflow{}, attrs)
-    |> save_workflow()
+    |> save_workflow(actor)
   end
 
   @spec publish_kafka_trigger_events(Ecto.Changeset.t(Workflow.t())) :: :ok
@@ -148,14 +151,18 @@ defmodule Lightning.Workflows do
   defp find_dependent_change(multi) do
     multi
     |> Multi.to_list()
-    |> Enum.find_value(fn {key, {_action, changeset_or_struct, _}} ->
-      case changeset_or_struct do
-        %{data: %{__struct__: model}} when model in [Job, Edge, Trigger] ->
-          key
+    |> Enum.find_value(fn
+      {key, {_action, changeset_or_struct, _}} ->
+        case changeset_or_struct do
+          %{data: %{__struct__: model}} when model in [Job, Edge, Trigger] ->
+            key
 
-        _other ->
-          false
-      end
+          _other ->
+            false
+        end
+
+      {_key, {:put, _struct}} ->
+        false
     end)
   end
 
@@ -166,6 +173,11 @@ defmodule Lightning.Workflows do
       &(Map.get(&1, :workflow) |> Snapshot.build()),
       returning: false
     )
+    |> Multi.insert(:audit, fn changes ->
+      %{snapshot: %{id: snapshot_id}, workflow: %{id: workflow_id}} = changes
+
+      Audit.snapshot_created(workflow_id, snapshot_id, changes.actor)
+    end)
   end
 
   # Helper to preload associations only if they are present in the attributes
@@ -269,8 +281,9 @@ defmodule Lightning.Workflows do
   @doc """
   Creates an edge
   """
-  def create_edge(attrs) do
+  def create_edge(attrs, actor) do
     Multi.new()
+    |> Multi.put(:actor, actor)
     |> Multi.insert(:edge, Edge.new(attrs))
     |> capture_snapshot()
     |> Repo.transaction()

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -54,8 +54,7 @@ defmodule Lightning.Workflows do
 
   def get_workflow(id), do: Repo.get(Workflow, id)
 
-  # TODO Change typespec from any() to struct() when done
-  @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map(), any()) ::
+  @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map(), struct()) ::
           {:ok, Workflow.t()} | {:error, Ecto.Changeset.t(Workflow.t())}
   def save_workflow(%Ecto.Changeset{data: %Workflow{}} = changeset, actor) do
     Multi.new()

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -151,16 +151,11 @@ defmodule Lightning.Workflows do
     multi
     |> Multi.to_list()
     |> Enum.find_value(fn
-      {key, {_action, changeset_or_struct, _}} ->
-        case changeset_or_struct do
-          %{data: %{__struct__: model}} when model in [Job, Edge, Trigger] ->
-            key
+      {key, {_action, %Ecto.Changeset{data: %mod{}}, _}}
+      when mod in [Job, Edge, Trigger] ->
+        key
 
-          _other ->
-            false
-        end
-
-      {_key, {:put, _struct}} ->
+      _other ->
         false
     end)
   end

--- a/lib/lightning/workflows/audit.ex
+++ b/lib/lightning/workflows/audit.ex
@@ -6,7 +6,7 @@ defmodule Lightning.Workflows.Audit do
     repo: Lightning.Repo,
     item: "workflow",
     events: [
-      "snapshot_created",
+      "snapshot_created"
     ]
 
   def snapshot_created(workflow_id, snapshot_id, actor) do

--- a/lib/lightning/workflows/audit.ex
+++ b/lib/lightning/workflows/audit.ex
@@ -1,0 +1,22 @@
+defmodule Lightning.Workflows.Audit do
+  @moduledoc """
+  Generate Audit changesets for selected changes to workflows.
+  """
+  use Lightning.Auditing.Audit,
+    repo: Lightning.Repo,
+    item: "workflow",
+    events: [
+      "snapshot_created",
+    ]
+
+  def snapshot_created(workflow_id, snapshot_id, actor) do
+    event(
+      "snapshot_created",
+      workflow_id,
+      actor,
+      %{
+        after: %{snapshot_id: snapshot_id}
+      }
+    )
+  end
+end

--- a/lib/lightning/workflows/scheduler.ex
+++ b/lib/lightning/workflows/scheduler.ex
@@ -59,6 +59,7 @@ defmodule Lightning.Workflows.Scheduler do
           # %{id: uuid, type: :global, body: %{arbitrary: true}}
 
           WorkOrders.create_for(trigger,
+            actor: trigger,
             dataclip: %{
               type: :global,
               body: %{},
@@ -75,6 +76,7 @@ defmodule Lightning.Workflows.Scheduler do
           end)
 
           WorkOrders.create_for(trigger,
+            actor: trigger,
             dataclip: dataclip,
             workflow: job.workflow
           )

--- a/lib/lightning_web/controllers/webhooks_controller.ex
+++ b/lib/lightning_web/controllers/webhooks_controller.ex
@@ -49,6 +49,7 @@ defmodule LightningWeb.WebhooksController do
            ) do
       {:ok, work_order} =
         WorkOrders.create_for(trigger,
+          actor: trigger,
           workflow: trigger.workflow,
           dataclip: %{
             body: conn.body_params,

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1621,7 +1621,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
              selected_job: selected_job,
              created_by: current_user
            ) do
-
       %{runs: [run]} = workorder
 
       Runs.subscribe(run)

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1404,6 +1404,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   def handle_event("save", params, socket) do
     %{
+      current_user: _current_user,
       project: project,
       workflow_params: initial_params,
       can_edit_workflow: can_edit_workflow,
@@ -1432,7 +1433,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       %{assigns: %{changeset: changeset}} =
         socket = socket |> apply_params(next_params, :workflow)
 
-      case Helpers.save_workflow(changeset) do
+      case Helpers.save_workflow(changeset, nil) do
         {:ok, workflow} ->
           snapshot = snapshot_by_version(workflow.id, workflow.lock_version)
 
@@ -2346,7 +2347,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     save_or_get_workflow =
       if has_edit_priority? do
-        Helpers.save_workflow(%{changeset | action: :update})
+        Helpers.save_workflow(%{changeset | action: :update}, nil)
       else
         {:ok, get_workflow_by_id(workflow_id)}
       end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1404,7 +1404,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   def handle_event("save", params, socket) do
     %{
-      current_user: _current_user,
+      current_user: current_user,
       project: project,
       workflow_params: initial_params,
       can_edit_workflow: can_edit_workflow,
@@ -1433,7 +1433,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       %{assigns: %{changeset: changeset}} =
         socket = socket |> apply_params(next_params, :workflow)
 
-      case Helpers.save_workflow(changeset, nil) do
+      case Helpers.save_workflow(changeset, current_user) do
         {:ok, workflow} ->
           snapshot = snapshot_by_version(workflow.id, workflow.lock_version)
 
@@ -1621,6 +1621,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
              selected_job: selected_job,
              created_by: current_user
            ) do
+
       %{runs: [run]} = workorder
 
       Runs.subscribe(run)
@@ -2347,7 +2348,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
     save_or_get_workflow =
       if has_edit_priority? do
-        Helpers.save_workflow(%{changeset | action: :update}, nil)
+        Helpers.save_workflow(%{changeset | action: :update}, current_user)
       else
         {:ok, get_workflow_by_id(workflow_id)}
       end

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -23,13 +23,13 @@ defmodule LightningWeb.WorkflowLive.Helpers do
     Lightning.local_broadcast(socket.id, {:updated_params, params})
   end
 
-  @spec save_workflow(Ecto.Changeset.t()) ::
+  @spec save_workflow(Ecto.Changeset.t(), struct()) ::
           {:ok, Workflows.Workflow.t()}
           | {:error, Ecto.Changeset.t() | UsageLimiting.message()}
-  def save_workflow(changeset) do
+  def save_workflow(changeset, actor) do
     case WorkflowUsageLimiter.limit_workflow_activation(changeset) do
       :ok ->
-        Workflows.save_workflow(changeset)
+        Workflows.save_workflow(changeset, actor)
 
       {:error, _reason, message} ->
         {:error, message}
@@ -73,7 +73,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
   end
 
   defp maybe_save_workflow(%Ecto.Changeset{} = changeset) do
-    Workflows.save_workflow(changeset)
+    Workflows.save_workflow(changeset, nil)
   end
 
   defp maybe_save_workflow(%Workflow{} = workflow) do

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -64,7 +64,8 @@ defmodule LightningWeb.WorkflowLive.Helpers do
           {:error, message}
 
         :ok ->
-          with {:ok, workflow} <- maybe_save_workflow(workflow_or_changeset, actor),
+          with {:ok, workflow} <-
+                 maybe_save_workflow(workflow_or_changeset, actor),
                {:ok, manual} <- build_manual_workorder(params, workflow, opts),
                {:ok, workorder} <- WorkOrders.create_for(manual) do
             {:ok, %{workorder: workorder, workflow: workflow}}

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -55,6 +55,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
   def run_workflow(workflow_or_changeset, params, opts) do
     Lightning.Repo.transact(fn ->
       %{id: project_id} = Keyword.fetch!(opts, :project)
+      actor = Keyword.fetch!(opts, :created_by)
 
       case UsageLimiter.limit_action(%Action{type: :new_run}, %Context{
              project_id: project_id
@@ -63,7 +64,7 @@ defmodule LightningWeb.WorkflowLive.Helpers do
           {:error, message}
 
         :ok ->
-          with {:ok, workflow} <- maybe_save_workflow(workflow_or_changeset),
+          with {:ok, workflow} <- maybe_save_workflow(workflow_or_changeset, actor),
                {:ok, manual} <- build_manual_workorder(params, workflow, opts),
                {:ok, workorder} <- WorkOrders.create_for(manual) do
             {:ok, %{workorder: workorder, workflow: workflow}}
@@ -72,11 +73,11 @@ defmodule LightningWeb.WorkflowLive.Helpers do
     end)
   end
 
-  defp maybe_save_workflow(%Ecto.Changeset{} = changeset) do
-    Workflows.save_workflow(changeset, nil)
+  defp maybe_save_workflow(%Ecto.Changeset{} = changeset, actor) do
+    Workflows.save_workflow(changeset, actor)
   end
 
-  defp maybe_save_workflow(%Workflow{} = workflow) do
+  defp maybe_save_workflow(%Workflow{} = workflow, _actor) do
     {:ok, workflow}
   end
 

--- a/test/lightning/extensions/fifo_run_queue_test.exs
+++ b/test/lightning/extensions/fifo_run_queue_test.exs
@@ -15,26 +15,32 @@ defmodule Lightning.Extensions.FifoRunQueueTest do
       %{triggers: [trigger2]} =
         workflow2 = insert(:simple_workflow, project: project2)
 
+      actor = insert(:user)
+
       {:ok, %{runs: [%{id: run1_id}]}} =
         WorkOrders.create_for(trigger1,
+          actor: actor,
           workflow: workflow1,
           dataclip: params_with_assocs(:dataclip)
         )
 
       {:ok, %{runs: [%{id: run2_id}]}} =
         WorkOrders.create_for(trigger1,
+          actor: actor,
           workflow: workflow1,
           dataclip: params_with_assocs(:dataclip)
         )
 
       {:ok, %{runs: [%{id: run3_id}]}} =
         WorkOrders.create_for(trigger2,
+          actor: actor,
           workflow: workflow2,
           dataclip: params_with_assocs(:dataclip)
         )
 
       {:ok, %{runs: [%{id: run4_id}]}} =
         WorkOrders.create_for(trigger2,
+          actor: actor,
           workflow: workflow2,
           dataclip: params_with_assocs(:dataclip)
         )

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -11,6 +11,7 @@ defmodule Lightning.InvocationTest do
   require SearchParams
 
   defp build_workflow(opts) do
+    actor = insert(:user)
     job = build(:job)
     trigger = build(:trigger)
 
@@ -22,7 +23,7 @@ defmodule Lightning.InvocationTest do
       |> insert()
 
     {:ok, snapshot} =
-      Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow)
+      Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow, actor)
 
     %{
       workflow: workflow,

--- a/test/lightning/jobs_test.exs
+++ b/test/lightning/jobs_test.exs
@@ -160,11 +160,14 @@ defmodule Lightning.JobsTest do
 
     test "new job without a workflow", %{actor: actor} do
       assert_raise Postgrex.Error, fn ->
-        Jobs.create_job(%{
-          body: "some body",
-          name: "some name",
-          adaptor: "@openfn/language-common"
-        }, actor)
+        Jobs.create_job(
+          %{
+            body: "some body",
+            name: "some name",
+            adaptor: "@openfn/language-common"
+          },
+          actor
+        )
       end
     end
 
@@ -181,14 +184,17 @@ defmodule Lightning.JobsTest do
         )
 
       assert {:ok, %Job{} = job} =
-               Jobs.create_job(%{
-                 body: "some body",
-                 name: "some name",
-                 trigger: %{type: "webhook", comment: "foo"},
-                 adaptor: "@openfn/language-common",
-                 project_credential_id: project_credential.id,
-                 workflow_id: insert(:workflow).id
-               }, actor)
+               Jobs.create_job(
+                 %{
+                   body: "some body",
+                   name: "some name",
+                   trigger: %{type: "webhook", comment: "foo"},
+                   adaptor: "@openfn/language-common",
+                   project_credential_id: project_credential.id,
+                   workflow_id: insert(:workflow).id
+                 },
+                 actor
+               )
 
       job = Repo.preload(job, :credential)
 
@@ -248,28 +254,35 @@ defmodule Lightning.JobsTest do
       assert %{event: "snapshot_created", actor_id: ^actor_id} = audit
     end
 
-    test "with an upstream job returns a job with the upstream job's workflow_id", %{
-      actor: actor
-    } do
+    test "with an upstream job returns a job with the upstream job's workflow_id",
+         %{
+           actor: actor
+         } do
       workflow = insert(:workflow)
 
       {:ok, %Job{} = upstream_job} =
-        Jobs.create_job(%{
-          name: "job 1",
-          body: "some body",
-          adaptor: "@openfn/language-common",
-          trigger: %{type: "webhook"},
-          workflow_id: workflow.id
-        }, actor)
+        Jobs.create_job(
+          %{
+            name: "job 1",
+            body: "some body",
+            adaptor: "@openfn/language-common",
+            trigger: %{type: "webhook"},
+            workflow_id: workflow.id
+          },
+          actor
+        )
 
       {:ok, %Job{} = job} =
-        Jobs.create_job(%{
-          name: "job 2",
-          body: "some body",
-          adaptor: "@openfn/language-common",
-          trigger: %{type: "on_job_success", upstream_job_id: upstream_job.id},
-          workflow_id: workflow.id
-        }, actor)
+        Jobs.create_job(
+          %{
+            name: "job 2",
+            body: "some body",
+            adaptor: "@openfn/language-common",
+            trigger: %{type: "on_job_success", upstream_job_id: upstream_job.id},
+            workflow_id: workflow.id
+          },
+          actor
+        )
 
       assert job.workflow_id == upstream_job.workflow_id
     end
@@ -278,24 +291,30 @@ defmodule Lightning.JobsTest do
       workflow = insert(:workflow)
 
       {:ok, %Job{} = upstream_job} =
-        Jobs.create_job(%{
-          body: "some body",
-          name: "job 1",
-          adaptor: "@openfn/language-common",
-          trigger: %{type: "webhook"},
-          workflow_id: workflow.id
-        }, actor)
+        Jobs.create_job(
+          %{
+            body: "some body",
+            name: "job 1",
+            adaptor: "@openfn/language-common",
+            trigger: %{type: "webhook"},
+            workflow_id: workflow.id
+          },
+          actor
+        )
 
       count_workflows_before = Workflows.list_workflows() |> Enum.count()
 
       {:ok, %Job{} = _job} =
-        Jobs.create_job(%{
-          body: "some body",
-          name: "job 2",
-          adaptor: "@openfn/language-common",
-          trigger: %{type: "on_job_success", upstream_job_id: upstream_job.id},
-          workflow_id: workflow.id
-        }, actor)
+        Jobs.create_job(
+          %{
+            body: "some body",
+            name: "job 2",
+            adaptor: "@openfn/language-common",
+            trigger: %{type: "on_job_success", upstream_job_id: upstream_job.id},
+            workflow_id: workflow.id
+          },
+          actor
+        )
 
       assert count_workflows_before == Workflows.list_workflows() |> Enum.count()
     end

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -47,6 +47,7 @@ defmodule Lightning.RunsTest do
 
       {:ok, %{runs: [run]}} =
         WorkOrders.create_for(trigger,
+          actor: insert(:user),
           workflow: workflow,
           dataclip: params_with_assocs(:dataclip)
         )
@@ -67,6 +68,7 @@ defmodule Lightning.RunsTest do
         |> Enum.map(fn _ ->
           {:ok, %{runs: [run]}} =
             WorkOrders.create_for(trigger,
+              actor: insert(:user),
               workflow: workflow,
               dataclip: params_with_assocs(:dataclip)
             )
@@ -93,6 +95,7 @@ defmodule Lightning.RunsTest do
       [second_last_run, last_run] =
         Enum.map(1..2, fn _i ->
           WorkOrders.create_for(trigger,
+            actor: insert(:user),
             workflow: workflow,
             dataclip: params_with_assocs(:dataclip)
           )
@@ -158,6 +161,7 @@ defmodule Lightning.RunsTest do
 
       {:ok, %{runs: [run]}} =
         WorkOrders.create_for(trigger,
+          actor: insert(:user),
           workflow: workflow,
           dataclip: params_with_assocs(:dataclip)
         )

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -234,7 +234,7 @@ defmodule Lightning.RunsTest do
       # creating a new snapshot.
       {:ok, %{jobs: [new_job]}} =
         Workflows.change_workflow(workflow, %{jobs: [params_for(:job)]})
-        |> Workflows.save_workflow()
+        |> Workflows.save_workflow(insert(:user))
 
       {:error, changeset} =
         Runs.start_step(run_1, %{

--- a/test/lightning/usage_tracking/day_worker_test.exs
+++ b/test/lightning/usage_tracking/day_worker_test.exs
@@ -17,8 +17,8 @@ defmodule Lightning.UsageTracking.DayWorkerTest do
     # to prevent the tests flickering - e.g if .utc_now() changes during
     # the execution of the test
     setup do
-      stub(Lightning.MockConfig, :usage_tracking, fn ->
-        %{enabled: true}
+      stub(Lightning.MockConfig, :usage_tracking_enabled?, fn ->
+        true
       end)
 
       :ok

--- a/test/lightning/usage_tracking/report_data_test.exs
+++ b/test/lightning/usage_tracking/report_data_test.exs
@@ -27,7 +27,7 @@ defmodule Lightning.UsageTracking.ReportDataTest do
       %{generated_at: generated_at} =
         ReportData.generate(report_config, enabled, date)
 
-      assert DateTime.diff(DateTime.utc_now(), generated_at, :second) < 1
+      assert DateTime.diff(DateTime.utc_now(), generated_at, :second) < 2
     end
 
     test "contains hashed uuid of reporting instance", %{

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -433,8 +433,6 @@ defmodule Lightning.VersionControlTest do
       repo_connection: %{id: repo_connection_id} = repo_connection,
       workflow: %{id: workflow_id} = workflow
     } do
-      # refute Snapshot.get_current_for(workflow)
-
       expect_create_installation_token(repo_connection.github_installation_id)
       expect_get_repo(repo_connection.repo)
       expect_create_workflow_dispatch(repo_connection.repo, "openfn-pull.yml")

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -349,7 +349,7 @@ defmodule Lightning.WorkOrdersTest do
 
       # This isn't the best place to test for this specific case.
       Lightning.Workflows.change_workflow(workflow, %{name: "new name"})
-      |> Lightning.Workflows.save_workflow()
+      |> Lightning.Workflows.save_workflow(insert(:user))
 
       snapshot2 = Lightning.Workflows.Snapshot.get_current_for(workflow)
 

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -4,10 +4,12 @@ defmodule Lightning.WorkOrdersTest do
   import Lightning.Factories
 
   alias Ecto.Multi
+  alias Lightning.Auditing.Audit
   alias Lightning.Extensions.MockUsageLimiter
   alias Lightning.Extensions.UsageLimiting.Action
   alias Lightning.Extensions.Message
   alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord
+  alias Lightning.Workflows.Snapshot
   alias Lightning.WorkOrders
   alias Lightning.WorkOrders.Events
   alias Lightning.WorkOrders.RetryManyWorkOrdersJob
@@ -182,6 +184,29 @@ defmodule Lightning.WorkOrdersTest do
              |> Repo.get_by(trigger_id: trigger.id) != nil
     end
 
+    @tag trigger_type: :cron
+    test "with a trigger assigns the provided actor to the event", %{
+      snapshot: snapshot,
+      trigger: trigger,
+      workflow: workflow
+    } do
+      Repo.delete!(snapshot)
+
+      Lightning.WorkOrders.subscribe(workflow.project_id)
+
+      dataclip = insert(:dataclip)
+      %{id: actor_id} = actor = insert(:user)
+
+      WorkOrders.create_for(
+        trigger,
+        actor: actor,
+        dataclip: dataclip,
+        workflow: workflow
+      )
+
+      assert %{actor_id: ^actor_id} = Repo.one(Audit)
+    end
+
     test "with a manual workorder", context do
       %{workflow: workflow, job: job, snapshot: snapshot} = context
       user = insert(:user)
@@ -230,6 +255,38 @@ defmodule Lightning.WorkOrdersTest do
       assert_received %Events.WorkOrderCreated{
         work_order: %{id: ^workorder_id}
       }
+    end
+
+    test "assigns the created_by of the Manual as the actor for the audit", %{
+      job: job,
+      snapshot: snapshot,
+      workflow: workflow
+    } do
+      Repo.delete(snapshot)
+
+      %{id: user_id} = user = insert(:user)
+      project_id = workflow.project_id
+      Lightning.WorkOrders.subscribe(project_id)
+
+      {:ok, manual} =
+        Lightning.WorkOrders.Manual.new(
+          %{
+            "body" =>
+            Jason.encode!(%{
+              "key_left" => "value_left",
+              "configuration" => %{"password" => "secret"}
+            })
+          },
+          workflow: workflow,
+          project: workflow.project,
+          job: job,
+          created_by: user
+        )
+        |> Ecto.Changeset.apply_action(:validate)
+
+      WorkOrders.create_for(manual)
+
+      assert %{actor_id: ^user_id} = Repo.one!(Audit)
     end
 
     test "with a job", %{job: job, workflow: workflow, snapshot: snapshot} do
@@ -288,6 +345,34 @@ defmodule Lightning.WorkOrdersTest do
 
       assert TriggerKafkaMessageRecord
              |> Repo.get_by(trigger_id: trigger.id) != nil
+    end
+
+    test "with a job, assigns the actor to the audit if snapshot created", %{
+      job: job,
+      workflow: workflow,
+    } do
+      Repo.delete_all(Snapshot)
+
+      project_id = workflow.project_id
+
+      project =
+        Repo.get(Lightning.Projects.Project, project_id)
+        |> Lightning.Projects.Project.changeset(%{retention_policy: :erase_all})
+        |> Repo.update!()
+
+      dataclip = insert(:dataclip, project: project)
+      user = insert(:user)
+      %{id: actor_id} = actor = insert(:user)
+
+      WorkOrders.create_for(
+        job,
+        actor: actor,
+        dataclip: dataclip,
+        workflow: workflow,
+        created_by: user
+      )
+
+      assert %{actor_id: ^actor_id} = Repo.one!(Audit)
     end
   end
 
@@ -572,6 +657,48 @@ defmodule Lightning.WorkOrdersTest do
       assert_received %Events.WorkOrderUpdated{
         work_order: %{id: ^workorder_id}
       }
+    end
+
+    test "if snapshot is created, uses creating user as audit actor", %{
+      workflow: workflow,
+      snapshot: snapshot,
+      trigger: trigger,
+      jobs: [job_a, job_b, job_c]
+    } do
+      %{id: user_id} = user = insert(:user)
+      dataclip = insert(:dataclip)
+      output_dataclip = insert(:dataclip)
+
+      # create existing complete run
+      %{runs: [run]} =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: dataclip,
+          runs: [
+            %{
+              state: :failed,
+              dataclip: dataclip,
+              starting_trigger: trigger,
+              steps: [
+                  insert(:step,
+                    job: job_a,
+                    input_dataclip: dataclip,
+                    output_dataclip: output_dataclip
+                  ),
+                second_step =
+                  insert(:step, job: job_b, input_dataclip: output_dataclip),
+                insert(:step, job: job_c)
+              ]
+            }
+          ]
+        )
+
+      Repo.delete(snapshot)
+
+      WorkOrders.retry(run, second_step, created_by: user)
+
+      assert %{actor_id: ^user_id} = Repo.one!(Audit)
     end
   end
 
@@ -2444,6 +2571,48 @@ defmodule Lightning.WorkOrdersTest do
       {:ok, work_order} = WorkOrders.update_state(run)
 
       assert work_order.state == :running
+    end
+  end
+
+  describe ".enqueue_many_for_retry/2" do
+    test "assigns the creating user as the auditing actor" do
+      dataclip = insert(:dataclip)
+      workflow = insert(:simple_workflow)
+      %{id: work_order_id} =
+        insert(:workorder, workflow: workflow, dataclip: dataclip)
+      %{id: user_id} = insert(:user)
+      
+      WorkOrders.enqueue_many_for_retry([work_order_id], user_id)
+
+      assert %{actor_id: ^user_id} = Repo.one(Audit)
+    end
+  end
+
+  describe ".build"  do
+    test "uses the provided actor for the snapshot audit event" do
+      dataclip = insert(:dataclip)
+      workflow = insert(:simple_workflow)
+      %{id: actor_id} = actor = insert(:user)
+
+      WorkOrders.build(%{dataclip: dataclip, workflow: workflow, actor: actor})
+
+      assert %{actor_id: ^actor_id} = Repo.one(Audit)
+    end
+  end
+
+  describe ".build_for" do
+    test "uses the provided actor for the snapshot audit event" do
+      dataclip = insert(:dataclip)
+      trigger = insert(:trigger)
+      workflow = insert(:simple_workflow)
+      %{id: actor_id} = actor = insert(:user)
+
+      WorkOrders.build_for(
+        trigger,
+        %{dataclip: dataclip, workflow: workflow, actor: actor}
+      )
+
+      assert %{actor_id: ^actor_id} = Repo.one(Audit)
     end
   end
 end

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -272,10 +272,10 @@ defmodule Lightning.WorkOrdersTest do
         Lightning.WorkOrders.Manual.new(
           %{
             "body" =>
-            Jason.encode!(%{
-              "key_left" => "value_left",
-              "configuration" => %{"password" => "secret"}
-            })
+              Jason.encode!(%{
+                "key_left" => "value_left",
+                "configuration" => %{"password" => "secret"}
+              })
           },
           workflow: workflow,
           project: workflow.project,
@@ -349,7 +349,7 @@ defmodule Lightning.WorkOrdersTest do
 
     test "with a job, assigns the actor to the audit if snapshot created", %{
       job: job,
-      workflow: workflow,
+      workflow: workflow
     } do
       Repo.delete_all(Snapshot)
 
@@ -681,11 +681,11 @@ defmodule Lightning.WorkOrdersTest do
               dataclip: dataclip,
               starting_trigger: trigger,
               steps: [
-                  insert(:step,
-                    job: job_a,
-                    input_dataclip: dataclip,
-                    output_dataclip: output_dataclip
-                  ),
+                insert(:step,
+                  job: job_a,
+                  input_dataclip: dataclip,
+                  output_dataclip: output_dataclip
+                ),
                 second_step =
                   insert(:step, job: job_b, input_dataclip: output_dataclip),
                 insert(:step, job: job_c)
@@ -2578,17 +2578,19 @@ defmodule Lightning.WorkOrdersTest do
     test "assigns the creating user as the auditing actor" do
       dataclip = insert(:dataclip)
       workflow = insert(:simple_workflow)
+
       %{id: work_order_id} =
         insert(:workorder, workflow: workflow, dataclip: dataclip)
+
       %{id: user_id} = insert(:user)
-      
+
       WorkOrders.enqueue_many_for_retry([work_order_id], user_id)
 
       assert %{actor_id: ^user_id} = Repo.one(Audit)
     end
   end
 
-  describe ".build"  do
+  describe ".build" do
     test "uses the provided actor for the snapshot audit event" do
       dataclip = insert(:dataclip)
       workflow = insert(:simple_workflow)

--- a/test/lightning/workflows/audit_test.exs
+++ b/test/lightning/workflows/audit_test.exs
@@ -12,20 +12,20 @@ defmodule Lightning.Workflows.AuditTest do
       changeset = Audit.snapshot_created(workflow_id, snapshot_id, user)
 
       assert %{
-        changes: %{
-          event: "snapshot_created",
-          item_id: ^workflow_id,
-          item_type: "workflow",
-          actor_id: ^user_id,
-          changes: %{
-            changes: %{
-              after: %{
-                snapshot_id: ^snapshot_id
-              }
-            }
-          }
-        }
-      } = changeset
+               changes: %{
+                 event: "snapshot_created",
+                 item_id: ^workflow_id,
+                 item_type: "workflow",
+                 actor_id: ^user_id,
+                 changes: %{
+                   changes: %{
+                     after: %{
+                       snapshot_id: ^snapshot_id
+                     }
+                   }
+                 }
+               }
+             } = changeset
     end
   end
 end

--- a/test/lightning/workflows/audit_test.exs
+++ b/test/lightning/workflows/audit_test.exs
@@ -1,0 +1,31 @@
+defmodule Lightning.Workflows.AuditTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Workflows.Audit
+
+  describe ".snapshot_created/3" do
+    test "saves a `snapshot_created` event" do
+      %{id: user_id} = user = insert(:user)
+      snapshot_id = Ecto.UUID.generate()
+      workflow_id = Ecto.UUID.generate()
+
+      changeset = Audit.snapshot_created(workflow_id, snapshot_id, user)
+
+      assert %{
+        changes: %{
+          event: "snapshot_created",
+          item_id: ^workflow_id,
+          item_type: "workflow",
+          actor_id: ^user_id,
+          changes: %{
+            changes: %{
+              after: %{
+                snapshot_id: ^snapshot_id
+              }
+            }
+          }
+        }
+      } = changeset
+    end
+  end
+end

--- a/test/lightning/workflows/scheduler_test.exs
+++ b/test/lightning/workflows/scheduler_test.exs
@@ -2,7 +2,9 @@ defmodule Lightning.Workflows.SchedulerTest do
   @moduledoc false
   use Lightning.DataCase, async: true
 
+  alias Lightning.Auditing.Audit
   alias Lightning.Invocation
+  alias Lightning.Repo
   alias Lightning.Run
   alias Lightning.Workflows.Scheduler
 
@@ -109,6 +111,89 @@ defmodule Lightning.Workflows.SchedulerTest do
       refute new_run.id == run.id
       assert new_run.dataclip.type == :step_result
       assert new_run.dataclip.body == old_step.output_dataclip.body
+    end
+
+    test "uses the trigger as the actor for audit event if job has never run" do
+      job = insert(:job)
+
+      %{id: trigger_id} =
+        trigger =
+        insert(:trigger, %{
+          type: :cron,
+          cron_expression: "* * * * *",
+          workflow: job.workflow
+        })
+
+      insert(:edge, %{
+        workflow: job.workflow,
+        source_trigger: trigger,
+        target_job: job
+      })
+
+      Mox.expect(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, _context -> :ok end
+      )
+
+      Scheduler.enqueue_cronjobs()
+
+      assert %{actor_id: ^trigger_id} = Repo.one!(Audit)
+    end
+
+    test "uses the trigger as the actor for audit event if job has run before" do
+      job =
+        insert(:job,
+          body: "fn(state => { console.log(state); return { changed: true }; })"
+        )
+
+      %{id: trigger_id} =
+        trigger =
+          insert(:trigger, %{
+            type: :cron,
+            cron_expression: "* * * * *",
+            workflow: job.workflow
+          })
+
+      insert(:edge, %{
+        workflow: job.workflow,
+        source_trigger: trigger,
+        target_job: job
+      })
+
+      dataclip = insert(:dataclip)
+
+      insert(:run,
+        work_order:
+        build(:workorder,
+          workflow: job.workflow,
+          dataclip: dataclip,
+          trigger: trigger,
+          state: :success
+        ),
+        starting_trigger: trigger,
+        state: :success,
+        dataclip: dataclip,
+        steps: [
+          build(:step,
+            exit_reason: "success",
+            job: job,
+            input_dataclip: dataclip,
+            output_dataclip:
+            build(:dataclip, type: :step_result, body: %{"changed" => true})
+          )
+        ]
+      )
+
+      Mox.expect(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, _context -> :ok end
+      )
+
+      Scheduler.enqueue_cronjobs()
+
+      assert %{actor_id: ^trigger_id} = Repo.one!(Audit)
     end
   end
 end

--- a/test/lightning/workflows/scheduler_test.exs
+++ b/test/lightning/workflows/scheduler_test.exs
@@ -149,11 +149,11 @@ defmodule Lightning.Workflows.SchedulerTest do
 
       %{id: trigger_id} =
         trigger =
-          insert(:trigger, %{
-            type: :cron,
-            cron_expression: "* * * * *",
-            workflow: job.workflow
-          })
+        insert(:trigger, %{
+          type: :cron,
+          cron_expression: "* * * * *",
+          workflow: job.workflow
+        })
 
       insert(:edge, %{
         workflow: job.workflow,
@@ -165,12 +165,12 @@ defmodule Lightning.Workflows.SchedulerTest do
 
       insert(:run,
         work_order:
-        build(:workorder,
-          workflow: job.workflow,
-          dataclip: dataclip,
-          trigger: trigger,
-          state: :success
-        ),
+          build(:workorder,
+            workflow: job.workflow,
+            dataclip: dataclip,
+            trigger: trigger,
+            state: :success
+          ),
         starting_trigger: trigger,
         state: :success,
         dataclip: dataclip,
@@ -180,7 +180,7 @@ defmodule Lightning.Workflows.SchedulerTest do
             job: job,
             input_dataclip: dataclip,
             output_dataclip:
-            build(:dataclip, type: :step_result, body: %{"changed" => true})
+              build(:dataclip, type: :step_result, body: %{"changed" => true})
           )
         ]
       )

--- a/test/lightning/workflows/snapshots_test.exs
+++ b/test/lightning/workflows/snapshots_test.exs
@@ -40,7 +40,7 @@ defmodule Lightning.Workflows.SnapshotsTest do
     {:ok, workflow} =
       workflow
       |> Workflows.change_workflow(%{name: "new name", jobs: [params_for(:job)]})
-      |> Workflows.save_workflow()
+      |> Workflows.save_workflow(insert(:user))
 
     {:error, changeset} = Workflows.Snapshot.create(workflow)
 

--- a/test/lightning/workflows/snapshots_test.exs
+++ b/test/lightning/workflows/snapshots_test.exs
@@ -182,7 +182,6 @@ defmodule Lightning.Workflows.SnapshotsTest do
                  after: %{"snapshot_id" => ^snapshot_id}
                }
              } = audit
-
     end
 
     test "with an existing snapshot", %{actor: actor} do

--- a/test/lightning/workflows/snapshots_test.exs
+++ b/test/lightning/workflows/snapshots_test.exs
@@ -159,6 +159,32 @@ defmodule Lightning.Workflows.SnapshotsTest do
              } = audit
     end
 
+    test "called with multi - creates an audit entry if snapshot was created", %{
+      actor: %{id: actor_id} = actor
+    } do
+      %{id: workflow_id} = workflow = insert(:simple_workflow)
+
+      {:ok, %{snapshot: %{id: snapshot_id}}} =
+        Workflows.Snapshot.get_or_create_latest_for(
+          Ecto.Multi.new(),
+          workflow,
+          actor
+        )
+        |> Repo.transaction()
+
+      audit = Repo.one!(Audit)
+
+      assert %{
+               event: "snapshot_created",
+               item_id: ^workflow_id,
+               actor_id: ^actor_id,
+               changes: %{
+                 after: %{"snapshot_id" => ^snapshot_id}
+               }
+             } = audit
+
+    end
+
     test "with an existing snapshot", %{actor: actor} do
       workflow = insert(:simple_workflow)
 

--- a/test/lightning/workflows/workflow_test.exs
+++ b/test/lightning/workflows/workflow_test.exs
@@ -12,7 +12,7 @@ defmodule Lightning.Workflows.WorkflowTest do
       {:ok, workflow} =
         insert(:simple_workflow, project: insert(:project))
         |> Workflow.touch()
-        |> Workflows.save_workflow()
+        |> Workflows.save_workflow(insert(:user))
 
       assert from(s in Ecto.assoc(workflow, :snapshots),
                where: s.lock_version == ^workflow.lock_version

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -81,16 +81,16 @@ defmodule Lightning.WorkflowsTest do
       %{id: snapshot_id} = Snapshot |> Repo.one!()
 
       assert %{
-        event: "snapshot_created",
-        item_type: "workflow",
-        item_id: ^workflow_id,
-        actor_id: ^user_id,
-        changes: %{
-          after: %{
-            "snapshot_id" => ^snapshot_id
-          }
-        }
-      } = Audit |> Repo.one()
+               event: "snapshot_created",
+               item_type: "workflow",
+               item_id: ^workflow_id,
+               actor_id: ^user_id,
+               changes: %{
+                 after: %{
+                   "snapshot_id" => ^snapshot_id
+                 }
+               }
+             } = Audit |> Repo.one()
     end
 
     test "save_workflow/1 with attrs audits creation of the snapshot" do
@@ -103,16 +103,16 @@ defmodule Lightning.WorkflowsTest do
       %{id: snapshot_id} = Snapshot |> Repo.one!()
 
       assert %{
-        event: "snapshot_created",
-        item_type: "workflow",
-        item_id: ^workflow_id,
-        actor_id: ^user_id,
-        changes: %{
-          after: %{
-            "snapshot_id" => ^snapshot_id
-          }
-        }
-      } = Audit |> Repo.one()
+               event: "snapshot_created",
+               item_type: "workflow",
+               item_id: ^workflow_id,
+               actor_id: ^user_id,
+               changes: %{
+                 after: %{
+                   "snapshot_id" => ^snapshot_id
+                 }
+               }
+             } = Audit |> Repo.one()
     end
 
     test "save_workflow/1 publishes event for updated Kafka triggers" do
@@ -235,7 +235,7 @@ defmodule Lightning.WorkflowsTest do
       user = insert(:user)
 
       assert {:ok, workflow} =
-        Lightning.Workflows.save_workflow(valid_attrs, user)
+               Lightning.Workflows.save_workflow(valid_attrs, user)
 
       assert workflow.name == "some-name"
 
@@ -257,7 +257,7 @@ defmodule Lightning.WorkflowsTest do
       }
 
       assert {:ok, workflow} =
-        Lightning.Workflows.save_workflow(valid_attrs, user)
+               Lightning.Workflows.save_workflow(valid_attrs, user)
 
       edge = workflow.edges |> List.first()
       assert edge.source_trigger_id == trigger_id
@@ -337,7 +337,7 @@ defmodule Lightning.WorkflowsTest do
       valid_attrs = params_with_assocs(:workflow, jobs: [params_for(:job)])
 
       assert {:ok, workflow} =
-        Workflows.save_workflow(valid_attrs, insert(:user))
+               Workflows.save_workflow(valid_attrs, insert(:user))
 
       assert workflow.lock_version == 1
 
@@ -506,10 +506,10 @@ defmodule Lightning.WorkflowsTest do
     } do
       workflow = insert(:workflow)
 
-      assert {:ok, _} = 
-        :edge
-        |> params_for(workflow: workflow)
-        |> Workflows.create_edge(user)
+      assert {:ok, _} =
+               :edge
+               |> params_for(workflow: workflow)
+               |> Workflows.create_edge(user)
 
       assert %{actor_id: ^user_id} = Audit |> Repo.one!()
     end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -90,7 +90,7 @@ defmodule Lightning.WorkflowsTest do
                    "snapshot_id" => ^snapshot_id
                  }
                }
-             } = Audit |> Repo.one()
+             } = Repo.one(Audit)
     end
 
     test "save_workflow/1 with attrs audits creation of the snapshot" do
@@ -112,7 +112,7 @@ defmodule Lightning.WorkflowsTest do
                    "snapshot_id" => ^snapshot_id
                  }
                }
-             } = Audit |> Repo.one()
+             } = Repo.one(Audit)
     end
 
     test "save_workflow/1 publishes event for updated Kafka triggers" do

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -10,10 +10,12 @@ defmodule LightningWeb.RunWithOptionsTest do
 
   describe "rendering a run" do
     test "renders a workflow using a snapshot" do
+      user = insert(:user)
+
       {:ok, %{triggers: [trigger], jobs: [job], edges: [edge]} = workflow} =
         insert(:simple_workflow)
         |> Workflow.touch()
-        |> Workflows.save_workflow()
+        |> Workflows.save_workflow(user)
 
       %{runs: [run]} =
         work_order_for(trigger,
@@ -60,7 +62,7 @@ defmodule LightningWeb.RunWithOptionsTest do
       {:ok, workflow} =
         workflow
         |> Workflows.change_workflow(%{jobs: [%{id: job.id, body: "foo()"}]})
-        |> Workflows.save_workflow()
+        |> Workflows.save_workflow(user)
 
       %{runs: [run]} =
         work_order_for(trigger,

--- a/test/lightning_web/channels/worker_channel_test.exs
+++ b/test/lightning_web/channels/worker_channel_test.exs
@@ -54,6 +54,7 @@ defmodule LightningWeb.WorkerChannelTest do
         |> Enum.map(fn _ ->
           {:ok, %{runs: [run]}} =
             WorkOrders.create_for(trigger,
+              actor: insert(:user),
               workflow: workflow,
               dataclip: params_with_assocs(:dataclip)
             )

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -211,7 +211,8 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
           name: "workflow 1"
         )
 
-      {:ok, snapshot_1} = Snapshot.get_or_create_latest_for(workflow_1)
+      {:ok, snapshot_1} =
+        Snapshot.get_or_create_latest_for(workflow_1, insert(:user))
 
       {:ok, updated_workflow_1} =
         workflow_1
@@ -224,7 +225,8 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
           name: "workflow 2"
         )
 
-      {:ok, snapshot_2} = Snapshot.get_or_create_latest_for(workflow_2)
+      {:ok, snapshot_2} =
+        Snapshot.get_or_create_latest_for(workflow_2, insert(:user))
 
       conn =
         get(conn, ~p"/api/provision/#{project_id}", snapshots: [snapshot_1.id])
@@ -426,7 +428,8 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
           name: "workflow 1"
         )
 
-      {:ok, snapshot_1} = Snapshot.get_or_create_latest_for(workflow_1)
+      {:ok, snapshot_1} =
+        Snapshot.get_or_create_latest_for(workflow_1, insert(:user))
 
       {:ok, updated_workflow_1} =
         workflow_1
@@ -439,7 +442,8 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
           name: "workflow 2"
         )
 
-      {:ok, snapshot_2} = Snapshot.get_or_create_latest_for(workflow_2)
+      {:ok, snapshot_2} =
+        Snapshot.get_or_create_latest_for(workflow_2, insert(:user))
 
       conn =
         Plug.Conn.put_req_header(

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -21,11 +21,12 @@ defmodule LightningWeb.WorkOrderLiveTest do
   setup :stub_usage_limiter_ok
 
   defp setup_work_order(project) do
+    actor = insert(:user)
     dataclip = insert(:dataclip)
     %{jobs: [job]} = workflow = insert(:simple_workflow, project: project)
 
     {:ok, snapshot} =
-      Workflows.Snapshot.get_or_create_latest_for(workflow)
+      Workflows.Snapshot.get_or_create_latest_for(workflow, actor)
 
     work_order =
       work_order_for(job,
@@ -497,7 +498,8 @@ defmodule LightningWeb.WorkOrderLiveTest do
       job = insert(:job, workflow: workflow)
       dataclip = insert(:dataclip)
 
-      {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       runs_params = [
         %{state: :claimed, state_timestamp: build(:timestamp)},
@@ -546,7 +548,8 @@ defmodule LightningWeb.WorkOrderLiveTest do
       trigger = insert(:trigger, type: :webhook, workflow: workflow)
       job = insert(:job, workflow: workflow)
 
-      {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       dataclip = insert(:dataclip)
 
@@ -710,7 +713,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
       dataclip = insert(:dataclip)
 
       {:ok, snapshot} =
-        Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow)
+        Lightning.Workflows.Snapshot.get_or_create_latest_for(
+          workflow,
+          insert(:user)
+        )
 
       work_order =
         insert(:workorder,
@@ -817,7 +823,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
       dataclip = insert(:dataclip)
 
       {:ok, snapshot} =
-        Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow)
+        Lightning.Workflows.Snapshot.get_or_create_latest_for(
+          workflow,
+          insert(:user)
+        )
 
       work_order =
         insert(:workorder,
@@ -894,7 +903,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
         )
 
       {:ok, snapshot} =
-        Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow)
+        Lightning.Workflows.Snapshot.get_or_create_latest_for(
+          workflow,
+          insert(:user)
+        )
 
       dataclip = insert(:dataclip)
 
@@ -933,7 +945,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
         )
 
       {:ok, snapshot_two} =
-        Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow_two)
+        Lightning.Workflows.Snapshot.get_or_create_latest_for(
+          workflow_two,
+          insert(:user)
+        )
 
       dataclip_two = insert(:dataclip)
 
@@ -1018,7 +1033,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
         )
 
       {:ok, snapshot_one} =
-        Workflows.Snapshot.get_or_create_latest_for(workflow_one)
+        Workflows.Snapshot.get_or_create_latest_for(
+          workflow_one,
+          insert(:user)
+        )
 
       dataclip =
         insert(:dataclip,
@@ -1057,7 +1075,10 @@ defmodule LightningWeb.WorkOrderLiveTest do
       job_two = insert(:job, workflow: workflow_two)
 
       {:ok, snapshot_two} =
-        Workflows.Snapshot.get_or_create_latest_for(workflow_two)
+        Workflows.Snapshot.get_or_create_latest_for(
+          workflow_two,
+          insert(:user)
+        )
 
       dataclip =
         insert(:dataclip, type: :http_request, body: %{"username" => "qassim"})
@@ -1369,7 +1390,8 @@ defmodule LightningWeb.WorkOrderLiveTest do
 
       dataclip = insert(:dataclip, project: project)
 
-      {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       workorder =
         insert(:workorder,
@@ -1478,7 +1500,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
       )
 
       {:ok, snapshot} =
-        Workflows.Snapshot.get_or_create_latest_for(workflow)
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       dataclip = insert(:dataclip, project: project)
 
@@ -1636,7 +1658,8 @@ defmodule LightningWeb.WorkOrderLiveTest do
       job_1 = insert(:job, workflow: workflow)
       job_2 = insert(:job, workflow: workflow)
 
-      {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       dataclip = insert(:dataclip)
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -22,9 +22,11 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
   describe "New credential from project context " do
     setup %{project: project} do
+      actor = insert(:user)
       %{job: job} = workflow_job_fixture(project_id: project.id)
       workflow = Repo.get(Workflow, job.workflow_id)
-      {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, actor)
       %{job: job, workflow: workflow, snapshot: snapshot}
     end
 
@@ -346,7 +348,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version]}"
         )
 
-      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow)
+       {:ok, snapshot} =
+         Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       assert snapshot.lock_version == workflow.lock_version
 
@@ -597,7 +600,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
     test "Creating an audit event on rerun", %{
       conn: conn,
       project: project,
-      user: %{id: user_id},
+      user: %{id: user_id} = user,
       workflow: %{id: workflow_id} = workflow
     } do
       {:ok, view, _html} =
@@ -606,7 +609,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version]}"
         )
 
-      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow, user)
 
       view |> fill_workflow_name("#{workflow.name} v2")
 
@@ -685,7 +688,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
            user: user,
            workflow: workflow
          } do
-      {:ok, earliest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
+         {:ok, earliest_snapshot} =
+           Snapshot.get_or_create_latest_for(workflow, user)
 
       run_1 =
         insert(:run,
@@ -713,7 +717,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         Workflows.change_workflow(workflow, %{jobs: jobs_attrs})
         |> Workflows.save_workflow(user)
 
-      {:ok, latest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
+      {:ok, latest_snapshot} = Snapshot.get_or_create_latest_for(workflow, user)
 
       run_2 =
         insert(:run,
@@ -788,7 +792,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       user: user,
       workflow: workflow
     } do
-      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow, user)
 
       run =
         insert(:run,
@@ -816,7 +820,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         Workflows.change_workflow(workflow, %{jobs: jobs_attrs})
         |> Workflows.save_workflow(user)
 
-      {:ok, latest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
+      {:ok, latest_snapshot} = Snapshot.get_or_create_latest_for(workflow, user)
 
       insert(:run,
         work_order: build(:workorder, workflow: workflow),
@@ -1253,7 +1257,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         |> with_edge({trigger, job})
         |> insert()
 
-      {:ok, _snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, _snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       {:ok, view, _html} =
         live(
@@ -1289,7 +1294,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       insert(:step, job: job_b)
 
-      {:ok, _snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, _snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       {:ok, view, _html} =
         live(
@@ -1340,7 +1346,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         |> with_edge({job_b, job_c})
         |> insert()
 
-      {:ok, _snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+       {:ok, _snapshot} =
+         Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       {:ok, view, html} =
         live(
@@ -2162,7 +2169,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       workflow = insert(:simple_workflow, project: project)
 
-      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow)
+      {:ok, snapshot} =
+        Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       %{jobs: [job], triggers: [trigger]} = workflow
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -235,7 +235,9 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
     @tag role: :editor
     test "auditing snapshot creation", %{
-      conn: conn, project: project, user: %{id: user_id}
+      conn: conn,
+      project: project,
+      user: %{id: user_id}
     } do
       {:ok, view, _html} =
         live(conn, ~p"/projects/#{project.id}/w/new?m=settings")
@@ -281,10 +283,10 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       audit_event = Lightning.Repo.one(audit_query)
 
       assert %{
-        actor_id: ^user_id,
-        item_id: ^workflow_id,
-        item_type: "workflow"
-      } = audit_event
+               actor_id: ^user_id,
+               item_id: ^workflow_id,
+               item_type: "workflow"
+             } = audit_event
     end
 
     @tag role: :viewer
@@ -656,7 +658,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       snapshots_query = from s in Snapshot, order_by: [desc: s.inserted_at]
 
       [%{id: latest_snapshot_id} | [_, _]] =
-          Lightning.Repo.all(snapshots_query)
+        Lightning.Repo.all(snapshots_query)
 
       audit_query =
         from a in Audit,
@@ -667,21 +669,22 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       audit_event = Lightning.Repo.one(audit_query)
 
       assert %{
-        actor_id: ^user_id,
-        item_id: ^workflow_id,
-        item_type: "workflow",
-        changes: %{
-          after: %{"snapshot_id" => ^latest_snapshot_id}
-        }
-      } = audit_event
+               actor_id: ^user_id,
+               item_id: ^workflow_id,
+               item_type: "workflow",
+               changes: %{
+                 after: %{"snapshot_id" => ^latest_snapshot_id}
+               }
+             } = audit_event
     end
 
-    test "Inspector renders run thru their snapshots and allows switching to the latest versions for editing", %{
-      conn: conn,
-      project: project,
-      user: user,
-      workflow: workflow
-    } do
+    test "Inspector renders run thru their snapshots and allows switching to the latest versions for editing",
+         %{
+           conn: conn,
+           project: project,
+           user: user,
+           workflow: workflow
+         } do
       {:ok, earliest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
 
       run_1 =

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -474,7 +474,6 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: snapshot.lock_version]}"
         )
 
-      # RORY COPY FROM HERE
       assert view
              |> has_element?(
                "[id='canvas-workflow-version'][aria-label='You are viewing a snapshot of this workflow that was taken on #{Helpers.format_date(snapshot.inserted_at)}']",

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -25,8 +25,10 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       actor = insert(:user)
       %{job: job} = workflow_job_fixture(project_id: project.id)
       workflow = Repo.get(Workflow, job.workflow_id)
+
       {:ok, snapshot} =
         Workflows.Snapshot.get_or_create_latest_for(workflow, actor)
+
       %{job: job, workflow: workflow, snapshot: snapshot}
     end
 
@@ -348,8 +350,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version]}"
         )
 
-       {:ok, snapshot} =
-         Snapshot.get_or_create_latest_for(workflow, insert(:user))
+      {:ok, snapshot} =
+        Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       assert snapshot.lock_version == workflow.lock_version
 
@@ -688,8 +690,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
            user: user,
            workflow: workflow
          } do
-         {:ok, earliest_snapshot} =
-           Snapshot.get_or_create_latest_for(workflow, user)
+      {:ok, earliest_snapshot} =
+        Snapshot.get_or_create_latest_for(workflow, user)
 
       run_1 =
         insert(:run,
@@ -1346,8 +1348,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         |> with_edge({job_b, job_c})
         |> insert()
 
-       {:ok, _snapshot} =
-         Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
+      {:ok, _snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       {:ok, view, html} =
         live(

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -9,6 +9,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
   import Lightning.WorkflowsFixtures
   import Phoenix.LiveViewTest
 
+  alias Lightning.Auditing.Audit
   alias Lightning.Helpers
   alias Lightning.Repo
   alias Lightning.Workflows
@@ -224,12 +225,66 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         ~p"/projects/#{project.id}/w/#{workflow_id}?#{[m: "expand", s: job.id, v: workflow.lock_version]}"
       )
 
-      render(view) =~ "Workflow saved"
+      assert render(view) =~ "Workflow saved"
 
       # workflow updated event is emitted
       assert_received %Lightning.Workflows.Events.WorkflowUpdated{
         workflow: %{id: ^workflow_id}
       }
+    end
+
+    @tag role: :editor
+    test "auditing snapshot creation", %{
+      conn: conn, project: project, user: %{id: user_id}
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project.id}/w/new?m=settings")
+
+      assert view |> push_patches_to_view(initial_workflow_patchset(project))
+
+      workflow_name = "My Workflow"
+      view |> fill_workflow_name(workflow_name)
+
+      {job, _, _} = view |> select_first_job()
+
+      view |> fill_job_fields(job, %{name: "My Job"})
+
+      view |> CredentialLiveHelpers.select_credential_type("dhis2")
+
+      view |> CredentialLiveHelpers.click_continue()
+
+      # Creating a new credential from the Job panel
+      view
+      |> CredentialLiveHelpers.fill_credential(%{
+        name: "My Credential",
+        body: %{username: "foo", password: "bar", hostUrl: "http://someurl"}
+      })
+
+      view |> CredentialLiveHelpers.click_save()
+
+      # Editing the Jobs' body
+      view |> click_edit(job)
+
+      view |> change_editor_text("some body")
+
+      click_save(view)
+
+      assert %{id: workflow_id} =
+               Lightning.Repo.one(
+                 from w in Workflow,
+                   where:
+                     w.project_id == ^project.id and w.name == ^workflow_name
+               )
+
+      audit_query = from a in Audit, where: a.event == "snapshot_created"
+
+      audit_event = Lightning.Repo.one(audit_query)
+
+      assert %{
+        actor_id: ^user_id,
+        item_id: ^workflow_id,
+        item_type: "workflow"
+      } = audit_event
     end
 
     @tag role: :viewer
@@ -412,6 +467,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
           ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: snapshot.lock_version]}"
         )
 
+      # RORY COPY FROM HERE
       assert view
              |> has_element?(
                "[id='canvas-workflow-version'][aria-label='You are viewing a snapshot of this workflow that was taken on #{Helpers.format_date(snapshot.inserted_at)}']",
@@ -536,6 +592,78 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert view |> element("[type='submit']", "Save") |> has_element?()
     end
 
+    test "Creating an audit event on rerun", %{
+      conn: conn,
+      project: project,
+      user: %{id: user_id},
+      workflow: %{id: workflow_id} = workflow
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version]}"
+        )
+
+      {:ok, snapshot} = Snapshot.get_or_create_latest_for(workflow)
+
+      view |> fill_workflow_name("#{workflow.name} v2")
+
+      job_1 = List.first(workflow.jobs)
+
+      view |> select_node(job_1, workflow.lock_version)
+
+      view
+      |> form("#workflow-form", %{
+        "workflow" => %{
+          "jobs" => %{
+            "0" => %{
+              "name" => "#{job_1.name} v2"
+            }
+          }
+        }
+      })
+      |> render_change()
+
+      view
+      |> form("#workflow-form")
+      |> render_submit()
+
+      workflow = Repo.reload!(workflow)
+
+      view
+      |> element(
+        "a[href='/projects/#{project.id}/w'][data-phx-link='redirect']",
+        "Workflows"
+      )
+      |> render_click()
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: snapshot.lock_version]}"
+        )
+
+      last_edge = List.last(snapshot.edges)
+
+      view |> select_node(last_edge, snapshot.lock_version)
+
+      assert force_event(view, :manual_run_submit, %{}) =~
+               "Cannot run in snapshot mode, switch to latest."
+
+      assert force_event(view, :rerun, nil, nil) =~
+               "Cannot rerun in snapshot mode, switch to latest."
+
+      audit_query = from a in Audit, where: a.event == "snapshot_created"
+
+      audit_event = Lightning.Repo.one(audit_query)
+
+      assert %{
+        actor_id: ^user_id,
+        item_id: ^workflow_id,
+        item_type: "workflow"
+      } = audit_event
+    end
+
     test "Inspector renders run thru their snapshots and allows switching to the latest versions for editing",
          %{conn: conn, project: project, workflow: workflow} do
       {:ok, earliest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
@@ -564,7 +692,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       {:ok, workflow} =
         Workflows.change_workflow(workflow, %{jobs: jobs_attrs})
-        |> Workflows.save_workflow()
+        |> Workflows.save_workflow(nil)
 
       {:ok, latest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
 
@@ -666,7 +794,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       {:ok, workflow} =
         Workflows.change_workflow(workflow, %{jobs: jobs_attrs})
-        |> Workflows.save_workflow()
+        |> Workflows.save_workflow(nil)
 
       {:ok, latest_snapshot} = Snapshot.get_or_create_latest_for(workflow)
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -434,7 +434,8 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         insert(:workflow, project: project)
         |> Lightning.Repo.preload([:jobs, :work_orders])
 
-      {:ok, _snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+           {:ok, _snapshot} =
+             Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       new_job_name = "new job"
 
@@ -1368,7 +1369,10 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         )
 
       {:ok, snapshot} =
-        Lightning.Workflows.Snapshot.get_or_create_latest_for(workflow)
+        Lightning.Workflows.Snapshot.get_or_create_latest_for(
+          workflow,
+          insert(:user)
+        )
 
       %{runs: [run]} =
         insert(:workorder,
@@ -1455,7 +1459,8 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         insert(:workflow, project: project)
         |> Lightning.Repo.preload([:jobs, :work_orders])
 
-      {:ok, _snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+      {:ok, _snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       new_job_name = "new job"
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -1482,6 +1482,10 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
 
       view |> change_editor_text("some body")
 
+      # Clear any audit entries that may have been created by fixtures
+
+      Repo.delete_all(Audit)
+
       view
       |> form("#manual_run_form", %{
         manual: %{body: Jason.encode!(%{})}

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -434,8 +434,8 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
         insert(:workflow, project: project)
         |> Lightning.Repo.preload([:jobs, :work_orders])
 
-           {:ok, _snapshot} =
-             Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
+      {:ok, _snapshot} =
+        Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
       new_job_name = "new job"
 

--- a/test/lightning_web/live/workflow_live/trigger_test.exs
+++ b/test/lightning_web/live/workflow_live/trigger_test.exs
@@ -13,10 +13,12 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
   setup :create_project_for_current_user
 
   setup %{project: project} do
+    actor = insert(:user)
     workflow = insert(:workflow, project: project)
     trigger = insert(:trigger, type: :webhook, workflow: workflow)
 
-    {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+    {:ok, snapshot} =
+      Workflows.Snapshot.get_or_create_latest_for(workflow, actor)
 
     [
       workflow: workflow,

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -581,7 +581,10 @@ defmodule Lightning.Factories do
   end
 
   def work_order_for(trigger_or_job, attrs) do
-    Lightning.WorkOrders.build_for(trigger_or_job, Map.new(attrs))
+    Lightning.WorkOrders.build_for(
+      trigger_or_job,
+      Map.new(attrs) |> Map.merge(%{actor: insert(:user)})
+    )
     |> Ecto.Changeset.apply_changes()
   end
 

--- a/test/support/fixtures/jobs_fixtures.ex
+++ b/test/support/fixtures/jobs_fixtures.ex
@@ -31,7 +31,7 @@ defmodule Lightning.JobsFixtures do
         name: "some name",
         adaptor: "@openfn/language-common"
       })
-      |> Lightning.Jobs.create_job()
+      |> Lightning.Jobs.create_job(insert(:user))
 
     job
   end

--- a/test/support/fixtures/workflows_fixtures.ex
+++ b/test/support/fixtures/workflows_fixtures.ex
@@ -24,7 +24,7 @@ defmodule Lightning.WorkflowsFixtures do
           )
           |> to_string()
       })
-      |> Lightning.Workflows.save_workflow()
+      |> Lightning.Workflows.save_workflow(nil)
 
     workflow
   end

--- a/test/support/fixtures/workflows_fixtures.ex
+++ b/test/support/fixtures/workflows_fixtures.ex
@@ -24,7 +24,7 @@ defmodule Lightning.WorkflowsFixtures do
           )
           |> to_string()
       })
-      |> Lightning.Workflows.save_workflow(nil)
+      |> Lightning.Workflows.save_workflow(insert(:user))
 
     workflow
   end

--- a/test/support/workflow_live_helpers.ex
+++ b/test/support/workflow_live_helpers.ex
@@ -428,7 +428,8 @@ defmodule Lightning.WorkflowLive.Helpers do
       |> with_edge({job_1, job_2}, %{condition_type: :on_job_success})
       |> insert()
 
-    {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow, nil)
+    {:ok, snapshot} =
+      Workflows.Snapshot.get_or_create_latest_for(workflow, insert(:user))
 
     %{
       workflow: workflow |> Lightning.Repo.preload([:jobs, :triggers, :edges]),

--- a/test/support/workflow_live_helpers.ex
+++ b/test/support/workflow_live_helpers.ex
@@ -428,7 +428,7 @@ defmodule Lightning.WorkflowLive.Helpers do
       |> with_edge({job_1, job_2}, %{condition_type: :on_job_success})
       |> insert()
 
-    {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow)
+    {:ok, snapshot} = Workflows.Snapshot.get_or_create_latest_for(workflow, nil)
 
     %{
       workflow: workflow |> Lightning.Repo.preload([:jobs, :triggers, :edges]),


### PR DESCRIPTION
### Description

This adds code to audit when a snapshot is created. The actor can be a User, a ProjectRepoConnection (e.g. for a Github sync) or a trigger (if a snapshot is created as the result of, say, a call to a webhook.

Unfortunately, there were a lot of files that needed to be changed, but I did not want to break this over multiple PRs as it felt like auditing requires an all-or-nothing approach when it comes to implementation (i.e. all snapshot creation is audited or none of it is).

Note: As `SetupUtils.setup_demo()` creates a number of snapshots, there will be a lot more entries in the audit log after setting up the DB.

Closes #2601 

### Validation steps

1. Open a workflow, change the job description and then save the workflow. An audit entry should be created.
2. Open a workflow, edit the job itself (i.e. change the JS) , select an input and then hit 'Create New Work Order'. An audit entry should be created.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
