### PR TITLE
Editor: adjust how types are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fixes to some issues with code-complete in the editor
+  [#3052](https://github.com/OpenFn/lightning/pull/3052)
+
 ## [v2.11.0] - 2025-03-19
 
 ### Added

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -95,8 +95,6 @@ type Lib = {
 };
 
 async function loadDTS(specifier: string): Promise<Lib[]> {
-  const useLocal = specifier.endsWith('@local');
-
   // Work out the module name from the specifier
   // (his gets a bit tricky with @openfn/ module names)
   const nameParts = specifier.split('@');
@@ -146,9 +144,6 @@ async function loadDTS(specifier: string): Promise<Lib[]> {
   for await (const filePath of fetchDTSListing(specifier)) {
     if (!filePath.startsWith('node_modules')) {
       let content = await fetchFile(`${specifier}${filePath}`);
-      if (content.match(/<!doctype html>/i)) {
-        continue;
-      }
       // Convert relative paths
       content = content
         .replace(/from '\.\//g, `from '${name}/`)

--- a/assets/js/editor/Editor.tsx
+++ b/assets/js/editor/Editor.tsx
@@ -109,18 +109,16 @@ async function loadDTS(specifier: string): Promise<Lib[]> {
   // TODO maybe we need other dependencies too? collections?
   if (name !== '@openfn/language-common') {
     const pkg = await fetchFile(`${specifier}/package.json`);
-    const commonVersion = useLocal
-      ? 'local'
-      : JSON.parse(pkg || '{}').dependencies?.['@openfn/language-common'];
+    const commonVersion = JSON.parse(pkg || '{}').dependencies?.[
+      '@openfn/language-common'
+    ];
 
-    if (!useLocal) {
-      // jsDeliver doesn't appear to support semver range syntax (^1.0.0, 1.x, ~1.1.0)
-      const commonVersionMatch = commonVersion?.match(/^\d+\.\d+\.\d+/);
-      if (!commonVersionMatch) {
-        console.warn(
-          `@openfn/language-common@${commonVersion} contains semver range syntax.`
-        );
-      }
+    // jsDeliver doesn't appear to support semver range syntax (^1.0.0, 1.x, ~1.1.0)
+    const commonVersionMatch = commonVersion?.match(/^\d+\.\d+\.\d+/);
+    if (!commonVersionMatch) {
+      console.warn(
+        `@openfn/language-common@${commonVersion} contains semver range syntax.`
+      );
     }
 
     const commonSpecifier = `@openfn/language-common@${commonVersion.replace(
@@ -131,12 +129,10 @@ async function loadDTS(specifier: string): Promise<Lib[]> {
       if (!filePath.startsWith('node_modules')) {
         // Load every common typedef into the common module
         let content = await fetchFile(`${commonSpecifier}${filePath}`);
-        if (!content.match(/<!doctype html>/i)) {
-          content = content.replace(/\* +@(.+?)\*\//gs, '*/');
-          results.push({
-            content: `declare module '@openfn/language-common' { ${content} }`,
-          });
-        }
+        content = content.replace(/\* +@(.+?)\*\//gs, '*/');
+        results.push({
+          content: `declare module '@openfn/language-common' { ${content} }`,
+        });
       }
     }
   }

--- a/assets/js/editor/lib/es5.dts.js
+++ b/assets/js/editor/lib/es5.dts.js
@@ -180,7 +180,6 @@ interface Array<T> {
    */
   reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
 
-  // JC copied out of VSC core. Needed to support union types apparently
   copyWithin(target: number, start: number, end?: number): this;
   
   // JC note that this is the only thing we actually need to get the types to track

--- a/assets/js/editor/lib/es5.dts.js
+++ b/assets/js/editor/lib/es5.dts.js
@@ -1,5 +1,7 @@
 // https://github.com/microsoft/TypeScript/blob/main/lib/lib.es5.d.ts
 export default `
+
+
 interface Array<T> {
   /**
    * Gets or sets the length of the array. This is a number one higher than the highest index in the array.
@@ -178,6 +180,9 @@ interface Array<T> {
    */
   reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
 
+  // JC copied out of VSC core. Needed to support union types apparently
+  copyWithin(target: number, start: number, end?: number): this;
+  
   // JC note that this is the only thing we actually need to get the types to track
   // we could ditch the rest of the definition (if no-one wants to code-complete array.length)
   [n: number]: T;

--- a/assets/js/editor/lib/es5.min.dts.js
+++ b/assets/js/editor/lib/es5.min.dts.js
@@ -1,6 +1,7 @@
 // Super minimal array definition to support typings
 export default `
   interface Array<T> {
+    copyWithin(target: number, start: number, end?: number): this;
     [n: number]: T;
   }
 


### PR DESCRIPTION
## Description

This PR adjusts how type definitions are loaded into Monaco

To provide language support and code assist and stuff, the editor loads d.ts files out of adaptors and loads them into Monaco. We do this with some pretty hairy namespacing stuff, lightly refactoring the definitions on the fly so that they load into Monaco the right way.

To support fhir-4, which is a pure typescript adaptor, a couple of tweaks to this loading are needed.

* We update our minimal JS environment to support `Array.copyWithin()`. Don't ask me why, but this is needed to properly provide code assist for union types like `type X = a | b`
* For d.ts bundles which cross-reference each other, we update import paths so that they work

## Validation steps

1. First off, load a known adaptor like http or common and make sure you get code complete (ctrl + space) on the basic operations. Maybe compare main and this branch to ensure behaviour is the same. This is important because I don't want to accidentally break other adaptors!! (I think it's fine). Salesforce create is probably a good one.
2. Then load `fhir-4` (make sure you're on at least 0.1.2). You should get code assist for `b.patient({ identifier: })` (where identifier takes a string or object). Note that on main, you won't get code assist for this

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
