### PR TITLE
Standardize dates and sort icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,19 @@ and this project adheres to
 
 ### Added
 
+- Adds project name to failure alert email
+  [#2884](https://github.com/OpenFn/lightning/pull/2884)
+
 ### Changed
 
+- Standardizes date formats to YYYY-MM-DD
+  [#2884](https://github.com/OpenFn/lightning/pull/2884)
+
 ### Fixed
+
+- Standardizes sort order arrows (all now show the direction of sort, rather
+  than the direction they would sort if toggled)
+  [#2423](https://github.com/OpenFn/lightning/issues/2423)
 
 ## [v2.10.13] - 2025-01-29
 

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -344,7 +344,7 @@ defmodule Lightning.Accounts.UserNotifier do
     body = """
     Hi #{user.first_name},
 
-    Here's your #{Atom.to_string(digest)} project digest for "#{project.name}", covering activity from #{start_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")} to #{end_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")}.
+    Here's your #{Atom.to_string(digest)} project digest for "#{project.name}", covering activity from #{start_date |> Lightning.Helpers.format_date_long()} to #{end_date |> Lightning.Helpers.format_date_long()}.
 
     #{body}
 

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -62,8 +62,15 @@ defmodule Lightning.Helpers do
     Crontab.Scheduler.get_next_run_date!(cron_expression, due_date)
   end
 
-  def format_date(date, formatter \\ "%a %d/%m/%Y at %H:%M:%S") do
+  def format_date(date, formatter \\ "%F %T") do
     Timex.Format.DateTime.Formatters.Strftime.format!(date, formatter)
+  end
+
+  def format_date_long(date) do
+    Timex.Format.DateTime.Formatters.Strftime.format!(
+      date,
+      "%A, %B %d, %Y at %H:%M %Z"
+    )
   end
 
   @doc """

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -3,6 +3,8 @@ defmodule Lightning.Helpers do
   Common functions for the context
   """
 
+  alias Timex.Format.DateTime.Formatters.Strftime
+
   @doc """
   Changes a given maps field from a json string to a map.
   If it cannot be converted, it leaves the original value
@@ -63,11 +65,11 @@ defmodule Lightning.Helpers do
   end
 
   def format_date(date, formatter \\ "%F %T") do
-    Timex.Format.DateTime.Formatters.Strftime.format!(date, formatter)
+    Strftime.format!(date, formatter)
   end
 
   def format_date_long(date) do
-    Timex.Format.DateTime.Formatters.Strftime.format!(
+    Strftime.format!(
       date,
       "%A, %B %d, %Y at %H:%M %Z"
     )

--- a/lib/lightning/pipeline/failure_alerter.ex
+++ b/lib/lightning/pipeline/failure_alerter.ex
@@ -15,6 +15,8 @@ defmodule Lightning.FailureAlerter do
     workflow = run.work_order.workflow
 
     if :ok == ProjectLimiter.limit_failure_alert(workflow.project_id) do
+      project = Lightning.Projects.get_project!(workflow.project_id)
+
       Lightning.Accounts.get_users_to_alert_for_project(%{
         id: workflow.project_id
       })
@@ -22,6 +24,7 @@ defmodule Lightning.FailureAlerter do
         %{
           "workflow_id" => workflow.id,
           "workflow_name" => workflow.name,
+          "project_name" => project.name,
           "work_order_id" => run.work_order_id,
           "run_id" => run.id,
           "project_id" => workflow.project_id,
@@ -36,6 +39,7 @@ defmodule Lightning.FailureAlerter do
   def alert(%{
         "workflow_id" => workflow_id,
         "workflow_name" => workflow_name,
+        "project_name" => project_name,
         "work_order_id" => work_order_id,
         "run_id" => run_id,
         "project_id" => project_id,
@@ -76,6 +80,7 @@ defmodule Lightning.FailureAlerter do
           run_id: run_id,
           run_url: run_url,
           run_logs: run_logs,
+          project_name: project_name,
           workflow_name: workflow_name,
           workflow_id: workflow_id,
           recipient: recipient

--- a/lib/lightning_web/live/audit_live/index.html.heex
+++ b/lib/lightning_web/live/audit_live/index.html.heex
@@ -15,7 +15,7 @@
       <%= for audit <- @page.entries do %>
         <.tr id={"audit-#{audit.id}"} class="border-dotted border-gray-100">
           <.td>
-            <%= audit.inserted_at |> Calendar.strftime("%c %Z") %>
+            <%= audit.inserted_at |> Lightning.Helpers.format_date() %>
           </.td>
           <.td>
             <.badge color="success" label={audit.event} />

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -65,14 +65,15 @@ defmodule LightningWeb.CollectionLive.Components do
     """
   end
 
+  # TODO - replace with common table when moving to project scope!
   def collections_table(assigns) do
-    next_sort_icon = %{asc: "hero-chevron-down", desc: "hero-chevron-up"}
+    sort_icon = %{asc: "hero-chevron-down", desc: "hero-chevron-up"}
 
     assigns =
       assign(assigns,
         collections_count: Enum.count(assigns.collections),
         empty?: Enum.empty?(assigns.collections),
-        name_sort_icon: next_sort_icon[assigns.name_direction]
+        name_sort_icon: sort_icon[assigns.name_direction]
       )
 
     ~H"""
@@ -88,6 +89,7 @@ defmodule LightningWeb.CollectionLive.Components do
       <div id="collections-table">
         <.table>
           <.tr>
+            # TODO - replace with common sortable header when moving to project scope!
             <.th>
               <div class="group inline-flex items-center">
                 Name

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -569,9 +569,9 @@ defmodule LightningWeb.Components.Common do
         )
       ]}>
         <%= if @active and @sort_direction == "desc" do %>
-          <.icon name="hero-chevron-up" class="size-5" />
-        <% else %>
           <.icon name="hero-chevron-down" class="size-5" />
+        <% else %>
+          <.icon name="hero-chevron-up" class="size-5" />
         <% end %>
       </span>
     </.link>

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -18,7 +18,7 @@ defmodule LightningWeb.DashboardLive.Components do
           class="text-gray-500 focus:outline-none"
         >
           <span class="text-lg">
-            <.icon name={"hero-chevron-#{if @collapsed, do: "down", else: "up"}"} />
+            <.icon name={"hero-chevron-#{if @collapsed, do: "up", else: "down"}"} />
           </span>
         </button>
       </div>
@@ -201,10 +201,7 @@ defmodule LightningWeb.DashboardLive.Components do
             </.td>
             <.td>
               <%= if project.last_updated_at do %>
-                <%= Lightning.Helpers.format_date(
-                  project.last_updated_at,
-                  "%d/%m/%Y %H:%M:%S"
-                ) %>
+                <%= Lightning.Helpers.format_date(project.last_updated_at) %>
               <% else %>
                 N/A
               <% end %>

--- a/lib/lightning_web/live/profile_live/components.ex
+++ b/lib/lightning_web/live/profile_live/components.ex
@@ -14,7 +14,7 @@ defmodule LightningWeb.ProfileLive.Components do
       </p>
       <div class="border-b border-gray-900/10 mt-6 mb-6" />
       <p class="mt-1 text-sm leading-6 text-gray-600">
-        Created: <%= @current_user.inserted_at |> Calendar.strftime("%c %Z") %> UTC
+        Created: <%= @current_user.inserted_at |> Lightning.Helpers.format_date() %>
       </p>
       <p class="mt-1 text-sm leading-6 text-gray-600">
         Email: <%= @current_user.email %>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -1077,7 +1077,7 @@
               label="Export Date"
             >
               <%= file.inserted_at
-              |> Lightning.Helpers.format_date("%d/%m/%Y %H:%M:%S") %>
+              |> Lightning.Helpers.format_date() %>
             </:col>
             <:col
               :let={file}

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -34,7 +34,9 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   defp set_details(socket, work_order) do
     last_step = get_last_step(work_order)
     last_step_finished_at = format_finished_at(last_step)
-    work_order_inserted_at = Calendar.strftime(work_order.inserted_at, "%c %Z")
+
+    work_order_inserted_at =
+      Lightning.Helpers.format_date(work_order.inserted_at)
 
     workflow_name =
       cond do
@@ -71,7 +73,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   defp format_finished_at(last_step) do
     case last_step do
       %{finished_at: %_{} = finished_at} ->
-        Calendar.strftime(finished_at, "%c %Z")
+        Lightning.Helpers.format_date(finished_at)
 
       _ ->
         nil

--- a/lib/lightning_web/live/tokens_live/index.html.heex
+++ b/lib/lightning_web/live/tokens_live/index.html.heex
@@ -61,9 +61,9 @@
           </span>
         </code>
       </:col>
-      <:col :let={token} label="Created at">
+      <:col :let={token} label="Created on">
         <span class="my-auto whitespace-nowrap text-center align-baseline font-medium leading-none">
-          <%= Calendar.strftime(token.inserted_at, "%a, %-d %b %Y at %X") %>
+          <%= Lightning.Helpers.format_date_long(token.inserted_at) %>
         </span>
       </:col>
       <:col :let={token} label="Last Used at">

--- a/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
+++ b/lib/lightning_web/live/workflow_live/ai_assistant_component.ex
@@ -711,9 +711,9 @@ defmodule LightningWeb.WorkflowLive.AiAssistantComponent do
           >
             <%= if @sort_direction == :desc, do: "Latest", else: "Oldest" %>
             <%= if @sort_direction == :desc do %>
-              <.icon name="hero-chevron-up" class="size-5" />
-            <% else %>
               <.icon name="hero-chevron-down" class="size-5" />
+            <% else %>
+              <.icon name="hero-chevron-up" class="size-5" />
             <% end %>
           </button>
         </div>

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -99,7 +99,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
             Created at
           </div>
           <div class="basis-1/2 text-right">
-            <%= Calendar.strftime(@selected_dataclip.inserted_at, "%c %Z") %>
+            <%= Lightning.Helpers.format_date(@selected_dataclip.inserted_at) %>
           </div>
         </div>
       <% end %>

--- a/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
+++ b/lib/lightning_web/templates/failure_notifier/failure_alert.html.heex
@@ -2,8 +2,8 @@
   <p>Hi <%= @recipient.first_name %>,</p>
 
   <p>
-    A run just failed for the "<%= @workflow_name %>" workflow.<br /> Click
-    <a href={@work_order_url}>here</a>
+    A "<%= @workflow_name %>" run just failed in "<%= @project_name %>". <br />
+    Click <a href={@work_order_url}>here</a>
     to view the state of the work order and <a href={@run_url}>here</a>
     to inspect the run or view the logs at the bottom of this email.
   </p>

--- a/test/lightning/accounts/user_notifier_test.exs
+++ b/test/lightning/accounts/user_notifier_test.exs
@@ -251,7 +251,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
         text_body: """
         Hi Elias,
 
-        Here's your daily project digest for "Real Project", covering activity from #{start_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")} to #{end_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")}.
+        Here's your daily project digest for "Real Project", covering activity from #{start_date |> Lightning.Helpers.format_date_long()} to #{end_date |> Lightning.Helpers.format_date_long()}.
 
         Workflow A:
         - 12 workorders correctly processed today
@@ -327,7 +327,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
         text_body: """
         Hi Elias,
 
-        Here's your weekly project digest for "Real Project", covering activity from #{start_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")} to #{end_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")}.
+        Here's your weekly project digest for "Real Project", covering activity from #{start_date |> Lightning.Helpers.format_date_long()} to #{end_date |> Lightning.Helpers.format_date_long()}.
 
         Workflow A:
         - 12 workorders correctly processed this week
@@ -405,7 +405,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
         text_body: """
         Hi Elias,
 
-        Here's your monthly project digest for "Real Project", covering activity from #{start_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")} to #{end_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")}.
+        Here's your monthly project digest for "Real Project", covering activity from #{start_date |> Lightning.Helpers.format_date_long()} to #{end_date |> Lightning.Helpers.format_date_long()}.
 
         Workflow A:
         - 12 workorders correctly processed this month
@@ -470,7 +470,7 @@ defmodule Lightning.Accounts.UserNotifierTest do
           text_body: """
           Hi Elias,
 
-          Here's your #{digest_type} project digest for "Real Project", covering activity from #{start_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")} to #{end_date |> Calendar.strftime("%a %B %d %Y at %H:%M %Z")}.
+          Here's your #{digest_type} project digest for "Real Project", covering activity from #{start_date |> Lightning.Helpers.format_date_long()} to #{end_date |> Lightning.Helpers.format_date_long()}.
 
           Workflow A:
           - 0 workorders correctly processed #{period}

--- a/test/lightning/failure_alert_test.exs
+++ b/test/lightning/failure_alert_test.exs
@@ -147,6 +147,9 @@ defmodule Lightning.FailureAlertTest do
       assert html_body =~ "workflow-a"
       assert html_body =~ workorder.id
 
+      assert html_body =~
+               "A \"#{workorder.workflow.name}\" run just failed in \"#{workorder.workflow.project.name}\""
+
       s2 = "\"workflow-a\" has failed 2 times in the last #{period}."
       assert_receive {:email, %Swoosh.Email{subject: ^s2}}, 1500
 

--- a/test/lightning_web/live/dashboard_live_test.exs
+++ b/test/lightning_web/live/dashboard_live_test.exs
@@ -344,7 +344,7 @@ defmodule LightningWeb.DashboardLiveTest do
            )
 
     formatted_date =
-      Lightning.Helpers.format_date(max_updated_at, "%d/%m/%Y %H:%M:%S")
+      Lightning.Helpers.format_date(max_updated_at)
 
     assert has_element?(
              view,
@@ -374,7 +374,7 @@ defmodule LightningWeb.DashboardLiveTest do
         |> Enum.max(fn -> nil end)
 
       if last_updated_at do
-        Lightning.Helpers.format_date(last_updated_at, "%d/%m/%Y %H:%M:%S")
+        Lightning.Helpers.format_date(last_updated_at)
       else
         "N/A"
       end


### PR DESCRIPTION
## Description

This PR fixes #2423 (https://openfn.slack.com/archives/C031G8JAU/p1724414804213229) but also standardizes our date formats: YYYY-MM-DD is better than DD/MM/YYYY because we have a very international (including Americans) and it removes ambiguity between mm/dd and dd/mm.

Finally, it adds this: https://community.openfn.org/t/add-project-name-on-failure-alert-emails/809

## Validation steps

1. See that chevrons point the way that the sort is CURRENTLY going, rather than the way they will go in the future.
2. See date formats are standardized on User Profile, Projects Table, Access Token Table

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
