### PR TITLE
Restrict editors from creating collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 - Allow empty/blank log lines from the worker/jobs
   [#2914](https://github.com/OpenFn/lightning/issues/2914)
+- Only allow `owner` and `admin` users to manage collections
+  [#2923](https://github.com/OpenFn/lightning/issues/2923)
 
 ### Fixed
 

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -73,7 +73,8 @@ defmodule Lightning.Policies.ProjectUsers do
              :edit_project,
              :edit_data_retention,
              :add_project_user,
-             :remove_project_user
+             :remove_project_user,
+             :create_collection
            ],
       do: project_user.role in [:owner, :admin]
 
@@ -85,8 +86,7 @@ defmodule Lightning.Policies.ProjectUsers do
              :run_workflow,
              :provision_project,
              :create_project_credential,
-             :initiate_github_sync,
-             :create_collection
+             :initiate_github_sync
            ],
       do: project_user.role in [:owner, :admin, :editor]
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -4964,7 +4964,7 @@ defmodule LightningWeb.ProjectLiveTest do
     } do
       project = insert(:project)
 
-      for {conn, _user} <- setup_project_users(conn, project, [:viewer]) do
+      for {conn, _user} <- setup_project_users(conn, project, [:viewer, :editor]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -4997,7 +4997,7 @@ defmodule LightningWeb.ProjectLiveTest do
       end
 
       for {conn, _user} <-
-            setup_project_users(conn, project, [:owner, :admin, :editor]) do
+            setup_project_users(conn, project, [:owner, :admin]) do
         {:ok, view, _html} =
           live(
             conn,
@@ -5032,7 +5032,7 @@ defmodule LightningWeb.ProjectLiveTest do
       project = insert(:project)
 
       for {{conn, _user}, index} <-
-            setup_project_users(conn, project, [:owner, :admin, :editor])
+            setup_project_users(conn, project, [:owner, :admin])
             |> Enum.with_index() do
         {:ok, view, _html} =
           live(
@@ -5172,7 +5172,7 @@ defmodule LightningWeb.ProjectLiveTest do
     } do
       project = insert(:project)
 
-      for {conn, _user} <- setup_project_users(conn, project, [:viewer]) do
+      for {conn, _user} <- setup_project_users(conn, project, [:viewer, :editor]) do
         collection = insert(:collection, project: project)
 
         {:ok, view, _html} =
@@ -5216,7 +5216,7 @@ defmodule LightningWeb.ProjectLiveTest do
       project = insert(:project)
 
       for {conn, _user} <-
-            setup_project_users(conn, project, [:owner, :admin, :editor]) do
+            setup_project_users(conn, project, [:owner, :admin]) do
         collection = insert(:collection, project: project)
 
         {:ok, view, _html} =
@@ -5276,7 +5276,7 @@ defmodule LightningWeb.ProjectLiveTest do
     } do
       project = insert(:project)
 
-      for {conn, _user} <- setup_project_users(conn, project, [:viewer]) do
+      for {conn, _user} <- setup_project_users(conn, project, [:viewer, :editor]) do
         collection = insert(:collection, project: project)
 
         {:ok, view, _html} =
@@ -5319,45 +5319,8 @@ defmodule LightningWeb.ProjectLiveTest do
     } do
       project = insert(:project)
 
-      for {conn, _user} <- setup_project_users(conn, project, [:viewer]) do
-        collection = insert(:collection, project: project)
-
-        {:ok, view, _html} =
-          live(
-            conn,
-            ~p"/projects/#{project.id}/settings#collections"
-          )
-
-        button = element(view, "#delete-collection-#{collection.id}-button")
-        assert has_element?(button)
-
-        # modal is not present
-        refute has_element?(view, "#delete-collection-#{collection.id}-modal")
-
-        # try clicking the button
-        assert_raise ArgumentError, ~r/is disabled/, fn ->
-          render_click(button)
-        end
-
-        # send event either way
-        view
-        |> with_target("#collections")
-        |> render_click("toggle_action", %{
-          "action" => "delete",
-          "collection" => collection.name
-        })
-
-        flash =
-          assert_redirected(
-            view,
-            ~p"/projects/#{project.id}/settings#collections"
-          )
-
-        assert flash["error"] == "You are not authorized to perform this action"
-      end
-
       for {conn, _user} <-
-            setup_project_users(conn, project, [:owner, :admin, :editor]) do
+            setup_project_users(conn, project, [:owner, :admin]) do
         collection = insert(:collection, project: project)
 
         {:ok, view, _html} =


### PR DESCRIPTION
## Description

This PR makes it such that only `owners` and `admins` can create/update/delete collections

Closes #2923

## Validation steps
- Log in as an `editor`. 
- You'll see that the action buttons are greyed out



## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
