### PR TITLE
Fix another variant blank log lines

### DIFF
--- a/lib/lightning/invocation/log_line.ex
+++ b/lib/lightning/invocation/log_line.ex
@@ -50,7 +50,7 @@ defmodule Lightning.Invocation.LogLine do
   def new(%Run{} = run, attrs \\ %{}, scrubber) do
     %__MODULE__{id: Ecto.UUID.generate()}
     |> cast(attrs, [:message, :timestamp, :step_id, :run_id, :level, :source],
-      empty_values: [[], nil]
+      empty_values: [nil]
     )
     |> put_assoc(:run, run)
     |> validate(scrubber)

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -287,7 +287,7 @@ defmodule Lightning.WebAndWorkerTest do
       # console.log('');        => new line
       # console.log(null);      => null
       # console.log(undefined); => new line
-      assert log =~ "Starting operation 1\n\nnull\n{"
+      assert log =~ "Starting operation 1\n\n\nnull\n{"
 
       assert log =~ ~S[{"password":"***","username":"quux"}]
       assert log =~ ~S"Check state.errors"


### PR DESCRIPTION
## Description

Re: #2914

Been seeing a bunch of warnings on Sentry saying that a log line couldn't be blank/is rejected.

Really thought I fixed this one.

From what it looks like, `console.log(undefined)` arrives as `%{"message": []}` which was previously considered blank.

This PR converts drops `[]` from the list of 'empty values' when casting, which is valid (from the previous set of changes on this issue).

Now the question is here, is there such a thing as a log line that is "too blank"?

```
> console.log()

undefined
> console.log(undefined)
undefined
undefined
```

So in the node real, an empty console.log, really logs an empty string, and logging `undefined` prints `undefined`. 

Perhaps this should be changed upstream in the worker, either actually send `['undefined']` or skip sending the message?

## Validation steps

See: `test/integration/web_and_worker_test.exs:290`, and run it with `mix test.watch test/integration/web_and_worker_test.exs:290`.

This test checks the different output casting for log lines.

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
