### PR TITLE
Introduce `lv-keep-type` for password inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,6 @@ and this project adheres to
   [#2621](https://github.com/OpenFn/lightning/issues/2621)
 - Attempt to reduce memory consumption when generating UsageTracking reports.
   [#2636](https://github.com/OpenFn/lightning/issues/2636)
-- Attempt to reduce memory consumption when generating UsageTracking reports.
-  [#2636](https://github.com/OpenFn/lightning/issues/2636)
 
 ## [v2.10.2] - 2024-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix show password toggle icon gets flipped after changing the password value
+  [#2611](https://github.com/OpenFn/lightning/issues/2611)
+
 ## [v2.10.3] - 2024-11-13
 
 ### Added
@@ -37,6 +40,8 @@ and this project adheres to
 
 - Superusers can't update users passwords
   [#2621](https://github.com/OpenFn/lightning/issues/2621)
+- Attempt to reduce memory consumption when generating UsageTracking reports.
+  [#2636](https://github.com/OpenFn/lightning/issues/2636)
 - Attempt to reduce memory consumption when generating UsageTracking reports.
   [#2636](https://github.com/OpenFn/lightning/issues/2636)
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,6 +64,10 @@ let liveSocket = new LiveSocket('/live', Socket, {
         to.setAttribute('hidden', from.getAttribute('hidden'));
       }
 
+      if (from.attributes['lv-keep-type']) {
+        to.setAttribute('type', from.getAttribute('type'));
+      }
+
       if (from.attributes['lv-keep-aria']) {
         Object.values(from.attributes).forEach(attr => {
           if (attr.name.startsWith('aria-')) {

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -295,6 +295,7 @@ defmodule LightningWeb.Components.NewInputs do
           name={@name}
           id={@id}
           value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+          lv-keep-type
           class={[
             "focus:outline focus:outline-2 focus:outline-offset-1 block w-full rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
             "phx-no-feedback:border-slate-300 phx-no-feedback:focus:border-slate-400 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500",

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -332,7 +332,7 @@ defmodule LightningWeb.Components.NewInputs do
           />
         </div>
       </div>
-      <div :if={Enum.any?(@errors) and @display_errors} class="error-space h-6">
+      <div :if={Enum.any?(@errors) and @display_errors} class="error-space">
         <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
     </div>
@@ -383,7 +383,7 @@ defmodule LightningWeb.Components.NewInputs do
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         {@rest}
       />
-      <div :if={Enum.any?(@errors) and @display_errors} class="error-space h-6">
+      <div :if={Enum.any?(@errors) and @display_errors} class="error-space">
         <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
     </div>
@@ -557,7 +557,7 @@ defmodule LightningWeb.Components.NewInputs do
       )
 
     ~H"""
-    <div :if={Enum.any?(@errors)} class="error-space h-6">
+    <div :if={Enum.any?(@errors)} class="error-space">
       <.error :for={msg <- @errors}><%= msg %></.error>
     </div>
     """

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -119,7 +119,7 @@
     <div class="space-y-6">
       <div class="space-y-4">
         <.input
-          type="text"
+          type="password"
           field={f[:password]}
           label="New password"
           required="true"
@@ -127,7 +127,7 @@
       </div>
       <div class="space-y-4">
         <.input
-          type="text"
+          type="password"
           field={f[:password_confirmation]}
           label="Confirm new password"
           required="true"
@@ -135,7 +135,7 @@
       </div>
       <div class="space-y-4">
         <.input
-          type="text"
+          type="password"
           field={f[:current_password]}
           label="Current password"
           required="true"


### PR DESCRIPTION
### Description

This PR adds a `lv-keep-type` attribute to `<.input type="password" />`. 
This ensures that once the type has been toggled in the browser to `type text`, it stays that way until the user toggles it back.

Closes #2611

### Validation steps

You can test this on any password field that uses liveview e.g. On the user profile page, or the credentials form


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
