### PR TITLE
Use workflow activation limiter on index toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
 - Delete user modal no longer uses the same id as the underlying user record.
   [#2751](https://github.com/OpenFn/lightning/issues/2751)
 
+- Use workflow activation limiter on index toggle.
+  [#2777](https://github.com/OpenFn/lightning/issues/2777)
+
 ## [v2.10.6] - 2024-12-10
 
 ### Added

--- a/lib/lightning/workflows/workflow_usage_limiter.ex
+++ b/lib/lightning/workflows/workflow_usage_limiter.ex
@@ -35,10 +35,9 @@ defmodule Lightning.Workflows.WorkflowUsageLimiter do
     end
   end
 
-  @spec limit_workflow_creation(project :: Project.t()) ::
-          :ok | UsageLimiting.error()
-  def limit_workflow_creation(project) do
-    %Workflow{project_id: project.id}
+  @spec limit_workflow_creation(Ecto.UUID.t()) :: :ok | UsageLimiting.error()
+  def limit_workflow_creation(project_id) do
+    %Workflow{project_id: project_id}
     |> Workflow.changeset(%{triggers: [%{enabled: true}]})
     |> limit_workflow_activation()
   end

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -6,7 +6,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
 
   alias Lightning.DashboardStats.ProjectMetrics
   alias Lightning.Projects.Project
-  alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrders.SearchParams
   alias LightningWeb.WorkflowLive.Helpers
   alias Timex.Format.DateTime.Formatters.Relative
@@ -22,7 +21,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           </span>
         </h3>
         <.create_workflow_card
-          limit_error={limit_workflow_creation_error(@project)}
+          limit_error={@workflow_creation_limit_error}
           can_create_workflow={@can_create_workflow}
         />
       </div>
@@ -255,16 +254,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
       </.button>
     </div>
     """
-  end
-
-  defp limit_workflow_creation_error(project) do
-    case WorkflowUsageLimiter.limit_workflow_creation(project) do
-      :ok ->
-        nil
-
-      {:error, _reason, %{text: error_msg}} ->
-        error_msg
-    end
   end
 
   attr :metrics, ProjectMetrics, required: true

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -22,7 +22,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           </span>
         </h3>
         <.create_workflow_card
-          project={@project}
+          limit_error={limit_workflow_creation_error(@project)}
           can_create_workflow={@can_create_workflow}
         />
       </div>
@@ -229,18 +229,16 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
   end
 
   attr :can_create_workflow, :boolean, required: true
-  attr :project, :map, required: true
+  attr :limit_error, :string
 
   def create_workflow_card(assigns) do
-    limit_error = limit_workflow_creation_error(assigns.project)
-
     assigns =
       assigns
       |> assign_new(:disabled, fn ->
-        !assigns.can_create_workflow || is_binary(limit_error)
+        !assigns.can_create_workflow || assigns.limit_error
       end)
       |> assign_new(:tooltip, fn ->
-        limit_error || "You are not authorized to perform this action."
+        assigns.limit_error || "You are not authorized to perform this action."
       end)
 
     ~H"""

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -234,7 +234,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     assigns =
       assigns
       |> assign_new(:disabled, fn ->
-        !assigns.can_create_workflow || assigns.limit_error
+        !assigns.can_create_workflow or is_binary(assigns.limit_error)
       end)
       |> assign_new(:tooltip, fn ->
         assigns.limit_error || "You are not authorized to perform this action."

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -210,8 +210,8 @@ defmodule LightningWeb.WorkflowLive.Index do
     |> LiveHelpers.check_limits(project_id)
   end
 
-  defp limit_workflow_creation_error(project) do
-    case WorkflowUsageLimiter.limit_workflow_creation(project) do
+  defp limit_workflow_creation_error(project_id) do
+    case WorkflowUsageLimiter.limit_workflow_creation(project_id) do
       :ok ->
         nil
 

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -10,6 +10,7 @@ defmodule LightningWeb.WorkflowLive.Index do
   alias Lightning.Workflows
   alias LightningWeb.LiveHelpers
   alias LightningWeb.WorkflowLive.DashboardComponents
+  alias LightningWeb.WorkflowLive.Helpers
   alias LightningWeb.WorkflowLive.NewWorkflowForm
 
   alias Phoenix.LiveView.TagEngine
@@ -122,10 +123,10 @@ defmodule LightningWeb.WorkflowLive.Index do
       ) do
     %{current_user: actor, project: project_id} = socket.assigns
 
-    workflow = Workflows.get_workflow!(workflow_id, include: [:triggers])
-
-    Workflows.update_triggers_enabled_state(workflow, state)
-    |> Workflows.save_workflow(actor)
+    workflow_id
+    |> Workflows.get_workflow!(include: [:triggers])
+    |> Workflows.update_triggers_enabled_state(state)
+    |> Helpers.save_workflow(actor)
     |> case do
       {:ok, _workflow} ->
         {:noreply,

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -8,6 +8,7 @@ defmodule LightningWeb.WorkflowLive.Index do
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.ProjectUsers
   alias Lightning.Workflows
+  alias Lightning.Workflows.WorkflowUsageLimiter
   alias LightningWeb.LiveHelpers
   alias LightningWeb.WorkflowLive.DashboardComponents
   alias LightningWeb.WorkflowLive.Helpers
@@ -29,8 +30,7 @@ defmodule LightningWeb.WorkflowLive.Index do
 
   @impl true
   def render(%{project: %{id: project_id}} = assigns) do
-    assigns =
-      LiveHelpers.check_limits(assigns, project_id)
+    assigns = check_workflow_and_run_limits(assigns, project_id)
 
     ~H"""
     <LayoutComponents.page_content>
@@ -55,6 +55,7 @@ defmodule LightningWeb.WorkflowLive.Index do
           period={@dashboard_period}
           can_create_workflow={@can_create_workflow}
           can_delete_workflow={@can_delete_workflow}
+          workflow_creation_limit_error={@workflow_creation_limit_error}
           workflows_stats={@workflows_stats}
           project={@project}
         />
@@ -199,5 +200,23 @@ defmodule LightningWeb.WorkflowLive.Index do
 
   defp assign_workflow_form(socket, changeset) do
     socket |> assign(form: to_form(changeset, as: :new_workflow))
+  end
+
+  defp check_workflow_and_run_limits(assigns, project_id) do
+    assigns
+    |> assign(
+      workflow_creation_limit_error: limit_workflow_creation_error(project_id)
+    )
+    |> LiveHelpers.check_limits(project_id)
+  end
+
+  defp limit_workflow_creation_error(project) do
+    case WorkflowUsageLimiter.limit_workflow_creation(project) do
+      :ok ->
+        nil
+
+      {:error, _reason, %{text: error_msg}} ->
+        error_msg
+    end
   end
 end


### PR DESCRIPTION
### Description

This PR fixes the workflow usage limiting when using the a toggle on the workflows index/list.

It also propagates the limit error change/assigns so that the create button is disabled without a page refresh.

Closes #2778 

### Validation steps

1. On the billing app using this branch, go to the workflows list of a free subscription
2. Deactivate the existing workflow(s)
3. Create a new one and activate it
4. Try to activate another one on the workflows list

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
