### PR TITLE
Fix: AI Assistant text gets cleared in the form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
 
 - Collections controller sending an invalid response body when a item doesn't
   exist [#2733](https://github.com/OpenFn/lightning/issues/2733)
+- AI Assistant: Text in the form gets cleared when you change the editor content
+  [#2739](https://github.com/OpenFn/lightning/issues/2739)
 
 ## [v2.10.4] - 2024-11-22
 

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -78,6 +78,10 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
     """
   end
 
+  def handle_event("validate", params, socket) do
+    {:noreply, assign(socket, form: to_form(params))}
+  end
+
   def handle_event("send_message", %{"content" => content}, socket) do
     if socket.assigns.can_edit_workflow do
       %{action: action} = socket.assigns
@@ -494,6 +498,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
         <.form
           for={@form}
           phx-submit="send_message"
+          phx-change="validate"
           class="row-span-1 pl-2 pr-2 pb-1"
           phx-target={@myself}
           id="ai-assistant-form"


### PR DESCRIPTION
### Description

This PR fixes an issue in the AI Assistant that was clearing the text when the editor content is changed

Closes #2739 

### Validation steps

1. Type text in the AI assistant form. Don't submit
2. Try updating the job code. You'll notice the text in the AI assistant form isn't cleared


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
