### PR TITLE
Allow non-openfn.org users to access AI Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,16 @@ and this project adheres to
 
 ### Changed
 
+### Fixed
+
+## [v2.10.12] - 2025-01-21
+
+### Changed
+
 - PromEx metrics endpoint returns 401 on unauthorized requests.
   [#2823](https://github.com/OpenFn/lightning/issues/2823)
-
-### Fixed
+- Allow non-openfn.org users to access AI Assistant
+  [#2845](https://github.com/OpenFn/lightning/issues/2845)
 
 ## [v2.10.11] - 2025-01-21
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -196,10 +196,6 @@ defmodule Lightning.AiAssistant do
     is_binary(endpoint) && is_binary(api_key)
   end
 
-  def available?(user) do
-    String.match?(user.email, ~r/@openfn\.org/i)
-  end
-
   @spec user_has_read_disclaimer?(User.t()) :: boolean()
   def user_has_read_disclaimer?(user) do
     read_at =

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -208,10 +208,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     <:tab hash="manual">
                       <span class="inline-block align-middle">Input</span>
                     </:tab>
-                    <:tab
-                      :if={Lightning.AiAssistant.available?(@current_user)}
-                      hash="aichat"
-                    >
+                    <:tab hash="aichat">
                       <span class="inline-block align-middle">AI Assistant</span>
                     </:tab>
                   </LightningWeb.Components.Tabbed.tabs>
@@ -242,11 +239,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                       />
                     </div>
                   </:panel>
-                  <:panel
-                    :if={Lightning.AiAssistant.available?(@current_user)}
-                    hash="aichat"
-                    class="h-full"
-                  >
+                  <:panel hash="aichat" class="h-full">
                     <%= if @ai_assistant_enabled do %>
                       <div class="grow min-h-0 h-full text-sm">
                         <.live_component

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lightning.MixProject do
   def project do
     [
       app: :lightning,
-      version: "2.10.11",
+      version: "2.10.12",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -13,16 +13,6 @@ defmodule Lightning.AiAssistantTest do
     [user: user, project: project, workflow: workflow]
   end
 
-  describe "available?/1" do
-    test "is not available for users without openfn.org email" do
-      user = build(:user, email: "test@openFn.org")
-      assert AiAssistant.available?(user)
-
-      user = build(:user, email: "test@example.net")
-      refute AiAssistant.available?(user)
-    end
-  end
-
   describe "endpoint_available?" do
     test "availability" do
       Mox.stub(Lightning.MockConfig, :apollo, fn key ->


### PR DESCRIPTION
### Description

This PR allows non-openfn.org users to access AI Assistant.
It also bumps the lightning version for the `2.10.12` release

Closes #2845

### Validation steps

The easiest way to test this locally is to update the email address for your currently logged in user through a db client, I use DBeaver.

Alternatively, you can invite a new user, with a non-openfn email address. You can access the email invite sent out at http://localhost:4000/dev/mailbox

Ensure you have `APOLLO_ENDPOINT` and `AI_ASSISTANT_API_KEY` envs set

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
