### PR TITLE
remove space above first line

### DIFF
--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -9,8 +9,7 @@ import { initiateSaveAndRun } from '../common';
 // static imports for core lib
 import dts_es5 from './lib/es5.min.dts';
 
-export const DEFAULT_TEXT = `
-// Check out the Job Writing Guide for help getting started:
+export const DEFAULT_TEXT = `// Check out the Job Writing Guide for help getting started:
 // https://docs.openfn.org/documentation/jobs/job-writing-guide
 `;
 


### PR DESCRIPTION
## Description

There is an empty line that shows up above the "first line comment". This has been removed.

## Validation steps

1. Create a new job.
2. See that the comment is on line 1, not line 2 with an empty line 1.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
