### PR TITLE
Don't allow users to disable edges coming from a trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ and this project adheres to
 
 ### Fixed
 
-- Fix broken highlighter for selcted step in the log viewer
+- Fix broken highlighter for selected step in the log viewer
   [#2980](https://github.com/OpenFn/lightning/issues/2980)
 - Don't delete latest snapshot when deleting unused snaphots in workorders
   [#2996](https://github.com/OpenFn/lightning/issues/2996)
+- Don't allow users to disable edges coming from a trigger
+  [#3008](https://github.com/OpenFn/lightning/issues/3008)
 
 ## [v2.10.16] - 2025-02-28
 

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -78,6 +78,15 @@ defmodule Lightning.Workflows.Edge do
       :condition_expression
     ])
     |> validate()
+    |> enable_if_source_trigger()
+  end
+
+  defp enable_if_source_trigger(changeset) do
+    if changeset.valid? and get_field(changeset, :source_trigger_id) do
+      put_change(changeset, :enabled, true)
+    else
+      changeset
+    end
   end
 
   def validate(changeset) do


### PR DESCRIPTION
## Description

This PR makes it such that users cannot disable edges coming from a trigger

Closes #3008 

## Validation steps

You can validate this using the Provisioner

1. Pull your project . `OPENFN_ENDPOINT=http://localhost:4000 openfn pull <projectid>`
2. Modify the edge the links the trigger to the first job. Set `enabled: false`
3. Deploy your changes `openfn deploy`
4. In the `projectState.json`, you'll notice that edge still has `enabled: true`.
5. You can confirm this in the db as well, the edge is still enabled


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
