### PR TITLE
2751 remove duplicate ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Delete user modal no longer uses the same id as the underlying user record.
+  [#2751](https://github.com/OpenFn/lightning/issues/2751)
+
 ## [v2.10.6] - 2024-12-10
 
 ### Added

--- a/lib/lightning_web/live/components/user_deletion_modal.ex
+++ b/lib/lightning_web/live/components/user_deletion_modal.ex
@@ -85,7 +85,7 @@ defmodule LightningWeb.Components.UserDeletionModal do
   def render(%{delete_now?: true, has_activity_in_projects?: true} = assigns) do
     ~H"""
     <div>
-      <.modal id={"user-#{@id}"} width="max-w-md" show={true}>
+      <.modal id={"user-#{@id}-delete-modal"} width="max-w-md" show={true}>
         <:title>
           <div class="flex justify-between">
             <span class="font-bold">
@@ -129,7 +129,7 @@ defmodule LightningWeb.Components.UserDeletionModal do
   def render(assigns) do
     ~H"""
     <div>
-      <.modal id={"user-#{@id}"} show={true} width="max-w-md">
+      <.modal id={"user-#{@id}-delete-modal"} show={true} width="max-w-md">
         <:title>
           <div class="flex justify-between">
             <span class="font-bold">


### PR DESCRIPTION
### Description

The Delete User modal uses the same id as the table row that launched and, as a result, Firefox is not amused. This PR just changes the ID.

![before](https://github.com/user-attachments/assets/2a10bd49-674b-46fa-a587-b9715a29687a)


Closes #2751 

### Validation steps

Confirm that the deletion modal pops up correctly and that user deletion still functions?

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
