### PR TITLE
Fix: config_env/0 returns an atom not a string

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -125,7 +125,7 @@ config :esbuild,
         )
       |> then(fn args ->
         case config_env() do
-          "prod" -> args
+          :prod -> args
           _ -> args ++ ["--jsx-dev"]
         end
       end),


### PR DESCRIPTION
## Description

This is a tiny PR for fixing a potential bug that would happen on prod where esbuild would always pipe in `["--jsx-dev"]` into the args because `config_env/0` returns environment in atom values and we were matching them to string values.

The fix changes this:

```elixir
case config_env() do
    "prod" -> args
    _ -> args ++ ["--jsx-dev"]
end
```
 
to this:

```elixir
case config_env() do
    :prod -> args
    _ -> args ++ ["--jsx-dev"]
end
```

## Validation steps

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
