### PR TITLE
2870 mfa bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
 - Standardizes sort order arrows (all now show the direction of sort, rather
   than the direction they would sort if toggled)
   [#2423](https://github.com/OpenFn/lightning/issues/2423)
+- Project combobox is populated when viewing MFA backup codes.
+  [#2870](https://github.com/OpenFn/lightning/issues/2870)
 
 ## [v2.10.13] - 2025-01-29
 

--- a/lib/lightning_web/live/backup_codes_live/index.ex
+++ b/lib/lightning_web/live/backup_codes_live/index.ex
@@ -6,6 +6,8 @@ defmodule LightningWeb.BackupCodesLive.Index do
   alias Lightning.Accounts
   alias Phoenix.LiveView.JS
 
+  on_mount {LightningWeb.Hooks, :assign_projects}
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok, socket |> assign(:active_menu_item, :profile)}

--- a/test/lightning_web/live/backup_codes_live_test.exs
+++ b/test/lightning_web/live/backup_codes_live_test.exs
@@ -48,6 +48,38 @@ defmodule LightningWeb.BackupCodesLiveTest do
     end
   end
 
+  test "the project combobox is popualted", %{
+    conn: conn,
+    user: user
+  } do
+    project_1 = insert(:project, project_users: [%{user: user, role: :owner}])
+
+    project_2 = insert(:project, project_users: [%{user: user, role: :admin}])
+
+    project_3 =
+      insert(:project, project_users: [%{user: build(:user), role: :owner}])
+
+    {:ok, view, _html} = live(conn, ~p"/profile/auth/backup_codes")
+
+    assert view
+           |> has_element?(
+             "ul[aria-labelledby='combobox'] li#option-#{project_1.id}",
+             project_1.name
+           )
+
+    assert view
+           |> has_element?(
+             "ul[aria-labelledby='combobox'] li#option-#{project_2.id}",
+             project_2.name
+           )
+
+    refute view
+           |> has_element?(
+             "ul[aria-labelledby='combobox'] li#option-#{project_3.id}",
+             project_3.name
+           )
+  end
+
   test "user can regenerate backup codes", %{
     conn: conn,
     user: user

--- a/test/lightning_web/live/backup_codes_live_test.exs
+++ b/test/lightning_web/live/backup_codes_live_test.exs
@@ -48,7 +48,7 @@ defmodule LightningWeb.BackupCodesLiveTest do
     end
   end
 
-  test "the project combobox is popualted", %{
+  test "the project combobox is populated with the user's projects", %{
     conn: conn,
     user: user
   } do

--- a/test/lightning_web/live/dashboard_live_test.exs
+++ b/test/lightning_web/live/dashboard_live_test.exs
@@ -100,6 +100,38 @@ defmodule LightningWeb.DashboardLiveTest do
       assert_project_listed(view, project_2, user, ~N[2023-10-05 12:00:00])
     end
 
+    test "User's projects are listed in the project combobox", %{
+      conn: conn,
+      user: user
+    } do
+      project_1 = insert(:project, project_users: [%{user: user, role: :owner}])
+
+      project_2 = insert(:project, project_users: [%{user: user, role: :admin}])
+
+      project_3 =
+        insert(:project, project_users: [%{user: build(:user), role: :owner}])
+
+      {:ok, view, _html} = live(conn, ~p"/projects")
+
+      assert view
+             |> has_element?(
+               "ul[aria-labelledby='combobox'] li#option-#{project_1.id}",
+               project_1.name
+             )
+
+      assert view
+             |> has_element?(
+               "ul[aria-labelledby='combobox'] li#option-#{project_2.id}",
+               project_2.name
+             )
+
+      refute view
+             |> has_element?(
+               "ul[aria-labelledby='combobox'] li#option-#{project_3.id}",
+               project_3.name
+             )
+    end
+
     test "projects list do not count deleted workflows", %{
       conn: conn,
       user: user


### PR DESCRIPTION
## Description

In Lightning, this bug manifests as an empty project selector combobox but the backup codes page loads. In Thunderbolt, extra plumbing results in this becoming a 500. 

I added some extra test coverage and the bug fix can be found here. 

Closes #2870

## Validation steps

If you already have a user with MFA setup, navigate to 'User Profile'. Scroll down to the MFA section, and click on the 'View' button for 'Recovery codes'. When the page loads, the Project selector combobox at the top of the LH menu bar should include any projects your user has access to.

Alternatively, if you do not have a user with MFA enabled, go to 'User Profile' and toggle 'Enable multi-factor authentication'. Once you have completed the MFA process, you will be directed to the recovery codes page. When the page loads, the Project selector combobox at the top of the LH menu bar should include any projects your user has access to.

## Additional notes for the reviewer

Inoculation against diseases is based on an ancient practice known as variolation which was used to reduce susceptibility to smallpox in Africa and Asia. This practice was brought to Europe in the 1700s and would result in the first smallpox vaccine being developed in 1796.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
