### PR TITLE
Audit Enabling / Disabling Workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Audit Enabling / Disabling Workflows
+  [#2697](https://github.com/OpenFn/lightning/issues/2697)
 - Enable / Disable Workflows UI
   [#2698](https://github.com/OpenFn/lightning/issues/2698)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to
 
 ### Added
 
-- Audit Enabling / Disabling Workflows
+- Auditing when enabling/disabling a workflow
   [#2697](https://github.com/OpenFn/lightning/issues/2697)
-- Enable / Disable Workflows UI
+- Ability to enable/disable a workflow from the workflow editor
   [#2698](https://github.com/OpenFn/lightning/issues/2698)
 
 ### Changed

--- a/lib/lightning/workflows/audit.ex
+++ b/lib/lightning/workflows/audit.ex
@@ -6,7 +6,9 @@ defmodule Lightning.Workflows.Audit do
     repo: Lightning.Repo,
     item: "workflow",
     events: [
-      "snapshot_created"
+      "snapshot_created",
+      "enabled",
+      "disabled"
     ]
 
   def snapshot_created(workflow_id, snapshot_id, actor) do
@@ -17,6 +19,15 @@ defmodule Lightning.Workflows.Audit do
       %{
         after: %{snapshot_id: snapshot_id}
       }
+    )
+  end
+
+  def workflow_state_changed(event, workflow_id, actor, changes) do
+    event(
+      event,
+      workflow_id,
+      actor,
+      changes
     )
   end
 end


### PR DESCRIPTION
### Description

This PR introduces a function that allows to write audit logs when a workflow is enabled or disabled. That function is used in the `Workflows.save_workflow/2` function as a step in the `Ecto.Multi` to achieve atomicity.

Closes #2697 

### Validation steps

1. Toggle the enable / disable state of a workflow
2. Save
3. See the action written in the audit logs

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
