### PR TITLE
Delete unused snapshots on workorders retention cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Delete unused snapshots on workorders retention cleanup
+  [#1832](https://github.com/OpenFn/lightning/issues/1832)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -739,13 +739,10 @@ defmodule Lightning.Projects do
   """
   @spec delete_project_workorders(Project.t(), non_neg_integer()) :: :ok
   def delete_project_workorders(project, batch_size \\ 1000) do
-    workorders_query =
-      from wo in WorkOrder,
-        join: wf in assoc(wo, :workflow),
-        on: wf.project_id == ^project.id,
-        select: wo.id
-
-    delete_workorders_history(workorders_query, batch_size)
+    :ok =
+      project
+      |> project_workorders_query()
+      |> delete_workorders_history(batch_size)
   end
 
   @doc """
@@ -793,22 +790,22 @@ defmodule Lightning.Projects do
     {:error, :missing_dataclip_retention_period}
   end
 
-  defp delete_history_for(%Project{history_retention_period: period} = project)
-       when is_integer(period) do
-    workorders_query =
-      from wo in WorkOrder,
-        join: wf in assoc(wo, :workflow),
-        on: wf.project_id == ^project.id,
-        where: wo.last_activity < ago(^period, "day"),
-        select: wo.id
-
-    delete_workorders_history(workorders_query, 1000)
+  defp delete_history_for(
+         %Project{
+           history_retention_period: period_days
+         } = project
+       )
+       when is_integer(period_days) do
+    :ok =
+      project
+      |> project_workorders_query()
+      |> delete_workorders_history(1000, period_days)
 
     dataclips_query =
       from d in Dataclip,
         as: :dataclip,
         where: d.project_id == ^project.id,
-        where: d.inserted_at < ago(^period, "day"),
+        where: d.inserted_at < ago(^period_days, "day"),
         left_join: wo in WorkOrder,
         on: d.id == wo.dataclip_id,
         left_join: r in Run,
@@ -827,8 +824,21 @@ defmodule Lightning.Projects do
     {:error, :missing_history_retention_period}
   end
 
-  defp delete_workorders_history(workorders_query, batch_size) do
-    workorders_count = Repo.aggregate(workorders_query, :count)
+  defp delete_workorders_history(
+         project_workorders_query,
+         batch_size,
+         retention_period_days \\ nil
+       ) do
+    workorders_query =
+      if retention_period_days do
+        where(
+          project_workorders_query,
+          [wo],
+          wo.last_activity < ago(^retention_period_days, "day")
+        )
+      else
+        project_workorders_query
+      end
 
     workorders_delete_query =
       WorkOrder
@@ -847,6 +857,16 @@ defmodule Lightning.Projects do
         on: r.work_order_id == wtd.id
       )
 
+    workorders_count = Repo.aggregate(workorders_query, :count)
+
+    snapshot_ids_on_delete =
+      if retention_period_days do
+        workorders_query
+        |> distinct(true)
+        |> select([wo], wo.snapshot_id)
+        |> Repo.all()
+      end
+
     for _i <- 1..ceil(workorders_count / batch_size) do
       Repo.transaction(
         fn ->
@@ -857,6 +877,28 @@ defmodule Lightning.Projects do
         end,
         timeout: 50_000
       )
+    end
+
+    # If it's on a retention cleanup, it also deletes unused snapshots after the workorders deletion.
+    # Otherwise, it's a cleanup for the whole project when the snapshots are automatically deleted
+    # by the workflows deletion.
+    if retention_period_days do
+      snapshot_ids_in_use =
+        project_workorders_query
+        |> distinct(true)
+        |> select([wo], wo.snapshot_id)
+        |> Repo.all()
+
+      snapshots_to_delete =
+        snapshot_ids_on_delete
+        |> MapSet.new()
+        |> MapSet.difference(MapSet.new(snapshot_ids_in_use))
+        |> MapSet.to_list()
+
+      {_count, nil} =
+        Repo.delete_all(from(s in Snapshot, where: s.id in ^snapshots_to_delete),
+          returning: false
+        )
     end
 
     :ok

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -237,7 +237,8 @@ defmodule Lightning.ProjectsTest do
     test "delete_project/1 deletes the project" do
       %{project: p1, workflow_1_job: w1_job, workflow_1: w1} =
         full_project_fixture(
-          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second),
+          scheduled_deletion:
+            Lightning.current_time() |> DateTime.truncate(:second),
           collections: [build(:collection, project: nil)]
         )
 
@@ -496,7 +497,8 @@ defmodule Lightning.ProjectsTest do
       {:ok, %{scheduled_deletion: scheduled_deletion}} =
         Projects.schedule_project_deletion(project)
 
-      assert Timex.diff(scheduled_deletion, DateTime.utc_now(), :seconds) <= 10
+      assert Timex.diff(scheduled_deletion, Lightning.current_time(), :seconds) <=
+               10
     end
 
     test "schedule_project_deletion/1 schedules a project for deletion to purge_deleted_after_days days from now" do
