### PR TITLE
Dont allow special characters in credential names 

### DIFF
--- a/lib/lightning/credentials/credential.ex
+++ b/lib/lightning/credentials/credential.ex
@@ -49,6 +49,9 @@ defmodule Lightning.Credentials.Credential do
     )
     |> assoc_constraint(:user)
     |> assoc_constraint(:oauth_client)
+    |> validate_format(:name, ~r/^[a-zA-Z0-9_\- ]*$/,
+      message: "credential name has invalid format"
+    )
     |> validate_oauth()
     |> validate_transfer_ownership()
   end

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -299,6 +299,10 @@ defmodule LightningWeb.CredentialLiveTest do
              |> form("#credential-form-new", credential: %{name: ""})
              |> render_change() =~ "can&#39;t be blank"
 
+      assert index_live
+             |> form("#credential-form-new", credential: %{name: "MailChimp'24"})
+             |> render_change() =~ "credential name has invalid format"
+
       {:ok, _index_live, html} =
         index_live
         |> form("#credential-form-new", credential: @create_attrs)


### PR DESCRIPTION
## Description

This PR adds a validation on the changeset that rejects special characters in credential names.
Some of these characters are used in YAML definitions and are a nuisance to handle when working with `cli deploy`.

A sister PR to this is on kit: https://github.com/OpenFn/kit/pull/863 which now helps print helpful debug errors 

Closes #2808

## Validation steps

1. Try creating/editing a credential
2. In the name key in any special character e.g. `:  or ' `
3. An error will show

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
