### PR TITLE
Fix dataclip tsvector error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
 
 ### Fixed
 
+- Creating a dataclip fails on indexing when it's too large
+  [#2682](https://github.com/OpenFn/lightning/issues/2682)
+
 ## [v2.10.15] - 2025-02-14
 
 ### Changed

--- a/priv/repo/migrations/20250219122902_catch_ts_vector_size_exception.exs
+++ b/priv/repo/migrations/20250219122902_catch_ts_vector_size_exception.exs
@@ -1,0 +1,61 @@
+defmodule Lightning.Repo.Migrations.CatchTsVectorSizeException do
+  use Ecto.Migration
+
+  def up do
+    execute "DROP TRIGGER IF EXISTS set_search_vector ON dataclips"
+
+    execute "DROP FUNCTION IF EXISTS update_dataclip_search_vector"
+
+    execute("""
+    CREATE OR REPLACE FUNCTION update_dataclip_search_vector()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      BEGIN
+        UPDATE dataclips
+        SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"')
+        WHERE id = NEW.id;
+      EXCEPTION
+        WHEN program_limit_exceeded THEN
+          RAISE NOTICE 'Message too long for tsvector at id: %. Error: %', NEW.id, SQLERRM;
+      END;
+
+      RETURN NEW;
+    END;
+    $function$;
+    """)
+
+    execute("""
+    CREATE TRIGGER set_search_vector
+    AFTER INSERT ON dataclips FOR EACH ROW
+    WHEN (NEW."search_vector" IS NULL)
+    EXECUTE PROCEDURE update_dataclip_search_vector()
+    """)
+  end
+
+  def down do
+    execute "DROP TRIGGER IF EXISTS set_search_vector ON dataclips"
+
+    execute "DROP FUNCTION IF EXISTS update_dataclip_search_vector"
+
+    execute("""
+    CREATE OR REPLACE FUNCTION update_dataclip_search_vector()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+      begin
+        UPDATE log_lines SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"') WHERE id = NEW.id;
+        RETURN NEW;
+      end
+    $function$ ;
+    """)
+
+    execute("""
+    CREATE TRIGGER set_search_vector
+    AFTER INSERT ON dataclips FOR EACH ROW
+    WHEN (NEW."search_vector" IS NULL)
+    EXECUTE PROCEDURE update_dataclip_search_vector()
+    """)
+  end
+end

--- a/priv/repo/migrations/20250219122902_catch_ts_vector_size_exception.exs
+++ b/priv/repo/migrations/20250219122902_catch_ts_vector_size_exception.exs
@@ -45,7 +45,7 @@ defmodule Lightning.Repo.Migrations.CatchTsVectorSizeException do
     LANGUAGE plpgsql
     AS $function$
       begin
-        UPDATE log_lines SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"') WHERE id = NEW.id;
+        UPDATE dataclips SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"') WHERE id = NEW.id;
         RETURN NEW;
       end
     $function$ ;

--- a/priv/repo/migrations/20250219122902_catch_ts_vector_size_exception.exs
+++ b/priv/repo/migrations/20250219122902_catch_ts_vector_size_exception.exs
@@ -1,61 +1,38 @@
 defmodule Lightning.Repo.Migrations.CatchTsVectorSizeException do
   use Ecto.Migration
 
-  def up do
-    execute "DROP TRIGGER IF EXISTS set_search_vector ON dataclips"
-
-    execute "DROP FUNCTION IF EXISTS update_dataclip_search_vector"
-
-    execute("""
-    CREATE OR REPLACE FUNCTION update_dataclip_search_vector()
-    RETURNS trigger
-    LANGUAGE plpgsql
-    AS $function$
-    BEGIN
+  def change do
+    execute(
+      """
+      CREATE OR REPLACE FUNCTION update_dataclip_search_vector()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
       BEGIN
-        UPDATE dataclips
-        SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"')
-        WHERE id = NEW.id;
-      EXCEPTION
-        WHEN program_limit_exceeded THEN
-          RAISE NOTICE 'Message too long for tsvector at id: %. Error: %', NEW.id, SQLERRM;
-      END;
+        BEGIN
+          UPDATE dataclips
+          SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"')
+          WHERE id = NEW.id;
+        EXCEPTION
+          WHEN program_limit_exceeded THEN
+            RAISE NOTICE 'Message too long for tsvector at id: %. Error: %', NEW.id, SQLERRM;
+        END;
 
-      RETURN NEW;
-    END;
-    $function$;
-    """)
-
-    execute("""
-    CREATE TRIGGER set_search_vector
-    AFTER INSERT ON dataclips FOR EACH ROW
-    WHEN (NEW."search_vector" IS NULL)
-    EXECUTE PROCEDURE update_dataclip_search_vector()
-    """)
-  end
-
-  def down do
-    execute "DROP TRIGGER IF EXISTS set_search_vector ON dataclips"
-
-    execute "DROP FUNCTION IF EXISTS update_dataclip_search_vector"
-
-    execute("""
-    CREATE OR REPLACE FUNCTION update_dataclip_search_vector()
-    RETURNS trigger
-    LANGUAGE plpgsql
-    AS $function$
-      begin
-        UPDATE dataclips SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"') WHERE id = NEW.id;
         RETURN NEW;
-      end
-    $function$ ;
-    """)
-
-    execute("""
-    CREATE TRIGGER set_search_vector
-    AFTER INSERT ON dataclips FOR EACH ROW
-    WHEN (NEW."search_vector" IS NULL)
-    EXECUTE PROCEDURE update_dataclip_search_vector()
-    """)
+      END;
+      $function$;
+      """,
+      """
+      CREATE OR REPLACE FUNCTION update_dataclip_search_vector()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+        begin
+          UPDATE dataclips SET search_vector = jsonb_to_tsvector('english_nostop', body, '"all"') WHERE id = NEW.id;
+          RETURN NEW;
+        end
+      $function$ ;
+      """
+    )
   end
 end

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -101,6 +101,24 @@ defmodule Lightning.InvocationTest do
                Invocation.create_dataclip(@invalid_attrs)
     end
 
+    test "huge dataclips can get saved" do
+      project = insert(:project)
+
+      body =
+        Map.new(1..20_000, fn _n ->
+          {Ecto.UUID.generate(), Ecto.UUID.generate()}
+        end)
+
+      assert {:ok, _dataclip} =
+               Dataclip.new(%{
+                 id: Ecto.UUID.generate(),
+                 project_id: project.id,
+                 body: body,
+                 type: :step_result
+               })
+               |> Repo.insert()
+    end
+
     test "update_dataclip/2 with valid data updates the dataclip" do
       dataclip = insert(:dataclip)
       update_attrs = %{body: %{}, type: :global}


### PR DESCRIPTION
## Description

This PR catches `program_limit_exceeded` exception when creating a dataclip. When the exception is raised, the `search_vector` column isn't populated 

Closes #2682


## Validation steps

Insert a huge dataclip with unique keys in the `body`. In the tests, using `20_000` unique keys was able to trigger that exception

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
