### PR TITLE
Limit AI Usage

### DIFF
--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -137,7 +137,7 @@ defmodule Lightning.AiAssistant do
   end
 
   defp handle_apollo_resp(
-         {:ok, %Tesla.Env{status: status, body: %{"history" => history}}},
+         {:ok, %Tesla.Env{status: status, body: body}},
          session
        )
        when status in 200..299 do
@@ -146,10 +146,11 @@ defmodule Lightning.AiAssistant do
   end
 
   defp handle_apollo_resp(
-         {:ok, %Tesla.Env{status: status, body: %{"message" => error_message}}},
+         {:ok, %Tesla.Env{status: status, body: body}},
          session
        )
        when status not in 200..299 do
+    error_message = body["message"]
     Logger.error("AI query failed for session #{session.id}: #{error_message}")
     {:error, error_message}
   end

--- a/lib/lightning/ai_assistant/limiter.ex
+++ b/lib/lightning/ai_assistant/limiter.ex
@@ -13,7 +13,7 @@ defmodule Lightning.AiAssistant.Limiter do
   """
   @spec validate_quota(Ecto.UUID.t()) :: :ok | UsageLimiting.error()
   def validate_quota(project_id) do
-    UsageLimiter.limit_action(%Action{type: :ai_query}, %Context{
+    UsageLimiter.limit_action(%Action{type: :ai_usage}, %Context{
       project_id: project_id
     })
   end

--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -11,7 +11,7 @@ defmodule Lightning.Extensions.UsageLimiter do
   def limit_action(_action, _context), do: :ok
 
   @impl true
-  def increment_ai_queries(_session), do: Ecto.Multi.new()
+  def increment_ai_usage(_session, _message), do: Ecto.Multi.new()
 
   @impl true
   def get_run_options(context) do

--- a/lib/lightning/extensions/usage_limiter.ex
+++ b/lib/lightning/extensions/usage_limiter.ex
@@ -11,7 +11,7 @@ defmodule Lightning.Extensions.UsageLimiter do
   def limit_action(_action, _context), do: :ok
 
   @impl true
-  def increment_ai_usage(_session, _message), do: Ecto.Multi.new()
+  def increment_ai_usage(_session, _usage), do: Ecto.Multi.new()
 
   @impl true
   def get_run_options(context) do

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -16,7 +16,7 @@ defmodule Lightning.Extensions.UsageLimiting do
             type:
               :new_run
               | :activate_workflow
-              | :ai_query
+              | :ai_usage
               | :alert_failure
               | :github_sync
               | :new_user

--- a/lib/lightning/extensions/usage_limiting.ex
+++ b/lib/lightning/extensions/usage_limiting.ex
@@ -72,7 +72,7 @@ defmodule Lightning.Extensions.UsageLimiting do
 
     - An Ecto.Multi struct representing the transaction to increment AI queries.
   """
-  @callback increment_ai_queries(Lightning.AiAssistant.ChatSession.t()) ::
+  @callback increment_ai_usage(Lightning.AiAssistant.ChatSession.t(), map()) ::
               Ecto.Multi.t()
 
   @doc """

--- a/lib/lightning/services/usage_limiter.ex
+++ b/lib/lightning/services/usage_limiter.ex
@@ -17,8 +17,8 @@ defmodule Lightning.Services.UsageLimiter do
   end
 
   @impl true
-  def increment_ai_usage(session, message) do
-    adapter().increment_ai_usage(session, message)
+  def increment_ai_usage(session, usage) do
+    adapter().increment_ai_usage(session, usage)
   end
 
   @impl true

--- a/lib/lightning/services/usage_limiter.ex
+++ b/lib/lightning/services/usage_limiter.ex
@@ -17,8 +17,8 @@ defmodule Lightning.Services.UsageLimiter do
   end
 
   @impl true
-  def increment_ai_queries(session) do
-    adapter().increment_ai_queries(session)
+  def increment_ai_usage(session, message) do
+    adapter().increment_ai_usage(session, message)
   end
 
   @impl true

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -945,8 +945,7 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
   defp maybe_check_limit(socket), do: socket
 
   defp check_limit(socket) do
-    %{project_id: project_id} = socket.assigns
-    limit = Limiter.validate_quota(project_id)
+    limit = Limiter.validate_quota(socket.assigns.project_id)
     error_message = if limit != :ok, do: error_message(limit)
     assign(socket, ai_limit_result: limit, error_message: error_message)
   end

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -945,7 +945,8 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
   defp maybe_check_limit(socket), do: socket
 
   defp check_limit(socket) do
-    limit = Limiter.validate_quota(socket.assigns.project_id)
+    %{project_id: project_id} = socket.assigns
+    limit = Limiter.validate_quota(project_id)
     error_message = if limit != :ok, do: error_message(limit)
     assign(socket, ai_limit_result: limit, error_message: error_message)
   end

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -110,39 +110,6 @@ defmodule Lightning.AiAssistantTest do
 
       assert Lightning.Repo.reload!(saved_message)
     end
-
-    test "handles empty history in response", %{
-      user: user,
-      workflow: %{jobs: [job_1 | _]}
-    } do
-      session =
-        insert(:chat_session,
-          user: user,
-          job: job_1,
-          messages: [%{role: :user, content: "what?", user: user}]
-        )
-
-      Mox.stub(Lightning.MockConfig, :apollo, fn key ->
-        case key do
-          :endpoint -> "http://localhost:3000"
-          :openai_api_key -> "api_key"
-        end
-      end)
-
-      empty_history_reply =
-        Jason.encode!(%{
-          "response" => "Some response",
-          "history" => []
-        })
-
-      expect(Lightning.Tesla.Mock, :call, fn %{method: :post, url: url}, _opts ->
-        assert url =~ "/services/job_chat"
-        {:ok, %Tesla.Env{status: 200, body: Jason.decode!(empty_history_reply)}}
-      end)
-
-      assert {:error, "No message history received"} =
-               AiAssistant.query(session, "foo")
-    end
   end
 
   describe "list_sessions_for_job/1" do

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -253,7 +253,7 @@ defmodule Lightning.AiAssistantTest do
         Lightning.Extensions.MockUsageLimiter,
         :increment_ai_usage,
         1,
-        fn %{job_id: ^job_id}, _message -> Ecto.Multi.new() end
+        fn %{job_id: ^job_id}, _usage -> Ecto.Multi.new() end
       )
 
       content1 = """
