### PR TITLE
Don't clear dataclip input when user saves workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Dont clear dataclip input when user saves workflow
+  [#2944](https://github.com/OpenFn/lightning/issues/2944)
+
 ## [v2.10.16-pre.0] - 2025-02-26
 
 ### Added

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2028,9 +2028,16 @@ defmodule LightningWeb.WorkflowLive.Edit do
           assigns[:follow_run] &&
             get_selected_dataclip(assigns[:follow_run], job.id)
 
+        body =
+          new_manual_run_form_body(
+            assigns.manual_run_form,
+            job,
+            dataclip
+          )
+
         changeset =
           WorkOrders.Manual.new(
-            %{dataclip_id: dataclip && dataclip.id},
+            %{dataclip_id: dataclip && dataclip.id, body: body},
             project: socket.assigns.project,
             workflow: socket.assigns.workflow,
             job: socket.assigns.selected_job,
@@ -2054,6 +2061,25 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
       _ ->
         socket
+    end
+  end
+
+  defp new_manual_run_form_body(
+         prev_manual_run_form,
+         selected_job,
+         selected_dataclip
+       ) do
+    prev_job =
+      prev_manual_run_form &&
+        Ecto.Changeset.get_embed(
+          prev_manual_run_form.source,
+          :job,
+          :struct
+        )
+
+    if is_nil(selected_dataclip) and is_struct(prev_job) and
+         prev_job.id == selected_job.id do
+      Ecto.Changeset.get_change(prev_manual_run_form.source, :body)
     end
   end
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the dataclip input was being cleared whenever the user clicks to save the workflow

Closes #2944

## Validation steps

1. Open up the job inspector
2. Enter your dataclip input
3. Click to save the workflow. Notice that the dataclip is still present


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
