### PR TITLE
2703 getter setter version control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 
 ### Changed
 
+- Remove snapshot creation when performing the Github sync - no longer needed
+  post-migration.
+  [#2703](https://github.com/OpenFn/lightning/issues/2703)
+
 ### Fixed
 
 ## [v2.10.12] - 2025-01-21

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -145,7 +145,7 @@ defmodule Lightning.VersionControl do
              repo_connection.project_id
            ),
          snapshots <-
-           list_or_create_snapshots_for_project(repo_connection),
+           list_snapshots_for_project(repo_connection),
          {:ok, client} <-
            GithubClient.build_installation_client(
              repo_connection.github_installation_id
@@ -174,7 +174,7 @@ defmodule Lightning.VersionControl do
     end
   end
 
-  defp list_or_create_snapshots_for_project(%{project_id: project_id}) do
+  defp list_snapshots_for_project(%{project_id: project_id}) do
     current_query =
       from w in Workflow,
         join: s in assoc(w, :snapshots),

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -18,7 +18,6 @@ defmodule Lightning.VersionControl do
   alias Lightning.VersionControl.GithubError
   alias Lightning.VersionControl.ProjectRepoConnection
   alias Lightning.VersionControl.VersionControlUsageLimiter
-  alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Workflow
 
   require Logger
@@ -175,28 +174,15 @@ defmodule Lightning.VersionControl do
     end
   end
 
-  defp list_or_create_snapshots_for_project(
-         %{project_id: project_id} = repo_connection
-       ) do
+  defp list_or_create_snapshots_for_project(%{project_id: project_id}) do
     current_query =
       from w in Workflow,
-        left_join: s in assoc(w, :snapshots),
+        join: s in assoc(w, :snapshots),
         on: s.lock_version == w.lock_version,
         where: w.project_id == ^project_id and is_nil(w.deleted_at),
-        select: {w, s.id}
+        select: s.id
 
-    workflows = Repo.all(current_query)
-
-    Enum.reduce(workflows, [], fn {workflow, snapshot_id}, acc ->
-      if is_nil(snapshot_id) do
-        {:ok, snapshot} =
-          Snapshot.get_or_create_latest_for(workflow, repo_connection)
-
-        [snapshot.id | acc]
-      else
-        [snapshot_id | acc]
-      end
-    end)
+    Repo.all(current_query) |> Enum.reverse()
   end
 
   defp maybe_add_snapshots(inputs, snapshot_ids) do

--- a/test/lightning/version_control/version_control_usage_limiter_test.ex
+++ b/test/lightning/version_control/version_control_usage_limiter_test.ex
@@ -1,0 +1,47 @@
+defmodule Lightning.VersionControl.VersionControlUsageLimiterTest do
+  use ExUnit.Case, async: true
+
+  alias Lightning.Extensions.MockUsageLimiter
+  alias Lightning.Extensions.Message
+  alias Lightning.Extensions.UsageLimiting.Action
+  alias Lightning.Extensions.UsageLimiting.Context
+  alias Lightning.VersionControl.VersionControlUsageLimiter
+
+  describe ".limit_github_sync/1" do
+    test "returns :ok when passed nil" do
+      assert VersionControlUsageLimiter.limit_github_sync(nil) == :ok
+    end
+
+    test "with a project_id, indicates if request is allowed" do
+      project_id = Ecto.UUID.generate()
+
+      action = %Action{type: :github_sync}
+      context = %Context{project_id: project_id}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        :ok
+        # {:error, :too_many_runs,
+        #  %Message{text: "Too many runs in the last minute"}}
+      end)
+
+      assert VersionControlUsageLimiter.limit_github_sync(project_id) == :ok
+    end
+
+    test "with a project_id, indicates if request is denied" do
+      project_id = Ecto.UUID.generate()
+
+      action = %Action{type: :github_sync}
+      context = %Context{project_id: project_id}
+
+      message = %Message{text: "You melted the CPU."}
+
+      Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
+        {:error, :melted, message}
+      end)
+
+      assert VersionControlUsageLimiter.limit_github_sync(project_id) ==
+             {:error, message}
+
+    end
+  end
+end

--- a/test/lightning/version_control/version_control_usage_limiter_test.exs
+++ b/test/lightning/version_control/version_control_usage_limiter_test.exs
@@ -7,7 +7,7 @@ defmodule Lightning.VersionControl.VersionControlUsageLimiterTest do
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.VersionControl.VersionControlUsageLimiter
 
-  describe ".limit_github_sync/1" do
+  describe "limit_github_sync/1" do
     test "returns :ok when passed nil" do
       assert VersionControlUsageLimiter.limit_github_sync(nil) == :ok
     end

--- a/test/lightning/version_control/version_control_usage_limiter_test.exs
+++ b/test/lightning/version_control/version_control_usage_limiter_test.exs
@@ -38,8 +38,7 @@ defmodule Lightning.VersionControl.VersionControlUsageLimiterTest do
       end)
 
       assert VersionControlUsageLimiter.limit_github_sync(project_id) ==
-             {:error, message}
-
+               {:error, message}
     end
   end
 end

--- a/test/lightning/version_control/version_control_usage_limiter_test.exs
+++ b/test/lightning/version_control/version_control_usage_limiter_test.exs
@@ -20,8 +20,6 @@ defmodule Lightning.VersionControl.VersionControlUsageLimiterTest do
 
       Mox.stub(MockUsageLimiter, :limit_action, fn ^action, ^context ->
         :ok
-        # {:error, :too_many_runs,
-        #  %Message{text: "Too many runs in the last minute"}}
       end)
 
       assert VersionControlUsageLimiter.limit_github_sync(project_id) == :ok

--- a/test/support/github_helpers.ex
+++ b/test/support/github_helpers.ex
@@ -324,12 +324,40 @@ defmodule Lightning.GithubHelpers do
     )
   end
 
+  def expect_create_workflow_dispatch_with_request_body(
+        repo,
+        workflow_path,
+        request_body,
+        opts \\ []
+      ) do
+    resp_body = Keyword.get(opts, :resp_body, "")
+    resp_status = Keyword.get(opts, :resp_status, 204)
+
+    json_body = Jason.encode!(request_body)
+
+    Mox.expect(
+      Lightning.Tesla.Mock,
+      :call,
+      fn %{
+           url:
+             "https://api.github.com/repos/" <>
+               ^repo <> "/actions/workflows/" <> ^workflow_path <> "/dispatches",
+           body: ^json_body
+         },
+         _opts ->
+        {:ok, %Tesla.Env{status: resp_status, body: resp_body}}
+      end
+    )
+  end
+
   def expect_create_workflow_dispatch(
         repo,
         workflow_path,
-        resp_status \\ 204,
-        resp_body \\ ""
+        opts \\ []
       ) do
+    resp_body = Keyword.get(opts, :resp_body, "")
+    resp_status = Keyword.get(opts, :resp_status, 204)
+
     Mox.expect(
       Lightning.Tesla.Mock,
       :call,


### PR DESCRIPTION
### Description

Removing another use of `get_or_create_latest_for`.

#2703 

### Validation steps

No new functionality has been added and redundant code has been removed. As a sanity check you could do the following (I did):

- Setup Github integration as per the [docs](https://github.com/OpenFn/lightning/blob/main/DEPLOYMENT.md#github).
- In the Project Settings, navigate to `Sync to Github`, fill in the necessary details and submit.
- Confirm that the sync went through successfully.

### Additional notes for the reviewer

Did you know that the kiwi fruit used to be primarily know as a Chinese Gooseberry until the 1950s?

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
