### PR TITLE
add search warning for ts_vector limitation

### DIFF
--- a/lib/lightning_web/live/run_live/index.ex
+++ b/lib/lightning_web/live/run_live/index.ex
@@ -105,7 +105,12 @@ defmodule LightningWeb.RunLive.Index do
 
     search_fields = [
       %{id: :id, icon: "hero-finger-print-mini", label: "Include IDs"},
-      %{id: :body, icon: "hero-document-arrow-down", label: "Include inputs"},
+      %{
+        id: :body,
+        icon: "hero-document-arrow-down",
+        label:
+          "Include inputs (note that very large/complex inputs—often around 10MB—may not appear in string search due to a ts_vector index length limit of 1MB)"
+      },
       %{id: :log, icon: "hero-bars-arrow-down-mini", label: "Include run logs"}
     ]
 


### PR DESCRIPTION
## Description

This PR adds a line to the search hover when selecting dataclips. Hard to estimate (see ratios) so I'm being vague.

The docs have been updated here: https://github.com/OpenFn/docs/commit/ceecd2f4d29ba49aa2f546788f082c8d731e76fe

<img width="1777" alt="image" src="https://github.com/user-attachments/assets/f5d0d357-19ff-4319-b515-ec35e71af90a" />

closes #2682

## Validation steps

1. Hover over the "search inputs" toggle.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
