### PR TITLE
Do not include `v`  param in workflow links when latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Do not include `v` param in workflow links when it is latest
+  [#2941](https://github.com/OpenFn/lightning/issues/2941)
+
 ### Fixed
 
 ## [v2.10.16] - 2025-02-28

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -132,6 +132,7 @@ defmodule LightningWeb.RunLive.Components do
     """
   end
 
+  attr :workflow_version, :integer, required: true
   attr :step, Lightning.Invocation.Step, required: true
   attr :is_clone, :boolean, default: false
   attr :run_id, :string
@@ -192,7 +193,7 @@ defmodule LightningWeb.RunLive.Components do
             <.link
               class="pl-1"
               patch={
-                ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}?#{%{v: @step.snapshot.lock_version, a: @run_id, m: "expand", s: @job.id}}" <> "#log"
+                ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}?#{maybe_add_snapshot_version(%{a: @run_id, m: "expand", s: @job.id}, @step.snapshot.lock_version, @workflow_version)}" <> "#log"
               }
             >
               <.icon
@@ -224,6 +225,14 @@ defmodule LightningWeb.RunLive.Components do
           DateTime.to_unix(@step.started_at, :millisecond) %> ms
     <% end %>
     """
+  end
+
+  defp maybe_add_snapshot_version(params, snapshot_version, workflow_version) do
+    if snapshot_version != workflow_version do
+      Map.merge(params, %{v: snapshot_version})
+    else
+      params
+    end
   end
 
   def loading_filler(assigns) do
@@ -380,8 +389,8 @@ defmodule LightningWeb.RunLive.Components do
               aria-label="Inspect this step"
               class="cursor-pointer"
               navigate={
-                ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}"
-                  <> "?v=#{@step.snapshot.lock_version}&a=#{@run.id}&m=expand&s=#{@job.id}#log"
+                ~p"/projects/#{@project_id}/w/#{@step.snapshot.workflow_id}?#{maybe_add_snapshot_version(%{a: @run.id, m: "expand", s: @job.id}, @step.snapshot.lock_version, @workflow_version)}"
+                  <> "#log"
               }
             >
               <.icon

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -97,6 +97,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                 >
                   <.step_item
                     step={step}
+                    workflow_version={@workflow.lock_version}
                     run_id={run.id}
                     job_id={@job_id}
                     is_clone={
@@ -121,6 +122,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                     >
                       <.step_item
                         step={step}
+                        workflow_version={@workflow.lock_version}
                         run_id={run.id}
                         job_id={@job_id}
                         is_clone={
@@ -165,6 +167,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                       >
                         <.step_item
                           step={step}
+                          workflow_version={@workflow.lock_version}
                           run_id={run.id}
                           job_id={@job_id}
                           is_clone={
@@ -213,6 +216,7 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                       >
                         <.step_item
                           step={step}
+                          workflow_version={@workflow.lock_version}
                           run_id={run.id}
                           job_id={@job_id}
                           is_clone={

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -165,6 +165,7 @@ defmodule LightningWeb.RunLive.Show do
                 <.link patch={"?step=#{step.id}"}>
                   <.step_item
                     step={step}
+                    workflow_version={@workflow.lock_version}
                     is_clone={
                       DateTime.compare(step.inserted_at, run.inserted_at) == :lt
                     }

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -193,9 +193,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     <div class="flex flex-1 items-center truncate">
       <.link
         id={"workflow-card-#{@workflow.id}"}
-        navigate={
-          ~p"/projects/#{@project.id}/w/#{@workflow.id}?v=#{@workflow.lock_version}"
-        }
+        navigate={~p"/projects/#{@project.id}/w/#{@workflow.id}"}
         role="button"
       >
         <div class="text-sm">

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -168,19 +168,19 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       # Workflow links
       assert view
              |> has_link?(
-               ~p"/projects/#{project.id}/w/#{workflow1.id}?v=#{workflow1.lock_version}",
+               ~p"/projects/#{project.id}/w/#{workflow1.id}",
                "One"
              )
 
       assert view
              |> has_link?(
-               ~p"/projects/#{project.id}/w/#{workflow2.id}?v=#{workflow2.lock_version}",
+               ~p"/projects/#{project.id}/w/#{workflow2.id}",
                "Two"
              )
 
       assert view
              |> has_link?(
-               ~p"/projects/#{project.id}/w/#{new_workflow.id}?v=#{new_workflow.lock_version}",
+               ~p"/projects/#{project.id}/w/#{new_workflow.id}",
                new_workflow.name
              )
 


### PR DESCRIPTION
## Description

This PR ensures that workflow links only include the `v` param when it is **NOT** the `latest`

Closes #2941

## Validation steps

In order to test this, you need 2 workorders. 1 created using a previous version of the workflow and the other with the latest. You can achieve this in the workflow edit page by creating a manual run, editing the workflow and save then create another manual run.

In the history page, when you check the steps for the 2 different workorders, you'll notice that the latest one doesn't have the `v` param 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
