### PR TITLE
Fix horiz scrolling

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -378,7 +378,7 @@ div.line-num::before {
   }
 
   pre {
-    @apply text-wrap text-slate-200 bg-slate-700 rounded-md p-2 my-2;
+    @apply text-slate-200 bg-slate-700 rounded-md p-2 my-2 overflow-x-auto;
 
     code {
       @apply text-sm leading-3;

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -662,15 +662,13 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
           <div
             :if={message.role == :assistant}
             id={"message-#{message.id}"}
-            class="mr-auto p-2 rounded-lg break-words text-wrap flex flex-row gap-x-2 makeup-html"
+            class="mr-auto p-2 rounded-lg break-words text-wrap w-full gap-x-2 makeup-html"
           >
-            <div>
-              <div class="rounded-full p-2 bg-indigo-200 text-indigo-700 ring-4 ring-white">
-                <.icon name="hero-cpu-chip" class="" />
-              </div>
+            <div class="float-left rounded-full p-2 bg-indigo-200 text-indigo-700 ring-4 ring-white">
+              <.icon name="hero-cpu-chip" class="" />
             </div>
 
-            <div>
+            <div class="ml-12">
               <.formatted_content content={message.content} />
               <!-- TODO: restore this message and add a link to the docs site -->
               <%!-- <div


### PR DESCRIPTION
### Description

This PR fixes the layout inside the AI assistant text so that normal text can wrap as usual, but code blocks will refuse to line break AND show a horizontal scroller.

This took way too long

As usual with flexbox stuff I don't really understand it. With the flexbox layout it seems possible to fix the width of the content parent without an explicit width, and the content will just stretch.

If I take the flexbox away, and I use a different technique to position the AI-icon and content, the flow layout seems todo the right thing.

![image](https://github.com/user-attachments/assets/f051c07b-6322-4c4b-ba1d-0cd9c3f08d71)

### Validation steps

This needs testing really  carefully! I think this is looking alright but it's always hard to tell.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