@@ -510,7 +512,7 @@ defmodule Lightning.ProjectsTest do
 
       assert project.scheduled_deletion == nil
 
-      now = DateTime.utc_now() |> DateTime.add(-1, :second)
+      now = Lightning.current_time() |> DateTime.add(-1, :second)
       {:ok, project} = Projects.schedule_project_deletion(project)
 
       project_triggers = Projects.project_triggers_query(project) |> Repo.all()
@@ -524,7 +526,8 @@ defmodule Lightning.ProjectsTest do
     test "cancel_scheduled_deletion/2" do
       project =
         project_fixture(
-          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+          scheduled_deletion:
+            Lightning.current_time() |> DateTime.truncate(:second)
         )
 
       assert project.scheduled_deletion
@@ -775,12 +778,14 @@ defmodule Lightning.ProjectsTest do
     test "removes all projects past deletion date when called with type 'purge_deleted'" do
       project_to_delete =
         project_fixture(
-          scheduled_deletion: DateTime.utc_now() |> Timex.shift(seconds: -10)
+          scheduled_deletion:
+            Lightning.current_time() |> Timex.shift(seconds: -10)
         )
 
       not_to_delete =
         project_fixture(
-          scheduled_deletion: DateTime.utc_now() |> Timex.shift(seconds: 10)
+          scheduled_deletion:
+            Lightning.current_time() |> Timex.shift(seconds: 10)
         )
 
       count_before = Repo.all(Project) |> Enum.count()
@@ -801,7 +806,7 @@ defmodule Lightning.ProjectsTest do
       %{triggers: [trigger], jobs: [job | _rest]} =
         workflow = insert(:simple_workflow, project: project)
 
-      now = DateTime.utc_now()
+      now = Lightning.current_time()
 
       snapshot_to_delete = insert(:snapshot, workflow: workflow, lock_version: 1)
       snapshot_to_keep = insert(:snapshot, workflow: workflow, lock_version: 2)
@@ -888,7 +893,7 @@ defmodule Lightning.ProjectsTest do
     test "deletes project dataclips not associated to any work order correctly" do
       project = insert(:project, history_retention_period: 7)
       workflow = insert(:simple_workflow, project: project)
-      now = DateTime.utc_now()
+      now = Lightning.current_time()
 
       # pre_retention means it exists earlier than the retention cut off time
       # post_retention means it exists later than the retention cut off time
@@ -982,7 +987,7 @@ defmodule Lightning.ProjectsTest do
       %{triggers: [trigger]} =
         workflow = insert(:simple_workflow, project: project)
 
-      now = DateTime.utc_now()
+      now = Lightning.current_time()
 
       # pre_retention means it exists earlier than the retention cut off time
       # post_retention means it exists later than the retention cut off time
@@ -1089,7 +1094,7 @@ defmodule Lightning.ProjectsTest do
       %{triggers: [trigger], jobs: [job | _rest]} =
         workflow = insert(:simple_workflow, project: project)
 
-      now = DateTime.utc_now()
+      now = Lightning.current_time()
 
       # pre_retention means it exists earlier than the retention cut off time
       # post_retention means it exists later than the retention cut off time
@@ -1217,7 +1222,7 @@ defmodule Lightning.ProjectsTest do
       %{triggers: [trigger], jobs: [job | _rest]} =
         workflow = insert(:simple_workflow, project: project)
 
-      now = DateTime.utc_now()
+      now = Lightning.current_time()
 
       # pre_retention means it exists earlier than the retention cut off time
       # post_retention means it exists later than the retention cut off time


### PR DESCRIPTION
## Description

This PR adds an deletion for unused snapshots (those are referenced by no work orders anymore).

There are two scenarios when snapshots needs to be deleted:
a) on project deletion, when workflows deletion takes care of it
b) on data retention cleanup, when much work orders are left after deleting the old ones.

The filtering of the snapshots to delete come from the set difference between snapshots from the deleted work orders and snapshots that are still in use (referenced by recent work orders that are still in the retention period).  

Closes #1832 

## Validation steps

0. Setup some retention period. 
1. Insert 10k work orders, stop Lightning and update their date to be out of the retention period (older). Also update the `state` of both the work orders and runs to `success`.
2. Take note of the snapshot id used.
3. Edit the workflow.
4. Insert 2k work orders and update their date to be out of the retention period (older).
5. Insert more 2k work orders.
6. Call `Lightning.Projects.perform(%Oban.Job{args: %{"project_id" => "4adf2644-ed4e-4f97-a24c-ab35b3cb1efa", "type" => "data_retention"}})` using your `project_id` 
7. It shall delete all work orders from steps 1 and 4 in less than 3 seconds. The snapshot of step 2 is also deleted.
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/df0633a3-05b3-4912-9be7-32266052dabc" />
and only one snapshot is left
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/e5ef362f-d280-42e9-87f4-9ca6dba4b89a" />

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
