### PR TITLE
Show credential owner on project settings credentials page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Show email address of credential owner on project credentials page
+  [#2210](https://github.com/OpenFn/lightning/issues/2210)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -357,6 +357,7 @@ defmodule LightningWeb.Components.Credentials do
   attr :credentials, :list, required: true
   attr :title, :string, required: true
   attr :display_table_title, :boolean, default: true
+  attr :show_owner, :boolean, default: false
 
   slot :actions,
     doc: "the slot for showing user actions in the last table column"
@@ -376,8 +377,9 @@ defmodule LightningWeb.Components.Credentials do
         <.table id={"#{@id}-table"}>
           <.tr>
             <.th>Name</.th>
+            <.th :if={@show_owner}>Type</.th>
+            <.th>Owner</.th>
             <.th>Projects with access</.th>
-            <.th>Type</.th>
             <.th>Production</.th>
             <.th>
               <span class="sr-only">Actions</span>
@@ -404,15 +406,20 @@ defmodule LightningWeb.Components.Credentials do
                 <% end %>
               </div>
             </.td>
+            <.td class="break-words max-w-[10rem] border-">
+              <%= credential.schema %>
+            </.td>
+            <.td :if={@show_owner} class="break-words max-w-[15rem]">
+              <div class="flex-auto items-center">
+                <%= credential.user.email %>
+              </div>
+            </.td>
             <.td class="break-words max-w-[25rem]">
               <%= for project_name <- credential.project_names do %>
                 <span class="inline-flex items-center rounded-md bg-primary-50 p-1 my-0.5 text-xs font-medium ring-1 ring-inset ring-gray-500/10">
                   <%= project_name %>
                 </span>
               <% end %>
-            </.td>
-            <.td class="break-words max-w-[10rem] border-">
-              <%= credential.schema %>
             </.td>
             <.td class="break-words max-w-[5rem]">
               <%= if credential.production do %>

--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -377,8 +377,8 @@ defmodule LightningWeb.Components.Credentials do
         <.table id={"#{@id}-table"}>
           <.tr>
             <.th>Name</.th>
-            <.th :if={@show_owner}>Type</.th>
-            <.th>Owner</.th>
+            <.th>Type</.th>
+            <.th :if={@show_owner}>Owner</.th>
             <.th>Projects with access</.th>
             <.th>Production</.th>
             <.th>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -287,6 +287,7 @@
           id="credentials"
           title="Credentials"
           credentials={@credentials}
+          show_owner={true}
         >
           <:empty_state>
             <button


### PR DESCRIPTION
This PR fixes #2210 

<img width="767" alt="image" src="https://github.com/user-attachments/assets/e7cad235-6e54-4c6c-a4b3-dacaebfc8697" />

### Validation steps

1. click project settings
2. click credentials
3. note credential owner email address
4. click username
5. click credentials
6. note that owner email address does _not_ show up on that table, these are _all_ owned by the current user

### Additional notes for the reviewer

1. I've changed the order of the columns... `type` feels more important and should be farther left

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
