### PR TITLE
Bump Node to 22.12.0 in CI and .tool-versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       nodejs_version:
         description: NodeJS version
         type: string
-        default: "18.17.1"
+        default: "22.12.0"
       execute:
         description: What steps to execute after build
         type: steps
@@ -46,7 +46,7 @@ jobs:
     parallelism: 1
     docker:
       - image: elixir:<< parameters.elixir_version >>
-      - image: cimg/postgres:15.3
+      - image: cimg/postgres:17.3
     environment:
       ERL_FLAGS: +S 4:4
       ASSERT_RECEIVE_TIMEOUT: 1000

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 erlang 26.2.5
 elixir 1.16.2-otp-26
-nodejs 18.17.1
+nodejs 22.12.0
 k6 0.49.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Bumped CI NodeJS and Postgres versions to 22.12.0 and 17.3 respectively
+  [#2938](https://github.com/OpenFn/lightning/pull/2938)
+
 ### Fixed
 
 ## [v2.10.15] - 2025-02-14

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -40,7 +40,7 @@
         "esbuild": "^0.17.18",
         "puppeteer": "^23.0.2",
         "tap-xunit": "^2.4.1",
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.2"
       }
     },
     "../../dagre": {
@@ -5822,10 +5822,11 @@
       "peer": true
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/assets/package.json
+++ b/assets/package.json
@@ -42,8 +42,9 @@
     "esbuild": "^0.17.18",
     "puppeteer": "^23.0.2",
     "tap-xunit": "^2.4.1",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.2"
   },
+  "type": "module",
   "ava": {
     "extensions": {
       "ts": "module"

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -252,7 +252,7 @@ defmodule Lightning.WebAndWorkerTest do
           |> Map.get(:message)
         end)
 
-      assert version_logs =~ "▸ node.js                  18.17"
+      assert version_logs =~ "▸ node.js                  22.12"
       assert version_logs =~ "▸ worker                   1.9"
       assert version_logs =~ "▸ @openfn/language-http    3.1.12"
 


### PR DESCRIPTION
Also bumping Postgres to 17.3 for CI.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
