### PR TITLE
When changing adaptors, default to the newest specific version

### DIFF
--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -164,11 +164,24 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
         %{"adaptor_picker" => %{"adaptor_name" => value}},
         socket
       ) do
+    # Get versions for this adaptor
+    {_module_name, _version, _adaptors, versions} =
+      get_adaptor_version_options("#{value}@latest")
+
+    # Get the first specific version if available
+    version_str =
+      if length(versions) > 1 do
+        [_latest | specific_versions] = versions
+        List.first(specific_versions)[:value]
+      else
+        "#{value}@latest"
+      end
+
     params =
       LightningWeb.Utils.build_params_for_field(
         socket.assigns.form,
         :adaptor,
-        "#{value}@latest"
+        version_str
       )
 
     socket.assigns.on_change.(params)


### PR DESCRIPTION
## Description

This is a hotfix for #2843. It's not a deep fix, and you'll note that when creating a new workflow you still start with `language-common@latest` but frankly I think that's just fine—we don't do breaking changes to common very often.

I don't want to spend much time on this if we're all in agreement that the way to go is SEMVER (see #2844) and _not_ getting the normal behavior to be "the most recent specific version" is already costing us lots of time.

Also note that it appears we tried to fix this before: https://github.com/OpenFn/lightning/blob/main/lib/lightning_web/live/workflow_live/edit.ex#L2374C1-L2387C6

## Validation steps

1. Create a new step in a workflow.
2. See that it defaults of `language-common@latest`.
3. Pick an adaptor.
4. See that it changes to the latest SPECIFIC version for that adaptor.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
