### PR TITLE
Fix use of small limit on collections request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to
 
 ### Fixed
 
+
+- Fix cursor for small limit on collections request
+  [#2683](https://github.com/OpenFn/lightning/issues/2683)
 - Disable save and run actions on deleted workflows
   [#2170](https://github.com/OpenFn/lightning/issues/2170)
 - Distinguish active and inactive sort arrows in projects overview table

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -106,7 +106,8 @@ defmodule LightningWeb.CollectionsController do
       end
     end
   end
- # Streams records from database without depending on holding a transaction from database pool.
+
+  # Streams records from database without depending on holding a transaction from database pool.
   # It streams one more than the limit to allow determining if there are more items for the response cursor.
   defp stream_all_in_chunks(collection, %{limit: limit} = filters, key_pattern)
        when limit <= @max_database_limit do

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -106,9 +106,12 @@ defmodule LightningWeb.CollectionsController do
       end
     end
   end
-
+ # Streams records from database without depending on holding a transaction from database pool.
+  # It streams one more than the limit to allow determining if there are more items for the response cursor.
   defp stream_all_in_chunks(collection, %{limit: limit} = filters, key_pattern)
        when limit <= @max_database_limit do
+    filters = Map.put(filters, :limit, limit + 1)
+
     Collections.get_all(collection, filters, key_pattern)
   end
 
@@ -117,7 +120,6 @@ defmodule LightningWeb.CollectionsController do
          %{cursor: initial_cursor} = filters,
          key_pattern
        ) do
-    # returns one more than the limit to determine if there are more items for the cursor
     filters = Map.put(filters, :limit, @max_database_limit + 1)
 
     Stream.unfold(initial_cursor, fn cursor ->

--- a/test/lightning_web/collections_controller_test.exs
+++ b/test/lightning_web/collections_controller_test.exs
@@ -710,6 +710,30 @@ defmodule LightningWeb.API.CollectionsControllerTest do
                  Base.encode64(DateTime.to_iso8601(last_item.inserted_at))
              }
 
+      # Test for the existence of a cursor when the limit is less than the
+      # database limit
+      half_limit = (@max_database_limit / 2) |> floor()
+
+      expected_items =
+        all_items |> Enum.take(half_limit)
+
+      last_item =
+        collection.items
+        |> Enum.take(half_limit)
+        |> List.last()
+
+      conn =
+        conn
+        |> get(~p"/collections/#{collection.name}",
+          limit: half_limit
+        )
+
+      assert json_response(conn, 200) == %{
+               "items" => expected_items,
+               "cursor" =>
+                 Base.encode64(DateTime.to_iso8601(last_item.inserted_at))
+             }
+
       # Request everything, shouldn't be getting a cursor
       conn =
         conn |> get(~p"/collections/#{collection.name}", limit: limit + 1)


### PR DESCRIPTION
### Description

This PR fixes the response cursor for requests with limit smaller than or equal to 500. 

Refs OpenFn/adaptors#829 

### Validation steps

GET /collections/some-col?limit=500

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
