### PR TITLE
remove `type: module` from package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -44,7 +44,6 @@
     "tap-xunit": "^2.4.1",
     "ts-node": "^10.9.2"
   },
-  "type": "module",
   "ava": {
     "extensions": {
       "ts": "module"


### PR DESCRIPTION
## Description

This PR fixes a bug on the asset build pipeline. 
```log
▲ [WARNING] The CommonJS "module" variable is treated as a global variable in an ECMAScript module and may not work as expected [commonjs-variable-in-esm]

    vendor/topbar.js:149:4:
      149 │     module.exports = topbar;
          ╵     ~~~~~~

  This file is considered to be an ECMAScript module because the enclosing "package.json" file sets the type of this file to "module":
```


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
