### PR TITLE
2719 allow superuser creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   > `REQUIRE_EMAIL_VERIFICATION` to `true` to revert to the old behaviour.
 - Enhance AI assistant panel UI
   [#2497](https://github.com/OpenFn/lightning/issues/2497)
+- Allow superusers to be created via the user UI.
+  [#2719](https://github.com/OpenFn/lightning/issues/2719)
 
 ### Fixed
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -467,4 +467,11 @@ div.line-num::before {
     disabled:opacity-30
     disabled:hover:bg-white;
   }
+
+  .table-action-disabled {
+    @apply table-action
+    cursor-not-allowed
+    opacity-30
+    hover:bg-white;
+  }
 }

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -56,7 +56,8 @@ defmodule Lightning.Accounts.User do
       :last_name,
       :email,
       :password,
-      :contact_preference
+      :contact_preference,
+      :role
     ])
     |> validate_name()
     |> trim_name()

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -193,11 +193,6 @@ defmodule Lightning.Accounts.User do
     |> validate_required([:first_name, :last_name], message: "can't be blank")
   end
 
-  defp validate_role(changeset) do
-    changeset
-    |> validate_inclusion(:role, RolesEnum)
-  end
-
   defp maybe_hash_password(changeset, opts) do
     hash_password? = Keyword.get(opts, :hash_password, true)
     password = get_change(changeset, :password)
@@ -235,7 +230,6 @@ defmodule Lightning.Accounts.User do
     |> maybe_validate_password([])
     |> validate_name()
     |> trim_name()
-    |> validate_role()
   end
 
   @doc """

--- a/lib/lightning/accounts/user.ex
+++ b/lib/lightning/accounts/user.ex
@@ -230,6 +230,7 @@ defmodule Lightning.Accounts.User do
     |> maybe_validate_password([])
     |> validate_name()
     |> trim_name()
+    |> maybe_clear_scheduled_deletion()
   end
 
   @doc """
@@ -372,5 +373,12 @@ defmodule Lightning.Accounts.User do
     changeset
     |> update_change(:first_name, &String.trim/1)
     |> update_change(:last_name, &String.trim/1)
+  end
+
+  defp maybe_clear_scheduled_deletion(changeset) do
+    case fetch_field(changeset, :role) do
+      {_source, :superuser} -> put_change(changeset, :scheduled_deletion, nil)
+      _anything_else -> changeset
+    end
   end
 end

--- a/lib/lightning_web/live/user_live/form_component.ex
+++ b/lib/lightning_web/live/user_live/form_component.ex
@@ -10,9 +10,12 @@ defmodule LightningWeb.UserLive.FormComponent do
   def update(%{user: user} = assigns, socket) do
     changeset = Accounts.change_user(user, %{})
 
+    {_source, role} = Ecto.Changeset.fetch_field(changeset, :role)
+
     {:ok,
      socket
      |> assign(assigns)
+     |> assign(:role, role)
      |> assign(:changeset, changeset)}
   end
 
@@ -23,7 +26,12 @@ defmodule LightningWeb.UserLive.FormComponent do
       |> Accounts.change_user(user_params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, :changeset, changeset)}
+    {_source, role} = Ecto.Changeset.fetch_field(changeset, :role)
+
+    {:noreply,
+     socket
+     |> assign(:role, role)
+     |> assign(:changeset, changeset)}
   end
 
   def handle_event("save", %{"user" => user_params}, socket) do
@@ -31,8 +39,8 @@ defmodule LightningWeb.UserLive.FormComponent do
   end
 
   def user_options do
-    Accounts.User.RolesEnum.__valid_values__() 
-    |> Enum.filter(& is_binary(&1))
+    Accounts.User.RolesEnum.__valid_values__()
+    |> Enum.filter(&is_binary(&1))
     |> Enum.sort()
     |> Enum.map(fn role -> {String.capitalize(role), role} end)
   end

--- a/lib/lightning_web/live/user_live/form_component.ex
+++ b/lib/lightning_web/live/user_live/form_component.ex
@@ -30,6 +30,13 @@ defmodule LightningWeb.UserLive.FormComponent do
     save_user(socket, socket.assigns.action, user_params)
   end
 
