### PR TITLE
Render Apollo Error Messages in the AI Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Handle errors from the AI Assistant more gracefully
+  [#2741](https://github.com/OpenFn/lightning/issues/2741)
 - Enable Tab Key for Indenting Text in AI Assistant Input Box
   [#2407](https://github.com/OpenFn/lightning/issues/2407)
 - Ctrl/Cmd + Enter to Send a Message to the AI Assistant

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -121,7 +121,7 @@ defmodule Lightning.AiAssistant do
         {:error, "Request timed out. Please try again."}
 
       {:error, :econnrefused} ->
-        {:error, "Unable to reach the AI service. Please try again later."}
+        {:error, "Unable to reach the AI server. Please try again later."}
 
       {:error, _error} ->
         {:error, "An unexpected error occurred. Please try again."}

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -100,7 +100,7 @@ defmodule Lightning.AiAssistant do
   """
   @spec query(ChatSession.t(), String.t()) ::
           {:ok, ChatSession.t()}
-          | {:error, Ecto.Changeset.t() | :apollo_unavailable}
+          | {:error, String.t() | Ecto.Changeset.t()}
   def query(session, content) do
     apollo_resp =
       ApolloClient.query(

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -106,50 +106,22 @@ defmodule Lightning.AiAssistant do
            content,
            %{expression: session.expression, adaptor: session.adaptor},
            build_history(session)
-    ) |> IO.inspect() do
+         ) do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         message = body["history"] |> Enum.reverse() |> hd()
         save_message(session, message)
 
-      {:ok, %Tesla.Env{body: %{"type" => type, "message" => message}}} ->
-        error_message = humanize_error(type, message)
+      {:ok, %Tesla.Env{body: %{"message" => message}}} ->
+        {:error, message}
 
-        {:error, error_message}
+      {:error, :timeout} ->
+        {:error, "Request timed out. Please try again."}
 
-      {:error, _} ->
-        {:error,
-         "Unable to reach the AI service. Please check your connection and try again."}
-    end
-  end
+      {:error, :econnrefused} ->
+        {:error, "Unable to reach the AI service. Please try again later."}
 
-  defp humanize_error(type, message) do
-    case type do
-      "AUTH_ERROR" ->
-        "Authentication failed. Please check your credentials."
-
-      "FORBIDDEN" ->
-        "You are not authorized to perform this action."
-
-      "RATE_LIMIT" ->
-        "Rate limit exceeded. Please wait a moment before trying again."
-
-      "CONNECTION_ERROR" ->
-        "Unable to reach the AI service. Please try again."
-
-      "BAD_REQUEST" ->
-        message
-
-      "INVALID_REQUEST" ->
-        message
-
-      "NOT_FOUND" ->
-        "The requested resource was not found."
-
-      "PROVIDER_ERROR" ->
-        "The AI service encountered an error. Please try again later."
-
-      _ ->
-        message
+      {:error, _error} ->
+        {:error, "An unexpected error occurred. Please try again."}
     end
   end
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -102,11 +102,14 @@ defmodule Lightning.AiAssistant do
           {:ok, ChatSession.t()}
           | {:error, Ecto.Changeset.t() | :apollo_unavailable}
   def query(session, content) do
-    case ApolloClient.query(
-           content,
-           %{expression: session.expression, adaptor: session.adaptor},
-           build_history(session)
-         ) do
+    apollo_resp =
+      ApolloClient.query(
+        content,
+        %{expression: session.expression, adaptor: session.adaptor},
+        build_history(session)
+      )
+
+    case apollo_resp do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         message = body["history"] |> Enum.reverse() |> hd()
         save_message(session, message)

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -13,6 +13,8 @@ defmodule Lightning.AiAssistant do
   alias Lightning.Services.UsageLimiter
   alias Lightning.Workflows.Job
 
+  require Logger
+
   @spec put_expression_and_adaptor(ChatSession.t(), String.t(), String.t()) ::
           ChatSession.t()
   def put_expression_and_adaptor(session, expression, adaptor) do
@@ -123,8 +125,12 @@ defmodule Lightning.AiAssistant do
       {:error, :econnrefused} ->
         {:error, "Unable to reach the AI server. Please try again later."}
 
-      {:error, _error} ->
-        {:error, "An unexpected error occurred. Please try again."}
+      unexpected_error ->
+        Logger.warning(
+          "Received an unexpected error: #{inspect(unexpected_error)}"
+        )
+
+        {:error, "Oops! Something went wrong. Please try again."}
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -138,12 +138,12 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
     end
   end
 
-  defp error_message({:error, %Ecto.Changeset{}}) do
-    "Oops! Could not save message. Please try again."
+  defp error_message({:error, message}) when is_binary(message) do
+    message
   end
 
-  defp error_message({:error, :apollo_unavailable}) do
-    "Oops! Could not reach the Ai Server. Please try again later."
+  defp error_message({:error, %Ecto.Changeset{}}) do
+    "Could not save message. Please try again."
   end
 
   defp error_message({:error, _reason, %{text: text_message}}) do
@@ -567,17 +567,17 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
               id="assistant-failed-message"
               class="mr-auto p-2 rounded-lg break-words text-wrap flex flex-row gap-x-2"
             >
-              <div class="">
+              <div class="flex-shrink-0">
                 <div class="rounded-full p-2 bg-indigo-200 text-indigo-700 ring-4 ring-white">
-                  <.icon name="hero-sparkles" class="" />
+                  <.icon name="hero-sparkles" />
                 </div>
               </div>
-              <div class="flex gap-2">
+              <div class="flex-1 flex items-center gap-2 bg-red-50 p-3 rounded-lg">
                 <.icon
                   name="hero-exclamation-triangle"
-                  class="text-amber-400 h-8 w-8"
+                  class="h-5 w-5 flex-shrink-0 text-red-400"
                 />
-                <span><%= error_message(failure) %></span>
+                <span class="text-red-700"><%= error_message(failure) %></span>
               </div>
             </div>
           </:failed>

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -138,19 +138,19 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
     end
   end
 
-  defp error_message({:error, message}) when is_binary(message) do
+  def error_message({:error, message}) when is_binary(message) do
     message
   end
 
-  defp error_message({:error, %Ecto.Changeset{}}) do
+  def error_message({:error, %Ecto.Changeset{}}) do
     "Could not save message. Please try again."
   end
 
-  defp error_message({:error, _reason, %{text: text_message}}) do
+  def error_message({:error, _reason, %{text: text_message}}) do
     text_message
   end
 
-  defp error_message(_error) do
+  def error_message(_error) do
     "Oops! Something went wrong. Please try again."
   end
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2544,7 +2544,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       render_async(view)
 
       assert view |> element("#assistant-failed-message") |> render() =~
-               "An unexpected error occurred. Please try again."
+               "Oops! Something went wrong. Please try again."
     end
   end
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2228,7 +2228,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
             {:ok, %Tesla.Env{status: 200}}
 
           %{method: :post}, _opts ->
-            {:ok, %Tesla.Env{status: 400}}
+            {:ok, %Tesla.Env{status: 400, body: %{"type" => "CONNECTION_ERROR"}}}
         end
       )
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2357,6 +2357,60 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert has_element?(view, "#ai-assistant-error", error_message)
     end
+
+    @tag email: "user@openfn.org"
+    test "displays apollo service error messages", %{
+      conn: conn,
+      project: project,
+      workflow: %{jobs: [job_1 | _]} = workflow
+    } do
+      apollo_endpoint = "http://localhost:4001"
+
+      Mox.stub(Lightning.MockConfig, :apollo, fn
+        :endpoint -> apollo_endpoint
+        :openai_api_key -> "openai_api_key"
+      end)
+
+      error_message = "Service is temporarily unavailable"
+
+      Mox.stub(
+        Lightning.Tesla.Mock,
+        :call,
+        fn
+          %{method: :get, url: ^apollo_endpoint <> "/"}, _opts ->
+            {:ok, %Tesla.Env{status: 200}}
+
+          %{method: :post}, _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 503,
+               body: %{
+                 "code" => 503,
+                 "message" => error_message
+               }
+             }}
+        end
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version, s: job_1.id, m: "expand"]}"
+        )
+
+      render_async(view)
+      view |> element("#get-started-with-ai-btn") |> render_click()
+
+      view
+      |> form("#ai-assistant-form")
+      |> render_submit(%{content: "Ping"})
+
+      assert_patch(view)
+      render_async(view)
+
+      assert view |> element("#assistant-failed-message") |> render() =~
+               error_message
+    end
   end
 
   describe "Allow low priority access users to retry steps and create workorders" do

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2228,7 +2228,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
             {:ok, %Tesla.Env{status: 200}}
 
           %{method: :post}, _opts ->
-            {:ok, %Tesla.Env{status: 400, body: %{"type" => "CONNECTION_ERROR"}}}
+            {:ok, %Tesla.Env{status: 400}}
         end
       )
 
@@ -2256,7 +2256,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert has_element?(view, "#assistant-failed-message")
 
       assert view |> element("#assistant-failed-message") |> render() =~
-               "Oops! Could not reach the Ai Server. Please try again later."
+               "Oops! Something went wrong. Please try again."
     end
 
     @tag email: "user@openfn.org"

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2359,7 +2359,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
     end
 
     @tag email: "user@openfn.org"
-    test "displays apollo service error messages", %{
+    test "displays apollo server error messages", %{
       conn: conn,
       project: project,
       workflow: %{jobs: [job_1 | _]} = workflow
@@ -2371,7 +2371,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         :openai_api_key -> "openai_api_key"
       end)
 
-      error_message = "Service is temporarily unavailable"
+      error_message = "Server is temporarily unavailable"
 
       Mox.stub(
         Lightning.Tesla.Mock,


### PR DESCRIPTION
### Description

This PR improves error handling in the AI Assistant by simplifying how we process Apollo service errors. Key changes:

- Removes custom error message mapping in favor of using Apollo service messages directly
- Retains specific handling for transport-level errors (timeout, connection refused)
- Maintains existing error handling for application-specific cases (Ecto, etc.)

These changes make the error handling more maintainable and future-proof as we add more Apollo services.

Closes #2474 

### Validation steps

1. Start the application with Apollo server running
2. Try various error scenarios in AI Assistant:
   - Timeout error (stop Apollo service temporarily)
   - Connection refused (wrong endpoint)
   - Various Apollo service errors (invalid API key, rate limit, etc.)
3. Verify error messages are clear and helpful to users
4. Verify existing error cases still work (database errors, etc.)

### Additional notes for the reviewer

The key decision was to trust Apollo server's error messages rather than maintaining our own mapping. This is because:
- Apollo errors are already user-friendly
- Reduces maintenance burden
- More consistent across different Apollo services

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
