### PR TITLE
tiny assistant style tweaks

### DIFF
--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -594,9 +594,9 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
           phx-hook="TabIndent"
         ><%= Phoenix.HTML.Form.normalize_value("textarea", @form[:content].value) %></textarea>
 
-        <div class="flex items-center justify-between px-4 py-1 mt-1 border-t border-gray-200 bg-gray-100 rounded-none rounded-b-lg">
-          <span class="text-xs text-gray-500">
-            <strong>Do not paste PII or sensitive business data</strong>
+        <div class="flex items-center justify-end px-2 py-1 mt-1 border-t border-gray-200 bg-gray-100 rounded-none rounded-b-lg">
+          <span class="text-xs text-gray-500 mr-2 select-none font-bold">
+            Do not paste PII or sensitive business data
           </span>
           <.simple_button_with_tooltip
             id="ai-assistant-form-submit-btn"
@@ -668,7 +668,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
                   <%= session.title %><%= "..." %>
                 </span>
               </div>
-              <span class="text-xs text-gray-500 group-hover:text-gray-700">
+              <span class="text-xs text-gray-500 group-hover:text-gray-700 whitespace-nowrap">
                 <%= time_ago(session.inserted_at) %>
               </span>
             </.link>


### PR DESCRIPTION
@elias-ba a couple of tiny changes:

![image](https://github.com/user-attachments/assets/335e998b-4b01-4ad6-a6fb-fc1e451ae038)

* The Send button is moved slightly right, so it's less floaty
* I've aligned the PII warning right, closer to the send button. It's OK, but also it's way better if you have a wide chat input box. I tried taking the bold off but think I prefer it on (although it still bugs me that this is so dominant)
* I've ensured the date doesn't wrap

![image](https://github.com/user-attachments/assets/00ddf99c-a1a5-4abd-8546-6311ba6b9c54)