+  def user_options do
+    Accounts.User.RolesEnum.__valid_values__() 
+    |> Enum.filter(& is_binary(&1))
+    |> Enum.sort()
+    |> Enum.map(fn role -> {String.capitalize(role), role} end)
+  end
+
   defp save_user(socket, :edit, user_params) do
     case Accounts.update_user_details(socket.assigns.user, user_params) do
       {:ok, _user} ->

--- a/lib/lightning_web/live/user_live/form_component.html.heex
+++ b/lib/lightning_web/live/user_live/form_component.html.heex
@@ -51,6 +51,21 @@
       <div class="py-2"></div>
     </div>
 
+    <div class="grid grid-cols-6 gap-6">
+      <div class="col-span-3">
+        <.input
+        type="select"
+        field={f[:role]}
+        label="Role"
+        options={user_options()}
+        />
+      </div>
+    </div>
+
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-2"></div>
+    </div>
+
     <%= if @action in [:edit] do %>
       <div class="grid grid-cols-6 gap-6">
         <div class="col-span-3">

--- a/lib/lightning_web/live/user_live/form_component.html.heex
+++ b/lib/lightning_web/live/user_live/form_component.html.heex
@@ -54,10 +54,10 @@
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
         <.input
-        type="select"
-        field={f[:role]}
-        label="Role"
-        options={user_options()}
+          type="select"
+          field={f[:role]}
+          label="Role"
+          options={user_options()}
         />
       </div>
     </div>
@@ -67,12 +67,14 @@
     </div>
 
     <%= if @action in [:edit] do %>
-      <div class="grid grid-cols-6 gap-6">
-        <div class="col-span-3">
-          <.label for={:scheduled_deletion}>Scheduled Deletion</.label>
-          <.input type="text" field={f[:scheduled_deletion]} />
+      <%= if @role == :user do %>
+        <div class="grid grid-cols-6 gap-6">
+          <div class="col-span-3">
+            <.label for={:scheduled_deletion}>Scheduled Deletion</.label>
+            <.input type="text" field={f[:scheduled_deletion]} />
+          </div>
         </div>
-      </div>
+      <% end %>
 
       <div class="hidden sm:block" aria-hidden="true">
         <div class="py-2"></div>

--- a/lib/lightning_web/live/user_live/index.ex
+++ b/lib/lightning_web/live/user_live/index.ex
@@ -66,8 +66,7 @@ defmodule LightningWeb.UserLive.Index do
   def delete_action(%{user: %{role: :user}} = assigns) do
     if assigns.user.scheduled_deletion do
       ~H"""
-      <.cancel_deletion user={@user} />
-      |
+      <.cancel_deletion user={@user} /> |
       <span>
         <.link
           id={"delete-now-#{@user.id}"}
@@ -96,8 +95,7 @@ defmodule LightningWeb.UserLive.Index do
   def delete_action(%{user: %{role: :superuser}} = assigns) do
     if assigns.user.scheduled_deletion do
       ~H"""
-      <.cancel_deletion user={@user} />
-      |
+      <.cancel_deletion user={@user} /> |
       <span id={"delete-now-#{@user.id}"} class="table-action-disabled">
         Delete now
       </span>
@@ -113,17 +111,17 @@ defmodule LightningWeb.UserLive.Index do
 
   defp cancel_deletion(assigns) do
     ~H"""
-      <span>
-        <.link
-          id={"cancel-deletion-#{@user.id}"}
-          href="#"
-          phx-click="cancel_deletion"
-          phx-value-id={@user.id}
-          class="table-action"
-        >
-          Cancel deletion
-        </.link>
-      </span>
+    <span>
+      <.link
+        id={"cancel-deletion-#{@user.id}"}
+        href="#"
+        phx-click="cancel_deletion"
+        phx-value-id={@user.id}
+        class="table-action"
+      >
+        Cancel deletion
+      </.link>
+    </span>
     """
   end
 end

--- a/lib/lightning_web/live/user_live/index.ex
+++ b/lib/lightning_web/live/user_live/index.ex
@@ -63,20 +63,10 @@ defmodule LightningWeb.UserLive.Index do
     Accounts.list_users()
   end
 
