### PR TITLE
2703 getter setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   [#2403](https://github.com/OpenFn/lightning/pull/2403)
 - OPENAI_API_KEY renamed to AI_ASSISTANT_API_KEY
   [#2403](https://github.com/OpenFn/lightning/pull/2403)
+- Remove snapshot creation from WorkOrders, no longer necessary post-migration.
+  [#2703](https://github.com/OpenFn/lightning/issues/2703)
 
 ### Fixed
 

--- a/lib/lightning/kafka_triggers/message_handling.ex
+++ b/lib/lightning/kafka_triggers/message_handling.ex
@@ -41,8 +41,7 @@ defmodule Lightning.KafkaTriggers.MessageHandling do
                type: :kafka,
                project_id: workflow.project_id
              },
-             without_run: without_run?,
-             actor: trigger
+             without_run: without_run?
            ) do
       {:ok, work_order}
     else

--- a/lib/lightning/work_orders.ex
+++ b/lib/lightning/work_orders.ex
@@ -200,10 +200,10 @@ defmodule Lightning.WorkOrders do
 
   defp try_put_snapshot(changeset, attrs) do
     if snapshot = attrs |> Map.get(:snapshot) do
-      changeset |> put_assoc(:snapshot, snapshot)
+      put_assoc(changeset, :snapshot, snapshot)
     else
       snapshot = Snapshot.get_current_for(attrs[:workflow])
-      changeset |> put_assoc(:snapshot, snapshot)
+      put_assoc(changeset, :snapshot, snapshot)
     end
   end
 

--- a/lib/lightning/workflows/scheduler.ex
+++ b/lib/lightning/workflows/scheduler.ex
@@ -59,7 +59,6 @@ defmodule Lightning.Workflows.Scheduler do
           # %{id: uuid, type: :global, body: %{arbitrary: true}}
 
           WorkOrders.create_for(trigger,
-            actor: trigger,
             dataclip: %{
               type: :global,
               body: %{},
@@ -76,7 +75,6 @@ defmodule Lightning.Workflows.Scheduler do
           end)
 
           WorkOrders.create_for(trigger,
-            actor: trigger,
             dataclip: dataclip,
             workflow: job.workflow
           )

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -260,4 +260,14 @@ defmodule Lightning.Workflows.Snapshot do
       end)
     end
   end
+
+  @spec include_latest_snapshot(Multi.t(), binary() | :snapshot, Workflow.t()) ::
+          Multi.t()
+  def include_latest_snapshot(multi, name \\ :snapshot, workflow) do
+    get_snapshot  = fn repo, _changes ->
+      {:ok, get_current_query(workflow) |> repo.one()}
+    end
+
+    multi |> Multi.run(name, get_snapshot)
+  end
 end

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -264,10 +264,8 @@ defmodule Lightning.Workflows.Snapshot do
   @spec include_latest_snapshot(Multi.t(), binary() | :snapshot, Workflow.t()) ::
           Multi.t()
   def include_latest_snapshot(multi, name \\ :snapshot, workflow) do
-    get_snapshot = fn repo, _changes ->
+    Multi.run(multi, name, fn repo, _changes ->
       {:ok, get_current_query(workflow) |> repo.one()}
-    end
-
-    multi |> Multi.run(name, get_snapshot)
+    end)
   end
 end

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -264,7 +264,7 @@ defmodule Lightning.Workflows.Snapshot do
   @spec include_latest_snapshot(Multi.t(), binary() | :snapshot, Workflow.t()) ::
           Multi.t()
   def include_latest_snapshot(multi, name \\ :snapshot, workflow) do
-    get_snapshot  = fn repo, _changes ->
+    get_snapshot = fn repo, _changes ->
       {:ok, get_current_query(workflow) |> repo.one()}
     end
 

--- a/lib/lightning_web/controllers/webhooks_controller.ex
+++ b/lib/lightning_web/controllers/webhooks_controller.ex
@@ -49,7 +49,6 @@ defmodule LightningWeb.WebhooksController do
            ) do
       {:ok, work_order} =
         WorkOrders.create_for(trigger,
-          actor: trigger,
           workflow: trigger.workflow,
           dataclip: %{
             body: conn.body_params,

--- a/test/lightning/extensions/fifo_run_queue_test.exs
+++ b/test/lightning/extensions/fifo_run_queue_test.exs
@@ -10,37 +10,33 @@ defmodule Lightning.Extensions.FifoRunQueueTest do
       project2 = insert(:project)
 
       %{triggers: [trigger1]} =
-        workflow1 = insert(:simple_workflow, project: project1)
+        workflow1 =
+        insert(:simple_workflow, project: project1) |> with_snapshot()
 
       %{triggers: [trigger2]} =
-        workflow2 = insert(:simple_workflow, project: project2)
-
-      actor = insert(:user)
+        workflow2 =
+        insert(:simple_workflow, project: project2) |> with_snapshot()
 
       {:ok, %{runs: [%{id: run1_id}]}} =
         WorkOrders.create_for(trigger1,
-          actor: actor,
           workflow: workflow1,
           dataclip: params_with_assocs(:dataclip)
         )
 
       {:ok, %{runs: [%{id: run2_id}]}} =
         WorkOrders.create_for(trigger1,
-          actor: actor,
           workflow: workflow1,
           dataclip: params_with_assocs(:dataclip)
         )
 
       {:ok, %{runs: [%{id: run3_id}]}} =
         WorkOrders.create_for(trigger2,
-          actor: actor,
           workflow: workflow2,
           dataclip: params_with_assocs(:dataclip)
         )
 
       {:ok, %{runs: [%{id: run4_id}]}} =
         WorkOrders.create_for(trigger2,
-          actor: actor,
           workflow: workflow2,
           dataclip: params_with_assocs(:dataclip)
         )

--- a/test/lightning/kafka_triggers/message_handling_test.exs
+++ b/test/lightning/kafka_triggers/message_handling_test.exs
@@ -6,7 +6,6 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
   require Lightning.Run
 
   alias Ecto.Multi
-  alias Lightning.Auditing.Audit
   alias Lightning.Extensions.MockUsageLimiter
   alias Lightning.Extensions.Message
   alias Lightning.Extensions.UsageLimiting.Action
@@ -29,7 +28,9 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
           ]
         )
 
