### PR TITLE
AI Assistant: Retry or Cancel Messages with Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Add ability to retry or cancel AI Assistant error responses for user messages
+  [#2704](https://github.com/OpenFn/lightning/issues/2704)
+
 ### Changed
 
 ### Fixed
@@ -29,6 +32,8 @@ and this project adheres to
   [#2781](https://github.com/OpenFn/lightning/issues/2781)
 - Allow different rules and action for delete user.
   [#2500](https://github.com/OpenFn/lightning/issues/2500)
+- Handle errors from the AI Assistant more gracefully
+  [#2741](https://github.com/OpenFn/lightning/issues/2741)
 
 ### Changed
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -8,12 +8,12 @@ defmodule Lightning.AiAssistant do
   alias Ecto.Multi
   alias Lightning.Accounts
   alias Lightning.Accounts.User
+  alias Lightning.AiAssistant.ChatMessage
   alias Lightning.AiAssistant.ChatSession
   alias Lightning.ApolloClient
   alias Lightning.Repo
   alias Lightning.Services.UsageLimiter
   alias Lightning.Workflows.Job
-  alias Lightning.AiAssistant.ChatMessage
 
   require Logger
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -260,15 +260,4 @@ defmodule Lightning.AiAssistant do
       {:error, _, changeset, _} -> {:error, changeset}
     end
   end
-
-  def retry_message(session, message_id) do
-    with message when not is_nil(message) <-
-           Enum.find(session.messages, &(&1.id == message_id)),
-         {:ok, session} <- update_message_status(session, message_id, :success) do
-      query(session, message.content)
-    else
-      nil -> {:error, "Message not found"}
-      error -> error
-    end
-  end
 end

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -5,6 +5,7 @@ defmodule Lightning.AiAssistant do
 
   import Ecto.Query
 
+  alias Ecto.Changeset
   alias Ecto.Multi
   alias Lightning.Accounts
   alias Lightning.Accounts.User
@@ -117,7 +118,7 @@ defmodule Lightning.AiAssistant do
   @doc """
   Queries the AI assistant with the given content.
 
-  Returns `{:ok, session}` if the query was successful, otherwise `:error`.
+  Returns `{:ok, session}` if the query was successful, otherwise `{:error, reason}`.
 
   **Example**
 
@@ -128,34 +129,53 @@ defmodule Lightning.AiAssistant do
           {:ok, ChatSession.t()}
           | {:error, String.t() | Ecto.Changeset.t()}
   def query(session, content) do
-    apollo_resp =
-      ApolloClient.query(
-        content,
-        %{expression: session.expression, adaptor: session.adaptor},
-        build_history(session)
-      )
+    ApolloClient.query(
+      content,
+      %{expression: session.expression, adaptor: session.adaptor},
+      build_history(session)
+    )
+    |> handle_apollo_resp(session)
+  end
 
-    case apollo_resp do
-      {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
-        message = body["history"] |> Enum.reverse() |> hd()
+  defp handle_apollo_resp(
+         {:ok, %Tesla.Env{status: status, body: %{"history" => history}}},
+         session
+       )
+       when status in 200..299 do
+    case List.last(history) do
+      nil ->
+        {:error, "No message history received"}
+
+      message ->
         save_message(session, message)
-
-      {:ok, %Tesla.Env{body: %{"message" => message}}} ->
-        {:error, message}
-
-      {:error, :timeout} ->
-        {:error, "Request timed out. Please try again."}
-
-      {:error, :econnrefused} ->
-        {:error, "Unable to reach the AI server. Please try again later."}
-
-      unexpected_error ->
-        Logger.warning(
-          "Received an unexpected error: #{inspect(unexpected_error)}"
-        )
-
-        {:error, "Oops! Something went wrong. Please try again."}
     end
+  end
+
+  defp handle_apollo_resp(
+         {:ok, %Tesla.Env{status: status, body: %{"message" => error_message}}},
+         session
+       )
+       when status not in 200..299 do
+    Logger.error("AI query failed for session #{session.id}: #{error_message}")
+    {:error, error_message}
+  end
+
+  defp handle_apollo_resp({:error, :timeout}, session) do
+    Logger.error("AI query timed out for session #{session.id}")
+    {:error, "Request timed out. Please try again."}
+  end
+
+  defp handle_apollo_resp({:error, :econnrefused}, session) do
+    Logger.error("Connection to AI server refused for session #{session.id}")
+    {:error, "Unable to reach the AI server. Please try again later."}
+  end
+
+  defp handle_apollo_resp(unexpected_error, session) do
+    Logger.error(
+      "Received an unexpected error for session #{session.id}: #{inspect(unexpected_error)}"
+    )
+
+    {:error, "Oops! Something went wrong. Please try again."}
   end
 
   defp build_history(session) do
@@ -246,17 +266,25 @@ defmodule Lightning.AiAssistant do
 
   defp maybe_increment_msgs_counter(_user_role), do: Multi.new()
 
-  def update_message_status(session, message_id, status) do
-    message = Enum.find(session.messages, &(&1.id == message_id))
+  @doc """
+  Updates the status of a specific message within a chat session.
 
+  Returns `{:ok, session}` if the update is successful, otherwise `{:error, changeset}`.
+  """
+  @spec update_message_status(ChatSession.t(), ChatMessage.t(), atom()) ::
+          {:ok, ChatSession.t()} | {:error, Changeset.t()}
+  def update_message_status(session, message, status) do
     Multi.new()
-    |> Multi.update(:message, ChatMessage.changeset(message, %{status: status}))
+    |> Multi.update(
+      :message,
+      ChatMessage.changeset(message, %{status: status})
+    )
     |> Multi.run(:session, fn _repo, _changes ->
       {:ok, get_session!(session.id)}
     end)
     |> Repo.transaction()
     |> case do
-      {:ok, %{session: session}} -> {:ok, session}
+      {:ok, %{session: updated_session}} -> {:ok, updated_session}
       {:error, _, changeset, _} -> {:error, changeset}
     end
   end

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -274,18 +274,9 @@ defmodule Lightning.AiAssistant do
   @spec update_message_status(ChatSession.t(), ChatMessage.t(), atom()) ::
           {:ok, ChatSession.t()} | {:error, Changeset.t()}
   def update_message_status(session, message, status) do
-    Multi.new()
-    |> Multi.update(
-      :message,
-      ChatMessage.changeset(message, %{status: status})
-    )
-    |> Multi.run(:session, fn _repo, _changes ->
-      {:ok, get_session!(session.id)}
-    end)
-    |> Repo.transaction()
-    |> case do
-      {:ok, %{session: updated_session}} -> {:ok, updated_session}
-      {:error, _, changeset, _} -> {:error, changeset}
+    case Repo.update(ChatMessage.changeset(message, %{status: status})) do
+      {:ok, _updated_message} -> {:ok, get_session!(session.id)}
+      {:error, changeset} -> {:error, changeset}
     end
   end
 end

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -45,15 +45,15 @@ defmodule Lightning.AiAssistant do
 
   @spec get_session!(Ecto.UUID.t()) :: ChatSession.t()
   def get_session!(id) do
+    message_query =
+      from(m in ChatMessage,
+        where: m.status != :cancelled,
+        order_by: [asc: :inserted_at]
+      )
+
     ChatSession
     |> Repo.get!(id)
-    |> Repo.preload(
-      messages:
-        {from(m in ChatMessage,
-           where: m.status != :cancelled,
-           order_by: [asc: :inserted_at]
-         ), :user}
-    )
+    |> Repo.preload(messages: {message_query, :user})
   end
 
   @spec create_session(Job.t(), User.t(), String.t()) ::

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -6,10 +6,13 @@ defmodule Lightning.AiAssistant.ChatMessage do
   import Lightning.Validators, only: [validate_required_assoc: 2]
 
   @type role() :: :user | :assistant
+  @type status() :: :success | :error | :cancelled
+
   @type t() :: %__MODULE__{
           id: Ecto.UUID.t(),
           content: String.t() | nil,
           role: role(),
+          status: status(),
           is_deleted: boolean(),
           is_public: boolean()
         }
@@ -17,6 +20,11 @@ defmodule Lightning.AiAssistant.ChatMessage do
   schema "ai_chat_messages" do
     field :content, :string
     field :role, Ecto.Enum, values: [:user, :assistant]
+
+    field :status, Ecto.Enum,
+      values: [:success, :error, :cancelled],
+      default: :success
+
     field :is_deleted, :boolean, default: false
     field :is_public, :boolean, default: true
 
@@ -31,6 +39,7 @@ defmodule Lightning.AiAssistant.ChatMessage do
     |> cast(attrs, [
       :content,
       :role,
+      :status,
       :is_deleted,
       :is_public,
       :chat_session_id

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -786,7 +786,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
                 <.icon name="hero-arrow-path-mini" class="h-4 w-4" />
               </button>
               <button
-                :if={display_cancel_message_btn(@session)}
+                :if={display_cancel_message_btn?(@session)}
                 id={"cancel-message-#{message.id}"}
                 phx-click="cancel_message"
                 phx-value-message-id={message.id}
@@ -956,7 +956,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
     end
   end
 
-  defp display_cancel_message_btn(session) do
+  defp display_cancel_message_btn?(session) do
     user_messages = Enum.filter(session.messages, &(&1.role == :user))
     length(user_messages) > 1
   end

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -825,7 +825,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
                 <.icon name="hero-arrow-path-mini" class="h-4 w-4" />
               </button>
               <button
-                :if={length(@session.messages) > 1}
+                :if={display_cancel_message_btn(@session)}
                 id={"cancel-message-#{message.id}"}
                 phx-click="cancel_message"
                 phx-value-message-id={message.id}
@@ -993,5 +993,10 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
     else
       title
     end
+  end
+
+  defp display_cancel_message_btn(session) do
+    user_messages = Enum.filter(session.messages, &(&1.role == :user))
+    length(user_messages) > 1
   end
 end

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -131,11 +131,12 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
   def handle_event("retry_message", %{"message-id" => message_id}, socket) do
     message = Enum.find(socket.assigns.session.messages, &(&1.id == message_id))
 
-    case AiAssistant.update_message_status(
-           socket.assigns.session,
-           message_id,
-           :success
-         ) do
+    AiAssistant.update_message_status(
+      socket.assigns.session,
+      message_id,
+      :success
+    )
+    |> case do
       {:ok, session} ->
         {:noreply,
          socket
@@ -782,7 +783,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
             class="flex flex-row-reverse items-end gap-x-3 mr-3"
           >
             <.user_avatar user={message.user} size_class="min-w-10 h-10 w-10" />
-            <div class="bg-blue-300 bg-opacity-50 p-2 mb-0.5 rounded-lg break-words max-w-[80%]">
+            <div class="bg-blue-300 bg-opacity-50 p-2 mb-0.5 rounded-lg break-words max-w-[70%]">
               <%= message.content %>
             </div>
             <div
@@ -794,22 +795,23 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
                 phx-click="retry_message"
                 phx-value-message-id={message.id}
                 phx-target={@target}
-                class="text-indigo-600 hover:text-indigo-800"
+                class="flex items-center justify-center w-5 h-5 rounded-full bg-gray-100 text-gray-400 hover:bg-gray-200 hover:text-gray-600 transition duration-200"
                 phx-hook="Tooltip"
                 aria-label="Retry this message"
               >
                 <.icon name="hero-arrow-path-mini" class="h-4 w-4" />
               </button>
               <button
+                :if={length(@session.messages) > 1}
                 id={"cancel-message-#{message.id}"}
                 phx-click="cancel_message"
                 phx-value-message-id={message.id}
                 phx-target={@target}
-                class="text-gray-400 hover:text-gray-600"
+                class="flex items-center justify-center w-5 h-5 rounded-full bg-gray-100 text-gray-400 hover:bg-gray-200 hover:text-gray-600 transition duration-200"
                 phx-hook="Tooltip"
                 aria-label="Cancel this message"
               >
-                <.icon name="hero-x-mark-mini" class="h-4 w-4" />
+                <.icon name="hero-x-mark" class="h-4 w-4" />
               </button>
             </div>
           </div>

--- a/priv/repo/migrations/20241210004733_add_status_to_chat_messages.exs
+++ b/priv/repo/migrations/20241210004733_add_status_to_chat_messages.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddStatusToChatMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ai_chat_messages) do
+      add :status, :string, default: "success", null: false
+    end
+  end
+end

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2910,6 +2910,129 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       refute has_element?(view, "#assistant-failed-message")
     end
+
+    @tag email: "user@openfn.org"
+    test "cancel buttons are available until only one message remains", %{
+      conn: conn,
+      project: project,
+      user: user,
+      workflow: %{jobs: [job_1 | _]} = workflow
+    } do
+      apollo_endpoint = "http://localhost:4001"
+
+      Mox.stub(Lightning.MockConfig, :apollo, fn
+        :endpoint -> apollo_endpoint
+        :openai_api_key -> "openai_api_key"
+      end)
+
+      Mox.stub(Lightning.Tesla.Mock, :call, fn
+        %{method: :get, url: ^apollo_endpoint <> "/"}, _opts ->
+          {:ok, %Tesla.Env{status: 200}}
+      end)
+
+      session =
+        insert(:chat_session,
+          user: user,
+          job: job_1,
+          messages: [
+            %{role: :user, content: "First message", status: :error, user: user},
+            %{role: :assistant, content: "First response"},
+            %{
+              role: :user,
+              content: "Second message",
+              status: :error,
+              user: user
+            },
+            %{role: :assistant, content: "Second response"},
+            %{role: :user, content: "Third message", status: :error, user: user}
+          ]
+        )
+
+      timestamp = DateTime.utc_now() |> DateTime.to_unix()
+
+      Ecto.Changeset.change(user, %{
+        preferences: %{"ai_assistant.disclaimer_read_at" => timestamp}
+      })
+      |> Lightning.Repo.update!()
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version, s: job_1.id, m: "expand", chat: session.id]}"
+        )
+
+      render_async(view)
+
+      failed_messages = Enum.filter(session.messages, &(&1.status == :error))
+
+      # Initially, all failed messages should have both retry and cancel buttons
+      Enum.each(failed_messages, fn message ->
+        assert has_element?(view, "#retry-message-#{message.id}")
+        assert has_element?(view, "#cancel-message-#{message.id}")
+      end)
+
+      # Cancel messages one by one until only one remains
+      Enum.take(failed_messages, length(failed_messages) - 1)
+      |> Enum.each(fn message ->
+        view
+        |> element("#cancel-message-#{message.id}")
+        |> render_click()
+
+        refute has_element?(view, "#retry-message-#{message.id}")
+        refute has_element?(view, "#cancel-message-#{message.id}")
+
+        updated_session = Lightning.AiAssistant.get_session!(session.id)
+
+        refute Enum.any?(updated_session.messages, &(&1.id == message.id))
+      end)
+
+      # After cancelling all messages except one, get the current session state
+      updated_session = Lightning.AiAssistant.get_session!(session.id)
+
+      # Verify total remaining messages
+      user_messages = Enum.filter(updated_session.messages, &(&1.role == :user))
+      assert length(user_messages) == 1
+
+      # Get the remaining failed message
+      current_failed_messages =
+        Enum.filter(updated_session.messages, &(&1.status == :error))
+
+      assert length(current_failed_messages) == 1
+
+      last_remaining_message = List.first(user_messages)
+
+      assert has_element?(view, "#retry-message-#{last_remaining_message.id}")
+      refute has_element?(view, "#cancel-message-#{last_remaining_message.id}")
+
+      # Compare with single message session behavior
+      single_message_session =
+        insert(:chat_session,
+          user: user,
+          job: job_1,
+          messages: [
+            %{role: :user, content: "Hello", status: :error, user: user}
+          ]
+        )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}?#{[v: workflow.lock_version, s: job_1.id, m: "expand", chat: single_message_session.id]}"
+        )
+
+      render_async(view)
+
+      # Verify single message session only shows retry button
+      assert has_element?(
+               view,
+               "#retry-message-#{List.first(single_message_session.messages).id}"
+             )
+
+      refute has_element?(
+               view,
+               "#cancel-message-#{List.first(single_message_session.messages).id}"
+             )
+    end
   end
 
   describe "Allow low priority access users to retry steps and create workorders" do


### PR DESCRIPTION
### Description

This PR introduces the retry and cancel functionality for messages in the AI assistant. Users can now retry or cancel a failed message, ensuring better control and allowing to clean up the chat logs.

The retry feature updates a message's status to `:success` and uses its content to perform a new query with the AI Assistant. This allows users to address transient issues or reattempt queries after resolving any underlying problems. The cancel feature allows users to mark a message as `:cancelled`, immediately removing it from the chat logs.

Closes #2704 

### Validation steps

1. Set an invalid API key for the AI assistant in your env variables
2. Start a conversation with the AI assistant
3. Because your API key is invalid, you will receive an error message from Apollo
4. Notice next to the message you sent (left side of the message bubble) the presence of a `retry`button / icon
5. Click on it to see your message being retried
6. Keep generating more messages with errors
7. See that the following messages with errors have also the option to cancel them (`cancel`button / icon next to the `retry`button / icon)
8. Notice that you can cancel messages up until only one left in the chat session. You wont be able to cancel that one. This is guard we implemented to avoid empty chat sessions.

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