-  def delete_action(assigns) do
+  def delete_action(%{user: %{role: :user}} = assigns) do
     if assigns.user.scheduled_deletion do
       ~H"""
-      <span>
-        <.link
-          id={"cancel-deletion-#{@user.id}"}
-          href="#"
-          phx-click="cancel_deletion"
-          phx-value-id={@user.id}
-          class="table-action"
-        >
-          Cancel deletion
-        </.link>
-      </span>
+      <.cancel_deletion user={@user} />
       |
       <span>
         <.link
@@ -101,5 +91,39 @@ defmodule LightningWeb.UserLive.Index do
       </span>
       """
     end
+  end
+
+  def delete_action(%{user: %{role: :superuser}} = assigns) do
+    if assigns.user.scheduled_deletion do
+      ~H"""
+      <.cancel_deletion user={@user} />
+      |
+      <span id={"delete-now-#{@user.id}"} class="table-action-disabled">
+        Delete now
+      </span>
+      """
+    else
+      ~H"""
+      <span id={"delete-#{@user.id}"} class="table-action-disabled">
+        Delete
+      </span>
+      """
+    end
+  end
+
+  defp cancel_deletion(assigns) do
+    ~H"""
+      <span>
+        <.link
+          id={"cancel-deletion-#{@user.id}"}
+          href="#"
+          phx-click="cancel_deletion"
+          phx-value-id={@user.id}
+          class="table-action"
+        >
+          Cancel deletion
+        </.link>
+      </span>
+    """
   end
 end

--- a/lib/lightning_web/live/user_live/index.html.heex
+++ b/lib/lightning_web/live/user_live/index.html.heex
@@ -63,7 +63,7 @@
       *Note that a <code>superuser</code> can access <em>everything</em> in a
       Lightning installation across all projects, including this page. Most
       day-to-day user management (adding and removing collaborators) will be
-      done by project "admins" via the forthcoming project settings page.
+      done by project "admins" via the project settings page.
     </.p>
   </LayoutComponents.centered>
 </LayoutComponents.page_content>

--- a/test/lightning/accounts/user_test.exs
+++ b/test/lightning/accounts/user_test.exs
@@ -368,6 +368,21 @@ defmodule Lightning.Accounts.UserTest do
 
       assert errors[:scheduled_deletion_email] == nil
     end
+
+    test "user being deleted is a superuser" do
+      user = %User{email: "real@email.com", role: :superuser}
+
+      errors =
+        User.scheduled_deletion_changeset(user, %{
+          "id" => "86201fff-a699-4eca-bb53-8736228ff187",
+          "scheduled_deletion_email" => "real@email.com"
+        })
+        |> errors_on()
+
+      assert errors[:scheduled_deletion_email] == [
+               "You can't delete a superuser account."
+             ]
+    end
   end
 
   describe "superuser_registration_changeset/1" do

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -68,10 +68,10 @@ defmodule LightningWeb.UserLiveTest do
       assert html =~ "test@example.com"
 
       assert %{
-        first_name: ^first_name,
-        last_name: ^last_name,
-        role: :user
-      } = Repo.get_by(User, email: @create_attrs.email)
+               first_name: ^first_name,
+               last_name: ^last_name,
+               role: :user
+             } = Repo.get_by(User, email: @create_attrs.email)
     end
 
     test "allows creation of a super user", %{conn: conn} do
@@ -100,10 +100,10 @@ defmodule LightningWeb.UserLiveTest do
       assert html =~ "test@example.com"
 
       assert %{
-        first_name: ^first_name,
-        last_name: ^last_name,
-        role: :superuser
-      } = Repo.get_by(User, email: @create_attrs.email)
+               first_name: ^first_name,
+               last_name: ^last_name,
+               role: :superuser
+             } = Repo.get_by(User, email: @create_attrs.email)
     end
 
     test "updates user in listing", %{conn: conn} do
@@ -132,6 +132,88 @@ defmodule LightningWeb.UserLiveTest do
       assert html =~ "User updated successfully"
 
       assert Repo.reload!(user) |> user_attrs_match?(@update_attrs)
