### PR TITLE
Make email verification optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Make user email verification optional. Defaults to `false`
+  [#2755](https://github.com/OpenFn/lightning/issues/2755)
+
 ### Fixed
 
 - Return a 422 when a duplicate key is sent to the collections post/put_all API

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -196,6 +196,7 @@ For SMTP, the following environment variables are required:
 | `USAGE_TRACKING_RESUBMISSION_BATCH_SIZE` | The number of failed reports that will be submitted on each resubmission run (defaults to 10)                                                                                                                                          |
 | `USAGE_TRACKING_RUN_CHUNK_SIZE`          | The size of each batch of runs that is streamed from the database when generating UsageTracking reports (default 100). Decreasing this may decrease memory consumption when generating reports.                                        |
 | `USAGE_TRACKING_UUIDS`                   | Indicates whether submissions should include cleartext UUIDs or not. Options are `cleartext` or `hashed_only`, with the default being `hashed_only`.                                                                                   |
+| `REQUIRE_EMAIL_VERIFICATION`             | Indicates whether user email addresses should be verified. Defaults to `false`.                                                                                                                                                        |
 
 ### AI Chat
 

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -1021,7 +1021,8 @@ defmodule Lightning.Accounts do
   end
 
   def confirmation_required?(%User{confirmed_at: nil, inserted_at: inserted_at}) do
-    DateTime.diff(DateTime.utc_now(), inserted_at, :hour) >= 48
+    Lightning.Config.check_flag?(:require_email_verification) &&
+      DateTime.diff(DateTime.utc_now(), inserted_at, :hour) >= 48
   end
 
   def confirmation_required?(_user), do: false

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -253,6 +253,10 @@ defmodule Lightning.Config.Bootstrap do
            :init_project_for_new_user,
            env!("INIT_PROJECT_FOR_NEW_USER", &Utils.ensure_boolean/1, false)
 
+    config :lightning,
+           :require_email_verification,
+           env!("REQUIRE_EMAIL_VERIFICATION", &Utils.ensure_boolean/1, false)
+
     # To actually send emails you need to configure the mailer to use a real
     # adapter. You may configure the swoosh api client of your choice.
     # See # https://hexdocs.pm/swoosh/Swoosh.html#module-installation for more details.

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -84,7 +84,10 @@ defmodule LightningWeb.LayoutComponents do
 
     ~H"""
     <LightningWeb.Components.Common.banner
-      :if={@current_user && !@current_user.confirmed_at}
+      :if={
+        Lightning.Config.check_flag?(:require_email_verification) && @current_user &&
+          !@current_user.confirmed_at
+      }
       id="account-confirmation-alert"
       type="danger"
       centered

--- a/test/lightning_web/controllers/user_registration_controller_test.exs
+++ b/test/lightning_web/controllers/user_registration_controller_test.exs
@@ -10,6 +10,7 @@ defmodule LightningWeb.UserRegistrationControllerTest do
     Mox.stub(Lightning.MockConfig, :check_flag?, fn
       :allow_signup -> true
       :init_project_for_new_user -> false
+      :require_email_verification -> true
     end)
 
     :ok
@@ -64,6 +65,7 @@ defmodule LightningWeb.UserRegistrationControllerTest do
       Lightning.MockConfig
       |> expect(:check_flag?, fn :allow_signup -> true end)
       |> expect(:check_flag?, fn :init_project_for_new_user -> true end)
+      |> expect(:check_flag?, fn :require_email_verification -> true end)
 
       conn =
         conn

--- a/test/lightning_web/live/accounts_confirmation_live_test.exs
+++ b/test/lightning_web/live/accounts_confirmation_live_test.exs
@@ -4,6 +4,16 @@ defmodule LightningWeb.AccountsConfirmationLiveTest do
   import Phoenix.LiveViewTest
   import Lightning.Factories
 
+  setup do
+    Mox.stub(
+      Lightning.MockConfig,
+      :check_flag?,
+      fn :require_email_verification -> true end
+    )
+
+    :ok
+  end
+
   test "Users who have their accounts confirmed do not see the banner nor the modal in the sessions",
        %{conn: conn} do
     user = insert(:user, confirmed_at: DateTime.utc_now())
@@ -24,6 +34,22 @@ defmodule LightningWeb.AccountsConfirmationLiveTest do
     refute view |> has_element?("#account-confirmation-modal")
   end
 
+  test "Users who have their account not confirmed but created them within 48 hours dont see the alert and modal if email verification isn't enabled",
+       %{conn: conn} do
+    Mox.stub(
+      Lightning.MockConfig,
+      :check_flag?,
+      fn :require_email_verification -> false end
+    )
+
+    user = insert(:user, confirmed_at: nil, inserted_at: DateTime.utc_now())
+
+    {:ok, view, _html} = conn |> log_in_user(user) |> live("/projects")
+
+    refute view |> has_element?("#account-confirmation-alert")
+    refute view |> has_element?("#account-confirmation-modal")
+  end
+
   test "Users who have their account not confirmed but created them after 48 hours see both the confirmation alert and the modal",
        %{conn: conn} do
     user =
@@ -36,5 +62,25 @@ defmodule LightningWeb.AccountsConfirmationLiveTest do
 
     refute view |> has_element?("#account-confirmation-alert")
     assert view |> has_element?("#account-confirmation-modal")
+  end
+
+  test "Users who have their account not confirmed but created them after 48 hours dont see the alert and modal when verification is disabled",
+       %{conn: conn} do
+    Mox.stub(
+      Lightning.MockConfig,
+      :check_flag?,
+      fn :require_email_verification -> false end
+    )
+
+    user =
+      insert(:user,
+        confirmed_at: nil,
+        inserted_at: DateTime.utc_now() |> Timex.shift(hours: -50)
+      )
+
+    {:ok, view, _html} = conn |> log_in_user(user) |> live("/projects")
+
+    refute view |> has_element?("#account-confirmation-alert")
+    refute view |> has_element?("#account-confirmation-modal")
   end
 end


### PR DESCRIPTION
### Description

This PR makes email verification. By default, it is set to `false`

*NOTE:* We will need to add `REQUIRE_EMAIL_VERIFICATION=true` for our prod envs in order to continue requiring verification

Closes #2755

### Validation steps

You can verify this using the demo seeds data. By default, the demo users have a `confirmed_at` field populated in the db. Update that field to `null`

1. Now login to the app. You'll notice that there is no warning whatsoever
2. Stop your server and add `REQUIRE_EMAIL_VERIFICATION=true` to your env and restart the server. You'll notice that a warning is displayed urging that you confirm your email.


### Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