-      trigger = insert(:trigger, type: :kafka)
+      %{workflow: workflow} = trigger = insert(:trigger, type: :kafka)
+
+      workflow |> with_snapshot()
 
       record_changeset =
         TriggerKafkaMessageRecord.changeset(
@@ -55,6 +56,7 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
       trigger: trigger
     } do
       %{workflow: workflow} = trigger
+
       MessageHandling.persist_message(multi, trigger.id, message)
 
       created_workorder =
@@ -103,16 +105,6 @@ defmodule Lightning.KafkaTriggers.MessageHandlingTest do
       assert dataclip.body["request"] == message.metadata |> persisted_metadata()
       assert dataclip.type == :kafka
       assert dataclip.project_id == workflow.project_id
-    end
-
-    test "identifies the trigger as the actor for the audit event", %{
-      message: message,
-      multi: multi,
-      trigger: %{id: trigger_id}
-    } do
-      MessageHandling.persist_message(multi, trigger_id, message)
-
-      assert %{actor_id: ^trigger_id} = Repo.one(Audit)
     end
 
     test "executes any other instructions in the multi", %{

--- a/test/lightning/kafka_triggers/message_recovery_test.exs
+++ b/test/lightning/kafka_triggers/message_recovery_test.exs
@@ -12,8 +12,8 @@ defmodule Lightning.KafkaTriggers.MessageRecoveryTest do
 
   describe ".recover_messages" do
     setup %{tmp_dir: tmp_dir} do
-      workflow_1 = insert(:workflow)
-      workflow_2 = insert(:workflow)
+      workflow_1 = insert(:workflow) |> with_snapshot()
+      workflow_2 = insert(:workflow) |> with_snapshot()
 
       kafka_configuration = build(:triggers_kafka_configuration)
 

--- a/test/lightning/kafka_triggers/pipeline_test.exs
+++ b/test/lightning/kafka_triggers/pipeline_test.exs
@@ -15,9 +15,9 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
   alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord
   alias Lightning.KafkaTriggers.Pipeline
   alias Lightning.Repo
+  alias Lightning.WorkOrder
   alias Lightning.Workflows.Triggers.Events
   alias Lightning.Workflows.Triggers.Events.KafkaTriggerNotificationSent
-  alias Lightning.WorkOrder
 
   describe ".start_link/1" do
     test "starts a Broadway GenServer process with SASL credentials" do
@@ -173,6 +173,8 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
           enabled: true
         )
 
