### PR TITLE
Fix error when minifying assets using esbuild 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to
 
 ### Fixed
 
-## [v2.11.0-pre.0] - 2025-03-12
+## [v2.11.0-pre.1] - 2025-03-12
 
 ### Added
 
@@ -36,6 +36,8 @@ and this project adheres to
   [#2941](https://github.com/OpenFn/lightning/issues/2941)
 - Use dropdown instead of modal for the log level filter
   [#2980](https://github.com/OpenFn/lightning/issues/2980)
+- Upgrade esbuild to 0.25.0
+  [#2962](https://github.com/OpenFn/lightning/issues/2962)
 
 ### Fixed
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -99,6 +99,7 @@ config :esbuild,
          --loader:.woff2=file
          --loader:.ttf=copy
          --format=esm --splitting --bundle
+         --external:path
          --jsx=automatic
          --tsconfig=tsconfig.browser.json
          --target=es2020


### PR DESCRIPTION
## Description

This PR fixes an error when minifying assets using esbuild 0.25.0. This fix is based on the feedback in https://github.com/OpenFn/lightning/issues/2962#issuecomment-2708190923

Closes #2962

## Validation steps

Running `mix assets.deploy` should not throw an errow

## Additional notes for the reviewer

The changelog entry reads `upgrade esbuild to 0.25.0` which is different from the title of this PR. However, esbuild was in fact upgraded in an earlier commit which didn't update the changelog. 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
