### PR TITLE
Add empty body as default new input on Job inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Add empty body as default new input on Job inspector
+  [#2952](https://github.com/OpenFn/lightning/issues/2952)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/workorders/manual.ex
+++ b/lib/lightning/workorders/manual.ex
@@ -29,6 +29,14 @@ defmodule Lightning.WorkOrders.Manual do
   end
 
   def new(params, attrs \\ []) do
+    params = Map.update(params, "body", "{}", fn body ->
+      if is_nil(body) and (params["dataclip_id"] || "") == "" do
+        "{}"
+      else
+        body
+      end
+    end)
+
     struct(__MODULE__, attrs)
     |> cast(params, [:dataclip_id, :body])
     |> validate_required([:project, :job, :created_by, :workflow])

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2068,7 +2068,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           end
 
         WorkOrders.Manual.new(
-          %{dataclip_id: dataclip && dataclip.id, body: body},
+          %{"dataclip_id" => dataclip && dataclip.id, "body" => body},
           attrs
         )
       end)

--- a/priv/bench/collections.exs
+++ b/priv/bench/collections.exs
@@ -143,10 +143,10 @@ stream_match_trigram =
 # Process.exit(self(), :normal)
 
 IO.puts("\n### Round record count ({microsecs, count}):")
-:timer.tc(fn -> stream_all.() |> Enum.count() end) |> IO.inspect(label: "stream_all")
-:timer.tc(fn -> stream_match_all.() |> Enum.count() end) |> IO.inspect(label: "stream_match_all")
-:timer.tc(fn -> stream_match_prefix.() |> Enum.count() end) |> IO.inspect(label: "stream_match_prefix")
-:timer.tc(fn -> stream_match_trigram.() |> Enum.count() end) |> IO.inspect(label: "stream_match_trigram")
+:timer.tc(fn -> stream_all.() |> Enum.count() end) |> then(&IO.puts("stream_all: #{&1}"))
+:timer.tc(fn -> stream_match_all.() |> Enum.count() end) |> then(&IO.puts("stream_match_all: #{&1}"))
+:timer.tc(fn -> stream_match_prefix.() |> Enum.count() end) |> then(&IO.puts("stream_match_prefix: #{&1}"))
+:timer.tc(fn -> stream_match_trigram.() |> Enum.count() end) |> then(&IO.puts("stream_match_trigram: #{&1}"))
 IO.puts("\n")
 
 Benchee.run(

--- a/test/lightning/workorders/manual_test.exs
+++ b/test/lightning/workorders/manual_test.exs
@@ -14,7 +14,11 @@ defmodule Lightning.WorkOrders.ManualTest do
   end
 
   test "removes body if dataclip_id is present" do
-    params = %{"dataclip_id" => Ecto.UUID.generate(), "body" => ~s({"foo": "bar"})}
+    params = %{
+      "dataclip_id" => Ecto.UUID.generate(),
+      "body" => ~s({"foo": "bar"})
+    }
+
     changeset = Manual.new(params)
 
     assert get_change(changeset, :body) == nil

--- a/test/lightning/workorders/manual_test.exs
+++ b/test/lightning/workorders/manual_test.exs
@@ -14,28 +14,28 @@ defmodule Lightning.WorkOrders.ManualTest do
   end
 
   test "removes body if dataclip_id is present" do
-    params = %{dataclip_id: Ecto.UUID.generate(), body: ~s({"foo": "bar"})}
+    params = %{"dataclip_id" => Ecto.UUID.generate(), "body" => ~s({"foo": "bar"})}
     changeset = Manual.new(params)
 
     assert get_change(changeset, :body) == nil
   end
 
   test "validate_json/2 validates json body" do
-    changeset = Manual.new(%{body: "{invalid json"})
+    changeset = Manual.new(%{"body" => "{invalid json"})
 
     assert "Invalid JSON" in errors_on(changeset).body
 
-    changeset = Manual.new(%{body: "1"})
+    changeset = Manual.new(%{"body" => "1"})
 
     assert "Must be an object" in errors_on(changeset).body
 
-    changeset = Manual.new(%{body: ~s({"foo": "bar"})})
+    changeset = Manual.new(%{"body" => ~s({"foo": "bar"})})
 
     assert changeset |> Ecto.Changeset.get_field(:body) == ~s({"foo": "bar"})
   end
 
   test "validates presence of either dataclip_id or body" do
-    changeset = Manual.new(%{})
+    changeset = Manual.new(%{"dataclip_id" => "", "body" => ""})
 
     assert "Either a dataclip or a custom body must be present." in errors_on(
              changeset

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -323,7 +323,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
           ~p"/projects/#{p}/w/#{w}?#{[s: job, m: "expand", v: w.lock_version]}"
         )
 
-      assert view
+      refute view
              |> element(
                "button[type='submit'][form='manual_run_form'][disabled]"
              )
@@ -1384,7 +1384,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       refute has_element?(view, "button", "Retry from here")
 
       assert has_element?(view, "button:disabled", "Create New Work Order"),
-             "create new workorder button is disabled"
+             "create new workorder button should be disabled"
 
       # Wait out all the async renders on RunViewerLive, avoiding Postgrex client
       # disconnection warnings.


### PR DESCRIPTION
## Description

This PR adds an empty body `{}` for the creation of new input on the job inspector. 

Closes #2952

## Validation steps

1. Access the job inspector without any additional query params.
2. The `{}` is suggested as basic dataclip for start and to create a new work order.
3. Create a new workorder and notice the Rerun button is enabled.
4. Select another job and use an existing _non-empty_ dataclip to create a new work order.
5. After running click on Create a new input and the empty dataclip is suggested.

## Additional notes for the reviewer

Notice that if you copy a link of a run to follow it and this run has a wiped input dataclip the empty dataclip is NOT suggested to honor the fact that this run does NOT have any dataclip.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
