### PR TITLE
Enable Tab Key for Indenting Text in AI Assistant Input Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project adheres to
 - Extend display of audit events to cater for deletions.
   [#2701](https://github.com/OpenFn/lightning/issues/2701)
 
-
 ### Fixed
 
 ## [v2.10.4] - 2024-11-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Enable Tab Key for Indenting Text in AI Assistant Input Box
+  [#2407](https://github.com/OpenFn/lightning/issues/2407)
 - Add styles to AI chat messages
   [#2484](https://github.com/OpenFn/lightning/issues/2484)
 - Auditing when enabling/disabling a workflow

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -18,6 +18,38 @@ export {
   TabbedPanels,
 };
 
+export const TabIndent = {
+  mounted() {
+    this.el.addEventListener('keydown', e => {
+      const indent = '\t';
+
+      if (e.key === 'Tab') {
+        e.preventDefault();
+
+        if (this.el.selectionStart !== undefined) {
+          const start = this.el.selectionStart;
+          const end = this.el.selectionEnd;
+
+          this.el.value =
+            this.el.value.substring(0, start) +
+            indent +
+            this.el.value.substring(end);
+
+          this.el.selectionStart = this.el.selectionEnd = start + indent.length;
+        } else if (this.el.isContentEditable) {
+          const selection = window.getSelection();
+          const range = selection.getRangeAt(0);
+
+          range.deleteContents();
+          range.insertNode(document.createTextNode(indent));
+
+          range.collapse(false);
+        }
+      }
+    });
+  },
+};
+
 export const Combobox = {
   mounted() {
     this.input = this.el.querySelector('input');

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -26,25 +26,15 @@ export const TabIndent = {
       if (e.key === 'Tab') {
         e.preventDefault();
 
-        if (this.el.selectionStart !== undefined) {
-          const start = this.el.selectionStart;
-          const end = this.el.selectionEnd;
+        const start = this.el.selectionStart;
+        const end = this.el.selectionEnd;
 
-          this.el.value =
-            this.el.value.substring(0, start) +
-            indent +
-            this.el.value.substring(end);
+        this.el.value =
+          this.el.value.substring(0, start) +
+          indent +
+          this.el.value.substring(end);
 
-          this.el.selectionStart = this.el.selectionEnd = start + indent.length;
-        } else if (this.el.isContentEditable) {
-          const selection = window.getSelection();
-          const range = selection.getRangeAt(0);
-
-          range.deleteContents();
-          range.insertNode(document.createTextNode(indent));
-
-          range.collapse(false);
-        }
+        this.el.selectionStart = this.el.selectionEnd = start + indent.length;
       }
     });
   },

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -442,6 +442,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
         class="block grow resize-none overflow-y-auto max-h-48 border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 placeholder:text-xs placeholder:italic focus:ring-0 text-sm"
         placeholder="Open a previous session or send a message to start a new session"
         disabled={@disabled}
+        phx-hook="TabIndent"
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @form[:content].value) %></textarea>
       <div class="py-2 pl-3 pr-2">
         <div class="flex items-center space-x-5"></div>


### PR DESCRIPTION
### Description

This PR adds support for the Tab key to indent text in the AI Assistant input box. When users press the Tab key while typing, instead of moving focus to another element, it inserts a tab character (\t) at the current cursor position, providing a smoother experience for writing or editing content in the input box.

Closes #2407 

### Validation steps

1. Open the AI assistant
2. Write something in the input
3. Press the `Tab` key
4. See your text being indented

### Additional notes for the reviewer

This functionality is implemented using a lightweight JavaScript hook, ensuring efficient and client-side-only behavior without server round trips.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
