### PR TITLE
Reduce Code Editor Debounce Delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed Save and Run to always execute jobs with latest changes
+  [#2804](https://github.com/OpenFn/lightning/issues/2804)
 - Fixed aggressive CSS rule in app.css that made it hard to style menu items
   [#2807](https://github.com/OpenFn/lightning/pull/2807)
 - `z-index` broken on unsaved dot on workflow edit page

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,18 +1,34 @@
-// this has been added here because we still can't find a better place for it
-// it's being used in both the hooks and the job editor
+// @ts-nocheck
+import pDebounce from 'p-debounce';
+
+export const EDITOR_DEBOUNCE_MS = 300
+
+const debouncedDispatchEvent = pDebounce(
+  (eventTarget, event) => {
+    eventTarget.dispatchEvent(event);
+  },
+  EDITOR_DEBOUNCE_MS
+);
+
 export function initiateSaveAndRun(buttonElement) {
-  if (buttonElement.getAttribute('type') == 'submit') {
+  if (buttonElement.getAttribute('type') === 'submit') {
     const formId = buttonElement.getAttribute('form');
     const form = document.getElementById(formId);
-    form.dispatchEvent(
-      new Event('submit', { bubbles: true, cancelable: true })
-    );
+
+    if (form) {
+      debouncedDispatchEvent(
+        form,
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    }
   } else {
-    buttonElement.dispatchEvent(
+    debouncedDispatchEvent(
+      buttonElement,
       new Event('click', { bubbles: true, cancelable: true })
     );
   }
 }
+
 
 export function randomUUID() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c =>

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -29,7 +29,6 @@ export function initiateSaveAndRun(buttonElement) {
   }
 }
 
-
 export function randomUUID() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c =>
     (c === 'x' ? (Math.random() * 16) | 0 : 'r&0x3' | '0x8').toString(16)

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -42,7 +42,7 @@ type AttributeMutationRecord = MutationRecord & {
 
 let JobEditorComponent: typeof JobEditor | undefined;
 
-const EDITOR_DEBOUNCE_MS = 300;
+const EDITOR_DEBOUNCE_MS = 100;
 
 export default {
   findWorkflowEditorStore() {

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -8,6 +8,7 @@ import pRetry from 'p-retry';
 import pDebounce from 'p-debounce';
 import { WorkflowStore } from '../workflow-editor/store';
 import { Lightning } from '../workflow-diagram/types';
+import { EDITOR_DEBOUNCE_MS } from '../common';
 
 type JobEditorEntrypoint = PhoenixHook<
   {
@@ -41,8 +42,6 @@ type AttributeMutationRecord = MutationRecord & {
 };
 
 let JobEditorComponent: typeof JobEditor | undefined;
-
-const EDITOR_DEBOUNCE_MS = 100;
 
 export default {
   findWorkflowEditorStore() {


### PR DESCRIPTION
### Description

The code editor employs a debounce delay of 300 ms to push code changes back to the server. This delay occasionally caused issues for users leveraging the CTRL+ENTER keybinding. They would type code and immediately run a job, but the delay prevented the server from receiving the latest changes in time, resulting in outdated executions.

I propose introducing the same 300 ms delay to the CTRL+ENTER keybinding as is applied elsewhere. This ensures that when a user runs a job, we allow sufficient time for the code editor to send the latest changes before execution. The delay is centralized in the `common.js` file, ensuring seamless synchronization between the hook and the editor. At 300 ms, the delay is optimized—long enough to guarantee synchronization but short enough to remain imperceptible to the user.

Closes #2804 

### Validation steps

1. Fire up the editor and get ready to type some code.
2. Channel your inner Flash or Taylor and type some code at lightning speed. Immediately hit CTRL+ENTER (or CMD+ENTER on Mac).
3. Observe that your latest changes are both saved and successfully executed without any delays. If you manage to break it, congratulations; you’re faster than Flash! Let me know so we can adjust further.

### Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
