### PR TITLE
Quick AI Disclaimer Tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 
 ### Changed
 
+- Adjusted AI Assistant documentation to note that messages may be monitored
+
 ### Fixed
 
 ## [v2.10.7] - 2024-12-13 🎂 ❤️ Happy Birthday, Mom!

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -465,6 +465,9 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
             <li>Proofread and debug your job code</li>
             <li>Help understand why you are seeing an error</li>
           </ul>
+          <p>
+            Messages are saved unencrypted to the OpenFn database and may be monitored for quality control.
+          </p>
           <h2 class="font-bold">
             Usage Tips
           </h2>


### PR DESCRIPTION
### Description

After a phone call with @christad92 and @stuartc, a quick addition to the AI Assistant help text to indicate that sysadmins may be able to view chat history.

I don't think need to do more than this at this stage?

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
