### PR TITLE
Fix put project credentials on new credential

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
       - run: chown -R lightning /home/lightning
       - run: sudo -u lightning mix local.hex --force && mix local.rebar --force
-      - run: cd assets; sudo -u lightning npm install
+      - run: cd assets; sudo -u lightning npm install --force
       - run: sudo -u lightning mix do deps.get --only test, deps.compile, compile
       - run: sudo -u lightning mix lightning.install_runtime
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Fix putting project credentials on a new credential
+  [#2993](https://github.com/OpenFn/lightning/issues/2993)
 - Allow users to book for demo sessions
   [PR#3035](https://github.com/OpenFn/lightning/pull/3035)
 - Allow workflow and project concurrency progress windows

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -688,16 +688,9 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
        ) do
     user_id = Ecto.Changeset.fetch_field!(changeset, :user_id)
 
-    project_credentials =
-      Ecto.Changeset.fetch_field!(changeset, :project_credentials)
-      |> Enum.map(fn %{project_id: project_id} ->
-        %{"project_id" => project_id}
-      end)
-
     credential_params
     |> Map.put("user_id", user_id)
     |> Map.put("schema", schema_name)
-    |> Map.put("project_credentials", project_credentials)
     |> Credentials.create_credential()
     |> case do
       {:ok, credential} ->

--- a/lib/lightning_web/live/credential_live/helpers.ex
+++ b/lib/lightning_web/live/credential_live/helpers.ex
@@ -31,8 +31,8 @@ defmodule LightningWeb.CredentialLive.Helpers do
   """
   def prepare_projects_associations(changeset, selected_projects, assoc_key) do
     project_credentials = Ecto.Changeset.fetch_field!(changeset, assoc_key)
-    selected_ids = MapSet.new(Enum.map(selected_projects, & &1.id))
-    project_ids = MapSet.new(Enum.map(project_credentials, & &1.project_id))
+    selected_ids = MapSet.new(selected_projects, & &1.id)
+    project_ids = MapSet.new(project_credentials, & &1.project_id)
 
     {projects_to_keep, projects_to_delete} =
       Enum.split_with(


### PR DESCRIPTION
## Description

This PR fixes putting the project credentials relations on a new credential.

Closes #2993

## Validation steps

1. Select a credential to create
2. Still on the Add Credential modal, select on "Grant project access to this credential" a project and add it
3. Repeat for another project before saving the credential
4.  Save the credential and it shows associated to the credential the projects you've selected.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