+      with_snapshot(trigger_1.workflow)
+
       trigger_2 =
         insert(
           :trigger,
@@ -180,6 +182,8 @@ defmodule Lightning.KafkaTriggers.PipelineTest do
           kafka_configuration: configuration(index: 2, ssl: false),
           enabled: true
         )
+
+      with_snapshot(trigger_2.workflow)
 
       context = %{trigger_id: trigger_1.id |> String.to_atom()}
 

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -43,11 +43,10 @@ defmodule Lightning.RunsTest do
   describe "claim/1" do
     test "claims a run from the queue" do
       %{triggers: [trigger]} =
-        workflow = insert(:simple_workflow)
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       {:ok, %{runs: [run]}} =
         WorkOrders.create_for(trigger,
-          actor: insert(:user),
           workflow: workflow,
           dataclip: params_with_assocs(:dataclip)
         )
@@ -61,14 +60,14 @@ defmodule Lightning.RunsTest do
     end
 
     test "claims with demand" do
-      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+      %{triggers: [trigger]} =
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       [run_1, run_2, run_3] =
         1..3
         |> Enum.map(fn _ ->
           {:ok, %{runs: [run]}} =
             WorkOrders.create_for(trigger,
-              actor: insert(:user),
               workflow: workflow,
               dataclip: params_with_assocs(:dataclip)
             )
@@ -90,12 +89,12 @@ defmodule Lightning.RunsTest do
     end
 
     test "claims with demand for all immediate run" do
-      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+      %{triggers: [trigger]} =
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       [second_last_run, last_run] =
         Enum.map(1..2, fn _i ->
           WorkOrders.create_for(trigger,
-            actor: insert(:user),
             workflow: workflow,
             dataclip: params_with_assocs(:dataclip)
           )
@@ -157,11 +156,11 @@ defmodule Lightning.RunsTest do
 
   describe "dequeue/1" do
     test "removes a run from the queue" do
-      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+      %{triggers: [trigger]} =
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       {:ok, %{runs: [run]}} =
         WorkOrders.create_for(trigger,
-          actor: insert(:user),
           workflow: workflow,
           dataclip: params_with_assocs(:dataclip)
         )
@@ -175,7 +174,9 @@ defmodule Lightning.RunsTest do
   describe "start_step/1" do
     test "creates a new step for a run" do
       dataclip = insert(:dataclip)
-      %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
+
+      %{triggers: [trigger], jobs: [job]} =
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       %{runs: [run]} =
         work_order_for(trigger, workflow: workflow, dataclip: dataclip)
@@ -228,7 +229,7 @@ defmodule Lightning.RunsTest do
       dataclip = insert(:dataclip)
 
       %{triggers: [trigger], jobs: [old_job]} =
-        workflow = insert(:simple_workflow)
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       %{runs: [run_1]} =
         work_order_for(trigger, workflow: workflow, dataclip: dataclip)
@@ -434,7 +435,8 @@ defmodule Lightning.RunsTest do
 
   describe "get/2" do
     setup context do
-      %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+      %{triggers: [trigger]} =
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       dataclip =
         case context.dataclip_type do
@@ -483,6 +485,7 @@ defmodule Lightning.RunsTest do
         |> with_job(job)
         |> with_edge({trigger, job}, condition_type: :always)
         |> insert()
+        |> with_snapshot()
 
       dataclip = insert(:dataclip)
 

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -4,12 +4,10 @@ defmodule Lightning.WorkOrdersTest do
   import Lightning.Factories
 
   alias Ecto.Multi
-  alias Lightning.Auditing.Audit
   alias Lightning.Extensions.MockUsageLimiter
   alias Lightning.Extensions.UsageLimiting.Action
   alias Lightning.Extensions.Message
   alias Lightning.KafkaTriggers.TriggerKafkaMessageRecord
-  alias Lightning.Workflows.Snapshot
   alias Lightning.WorkOrders
   alias Lightning.WorkOrders.Events
   alias Lightning.WorkOrders.RetryManyWorkOrdersJob
@@ -184,29 +182,6 @@ defmodule Lightning.WorkOrdersTest do
              |> Repo.get_by(trigger_id: trigger.id) != nil
     end
 
-    @tag trigger_type: :cron
-    test "with a trigger assigns the provided actor to the event", %{
-      snapshot: snapshot,
-      trigger: trigger,
-      workflow: workflow
-    } do
-      Repo.delete!(snapshot)
-
-      Lightning.WorkOrders.subscribe(workflow.project_id)
-
-      dataclip = insert(:dataclip)
-      %{id: actor_id} = actor = insert(:user)
-
-      WorkOrders.create_for(
-        trigger,
-        actor: actor,
-        dataclip: dataclip,
-        workflow: workflow
-      )
-
-      assert %{actor_id: ^actor_id} = Repo.one(Audit)
-    end
-
     test "with a manual workorder", context do
       %{workflow: workflow, job: job, snapshot: snapshot} = context
       user = insert(:user)
@@ -255,38 +230,6 @@ defmodule Lightning.WorkOrdersTest do
       assert_received %Events.WorkOrderCreated{
         work_order: %{id: ^workorder_id}
       }
-    end
-
-    test "assigns the created_by of the Manual as the actor for the audit", %{
-      job: job,
-      snapshot: snapshot,
-      workflow: workflow
-    } do
-      Repo.delete(snapshot)
-
-      %{id: user_id} = user = insert(:user)
-      project_id = workflow.project_id
-      Lightning.WorkOrders.subscribe(project_id)
-
-      {:ok, manual} =
-        Lightning.WorkOrders.Manual.new(
-          %{
-            "body" =>
-              Jason.encode!(%{
-                "key_left" => "value_left",
-                "configuration" => %{"password" => "secret"}
-              })
-          },
-          workflow: workflow,
-          project: workflow.project,
-          job: job,
-          created_by: user
-        )
-        |> Ecto.Changeset.apply_action(:validate)
-
-      WorkOrders.create_for(manual)
-
-      assert %{actor_id: ^user_id} = Repo.one!(Audit)
     end
 
     test "with a job", %{job: job, workflow: workflow, snapshot: snapshot} do
@@ -345,34 +288,6 @@ defmodule Lightning.WorkOrdersTest do
 
       assert TriggerKafkaMessageRecord
              |> Repo.get_by(trigger_id: trigger.id) != nil
-    end
-
-    test "with a job, assigns the actor to the audit if snapshot created", %{
-      job: job,
-      workflow: workflow
-    } do
-      Repo.delete_all(Snapshot)
-
-      project_id = workflow.project_id
-
-      project =
-        Repo.get(Lightning.Projects.Project, project_id)
-        |> Lightning.Projects.Project.changeset(%{retention_policy: :erase_all})
-        |> Repo.update!()
-
-      dataclip = insert(:dataclip, project: project)
-      user = insert(:user)
-      %{id: actor_id} = actor = insert(:user)
-
-      WorkOrders.create_for(
-        job,
-        actor: actor,
-        dataclip: dataclip,
-        workflow: workflow,
-        created_by: user
-      )
-
-      assert %{actor_id: ^actor_id} = Repo.one!(Audit)
     end
   end
 
@@ -696,48 +611,6 @@ defmodule Lightning.WorkOrdersTest do
 
       assert {:error, :workflow_deleted} =
                WorkOrders.retry(run, step, created_by: user)
-    end
-
-    test "if snapshot is created, uses creating user as audit actor", %{
-      workflow: workflow,
-      snapshot: snapshot,
-      trigger: trigger,
-      jobs: [job_a, job_b, job_c]
-    } do
-      %{id: user_id} = user = insert(:user)
-      dataclip = insert(:dataclip)
-      output_dataclip = insert(:dataclip)
-
-      # create existing complete run
-      %{runs: [run]} =
-        insert(:workorder,
-          workflow: workflow,
-          trigger: trigger,
-          dataclip: dataclip,
-          runs: [
-            %{
-              state: :failed,
-              dataclip: dataclip,
-              starting_trigger: trigger,
-              steps: [
-                insert(:step,
-                  job: job_a,
-                  input_dataclip: dataclip,
-                  output_dataclip: output_dataclip
-                ),
-                second_step =
-                  insert(:step, job: job_b, input_dataclip: output_dataclip),
-                insert(:step, job: job_c)
-              ]
-            }
-          ]
-        )
-
-      Repo.delete(snapshot)
-
-      WorkOrders.retry(run, second_step, created_by: user)
-
-      assert %{actor_id: ^user_id} = Repo.one!(Audit)
     end
   end
 
@@ -2702,50 +2575,6 @@ defmodule Lightning.WorkOrdersTest do
       {:ok, work_order} = WorkOrders.update_state(run)
 
       assert work_order.state == :running
-    end
-  end
-
-  describe ".enqueue_many_for_retry/2" do
-    test "assigns the creating user as the auditing actor" do
-      dataclip = insert(:dataclip)
-      workflow = insert(:simple_workflow)
-
-      %{id: work_order_id} =
-        insert(:workorder, workflow: workflow, dataclip: dataclip)
-
-      %{id: user_id} = insert(:user)
-
-      WorkOrders.enqueue_many_for_retry([work_order_id], user_id)
-
-      assert %{actor_id: ^user_id} = Repo.one(Audit)
-    end
-  end
-
-  describe ".build" do
-    test "uses the provided actor for the snapshot audit event" do
-      dataclip = insert(:dataclip)
-      workflow = insert(:simple_workflow)
-      %{id: actor_id} = actor = insert(:user)
-
-      WorkOrders.build(%{dataclip: dataclip, workflow: workflow, actor: actor})
-
-      assert %{actor_id: ^actor_id} = Repo.one(Audit)
-    end
-  end
-
-  describe ".build_for" do
-    test "uses the provided actor for the snapshot audit event" do
-      dataclip = insert(:dataclip)
-      trigger = insert(:trigger)
-      workflow = insert(:simple_workflow)
-      %{id: actor_id} = actor = insert(:user)
-
-      WorkOrders.build_for(
-        trigger,
-        %{dataclip: dataclip, workflow: workflow, actor: actor}
-      )
-
-      assert %{actor_id: ^actor_id} = Repo.one(Audit)
     end
   end
 end

--- a/test/lightning/workflows/scheduler_test.exs
+++ b/test/lightning/workflows/scheduler_test.exs
@@ -2,7 +2,6 @@ defmodule Lightning.Workflows.SchedulerTest do
   @moduledoc false
   use Lightning.DataCase, async: true
 
-  alias Lightning.Auditing.Audit
   alias Lightning.Invocation
   alias Lightning.Repo
   alias Lightning.Run
@@ -24,6 +23,8 @@ defmodule Lightning.Workflows.SchedulerTest do
         source_trigger: trigger,
         target_job: job
       })
