### PR TITLE
Updates the collection size on delete all matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Update Collections admin UI storage counter after deleting all
+  [#2986](https://github.com/OpenFn/lightning/issues/2986)
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
## Description

This PR updates the Used Storage on the Collections Admin UI after a delete all items (matching or not).  

Additionally it prevents an exception when there are no records to be deleted.

Closes #2986 

## Validation steps

1. Create a collection
2. Use `Collections.put` to put items
3. Delete some matching items with `Collections.delete_all`. The Used Storage on the Admin UI is decremented.
4. Delete all remaining items and the Used Storage should be 0

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
