### PR TITLE
fix `z-index` on unsaved dot on the modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix `z-index` for unsaved workflow dot on workflow edit page
+  [#2809](https://github.com/OpenFn/lightning/issues/2809)
+
 ## [v2.10.10] - 2025-01-15
 
 ### Added

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2463,7 +2463,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     <div class="relative">
       <div
         :if={@changeset.changes |> Enum.any?()}
-        class="absolute -m-1 rounded-full bg-danger-500 w-3 h-3 top-0 right-0 z-50"
+        class="absolute -m-1 rounded-full bg-danger-500 w-3 h-3 top-0 right-0 z-10"
         data-is-dirty="true"
       >
       </div>


### PR DESCRIPTION
### Description

This PR fixes the unsaved dot on the workflow edit page. The dot was persisting even on top of the modal.
This PR just reduces the value

Closes #2809 

### Validation steps

https://github.com/user-attachments/assets/2581eedf-3834-4182-97be-d149e1c5bb11



## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
