### PR TITLE
2891 fix job editor metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to
 - Standardizes sort order arrows (all now show the direction of sort, rather
   than the direction they would sort if toggled)
   [#2423](https://github.com/OpenFn/lightning/issues/2423)
+- Allow JobEditor metrics to be tracked when the version of the workflow being
+  viewed is not the latest version.
+  [#2891](https://github.com/OpenFn/lightning/issues/2891)
 
 ## [v2.10.13] - 2025-01-29
 

--- a/lib/lightning_web/ui_metrics.ex
+++ b/lib/lightning_web/ui_metrics.ex
@@ -3,10 +3,11 @@ defmodule LightningWeb.UiMetrics do
   A temporary measure to allow WorkflowEditor and JobEditor UI components to
   report selected metrics and have these logged.
   """
-  require Logger
 
   alias Lightning.Repo
   alias Lightning.Workflows.Job
+
+  require Logger
 
   def log_job_editor_metrics(job, metrics) do
     if Lightning.Config.ui_metrics_tracking_enabled?() do


### PR DESCRIPTION
## Description

The method that logs JobEditor metrics expects to be provided with an instance of `Workflows.Job`. However, if the user is not viewing the latest version of a workflow, the method will be passed an instance of `Snapshot.Job` which does not have a `workflow_id` attribute. This change allows the method to lookup the workflow, if possible.

Closes #2891 

## Validation steps

- Set `UI_METRICS_ENABLED` to `true`.
- Browse to a workflow, and select a version that is earlier than the current version (I just edited the `v` url parameter, is there another way to do this?).
- Open the job editor for one of the workflow jobs
- You should see a `[info] UiMetrics: [JobEditor]` entry appear in the logs.

## Additional notes for the reviewer

The Casio F-91W is the most sold watch in the world - it has been in production since 1989 and, as of 2011, 3 million units are produced every year. Just be careful where you wear it, US military intelligence believed that wearing an F-91W was a sign that the user could be a trained bomb maker. :)

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
