### PR TITLE
restore esbuild to `0.17.13`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -88,7 +88,7 @@ config :lightning, :oauth_clients,
 
 # Configure esbuild (the version is required)
 config :esbuild,
-  version: "0.24.2",
+  version: "0.17.13",
   default: [
     args:
       ~w(js/app.js


### PR DESCRIPTION
## Description

This current esbuild, `0.24.2`, fails when `--minify` is provided:

```sh
✘ [ERROR] Could not resolve "path"

    node_modules/@typescript/vfs/dist/vfs.esm.js:575:17:
      575 │   return require(String.fromCharCode(112, 97, 116, 104));
          ╵                  ^

  The package "path" wasn't found on the file system but is built into node. Are you trying to bundle for node? You can use "--platform=node" to do that, which will remove this error.

1 error
** (Mix) `mix esbuild default --minify` exited with 1 
```

## Validation steps

1. Run `mix setup` to install the configured esbuild version
2. Purge the old static files that were generated by running `git clean -fdx priv/static`
3. Run `mix assets.deploy`. No error should be logged

## Additional notes for the reviewer

There is a follow up issue to upgrade esbuild: https://github.com/OpenFn/lightning/issues/2962

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
