### PR TITLE
AI Assistant: Clear Chat Input After Sending Message 🧹 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Clear AI assistant's chat input after a message is sent 
+  [#2781](https://github.com/OpenFn/lightning/issues/2781)
 - Allow different rules and action for delete user.
   [#2500](https://github.com/OpenFn/lightning/issues/2500)
 

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -89,13 +89,15 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
   def handle_event("send_message", %{"content" => content}, socket) do
     if socket.assigns.can_edit_workflow do
       %{action: action} = socket.assigns
-      # clear error
+
       socket
       |> assign(error_message: nil)
       |> check_limit()
       |> then(fn socket ->
         if socket.assigns.ai_limit_result == :ok do
-          {:noreply, save_message(socket, action, content)}
+          {:noreply,
+           save_message(socket, action, content)
+           |> assign(:form, to_form(%{"content" => nil}))}
         else
           {:noreply, socket}
         end


### PR DESCRIPTION
### Description

This PR ensures that the input field in the AI Assistant form is cleared after a message is successfully sent.

Closes #2781 

### Validation steps

1. Open the AI Assistant chat
2. Type your message in the input and send it
3. See that the message is cleared in the input

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
