### PR TITLE
use dropdown instead of modal for log filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             - v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}
             - v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}
 
-      - run: chown -R lightning priv/plts
+      - run: chown -Rf lightning priv/plts
       - run: sudo -u lightning env MIX_ENV=test mix dialyzer --plt
       - save_cache:
           key: v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             - v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}
             - v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}
 
-      - run: chown -Rf lightning priv/plts
+      - run: mkdir -p && chown -R lightning priv/plts
       - run: sudo -u lightning env MIX_ENV=test mix dialyzer --plt
       - save_cache:
           key: v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             - v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}
             - v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}
 
-      - run: mkdir -p && chown -R lightning priv/plts
+      - run: mkdir -p priv/plts && chown -R lightning priv/plts
       - run: sudo -u lightning env MIX_ENV=test mix dialyzer --plt
       - save_cache:
           key: v3-plt-{{ arch }}-{{ checksum ".elixir_otp_version" }}-{{ checksum "mix.lock" }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ and this project adheres to
 
 ### Changed
 
+- Use dropdown instead of modal for the log level filter
+  [#2980](https://github.com/OpenFn/lightning/issues/2980)
+
 ### Fixed
+
+- Fix broken highlighter for selcted step in the log viewer
+  [#2980](https://github.com/OpenFn/lightning/issues/2980)
 
 ## [v2.10.16] - 2025-02-28
 

--- a/assets/js/log-viewer/store.ts
+++ b/assets/js/log-viewer/store.ts
@@ -54,14 +54,19 @@ function findSelectedRanges(
     marker: number;
   }>(
     ({ ranges, marker }, log) => {
+      // Skip logs that don't match the desired log levels
+      if (!matchesLogFilter(log, desiredLogLevel)) {
+        return { ranges, marker: marker };
+      }
+
       // Get the number of newlines in the message, used to determine the end index.
       const newLineCount = [...possiblyPrettify(log.message).matchAll(/\n/g)]
         .length;
 
       const nextMarker = marker + 1 + newLineCount;
 
-      // Skip logs that don't match the step ID or desired log levels
-      if (log.step_id !== stepId || !matchesLogFilter(log, desiredLogLevel)) {
+      // Skip logs that don't match the step ID
+      if (log.step_id !== stepId) {
         return { ranges, marker: nextMarker };
       }
 

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -69,10 +69,10 @@ defmodule LightningWeb.Components.Viewers do
         </span>
       </div>
     <% else %>
-      <div class="flex flex-col grow rounded-md bg-slate-700 font-mono text-gray-200">
+      <div class="flex flex-col grow rounded-md bg-slate-700 font-mono text-gray-200 @container">
         <div class="border-b border-slate-500">
-          <div class="mx-auto px-4">
-            <div class="flex h-8 flex-row-reverse items-center">
+          <div class="mx-auto px-2">
+            <div class="flex h-6 @md:h-8 flex-row-reverse items-center">
               <.log_level_filter
                 :if={@current_user}
                 id={"#{@id}-filter"}
@@ -94,7 +94,10 @@ defmodule LightningWeb.Components.Viewers do
           data-viewer-el={"#{@id}-viewer"}
         >
           <div class="relative grow">
-            <div id={"#{@id}-nothing-yet"} class="relative p-12 text-center">
+            <div
+              id={"#{@id}-nothing-yet"}
+              class="relative text-xs @md:text-base p-12 text-center bg-slate-700 font-mono text-gray-200"
+            >
               <.text_ping_loader>
                 Nothing yet
               </.text_ping_loader>
@@ -127,17 +130,18 @@ defmodule LightningWeb.Components.Viewers do
       <div class="relative">
         <button
           type="button"
-          class="grid w-full cursor-pointer grid-cols-1 bg-inherit text-left sm:text-sm/6 hover:bg-slate-600 border-b border-gray-200"
+          class="grid w-full cursor-pointer grid-cols-1 bg-inherit text-left text-xs/4 @md:text-sm/6 text-inherit opacity-75 hover:opacity-100"
           aria-haspopup="listbox"
           aria-expanded="true"
           phx-click={show_dropdown("#{@id}-dropdown")}
         >
           <span class="col-start-1 row-start-1 truncate pr-6">
-            Level: <%= @selected_level %>
+            <.icon name="hero-adjustments-vertical" class="size-4 @md:size-6" />
+            <%= @selected_level %>
           </span>
           <.icon
             name="hero-chevron-down"
-            class="col-start-1 row-start-1 size-5 self-center justify-self-end"
+            class="col-start-1 row-start-1 size-4 self-center justify-self-end"
             aria-hidden="true"
             data-slot="icon"
           />
@@ -258,7 +262,7 @@ defmodule LightningWeb.Components.Viewers do
             is_nil(@dataclip)
         }
         id={"#{@id}-nothing-yet"}
-        class="relative rounded-md p-12 text-center bg-slate-700 font-mono text-gray-200"
+        class="relative rounded-md text-xs @md:text-base p-12 text-center bg-slate-700 font-mono text-gray-200"
       >
         <.text_ping_loader>
           Nothing yet

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -137,7 +137,7 @@ defmodule LightningWeb.Components.Viewers do
         >
           <span class="col-start-1 row-start-1 truncate pr-6">
             <.icon name="hero-adjustments-vertical" class="size-4 @md:size-6" />
-            <%= @selected_level %>
+            <span><%= @selected_level %></span>
           </span>
           <.icon
             name="hero-chevron-down"

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -3895,7 +3895,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       run_view = find_live_child(view, "run-viewer-#{run.id}")
 
       render_async(run_view)
-      assert render(run_view) =~ "Configure log levels"
+      assert render(run_view) =~ "Level: "
 
       # when the user has not set their preference, we assume they want info
       assert user.preferences["desired_log_level"] |> is_nil()
@@ -3907,8 +3907,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       # try choosing another level
       for log_level <- ["debug", "info", "error", "warn"] do
         run_view
-        |> form("#run-log-#{run.id}-filter-form")
-        |> render_change(%{desired_log_level: log_level})
+        |> element("#run-log-#{run.id}-filter-dropdown-#{log_level}-option")
+        |> render_click(%{})
 
         # selected level is set in the viewer
         assert log_viewer_selected_level(log_viewer) == log_level

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -3890,7 +3890,13 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       run_view = find_live_child(view, "run-viewer-#{run.id}")
 
       render_async(run_view)
-      assert render(run_view) =~ "Level: "
+
+      assert run_view
+             |> render()
+             |> Floki.parse_fragment!()
+             |> Floki.find("span.hero-adjustments-vertical + span")
+             |> Floki.text() ==
+               "info"
 
       # when the user has not set their preference, we assume they want info
       assert user.preferences["desired_log_level"] |> is_nil()

--- a/test/lightning_web/workflows_controller_test.exs
+++ b/test/lightning_web/workflows_controller_test.exs
@@ -847,7 +847,17 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
 
       saved_workflow = get_saved_workflow(workflow)
 
-      assert encode_decode(response_workflow) == encode_decode(saved_workflow)
+      # assert both response_workflow and saved_workflow has the same jobs
+      # regardless of order
+      assert MapSet.new(
+               response_workflow["jobs"],
+               &Map.take(&1, ["id", "name", "adaptor", "body"])
+             ) ==
+               MapSet.new(
+                 saved_workflow.jobs,
+                 &(Map.take(&1, [:id, :name, :adaptor, :body])
+                   |> Map.new(fn {k, v} -> {Atom.to_string(k), v} end))
+               )
 
       assert workflow
              |> Map.merge(patch)


### PR DESCRIPTION
## Description

This PR changes the log filter to be a dropdown instead of a modal.
Additionally, it fixes a bug on the step highlighter

Closes #2980

## Validation steps

Open up the log viewer, you'll see a dropdown button on the top right corner


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
