### PR TITLE
2617 console instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Audit the provisioning of projects via the API
   [#2718](https://github.com/OpenFn/lightning/issues/2718)
+- Temporary instrumentation for JobEditor to help identify performance issues.
+  [#2617](https://github.com/OpenFn/lightning/issues/2617)
 
 ### Changed
 

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -81,13 +81,7 @@ export default {
 
       instrumentFinish('editor load');
 
-      this.requestMetadata().then(() => {
-        instrumentStart('Render - metadata received');
-
-        this.render()
-
-        instrumentFinish('Render - metadata received');
-      });
+      this.requestMetadata().then(() => this.render());
     });
   },
   handleContentChange(content: string) {
@@ -136,13 +130,7 @@ export default {
   },
   requestMetadata() {
     this.metadata = true; // indicate we're loading
-
-    instrumentStart('Render - prior to requesting metadata');
-
     this.render();
-
-    instrumentFinish('Render - prior to requesting metadata');
-
     return new Promise(resolve => {
       const callbackRef = this.handleEvent('metadata_ready', data => {
         this.removeHandleEvent(callbackRef);

--- a/assets/js/job-editor/mount.tsx
+++ b/assets/js/job-editor/mount.tsx
@@ -60,7 +60,7 @@ export default {
     // this.handleContentChange(this.currentContent);
   },
   mounted(this: JobEditorEntrypoint) {
-    instrumentStart('Mount to first render');
+    instrumentStart('editor load');
 
     window.jobEditor = this;
 
@@ -79,7 +79,7 @@ export default {
       this.setupObserver();
       this.render();
 
-      instrumentFinish('Mount to first render');
+      instrumentFinish('editor load');
 
       this.requestMetadata().then(() => {
         instrumentStart('Render - metadata received');

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -222,6 +222,8 @@ export default {
     });
   },
   getWorkflowParams() {
+    console.debug('get-initial-state pushed', new Date().toISOString());
+    console.time('get-initial-state -> current-workflow-params');
     this.pushEventTo(this.el, 'get-initial-state', {});
   },
   handleWorkflowParams({ workflow_params: payload }) {
@@ -239,6 +241,8 @@ export default {
     }
 
     this.maybeMountComponent();
+    console.debug('current-worflow-params processed', new Date().toISOString());
+    console.timeEnd('get-initial-state -> current-workflow-params');
   },
   maybeMountComponent() {
     if (!this._isMounting && !this.component) {

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -223,7 +223,7 @@ export default {
   },
   getWorkflowParams() {
     console.debug('get-initial-state pushed', new Date().toISOString());
-    console.time('get-initial-state -> current-workflow-params');
+    console.time('workflow-params load');
     this.pushEventTo(this.el, 'get-initial-state', {});
   },
   handleWorkflowParams({ workflow_params: payload }) {
@@ -242,7 +242,7 @@ export default {
 
     this.maybeMountComponent();
     console.debug('current-worflow-params processed', new Date().toISOString());
-    console.timeEnd('get-initial-state -> current-workflow-params');
+    console.timeEnd('workflow-params load');
   },
   maybeMountComponent() {
     if (!this._isMounting && !this.component) {


### PR DESCRIPTION
### Description

At the moment, the exact cause of the job editor slow loading is unknown - so this is the first of 2 changes to attempt to at least instrument the slow behaviour. 

As I am unsure how this data will be used - I have included both start/end times (useful to identify possible overlaps) as well as span duration (useful to avoid a bunch of subtraction :)).

#2617 

### Validation steps

Confirm that both the workflow editor and the job editor still load correctly. In the browser console you should see logging similar to the below:

![image](https://github.com/user-attachments/assets/e0496e05-9275-49ef-acde-98512758c6a4)

As far as I can tell, there are no tests that cover this code, other than the LiveView tests?

### Additional notes for the reviewer

M & Ms are named after the two developers of the sweet - Mars and Murrie. Forrest Mars (of Mars Bar fame) is suspected of basing them off a British sweet, Smarties, during WW2. Both M&Ms and Smarties were developed to allow for more chocolate sales in summer as the coating meant that both sellers and consumers had less issues as result of melted chocolate.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

### Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
