### PR TITLE
2701 extend diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to
 ### Changed
 
 - Bumped dependencies
+- Extend display of audit events to cater for deletions.
+  [#2701](https://github.com/OpenFn/lightning/issues/2701)
+
 
 ### Fixed
 
@@ -46,9 +49,6 @@ and this project adheres to
   [#2699](https://github.com/OpenFn/lightning/issues/2699)  
   ⚠️️ Please note that `EMAIL_ADMIN` defaults to `lightning@example.com` in
   production environments
-
-- Extend display of audit events to cater for deletions.
-  [#2701](https://github.com/OpenFn/lightning/issues/2701)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to
   ⚠️️ Please note that `EMAIL_ADMIN` defaults to `lightning@example.com` in
   production environments
 
+- Extend display of audit events to cater for deletions.
+  [#2701](https://github.com/OpenFn/lightning/issues/2701)
+
 ### Fixed
 
 - Fix cursor for small limit on collections request

--- a/lib/lightning_web/live/audit_live/index.ex
+++ b/lib/lightning_web/live/audit_live/index.ex
@@ -46,38 +46,47 @@ defmodule LightningWeb.AuditLive.Index do
     |> assign(:page, Auditing.list_all(params))
   end
 
+  def diff(%{metadata: %{before: nil, after: nil}} = assigns) do
+    no_changes(assigns)
+  end
+
+  def diff(%{metadata: %{before: lhs, after: rhs}} = assigns)
+      when map_size(lhs) == 0 and map_size(rhs) == 0 do
+    no_changes(assigns)
+  end
+
   def diff(assigns) do
-    with lhs <- assigns.metadata.before || %{},
-         rhs <- assigns.metadata.after || %{},
-         true <- lhs != %{} || rhs != %{} do
-      changes =
-        lhs
-        |> Map.keys()
-        |> Enum.concat(Map.keys(rhs))
-        |> Enum.sort()
-        |> Enum.uniq()
-        |> Enum.map(fn key ->
-          {key, Map.get(lhs, key), Map.get(rhs, key)}
-        end)
+    lhs = assigns.metadata.before || %{}
+    rhs = assigns.metadata.after || %{}
 
-      assigns = assign(assigns, changes: changes)
+    changes =
+      lhs
+      |> Map.keys()
+      |> Enum.concat(Map.keys(rhs))
+      |> Enum.sort()
+      |> Enum.uniq()
+      |> Enum.map(fn key ->
+        {key, Map.get(lhs, key), Map.get(rhs, key)}
+      end)
 
-      ~H"""
-      <.td colspan="4" class="font-mono text-xs break-all">
-        <%= for {field, old, new} <- @changes do %>
-          <li><%= field %>&nbsp; <%= old %>
-            <.icon name="hero-arrow-right" class="h-5 w-5 inline-block mr-2" />
-            <%= new %></li>
-        <% end %>
-      </.td>
-      """
-    else
-      false ->
-        ~H"""
-        <.td colspan="4" class="font-mono text-xs">
-          No changes
-        </.td>
-        """
-    end
+    assigns = assign(assigns, changes: changes)
+
+    ~H"""
+    <.td colspan="4" class="font-mono text-xs break-all">
+      <%= for {field, old, new} <- @changes do %>
+        <li><%= field %>&nbsp; <%= old %>
+          <.icon name="hero-arrow-right" class="h-5 w-5 inline-block mr-2" />
+          <%= new %></li>
+      <% end %>
+    </.td>
+    """
+  end
+
+  defp no_changes(assigns) do
+    ~H"""
+    <.td colspan="4" class="font-mono text-xs">
+      No changes
+    </.td>
+    """
   end
 end

--- a/lib/lightning_web/live/audit_live/index.ex
+++ b/lib/lightning_web/live/audit_live/index.ex
@@ -66,7 +66,7 @@ defmodule LightningWeb.AuditLive.Index do
       <.td colspan="4" class="font-mono text-xs break-all">
         <%= for {field, old, new} <- @changes do %>
           <li><%= field %>&nbsp; <%= old %>
-            <Heroicons.arrow_right class="h-5 w-5 inline-block mr-2" />
+            <.icon name="hero-arrow-right" class="h-5 w-5 inline-block mr-2" />
             <%= new %></li>
         <% end %>
       </.td>

--- a/lib/lightning_web/live/audit_live/index.ex
+++ b/lib/lightning_web/live/audit_live/index.ex
@@ -53,11 +53,21 @@ defmodule LightningWeb.AuditLive.Index do
       assigns.metadata.before ||
         Enum.into(rhs, %{}, fn {key, _val} -> {key, nil} end)
 
-    assigns =
-      assign(assigns,
-        changes:
-          Enum.zip([lhs |> Map.keys(), lhs |> Map.values(), rhs |> Map.values()])
-      )
+    changes =
+      Map.keys(lhs)
+      |> Enum.concat(Map.keys(rhs))
+      |> Enum.sort()
+      |> Enum.uniq()
+      |> Enum.map(fn key ->
+        {key, Map.get(lhs, key), Map.get(rhs, key)}
+      end)
+
+    assigns = assign(assigns, changes: changes)
+    # assigns =
+    #   assign(assigns,
+    #     changes:
+    #       Enum.zip([lhs |> Map.keys(), lhs |> Map.values(), rhs |> Map.values()])
+    #   )
 
     ~H"""
     <%= for {field, old, new} <- @changes do %>

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -44,15 +44,7 @@
           </.td>
         </.tr>
         <.tr>
-          <%= if audit.changes.after do %>
-            <.td colspan="4" class="font-mono text-xs break-all">
-              <.diff metadata={audit.changes} />
-            </.td>
-          <% else %>
-            <.td colspan="4" class="font-mono text-xs">
-              No changes
-            </.td>
-          <% end %>
+          <.diff metadata={audit.changes} />
         </.tr>
       <% end %>
     </.table>

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -346,7 +346,7 @@ defmodule LightningWeb.AuditLiveTest do
     end
 
     test "when both before and after are empty, return `No changes`" do
-      assigns = %{metadata: %{before: nil, after: nil}}
+      assigns = %{metadata: %{before: %{}, after: %{}}}
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -113,8 +113,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
-      assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+      assert html =~ ~r"<li>foo&nbsp;\s+<span.+foo_after</li>"s
+      assert html =~ ~r"<li>bar&nbsp;\s+<span.+bar_after</li>"s
     end
 
     test "correctly lists changes if before is nil (atom keys)" do
@@ -127,8 +127,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
-      assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+      assert html =~ ~r"<li>foo&nbsp;\s+<span.+foo_after</li>"s
+      assert html =~ ~r"<li>bar&nbsp;\s+<span.+bar_after</li>"s
     end
 
     test "correctly lists changes if before is empty (string keys)" do
@@ -141,8 +141,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
-      assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+      assert html =~ ~r"<li>foo&nbsp;\s+<span.+foo_after</li>"s
+      assert html =~ ~r"<li>bar&nbsp;\s+<span.+bar_after</li>"s
     end
 
     test "correctly lists changes if before is empty (atom keys)" do
@@ -155,8 +155,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
-      assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+      assert html =~ ~r"<li>foo&nbsp;\s+<span.+foo_after</li>"s
+      assert html =~ ~r"<li>bar&nbsp;\s+<span.+bar_after</li>"s
     end
 
     test "correctly lists changes if after is nil (string keys)" do
@@ -169,8 +169,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
-      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>foo.+foo_before.+?span>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?span>\s+?</li>"s
     end
 
     test "correctly lists changes if after is nil (atom keys)" do
@@ -183,8 +183,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
-      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>foo.+foo_before.+?span>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?span>\s+?</li>"s
     end
 
     test "correctly lists changes if after is empty (string keys)" do
@@ -197,8 +197,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
-      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>foo.+foo_before.+?span>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?span>\s+?</li>"s
     end
 
     test "correctly lists changes if after is empty (atom keys)" do
@@ -211,8 +211,8 @@ defmodule LightningWeb.AuditLiveTest do
 
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
-      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
-      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>foo.+foo_before.+?span>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?span>\s+?</li>"s
     end
 
     test "includes any extra keys in the before (string keys)" do
@@ -234,7 +234,7 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      assert html =~ ~r"<li>baz.+baz_before.+?</svg>\s+?</li>"s
+      assert html =~ ~r"<li>baz.+baz_before.+?</span>\s+?</li>"s
     end
 
     test "includes any extra keys in the before (atom keys)" do
@@ -256,7 +256,7 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      assert html =~ ~r"<li>baz.+baz_before.+?</svg>\s+?</li>"s
+      assert html =~ ~r"<li>baz.+baz_before.+?</span>\s+?</li>"s
     end
 
     test "includes any extra keys in the after (string keys)" do
@@ -278,7 +278,7 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      assert html =~ ~r"<li>baz&nbsp;\s+?<svg.+?</svg>\s+?baz_after</li>"s
+      assert html =~ ~r"<li>baz&nbsp;\s+?<span.+?</span>\s+?baz_after</li>"s
     end
 
     test "includes any extra keys in the after (atom keys)" do
@@ -300,7 +300,7 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      assert html =~ ~r"<li>baz&nbsp;\s+?<svg.+?</svg>\s+?baz_after</li>"s
+      assert html =~ ~r"<li>baz&nbsp;\s+?<span.+?</span>\s+?baz_after</li>"s
     end
 
     test "list changes in order (string keys)" do

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -68,10 +68,12 @@ defmodule LightningWeb.AuditLiveTest do
         metadata: %{
           before: %{
             "foo" => "foo_before",
-            "bar" =>  "bar_before"
+            "bar" => "bar_before"
           },
           after: %{
-            "foo" => "foo_after", "bar" => "bar_after"}
+            "foo" => "foo_after",
+            "bar" => "bar_after"
+          }
         }
       }
 
@@ -86,7 +88,7 @@ defmodule LightningWeb.AuditLiveTest do
         metadata: %{
           before: %{
             foo: "foo_before",
-            bar:  "bar_before"
+            bar: "bar_before"
           },
           after: %{
             foo: "foo_after",

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -101,7 +101,7 @@ defmodule LightningWeb.AuditLiveTest do
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
     end
 
-    test "correctly lists changes if no before settings (string keys)" do
+    test "correctly lists changes if before is nil (string keys)" do
       assigns = %{
         metadata: %{
           before: nil,
@@ -115,7 +115,7 @@ defmodule LightningWeb.AuditLiveTest do
       assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
     end
 
-    test "correctly lists changes if no before settings (atom keys)" do
+    test "correctly lists changes if before is nil (atom keys)" do
       assigns = %{
         metadata: %{
           before: nil,
@@ -127,6 +127,90 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
       assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+    end
+
+    test "correctly lists changes if before is empty (string keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{},
+          after: %{"foo" => "foo_after", "bar" => "bar_after"}
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
+      assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+    end
+
+    test "correctly lists changes if before is empty (atom keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{},
+          after: %{foo: "foo_after", bar: "bar_after"}
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo&nbsp;\s+<svg.+foo_after</li>"s
+      assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
+    end
+
+    test "correctly lists changes if after is nil (string keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{"foo" => "foo_before", "bar" => "bar_before"},
+          after: nil
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+    end
+
+    test "correctly lists changes if after is nil (atom keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{foo: "foo_before", bar: "bar_before"},
+          after: nil
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+    end
+
+    test "correctly lists changes if after is empty (string keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{"foo" => "foo_before", "bar" => "bar_before"},
+          after: %{}
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
+    end
+
+    test "correctly lists changes if after is empty (atom keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{foo: "foo_before", bar: "bar_before"},
+          after: %{}
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo.+foo_before.+?svg>\s+?</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+?svg>\s+?</li>"s
     end
 
     test "includes any extra keys in the before (string keys)" do
@@ -249,6 +333,22 @@ defmodule LightningWeb.AuditLiveTest do
       html = render_component(&AuditLive.Index.diff/1, assigns)
 
       assert html =~ ~r"bar&nbsp;.+baz&nbsp;.+foo&nbsp;"s
+    end
+
+    test "when both before and after are nil, return `No changes`" do
+      assigns = %{metadata: %{before: nil, after: nil}}
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ "No changes"
+    end
+
+    test "when both before and after are empty, return `No changes`" do
+      assigns = %{metadata: %{before: nil, after: nil}}
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ "No changes"
     end
   end
 end

--- a/test/lightning_web/live/audit_live_test.exs
+++ b/test/lightning_web/live/audit_live_test.exs
@@ -129,12 +129,18 @@ defmodule LightningWeb.AuditLiveTest do
       assert html =~ ~r"<li>bar&nbsp;\s+<svg.+bar_after</li>"s
     end
 
-    @tag :skip
-    test "excludes any extra keys in the before" do
+    test "includes any extra keys in the before (string keys)" do
       assigns = %{
         metadata: %{
-          before: %{"foo" => "foo_before", "bar" => "bar_before", "baz" => "baz_before"},
-          after: %{"foo" => "foo_after", "bar" => "bar_after"}
+          before: %{
+            "foo" => "foo_before",
+            "bar" => "bar_before",
+            "baz" => "baz_before"
+          },
+          after: %{
+            "foo" => "foo_after",
+            "bar" => "bar_after"
+          }
         }
       }
 
@@ -142,11 +148,32 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      refute html =~ "baz"
+      assert html =~ ~r"<li>baz.+baz_before.+?</svg>\s+?</li>"s
     end
 
-    @tag :skip
-    test "excludes any extra keys in the after" do
+    test "includes any extra keys in the before (atom keys)" do
+      assigns = %{
+        metadata: %{
+          before: %{
+            foo: "foo_before",
+            bar: "bar_before",
+            baz: "baz_before"
+          },
+          after: %{
+            foo: "foo_after",
+            bar: "bar_after"
+          }
+        }
+      }
+
+      html = render_component(&AuditLive.Index.diff/1, assigns)
+
+      assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
+      assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
+      assert html =~ ~r"<li>baz.+baz_before.+?</svg>\s+?</li>"s
+    end
+
+    test "includes any extra keys in the after (string keys)" do
       assigns = %{
         metadata: %{
           before: %{
@@ -165,16 +192,21 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      refute html =~ "baz"
+      assert html =~ ~r"<li>baz&nbsp;\s+?<svg.+?</svg>\s+?baz_after</li>"s
     end
 
-    @tag :skip
-    # Currnet behaviour, but won't be retained
-    test "excludes any extra keys in the after (atom edition)" do
+    test "includes any extra keys in the after (atom keys)" do
       assigns = %{
         metadata: %{
-          before: %{foo: "foo_before", bar: "bar_before"},
-          after: %{foo: "foo_after", bar: "bar_after", baz: "baz_after"}
+          before: %{
+            foo: "foo_before",
+            bar: "bar_before"
+          },
+          after: %{
+            foo: "foo_after",
+            bar: "bar_after",
+            baz: "baz_after"
+          }
         }
       }
 
@@ -182,10 +214,10 @@ defmodule LightningWeb.AuditLiveTest do
 
       assert html =~ ~r"<li>foo.+foo_before.+foo_after</li>"s
       assert html =~ ~r"<li>bar.+bar_before.+bar_after</li>"s
-      refute html =~ "baz"
+      assert html =~ ~r"<li>baz&nbsp;\s+?<svg.+?</svg>\s+?baz_after</li>"s
     end
 
-    test "list changes in order if the keys are strings" do
+    test "list changes in order (string keys)" do
       assigns = %{
         metadata: %{
           before: %{
@@ -206,8 +238,7 @@ defmodule LightningWeb.AuditLiveTest do
       assert html =~ ~r"bar&nbsp;.+baz&nbsp;.+foo&nbsp;"s
     end
 
-    @tag :skip
-    test "list changes in sequence if the keys are atoms" do
+    test "list changes in order (atom keys)" do
       assigns = %{
         metadata: %{
           before: %{foo: "foo_before", bar: "bar_before", baz: "baz_before"},


### PR DESCRIPTION
### Description

This extends the display of audit events to cover a use case where an audit entry has `before` changes but no after `changes`.  This is required to address the display of audit entries relating to the removal of a Github connection.

While setting up covering tests for the functional component, I discovered some inconsistent behaviour when using maps with string keys vs atom keys as well as if the before and after maps have dissimilar keys. As both of these are errors that a particular kind of idiot (i.e. me) will make, I decide to make the behaviour more predictable.

(I think the inconsistent behaviour between string keys and atom keys probably occurred as a result of changes made last year to [OTP 26](https://fly.io/phoenix-files/taking-control-of-map-sort-order-in-elixir/).

Closes #2701 

### Validation steps

The Github auditing changes are not in main yet, so the only test that is cheap to do would be to ensure that the display of audit events ('Admin Menu -> Audit') should look exactly the same as it does when running on `main`.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
