### PR TITLE
remove version bg

### DIFF
--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -231,8 +231,8 @@ defmodule LightningWeb.Components.Common do
       <% end %>
       <code
         class={[
-          "px-2 py-1 flex-grow opacity-20 bg-gray-100 rounded-md",
-          "break-keep font-mono text-indigo-500",
+          "px-2 py-1 flex-grow opacity-20 rounded-md",
+          "break-keep font-mono text-gray-100",
           "inline-block align-middle text-center"
         ]}
         title={"OpenFn/Lightning #{@display}"}


### PR DESCRIPTION
@stuartc , we chatted about this a while back. happy to drop the BG here? this is a simpler look IMO.

<img width="146" alt="image" src="https://github.com/user-attachments/assets/62fcc477-0ff3-4503-9505-6721597ae757">

tested on thunderbolt:

<img width="193" alt="image" src="https://github.com/user-attachments/assets/e7b6dda5-5e2d-4743-a322-7d0a935c5970">

