### PR TITLE
Fix user deletion cancellation behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix User deletion cancellation behaviour.
+  [#2747](https://github.com/OpenFn/lightning/issues/2747)
+
 ## [v2.10.5] - 2024-12-04
 
 ### Added

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -448,12 +448,13 @@ defmodule Lightning.Accounts do
     User.scheduled_deletion_changeset(user, attrs)
   end
 
+  @spec cancel_scheduled_deletion(user_id :: binary()) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def cancel_scheduled_deletion(user_id) do
-    get_user!(user_id)
-    |> update_user_details(%{
-      scheduled_deletion: nil,
-      disabled: false
-    })
+    user_id
+    |> get_user!()
+    |> User.cancel_scheduled_deletion_changeset()
+    |> Repo.update()
   end
 
   @doc """

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -118,6 +118,10 @@ defmodule Lightning.Accounts.User do
     end)
   end
 
+  def cancel_scheduled_deletion_changeset(user) do
+    change(user, disabled: false, scheduled_deletion: nil)
+  end
+
   @spec superuser_registration_changeset(
           :invalid
           | %{optional(:__struct__) => none, optional(atom | binary) => any},

--- a/test/lightning/accounts/user_test.exs
+++ b/test/lightning/accounts/user_test.exs
@@ -65,4 +65,17 @@ defmodule Lightning.Accounts.UserTest do
                :superuser
     end
   end
+
+  describe "cancel_scheduled_deletion_changeset/1" do
+    test "returns a valid changeset" do
+      user =
+        insert(:user, disabled: true, scheduled_deletion: DateTime.utc_now())
+
+      changeset = User.cancel_scheduled_deletion_changeset(user)
+
+      assert changeset.valid?
+      assert get_change(changeset, :disabled) == false
+      assert get_change(changeset, :scheduled_deletion, "not nil") == nil
+    end
+  end
 end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -1538,6 +1538,31 @@ defmodule Lightning.AccountsTest do
     end
   end
 
+  describe "cancel_schedule_deletion" do
+    test "cancels the scheduled deletion" do
+      user =
+        insert(:user, disabled: true, scheduled_deletion: DateTime.utc_now())
+
+      Accounts.cancel_scheduled_deletion(user.id)
+
+      assert %{
+               disabled: false,
+               scheduled_deletion: nil
+             } = Repo.reload!(user)
+    end
+
+    test "returns the result of the cancellation" do
+      user =
+        insert(:user, disabled: true, scheduled_deletion: DateTime.utc_now())
+
+      response = Accounts.cancel_scheduled_deletion(user.id)
+
+      user = Repo.reload!(user)
+
+      assert {:ok, ^user} = response
+    end
+  end
+
   defp count_project_credentials_for_user(user) do
     from(pc in Ecto.assoc(user, [:credentials, :project_credentials]))
     |> Repo.aggregate(:count, :id)

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -199,13 +199,17 @@ defmodule LightningWeb.UserLiveTest do
       conn: conn
     } do
       user =
-        user_fixture(scheduled_deletion: Timex.now() |> Timex.shift(days: 7))
+        user_fixture(scheduled_deletion: DateTime.utc_now())
 
       {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
 
       assert index_live
              |> element("#user-#{user.id} a", "Cancel deletion")
              |> render_click() =~ "User deletion canceled"
+
+      assert %{scheduled_deletion: nil} = Repo.reload!(user)
+
+      refute has_element?(index_live, "#user-#{user.id}", "Cancel deletion")
     end
 
     test "allows a superuser to perform delete now action on users", %{


### PR DESCRIPTION
### Description

Fixes the behaviour of the 'Cancel Deletion' button on the user listing page.

Closes #2747 

### Validation steps

- Navigate to the [users page](http://localhost:4000/settings/users).
- Hit the 'Delete' button next to one of the users, and enter their email address to confirm the action.
- Once the page refreshes, click on 'Cancel deletion'. The cancel deletion button will be removed and the Scheduled Deletion field will be cleared.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
