### PR TITLE
Toggle for Enabling / Disabling Workflows, Triggers, and Edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Enable / Disable Workflows UI
+  [#2698](https://github.com/OpenFn/lightning/issues/2698)
+
 ### Changed
 
 ### Fixed

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -21,9 +21,6 @@ export {
 export const Toggle = {
   mounted() {
     const checkbox = this.el.querySelector('input[type="checkbox"]');
-    const formId = this.el.dataset.form;
-
-    console.log(formId);
 
     if (checkbox?.disabled) return;
 

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -18,19 +18,6 @@ export {
   TabbedPanels,
 };
 
-export const Toggle = {
-  mounted() {
-    const checkbox = this.el.querySelector('input[type="checkbox"]');
-
-    if (checkbox?.disabled) return;
-
-    this.el.addEventListener('click', () => {
-      checkbox.checked = !checkbox.checked;
-      checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-  },
-};
-
 export const Combobox = {
   mounted() {
     this.input = this.el.querySelector('input');

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -51,10 +51,8 @@ export const Toggle = {
       toggle.setAttribute('aria-checked', checked);
     };
 
-    // Update visual state whenever the component updates
     updateVisualState(checkbox.checked);
 
-    // Remove old event listeners if they exist
     if (this.clickListener) {
       toggle.removeEventListener('click', this.clickListener);
     }
@@ -62,7 +60,6 @@ export const Toggle = {
       checkbox.removeEventListener('change', this.changeListener);
     }
 
-    // Set up new event listeners
     if (!checkbox.disabled) {
       this.clickListener = () => {
         checkbox.checked = !checkbox.checked;
@@ -72,10 +69,12 @@ export const Toggle = {
           checkbox.dispatchEvent(new Event('change', { bubbles: true }));
         } else {
           const onClick = wrapper.dataset.onClick;
+          const valueKey = wrapper.dataset.valueKey;
           if (onClick) {
             this.pushEvent(onClick, {
               _target: checkbox.name,
               [checkbox.name]: checkbox.checked,
+              value_key: valueKey,
             });
           }
         }

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -20,73 +20,17 @@ export {
 
 export const Toggle = {
   mounted() {
-    this.setupToggle();
-  },
+    const checkbox = this.el.querySelector('input[type="checkbox"]');
+    const formId = this.el.dataset.form;
 
-  updated() {
-    this.setupToggle();
-  },
+    console.log(formId);
 
-  setupToggle() {
-    const wrapper = this.el;
-    const toggle = wrapper.querySelector('[data-toggle]');
-    const checkbox = wrapper.querySelector('input[type="checkbox"]');
-    const handle = toggle.querySelector('[data-handle]');
-    const xMark = handle.querySelector('[data-x-mark]');
-    const checkMark = handle.querySelector('[data-check-mark]');
-    const form = wrapper.closest('form');
+    if (checkbox?.disabled) return;
 
-    if (!toggle || !checkbox || !handle) return;
-
-    const updateVisualState = checked => {
-      const size = toggle.classList.contains('w-14') ? '7' : '5';
-      toggle.classList.toggle('bg-indigo-600', checked);
-      toggle.classList.toggle('bg-gray-200', !checked);
-      handle.classList.toggle(`translate-x-${size}`, checked);
-      handle.classList.toggle('translate-x-0', !checked);
-      xMark.classList.toggle('opacity-0', checked);
-      xMark.classList.toggle('opacity-100', !checked);
-      checkMark.classList.toggle('opacity-100', checked);
-      checkMark.classList.toggle('opacity-0', !checked);
-      toggle.setAttribute('aria-checked', checked);
-    };
-
-    updateVisualState(checkbox.checked);
-
-    if (this.clickListener) {
-      toggle.removeEventListener('click', this.clickListener);
-    }
-    if (this.changeListener) {
-      checkbox.removeEventListener('change', this.changeListener);
-    }
-
-    if (!checkbox.disabled) {
-      this.clickListener = () => {
-        checkbox.checked = !checkbox.checked;
-        updateVisualState(checkbox.checked);
-
-        if (form) {
-          checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-        } else {
-          const onClick = wrapper.dataset.onClick;
-          const valueKey = wrapper.dataset.valueKey;
-          if (onClick) {
-            this.pushEvent(onClick, {
-              _target: checkbox.name,
-              [checkbox.name]: checkbox.checked,
-              value_key: valueKey,
-            });
-          }
-        }
-      };
-
-      this.changeListener = () => {
-        updateVisualState(checkbox.checked);
-      };
-
-      toggle.addEventListener('click', this.clickListener);
-      checkbox.addEventListener('change', this.changeListener);
-    }
+    this.el.addEventListener('click', () => {
+      checkbox.checked = !checkbox.checked;
+      checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    });
   },
 };
 

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -18,6 +18,79 @@ export {
   TabbedPanels,
 };
 
+export const Toggle = {
+  mounted() {
+    this.setupToggle();
+  },
+
+  updated() {
+    this.setupToggle();
+  },
+
+  setupToggle() {
+    const wrapper = this.el;
+    const toggle = wrapper.querySelector('[data-toggle]');
+    const checkbox = wrapper.querySelector('input[type="checkbox"]');
+    const handle = toggle.querySelector('[data-handle]');
+    const xMark = handle.querySelector('[data-x-mark]');
+    const checkMark = handle.querySelector('[data-check-mark]');
+    const form = wrapper.closest('form');
+
+    if (!toggle || !checkbox || !handle) return;
+
+    const updateVisualState = checked => {
+      const size = toggle.classList.contains('w-14') ? '7' : '5';
+      toggle.classList.toggle('bg-indigo-600', checked);
+      toggle.classList.toggle('bg-gray-200', !checked);
+      handle.classList.toggle(`translate-x-${size}`, checked);
+      handle.classList.toggle('translate-x-0', !checked);
+      xMark.classList.toggle('opacity-0', checked);
+      xMark.classList.toggle('opacity-100', !checked);
+      checkMark.classList.toggle('opacity-100', checked);
+      checkMark.classList.toggle('opacity-0', !checked);
+      toggle.setAttribute('aria-checked', checked);
+    };
+
+    // Update visual state whenever the component updates
+    updateVisualState(checkbox.checked);
+
+    // Remove old event listeners if they exist
+    if (this.clickListener) {
+      toggle.removeEventListener('click', this.clickListener);
+    }
+    if (this.changeListener) {
+      checkbox.removeEventListener('change', this.changeListener);
+    }
+
+    // Set up new event listeners
+    if (!checkbox.disabled) {
+      this.clickListener = () => {
+        checkbox.checked = !checkbox.checked;
+        updateVisualState(checkbox.checked);
+
+        if (form) {
+          checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        } else {
+          const onClick = wrapper.dataset.onClick;
+          if (onClick) {
+            this.pushEvent(onClick, {
+              _target: checkbox.name,
+              [checkbox.name]: checkbox.checked,
+            });
+          }
+        }
+      };
+
+      this.changeListener = () => {
+        updateVisualState(checkbox.checked);
+      };
+
+      toggle.addEventListener('click', this.clickListener);
+      checkbox.addEventListener('change', this.changeListener);
+    }
+  },
+};
+
 export const Combobox = {
   mounted() {
     this.input = this.el.querySelector('input');

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -5,7 +5,6 @@ defmodule Lightning.Workflows do
 
   import Ecto.Query
 
-  alias Lightning.Workflows
   alias Ecto.Multi
 
   alias Lightning.KafkaTriggers
@@ -73,7 +72,7 @@ defmodule Lightning.Workflows do
       |> update_triggers(enabled?)
 
     workflow
-    |> Workflows.change_workflow()
+    |> change_workflow()
     |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
   end
 

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -37,7 +37,7 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
-  Gets a single workflow.
+  Gets a single workflow with optional preloads.
 
   Raises `Ecto.NoResultsError` if the Workflow does not exist.
 
@@ -49,10 +49,43 @@ defmodule Lightning.Workflows do
       iex> get_workflow!(456)
       ** (Ecto.NoResultsError)
 
-  """
-  def get_workflow!(id), do: Repo.get!(Workflow, id)
+      iex> get_workflow!(123, include: [:triggers])
+      %Workflow{triggers: [...]}
 
-  def get_workflow(id), do: Repo.get(Workflow, id)
+  """
+  def get_workflow!(id, opts \\ []) do
+    include = Keyword.get(opts, :include, [])
+
+    Workflow
+    |> Repo.get!(id)
+    |> Repo.preload(include)
+  end
+
+  @doc """
+  Gets a single workflow with optional preloads, returns `nil` if not found.
+
+  ## Examples
+
+      iex> get_workflow(123)
+      %Workflow{}
+
+      iex> get_workflow(456)
+      nil
+
+      iex> get_workflow(123, include: [:triggers])
+      %Workflow{triggers: [...]}
+
+  """
+  def get_workflow(id, opts \\ []) do
+    include = Keyword.get(opts, :include, [])
+
+    Workflow
+    |> Repo.get(id)
+    |> case do
+      nil -> nil
+      workflow -> Repo.preload(workflow, include)
+    end
+  end
 
   @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map(), struct()) ::
           {:ok, Workflow.t()}

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -24,63 +24,6 @@ defmodule Lightning.Workflows do
   require Logger
 
   @doc """
-  Updates the `enabled` state of triggers associated with a given workflow as a struct or as a changeset.
-
-  ## **Parameters**
-  - **`workflow_or_changeset`**:
-  - An `%Ecto.Changeset{}` containing a `:triggers` association.
-  - A `%Workflow{}` struct with a `triggers` field.
-  - **`enabled?`**:
-  - A boolean indicating whether to enable (`true`) or disable (`false`) the triggers.
-
-  ## **Returns**
-  - An updated `%Ecto.Changeset{}` with the `:triggers` association modified.
-  - An updated `%Ecto.Changeset{}` derived from the given `%Workflow{}`.
-
-  ## **Examples**
-
-  ### **Using an `Ecto.Changeset`**
-  ```elixir
-  changeset = Ecto.Changeset.change(%Workflow{}, %{triggers: [%Trigger{enabled: false}]})
-  updated_changeset = update_triggers_enabled_state(changeset, true)
-  # The triggers in the changeset will now have `enabled: true`.
-  ```
-
-  ### **Using a `Workflow` struct**
-  ```elixir
-  workflow = %Workflow{triggers: [%Trigger{enabled: false}]}
-  updated_changeset = update_triggers_enabled_state(workflow, true)
-  # The returned changeset will have triggers with `enabled: true`.
-  ```
-  """
-  def update_triggers_enabled_state(
-        %Ecto.Changeset{data: %Workflow{}} = changeset,
-        enabled?
-      ) do
-    updated_triggers =
-      changeset
-      |> Ecto.Changeset.get_field(:triggers, [])
-      |> update_triggers(enabled?)
-
-    changeset
-    |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
-  end
-
-  def update_triggers_enabled_state(%Workflow{} = workflow, enabled?) do
-    updated_triggers =
-      workflow.triggers
-      |> update_triggers(enabled?)
-
-    workflow
-    |> change_workflow()
-    |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
-  end
-
-  defp update_triggers(triggers, enabled?) do
-    Enum.map(triggers, &Ecto.Changeset.change(&1, %{enabled: enabled?}))
-  end
-
-  @doc """
   Returns the list of workflows.
 
   ## Examples
@@ -537,5 +480,62 @@ defmodule Lightning.Workflows do
   def has_newer_version?(%Workflow{lock_version: version, id: id}) do
     from(w in Workflow, where: w.lock_version > ^version and w.id == ^id)
     |> Repo.exists?()
+  end
+
+  @doc """
+  Updates the `enabled` state of triggers associated with a given workflow as a struct or as a changeset.
+
+  ## **Parameters**
+  - **`workflow_or_changeset`**:
+  - An `%Ecto.Changeset{}` containing a `:triggers` association.
+  - A `%Workflow{}` struct with a `triggers` field.
+  - **`enabled?`**:
+  - A boolean indicating whether to enable (`true`) or disable (`false`) the triggers.
+
+  ## **Returns**
+  - An updated `%Ecto.Changeset{}` with the `:triggers` association modified.
+  - An updated `%Ecto.Changeset{}` derived from the given `%Workflow{}`.
+
+  ## **Examples**
+
+  ### **Using an `Ecto.Changeset`**
+  ```elixir
+  changeset = Ecto.Changeset.change(%Workflow{}, %{triggers: [%Trigger{enabled: false}]})
+  updated_changeset = update_triggers_enabled_state(changeset, true)
+  # The triggers in the changeset will now have `enabled: true`.
+  ```
+
+  ### **Using a `Workflow` struct**
+  ```elixir
+  workflow = %Workflow{triggers: [%Trigger{enabled: false}]}
+  updated_changeset = update_triggers_enabled_state(workflow, true)
+  # The returned changeset will have triggers with `enabled: true`.
+  ```
+  """
+  def update_triggers_enabled_state(
+        %Ecto.Changeset{data: %Workflow{}} = changeset,
+        enabled?
+      ) do
+    updated_triggers =
+      changeset
+      |> Ecto.Changeset.get_field(:triggers, [])
+      |> update_triggers(enabled?)
+
+    changeset
+    |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
+  end
+
+  def update_triggers_enabled_state(%Workflow{} = workflow, enabled?) do
+    updated_triggers =
+      workflow.triggers
+      |> update_triggers(enabled?)
+
+    workflow
+    |> change_workflow()
+    |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
+  end
+
+  defp update_triggers(triggers, enabled?) do
+    Enum.map(triggers, &Ecto.Changeset.change(&1, %{enabled: enabled?}))
   end
 end

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -54,11 +54,7 @@ defmodule Lightning.Workflows do
 
   """
   def get_workflow!(id, opts \\ []) do
-    include = Keyword.get(opts, :include, [])
-
-    Workflow
-    |> Repo.get!(id)
-    |> Repo.preload(include)
+    get_workflow_query(id, opts) |> Repo.one!()
   end
 
   @doc """
@@ -77,14 +73,15 @@ defmodule Lightning.Workflows do
 
   """
   def get_workflow(id, opts \\ []) do
+    get_workflow_query(id, opts) |> Repo.one()
+  end
+
+  defp get_workflow_query(id, opts) do
     include = Keyword.get(opts, :include, [])
 
     Workflow
-    |> Repo.get(id)
-    |> case do
-      nil -> nil
-      workflow -> Repo.preload(workflow, include)
-    end
+    |> where(id: ^id)
+    |> preload(^include)
   end
 
   @spec save_workflow(Ecto.Changeset.t(Workflow.t()) | map(), struct()) ::

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -29,7 +29,7 @@ defmodule Lightning.Workflows.Trigger do
     field :comment, :string
     field :custom_path, :string
     field :cron_expression, :string
-    field :enabled, :boolean, default: false
+    field :enabled, :boolean, default: true
     belongs_to :workflow, Workflow
 
     has_many :edges, Lightning.Workflows.Edge, foreign_key: :source_trigger_id

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -29,7 +29,7 @@ defmodule Lightning.Workflows.Trigger do
     field :comment, :string
     field :custom_path, :string
     field :cron_expression, :string
-    field :enabled, :boolean, default: true
+    field :enabled, :boolean, default: false
     belongs_to :workflow, Workflow
 
     has_many :edges, Lightning.Workflows.Edge, foreign_key: :source_trigger_id

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -382,16 +382,21 @@ defmodule LightningWeb.Components.NewInputs do
 
     ~H"""
     <div
-      id={"toggle-wrapper-#{@id}"}
+      id={"toggle-container-#{@id}"}
       class={["flex flex-col gap-1", @class]}
       {if @tooltip, do: ["phx-hook": "Tooltip", "aria-label": @tooltip], else: []}
     >
       <div
         phx-hook="Toggle"
-        id={"toggle-#{@id}"}
+        id={"toggle-control-#{@id}"}
         class="flex items-center gap-3"
-        data-on-click={@on_click}
-        data-value-key={@value_key}
+        {if @on_click, do: ["phx-click": JS.push(@on_click,
+          value: %{
+            _target: @name,
+            "#{@name}": !@checked,
+            value_key: to_string(@value_key)
+          }
+        )], else: []}
       >
         <div class="relative inline-flex items-center">
           <%= if @checked do %>
@@ -428,58 +433,53 @@ defmodule LightningWeb.Components.NewInputs do
             tabindex={if @disabled, do: "-1", else: "0"}
             role="switch"
             aria-checked={@checked}
-            class={
-              [
-                "relative inline-flex rounded-full transition-colors duration-200 ease-in-out border-2 border-transparent",
-                "focus:outline-none focus:ring-2 focus:ring-offset-2",
-                @toggle_size_classes,
-                # Fixed initial state classes
-                (@checked && @active_color_classes) || "bg-gray-200",
-                if(@disabled,
-                  do: "opacity-50 cursor-not-allowed",
-                  else: "cursor-pointer"
-                )
-              ]
-            }
-            data-tooltip={@tooltip}
+            class={[
+              "relative inline-flex rounded-full transition-colors duration-200 ease-in-out border-2 border-transparent",
+              "focus:outline-none focus:ring-2 focus:ring-offset-2",
+              @toggle_size_classes,
+              @checked && "bg-indigo-600",
+              !@checked && "bg-gray-200",
+              if(@disabled,
+                do: "opacity-50 cursor-not-allowed",
+                else: "cursor-pointer"
+              )
+            ]}
           >
             <span
               data-handle
-              class={
-                [
-                  "pointer-events-none absolute inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
-                  @handle_size_classes,
-                  # Fixed initial transform state
-                  (@checked &&
-                     if(@size == "lg", do: "translate-x-7", else: "translate-x-5")) ||
-                    "translate-x-0"
-                ]
-              }
+              class={[
+                "pointer-events-none absolute inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                @handle_size_classes,
+                @checked && ((@size == "lg" && "translate-x-7") || "translate-x-5"),
+                !@checked && "translate-x-0"
+              ]}
             >
               <span
                 data-x-mark
                 class={[
                   "absolute inset-0 flex h-full w-full items-center justify-center transition-opacity duration-200 ease-in",
-                  (@checked && "opacity-0") || "opacity-100"
+                  @checked && "opacity-0",
+                  !@checked && "opacity-100"
                 ]}
                 aria-hidden="true"
               >
                 <.icon
                   name="hero-x-mark-micro"
-                  class={"#{@icon_size_classes} text-gray-400"}
+                  class={@icon_size_classes <> " text-gray-400"}
                 />
               </span>
               <span
                 data-check-mark
                 class={[
                   "absolute inset-0 flex h-full w-full items-center justify-center transition-opacity duration-200 ease-in",
-                  (@checked && "opacity-100") || "opacity-0"
+                  @checked && "opacity-100",
+                  !@checked && "opacity-0"
                 ]}
                 aria-hidden="true"
               >
                 <.icon
                   name="hero-check-micro"
-                  class={"#{@icon_size_classes} text-indigo-600"}
+                  class={@icon_size_classes <> " text-indigo-600"}
                 />
               </span>
             </span>
@@ -502,7 +502,7 @@ defmodule LightningWeb.Components.NewInputs do
       <div
         :if={@help_text}
         class="text-sm text-gray-500 ml-14"
-        id={"#{@id}-description"}
+        id={"toggle-description-#{@id}"}
       >
         <%= @help_text %>
       </div>

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -368,7 +368,6 @@ defmodule LightningWeb.Components.NewInputs do
       |> assign_new(:checked, fn -> get_checkbox_value(assigns) end)
       |> assign_new(:disabled, fn -> false end)
       |> assign_new(:required, fn -> false end)
-      |> assign_new(:help_text, fn -> nil end)
       |> assign_new(:tooltip, fn -> nil end)
       |> assign_new(:size, fn -> "md" end)
       |> assign_new(:color, fn -> "primary" end)
@@ -410,7 +409,6 @@ defmodule LightningWeb.Components.NewInputs do
               class="sr-only peer"
               disabled={@disabled}
               required={@required}
-              aria-describedby={if @help_text, do: "#{@id}-description"}
               {@rest}
             />
           <% else %>
@@ -423,7 +421,6 @@ defmodule LightningWeb.Components.NewInputs do
               class="sr-only peer"
               disabled={@disabled}
               required={@required}
-              aria-describedby={if @help_text, do: "#{@id}-description"}
               {@rest}
             />
           <% end %>
@@ -497,18 +494,6 @@ defmodule LightningWeb.Components.NewInputs do
           <%= @label %>
           <span :if={@required} class="text-red-500 ml-1">*</span>
         </label>
-      </div>
-
-      <div
-        :if={@help_text}
-        class="text-sm text-gray-500 ml-14"
-        id={"toggle-description-#{@id}"}
-      >
-        <%= @help_text %>
-      </div>
-
-      <div :if={@errors != [] and @display_errors} class="mt-1 ml-14">
-        <.error :for={msg <- @errors}><%= msg %></.error>
       </div>
     </div>
     """
@@ -738,46 +723,31 @@ defmodule LightningWeb.Components.NewInputs do
     """
   end
 
-  defp get_checkbox_value(%{field: %FormField{} = field}) do
-    Form.normalize_value("checkbox", field.value) == true
-  end
-
   defp get_checkbox_value(%{value: value}) do
     Form.normalize_value("checkbox", value) == true
   end
 
-  defp get_checkbox_value(_), do: false
-
   defp get_toggle_size_classes(assigns) do
     case assigns.size do
-      "sm" -> "w-8 h-4"
       "md" -> "w-11 h-6"
-      "lg" -> "w-14 h-7"
     end
   end
 
   defp get_handle_size_classes(assigns) do
     case assigns.size do
-      "sm" -> "h-3 w-3"
       "md" -> "h-5 w-5"
-      "lg" -> "h-6 w-6"
     end
   end
 
   defp get_icon_size_classes(assigns) do
     case assigns.size do
-      "sm" -> "h-2 w-2"
       "md" -> "h-4 w-4"
-      "lg" -> "h-5 w-5"
     end
   end
 
   defp get_active_color_classes(assigns) do
     case assigns.color do
       "primary" -> "bg-indigo-600 focus:ring-indigo-500"
-      "success" -> "bg-green-600 focus:ring-green-500"
-      "warning" -> "bg-yellow-600 focus:ring-yellow-500"
-      "danger" -> "bg-red-600 focus:ring-red-500"
     end
   end
 end

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -180,6 +180,8 @@ defmodule LightningWeb.Components.NewInputs do
 
   attr :on_click, :string, default: nil
 
+  attr :value_key, :any, default: nil
+
   slot :inner_block
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -427,6 +429,7 @@ defmodule LightningWeb.Components.NewInputs do
         id={"toggle-#{@id}"}
         class="flex items-center gap-3"
         data-on-click={@on_click}
+        data-value-key={@value_key}
       >
         <div class="relative inline-flex items-center">
           <%= if @checked do %>

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -465,7 +465,7 @@ defmodule LightningWeb.Components.NewInputs do
                 aria-hidden="true"
               >
                 <.icon
-                  name="hero-x-mark"
+                  name="hero-x-mark-micro"
                   class={"#{@icon_size_classes} text-gray-400"}
                 />
               </span>
@@ -478,7 +478,7 @@ defmodule LightningWeb.Components.NewInputs do
                 aria-hidden="true"
               >
                 <.icon
-                  name="hero-check"
+                  name="hero-check-micro"
                   class={"#{@icon_size_classes} text-indigo-600"}
                 />
               </span>

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -129,7 +129,7 @@ defmodule LightningWeb.Components.NewInputs do
     default: "text",
     values:
       ~w(checkbox color date datetime-local email file hidden month number password
-               range radio search select tel text textarea time url week)
+               range radio search select tel text textarea time url week toggle)
 
   attr :field, Phoenix.HTML.FormField,
     doc:
@@ -177,6 +177,8 @@ defmodule LightningWeb.Components.NewInputs do
   attr :display_errors, :boolean, default: true
 
   attr :tooltip, :any, default: nil
+
+  attr :on_click, :string, default: nil
 
   slot :inner_block
 
@@ -353,6 +355,193 @@ defmodule LightningWeb.Components.NewInputs do
       ]}
       {@rest}
     />
+    """
+  end
+
+  def input(%{type: "toggle"} = assigns) do
+    assigns =
+      assigns
+      |> assign_new(:checked, fn ->
+        case assigns do
+          %{field: %Phoenix.HTML.FormField{} = field} ->
+            Phoenix.HTML.Form.normalize_value("checkbox", field.value) == true
+
+          %{value: value} ->
+            Phoenix.HTML.Form.normalize_value("checkbox", value) == true
+
+          _ ->
+            false
+        end
+      end)
+      |> assign_new(:disabled, fn -> false end)
+      |> assign_new(:required, fn -> false end)
+      |> assign_new(:help_text, fn -> nil end)
+      |> assign_new(:tooltip, fn -> nil end)
+      |> assign_new(:size, fn -> "md" end)
+      |> assign_new(:color, fn -> "primary" end)
+
+    toggle_size_classes =
+      case assigns.size do
+        "sm" -> "w-8 h-4"
+        "md" -> "w-11 h-6"
+        "lg" -> "w-14 h-7"
+      end
+
+    handle_size_classes =
+      case assigns.size do
+        "sm" -> "h-3 w-3"
+        "md" -> "h-5 w-5"
+        "lg" -> "h-6 w-6"
+      end
+
+    icon_size_classes =
+      case assigns.size do
+        "sm" -> "h-2 w-2"
+        "md" -> "h-4 w-4"
+        "lg" -> "h-5 w-5"
+      end
+
+    active_color_classes =
+      case assigns.color do
+        "primary" -> "bg-indigo-600 focus:ring-indigo-500"
+        "success" -> "bg-green-600 focus:ring-green-500"
+        "warning" -> "bg-yellow-600 focus:ring-yellow-500"
+        "danger" -> "bg-red-600 focus:ring-red-500"
+      end
+
+    assigns =
+      assigns
+      |> assign(:toggle_size_classes, toggle_size_classes)
+      |> assign(:handle_size_classes, handle_size_classes)
+      |> assign(:icon_size_classes, icon_size_classes)
+      |> assign(:active_color_classes, active_color_classes)
+
+    ~H"""
+    <div class={["flex flex-col gap-1", @class]}>
+      <div
+        phx-hook="Toggle"
+        id={"toggle-#{@id}"}
+        class="flex items-center gap-3"
+        data-on-click={@on_click}
+      >
+        <div class="relative inline-flex items-center">
+          <%= if @checked do %>
+            <input type="hidden" name={@name} value="false" />
+            <input
+              type="checkbox"
+              id={@id}
+              name={@name}
+              value="true"
+              checked="checked"
+              class="sr-only peer"
+              disabled={@disabled}
+              required={@required}
+              aria-describedby={if @help_text, do: "#{@id}-description"}
+              {@rest}
+            />
+          <% else %>
+            <input type="hidden" name={@name} value="false" />
+            <input
+              type="checkbox"
+              id={@id}
+              name={@name}
+              value="true"
+              class="sr-only peer"
+              disabled={@disabled}
+              required={@required}
+              aria-describedby={if @help_text, do: "#{@id}-description"}
+              {@rest}
+            />
+          <% end %>
+
+          <div
+            data-toggle
+            tabindex={if @disabled, do: "-1", else: "0"}
+            role="switch"
+            aria-checked={@checked}
+            class={
+              [
+                "relative inline-flex rounded-full transition-colors duration-200 ease-in-out border-2 border-transparent",
+                "focus:outline-none focus:ring-2 focus:ring-offset-2",
+                @toggle_size_classes,
+                # Fixed initial state classes
+                (@checked && @active_color_classes) || "bg-gray-200",
+                if(@disabled,
+                  do: "opacity-50 cursor-not-allowed",
+                  else: "cursor-pointer"
+                )
+              ]
+            }
+            data-tooltip={@tooltip}
+          >
+            <span
+              data-handle
+              class={
+                [
+                  "pointer-events-none absolute inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                  @handle_size_classes,
+                  # Fixed initial transform state
+                  (@checked &&
+                     if(@size == "lg", do: "translate-x-7", else: "translate-x-5")) ||
+                    "translate-x-0"
+                ]
+              }
+            >
+              <span
+                data-x-mark
+                class={[
+                  "absolute inset-0 flex h-full w-full items-center justify-center transition-opacity duration-200 ease-in",
+                  (@checked && "opacity-0") || "opacity-100"
+                ]}
+                aria-hidden="true"
+              >
+                <.icon
+                  name="hero-x-mark"
+                  class={"#{@icon_size_classes} text-gray-400"}
+                />
+              </span>
+              <span
+                data-check-mark
+                class={[
+                  "absolute inset-0 flex h-full w-full items-center justify-center transition-opacity duration-200 ease-in",
+                  (@checked && "opacity-100") || "opacity-0"
+                ]}
+                aria-hidden="true"
+              >
+                <.icon
+                  name="hero-check"
+                  class={"#{@icon_size_classes} text-indigo-600"}
+                />
+              </span>
+            </span>
+          </div>
+        </div>
+
+        <label
+          :if={@label}
+          for={@id}
+          class={[
+            "text-sm font-medium select-none",
+            if(@disabled, do: "text-gray-400", else: "text-gray-900")
+          ]}
+        >
+          <%= @label %>
+          <span :if={@required} class="text-red-500 ml-1">*</span>
+        </label>
+      </div>
+
+      <div
+        :if={@help_text}
+        class="text-sm text-gray-500 ml-14"
+        id={"#{@id}-description"}
+      >
+        <%= @help_text %>
+      </div>
+
+      <div :if={@errors != [] and @display_errors} class="mt-1 ml-14">
+        <.error :for={msg <- @errors}><%= msg %></.error>
+      </div>
+    </div>
     """
   end
 

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -363,18 +363,7 @@ defmodule LightningWeb.Components.NewInputs do
   def input(%{type: "toggle"} = assigns) do
     assigns =
       assigns
-      |> assign_new(:checked, fn ->
-        case assigns do
-          %{field: %Phoenix.HTML.FormField{} = field} ->
-            Phoenix.HTML.Form.normalize_value("checkbox", field.value) == true
-
-          %{value: value} ->
-            Phoenix.HTML.Form.normalize_value("checkbox", value) == true
-
-          _ ->
-            false
-        end
-      end)
+      |> assign_new(:checked, fn -> get_checkbox_value(assigns) end)
       |> assign_new(:disabled, fn -> false end)
       |> assign_new(:required, fn -> false end)
       |> assign_new(:help_text, fn -> nil end)
@@ -382,41 +371,12 @@ defmodule LightningWeb.Components.NewInputs do
       |> assign_new(:size, fn -> "md" end)
       |> assign_new(:color, fn -> "primary" end)
 
-    toggle_size_classes =
-      case assigns.size do
-        "sm" -> "w-8 h-4"
-        "md" -> "w-11 h-6"
-        "lg" -> "w-14 h-7"
-      end
-
-    handle_size_classes =
-      case assigns.size do
-        "sm" -> "h-3 w-3"
-        "md" -> "h-5 w-5"
-        "lg" -> "h-6 w-6"
-      end
-
-    icon_size_classes =
-      case assigns.size do
-        "sm" -> "h-2 w-2"
-        "md" -> "h-4 w-4"
-        "lg" -> "h-5 w-5"
-      end
-
-    active_color_classes =
-      case assigns.color do
-        "primary" -> "bg-indigo-600 focus:ring-indigo-500"
-        "success" -> "bg-green-600 focus:ring-green-500"
-        "warning" -> "bg-yellow-600 focus:ring-yellow-500"
-        "danger" -> "bg-red-600 focus:ring-red-500"
-      end
-
     assigns =
       assigns
-      |> assign(:toggle_size_classes, toggle_size_classes)
-      |> assign(:handle_size_classes, handle_size_classes)
-      |> assign(:icon_size_classes, icon_size_classes)
-      |> assign(:active_color_classes, active_color_classes)
+      |> assign(:toggle_size_classes, get_toggle_size_classes(assigns))
+      |> assign(:handle_size_classes, get_handle_size_classes(assigns))
+      |> assign(:icon_size_classes, get_icon_size_classes(assigns))
+      |> assign(:active_color_classes, get_active_color_classes(assigns))
 
     ~H"""
     <div
@@ -774,5 +734,48 @@ defmodule LightningWeb.Components.NewInputs do
       <%= render_slot(@inner_block) %>
     </p>
     """
+  end
+
+  defp get_checkbox_value(%{field: %Phoenix.HTML.FormField{} = field}) do
+    Phoenix.HTML.Form.normalize_value("checkbox", field.value) == true
+  end
+
+  defp get_checkbox_value(%{value: value}) do
+    Phoenix.HTML.Form.normalize_value("checkbox", value) == true
+  end
+
+  defp get_checkbox_value(_), do: false
+
+  defp get_toggle_size_classes(assigns) do
+    case assigns.size do
+      "sm" -> "w-8 h-4"
+      "md" -> "w-11 h-6"
+      "lg" -> "w-14 h-7"
+    end
+  end
+
+  defp get_handle_size_classes(assigns) do
+    case assigns.size do
+      "sm" -> "h-3 w-3"
+      "md" -> "h-5 w-5"
+      "lg" -> "h-6 w-6"
+    end
+  end
+
+  defp get_icon_size_classes(assigns) do
+    case assigns.size do
+      "sm" -> "h-2 w-2"
+      "md" -> "h-4 w-4"
+      "lg" -> "h-5 w-5"
+    end
+  end
+
+  defp get_active_color_classes(assigns) do
+    case assigns.color do
+      "primary" -> "bg-indigo-600 focus:ring-indigo-500"
+      "success" -> "bg-green-600 focus:ring-green-500"
+      "warning" -> "bg-yellow-600 focus:ring-yellow-500"
+      "danger" -> "bg-red-600 focus:ring-red-500"
+    end
   end
 end

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -7,6 +7,8 @@ defmodule LightningWeb.Components.NewInputs do
 
   import LightningWeb.Components.Icons
 
+  alias Phoenix.HTML.Form
+  alias Phoenix.HTML.FormField
   alias Phoenix.LiveView.JS
 
   @doc """
@@ -278,7 +280,7 @@ defmodule LightningWeb.Components.NewInputs do
           @class
         ]}
         {@rest}
-      ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
+      ><%= Form.normalize_value("textarea", @value) %></textarea>
       <.error :for={msg <- @errors} :if={@display_errors}><%= msg %></.error>
     </div>
     """
@@ -298,7 +300,7 @@ defmodule LightningWeb.Components.NewInputs do
           type={@type}
           name={@name}
           id={@id}
-          value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+          value={Form.normalize_value(@type, @value)}
           lv-keep-type
           class={[
             "focus:outline focus:outline-2 focus:outline-offset-1 block w-full rounded-lg text-slate-900 focus:ring-0 sm:text-sm sm:leading-6",
@@ -518,7 +520,7 @@ defmodule LightningWeb.Components.NewInputs do
       type="hidden"
       name={@name}
       id={@id}
-      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+      value={Form.normalize_value(@type, @value)}
     />
     """
   end
@@ -536,7 +538,7 @@ defmodule LightningWeb.Components.NewInputs do
         name={@name}
         id={@id}
         class={@class}
-        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        value={Form.normalize_value(@type, @value)}
         {@rest}
       />
       <div :if={Enum.any?(@errors) and @display_errors} class="error-space">
@@ -736,12 +738,12 @@ defmodule LightningWeb.Components.NewInputs do
     """
   end
 
-  defp get_checkbox_value(%{field: %Phoenix.HTML.FormField{} = field}) do
-    Phoenix.HTML.Form.normalize_value("checkbox", field.value) == true
+  defp get_checkbox_value(%{field: %FormField{} = field}) do
+    Form.normalize_value("checkbox", field.value) == true
   end
 
   defp get_checkbox_value(%{value: value}) do
-    Phoenix.HTML.Form.normalize_value("checkbox", value) == true
+    Form.normalize_value("checkbox", value) == true
   end
 
   defp get_checkbox_value(_), do: false

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -364,7 +364,9 @@ defmodule LightningWeb.Components.NewInputs do
   def input(%{type: "toggle"} = assigns) do
     assigns =
       assigns
-      |> assign_new(:checked, fn -> get_checkbox_value(assigns) end)
+      |> assign_new(:checked, fn ->
+        Form.normalize_value("checkbox", assigns[:value]) == true
+      end)
       |> assign_new(:disabled, fn -> false end)
       |> assign_new(:required, fn -> false end)
       |> assign_new(:tooltip, fn -> nil end)
@@ -681,9 +683,5 @@ defmodule LightningWeb.Components.NewInputs do
       <%= render_slot(@inner_block) %>
     </p>
     """
-  end
-
-  defp get_checkbox_value(%{value: value}) do
-    Form.normalize_value("checkbox", value) == true
   end
 end

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -368,15 +368,6 @@ defmodule LightningWeb.Components.NewInputs do
       |> assign_new(:disabled, fn -> false end)
       |> assign_new(:required, fn -> false end)
       |> assign_new(:tooltip, fn -> nil end)
-      |> assign_new(:size, fn -> "md" end)
-      |> assign_new(:color, fn -> "primary" end)
-
-    assigns =
-      assigns
-      |> assign(:toggle_size_classes, get_toggle_size_classes(assigns))
-      |> assign(:handle_size_classes, get_handle_size_classes(assigns))
-      |> assign(:icon_size_classes, get_icon_size_classes(assigns))
-      |> assign(:active_color_classes, get_active_color_classes(assigns))
 
     ~H"""
     <div
@@ -397,32 +388,18 @@ defmodule LightningWeb.Components.NewInputs do
         )], else: []}
       >
         <div class="relative inline-flex items-center">
-          <%= if @checked do %>
-            <input type="hidden" name={@name} value="false" />
-            <input
-              type="checkbox"
-              id={@id}
-              name={@name}
-              value="true"
-              checked="checked"
-              class="sr-only peer"
-              disabled={@disabled}
-              required={@required}
-              {@rest}
-            />
-          <% else %>
-            <input type="hidden" name={@name} value="false" />
-            <input
-              type="checkbox"
-              id={@id}
-              name={@name}
-              value="true"
-              class="sr-only peer"
-              disabled={@disabled}
-              required={@required}
-              {@rest}
-            />
-          <% end %>
+          <input type="hidden" name={@name} value="false" />
+          <input
+            type="checkbox"
+            id={@id}
+            name={@name}
+            value="true"
+            class="sr-only peer"
+            checked={@checked}
+            disabled={@disabled}
+            required={@required}
+            {@rest}
+          />
 
           <div
             data-toggle
@@ -430,9 +407,8 @@ defmodule LightningWeb.Components.NewInputs do
             role="switch"
             aria-checked={@checked}
             class={[
-              "relative inline-flex rounded-full transition-colors duration-200 ease-in-out border-2 border-transparent",
-              "focus:outline-none focus:ring-2 focus:ring-offset-2",
-              @toggle_size_classes,
+              "relative inline-flex w-11 h-6 rounded-full transition-colors duration-200 ease-in-out border-2 border-transparent",
+              "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500",
               @checked && "bg-indigo-600",
               !@checked && "bg-gray-200",
               if(@disabled,
@@ -444,9 +420,8 @@ defmodule LightningWeb.Components.NewInputs do
             <span
               data-handle
               class={[
-                "pointer-events-none absolute inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
-                @handle_size_classes,
-                @checked && ((@size == "lg" && "translate-x-7") || "translate-x-5"),
+                "pointer-events-none absolute h-5 w-5 inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                @checked && "translate-x-5",
                 !@checked && "translate-x-0"
               ]}
             >
@@ -459,10 +434,7 @@ defmodule LightningWeb.Components.NewInputs do
                 ]}
                 aria-hidden="true"
               >
-                <.icon
-                  name="hero-x-mark-micro"
-                  class={@icon_size_classes <> " text-gray-400"}
-                />
+                <.icon name="hero-x-mark-micro" class="h-4 w-4 text-gray-400" />
               </span>
               <span
                 data-check-mark
@@ -473,10 +445,7 @@ defmodule LightningWeb.Components.NewInputs do
                 ]}
                 aria-hidden="true"
               >
-                <.icon
-                  name="hero-check-micro"
-                  class={@icon_size_classes <> " text-indigo-600"}
-                />
+                <.icon name="hero-check-micro" class="h-4 w-4 text-indigo-600" />
               </span>
             </span>
           </div>
@@ -724,29 +693,5 @@ defmodule LightningWeb.Components.NewInputs do
 
   defp get_checkbox_value(%{value: value}) do
     Form.normalize_value("checkbox", value) == true
-  end
-
-  defp get_toggle_size_classes(assigns) do
-    case assigns.size do
-      "md" -> "w-11 h-6"
-    end
-  end
-
-  defp get_handle_size_classes(assigns) do
-    case assigns.size do
-      "md" -> "h-5 w-5"
-    end
-  end
-
-  defp get_icon_size_classes(assigns) do
-    case assigns.size do
-      "md" -> "h-4 w-4"
-    end
-  end
-
-  defp get_active_color_classes(assigns) do
-    case assigns.color do
-      "primary" -> "bg-indigo-600 focus:ring-indigo-500"
-    end
   end
 end

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -8,7 +8,6 @@ defmodule LightningWeb.Components.NewInputs do
   import LightningWeb.Components.Icons
 
   alias Phoenix.HTML.Form
-  alias Phoenix.HTML.FormField
   alias Phoenix.LiveView.JS
 
   @doc """

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -376,7 +376,6 @@ defmodule LightningWeb.Components.NewInputs do
       {if @tooltip, do: ["phx-hook": "Tooltip", "aria-label": @tooltip], else: []}
     >
       <div
-        phx-hook="Toggle"
         id={"toggle-control-#{@id}"}
         class="flex items-center gap-3"
         {if @on_click, do: ["phx-click": JS.push(@on_click,
@@ -387,7 +386,7 @@ defmodule LightningWeb.Components.NewInputs do
           }
         )], else: []}
       >
-        <div class="relative inline-flex items-center">
+        <label class="relative inline-flex items-center cursor-pointer">
           <input type="hidden" name={@name} value="false" />
           <input
             type="checkbox"
@@ -402,7 +401,6 @@ defmodule LightningWeb.Components.NewInputs do
           />
 
           <div
-            data-toggle
             tabindex={if @disabled, do: "-1", else: "0"}
             role="switch"
             aria-checked={@checked}
@@ -417,16 +415,12 @@ defmodule LightningWeb.Components.NewInputs do
               )
             ]}
           >
-            <span
-              data-handle
-              class={[
-                "pointer-events-none absolute h-5 w-5 inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
-                @checked && "translate-x-5",
-                !@checked && "translate-x-0"
-              ]}
-            >
+            <span class={[
+              "pointer-events-none absolute h-5 w-5 inline-block transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+              @checked && "translate-x-5",
+              !@checked && "translate-x-0"
+            ]}>
               <span
-                data-x-mark
                 class={[
                   "absolute inset-0 flex h-full w-full items-center justify-center transition-opacity duration-200 ease-in",
                   @checked && "opacity-0",
@@ -437,7 +431,6 @@ defmodule LightningWeb.Components.NewInputs do
                 <.icon name="hero-x-mark-micro" class="h-4 w-4 text-gray-400" />
               </span>
               <span
-                data-check-mark
                 class={[
                   "absolute inset-0 flex h-full w-full items-center justify-center transition-opacity duration-200 ease-in",
                   @checked && "opacity-100",
@@ -449,18 +442,17 @@ defmodule LightningWeb.Components.NewInputs do
               </span>
             </span>
           </div>
-        </div>
 
-        <label
-          :if={@label}
-          for={@id}
-          class={[
-            "text-sm font-medium select-none",
-            if(@disabled, do: "text-gray-400", else: "text-gray-900")
-          ]}
-        >
-          <%= @label %>
-          <span :if={@required} class="text-red-500 ml-1">*</span>
+          <span
+            :if={@label}
+            class={[
+              "ml-3 text-sm font-medium select-none",
+              if(@disabled, do: "text-gray-400", else: "text-gray-900")
+            ]}
+          >
+            <%= @label %>
+            <span :if={@required} class="text-red-500 ml-1">*</span>
+          </span>
         </label>
       </div>
     </div>

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -417,7 +417,11 @@ defmodule LightningWeb.Components.NewInputs do
       |> assign(:active_color_classes, active_color_classes)
 
     ~H"""
-    <div class={["flex flex-col gap-1", @class]}>
+    <div
+      id={"toggle-wrapper-#{@id}"}
+      class={["flex flex-col gap-1", @class]}
+      {if @tooltip, do: ["phx-hook": "Tooltip", "aria-label": @tooltip], else: []}
+    >
       <div
         phx-hook="Toggle"
         id={"toggle-#{@id}"}

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -384,6 +384,22 @@ defmodule LightningWeb.WorkflowLive.Components do
           </div>
       <% end %>
     </div>
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-2"></div>
+    </div>
+    <hr class="h-px bg-gray-200 border-0 dark:bg-gray-700 position:absolute" />
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-2"></div>
+    </div>
+    <.input
+      type="checkbox"
+      field={@form[:enabled]}
+      label="Disable this trigger"
+      disabled={@disabled}
+      checked_value={false}
+      unchecked_value={true}
+      value={@trigger_enabled}
+    />
     """
   end
 
@@ -802,5 +818,89 @@ defmodule LightningWeb.WorkflowLive.Components do
       if is_nil(user.last_name),
         do: "",
         else: String.at(user.last_name, 0)
+  end
+
+  def enable_workflow_toggle(assigns) do
+    triggers_enabled? =
+      case Map.get(assigns, :source_type) do
+        :workflow ->
+          Map.get(assigns.source, :triggers, [])
+          |> Enum.all?(& &1.enabled)
+
+        :changeset ->
+          assigns.source
+          |> Ecto.Changeset.fetch_field!(:triggers)
+          |> Enum.all?(& &1.enabled)
+      end
+
+    assigns =
+      assigns
+      |> assign(:enabled?, triggers_enabled?)
+      |> assign(
+        :toggle_classes,
+        if(triggers_enabled?, do: "bg-indigo-600", else: "bg-gray-200")
+      )
+      |> assign(
+        :toggle_position,
+        if(triggers_enabled?, do: "translate-x-5", else: "translate-x-0")
+      )
+      |> assign(
+        :icon_inactive_classes,
+        if(triggers_enabled?,
+          do: "opacity-0 duration-100 ease-out",
+          else: "opacity-100 transition-opacity duration-200 ease-in"
+        )
+      )
+      |> assign(
+        :icon_active_classes,
+        if(triggers_enabled?,
+          do: "opacity-100 duration-200 ease-in",
+          else: "opacity-0 transition-opacity duration-100 ease-out"
+        )
+      )
+
+    ~H"""
+    <div class="flex flex-row m-auto gap-2">
+      <button
+        type="button"
+        class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@toggle_classes} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+        role="switch"
+        phx-click="toggle_enable_workflow"
+        phx-value-state={if @enabled?, do: "enabled", else: "disabled"}
+        phx-value-workflow={Map.get(assigns.source, :id)}
+        aria-checked={@enabled?}
+      >
+        <span class="sr-only">Use setting</span>
+        <span class={"pointer-events-none relative inline-block size-5 #{@toggle_position} transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}>
+          <span
+            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_inactive_classes}"}
+            aria-hidden="true"
+          >
+            <svg class="size-3 text-gray-400" fill="none" viewBox="0 0 12 12">
+              <path
+                d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span
+            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_active_classes}"}
+            aria-hidden="true"
+          >
+            <svg
+              class="size-3 text-indigo-600"
+              fill="currentColor"
+              viewBox="0 0 12 12"
+            >
+              <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+    """
   end
 end

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -509,41 +509,6 @@ defmodule LightningWeb.WorkflowLive.Components do
           </details>
         </div>
       <% end %>
-      <%= if @form[:source_trigger_id].value do %>
-        <div class="max-w-xl text-sm text-gray-500 mt-3">
-          <p>This path will be active if its trigger is enabled</p>
-        </div>
-      <% else %>
-        <div class="mt-7 border-t flex flex-col justify-between">
-          <h2 class=" flex mt-3">
-            <.input
-              type="checkbox"
-              field={@form[:enabled]}
-              disabled={@disabled}
-              label="Disable this path"
-              checked_value={false}
-              unchecked_value={true}
-              value={@edge_enabled}
-            />
-          </h2>
-        </div>
-      <% end %>
-      <%= unless @form[:source_trigger_id].value do %>
-        <div class="grow flex justify-end">
-          <label>
-            <.button
-              id="delete-edge-button"
-              class="focus:ring-red-500 bg-red-600 hover:bg-red-700 disabled:bg-red-300"
-              data-confirm="Are you sure you want to delete this path?"
-              phx-click="delete_edge"
-              phx-value-id={@form[:id].value}
-              disabled={@disabled or @form[:source_trigger_id].value}
-            >
-              Delete Path
-            </.button>
-          </label>
-        </div>
-      <% end %>
     </div>
     """
   end

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -384,22 +384,6 @@ defmodule LightningWeb.WorkflowLive.Components do
           </div>
       <% end %>
     </div>
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
-    <hr class="h-px bg-gray-200 border-0 dark:bg-gray-700 position:absolute" />
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
-    <.input
-      type="checkbox"
-      field={@form[:enabled]}
-      label="Disable this trigger"
-      disabled={@disabled}
-      checked_value={false}
-      unchecked_value={true}
-      value={@trigger_enabled}
-    />
     """
   end
 

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -4,7 +4,6 @@ defmodule LightningWeb.WorkflowLive.Components do
 
   import PetalComponents.Table
 
-  alias Lightning.Workflows.Workflow
   alias Phoenix.LiveView.JS
 
   attr :socket, :map, required: true
@@ -385,22 +384,6 @@ defmodule LightningWeb.WorkflowLive.Components do
           </div>
       <% end %>
     </div>
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
-    <hr class="h-px bg-gray-200 border-0 dark:bg-gray-700 position:absolute" />
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
-    <.input
-      type="checkbox"
-      field={@form[:enabled]}
-      label="Disable this trigger"
-      disabled={@disabled}
-      checked_value={false}
-      unchecked_value={true}
-      value={@trigger_enabled}
-    />
     """
   end
 
@@ -819,89 +802,5 @@ defmodule LightningWeb.WorkflowLive.Components do
       if is_nil(user.last_name),
         do: "",
         else: String.at(user.last_name, 0)
-  end
-
-  attr :id, :string
-  attr :label, :string, default: nil
-  attr :on_click, :string, required: true
-  attr :workflow_or_changeset, :any, required: true
-
-  def workflow_state_toggle(assigns) do
-    triggers_enabled? =
-      case assigns.workflow_or_changeset do
-        %Ecto.Changeset{} ->
-          assigns.workflow_or_changeset
-          |> Ecto.Changeset.fetch_field!(:triggers)
-          |> Enum.all?(& &1.enabled)
-
-        %Workflow{} ->
-          Map.get(assigns.workflow_or_changeset, :triggers, [])
-          |> Enum.all?(& &1.enabled)
-
-        _ ->
-          false
-      end
-
-    assigns =
-      assigns
-      |> assign(:enabled?, triggers_enabled?)
-      |> assign(
-        :bg,
-        if(triggers_enabled?, do: "bg-indigo-600", else: "bg-gray-200")
-      )
-      |> assign(
-        :translate,
-        if(triggers_enabled?, do: "translate-x-5", else: "translate-x-0")
-      )
-      |> assign(
-        :inactive_opacity,
-        if(triggers_enabled?,
-          do: "opacity-0 duration-100 ease-out",
-          else: "opacity-100 transition-opacity duration-200 ease-in"
-        )
-      )
-      |> assign(
-        :active_opacity,
-        if(triggers_enabled?,
-          do: "opacity-100 duration-200 ease-in",
-          else: "opacity-0 transition-opacity duration-100 ease-out"
-        )
-      )
-
-    ~H"""
-    <div id={@id} class="flex flex-row m-auto gap-2">
-      <button
-        id={"#{@id}-button"}
-        type="button"
-        class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@bg} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
-        role="switch"
-        phx-click={@on_click}
-        phx-value-state={if @enabled?, do: "enabled", else: "disabled"}
-        phx-value-workflow={Map.get(assigns.workflow_or_changeset, :id)}
-        aria-checked={@enabled?}
-      >
-        <span class={"pointer-events-none relative inline-block size-5 #{@translate} transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}>
-          <span
-            class={"absolute inset-0 flex size-full items-center justify-center #{@inactive_opacity}"}
-            aria-hidden="true"
-          >
-            <.icon name="hero-x-mark" class="h-4 w-4 text-gray-400" />
-          </span>
-          <span
-            class={"absolute inset-0 flex size-full items-center justify-center #{@active_opacity}"}
-            aria-hidden="true"
-          >
-            <.icon name="hero-check" class="h-4 w-4 text-indigo-600" />
-          </span>
-        </span>
-      </button>
-      <span
-        :if={@label}
-        class="flex flex-row m-auto text-sm font-medium text-gray-500"
-      >
-        <%= @label %>
-      </span>
-    </div>
-    """
   end
 end

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -895,7 +895,12 @@ defmodule LightningWeb.WorkflowLive.Components do
           </span>
         </span>
       </button>
-      <span :if={@label}><%= @label %></span>
+      <span
+        :if={@label}
+        class="flex flex-row m-auto text-sm font-medium text-gray-500"
+      >
+        <%= @label %>
+      </span>
     </div>
     """
   end

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -458,6 +458,7 @@ defmodule LightningWeb.WorkflowLive.Components do
           label="Label"
           field={@form[:condition_label]}
           maxlength="255"
+          disabled={@disabled}
         />
       </div>
       <div>
@@ -481,6 +482,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             phx-debounce="300"
             maxlength="255"
             placeholder="eg: !state.error"
+            disabled={@disabled}
           />
           <details class="mt-5 ml-1">
             <summary class="text-xs cursor-pointer">

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -821,6 +821,7 @@ defmodule LightningWeb.WorkflowLive.Components do
         else: String.at(user.last_name, 0)
   end
 
+  attr :id, :string
   attr :label, :string, default: nil
   attr :on_click, :string, required: true
   attr :workflow_or_changeset, :any, required: true
@@ -868,8 +869,9 @@ defmodule LightningWeb.WorkflowLive.Components do
       )
 
     ~H"""
-    <div class="flex flex-row m-auto gap-2">
+    <div id={@id} class="flex flex-row m-auto gap-2">
       <button
+        id={"#{@id}-button"}
         type="button"
         class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@bg} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
         role="switch"

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -148,10 +148,10 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
             <% end %>
           </div>
           <div class="mr-2 pt-2">
-            <div :if={@can_delete_workflow} class="py-0.5">
-              <Components.enable_workflow_toggle
-                source_type={:workflow}
-                source={workflow}
+            <div :if={@can_delete_workflow} class="flex items-center gap-2">
+              <Components.workflow_state_toggle
+                workflow_or_changeset={workflow}
+                on_click="toggle_workflow_state"
               />
               <.link
                 href="#"

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -190,17 +190,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
   defp workflow_enabled?(%Lightning.Workflows.Workflow{} = workflow),
     do: Enum.all?(workflow.triggers, & &1.enabled)
 
-  defp workflow_enabled?(%Ecto.Changeset{} = changeset),
-    do:
-      Ecto.Changeset.get_field(changeset, :triggers)
-      |> Enum.all?(&trigger_enabled?/1)
-
-  defp trigger_enabled?(%Ecto.Changeset{} = trigger),
-    do: Ecto.Changeset.get_field(trigger, :enabled)
-
-  defp trigger_enabled?(trigger),
-    do: trigger.enabled
-
   attr :project, :map, required: true
   attr :workflow, :map, required: true
   attr :trigger_enabled, :boolean

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -8,7 +8,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
   alias Lightning.Projects.Project
   alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrders.SearchParams
-  alias LightningWeb.WorkflowLive.Components
+  # alias LightningWeb.WorkflowLive.Components
   alias Timex.Format.DateTime.Formatters.Relative
 
   def workflow_list(assigns) do
@@ -149,11 +149,11 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           </div>
           <div class="mr-2 pt-2">
             <div :if={@can_delete_workflow} class="flex items-center gap-2">
-              <Components.workflow_state_toggle
+              <%!-- <Components.workflow_state_toggle
                 id={"toggle-workflow-state-#{workflow.id}"}
-                workflow_or_changeset={workflow}
+                state={:on}
                 on_click="toggle_workflow_state"
-              />
+              /> --%>
               <.link
                 href="#"
                 class="table-action"

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -36,6 +36,82 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     """
   end
 
+  defp enable_workflow_toggle(assigns) do
+    triggers_enabled? =
+      Map.get(assigns.workflow, :triggers)
+      |> Enum.all?(& &1.enabled)
+
+    assigns =
+      assigns
+      |> assign(:enabled?, triggers_enabled?)
+      |> assign(
+        :toggle_classes,
+        if(triggers_enabled?, do: "bg-indigo-600", else: "bg-gray-200")
+      )
+      |> assign(
+        :toggle_position,
+        if(triggers_enabled?, do: "translate-x-5", else: "translate-x-0")
+      )
+      |> assign(
+        :icon_inactive_classes,
+        if(triggers_enabled?,
+          do: "opacity-0 duration-100 ease-out",
+          else: "opacity-100 transition-opacity duration-200 ease-in"
+        )
+      )
+      |> assign(
+        :icon_active_classes,
+        if(triggers_enabled?,
+          do: "opacity-100 duration-200 ease-in",
+          else: "opacity-0 transition-opacity duration-100 ease-out"
+        )
+      )
+
+    ~H"""
+    <div class="flex flex-row m-auto gap-2">
+      <button
+        type="button"
+        class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@toggle_classes} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+        role="switch"
+        phx-click="toggle_enable_workflow"
+        phx-value-state={if @enabled?, do: "enabled", else: "disabled"}
+        phx-value-workflow={@workflow.id}
+        aria-checked={@enabled?}
+      >
+        <span class="sr-only">Use setting</span>
+        <span class={"pointer-events-none relative inline-block size-5 #{@toggle_position} transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}>
+          <span
+            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_inactive_classes}"}
+            aria-hidden="true"
+          >
+            <svg class="size-3 text-gray-400" fill="none" viewBox="0 0 12 12">
+              <path
+                d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span
+            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_active_classes}"}
+            aria-hidden="true"
+          >
+            <svg
+              class="size-3 text-indigo-600"
+              fill="currentColor"
+              viewBox="0 0 12 12"
+            >
+              <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+    """
+  end
+
   def workflows_table(%{workflows_stats: workflows_stats} = assigns) do
     assigns =
       assigns
@@ -146,8 +222,9 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
               </div>
             <% end %>
           </div>
-          <div class="mr-2 invisible group-hover:visible pt-2">
+          <div class="mr-2 pt-2">
             <div :if={@can_delete_workflow} class="py-0.5">
+              <.enable_workflow_toggle workflow={workflow} />
               <.link
                 href="#"
                 class="table-action"

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -8,6 +8,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
   alias Lightning.Projects.Project
   alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrders.SearchParams
+  alias LightningWeb.WorkflowLive.Helpers
   alias Timex.Format.DateTime.Formatters.Relative
 
   def workflow_list(assigns) do
@@ -152,8 +153,8 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
                 id={workflow.id}
                 type="toggle"
                 name="workflow_state"
-                value={workflow_enabled?(workflow)}
-                tooltip={workflow_state_tooltip(workflow)}
+                value={Helpers.workflow_enabled?(workflow)}
+                tooltip={Helpers.workflow_state_tooltip(workflow)}
                 on_click="toggle_workflow_state"
                 value_key={workflow.id}
               />
@@ -173,25 +174,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     </.table>
     """
   end
-
-  defp workflow_state_tooltip(%Lightning.Workflows.Workflow{triggers: triggers}) do
-    case {Enum.all?(triggers, & &1.enabled), triggers} do
-      {_, []} ->
-        "This workflow is inactive (no triggers configured)"
-
-      {true, [first_trigger | _]} ->
-        case first_trigger.type do
-          :cron -> "This workflow is active (cron trigger enabled)"
-          :webhook -> "This workflow is active (webhook trigger enabled)"
-        end
-
-      {false, _} ->
-        "This workflow is inactive (manual runs only)"
-    end
-  end
-
-  defp workflow_enabled?(%Lightning.Workflows.Workflow{} = workflow),
-    do: Enum.all?(workflow.triggers, & &1.enabled)
 
   attr :project, :map, required: true
   attr :workflow, :map, required: true

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -148,12 +148,8 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           </div>
           <div class="mr-2 pt-2">
             <div :if={@can_delete_workflow} class="flex items-center gap-2">
-              <%!-- <Components.workflow_state_toggle
-                id={"toggle-workflow-state-#{workflow.id}"}
-                state={:on}
-                on_click="toggle_workflow_state"
-              /> --%>
               <.input
+                id={workflow.id}
                 type="toggle"
                 name="workflow_state"
                 value={workflow_enabled?(workflow)}
@@ -178,12 +174,19 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     """
   end
 
-  defp workflow_state_tooltip(%Lightning.Workflows.Workflow{} = workflow) do
-    case {Enum.all?(workflow.triggers, & &1.enabled),
-          List.first(workflow.triggers) |> Map.get(:type)} do
-      {true, :cron} -> "This workflow is active (cron trigger enabled)"
-      {true, :webhook} -> "This workflow is active (webhook trigger enabled)"
-      {false, _} -> "This workflow is inactive (manual runs only)"
+  defp workflow_state_tooltip(%Lightning.Workflows.Workflow{triggers: triggers}) do
+    case {Enum.all?(triggers, & &1.enabled), triggers} do
+      {_, []} ->
+        "This workflow is inactive (no triggers configured)"
+
+      {true, [first_trigger | _]} ->
+        case first_trigger.type do
+          :cron -> "This workflow is active (cron trigger enabled)"
+          :webhook -> "This workflow is active (webhook trigger enabled)"
+        end
+
+      {false, _} ->
+        "This workflow is inactive (manual runs only)"
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -150,6 +150,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           <div class="mr-2 pt-2">
             <div :if={@can_delete_workflow} class="flex items-center gap-2">
               <Components.workflow_state_toggle
+                id={"toggle-workflow-state-#{workflow.id}"}
                 workflow_or_changeset={workflow}
                 on_click="toggle_workflow_state"
               />

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -8,6 +8,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
   alias Lightning.Projects.Project
   alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrders.SearchParams
+  alias LightningWeb.WorkflowLive.Components
   alias Timex.Format.DateTime.Formatters.Relative
 
   def workflow_list(assigns) do
@@ -32,82 +33,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
         can_delete_workflow={@can_delete_workflow}
         project={@project}
       />
-    </div>
-    """
-  end
-
-  defp enable_workflow_toggle(assigns) do
-    triggers_enabled? =
-      Map.get(assigns.workflow, :triggers)
-      |> Enum.all?(& &1.enabled)
-
-    assigns =
-      assigns
-      |> assign(:enabled?, triggers_enabled?)
-      |> assign(
-        :toggle_classes,
-        if(triggers_enabled?, do: "bg-indigo-600", else: "bg-gray-200")
-      )
-      |> assign(
-        :toggle_position,
-        if(triggers_enabled?, do: "translate-x-5", else: "translate-x-0")
-      )
-      |> assign(
-        :icon_inactive_classes,
-        if(triggers_enabled?,
-          do: "opacity-0 duration-100 ease-out",
-          else: "opacity-100 transition-opacity duration-200 ease-in"
-        )
-      )
-      |> assign(
-        :icon_active_classes,
-        if(triggers_enabled?,
-          do: "opacity-100 duration-200 ease-in",
-          else: "opacity-0 transition-opacity duration-100 ease-out"
-        )
-      )
-
-    ~H"""
-    <div class="flex flex-row m-auto gap-2">
-      <button
-        type="button"
-        class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@toggle_classes} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
-        role="switch"
-        phx-click="toggle_enable_workflow"
-        phx-value-state={if @enabled?, do: "enabled", else: "disabled"}
-        phx-value-workflow={@workflow.id}
-        aria-checked={@enabled?}
-      >
-        <span class="sr-only">Use setting</span>
-        <span class={"pointer-events-none relative inline-block size-5 #{@toggle_position} transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}>
-          <span
-            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_inactive_classes}"}
-            aria-hidden="true"
-          >
-            <svg class="size-3 text-gray-400" fill="none" viewBox="0 0 12 12">
-              <path
-                d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </span>
-          <span
-            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_active_classes}"}
-            aria-hidden="true"
-          >
-            <svg
-              class="size-3 text-indigo-600"
-              fill="currentColor"
-              viewBox="0 0 12 12"
-            >
-              <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-            </svg>
-          </span>
-        </span>
-      </button>
     </div>
     """
   end
@@ -224,7 +149,10 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           </div>
           <div class="mr-2 pt-2">
             <div :if={@can_delete_workflow} class="py-0.5">
-              <.enable_workflow_toggle workflow={workflow} />
+              <Components.enable_workflow_toggle
+                source_type={:workflow}
+                source={workflow}
+              />
               <.link
                 href="#"
                 class="table-action"

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2537,10 +2537,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   defp loaded?(%Workflow{} = workflow), do: workflow.__meta__.state == :loaded
 
-  @spec workflow_enabled?(
-          %Workflow{triggers: [Workflows.Trigger.t(), ...]}
-          | %Ecto.Changeset{}
-        ) :: boolean()
   defp workflow_enabled?(%Workflow{} = workflow),
     do: Enum.all?(workflow.triggers, & &1.enabled)
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -134,7 +134,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                   type="toggle"
                   name="workflow_state"
                   value={workflow_enabled?(@changeset)}
-                  tooltip={workflow_state_tooltip(@changeset) |> IO.inspect()}
+                  tooltip={workflow_state_tooltip(@changeset)}
                   on_click="toggle_workflow_state"
                 />
                 <div>
@@ -165,7 +165,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
       </:header>
 
       <div class="relative h-full flex" id={"workflow-edit-#{@workflow.id}"}>
-        <%!-- Job Edit View --%>
         <div class="flex-none" id="job-editor-pane">
           <div
             :if={@selected_job && @selection_mode == "expand"}

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -118,6 +118,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           >
             Switch to latest version
           </.button>
+
           <.with_changes_indicator
             :if={@snapshot_version_tag == "latest"}
             changeset={@changeset}
@@ -128,6 +129,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 name="hero-lock-closed"
                 class="w-5 h-5 place-self-center text-gray-300"
               />
+              <.enable_workflow_toggle changeset={@changeset} />
               <div class="flex flex-row m-auto gap-2">
                 <div>
                   <.link
@@ -1251,6 +1253,26 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   @impl true
+  def handle_event("toggle_enable_workflow", %{"state" => current_state}, socket) do
+    enabled = current_state == "disabled"
+
+    triggers =
+      socket.assigns.changeset
+      |> Ecto.Changeset.get_field(:triggers, [])
+      |> Enum.map(&Ecto.Changeset.change(&1, %{enabled: enabled}))
+
+    changeset =
+      socket.assigns.changeset
+      |> Ecto.Changeset.put_assoc(:triggers, triggers)
+
+    params = WorkflowParams.to_map(changeset)
+
+    {:noreply,
+     socket
+     |> assign(:changeset, changeset)
+     |> handle_new_params(params, :workflow)}
+  end
+
   def handle_event("get-initial-state", _params, socket) do
     {:noreply,
      socket
@@ -2357,6 +2379,81 @@ defmodule LightningWeb.WorkflowLive.Edit do
       >
       </div>
       <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  defp enable_workflow_toggle(assigns) do
+    triggers_enabled? =
+      Ecto.Changeset.fetch_field!(assigns.changeset, :triggers)
+      |> Enum.all?(& &1.enabled)
+
+    assigns =
+      assigns
+      |> assign(:enabled?, triggers_enabled?)
+      |> assign(
+        :toggle_classes,
+        if(triggers_enabled?, do: "bg-indigo-600", else: "bg-gray-200")
+      )
+      |> assign(
+        :toggle_position,
+        if(triggers_enabled?, do: "translate-x-5", else: "translate-x-0")
+      )
+      |> assign(
+        :icon_inactive_classes,
+        if(triggers_enabled?,
+          do: "opacity-0 duration-100 ease-out",
+          else: "opacity-100 transition-opacity duration-200 ease-in"
+        )
+      )
+      |> assign(
+        :icon_active_classes,
+        if(triggers_enabled?,
+          do: "opacity-100 duration-200 ease-in",
+          else: "opacity-0 transition-opacity duration-100 ease-out"
+        )
+      )
+
+    ~H"""
+    <div class="flex flex-row m-auto gap-2">
+      <button
+        type="button"
+        class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@toggle_classes} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+        role="switch"
+        phx-click="toggle_enable_workflow"
+        phx-value-state={if @enabled?, do: "enabled", else: "disabled"}
+        aria-checked={@enabled?}
+      >
+        <span class="sr-only">Use setting</span>
+        <span class={"pointer-events-none relative inline-block size-5 #{@toggle_position} transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}>
+          <span
+            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_inactive_classes}"}
+            aria-hidden="true"
+          >
+            <svg class="size-3 text-gray-400" fill="none" viewBox="0 0 12 12">
+              <path
+                d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span
+            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_active_classes}"}
+            aria-hidden="true"
+          >
+            <svg
+              class="size-3 text-indigo-600"
+              fill="currentColor"
+              viewBox="0 0 12 12"
+            >
+              <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
+            </svg>
+          </span>
+        </span>
+      </button>
     </div>
     """
   end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1464,11 +1464,19 @@ defmodule LightningWeb.WorkflowLive.Edit do
             |> Map.put("v", workflow.lock_version)
             |> Map.reject(fn {_key, value} -> is_nil(value) end)
 
+          flash_msg =
+            "Workflow saved successfully." <>
+              if not loaded?(changeset.data) and not workflow_enabled?(workflow) do
+                " Remember to enable your workflow to run it automatically."
+              else
+                ""
+              end
+
           {:noreply,
            socket
            |> assign(page_title: workflow.name)
            |> assign_workflow(workflow, snapshot)
-           |> put_flash(:info, "Workflow saved")
+           |> put_flash(:info, flash_msg)
            |> push_patches_applied(initial_params)
            |> maybe_push_workflow_created(workflow)
            |> push_patch(
@@ -2467,4 +2475,9 @@ defmodule LightningWeb.WorkflowLive.Edit do
        |> push_event("push-hash", %{"hash" => "log"})}
     end
   end
+
+  defp loaded?(%Workflow{} = workflow), do: workflow.__meta__.state == :loaded
+
+  defp workflow_enabled?(%Workflow{} = workflow),
+    do: Enum.all?(workflow.triggers, & &1.enabled)
 end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -129,7 +129,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 name="hero-lock-closed"
                 class="w-5 h-5 place-self-center text-gray-300"
               />
-              <.enable_workflow_toggle source_type={:changeset} source={@changeset} />
+              <.workflow_state_toggle
+                workflow_or_changeset={@changeset}
+                on_click="toggle_workflow_state"
+                label="Enabled"
+              />
               <div class="flex flex-row m-auto gap-2">
                 <div>
                   <.link
@@ -1253,11 +1257,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   @impl true
-  def handle_event("toggle_enable_workflow", %{"state" => current_state}, socket) do
+  def handle_event("toggle_workflow_state", %{"state" => state}, socket) do
     changeset =
-      Workflows.enable_or_disable_workflow(
+      Workflows.update_triggers_enabled_state(
         socket.assigns.changeset,
-        current_state == "disabled"
+        state == "disabled"
       )
 
     params = WorkflowParams.to_map(changeset)

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -129,7 +129,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 name="hero-lock-closed"
                 class="w-5 h-5 place-self-center text-gray-300"
               />
-              <.enable_workflow_toggle changeset={@changeset} />
+              <.enable_workflow_toggle source_type={:changeset} source={@changeset} />
               <div class="flex flex-row m-auto gap-2">
                 <div>
                   <.link
@@ -1254,16 +1254,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   @impl true
   def handle_event("toggle_enable_workflow", %{"state" => current_state}, socket) do
-    enabled = current_state == "disabled"
-
-    triggers =
-      socket.assigns.changeset
-      |> Ecto.Changeset.get_field(:triggers, [])
-      |> Enum.map(&Ecto.Changeset.change(&1, %{enabled: enabled}))
-
     changeset =
-      socket.assigns.changeset
-      |> Ecto.Changeset.put_assoc(:triggers, triggers)
+      Workflows.enable_or_disable_workflow(
+        socket.assigns.changeset,
+        current_state == "disabled"
+      )
 
     params = WorkflowParams.to_map(changeset)
 
@@ -2379,81 +2374,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
       >
       </div>
       <%= render_slot(@inner_block) %>
-    </div>
-    """
-  end
-
-  defp enable_workflow_toggle(assigns) do
-    triggers_enabled? =
-      Ecto.Changeset.fetch_field!(assigns.changeset, :triggers)
-      |> Enum.all?(& &1.enabled)
-
-    assigns =
-      assigns
-      |> assign(:enabled?, triggers_enabled?)
-      |> assign(
-        :toggle_classes,
-        if(triggers_enabled?, do: "bg-indigo-600", else: "bg-gray-200")
-      )
-      |> assign(
-        :toggle_position,
-        if(triggers_enabled?, do: "translate-x-5", else: "translate-x-0")
-      )
-      |> assign(
-        :icon_inactive_classes,
-        if(triggers_enabled?,
-          do: "opacity-0 duration-100 ease-out",
-          else: "opacity-100 transition-opacity duration-200 ease-in"
-        )
-      )
-      |> assign(
-        :icon_active_classes,
-        if(triggers_enabled?,
-          do: "opacity-100 duration-200 ease-in",
-          else: "opacity-0 transition-opacity duration-100 ease-out"
-        )
-      )
-
-    ~H"""
-    <div class="flex flex-row m-auto gap-2">
-      <button
-        type="button"
-        class={"relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent #{@toggle_classes} transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
-        role="switch"
-        phx-click="toggle_enable_workflow"
-        phx-value-state={if @enabled?, do: "enabled", else: "disabled"}
-        aria-checked={@enabled?}
-      >
-        <span class="sr-only">Use setting</span>
-        <span class={"pointer-events-none relative inline-block size-5 #{@toggle_position} transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"}>
-          <span
-            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_inactive_classes}"}
-            aria-hidden="true"
-          >
-            <svg class="size-3 text-gray-400" fill="none" viewBox="0 0 12 12">
-              <path
-                d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </span>
-          <span
-            class={"absolute inset-0 flex size-full items-center justify-center #{@icon_active_classes}"}
-            aria-hidden="true"
-          >
-            <svg
-              class="size-3 text-indigo-600"
-              fill="currentColor"
-              viewBox="0 0 12 12"
-            >
-              <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
-            </svg>
-          </span>
-        </span>
-      </button>
     </div>
     """
   end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -130,6 +130,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 class="w-5 h-5 place-self-center text-gray-300"
               />
               <.workflow_state_toggle
+                id="toggle-workflow-state"
                 workflow_or_changeset={@changeset}
                 on_click="toggle_workflow_state"
                 label="Enabled"
@@ -1432,24 +1433,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   def handle_event("save", params, socket) do
-    # <<<<<<< HEAD
-    #     %{
-    #       current_user: current_user,
-    #       project: project,
-    #       workflow_params: initial_params,
-    #       can_edit_workflow: can_edit_workflow,
-    #       snapshot_version_tag: tag,
-    #       has_presence_edit_priority: has_presence_edit_priority
-    #     } =
-    #       socket.assigns
-    # =======
     %{
       project: project,
       workflow_params: initial_params,
       current_user: current_user
     } = socket.assigns
-
-    # >>>>>>> origin/main
 
     with :ok <- check_user_can_save_workflow(socket) do
       next_params =

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2557,9 +2557,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
       Ecto.Changeset.get_field(changeset, :triggers)
       |> Enum.all?(&trigger_enabled?/1)
 
-  defp trigger_enabled?(%Ecto.Changeset{} = trigger),
-    do: Ecto.Changeset.get_field(trigger, :enabled)
-
   defp trigger_enabled?(trigger),
     do: trigger.enabled
 end

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -7,7 +7,6 @@ defmodule LightningWeb.WorkflowLive.Index do
   alias Lightning.DashboardStats
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.ProjectUsers
-  alias Lightning.Repo
   alias Lightning.Workflows
   alias LightningWeb.LiveHelpers
   alias LightningWeb.WorkflowLive.DashboardComponents
@@ -121,7 +120,8 @@ defmodule LightningWeb.WorkflowLive.Index do
         %{"state" => current_state, "workflow" => workflow_id},
         socket
       ) do
-    workflow = Workflows.get_workflow!(workflow_id, include: [:triggers])
+    workflow =
+      Workflows.get_workflow!(workflow_id, include: [:triggers])
 
     updated_triggers =
       workflow.triggers
@@ -131,10 +131,10 @@ defmodule LightningWeb.WorkflowLive.Index do
 
     workflow_changeset =
       workflow
-      |> Ecto.Changeset.change()
+      |> Workflows.change_workflow()
       |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
 
-    case Repo.update(workflow_changeset) do
+    case Workflows.save_workflow(workflow_changeset, socket.assigns.current_user) do
       {:ok, _workflow} ->
         {:noreply,
          socket

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -117,14 +117,14 @@ defmodule LightningWeb.WorkflowLive.Index do
   @impl true
   def handle_event(
         "toggle_workflow_state",
-        %{"state" => state, "workflow" => workflow_id},
+        %{"workflow_state" => state, "value_key" => workflow_id},
         socket
       ) do
     %{current_user: actor, project: project_id} = socket.assigns
 
     workflow = Workflows.get_workflow!(workflow_id, include: [:triggers])
 
-    Workflows.update_triggers_enabled_state(workflow, state == "disabled")
+    Workflows.update_triggers_enabled_state(workflow, state)
     |> Workflows.save_workflow(actor)
     |> case do
       {:ok, _workflow} ->

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -116,15 +116,15 @@ defmodule LightningWeb.WorkflowLive.Index do
 
   @impl true
   def handle_event(
-        "toggle_enable_workflow",
-        %{"state" => current_state, "workflow" => workflow_id},
+        "toggle_workflow_state",
+        %{"state" => state, "workflow" => workflow_id},
         socket
       ) do
     %{current_user: actor, project: project_id} = socket.assigns
 
     workflow = Workflows.get_workflow!(workflow_id, include: [:triggers])
 
-    Workflows.enable_or_disable_workflow(workflow, current_state == "disabled")
+    Workflows.update_triggers_enabled_state(workflow, state == "disabled")
     |> Workflows.save_workflow(actor)
     |> case do
       {:ok, _workflow} ->

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -738,7 +738,8 @@ defmodule Lightning.Projects.ProvisionerTest do
           ],
           "triggers" => [
             %{
-              "id" => trigger_id
+              "id" => trigger_id,
+              "enabled" => true
             }
           ],
           "edges" => [

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2483,7 +2483,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       refute_eventually(
         low_priority_view
         |> has_element?("#inspector-workflow-version", "latest"),
-        10_000
+        15_000
       )
 
       assert low_priority_view

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -181,6 +181,10 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       view |> change_editor_text("some body")
 
+      # By default, workflows are disabled to ensure a controlled setup.
+      # Here, we enable the workflow to test the :too_many_workflows limit action,
+      view |> element("#toggle-workflow-state-button") |> render_click()
+
       refute view |> save_is_disabled?()
 
       assert view |> has_pending_changes()

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1586,6 +1586,26 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert html =~ error_msg
     end
+
+    test "workflows are disabled by default", %{
+      conn: conn,
+      user: user
+    } do
+      project = insert(:project, project_users: [%{user: user, role: :editor}])
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project}/w/new?m=settings")
+
+      view |> fill_workflow_name("My Workflow")
+
+      html = click_save(view)
+
+      html |> IO.puts()
+
+      Workflows.get_workflows_for(project) |> IO.inspect()
+
+      assert html =~ "Workflow saved successfully"
+    end
   end
 
   describe "AI Assistant:" do

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1687,6 +1687,34 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       refute workflow.triggers |> Enum.any?(& &1.enabled)
     end
 
+    test "workflow can still be disabled / enabled from the trigger form", %{
+      conn: conn,
+      project: project,
+      workflow: workflow
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}"
+        )
+
+      assert workflow.triggers |> Enum.all?(& &1.enabled)
+
+      select_trigger(view)
+
+      view
+      |> form("#workflow-form", %{
+        "workflow" => %{"triggers" => %{"0" => %{"enabled" => "false"}}}
+      })
+      |> render_change()
+
+      click_save(view)
+
+      workflow = Workflows.get_workflow(workflow.id, include: [:triggers])
+
+      refute workflow.triggers |> Enum.any?(& &1.enabled)
+    end
+
     test "workflow state toggle tooltip messages vary by trigger type", %{
       conn: conn,
       user: user,

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -183,7 +183,9 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       # By default, workflows are disabled to ensure a controlled setup.
       # Here, we enable the workflow to test the :too_many_workflows limit action,
-      view |> element("#toggle-workflow-state-button") |> render_click()
+      view
+      |> element("#toggle-control-workflow")
+      |> render_click()
 
       refute view |> save_is_disabled?()
 
@@ -1482,7 +1484,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       idx = get_index_of_edge(view, edge)
 
-      assert html =~ "Disable this path"
+      assert html =~ "Enabled"
 
       assert view
              |> element("#workflow_edges_#{idx}_enabled")
@@ -1502,7 +1504,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       refute edge.enabled
 
-      assert view
+      refute view
              |> element("#workflow_edges_#{idx}_enabled[checked]")
              |> has_element?()
     end
@@ -1587,25 +1589,25 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert html =~ error_msg
     end
 
-    test "workflows are disabled by default", %{
-      conn: conn,
-      user: user
-    } do
-      project = insert(:project, project_users: [%{user: user, role: :editor}])
+    # test "workflows are disabled by default", %{
+    #   conn: conn,
+    #   user: user
+    # } do
+    #   project = insert(:project, project_users: [%{user: user, role: :editor}])
 
-      {:ok, view, _html} =
-        live(conn, ~p"/projects/#{project}/w/new?m=settings")
+    #   {:ok, view, _html} =
+    #     live(conn, ~p"/projects/#{project}/w/new?m=settings")
 
-      view |> fill_workflow_name("My Workflow")
+    #   view |> fill_workflow_name("My Workflow")
 
-      html = click_save(view)
+    #   html = click_save(view)
 
-      html |> IO.puts()
+    #   html |> IO.puts()
 
-      Workflows.get_workflows_for(project) |> IO.inspect()
+    #   Workflows.get_workflows_for(project) |> IO.inspect()
 
-      assert html =~ "Workflow saved successfully"
-    end
+    #   assert html =~ "Workflow saved successfully"
+    # end
   end
 
   describe "AI Assistant:" do


### PR DESCRIPTION
### Description

This PR introduces a toggle component in the new inputs module. We use this component to redesign the enable/disable features that existed in the triggers and edges forms but also to create a shortcut for allowing users to enable/disable workflows (enable/disable all the triggers of a given workflow). Also, all newly created workflows are now disabled by default and the user is notified thru a flash message when the first save it.

Closes #2698 

### Validation steps

#### Case 1

1. Open the workflow dashboard page
2. Note that next to the delete action button you have a new toggle button
3. Hover on the toggle button to see the displayed tooltip message. The message is: *This workflow is active (cron / webhook trigger enabled)* for when the workflow is enabled and *This workflow is inactive (manual runs only)* for when the workflow is disabled
4. Click on the toggle button to enable / disable the workflow

#### Case 2

1. Open the workflow canvas and note the presence of the same toggle button in the top bar next to the workflow settings icon
2. Hover the toggle button to see the same message described before
3. Click on the toggle button to enable / disable the workflow
4. Open the trigger pane and see the presence of the same toggle button for enabling / disabling the trigger.
5. Click on the toggle button to enable / disable the trigger
6. Open an edge pane and see the same toggle button and note the same behaviour (use it to enable / disable the edge)

#### Case 3

1. Create a new workflow
2. See how it is disabled by default
3. Save it
4. Note the presence of the following message in the flash message: *"Workflow saved successfully. Remember to enable your workflow to run it automatically.*

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