@@ -277,7 +277,7 @@ defmodule Lightning.AiAssistantTest do
         Lightning.Extensions.MockUsageLimiter,
         :increment_ai_usage,
         0,
-        fn %{job_id: ^job_id}, _message -> Ecto.Multi.new() end
+        fn %{job_id: ^job_id}, _usage -> Ecto.Multi.new() end
       )
 
       AiAssistant.save_message(session, %{

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -251,9 +251,9 @@ defmodule Lightning.AiAssistantTest do
 
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
-        :increment_ai_queries,
+        :increment_ai_usage,
         1,
-        fn %{job_id: ^job_id} -> Ecto.Multi.new() end
+        fn %{job_id: ^job_id}, _message -> Ecto.Multi.new() end
       )
 
       content1 = """
@@ -275,9 +275,9 @@ defmodule Lightning.AiAssistantTest do
 
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
-        :increment_ai_queries,
+        :increment_ai_usage,
         0,
-        fn %{job_id: ^job_id} -> Ecto.Multi.new() end
+        fn %{job_id: ^job_id}, _message -> Ecto.Multi.new() end
       )
 
       AiAssistant.save_message(session, %{

--- a/test/lightning/ai_assistant/limiter_test.exs
+++ b/test/lightning/ai_assistant/limiter_test.exs
@@ -13,7 +13,7 @@ defmodule Lightning.AiAssistant.LimiterTest do
 
       stub(Lightning.Extensions.MockUsageLimiter, :limit_action, fn %{
                                                                       type:
-                                                                        :ai_query
+                                                                        :ai_usage
                                                                     },
                                                                     %{
                                                                       project_id:
@@ -34,7 +34,7 @@ defmodule Lightning.AiAssistant.LimiterTest do
 
       stub(Lightning.Extensions.MockUsageLimiter, :limit_action, fn %{
                                                                       type:
-                                                                        :ai_query
+                                                                        :ai_usage
                                                                     },
                                                                     %{
                                                                       project_id:

--- a/test/lightning/extensions/usage_limiter_test.exs
+++ b/test/lightning/extensions/usage_limiter_test.exs
@@ -33,10 +33,10 @@ defmodule Lightning.Extensions.UsageLimiterTest do
     end
   end
 
-  describe "increment_ai_queries/2" do
+  describe "increment_ai_usage/2" do
     test "returns no change" do
       assert Ecto.Multi.new() ==
-               UsageLimiter.increment_ai_queries(build(:chat_session))
+               UsageLimiter.increment_ai_usage(build(:chat_session), %{})
     end
   end
 end

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2423,7 +2423,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       Mox.stub(Lightning.Extensions.MockUsageLimiter, :limit_action, fn %{
                                                                           type:
-                                                                            :ai_query
+                                                                            :ai_usage
                                                                         },
                                                                         %{
                                                                           project_id:

--- a/test/support/stub_usage_limiter.ex
+++ b/test/support/stub_usage_limiter.ex
@@ -33,7 +33,7 @@ defmodule Lightning.Extensions.StubUsageLimiter do
   end
 
   @impl true
-  def increment_ai_queries(multi), do: multi
+  def increment_ai_usage(session, _message), do: session
 
   @impl true
   def get_run_options(_context),

--- a/test/support/stub_usage_limiter.ex
+++ b/test/support/stub_usage_limiter.ex
@@ -33,7 +33,7 @@ defmodule Lightning.Extensions.StubUsageLimiter do
   end
 
   @impl true
-  def increment_ai_usage(session, _message), do: session
+  def increment_ai_usage(session, _usage), do: session
 
   @impl true
   def get_run_options(_context),


### PR DESCRIPTION
### Description

This PR updates the AI usage limiter to use the usage data sent by Apollo. This allows to extend the limiter beyond just counting number of messages in the chat, but include data like number of sent and received tokens.

### Validation steps

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
