### PR TITLE
Do not delete latest snapshot when deleting unused snaphots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
 
 ### Fixed
 
+- Don't delete latest snapshot when deleting unused snaphots in workorders
+  [#2996](https://github.com/OpenFn/lightning/issues/2996)
+
 ## [v2.10.16] - 2025-02-28
 
 ### Added

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -804,17 +804,21 @@ defmodule Lightning.ProjectsTest do
       project = insert(:project, history_retention_period: 7)
 
       %{triggers: [trigger], jobs: [job | _rest]} =
-        workflow = insert(:simple_workflow, project: project)
+        workflow = insert(:simple_workflow, project: project, lock_version: 3)
 
       now = Lightning.current_time()
 
       snapshot_to_delete = insert(:snapshot, workflow: workflow, lock_version: 1)
       snapshot_to_keep = insert(:snapshot, workflow: workflow, lock_version: 2)
+      latest_snapshot = insert(:snapshot, workflow: workflow, lock_version: 3)
+
+      all_snapshots = [snapshot_to_delete, snapshot_to_keep, latest_snapshot]
 
       workorders_to_delete =
-        Enum.map(1..10, fn i ->
-          snapshot =
-            if rem(i, 2) == 0, do: snapshot_to_delete, else: snapshot_to_keep
+        Enum.map(1..12, fn i ->
+          # this returns 0, 1 or 2
+          snapshot_index = rem(i, 3)
+          snapshot = Enum.at(all_snapshots, snapshot_index)
 
           insert(:workorder,
             workflow: workflow,
@@ -883,6 +887,10 @@ defmodule Lightning.ProjectsTest do
       # snapshot that is still in use
       assert workorder_to_remain.snapshot_id == snapshot_to_keep.id
       assert Repo.get(Snapshot, snapshot_to_keep.id)
+
+      # latest snapshot is not deleted
+      refute Repo.get_by(WorkOrder, snapshot_id: latest_snapshot.id)
+      assert Repo.get(Snapshot, latest_snapshot.id)
 
       # extra checks. Jobs, Triggers, Workflows are not deleted
       assert Repo.get(Lightning.Workflows.Job, job.id)


### PR DESCRIPTION
## Description

This PR fixes a bug in which when the latest snapshot of a workflow is attached to a work order and the work order is deleted during data retention, the snapshot is also deleted alongside it. When the latest snapshot is deleted, the workflow edit page crashes.

Closes #2996

## Validation steps

Look at the test case for a guideline

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
