### PR TITLE
Catch Postgrex.Error when duplicate keys are sent to put_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Return a 422 when a duplicate key is sent to the collections post/put_all API
+  [#2752](https://github.com/OpenFn/lightning/issues/2752)
+
 ## [v2.10.5] - 2024-12-04
 
 ### Added

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -188,7 +188,7 @@ defmodule Lightning.Collections do
       if e.postgres.code == :cardinality_violation do
         {:error, :duplicate_key}
       else
-        raise e
+        reraise e, __STACKTRACE__
       end
   end
 

--- a/lib/lightning_web/controllers/collections_controller.ex
+++ b/lib/lightning_web/controllers/collections_controller.ex
@@ -51,6 +51,14 @@ defmodule LightningWeb.CollectionsController do
          :ok <- authorize(conn, collection),
          {:ok, count} <- Collections.put_all(collection, items) do
       json(conn, %{upserted: count, error: nil})
+    else
+      {:error, :duplicate_key} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{upserted: 0, error: "Duplicate key found"})
+
+      other ->
+        other
     end
   end
 


### PR DESCRIPTION
Fixes #2752

### Validation steps

1. Create a collection
2. Sent a payload via a POST with two items with the same key
3. You should get a 422 instead of a 500.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
