### PR TITLE
Don't require password if not updating password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 
 - Return a 422 when a duplicate key is sent to the collections post/put_all API
   [#2752](https://github.com/OpenFn/lightning/issues/2752)
+- Do not require the user's password when a superuser updates a user.
+  [#2757](https://github.com/OpenFn/lightning/issues/2757)
 
 ## [v2.10.5] - 2024-12-04
 

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -61,7 +61,20 @@ defmodule Lightning.Accounts.User do
     |> validate_name()
     |> trim_name()
     |> validate_email()
-    |> validate_password([])
+    |> maybe_validate_password([])
+  end
+
+  defp maybe_validate_password(%{data: %{id: user_id}} = changeset, opts)
+       when not is_nil(user_id) do
+    if get_change(changeset, :password) do
+      validate_password(changeset, opts)
+    else
+      changeset
+    end
+  end
+
+  defp maybe_validate_password(changeset, opts) do
+    validate_password(changeset, opts)
   end
 
   @common_registration_attrs %{
@@ -218,7 +231,7 @@ defmodule Lightning.Accounts.User do
       :scheduled_deletion
     ])
     |> validate_email()
-    |> validate_password([])
+    |> maybe_validate_password([])
     |> validate_name()
     |> trim_name()
     |> validate_role()

--- a/test/lightning/accounts/user_test.exs
+++ b/test/lightning/accounts/user_test.exs
@@ -3,6 +3,109 @@ defmodule Lightning.Accounts.UserTest do
 
   alias Lightning.Accounts.User
 
+  describe "changeset/2" do
+    setup do
+      attrs = %{
+        "email" => "john@test.com",
+        "first_name" => "John",
+        "last_name" => "Doe",
+        "password" => "abc123456789"
+      }
+
+      %{attrs: attrs}
+    end
+
+    test "validates password if the struct is a new record", %{attrs: attrs} do
+      attrs_sans_password = Map.delete(attrs, "password")
+
+      %{valid?: valid?, errors: errors} =
+        User.changeset(%User{}, attrs_sans_password)
+
+      refute valid?
+      assert {:password, {"can't be blank", [validation: :required]}} in errors
+    end
+
+    test "does not require password to be present if user has an id", %{
+      attrs: attrs
+    } do
+      attrs_sans_password = Map.delete(attrs, "password")
+
+      assert %{valid?: true} =
+               User.changeset(
+                 %User{id: Ecto.UUID.generate()},
+                 attrs_sans_password
+               )
+    end
+
+    test "does validate password for an existing user if provided", %{
+      attrs: attrs
+    } do
+      attrs_password_too_short = Map.put(attrs, "password", "abc123")
+
+      %{valid?: valid?, errors: errors} =
+        User.changeset(%User{id: Ecto.UUID.generate()}, attrs_password_too_short)
+
+      refute valid?
+
+      assert {:password,
+              {"should be at least %{count} character(s)",
+               [count: 12, validation: :length, kind: :min, type: :string]}} in errors
+    end
+  end
+
+  describe "details_changeset/2" do
+    setup do
+      attrs = %{
+        "email" => "john@test.com",
+        "first_name" => "John",
+        "last_name" => "Doe",
+        "password" => "abc123456789"
+      }
+
+      %{attrs: attrs}
+    end
+
+    test "validates password if the struct is a new record", %{attrs: attrs} do
+      attrs_sans_password = Map.delete(attrs, "password")
+
+      %{valid?: valid?, errors: errors} =
+        User.details_changeset(%User{}, attrs_sans_password)
+
+      refute valid?
+      assert {:password, {"can't be blank", [validation: :required]}} in errors
+    end
+
+    test "does not require password to be present if user has an id", %{
+      attrs: attrs
+    } do
+      attrs_sans_password = Map.delete(attrs, "password")
+
+      assert %{valid?: true} =
+               User.details_changeset(
+                 %User{id: Ecto.UUID.generate()},
+                 attrs_sans_password
+               )
+    end
+
+    test "does validate password for an existing user if provided", %{
+      attrs: attrs
+    } do
+      attrs_password_too_short = Map.put(attrs, "password", "abc123")
+
+      %{valid?: valid?, errors: errors} =
+        User.details_changeset(
+          %User{id: Ecto.UUID.generate()},
+          attrs_password_too_short
+        )
+
+      refute valid?
+
+      assert {:password,
+              {"should be at least %{count} character(s)",
+               [count: 12, validation: :length, kind: :min, type: :string]}} in errors
+    end
+  end
+
   describe "password validation" do
     test "it allows passwords between 12 and 72 characters" do
       changeset =


### PR DESCRIPTION
### Description

This PR allows a user to be updated by a Superuser without the Superuser having to supply a new (r existing) password.

#2757 

### Validation steps

- Check that you can't create a user without a password.
- Check that you can edit user details without supplying a password.
- Check that you can edit a user's password.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
