### PR TITLE
Allow empty log lines to be sent from the worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Allow empty/blank log lines from the worker/jobs
+  [#2914](https://github.com/OpenFn/lightning/issues/2914)
+
 ### Fixed
 
 ## [v2.10.14] - 2025-02-06

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -65,10 +65,7 @@ defmodule Lightning.Invocation.LogLine do
     |> then(fn changeset ->
       fetch_field(changeset, :message)
       |> case do
-        {:changes, message} when message in [nil, [nil]] ->
-          add_error(changeset, :message, "can't be blank")
-
-        {:data, message} when is_nil(message) ->
+        {_type, message} when is_nil(message) ->
           add_error(changeset, :message, "can't be blank")
 
         _ ->

--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -39,7 +39,7 @@ defmodule Lightning.Invocation.LogLine do
       values: [:success, :always, :info, :warn, :error, :debug],
       default: :info
 
-    field :message, LogMessage, default: ""
+    field :message, LogMessage, default: nil
 
     belongs_to :step, Step
     belongs_to :run, Run
@@ -49,34 +49,46 @@ defmodule Lightning.Invocation.LogLine do
 
   def new(%Run{} = run, attrs \\ %{}, scrubber) do
     %__MODULE__{id: Ecto.UUID.generate()}
-    |> cast(attrs, [:message, :timestamp, :step_id, :run_id, :level, :source])
+    |> cast(attrs, [:message, :timestamp, :step_id, :run_id, :level, :source],
+      empty_values: [[], nil]
+    )
     |> put_assoc(:run, run)
     |> validate(scrubber)
   end
 
   def validate(changeset, scrubber \\ nil) do
     changeset
-    |> validate_required([:message, :timestamp])
+    |> validate_required([:timestamp])
     |> validate_length(:source, max: 8)
     |> assoc_constraint(:step)
     |> assoc_constraint(:run)
-    |> validate_change(:message, fn _, message ->
-      # cast converts [nil] into "null"
-      if message == "null" do
-        [message: "This field can't be blank."]
-      else
-        []
+    |> then(fn changeset ->
+      fetch_field(changeset, :message)
+      |> case do
+        {:changes, message} when message in [nil, [nil]] ->
+          add_error(changeset, :message, "can't be blank")
+
+        {:data, message} when is_nil(message) ->
+          add_error(changeset, :message, "can't be blank")
+
+        _ ->
+          changeset
       end
     end)
-    |> maybe_scrub(scrubber)
+    |> scrub_message(scrubber)
   end
 
-  defp maybe_scrub(%Ecto.Changeset{valid?: true} = changeset, scrubber)
+  defp scrub_message(%Ecto.Changeset{valid?: true} = changeset, scrubber)
        when scrubber != nil do
-    {:ok, message} = fetch_change(changeset, :message)
-    scrubbed = Scrubber.scrub(scrubber, message)
-    put_change(changeset, :message, scrubbed)
+    case fetch_change(changeset, :message) do
+      :error ->
+        changeset
+
+      {:ok, message} ->
+        scrubbed_message = Scrubber.scrub(scrubber, message)
+        put_change(changeset, :message, scrubbed_message)
+    end
   end
 
-  defp maybe_scrub(changeset, _scrubber), do: changeset
+  defp scrub_message(changeset, _scrubber), do: changeset
 end

--- a/lib/lightning_web/channels/channel_helpers.ex
+++ b/lib/lightning_web/channels/channel_helpers.ex
@@ -4,7 +4,7 @@ defmodule LightningWeb.ChannelHelpers do
   """
 
   def reply_with(socket, {:error, error}) do
-    send_error_to_sentry(socket, error)
+    send_warning_to_sentry(error)
     {:reply, {:error, error_to_map(error)}, socket}
   end
 
@@ -18,9 +18,10 @@ defmodule LightningWeb.ChannelHelpers do
 
   defp error_to_map(error), do: error
 
-  defp send_error_to_sentry(socket, error) do
-    Sentry.capture_message("#{socket.channel}.Error",
-      extra: %{error: inspect(error)}
+  defp send_warning_to_sentry(error) do
+    Sentry.capture_message("RunChannel replied with error",
+      extra: %{error: inspect(error)},
+      level: :warning
     )
   end
 end

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -282,6 +282,13 @@ defmodule Lightning.WebAndWorkerTest do
 
       log = Invocation.assemble_logs_for_step(step_2)
 
+      # Testing for how "empty" logs are handled
+      # console.log();          => new line
+      # console.log('');        => new line
+      # console.log(null);      => null
+      # console.log(undefined); => new line
+      assert log =~ "Starting operation 1\n\nnull\n{"
+
       assert log =~ ~S[{"password":"***","username":"quux"}]
       assert log =~ ~S"Check state.errors"
 
@@ -346,6 +353,10 @@ defmodule Lightning.WebAndWorkerTest do
 
   defp flow_expression do
     "fn(state => {
+      console.log();
+      console.log('');
+      console.log(null);
+      console.log(undefined);
       console.log(state.configuration);
       throw 'fail!'
     });"

--- a/test/lightning/invocation/log_line_test.exs
+++ b/test/lightning/invocation/log_line_test.exs
@@ -1,0 +1,45 @@
+defmodule Lightning.Invocation.LogLineTest do
+  use Lightning.DataCase, async: true
+
+  import Lightning.Factories
+
+  alias Lightning.Invocation.LogLine
+
+  test "new/2" do
+    dataclip = insert(:dataclip)
+
+    %{triggers: [trigger]} = workflow = insert(:simple_workflow)
+
+    work_order =
+      insert(:workorder,
+        workflow: workflow,
+        trigger: trigger,
+        dataclip: dataclip
+      )
+
+    run =
+      insert(:run,
+        work_order: work_order,
+        starting_trigger: trigger,
+        dataclip: dataclip
+      )
+
+    log_line =
+      LogLine.new(
+        run,
+        %{message: "Hello, World!", timestamp: DateTime.utc_now()},
+        nil
+      )
+
+    assert log_line.valid?
+
+    log_line =
+      LogLine.new(
+        run,
+        %{message: "", timestamp: DateTime.utc_now()},
+        nil
+      )
+
+    assert log_line.valid?, "should be able to have an empty message"
+  end
+end

--- a/test/lightning/invocation/log_line_test.exs
+++ b/test/lightning/invocation/log_line_test.exs
@@ -41,5 +41,15 @@ defmodule Lightning.Invocation.LogLineTest do
       )
 
     assert log_line.valid?, "should be able to have an empty message"
+
+    log_line =
+      LogLine.new(
+        run,
+        %{message: nil, timestamp: DateTime.utc_now()},
+        nil
+      )
+
+    assert {:message, {"can't be blank", []}} in log_line.errors
+    refute log_line.valid?
   end
 end

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -753,7 +753,7 @@ defmodule Lightning.RunsTest do
               {"should be at most %{count} character(s)",
                [count: 8, validation: :length, kind: :max, type: :string]}} in changeset.errors
 
-      assert {:message, {"can't be blank", [validation: :required]}} in changeset.errors
+      assert {:message, {"can't be blank", []}} in changeset.errors
 
       assert {:timestamp, {"can't be blank", [validation: :required]}} in changeset.errors
 

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -394,7 +394,7 @@ defmodule Lightning.SetupUtilsTest do
                  "references" => []
                }
 
-      assert Invocation.assemble_logs_for_step(first_step) <> "\n" ==
+      assert Invocation.assemble_logs_for_step(first_step) ==
                """
                -- THIS IS ONLY A SAMPLE --
                [CLI] ℹ Versions:
@@ -443,7 +443,7 @@ defmodule Lightning.SetupUtilsTest do
                  "references" => []
                }
 
-      assert Invocation.assemble_logs_for_step(last_step) <> "\n" ==
+      assert Invocation.assemble_logs_for_step(last_step) ==
                """
                -- THIS IS ONLY A SAMPLE --
                [CLI] ℹ Versions:
@@ -491,7 +491,7 @@ defmodule Lightning.SetupUtilsTest do
                  "references" => []
                }
 
-      assert Invocation.assemble_logs_for_step(second_step) <> "\n" ==
+      assert Invocation.assemble_logs_for_step(second_step) ==
                """
                -- THIS IS ONLY A SAMPLE --
                [CLI] ℹ Versions:
@@ -580,7 +580,7 @@ defmodule Lightning.SetupUtilsTest do
 
       assert failed_step.output_dataclip == nil
 
-      assert Invocation.assemble_logs_for_step(failed_step) <> "\n" ==
+      assert Invocation.assemble_logs_for_step(failed_step) ==
                """
                -- THIS IS ONLY A SAMPLE --
                [CLI] ℹ Versions:

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -979,9 +979,7 @@ defmodule LightningWeb.RunChannelTest do
           "message" => [nil]
         })
 
-      assert_reply ref, :error, errors
-
-      assert errors == %{message: ["This field can't be blank."]}
+      assert_reply ref, :ok, %{log_line_id: _}
     end
 
     test "run:log timestamp is handled at microsecond resolution", %{


### PR DESCRIPTION
Refactor log message handling to allow nil values and improve error validation.

```
console.log();          => new line
console.log('');        => new line
console.log(null);      => null
console.log(undefined); => new line
```

Closes #2914

## Description

We now allow the worker to send through empty log lines.

"Empty" in this case means 'something', the default value for the schema is now `nil`, and so `""` is valid because thats the value from the worker.

We still reject some messages, if the worker _doesn't_ send anything for a LogLine message, that's still invalid.

## Validation steps

This is not 1:1 demonstrable in a dev environment, because the error in Sentry is a "soft-error". There is not exception as such but rather a "error" logged to Sentry.

We never really tested for blank lines because (well 😅) it ignored them.

Applying this diff to `main`:

```diff
diff --git a/test/integration/web_and_worker_test.exs b/test/integration/web_and_worker_test.exs
index 263d1c459..f3c843d2d 100644
--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -346,6 +353,10 @@ defmodule Lightning.WebAndWorkerTest do
 
   defp flow_expression do
     "fn(state => {
+      console.log();
+      console.log('');
+      console.log(null);
+      console.log(undefined);
       console.log(state.configuration);
       throw 'fail!'
     });"
```

And adding something like a `raise "hell"` to `reply_with/2` at `lib/lightning_web/channels/channel_helpers.ex:7` and then run `mix test test/integration/web_and_worker_test.exs`; will result in a test failure.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
