### PR TITLE
Protect against flaky result on matching get_all

### DIFF
--- a/lib/lightning/collections/item.ex
+++ b/lib/lightning/collections/item.ex
@@ -17,6 +17,8 @@ defmodule Lightning.Collections.Item do
   @primary_key false
   schema "collection_items" do
     field :id, :integer, primary_key: true
+    # The collection belongs to the primary key for pagination purposes.
+    # The next node on the BTREE belongs to the collection.
     belongs_to :collection, Lightning.Collections.Collection, primary_key: true
 
     # Note: The value type is a string because Lightning doesn't need to decode it to a map and

--- a/test/lightning/factories_test.exs
+++ b/test/lightning/factories_test.exs
@@ -60,6 +60,22 @@ defmodule Lightning.FactoriesTest do
     end
   end
 
+  describe "collection_item" do
+    test "has a sequence on both id and inserted_at" do
+      items = build_list(100, :collection_item)
+
+      assert items == Enum.sort_by(items, & &1.id)
+      assert items == Enum.sort_by(items, & &1.inserted_at)
+    end
+
+    test "uses given inserted_at when saving the record" do
+      now =
+        DateTime.utc_now() |> DateTime.add(Enum.random(10..100), :second)
+
+      assert %{inserted_at: ^now} = insert(:collection_item, inserted_at: now)
+    end
+  end
+
   defp register_user(_context) do
     %{user: Lightning.AccountsFixtures.user_fixture()}
   end


### PR DESCRIPTION
## Description

This PR changes some collections tests due to some timestamp mismatch using factories sequence. It uses the inserted timestamp as a reference to compare with fetched results.

## Validation steps

Run multiple times

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
