### PR TITLE
Fix cosmetic offiine issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ and this project adheres to
 - `z-index` broken on unsaved dot on workflow edit page
   [#2809](https://github.com/OpenFn/lightning/issues/2809)
 - Fixed an issue in the editor where the Loading Types message displays forever
-  while running offline
+  while running offline [#2813](https://github.com/OpenFn/lightning/issues/2813)
+- Fixed an a small layout issue in the Docs panel when loading the editor
+  offline [#2813](https://github.com/OpenFn/lightning/issues/2813)
 
 ## [v2.10.9] - 2025-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 
 - `z-index` broken on unsaved dot on workflow edit page
   [#2809](https://github.com/OpenFn/lightning/issues/2809)
+- Fixed an issue in the editor where the Loading Types message displays forever
+  while running offline
 
 ## [v2.10.9] - 2025-01-09
 

--- a/assets/js/adaptor-docs/components/DocsPanel.tsx
+++ b/assets/js/adaptor-docs/components/DocsPanel.tsx
@@ -31,11 +31,7 @@ const DocsLink = ({ specifier }: { specifier: string }) => {
       </div>
       <div>
         Source code:
-        <a
-          className="link ml-2"
-          href={srcLink}
-          target="_blank"
-        >
+        <a className="link ml-2" href={srcLink} target="_blank">
           github.com/OpenFn/adaptors
         </a>
       </div>
@@ -43,19 +39,26 @@ const DocsLink = ({ specifier }: { specifier: string }) => {
   );
 };
 
-const EditorHelp = () => <details className="mb-4">
-  <summary className='text-sm cursor-pointer'>
-    <h3 className="inline">Editor tips & shortcuts</h3>
-  </summary>
-  <div className="text-sm border-solid border-grey-300 border-l-4 pl-2 mt-2">
-    <p className="mb-2">Most adaptors provide intelligent code suggestions to the editor. Start typing and press TAB or ENTER to accept a suggestion, or ESC to cancel</p>
-    <ul className="list-disc ml-4">
-      <li>Press CTRL+SPACE to show suggestions</li>
-      <li>Press CTRL+SPACE again to toggle suggestion details (recommended!)</li>
-      <li>Press F1 to show the command menu (not all commands will work!)</li>
-    </ul>
-  </div>
-</details>
+const EditorHelp = () => (
+  <details className="mb-4">
+    <summary className="text-sm cursor-pointer">
+      <h3 className="inline">Editor tips & shortcuts</h3>
+    </summary>
+    <div className="text-sm border-solid border-grey-300 border-l-4 pl-2 mt-2">
+      <p className="mb-2">
+        Most adaptors provide intelligent code suggestions to the editor. Start
+        typing and press TAB or ENTER to accept a suggestion, or ESC to cancel
+      </p>
+      <ul className="list-disc ml-4">
+        <li>Press CTRL+SPACE to show suggestions</li>
+        <li>
+          Press CTRL+SPACE again to toggle suggestion details (recommended!)
+        </li>
+        <li>Press F1 to show the command menu (not all commands will work!)</li>
+      </ul>
+    </div>
+  </details>
+);
 
 const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   if (!specifier) {
@@ -65,14 +68,18 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
   const pkg = useDocs(specifier);
 
   if (pkg === null) {
-    return <div className="block m-2">Loading docs...</div>;
+    return (
+      <div className="block w-full overflow-auto ml-1">Loading docs...</div>
+    );
   }
   if (pkg === false) {
     return (
       <>
-        <DocsLink specifier={specifier} />
-        <div className="block m-2">
-          <p>An error occurred loading the docs for this adaptor.</p>
+        <div className="block w-full overflow-auto ml-1 mt-1">
+          <p className="mt-2">
+            An error occurred loading the docs for this adaptor.
+          </p>
+          <DocsLink specifier={specifier} />
         </div>
       </>
     );
@@ -82,12 +89,12 @@ const DocsPanel = ({ specifier, onInsert }: DocsPanelProps) => {
 
   if (functions.length === 0) {
     return (
-      <div className="block m-2">
+      <div className="block w-full overflow-auto ml-1 mt-1">
         <h1 className="h1 text-lg font-bold text-secondary-700 mb-2">
           {name} ({version})
         </h1>
+        <p className="mt-2">Docs are unavailable for this adaptor.</p>
         <DocsLink specifier={specifier} />
-        <p>Docs are unavailable for this adaptor.</p>
       </div>
     );
   }

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -343,10 +343,13 @@ export default function Editor({
     if (adaptor) {
       setLoading(true);
       setLib([]); // instantly clear intelligence
-      loadDTS(adaptor).then(l => {
-        setLib(l);
-        setLoading(false);
-      });
+      loadDTS(adaptor)
+        .then(l => {
+          setLib(l);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
     }
   }, [adaptor]);
 


### PR DESCRIPTION
When loading the Inspector with no internet connection, this PR solves two small cosmetic issues:

1) A "Loading types" spinner runs over the editor forever
2) the Docs panel lays out its content a bit wierdly

Closes #2813

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
