### PR TITLE
fix: remove 'Gmail' from list for #2854"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 - Bump PostCSS [#2863](https://github.com/OpenFn/lightning/pull/2863)
 - Replaced HTTPoison with Tesla in the AdaptorRegistry.
   [#2861](https://github.com/OpenFn/lightning/pull/2861)
+- Remove googlesheets, gmail and collections from credential schemas list
+  [#2854](https://github.com/OpenFn/lightning/issues/2854)
 
 ### Fixed
 

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -604,11 +604,9 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
     # TODO: Gracefully determine which adaptors define custom credential types
     # and which adaptors use OAuth2 credential types. (Edit for Jan 24th, 2025:
     # or which adaptors shouldn't use credentials at all! E.g., "Collections".)
-    |> IO.inspect(label: "before")
     |> List.delete({"Googlesheets", "googlesheets", nil, nil})
     |> List.delete({"Gmail", "gmail", nil, nil})
     |> List.delete({"Collections", "collections", nil, nil})
-    |> IO.inspect(label: "after")
     |> Enum.sort_by(& &1, :asc)
   end
 

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -600,13 +600,10 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
       end)
 
     schemas_options
+    |> Enum.reject(fn {_, name, _, _} ->
+      name in ["googlesheets", "gmail", "collections"]
+    end)
     |> Enum.concat([{"Raw JSON", "raw", nil, nil}])
-    # TODO: Gracefully determine which adaptors define custom credential types
-    # and which adaptors use OAuth2 credential types. (Edit for Jan 24th, 2025:
-    # or which adaptors shouldn't use credentials at all! E.g., "Collections".)
-    |> List.delete({"Googlesheets", "googlesheets", nil, nil})
-    |> List.delete({"Gmail", "gmail", nil, nil})
-    |> List.delete({"Collections", "collections", nil, nil})
     |> Enum.sort_by(& &1, :asc)
   end
 

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -604,6 +604,7 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
     # TODO: Gracefully determine which adaptors define custom credential types
     # and which adaptors use OAuth2 credential types.
     |> List.delete({"Googlesheets", "googlesheets", nil, nil})
+    |> List.delete({"Gmail", "gmail", nil, nil})
     |> Enum.sort_by(& &1, :asc)
   end
 

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -602,9 +602,13 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
     schemas_options
     |> Enum.concat([{"Raw JSON", "raw", nil, nil}])
     # TODO: Gracefully determine which adaptors define custom credential types
-    # and which adaptors use OAuth2 credential types.
+    # and which adaptors use OAuth2 credential types. (Edit for Jan 24th, 2025:
+    # or which adaptors shouldn't use credentials at all! E.g., "Collections".)
+    |> IO.inspect(label: "before")
     |> List.delete({"Googlesheets", "googlesheets", nil, nil})
     |> List.delete({"Gmail", "gmail", nil, nil})
+    |> List.delete({"Collections", "collections", nil, nil})
+    |> IO.inspect(label: "after")
     |> Enum.sort_by(& &1, :asc)
   end
 


### PR DESCRIPTION
This fixes #2854 (the other part of that issue—Hubtel—will be resolved by the next build) and closes the bug.

The open question is how to handle this TODO for the future @elias-ba , @stuartc . (Don't think this is high priority, but will come up again next time we add another OAuth based adaptor, @theroinaochieng .)

See [here](https://github.com/OpenFn/lightning/blob/main/lib/lightning_web/live/credential_live/credential_form_component.ex#L604-L605).
```
    schemas_options
    |> Enum.concat([{"Raw JSON", "raw", nil, nil}])
    # TODO: Gracefully determine which adaptors define custom credential types
    # and which adaptors use OAuth2 credential types.
    |> List.delete({"Googlesheets", "googlesheets", nil, nil})
    |> List.delete({"Gmail", "gmail", nil, nil})
    |> Enum.sort_by(& &1, :asc)
```

Please feel free to open an issue and prioritize as you see fit!