### PR TITLE
Allow Injection of GDPR Compliance Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Allow possibility to inject components for implementing GDPR compliance
+  [PR#3056](https://github.com/OpenFn/lightning/pull/3056)
 - Allow users to book for demo sessions
   [PR#3035](https://github.com/OpenFn/lightning/pull/3035)
 - Allow workflow and project concurrency progress windows

--- a/config/config.exs
+++ b/config/config.exs
@@ -213,7 +213,7 @@ config :lightning, :ai_feedback, false
 # To enable the GDPR banner with a custom component:
 #
 # config :lightning, :gdpr_banner, %{
-#   component: ThunderboltWeb.Components.CookieConsentBanner,
+#   component: MyAppWeb.Components.CookieConsentBanner,
 #   id: "cookie-consent-banner"
 # }
 #
@@ -228,7 +228,7 @@ config :lightning, :ai_feedback, false
 # To enable GDPR preferences management with a custom component:
 #
 # config :lightning, :gdpr_preferences, %{
-#   component: ThunderboltWeb.Components.CookiePreferencesComponent,
+#   component: MyAppWeb.Components.CookiePreferencesComponent,
 #   id: "cookie-consent-preferences"
 # }
 #

--- a/config/config.exs
+++ b/config/config.exs
@@ -194,6 +194,52 @@ config :lightning, LightningWeb.CollectionsController,
 # To disable the feedback mechanism, set the value to `false` as shown below:
 config :lightning, :ai_feedback, false
 
+# Configuration for GDPR Compliance Components
+#
+# The GDPR configuration allows you to enable or disable user consent management
+# features across your application. This includes both a notification banner and
+# preference management components that handle user consent for data processing
+# activities in compliance with GDPR regulations.
+#
+# -------------------------
+# GDPR Banner Configuration
+# -------------------------
+#
+# The banner appears to users who have not yet specified their privacy preferences.
+# It provides information about data processing activities and prompts the user
+# to make choices about cookie and data usage.
+#
+# Example:
+# To enable the GDPR banner with a custom component:
+#
+# config :lightning, :gdpr_banner, %{
+#   component: ThunderboltWeb.Components.CookieConsentBanner,
+#   id: "cookie-consent-banner"
+# }
+#
+# ------------------------------
+# GDPR Preferences Configuration
+# ------------------------------
+#
+# The preferences component provides an interface for users to view and modify
+# their consent settings for various data processing activities.
+#
+# Example:
+# To enable GDPR preferences management with a custom component:
+#
+# config :lightning, :gdpr_preferences, %{
+#   component: ThunderboltWeb.Components.CookiePreferencesComponent,
+#   id: "cookie-consent-preferences"
+# }
+#
+# -----------------------
+# Disabling GDPR Components
+# -----------------------
+#
+# To disable either or both GDPR components, set their values to `false`:
+config :lightning, :gdpr_preferences, false
+config :lightning, :gdpr_banner, false
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -284,6 +284,16 @@ defmodule Lightning.Config do
     defp book_demo_banner_config do
       Application.get_env(:lightning, :book_demo_banner, [])
     end
+
+    @impl true
+    def gdpr_banner do
+      Application.get_env(:lightning, :gdpr_banner)
+    end
+
+    @impl true
+    def gdpr_preferences do
+      Application.get_env(:lightning, :gdpr_preferences)
+    end
   end
 
   @callback apollo(key :: atom() | nil) :: map()
@@ -328,6 +338,8 @@ defmodule Lightning.Config do
   @callback book_demo_banner_enabled?() :: boolean()
   @callback book_demo_calendly_url() :: String.t()
   @callback book_demo_openfn_workflow_url() :: String.t()
+  @callback gdpr_banner() :: map() | false
+  @callback gdpr_preferences() :: map() | false
 
   @doc """
   Returns the configuration for the `Lightning.AdaptorRegistry` service
@@ -516,6 +528,14 @@ defmodule Lightning.Config do
 
   def book_demo_openfn_workflow_url do
     impl().book_demo_openfn_workflow_url()
+  end
+
+  def gdpr_banner do
+    impl().gdpr_banner()
+  end
+
+  def gdpr_preferences do
+    impl().gdpr_preferences()
   end
 
   defp impl do

--- a/lib/lightning/schema.ex
+++ b/lib/lightning/schema.ex
@@ -1,6 +1,6 @@
 defmodule Lightning.Schema do
   @moduledoc """
-  Defines the database schema and primary key type for Thunderbolt schemas.
+  Defines the database schema and primary key type for the billing app's schemas.
   """
   defmacro __using__(_opts) do
     quote do

--- a/lib/lightning_web/components/layouts/live.html.heex
+++ b/lib/lightning_web/components/layouts/live.html.heex
@@ -68,6 +68,12 @@
         id="account-confirmation-modal"
         current_user={@current_user}
       />
+      <.live_component
+        :if={assigns[:gdpr_banner]}
+        module={@gdpr_banner.component}
+        id={@gdpr_banner.id}
+        current_user={@current_user}
+      />
     </div>
   </div>
 </main>

--- a/lib/lightning_web/init_assigns.ex
+++ b/lib/lightning_web/init_assigns.ex
@@ -25,6 +25,7 @@ defmodule LightningWeb.InitAssigns do
            attrs: %{current_user: current_user}
          }
        end
-     end)}
+     end)
+     |> assign_new(:gdpr_banner, fn -> Lightning.Config.gdpr_banner() end)}
   end
 end

--- a/lib/lightning_web/live/profile_live/components.ex
+++ b/lib/lightning_web/live/profile_live/components.ex
@@ -33,6 +33,9 @@ defmodule LightningWeb.ProfileLive.Components do
   attr :delete_user_url, :string, required: true
 
   def action_cards(assigns) do
+    assigns =
+      assign(assigns, gdpr_preferences: Lightning.Config.gdpr_preferences())
+
     ~H"""
     <div id={"user-#{@current_user.id}"} class="md:col-span-2">
       <.live_component
@@ -51,6 +54,13 @@ defmodule LightningWeb.ProfileLive.Components do
         user={@current_user}
         return_to={~p"/profile"}
       />
+      <%= if assigns[:gdpr_preferences] do %>
+        <.live_component
+          module={@gdpr_preferences.component}
+          id={@gdpr_preferences.id}
+          current_user={@current_user}
+        />
+      <% end %>
       <.live_component
         module={LightningWeb.ProfileLive.MfaComponent}
         id={"#{@current_user.id}_mfa_section"}

--- a/test/support/gdpr_helpers.ex
+++ b/test/support/gdpr_helpers.ex
@@ -1,0 +1,56 @@
+defmodule Lightning.GDPRHelpers do
+  import Mox
+  import Phoenix.Component
+
+  defmodule MockGDPRPreferencesComponent do
+    use LightningWeb, :live_component
+
+    def render(assigns) do
+      ~H"""
+      <div id={@id}>Manage your data here</div>
+      """
+    end
+  end
+
+  defmodule MockGDPRBannerComponent do
+    use LightningWeb, :live_component
+
+    def render(assigns) do
+      ~H"""
+      <div id={@id}>We value your privacy</div>
+      """
+    end
+  end
+
+  def setup_gdpr_component(context, type, enabled) do
+    config_func = :"gdpr_#{type}"
+
+    component_module =
+      Module.concat(__MODULE__, "MockGDPR#{String.capitalize(type)}Component")
+
+    stub(Lightning.MockConfig, config_func, fn ->
+      if enabled do
+        %{
+          component: component_module,
+          id: context[:id] || "gdpr-#{type}"
+        }
+      else
+        false
+      end
+    end)
+
+    context
+  end
+
+  def setup_enabled_gdpr_preferences(context),
+    do: setup_gdpr_component(context, "preferences", true)
+
+  def setup_disabled_gdpr_preferences(context),
+    do: setup_gdpr_component(context, "preferences", false)
+
+  def setup_enabled_gdpr_banner(context),
+    do: setup_gdpr_component(context, "banner", true)
+
+  def setup_disabled_gdpr_banner(context),
+    do: setup_gdpr_component(context, "banner", false)
+end


### PR DESCRIPTION
## Description

This PR adds the possibility to inject the GDPR compliance banners and management components. 

## Validation steps

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
