### PR TITLE
Track Collections storage usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   [#2495](https://github.com/OpenFn/lightning/issues/2495)
 - Audit the provisioning of projects via the API
   [#2718](https://github.com/OpenFn/lightning/issues/2718)
+- Track Collections storage usage based on items key and value sizes
+  [#2853](https://github.com/OpenFn/lightning/issues/2853)
 
 ### Changed
 

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -4,6 +4,8 @@ defmodule Lightning.Collections do
   """
   import Ecto.Query
 
+  alias Ecto.Multi
+
   alias Lightning.Collections.Collection
   alias Lightning.Collections.Item
   alias Lightning.Repo
@@ -149,16 +151,11 @@ defmodule Lightning.Collections do
 
   @spec put(Collection.t(), String.t(), String.t()) ::
           :ok | {:error, Ecto.Changeset.t()}
-  def put(%{id: collection_id}, key, value) do
-    %Item{}
-    |> Item.changeset(%{collection_id: collection_id, key: key, value: value})
-    |> Repo.insert(
-      conflict_target: [:collection_id, :key],
-      on_conflict: [set: [value: value, updated_at: DateTime.utc_now()]]
-    )
-    |> then(fn result ->
-      with {:ok, _no_return} <- result, do: :ok
-    end)
+  def put(%{id: collection_id} = collection, key, value) do
+    case get(collection, key) do
+      nil -> upsert_item(%Item{collection_id: collection_id, byte_size: 0}, key, value)
+      item -> upsert_item(item, key, value)
+    end
   end
 
   @spec put_all(Collection.t(), [{String.t(), String.t()}]) ::
@@ -166,23 +163,56 @@ defmodule Lightning.Collections do
   def put_all(%{id: collection_id}, kv_list) do
     now = DateTime.utc_now()
 
-    item_list =
-      Enum.map(kv_list, fn %{"key" => key, "value" => value} ->
-        %{
-          collection_id: collection_id,
-          key: key,
-          value: value,
-          inserted_at: now,
-          updated_at: now
+    {item_list, {key_list, new_mem_used}} =
+      Enum.map_reduce(kv_list, {[], 0}, fn %{"key" => key, "value" => value},
+                                           {key_list, mem_used} ->
+        item_size = byte_size(key) + byte_size(value)
+
+        {
+          %{
+            collection_id: collection_id,
+            key: key,
+            value: value,
+            inserted_at: now,
+            updated_at: now,
+            byte_size: item_size
+          },
+          {
+            [key | key_list],
+            mem_used + item_size
+          }
         }
       end)
 
-    with {count, _nil} <-
-           Repo.insert_all(Item, item_list,
-             conflict_target: [:collection_id, :key],
-             on_conflict: {:replace, [:value, :updated_at]}
-           ),
-         do: {:ok, count}
+    old_mem_used =
+      from(c in Item,
+        where: c.collection_id == ^collection_id and c.key in ^key_list,
+        select: sum(c.byte_size)
+      )
+      |> Repo.one() || 0
+
+    Multi.new()
+    |> Multi.insert_all(:items, Item, item_list,
+      conflict_target: [:collection_id, :key],
+      on_conflict: {:replace, [:value, :byte_size, :updated_at]}
+    )
+    |> Multi.update_all(
+      :collection,
+      fn _changes ->
+        increment = [byte_size_sum: new_mem_used - old_mem_used]
+
+        from(c in Collection,
+          where: c.id == ^collection_id,
+          update: [inc: ^increment]
+        )
+      end,
+      []
+    )
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{items: {count, nil}}} -> {:ok, count}
+      {:error, _op, changeset, _changes} -> {:error, changeset}
+    end
   rescue
     e in Postgrex.Error ->
       if e.postgres.code == :cardinality_violation do
@@ -193,13 +223,10 @@ defmodule Lightning.Collections do
   end
 
   @spec delete(Collection.t(), String.t()) :: :ok | {:error, :not_found}
-  def delete(%{id: collection_id}, key) do
-    query =
-      from(i in Item, where: i.collection_id == ^collection_id and i.key == ^key)
-
-    case Repo.delete_all(query) do
-      {0, nil} -> {:error, :not_found}
-      {1, nil} -> :ok
+  def delete(collection, key) do
+    case get(collection, key) do
+      nil -> {:error, :not_found}
+      item -> delete_item(item)
     end
   end
 
@@ -215,6 +242,68 @@ defmodule Lightning.Collections do
       end)
 
     with {count, _nil} <- Repo.delete_all(query), do: {:ok, count}
+  end
+
+  defp upsert_item(%Item{byte_size: old_size} = item, key, value) do
+    kv_size = byte_size(key) + byte_size(value)
+
+    Multi.new()
+    |> Multi.insert(
+      :item,
+      fn _no_change ->
+        Item.changeset(item, %{
+          key: key,
+          value: value,
+          byte_size: kv_size
+        })
+      end,
+      conflict_target: [:collection_id, :key],
+      on_conflict: [
+        set: [value: value, byte_size: kv_size, updated_at: DateTime.utc_now()]
+      ]
+    )
+    |> Multi.update_all(
+      :collection,
+      fn %{item: %{collection_id: collection_id}} ->
+        increment = [byte_size_sum: byte_size(key) + byte_size(value) - old_size]
+
+        from(c in Collection,
+          where: c.id == ^collection_id,
+          update: [inc: ^increment]
+        )
+      end,
+      []
+    )
+    |> Repo.transaction()
+    |> case do
+      {:ok, _changes} -> :ok
+      {:error, _op, changeset, _changes} -> {:error, changeset}
+    end
+  end
+
+  defp delete_item(%{collection_id: collection_id, key: key, value: value}) do
+    Multi.new()
+    |> Multi.delete_all(:item, fn _no_change ->
+      from(i in Item, where: i.collection_id == ^collection_id and i.key == ^key)
+    end)
+    |> Multi.update_all(
+      :collection,
+      fn _changes ->
+        increment = [byte_size_sum: -(byte_size(key) + byte_size(value))]
+
+        from(c in Collection,
+          where: c.id == ^collection_id,
+          update: [inc: ^increment]
+        )
+      end,
+      []
+    )
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{item: {1, nil}}} -> :ok
+      {:ok, %{item: {0, nil}}} -> {:error, :not_found}
+      {:error, _op, changeset, _changes} -> {:error, changeset}
+    end
   end
 
   defp all_query(collection_id, cursor, limit) do

--- a/lib/lightning/collections/collection.ex
+++ b/lib/lightning/collections/collection.ex
@@ -10,12 +10,14 @@ defmodule Lightning.Collections.Collection do
           id: Ecto.UUID.t(),
           project_id: Ecto.UUID.t(),
           name: String.t(),
+          byte_size_sum: integer(),
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
         }
 
   schema "collections" do
     field :name, :string
+    field :byte_size_sum, :integer
     belongs_to :project, Lightning.Projects.Project
     has_many :items, Lightning.Collections.Item
 

--- a/lib/lightning/collections/item.ex
+++ b/lib/lightning/collections/item.ex
@@ -10,7 +10,6 @@ defmodule Lightning.Collections.Item do
           collection_id: Ecto.UUID.t(),
           key: String.t(),
           value: String.t(),
-          byte_size: integer(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -27,7 +26,6 @@ defmodule Lightning.Collections.Item do
     #       max length is 1MB.
     field :key, :string
     field :value, :string
-    field :byte_size, :integer
 
     timestamps(type: :utc_datetime_usec)
   end
@@ -35,7 +33,7 @@ defmodule Lightning.Collections.Item do
   @doc false
   def changeset(entry, attrs) do
     entry
-    |> cast(attrs, [:collection_id, :key, :value, :byte_size])
+    |> cast(attrs, [:collection_id, :key, :value])
     |> validate_required([:collection_id, :key, :value])
     |> validate_length(:value, max: 1_000_000)
     |> unique_constraint([:collection_id, :key])

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -101,6 +101,7 @@ defmodule LightningWeb.CollectionLive.Components do
               </div>
             </.th>
             <.th>Project</.th>
+            <.th>Used Storage (MB)</.th>
             <.th></.th>
           </.tr>
 
@@ -115,7 +116,9 @@ defmodule LightningWeb.CollectionLive.Components do
             <.td class="break-words max-w-[25rem]">
               <%= collection.project.name %>
             </.td>
-
+            <.td class="break-words max-w-[25rem]">
+              <%= div(collection.byte_size_sum, 1_000_000) %>
+            </.td>
             <.td>
               <div class="text-right">
                 <button

--- a/priv/repo/migrations/20250123134213_add_collections_storage_columns.exs
+++ b/priv/repo/migrations/20250123134213_add_collections_storage_columns.exs
@@ -1,0 +1,13 @@
+defmodule Lightning.Repo.Migrations.AddCollectionsStorageColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:collections) do
+      add :byte_size_sum, :integer, default: 0
+    end
+
+    alter table(:collection_items) do
+      add :byte_size, :integer, default: 0
+    end
+  end
+end

--- a/priv/repo/migrations/20250123134213_add_collections_storage_columns.exs
+++ b/priv/repo/migrations/20250123134213_add_collections_storage_columns.exs
@@ -3,11 +3,7 @@ defmodule Lightning.Repo.Migrations.AddCollectionsStorageColumns do
 
   def change do
     alter table(:collections) do
-      add :byte_size_sum, :integer, default: 0
-    end
-
-    alter table(:collection_items) do
-      add :byte_size, :integer, default: 0
+      add :byte_size_sum, :bigint, default: 0
     end
   end
 end

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -250,10 +250,23 @@ defmodule Lightning.CollectionsTest do
     test "creates a new entry in the collection for the given collection" do
       collection = insert(:collection)
 
-      assert :ok = Collections.put(collection, "some-key", "some-value")
+      assert :ok = Collections.put(collection, "some-key1", "some-value1")
+      assert :ok = Collections.put(collection, "some-key12", "some-value12")
 
-      assert %{key: "some-key", value: "some-value"} =
-               Repo.get_by!(Item, key: "some-key")
+      byte_size1 = byte_size("some-key1") + byte_size("some-value1")
+
+      assert %{key: "some-key1", value: "some-value1", byte_size: ^byte_size1} =
+               Repo.get_by!(Item, key: "some-key1")
+
+      byte_size12 = byte_size("some-key12") + byte_size("some-value12")
+
+      assert %{key: "some-key12", value: "some-value12", byte_size: ^byte_size12} =
+               Repo.get_by!(Item, key: "some-key12")
+
+      byte_size_sum = byte_size1 + byte_size12
+
+      assert %{byte_size_sum: ^byte_size_sum} =
+               Repo.get!(Collection, collection.id)
     end
 
     test "updates the value of an item when key exists" do
@@ -264,10 +277,15 @@ defmodule Lightning.CollectionsTest do
       assert %{key: "some-key", value: "some-value1"} =
                Repo.get_by!(Item, key: "some-key")
 
-      assert :ok = Collections.put(collection, "some-key", "some-value2")
+      assert :ok = Collections.put(collection, "some-key", "some-value12")
 
-      assert %{key: "some-key", value: "some-value2"} =
+      assert %{key: "some-key", value: "some-value12"} =
                Repo.get_by!(Item, key: "some-key")
+
+      byte_size_sum = byte_size("some-key") + byte_size("some-value12")
+
+      assert %{byte_size_sum: ^byte_size_sum} =
+               Repo.get!(Collection, collection.id)
     end
 
     test "returns an :error if the value is bigger than max len" do
@@ -312,16 +330,32 @@ defmodule Lightning.CollectionsTest do
     test "inserts multiple entries at once in a given collection" do
       collection = insert(:collection)
 
-      items =
-        Enum.map(1..5, fn i -> %{"key" => "key#{i}", "value" => "value#{i}"} end)
+      {items, storage_used} =
+        Enum.map_reduce(10..50, 0, fn i, mem_used ->
+          {
+            %{"key" => "key#{i}", "value" => "value#{i}"},
+            mem_used + byte_size("key#{i}") + byte_size("value#{i}")
+          }
+        end)
 
-      assert {:ok, 5} = Collections.put_all(collection, items)
+      assert {:ok, 41} = Collections.put_all(collection, items)
 
-      assert Item |> Repo.all() |> Enum.map(&Map.take(&1, [:key, :value])) ==
-               Enum.map(items, &%{key: &1["key"], value: &1["value"]})
+      assert Item
+             |> Repo.all()
+             |> Enum.map(&Map.take(&1, [:key, :value, :byte_size])) ==
+               Enum.map(items, fn item ->
+                 %{
+                   key: item["key"],
+                   value: item["value"],
+                   byte_size: byte_size(item["key"]) + byte_size(item["value"])
+                 }
+               end)
+
+      assert %{byte_size_sum: ^storage_used} =
+               Repo.get!(Collection, collection.id)
     end
 
-    test "replaces conflicting values and updates timestamp" do
+    test "replaces conflicting values, timestamps and byte_size" do
       collection = insert(:collection)
 
       items =
@@ -352,6 +386,26 @@ defmodule Lightning.CollectionsTest do
 
       assert %{value: "value5", updated_at: ^updated_at5} =
                Repo.get_by(Item, key: "key5")
+
+      final_items = Enum.drop(items, 2) ++ update_items
+
+      assert Item
+             |> Repo.all()
+             |> Enum.map(&Map.take(&1, [:key, :value, :byte_size])) ==
+               Enum.map(final_items, fn item ->
+                 %{
+                   key: item["key"],
+                   value: item["value"],
+                   byte_size: byte_size(item["key"]) + byte_size(item["value"])
+                 }
+               end)
+
+      storage_used =
+        Enum.map(final_items, &(byte_size(&1["key"]) + byte_size(&1["value"])))
+        |> Enum.sum()
+
+      assert %{byte_size_sum: ^storage_used} =
+               Repo.get!(Collection, collection.id)
     end
 
     test "raises Postgrex error when an item is bigger than allowed max len" do
@@ -372,12 +426,26 @@ defmodule Lightning.CollectionsTest do
     test "deletes an entry for the given collection" do
       collection = insert(:collection)
 
-      %{key: key} =
+      %{key: key1, byte_size: byte_size1} =
         insert(:collection_item, collection: collection)
 
-      assert :ok = Collections.delete(collection, key)
+      %{key: key2, byte_size: byte_size2} =
+        insert(:collection_item, collection: collection)
 
-      refute Collections.get(collection, key)
+      _collection =
+        Repo.update!(
+          Ecto.Changeset.change(collection, %{
+            byte_size_sum: byte_size1 + byte_size2
+          })
+        )
+
+      assert :ok = Collections.delete(collection, key1)
+
+      refute Collections.get(collection, key1)
+      assert Collections.get(collection, key2)
+
+      assert %{byte_size_sum: ^byte_size2} =
+               Repo.get!(Collection, collection.id)
     end
 
     test "returns an :error if the collection does not exist" do

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -336,8 +336,7 @@ defmodule Lightning.Factories do
         sequence(
           :inserted_at,
           &DateTime.add(DateTime.utc_now(), &1, :microsecond)
-        ),
-      byte_size: String.length("key-100") + String.length("value-100")
+        )
     }
   end
 

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -321,21 +321,23 @@ defmodule Lightning.Factories do
   def collection_factory do
     %Lightning.Collections.Collection{
       project: build(:project),
-      name: sequence(:name, &"collection-#{&1}")
+      name: sequence(:name, &"collection-#{&1}"),
+      byte_size_sum: 0
     }
   end
 
   def collection_item_factory do
     %Lightning.Collections.Item{
       id: sequence(:id, & &1),
-      key: sequence(:key, &"key-#{&1}"),
-      value: sequence(:value, &"value-#{&1}"),
+      key: sequence(:key, &"key-#{&1}", start_at: 100),
+      value: sequence(:value, &"value-#{&1}", start_at: 100),
       collection: build(:collection),
       inserted_at:
         sequence(
           :inserted_at,
           &DateTime.add(DateTime.utc_now(), &1, :microsecond)
-        )
+        ),
+      byte_size: String.length("key-100") + String.length("value-100")
     }
   end
 


### PR DESCRIPTION
## Description

This PR adds a tracking of Collections API storage usage based on the items key and value sizes. It adds an accumulator column called `byte_size_sum` to the `collections` table which sums up the size of keys and values in bytes. Once the strings are UTF8 for some values it might differ from the length with the advantage that `:erlang.byte_size` is O(1). 

When updating a single item, the accumulator sums the size of new value and decrements the size of old value. For upserts involving multiple items, the accumulator is updated with a low cost simple formula (50ms) of `acc = updated_items_mem_used - old_items_mem_used` for the items on the upsert.   

Closes #2853 

## Validation steps

1. Login as a superuser and create a collection called `tracked-col` (as an example).
2. You can save this script to `gig-upsert.exs`:
``` 
collection =
  Lightning.Repo.get_by(Lightning.Collections.Collection, name: "tracked-col")

Enum.map(1..9, fn i ->
  bigkey = String.duplicate("#{i}", 200)
  bigvalue = String.duplicate("#{i}", 100_000)

  Enum.map(10_001..20_000, fn i ->
    %{"key" => "keyAB#{i}" <> bigkey, "value" => "value#{i}" <> bigvalue}
  end)
  |> then(&:timer.tc(fn -> Lightning.Collections.put_all(collection, &1) end))
end)
|> IO.inspect(label: "put-all")
```
3. And run `mix run gig-upsert.exs`
4. The size on the admin collections page should show 1000 MB of Used Storage.

## Additional notes for the reviewer

Using Postgres `octet_length` gave a result very close and sometimes faster than `sum(item.byte_size_column)`. So the item byte size could be easily derived from key and value columns (i.e the `byte_size` column on items table was not needed).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
