### PR TITLE
Fix collections controller 204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to
 
 ### Fixed
 
+- Collections controller sending an invalid response body when a item doesn't
+  exist [#2733](https://github.com/OpenFn/lightning/issues/2733)
+
 ## [v2.10.4] - 2024-11-22
 
 ### Added

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -59,9 +59,7 @@ defmodule LightningWeb.CollectionsController do
          :ok <- authorize(conn, collection) do
       case Collections.get(collection, key) do
         nil ->
-          conn
-          |> put_status(:no_content)
-          |> json(nil)
+          resp(conn, :no_content, "")
 
         item ->
           json(conn, item)

--- a/test/lightning_web/collections_controller_test.exs
+++ b/test/lightning_web/collections_controller_test.exs
@@ -131,7 +131,7 @@ defmodule LightningWeb.API.CollectionsControllerTest do
         |> assign_bearer(token)
         |> get(~p"/collections/#{collection.name}/some-unexisting-key")
 
-      assert json_response(conn, 204) == nil
+      assert response(conn, 204) == ""
     end
   end
 


### PR DESCRIPTION
### Description

The RFC spec for 204s specifies that you can't send through a response body. The tests didn't pick this up because we're not using a real webserver during tests.

Fixes #2733

### Validation steps

1. Create a collection called `stuff` that belongs to a project you have access to.
2. Create a personal access token.
3. `export LIGHTNING_PAT=<the token>`
4. `curl -X GET "http://localhost:4000/collections/stuff/zzz" -H "Authorization: Bearer $LIGHTNING_PAT"`
5. You should get an empty response, and observe no errors in the phoenix logs.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
