### PR TITLE
2727 audit workflow deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   [#2617](https://github.com/OpenFn/lightning/issues/2617)
 - Add temporary events to allow Lightning to log metrics reported by editors.
   [#2617](https://github.com/OpenFn/lightning/issues/2617)
+- Audit when workflow deletion is requested.
+  [#2727](https://github.com/OpenFn/lightning/issues/2727)
 
 ### Changed
 

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -334,7 +334,7 @@ defmodule Lightning.Workflows do
       %Ecto.Changeset{data: %Workflow{}}
 
   """
-  def mark_for_deletion(workflow, _attrs \\ %{}) do
+  def mark_for_deletion(workflow, actor, _attrs \\ %{}) do
     workflow_triggers_query =
       from(t in Lightning.Workflows.Trigger,
         where: t.workflow_id == ^workflow.id
@@ -347,6 +347,7 @@ defmodule Lightning.Workflows do
         "deleted_at" => DateTime.utc_now()
       })
     )
+    |> Multi.insert(:audit, Audit.marked_for_deletion(workflow.id, actor))
     |> Multi.update_all(
       :disable_triggers,
       workflow_triggers_query,

--- a/lib/lightning/workflows/audit.ex
+++ b/lib/lightning/workflows/audit.ex
@@ -11,7 +11,8 @@ defmodule Lightning.Workflows.Audit do
       "disabled",
       "deleted_by_provisioner",
       "inserted_by_provisioner",
-      "updated_by_provisioner"
+      "updated_by_provisioner",
+      "marked_for_deletion"
     ]
 
   def snapshot_created(workflow_id, snapshot_id, actor) do
@@ -45,5 +46,14 @@ defmodule Lightning.Workflows.Audit do
 
   def past_tense(action) do
     if action == :insert, do: "inserted", else: "#{action}d"
+  end
+
+  def marked_for_deletion(workflow_id, actor) do
+    event(
+      "marked_for_deletion",
+      workflow_id,
+      actor,
+      %{}
+    )
   end
 end

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -172,12 +172,15 @@ defmodule LightningWeb.WorkflowLive.Index do
   end
 
   def handle_event("delete_workflow", %{"id" => id}, socket) do
-    %{project: project, can_delete_workflow: can_delete_workflow?} =
-      socket.assigns
+    %{
+      project: project,
+      can_delete_workflow: can_delete_workflow?,
+      current_user: user
+    } = socket.assigns
 
     if can_delete_workflow? do
       Workflows.get_workflow!(id)
-      |> Workflows.mark_for_deletion()
+      |> Workflows.mark_for_deletion(user)
       |> case do
         {:ok, _} ->
           {

--- a/test/lightning/workflows/audit_test.exs
+++ b/test/lightning/workflows/audit_test.exs
@@ -96,4 +96,28 @@ defmodule Lightning.Workflows.AuditTest do
       assert changes == %{}
     end
   end
+
+  describe "marked_for_deletion" do
+    test "returns a changeset for a `marked_for_deletion` event" do
+      %{id: user_id} = user = insert(:user)
+      workflow_id = Ecto.UUID.generate()
+
+      changeset = Audit.marked_for_deletion(workflow_id, user)
+
+      assert %{
+               changes: %{
+                 event: "marked_for_deletion",
+                 item_id: ^workflow_id,
+                 item_type: "workflow",
+                 actor_id: ^user_id,
+                 changes: %{
+                   changes: changes
+                 }
+               },
+               valid?: true
+             } = changeset
+
+      assert changes == %{}
+    end
+  end
 end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -712,6 +712,7 @@ defmodule Lightning.WorkflowsTest do
 
       %{id: trigger_1_id} = insert(:trigger, workflow: w1, enabled: true)
       %{id: trigger_2_id} = insert(:trigger, workflow: w1, enabled: true)
+      %{id: trigger_3_id} = insert(:trigger, workflow: w2, enabled: true)
 
       # request workflow deletion (and disable all associated triggers)
       assert {:ok, _workflow} = Workflows.mark_for_deletion(w1)
@@ -724,6 +725,7 @@ defmodule Lightning.WorkflowsTest do
 
       assert Repo.get(Trigger, trigger_1_id) |> Map.get(:enabled) == false
       assert Repo.get(Trigger, trigger_2_id) |> Map.get(:enabled) == false
+      assert Repo.get(Trigger, trigger_3_id) |> Map.get(:enabled) == true
     end
 
     test "mark_for_deletion/2 publishes events for Kafka triggers", %{w1: w1} do

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -702,7 +702,9 @@ defmodule Lightning.WorkflowsTest do
              |> length() == 2
     end
 
-    test "mark_for_deletion/2", %{project: project, w1: w1, w2: w2} do
+    test "mark_for_deletion/3", %{project: project, w1: w1, w2: w2} do
+      user = insert(:user)
+
       workflows = Workflows.get_workflows_for(project)
 
       assert length(workflows) == 2
@@ -715,7 +717,7 @@ defmodule Lightning.WorkflowsTest do
       %{id: trigger_3_id} = insert(:trigger, workflow: w2, enabled: true)
 
       # request workflow deletion (and disable all associated triggers)
-      assert {:ok, _workflow} = Workflows.mark_for_deletion(w1)
+      assert {:ok, _workflow} = Workflows.mark_for_deletion(w1, user)
 
       assert Workflows.get_workflow!(w1.id).deleted_at != nil
       assert Workflows.get_workflow!(w2.id).deleted_at == nil
@@ -728,7 +730,25 @@ defmodule Lightning.WorkflowsTest do
       assert Repo.get(Trigger, trigger_3_id) |> Map.get(:enabled) == true
     end
 
-    test "mark_for_deletion/2 publishes events for Kafka triggers", %{w1: w1} do
+    test "mark_for_deletion/3 creates an audit event", %{
+      w1: %{id: workflow_id} = workflow
+    } do
+      %{id: user_id} = user = insert(:user)
+
+      assert {:ok, _workflow} = Workflows.mark_for_deletion(workflow, user)
+
+      audit = Repo.one!(Audit)
+
+      assert %{
+               event: "marked_for_deletion",
+               item_id: ^workflow_id,
+               actor_id: ^user_id
+             } = audit
+    end
+
+    test "mark_for_deletion/3 publishes events for Kafka triggers", %{w1: w1} do
+      user = insert(:user)
+
       %{id: kafka_trigger_1_id} =
         insert(:trigger, workflow: w1, enabled: true, type: :kafka)
 
@@ -740,7 +760,7 @@ defmodule Lightning.WorkflowsTest do
 
       Events.subscribe_to_kafka_trigger_updated()
 
-      assert {:ok, _workflow} = Workflows.mark_for_deletion(w1)
+      assert {:ok, _workflow} = Workflows.mark_for_deletion(w1, user)
 
       refute_received %KafkaTriggerUpdated{trigger_id: ^webhook_trigger_id}
       assert_received %KafkaTriggerUpdated{trigger_id: ^kafka_trigger_2_id}

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -429,8 +429,6 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       user: %{id: user_id},
       workflow: %{id: workflow_id} = workflow
     } do
-      Lightning.Repo.delete_all(Lightning.Auditing.Audit)
-
       {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w")
 
       view |> click_delete_workflow(workflow)

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -421,5 +421,27 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
 
       refute has_workflow_card?(view, workflow)
     end
+
+    @tag role: :editor
+    test "audits when a workflow has been marked for deletion", %{
+      conn: conn,
+      project: project,
+      user: %{id: user_id},
+      workflow: %{id: workflow_id} = workflow
+    } do
+      Lightning.Repo.delete_all(Lightning.Auditing.Audit)
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w")
+
+      view |> click_delete_workflow(workflow)
+
+      audit = Lightning.Repo.one(Lightning.Auditing.Audit)
+
+      assert %{
+               event: "marked_for_deletion",
+               item_id: ^workflow_id,
+               actor_id: ^user_id
+             } = audit
+    end
   end
 end


### PR DESCRIPTION
## Description

Audits when a workflow is marked for deletion.

Closes #2727 

## Validation steps

- Create a workflow
- Mark the workflow for deletion
- Navigate to the audit log and you should see an entry related to the workflow being marked for deletion.

![image](https://github.com/user-attachments/assets/b4cda671-7441-4c98-bbf7-7d0f3fcfcfb5)


## Additional notes for the reviewer

Until the 17th century, the word 'apple' in English could be used as a generic word to describe fruit. For example, in the 14th century, Middle English speakers would have referred to a banana as an `appel of paradis` and then there is [pineapple](https://www.merriam-webster.com/wordplay/word-history-pineapple).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [x] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
