### PR TITLE
More natural click behaviour for tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 
 ### Changed
 
+- Makes the whole project row in the projects table clickable.
+  [#2889](https://github.com/OpenFn/lightning/pull/2889)
 - Standardizes date formats to YYYY-MM-DD
   [#2884](https://github.com/OpenFn/lightning/pull/2884)
 

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -4,6 +4,7 @@ defmodule LightningWeb.DashboardLive.Components do
   import PetalComponents.Table
 
   alias LightningWeb.Components.Common
+  alias Phoenix.LiveView.JS
 
   def welcome_banner(assigns) do
     ~H"""
@@ -173,15 +174,11 @@ defmodule LightningWeb.DashboardLive.Components do
           <.tr
             :for={project <- @projects}
             id={"projects-table-row-#{project.id}"}
-            class="hover:bg-gray-100 transition-colors duration-200"
+            class="hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
+            phx-click={JS.navigate(~p"/projects/#{project.id}/w")}
           >
             <.td>
-              <.link
-                class="break-words max-w-[15rem] text-gray-800"
-                href={~p"/projects/#{project.id}/w"}
-              >
-                <%= project.name %>
-              </.link>
+              <%= project.name %>
             </.td>
             <.td class="break-words max-w-[25rem]">
               <%= project.role
@@ -195,6 +192,7 @@ defmodule LightningWeb.DashboardLive.Components do
               <.link
                 class="link"
                 href={~p"/projects/#{project.id}/settings#collaboration"}
+                onclick="event.stopPropagation()"
               >
                 <%= project.collaborators_count %>
               </.link>
@@ -210,6 +208,7 @@ defmodule LightningWeb.DashboardLive.Components do
               <.link
                 class="table-action"
                 navigate={~p"/projects/#{project.id}/history"}
+                onclick="event.stopPropagation()"
               >
                 History
               </.link>

--- a/test/lightning_web/live/dashboard_live_test.exs
+++ b/test/lightning_web/live/dashboard_live_test.exs
@@ -300,7 +300,7 @@ defmodule LightningWeb.DashboardLiveTest do
 
     assert has_element?(
              view,
-             "tr#projects-table-row-#{project.id} > td:nth-child(1) > a[href='/projects/#{project.id}/w']",
+             "tr#projects-table-row-#{project.id}",
              project.name
            )
 
@@ -405,7 +405,7 @@ defmodule LightningWeb.DashboardLiveTest do
     |> Floki.parse_document!()
     |> Floki.find("#projects-table tr")
     |> Enum.map(fn tr ->
-      Floki.find(tr, "td:nth-child(1) a")
+      Floki.find(tr, "td:nth-child(1)")
       |> Floki.text()
       |> String.trim()
     end)


### PR DESCRIPTION
## Description

In Ghana this week, users were having a _very hard time_ figuring out how to access their project after signing up. While other changes are required, this is a cheap fix for a behaviour I noticed... even when people move their mouse of the projects item in the table, they can't figure out how to actually access it. (Hint: you've got to move your mouse over the text of the project name.)

**This PR makes the whole row in the projects table clickable, while ensuring that individual links and buttons still prevent that row-level behaviour and take you where you want to go.**

Note that I _really_ wanted to do this for the workflow table, but that table seems to be built in a much different way and I couldn't figure it out with a quick google/chatgpt so moving on. (We don't have access to `<.tr >` in the workfows table 😔)

## Validation steps

1. Log in.
2. Click on a project row to see that it navigates to the project.
3. Go back.
4. Click on the collaborators link and see that it takes you to collabs.
5. Go back.
6. Click on the history link and see that it takes you to history.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
