### PR TITLE
Fix `z-index` on unsaved workflow dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- `z-index` broken on unsaved dot on workflow edit page
+  [#2809](https://github.com/OpenFn/lightning/issues/2809)
+
 ## [v2.10.9] - 2025-01-09
 
 ### Added

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2463,7 +2463,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     <div class="relative">
       <div
         :if={@changeset.changes |> Enum.any?()}
-        class="absolute -m-1 rounded-full bg-danger-500 w-3 h-3 top-0 right-0"
+        class="absolute -m-1 rounded-full bg-danger-500 w-3 h-3 top-0 right-0 z-50"
         data-is-dirty="true"
       >
       </div>
@@ -2516,7 +2516,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       )
 
     ~H"""
-    <div class="inline-flex rounded-md shadow-sm">
+    <div class="inline-flex rounded-md shadow-sm z-5">
       <.button
         id={@id}
         phx-disable-with="Saving..."


### PR DESCRIPTION
### Description

This PR makes the unsaved dot appears in front of the save workflow button
<img width="528" alt="Screenshot 2025-01-10 at 18 25 37" src="https://github.com/user-attachments/assets/b71f4706-ef19-45e7-a872-534e8328f5ad" />


Closes #2809 

### Validation steps

1. You'll need to enable github sync for your project. 
2. Modify your workflow. You can rename any of the jobs
3. The red dot now appears in front of the dropdown


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
