### PR TITLE
Enable project level concurrency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Enable project level concurrency limit
+  [#2906](https://github.com/OpenFn/lightning/issues/2906)
 - Delete unused snapshots on workorders retention cleanup
   [#1832](https://github.com/OpenFn/lightning/issues/1832)
 

--- a/lib/lightning/policies/permissions.ex
+++ b/lib/lightning/policies/permissions.ex
@@ -8,7 +8,7 @@ defmodule Lightning.Policies.Permissions do
   - The `users.ex` file has all the policies for the instances wide access levels
   - The `project_users.ex` file has all the policies for the project wide access levels
   - The `permissions.ex` file defines the `Lightning.Policies.Permissions.can/4` interface. Which is a wrapper around the `Bodyguard.permit/4` function.
-  We use that interface to be able to harmonize the use of policies accross the entire app.
+  We use that interface to be able to harmonize the use of policies across the entire app.
 
   All the policies are tested in the `test/lightning/policies` folder. And the test are written in a way that allows the reader to quickly who can do what in the app.
 

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -58,6 +58,7 @@ defmodule Lightning.Projects.Project do
     |> cast(attrs, [
       :id,
       :name,
+      :concurrency,
       :description,
       :scheduled_deletion,
       :requires_mfa,

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -19,6 +19,7 @@ defmodule Lightning.Projects.Project do
 
   schema "projects" do
     field :name, :string
+    field :concurrency, :integer
     field :description, :string
     field :scheduled_deletion, :utc_datetime
     field :requires_mfa, :boolean, default: false

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -75,6 +75,7 @@ defmodule Lightning.Projects.Project do
     |> validate_required([:name])
     |> validate_format(:name, ~r/^[a-z\-\d]+$/)
     |> validate_dataclip_retention_period()
+    |> validate_inclusion(:concurrency, [1, nil])
     |> validate_inclusion(:history_retention_period, data_retention_options())
     |> validate_inclusion(:dataclip_retention_period, data_retention_options())
   end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -133,7 +133,7 @@ defmodule Lightning.Runs.Query do
     |> where(
       [r, ipw],
       r.state == :available and
-      (is_nil(ipw.concurrency) or ipw.row_number <= ipw.concurrency)
+        (is_nil(ipw.concurrency) or ipw.row_number <= ipw.concurrency)
     )
     |> order_by([r], asc: r.inserted_at)
   end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -110,7 +110,25 @@ defmodule Lightning.Runs.Query do
       # calculated here?
       row_number: row_number() |> over(:row_number),
       project_id: w.project_id,
-      concurrency: coalesce(w.concurrency, p.concurrency),
+      concurrency: fragment(
+        """
+          CASE
+            WHEN ? IS NULL AND ? IS NULL THEN ?
+            WHEN ? IS NULL THEN ?
+            WHEN ? < ? THEN ?
+            ELSE ?
+          END
+        """,
+        p.concurrency,
+        w.concurrency,
+        nil,
+        p.concurrency,
+        w.concurrency,
+        w.concurrency,
+        p.concurrency,
+        w.concurrency,
+        p.concurrency
+      ),
       inserted_at: r.inserted_at
     })
   end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -69,37 +69,51 @@ defmodule Lightning.Runs.Query do
   - `row_number`, the number of the row in the window, per workflow
   - `limit`, the maximum number of runs that can be claimed for the workflow
   """
-  @spec in_progress_window() :: Ecto.Queryable.t()
-  def in_progress_window do
+  @spec in_progress_window(:workflow | :project) :: Ecto.Queryable.t()
+  def in_progress_window(scope \\ :workflow) do
     from(r in Run,
       where: r.state in [:available, :claimed, :started],
       join: wo in assoc(r, :work_order),
       join: w in assoc(wo, :workflow),
-      join: p in assoc(w, :project),
-      windows: [
-        row_number: [
-          partition_by: w.id,
-          order_by: [asc: r.inserted_at]
-        ]
-      ],
-      select: %{
-        id: r.id,
-        state: r.state,
-        # need to check what performance implications are of using row_number
-        # does the subsequent query's limit clause get applied to the row_number
-        # calculated here?
-        row_number: row_number() |> over(:row_number),
-        project_id: p.id,
-        concurrency: w.concurrency,
-        inserted_at: r.inserted_at
-      }
+      join: p in assoc(w, :project)
     )
+    |> then(fn query ->
+      if scope == :workflow do
+        query
+        |> windows([r, _wo, w],
+          row_number: [
+            partition_by: w.id,
+            order_by: [asc: r.inserted_at]
+          ]
+        )
+        |> select([_r, _wo, w], %{concurrency: w.concurrency})
+      else
+        query
+        |> windows([r, _wo, w],
+          row_number: [
+            partition_by: w.project_id,
+            order_by: [asc: r.inserted_at]
+          ]
+        )
+        |> select([_r, _wo, _w, p], %{concurrency: p.concurrency})
+      end
+    end)
+    |> select_merge([r, _wo, w], %{
+      id: r.id,
+      state: r.state,
+      # need to check what performance implications are of using row_number
+      # does the subsequent query's limit clause get applied to the row_number
+      # calculated here?
+      row_number: row_number() |> over(:row_number),
+      project_id: w.project_id,
+      inserted_at: r.inserted_at
+    })
   end
 
   @doc """
   Query to return runs that are eligible for claiming.
 
-  Uses `in_progress_window/0` and filters for runs that are either in the
+  Uses `in_progress_window/1` and filters for runs that are either in the
   available state and have not reached the concurrency limit for their workflow.
 
   > ### Note {: .info}
@@ -111,18 +125,18 @@ defmodule Lightning.Runs.Query do
   > eligible_for_claim() |> prepend_order_by([:priority])
   > ```
   """
-  @spec eligible_for_claim() :: Ecto.Queryable.t()
-  def eligible_for_claim do
+  @spec eligible_for_claim(:workflow | :project) :: Ecto.Queryable.t()
+  def eligible_for_claim(scope \\ :workflow) do
     Run
-    |> with_cte("in_progress_window", as: ^in_progress_window())
-    |> join(:inner, [r], w in fragment(~s("in_progress_window")),
-      on: r.id == w.id,
+    |> with_cte("in_progress_window", as: ^in_progress_window(scope))
+    |> join(:inner, [r], ipw in fragment(~s("in_progress_window")),
+      on: r.id == ipw.id,
       as: :in_progress_window
     )
     |> where(
-      [r, w],
-      (is_nil(w.concurrency) or w.row_number <= w.concurrency) and
-        w.state == "available"
+      [r, s],
+      s.state == "available" and
+      (is_nil(s.concurrency) or s.row_number <= s.concurrency)
     )
     |> order_by([r], asc: r.inserted_at)
   end

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -110,7 +110,7 @@ defmodule Lightning.Runs.Query do
   @doc """
   Query to return runs that are eligible for claiming.
 
-  Uses `in_progress_window/1` and filters for runs that are either in the
+  Uses `in_progress_window/0` and filters for runs that are either in the
   available state and have not reached the concurrency limit for their workflow.
 
   > ### Note {: .info}

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -73,7 +73,7 @@
         <div class="bg-white p-4 rounded-md">
           <div>
             <h6 class="font-medium text-black">
-              Project Identity and Execution
+              Project Identity
             </h6>
             <small class="block my-1 text-xs text-gray-600">
               This metadata helps you identify the types of workflows managed in this project and the people that have access.
@@ -119,6 +119,57 @@
             <div class="hidden sm:block" aria-hidden="true">
               <div class="py-2"></div>
             </div>
+            <div class="grid grid-cols gap-6">
+              <div class="md:col-span-2">
+                <.button
+                  id="project-identity-submit-btn"
+                  type="submit"
+                  disabled={!(@project_changeset.valid? and @can_edit_project)}
+                >
+                  Save
+                </.button>
+              </div>
+            </div>
+          </.form>
+        </div>
+        <div class="hidden sm:block" aria-hidden="true">
+          <div class="py-2"></div>
+        </div>
+        <div class="bg-white p-4 rounded-md">
+          <div>
+            <h6 class="font-medium text-black">
+              Project Execution
+            </h6>
+            <small class="block my-1 text-xs text-gray-600">
+              Decide how the runs from this project are executed across multiple workflows, whether in parallel or sequentially.
+            </small>
+          </div>
+          <.form
+            :let={f}
+            for={@project_changeset}
+            id="project-execution-form"
+            phx-change="validate"
+            phx-submit="save"
+          >
+            <div class="grid grid-cols gap-6">
+              <div class="md:col-span-2">
+                <.input
+                  type="hidden"
+                  field={f[:name]}
+                />
+              </div>
+            </div>
+            <div class="grid grid-cols gap-6">
+              <div class="md:col-span-2">
+                <.input
+                  type="hidden"
+                  field={f[:description]}
+                />
+              </div>
+            </div>
+            <div class="hidden sm:block" aria-hidden="true">
+              <div class="py-2"></div>
+            </div>
             <div class="grid grid-cols md:col-span-2">
               <div class="flex flex-row">
                 <div>
@@ -137,12 +188,11 @@
               </div>
               <div>
                 <small class="block my-1 text-xs text-gray-600">
-                  Additionally you can setup all runs from this project, accross multiple workflows, to not execute in parallel.
                 </small>
               </div>
             </div>
             <div class="hidden sm:block" aria-hidden="true">
-              <div class="py-4"></div>
+              <div class="py-2"></div>
             </div>
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -153,18 +153,12 @@
           >
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
-                <.input
-                  type="hidden"
-                  field={f[:name]}
-                />
+                <.input type="hidden" field={f[:name]} />
               </div>
             </div>
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
-                <.input
-                  type="hidden"
-                  field={f[:description]}
-                />
+                <.input type="hidden" field={f[:description]} />
               </div>
             </div>
             <div class="hidden sm:block" aria-hidden="true">
@@ -187,17 +181,20 @@
                 </div>
               </div>
               <Common.alert
-                  :if={f[:concurrency].value == 1 and Enum.any?(@project_changeset.changes)}
-                  id="heads-up-description"
-                  type="warning"
-                  header="Heads Up!"
-                  class="mt-2"
-                >
-                  <:message>
-                    <p>
-                      By disabling parallel execution, the work orders in this project will be processed sequentially.
-                    </p>
-                  </:message>
+                :if={
+                  f[:concurrency].value == 1 and
+                    Enum.any?(@project_changeset.changes)
+                }
+                id="heads-up-description"
+                type="warning"
+                header="Heads Up!"
+                class="mt-2"
+              >
+                <:message>
+                  <p>
+                    By disabling parallel execution, the work orders in this project will be processed sequentially.
+                  </p>
+                </:message>
               </Common.alert>
             </div>
             <div class="hidden sm:block" aria-hidden="true">
@@ -208,7 +205,9 @@
                 <.button
                   id="project-identity-submit-btn"
                   type="submit"
-                  disabled={!(Enum.any?(@project_changeset.changes) and @can_edit_project)}
+                  disabled={
+                    !(Enum.any?(@project_changeset.changes) and @can_edit_project)
+                  }
                 >
                   Save
                 </.button>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -186,10 +186,19 @@
                   />
                 </div>
               </div>
-              <div>
-                <small class="block my-1 text-xs text-gray-600">
-                </small>
-              </div>
+              <Common.alert
+                  :if={f[:concurrency].value == 1}
+                  id="heads-up-description"
+                  type="warning"
+                  header="Heads Up!"
+                  class="mt-2"
+                >
+                  <:message>
+                    <p>
+                      By disabling parallel execution, the work orders in this project will be processed sequentially.
+                    </p>
+                  </:message>
+              </Common.alert>
             </div>
             <div class="hidden sm:block" aria-hidden="true">
               <div class="py-2"></div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -72,7 +72,7 @@
         </div>
         <div class="bg-white p-4 rounded-md">
           <div>
-            <h6 class="font-medium text-black">Project Identity</h6>
+            <h6 class="font-medium text-black">Project Identity and Execution</h6>
             <small class="block my-1 text-xs text-gray-600">
               This metadata helps you identify the types of workflows managed in this project and the people that have access.
             </small>
@@ -111,6 +111,24 @@
                 />
                 <small class="mt-2 block text-xs text-gray-600">
                   A short description of a project [max 240 characters]
+                </small>
+              </div>
+            </div>
+            <div class="hidden sm:block" aria-hidden="true">
+              <div class="py-2"></div>
+            </div>
+            <div class="grid grid-cols gap-6">
+              <div class="md:col-span-2">
+                <.input
+                  type="checkbox"
+                  field={f[:concurrency]}
+                  disabled={!@can_edit_project}
+                  label="Disable Parallel Execution?"
+                  checked_value="1"
+                  unchecked_value={nil}
+                />
+                <small class="block my-1 text-xs text-gray-600">
+                  Additionally you can setup all runs from this project, accross multiple workflows, to not execute in parallel.  
                 </small>
               </div>
             </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -72,7 +72,9 @@
         </div>
         <div class="bg-white p-4 rounded-md">
           <div>
-            <h6 class="font-medium text-black">Project Identity and Execution</h6>
+            <h6 class="font-medium text-black">
+              Project Identity and Execution
+            </h6>
             <small class="block my-1 text-xs text-gray-600">
               This metadata helps you identify the types of workflows managed in this project and the people that have access.
             </small>
@@ -117,18 +119,25 @@
             <div class="hidden sm:block" aria-hidden="true">
               <div class="py-2"></div>
             </div>
-            <div class="grid grid-cols gap-6">
-              <div class="md:col-span-2">
-                <.input
-                  type="checkbox"
-                  field={f[:concurrency]}
-                  disabled={!@can_edit_project}
-                  label="Disable Parallel Execution?"
-                  checked_value="1"
-                  unchecked_value={nil}
-                />
+            <div class="grid grid-cols md:col-span-2">
+              <div class="flex flex-row">
+                <div>
+                  <.label>Disable parallel run execution?</.label>
+                </div>
+                <div class="ml-2 mt-1">
+                  <.input
+                    type="checkbox"
+                    field={f[:concurrency]}
+                    disabled={!@can_edit_project}
+                    label=""
+                    checked_value="1"
+                    unchecked_value={nil}
+                  />
+                </div>
+              </div>
+              <div>
                 <small class="block my-1 text-xs text-gray-600">
-                  Additionally you can setup all runs from this project, accross multiple workflows, to not execute in parallel.  
+                  Additionally you can setup all runs from this project, accross multiple workflows, to not execute in parallel.
                 </small>
               </div>
             </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -187,7 +187,7 @@
                 </div>
               </div>
               <Common.alert
-                  :if={f[:concurrency].value == 1}
+                  :if={f[:concurrency].value == 1 and Enum.any?(@project_changeset.changes)}
                   id="heads-up-description"
                   type="warning"
                   header="Heads Up!"
@@ -208,7 +208,7 @@
                 <.button
                   id="project-identity-submit-btn"
                   type="submit"
-                  disabled={!(@project_changeset.valid? and @can_edit_project)}
+                  disabled={!(Enum.any?(@project_changeset.changes) and @can_edit_project)}
                 >
                   Save
                 </.button>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -107,6 +107,7 @@ defmodule LightningWeb.WorkflowLive.Components do
   end
 
   attr :form, :map, required: true
+  attr :project_concurrency_disabled, :boolean, required: true
 
   def workflow_settings(assigns) do
     ~H"""
@@ -145,15 +146,26 @@ defmodule LightningWeb.WorkflowLive.Components do
         <div class="flex place-content-between items-center space-x-2 pt-1">
           <.errors field={@form[:concurrency]} />
           <div
-            :if={Enum.empty?(@form[:concurrency].errors)}
+            :if={
+              not @project_concurrency_disabled and
+                Enum.empty?(@form[:concurrency].errors)
+            }
             class="text-xs text-slate-500 italic"
           >
-            <%= case @form[:concurrency].value do
-              nil -> "Unlimited (up to max available)"
+            <%= case @form[:concurrency].value || "" do
               "" -> "Unlimited (up to max available)"
               1 -> "No more than one run at a time"
               value -> "No more than #{value} runs at a time"
             end %>
+          </div>
+          <div
+            :if={
+              @project_concurrency_disabled and
+                Enum.empty?(@form[:concurrency].errors)
+            }
+            class="text-xs text-red-500 italic"
+          >
+            Parallel execution of runs is disabled for this project. This workflow concurrency limit won't take effect.
           </div>
         </div>
       </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -108,6 +108,7 @@ defmodule LightningWeb.WorkflowLive.Components do
 
   attr :form, :map, required: true
   attr :project_concurrency_disabled, :boolean, required: true
+  attr :project_id, :string, required: true
 
   def workflow_settings(assigns) do
     ~H"""
@@ -165,7 +166,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             }
             class="text-xs text-red-500 italic"
           >
-            Parallel execution of runs is disabled for this project. This workflow concurrency limit won't take effect.
+            This workflow concurrency limit won't take effect. Parallel execution of runs is disabled for this project. You can modify this setting via your <.link class="underline" patch={~p"/projects/#{@project_id}/settings"}>project setup</.link> page.
           </div>
         </div>
       </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -166,7 +166,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             }
             class="text-xs text-red-500 italic"
           >
-            This workflow concurrency limit won't take effect. Parallel execution of runs is disabled for this project. You can modify this setting via your <.link class="underline" patch={~p"/projects/#{@project_id}/settings"}>project setup</.link> page.
+            This workflow concurrency limit won't take effect. Parallel execution of runs is disabled for this project. You can modify this setting on your <.link class="underline" patch={~p"/projects/#{@project_id}/settings"}>project setup</.link> page.
           </div>
         </div>
       </div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -166,7 +166,11 @@ defmodule LightningWeb.WorkflowLive.Components do
             }
             class="text-xs text-red-500 italic"
           >
-            This workflow concurrency limit won't take effect. Parallel execution of runs is disabled for this project. You can modify this setting on your <.link class="underline" patch={~p"/projects/#{@project_id}/settings"}>project setup</.link> page.
+            This workflow concurrency limit won't take effect. Parallel execution of runs is disabled for this project. You can modify this setting on your
+            <.link class="underline" patch={~p"/projects/#{@project_id}/settings"}>
+              project setup
+            </.link>
+            page.
           </div>
         </div>
       </div>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -434,7 +434,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
             phx-remove={fade_out()}
             cancel_url={@base_url}
           >
-            <.workflow_settings form={@workflow_form} />
+            <.workflow_settings
+              project_concurrency_disabled={@workflow.project.concurrency == 1}
+              form={@workflow_form}
+            />
           </.panel>
 
           <.single_inputs_for
@@ -1971,6 +1974,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   defp get_workflow_by_id(workflow_id) do
     Workflows.get_workflow(workflow_id)
     |> Lightning.Repo.preload([
+      :project,
       :edges,
       triggers: Trigger.with_auth_methods_query(),
       jobs:
@@ -2171,7 +2175,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   defp assign_workflow(socket, workflow) do
     socket
-    |> assign(workflow: workflow)
+    |> assign(workflow: Lightning.Repo.preload(workflow, :project))
     |> apply_params(socket.assigns.workflow_params, :workflow)
   end
 

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -435,6 +435,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             cancel_url={@base_url}
           >
             <.workflow_settings
+              project_id={@workflow.project_id}
               project_concurrency_disabled={@workflow.project.concurrency == 1}
               form={@workflow_form}
             />

--- a/priv/repo/migrations/20250217103202_add_project_concurrency.exs
+++ b/priv/repo/migrations/20250217103202_add_project_concurrency.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddProjectConcurrency do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :concurrency, :integer
+    end
+  end
+end

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -265,6 +265,7 @@ defmodule Lightning.Runs.QueryTest do
 
       # magenta project has only project level concurrecy
       Repo.update!(Projects.change_project(magenta.project, %{concurrency: 1}))
+
       # indigo project has project level concurrecy (serial execution). It overrides the workflow level one.
       Repo.update!(Projects.change_project(indigo.project, %{concurrency: 1}))
 
@@ -368,7 +369,8 @@ defmodule Lightning.Runs.QueryTest do
       runs_in_order_match =
         runs_in_order
         |> Enum.zip_with(
-          List.duplicate(%{state: :claimed}, 7) ++ List.duplicate(%{}, num_runs - 7),
+          List.duplicate(%{state: :claimed}, 7) ++
+            List.duplicate(%{}, num_runs - 7),
           &Map.merge(&1, &2)
         )
 
@@ -413,6 +415,7 @@ defmodule Lightning.Runs.QueryTest do
       for _ <- 1..2 do
         insert_run(magenta, :available)
       end
+
       # magenta project has only project level concurrecy
       Repo.update!(Projects.change_project(magenta.project, %{concurrency: 1}))
 
@@ -451,27 +454,27 @@ defmodule Lightning.Runs.QueryTest do
                      row_number: 1,
                      concurrency: 2
                    },
-                  %{
-                    id: _,
-                    project_id: ^blue_project_id,
-                    state: :available,
-                    row_number: 1,
-                    concurrency: 3
-                  },
-                  %{
-                    id: _,
-                    project_id: ^magenta_project_id,
-                    state: :available,
-                    row_number: 1,
-                    concurrency: 1
-                  },
-                  %{
-                    id: _,
-                    project_id: ^magenta_project_id,
-                    state: :available,
-                    row_number: 2,
-                    concurrency: 1
-                  },
+                   %{
+                     id: _,
+                     project_id: ^blue_project_id,
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 3
+                   },
+                   %{
+                     id: _,
+                     project_id: ^magenta_project_id,
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 1
+                   },
+                   %{
+                     id: _,
+                     project_id: ^magenta_project_id,
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 1
+                   }
                  ],
                  in_progress
                )
@@ -506,17 +509,17 @@ defmodule Lightning.Runs.QueryTest do
                      state: :available
                    },
                    %{
-                    project_id: ^magenta_project_id,
-                    state: :available,
-                    row_number: 1,
-                    concurrency: 1
-                    },
-                    %{
-                      project_id: ^magenta_project_id,
-                      state: :available,
-                      row_number: 2,
-                      concurrency: 1
-                    }
+                     project_id: ^magenta_project_id,
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 1
+                   },
+                   %{
+                     project_id: ^magenta_project_id,
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 1
+                   }
                  ],
                  in_progress
                ),
@@ -564,19 +567,19 @@ defmodule Lightning.Runs.QueryTest do
                      concurrency: 3
                    },
                    %{
-                    id: _,
-                    project_id: ^magenta_project_id,
-                    state: :available,
-                    row_number: 1,
-                    concurrency: 1
-                  },
-                  %{
-                    id: _,
-                    project_id: ^magenta_project_id,
-                    state: :available,
-                    row_number: 2,
-                    concurrency: 1
-                  }
+                     id: _,
+                     project_id: ^magenta_project_id,
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 1
+                   },
+                   %{
+                     id: _,
+                     project_id: ^magenta_project_id,
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 1
+                   }
                  ],
                  in_progress
                ),
@@ -597,7 +600,7 @@ defmodule Lightning.Runs.QueryTest do
         [
           {"red", 2},
           {"orange", nil},
-          {"green", 2},
+          {"green", 2}
         ]
         |> Enum.map(fn {name, concurrency} ->
           project = insert(:project, name: name)
@@ -605,8 +608,13 @@ defmodule Lightning.Runs.QueryTest do
           workflow1 =
             insert(:simple_workflow, project: project, concurrency: concurrency)
 
-          workflow2 = if name in ["red", "orange"], do:
-            insert(:simple_workflow, project: project, concurrency: concurrency)
+          workflow2 =
+            if name in ["red", "orange"],
+              do:
+                insert(:simple_workflow,
+                  project: project,
+                  concurrency: concurrency
+                )
 
           %{project: project, workflow1: workflow1, workflow2: workflow2}
         end)
@@ -652,30 +660,30 @@ defmodule Lightning.Runs.QueryTest do
                      concurrency: 1
                    },
                    %{
-                    project_id: ^orange_project_id,
-                    state: :available,
-                    row_number: 1,
-                    concurrency: 1
-                  },
-                  %{
-                    project_id: ^orange_project_id,
-                    state: :available,
-                    row_number: 2,
-                    concurrency: 1
-                  },
-                  %{
+                     project_id: ^orange_project_id,
+                     state: :available,
+                     row_number: 1,
+                     concurrency: 1
+                   },
+                   %{
+                     project_id: ^orange_project_id,
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 1
+                   },
+                   %{
                      project_id: ^green_project_id,
                      state: :available,
                      row_number: 1,
                      concurrency: 2
                    },
                    %{
-                    project_id: ^green_project_id,
-                    state: :available,
-                    row_number: 2,
-                    concurrency: 2
-                    }
-                ],
+                     project_id: ^green_project_id,
+                     state: :available,
+                     row_number: 2,
+                     concurrency: 2
+                   }
+                 ],
                  in_progress
                )
       end)
@@ -689,31 +697,31 @@ defmodule Lightning.Runs.QueryTest do
       |> then(fn in_progress ->
         assert match?(
                  [
-                  %{
-                    project_id: ^red_project_id,
-                    state: :claimed,
-                  },
                    %{
                      project_id: ^red_project_id,
-                     state: :available,
+                     state: :claimed
                    },
                    %{
-                    id: ^claimed_run_id,
-                    project_id: ^orange_project_id,
-                    state: :claimed,
-                  },
-                  %{
-                    project_id: ^orange_project_id,
-                    state: :available,
-                  },
-                  %{
+                     project_id: ^red_project_id,
+                     state: :available
+                   },
+                   %{
+                     id: ^claimed_run_id,
+                     project_id: ^orange_project_id,
+                     state: :claimed
+                   },
+                   %{
+                     project_id: ^orange_project_id,
+                     state: :available
+                   },
+                   %{
                      project_id: ^green_project_id,
-                     state: :available,
+                     state: :available
                    },
                    %{
-                    project_id: ^green_project_id,
-                    state: :available,
-                    },
+                     project_id: ^green_project_id,
+                     state: :available
+                   }
                  ],
                  in_progress
                ),
@@ -742,24 +750,24 @@ defmodule Lightning.Runs.QueryTest do
                    %{
                      id: ^claimed_run_id,
                      project_id: ^red_project_id,
-                     state: :claimed,
+                     state: :claimed
                    },
                    %{
                      project_id: ^orange_project_id,
-                     state: :claimed,
+                     state: :claimed
                    },
                    %{
-                    project_id: ^orange_project_id,
-                    state: :available,
-                  },
+                     project_id: ^orange_project_id,
+                     state: :available
+                   },
                    %{
-                    project_id: ^green_project_id,
-                    state: :available,
-                  },
-                  %{
-                    project_id: ^green_project_id,
-                    state: :available,
-                  },
+                     project_id: ^green_project_id,
+                     state: :available
+                   },
+                   %{
+                     project_id: ^green_project_id,
+                     state: :available
+                   }
                  ],
                  in_progress
                ),
@@ -779,26 +787,26 @@ defmodule Lightning.Runs.QueryTest do
         assert match?(
                  [
                    %{
-                    project_id: ^red_project_id,
-                    state: :claimed,
+                     project_id: ^red_project_id,
+                     state: :claimed
                    },
                    %{
-                    project_id: ^orange_project_id,
-                    state: :claimed,
+                     project_id: ^orange_project_id,
+                     state: :claimed
                    },
                    %{
-                    project_id: ^orange_project_id,
-                    state: :available,
+                     project_id: ^orange_project_id,
+                     state: :available
                    },
                    %{
-                    id: ^claimed_run_id,
-                    project_id: ^green_project_id,
-                    state: :claimed,
-                  },
-                  %{
-                    project_id: ^green_project_id,
-                    state: :available,
-                  },
+                     id: ^claimed_run_id,
+                     project_id: ^green_project_id,
+                     state: :claimed
+                   },
+                   %{
+                     project_id: ^green_project_id,
+                     state: :available
+                   }
                  ],
                  in_progress
                ),
@@ -806,7 +814,7 @@ defmodule Lightning.Runs.QueryTest do
                the first green should be claimed as the orange project has serial concurrency
                #{inspect(in_progress, pretty: true)}
                """
-        end)
+      end)
 
       {:ok, [%{id: claimed_run_id} = _green2]} =
         Lightning.Runs.Queue.claim(1, Query.eligible_for_claim())
@@ -817,27 +825,27 @@ defmodule Lightning.Runs.QueryTest do
       |> then(fn in_progress ->
         assert match?(
                  [
-                  %{
-                    project_id: ^red_project_id,
-                    state: :claimed,
+                   %{
+                     project_id: ^red_project_id,
+                     state: :claimed
                    },
                    %{
-                    project_id: ^orange_project_id,
-                    state: :claimed,
+                     project_id: ^orange_project_id,
+                     state: :claimed
                    },
                    %{
-                    project_id: ^orange_project_id,
-                    state: :available,
+                     project_id: ^orange_project_id,
+                     state: :available
                    },
                    %{
-                    project_id: ^green_project_id,
-                    state: :claimed,
-                  },
-                  %{
-                    id: ^claimed_run_id,
-                    project_id: ^green_project_id,
-                    state: :claimed,
-                  },
+                     project_id: ^green_project_id,
+                     state: :claimed
+                   },
+                   %{
+                     id: ^claimed_run_id,
+                     project_id: ^green_project_id,
+                     state: :claimed
+                   }
                  ],
                  in_progress
                ),
@@ -845,7 +853,7 @@ defmodule Lightning.Runs.QueryTest do
                the second green should be claimed since it doesn't have serial project concurrency
                #{inspect(in_progress, pretty: true)}
                """
-        end)
+      end)
     end
 
     test "eligible_for_claim/0 with multiple claims" do

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -278,7 +278,7 @@ defmodule Lightning.Runs.QueryTest do
             insert_run(cyan, :available)
           end,
           insert_run(magenta, :available),
-          # insert_run(yellow, :available),
+          insert_run(yellow, :available),
           for _ <- 1..9 do
             insert_run(indigo, :available)
           end,
@@ -301,7 +301,7 @@ defmodule Lightning.Runs.QueryTest do
             %{project_id: cyan.project.id, row_number: 9, concurrency: nil},
             %{project_id: cyan.project.id, row_number: 10, concurrency: nil},
             %{project_id: magenta.project.id, row_number: 1, concurrency: 5},
-            # %{project_id: yellow.project.id, row_number: 1, concurrency: 4},
+            %{project_id: yellow.project.id, row_number: 1, concurrency: 4},
             %{project_id: indigo.project.id, row_number: 1, concurrency: 6},
             %{project_id: indigo.project.id, row_number: 2, concurrency: 6},
             %{project_id: indigo.project.id, row_number: 3, concurrency: 6},

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -265,7 +265,7 @@ defmodule Lightning.Runs.QueryTest do
 
       # magenta project has only project level concurrecy
       Repo.update!(Projects.change_project(magenta.project, %{concurrency: 1}))
-      # indigo project has serialized project level concurrecy that overrides the workflow level one
+      # indigo project has project level concurrecy (serial execution). It overrides the workflow level one.
       Repo.update!(Projects.change_project(indigo.project, %{concurrency: 1}))
 
       runs_in_order =

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -20,6 +20,7 @@ defmodule LightningWeb.ProjectLiveTest do
   alias Lightning.Auditing.Audit
   alias Lightning.Name
   alias Lightning.Projects
+  alias Lightning.Projects.Project
   alias Lightning.Repo
 
   setup :stub_usage_limiter_ok
@@ -806,7 +807,7 @@ defmodule LightningWeb.ProjectLiveTest do
       assert view |> has_element?("button[disabled][type=submit]")
     end
 
-    test "project admin can edit project name and description with valid data",
+    test "project admin can edit project name, description and concurrency with valid data",
          %{
            conn: conn,
            user: user
@@ -827,12 +828,19 @@ defmodule LightningWeb.ProjectLiveTest do
 
       valid_project_attrs = %{
         name: "somename",
-        description: "some description"
+        description: "some description",
+        concurrency: "1"
       }
 
       assert view
              |> form("#project-settings-form", project: valid_project_attrs)
              |> render_submit() =~ "Project updated successfully"
+
+      assert %{
+               name: "somename",
+               description: "some description",
+               concurrency: 1
+             } = Repo.get!(Project, project.id)
     end
 
     test "only users with admin level on project can edit project details", %{

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -807,7 +807,7 @@ defmodule LightningWeb.ProjectLiveTest do
       assert view |> has_element?("button[disabled][type=submit]")
     end
 
-    test "project admin can edit project name, description and concurrency with valid data",
+    test "project admin can edit project name and description with valid data",
          %{
            conn: conn,
            user: user
@@ -829,7 +829,6 @@ defmodule LightningWeb.ProjectLiveTest do
       valid_project_attrs = %{
         name: "somename",
         description: "some description",
-        concurrency: "1"
       }
 
       assert view
@@ -839,8 +838,35 @@ defmodule LightningWeb.ProjectLiveTest do
       assert %{
                name: "somename",
                description: "some description",
-               concurrency: 1
              } = Repo.get!(Project, project.id)
+    end
+
+    test "project admin can edit project concurrency with valid data",
+         %{
+           conn: conn,
+           user: user
+         } do
+      project =
+        insert(:project,
+          name: "project-1",
+          project_users: [%{user_id: user.id, role: :admin}]
+        )
+
+      {:ok, view, html} =
+        live(
+          conn,
+          Routes.project_project_settings_path(conn, :index, project.id)
+        )
+
+      assert html =~ "Project settings"
+
+      assert view
+             |> form("#project-execution-form", project: %{
+              concurrency: "1",
+            })
+             |> render_submit() =~ "Project updated successfully"
+
+      assert %{concurrency: 1} = Repo.get!(Project, project.id)
     end
 
     test "only users with admin level on project can edit project details", %{

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -828,7 +828,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
       valid_project_attrs = %{
         name: "somename",
-        description: "some description",
+        description: "some description"
       }
 
       assert view
@@ -837,7 +837,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert %{
                name: "somename",
-               description: "some description",
+               description: "some description"
              } = Repo.get!(Project, project.id)
     end
 
@@ -861,9 +861,11 @@ defmodule LightningWeb.ProjectLiveTest do
       assert html =~ "Project settings"
 
       assert view
-             |> form("#project-execution-form", project: %{
-              concurrency: "1",
-            })
+             |> form("#project-execution-form",
+               project: %{
+                 concurrency: "1"
+               }
+             )
              |> render_submit() =~ "Project updated successfully"
 
       assert %{concurrency: 1} = Repo.get!(Project, project.id)

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -934,7 +934,9 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert path == ~p"/projects/#{project.id}/w/#{workflow.id}?m=settings"
 
       assert has_element?(view, "#workflow-settings-#{workflow.id}")
-      assert render(view) =~ "Workflow settings"
+      html = render(view)
+      assert html =~ "Workflow settings"
+      assert html =~ "Unlimited (up to max available)"
 
       assert view
              |> form("#workflow-form", %{"workflow" => %{"concurrency" => "0"}})
@@ -942,6 +944,10 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert view |> element("#workflow-form") |> render_submit() =~
                "Workflow could not be saved"
+
+      assert view
+             |> form("#workflow-form", %{"workflow" => %{"concurrency" => "1"}})
+             |> render_change() =~ "No more than one run at a time"
 
       assert view
              |> form("#workflow-form", %{"workflow" => %{"concurrency" => "5"}})


### PR DESCRIPTION
## Description

This PR enables the RunQueue (the scheduler that processes run claims) to limit the concurrency on the project level. This concurrency control allows disabling the execution of parallel runs as shown on the option given in the UI:

![image](https://github.com/user-attachments/assets/f0569cbf-d437-4d5d-ba41-6ba322800a8c)

Closes #2906 

## Validation steps

1. Go to settings and disable the parallel execution of runs.
2. On 2 workflows of the same project, add a job after the trigger that calls 
```
fn(state => {
  return new Promise((resolve) => {
    setTimeout(() => {
      resolve(state);
    }, 10000); // 10 second delay
  });
});
```
4. Send a POST request to each webhook of these workflows
5. While one is executing the other one is not.

## Additional notes for the reviewer

Using default configuration:
![image](https://github.com/user-attachments/assets/87977935-fe85-4a8d-bcf2-0ed292339aab)
After disabling concurrency on project settings:
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/f7cdbc4e-399a-4833-898e-37d407d07196" />

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