+
+      with_snapshot(job.workflow)
 
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
@@ -64,6 +65,8 @@ defmodule Lightning.Workflows.SchedulerTest do
       })
 
       dataclip = insert(:dataclip)
+
+      with_snapshot(job.workflow)
 
       run =
         insert(:run,
@@ -111,89 +114,6 @@ defmodule Lightning.Workflows.SchedulerTest do
       refute new_run.id == run.id
       assert new_run.dataclip.type == :step_result
       assert new_run.dataclip.body == old_step.output_dataclip.body
-    end
-
-    test "uses the trigger as the actor for audit event if job has never run" do
-      job = insert(:job)
-
-      %{id: trigger_id} =
-        trigger =
-        insert(:trigger, %{
-          type: :cron,
-          cron_expression: "* * * * *",
-          workflow: job.workflow
-        })
-
-      insert(:edge, %{
-        workflow: job.workflow,
-        source_trigger: trigger,
-        target_job: job
-      })
-
-      Mox.expect(
-        Lightning.Extensions.MockUsageLimiter,
-        :limit_action,
-        fn _action, _context -> :ok end
-      )
-
-      Scheduler.enqueue_cronjobs()
-
-      assert %{actor_id: ^trigger_id} = Repo.one!(Audit)
-    end
-
-    test "uses the trigger as the actor for audit event if job has run before" do
-      job =
-        insert(:job,
-          body: "fn(state => { console.log(state); return { changed: true }; })"
-        )
-
-      %{id: trigger_id} =
-        trigger =
-        insert(:trigger, %{
-          type: :cron,
-          cron_expression: "* * * * *",
-          workflow: job.workflow
-        })
-
-      insert(:edge, %{
-        workflow: job.workflow,
-        source_trigger: trigger,
-        target_job: job
-      })
-
-      dataclip = insert(:dataclip)
-
-      insert(:run,
-        work_order:
-          build(:workorder,
-            workflow: job.workflow,
-            dataclip: dataclip,
-            trigger: trigger,
-            state: :success
-          ),
-        starting_trigger: trigger,
-        state: :success,
-        dataclip: dataclip,
-        steps: [
-          build(:step,
-            exit_reason: "success",
-            job: job,
-            input_dataclip: dataclip,
-            output_dataclip:
-              build(:dataclip, type: :step_result, body: %{"changed" => true})
-          )
-        ]
-      )
-
-      Mox.expect(
-        Lightning.Extensions.MockUsageLimiter,
-        :limit_action,
-        fn _action, _context -> :ok end
-      )
-
-      Scheduler.enqueue_cronjobs()
-
-      assert %{actor_id: ^trigger_id} = Repo.one!(Audit)
     end
   end
 end

--- a/test/lightning/workflows/snapshots_test.exs
+++ b/test/lightning/workflows/snapshots_test.exs
@@ -199,11 +199,8 @@ defmodule Lightning.Workflows.SnapshotsTest do
 
   describe "include_latest_snapshot/3" do
     setup do
-      workflow = insert(:simple_workflow)
-      other_workflow = insert(:simple_workflow)
-
-      {:ok, _initial_snapshot} = Workflows.Snapshot.create(workflow)
-      {:ok, _other_snapshot} = Workflows.Snapshot.create(other_workflow)
+      workflow = insert(:simple_workflow) |> with_snapshot()
+      _other_workflow = insert(:simple_workflow) |> with_snapshot()
 
       updated_workflow =
         workflow

--- a/test/lightning_web/channels/worker_channel_test.exs
+++ b/test/lightning_web/channels/worker_channel_test.exs
@@ -44,8 +44,7 @@ defmodule LightningWeb.WorkerChannelTest do
 
     test "returns runs", %{socket: socket} do
       %{triggers: [trigger]} =
-        workflow =
-        insert(:simple_workflow)
+        workflow = insert(:simple_workflow) |> with_snapshot()
 
       Lightning.Stub.reset_time()
 
@@ -54,7 +53,6 @@ defmodule LightningWeb.WorkerChannelTest do
         |> Enum.map(fn _ ->
           {:ok, %{runs: [run]}} =
             WorkOrders.create_for(trigger,
-              actor: insert(:user),
               workflow: workflow,
               dataclip: params_with_assocs(:dataclip)
             )

--- a/test/lightning_web/controllers/webhooks_controller_test.exs
+++ b/test/lightning_web/controllers/webhooks_controller_test.exs
@@ -8,7 +8,6 @@ defmodule LightningWeb.WebhooksControllerTest do
   alias Lightning.Extensions.MockUsageLimiter
   alias Lightning.Extensions.StubUsageLimiter
 
-  alias Lightning.Auditing.Audit
   alias Lightning.Repo
   alias Lightning.Runs
   alias Lightning.WorkOrders
@@ -24,7 +23,9 @@ defmodule LightningWeb.WebhooksControllerTest do
       Mox.stub(MockUsageLimiter, :limit_action, &StubUsageLimiter.limit_action/2)
 
       %{triggers: [trigger]} =
-        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
+        insert(:simple_workflow)
+        |> Lightning.Repo.preload(:triggers)
+        |> with_snapshot()
 
       conn = post(conn, "/i/#{trigger.id}")
 
@@ -55,7 +56,9 @@ defmodule LightningWeb.WebhooksControllerTest do
 
     test "returns 413 with a body exceeding the limit", %{conn: conn} do
       %{triggers: [trigger]} =
-        insert(:simple_workflow) |> Repo.preload(:triggers)
+        insert(:simple_workflow)
+        |> Repo.preload(:triggers)
+        |> with_snapshot()
 
       Application.put_env(:lightning, :max_dataclip_size_bytes, 1_000_000)
 
@@ -106,7 +109,9 @@ defmodule LightningWeb.WebhooksControllerTest do
 
     test "creates a pending workorder with a valid trigger", %{conn: conn} do
       %{triggers: [%{id: trigger_id}]} =
-        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
+        insert(:simple_workflow)
+        |> Lightning.Repo.preload(:triggers)
+        |> with_snapshot()
 
       message = %{"foo" => "bar"}
       conn = post(conn, "/i/#{trigger_id}", message)
@@ -132,7 +137,9 @@ defmodule LightningWeb.WebhooksControllerTest do
     test "creates a pending workorder with a valid trigger and an additional path",
          %{conn: conn} do
       %{triggers: [%{id: trigger_id}]} =
-        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
+        insert(:simple_workflow)
+        |> Lightning.Repo.preload(:triggers)
+        |> with_snapshot()
 
       message = %{"foo" => "bar"}
       conn = post(conn, "/i/#{trigger_id}/Patient", message)
@@ -158,7 +165,9 @@ defmodule LightningWeb.WebhooksControllerTest do
     test "creates a pending workorder with a valid trigger and some query params",
          %{conn: conn} do
       %{triggers: [%{id: trigger_id}]} =
-        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
+        insert(:simple_workflow)
+        |> Lightning.Repo.preload(:triggers)
+        |> with_snapshot()
 
       message = %{"foo" => "bar"}
       conn = post(conn, "/i/#{trigger_id}?extra=stuff&moar=things", message)
@@ -179,16 +188,6 @@ defmodule LightningWeb.WebhooksControllerTest do
 
       assert Runs.get_dataclip_request(run) ==
                ~s({\"path\": [\"i\", \"#{trigger_id}\"], \"method\": \"POST\", \"headers\": {\"content-type\": \"multipart/mixed; boundary=plug_conn_test\"}, \"query_params\": {\"moar\": \"things\", \"extra\": \"stuff\"}})
-    end
-
-    test "assigns the trigger as the actor for the audit event", %{conn: conn} do
-      %{triggers: [%{id: trigger_id}]} =
-        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
-
-      message = %{"foo" => "bar"}
-      post(conn, "/i/#{trigger_id}", message)
-
-      assert %{actor_id: ^trigger_id} = Repo.one!(Audit)
     end
 
     test "returns 415 when client sends xml", %{conn: conn} do

--- a/test/lightning_web/live/run_live/show_test.exs
+++ b/test/lightning_web/live/run_live/show_test.exs
@@ -15,7 +15,7 @@ defmodule LightningWeb.RunLive.ShowTest do
 
     test "with exit error", %{conn: conn, project: project} do
       %{triggers: [%{id: webhook_trigger_id}]} =
-        insert(:simple_workflow, project: project)
+        insert(:simple_workflow, project: project) |> with_snapshot()
 
       # Post to webhook
       assert post(conn, "/i/#{webhook_trigger_id}", %{"x" => 1})
@@ -35,7 +35,7 @@ defmodule LightningWeb.RunLive.ShowTest do
 
     test "lifecycle of a run", %{conn: conn, project: project} do
       %{triggers: [%{id: webhook_trigger_id}], jobs: [job_a, job_b | _rest]} =
-        insert(:complex_workflow, project: project)
+        insert(:complex_workflow, project: project) |> with_snapshot()
 
       # Post to webhook
       assert %{"work_order_id" => wo_id} =

--- a/test/lightning_web/live/work_order_live_test.exs
+++ b/test/lightning_web/live/work_order_live_test.exs
@@ -2418,7 +2418,7 @@ defmodule LightningWeb.WorkOrderLiveTest do
   describe "bulk rerun from job" do
     setup %{project: project} do
       %{project: project, triggers: [trigger], jobs: jobs} =
-        workflow = insert(:complex_workflow, project: project)
+        workflow = insert(:complex_workflow, project: project) |> with_snapshot()
 
       dataclip = insert(:dataclip, project: project)
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -3159,7 +3159,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       refute_eventually(
         low_priority_view
         |> has_element?("#inspector-workflow-version", "latest"),
-        15_000
+        30_000
       )
 
       assert low_priority_view

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -606,4 +606,8 @@ defmodule Lightning.Factories do
         Enum.concat(left, List.wrap(right))
     end
   end
+
+  def with_snapshot(workflow) do
+    workflow |> tap(&Lightning.Workflows.Snapshot.create/1)
+  end
 end


### PR DESCRIPTION
### Description

This is the first of a series of PRs to cleanup usage of `Snapshot.get_or_create_latest_for`. This functionality was widely used to provide coverage as Lightning migrated to snapshots but is now superfluous for many of the use cases as Workflow creation or modification results in Snapshot creation.

As some of this PR includes updating test fixtures that were relying on the `or_create` functionality, I have used distinct commits to make it more digestible.

#2703 

### Validation steps

This functionality was superfluous so there will be no outwardly visible change. The best validation is probably to confirm that my logic as to the removal of the 'or_create' portion of the functionality is correct.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