+    end
+
+    test "provides `Scheduled Deletion` when editing a normal user", %{
+      conn: conn
+    } do
+      user = user_fixture()
+
+      {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
+
+      {:ok, form_live, _} =
+        index_live
+        |> element("#user-#{user.id} a", "Edit")
+        |> render_click()
+        |> follow_redirect(conn, Routes.user_edit_path(conn, :edit, user))
+
+      assert(
+        form_live
+        |> has_element?("input[name=\"user[scheduled_deletion]\"]")
+      )
+    end
+
+    test "hides `Scheduled Deletion` when changing to a superuser", %{
+      conn: conn
+    } do
+      user = user_fixture()
+
+      {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
+
+      {:ok, form_live, _} =
+        index_live
+        |> element("#user-#{user.id} a", "Edit")
+        |> render_click()
+        |> follow_redirect(conn, Routes.user_edit_path(conn, :edit, user))
+
+      form_live
+      |> element("#user-form")
+      |> render_change(%{"user" => %{"role" => "superuser"}})
+
+      refute(
+        form_live
+        |> has_element?("input[name=\"user[scheduled_deletion]\"]")
+      )
+    end
+
+    test "does not show `Scheduled Deletion` field when editing superuser", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
+
+      {:ok, form_live, _} =
+        index_live
+        |> element("#user-#{user.id} a", "Edit")
+        |> render_click()
+        |> follow_redirect(conn, Routes.user_edit_path(conn, :edit, user))
+
+      refute(
+        form_live
+        |> has_element?("input[name=\"user[scheduled_deletion]\"]")
+      )
+    end
+
+    test "shows `Scheduled Deletion` field when changing to user", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
+
+      {:ok, form_live, _} =
+        index_live
+        |> element("#user-#{user.id} a", "Edit")
+        |> render_click()
+        |> follow_redirect(conn, Routes.user_edit_path(conn, :edit, user))
+
+      form_live
+      |> element("#user-form")
+      |> render_change(%{"user" => %{"role" => "user"}})
+
+      assert(
+        form_live
+        |> has_element?("input[name=\"user[scheduled_deletion]\"]")
+      )
     end
 
     test "allows a superuser to schedule users for deletion in the users list",
@@ -187,7 +269,6 @@ defmodule LightningWeb.UserLiveTest do
     } do
       {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
 
-
       assert(
         index_live
         |> has_element?(
@@ -205,7 +286,7 @@ defmodule LightningWeb.UserLiveTest do
     test "allows superuser to click cancel for closing user deletion modal", %{
       conn: conn
     } do
-      user= user_fixture()
+      user = user_fixture()
 
       {:ok, index_live, html} = live(conn, Routes.user_index_path(conn, :index))
 
@@ -253,10 +334,10 @@ defmodule LightningWeb.UserLiveTest do
       {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
 
       assert index_live
-      |> has_element?(
-        "a#cancel-deletion-#{user.id}.table-action",
-        "Cancel deletion"
-      )
+             |> has_element?(
+               "a#cancel-deletion-#{user.id}.table-action",
+               "Cancel deletion"
+             )
     end
 
     test "allows a superuser to perform delete now action on users", %{

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -21,6 +21,7 @@ defmodule LightningWeb.UserLiveTest do
     first_name: "some updated first_name",
     last_name: "some updated last_name",
     password: "some updated password",
+    role: :superuser,
     disabled: true
   }
   @invalid_attrs %{email: nil, first_name: nil, last_name: nil, password: nil}
@@ -105,7 +106,9 @@ defmodule LightningWeb.UserLiveTest do
       } = Repo.get_by(User, email: @create_attrs.email)
     end
 
-    test "updates user in listing", %{conn: conn, user: user} do
+    test "updates user in listing", %{conn: conn} do
+      user = user_fixture()
+
       {:ok, index_live, _html} = live(conn, Routes.user_index_path(conn, :index))
 
       {:ok, form_live, _} =


### PR DESCRIPTION
### Description

Allows the a superuer to create other superusers via the Lightning UI. Also includes some changes to the deletion behaviour wrt superusers and removes redundant and broken role validation.

Closes #2719 

### Validation steps

- Confirm that you can create a superuser
- Confirm that the listing page does not provide delete options for a superuser
- Editing should allow you to change a user from normal to 'super-'
- When editing a superuser the `Scheduled deletion` field should not be visible unless you change the role to a normal user.
- If you choose to delete a normal user ('Delete' but not 'Delete now') - the Scheduled Deletion value should be set. If you then edit the user and change it to a superuser, the Scheduled Deletion value should be cleared.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
