### PR TITLE
Change edge color in the workflow when there is an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   [PR#3035](https://github.com/OpenFn/lightning/pull/3035)
 - Allow workflow and project concurrency progress windows
   [#2995](https://github.com/OpenFn/lightning/issues/2995)
+- Change edge color in the workflow when there is an error
+  [#2999](https://github.com/OpenFn/lightning/issues/2999)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Allow possibility to inject components for implementing GDPR compliance
   [PR#3056](https://github.com/OpenFn/lightning/pull/3056)
+- Change edge color in the workflow when there is an error
+  [#2999](https://github.com/OpenFn/lightning/issues/2999)
 
 ### Changed
 
@@ -37,8 +39,6 @@ and this project adheres to
   [PR#3035](https://github.com/OpenFn/lightning/pull/3035)
 - Allow workflow and project concurrency progress windows
   [#2995](https://github.com/OpenFn/lightning/issues/2995)
-- Change edge color in the workflow when there is an error
-  [#2999](https://github.com/OpenFn/lightning/issues/2999)
 
 ### Changed
 

--- a/assets/js/workflow-diagram/styles.ts
+++ b/assets/js/workflow-diagram/styles.ts
@@ -46,19 +46,27 @@ export const edgeLabelTextStyles = {
 
 export const edgeLabelStyles = (
   selected: boolean | undefined,
-  data?: { enabled?: boolean }
+  data?: { enabled?: boolean; errors?: object }
 ) => {
-  const { enabled } = data ?? {};
+  const { enabled, errors } = data ?? {};
   const primaryColor = (selected?: boolean, enabled?: boolean) => {
     if (enabled) return selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
     return selected ? EDGE_COLOR_SELECTED_DISABLED : EDGE_COLOR_DISABLED;
   };
 
+  const hasErrors = (errors: object | undefined | null) => {
+    if (!errors) return false;
+
+    return Object.values(errors).some(errorArray => errorArray.length > 0);
+  };
+
   // this is just styling the parent of the edge label
   // the icon and label will inherit
   return {
-    borderColor: primaryColor(selected, enabled),
-    color: primaryColor(selected, enabled),
+    borderColor: hasErrors(errors)
+      ? ERROR_COLOR
+      : primaryColor(selected, enabled),
+    color: hasErrors(errors) ? ERROR_COLOR : primaryColor(selected, enabled),
     backgroundColor: 'transparent',
     display: 'flex',
     alignItems: 'center',
@@ -87,9 +95,14 @@ export const styleNode = (node: Flow.Node) => {
 };
 
 export const styleEdge = (edge: Flow.Edge) => {
+  const primaryColor = edge.selected ? EDGE_COLOR_SELECTED : EDGE_COLOR;
+  const hasErrors =
+    typeof edge.data?.errors === 'object' &&
+    Object.values(edge.data.errors).some(errorArray => errorArray.length > 0);
+
   edge.style = {
     strokeWidth: '2',
-    stroke: edge.selected ? EDGE_COLOR_SELECTED : EDGE_COLOR,
+    stroke: hasErrors ? ERROR_COLOR : primaryColor,
   };
 
   if (edge.data?.placeholder) {
@@ -107,7 +120,7 @@ export const styleEdge = (edge: Flow.Edge) => {
     edge.markerEnd = {
       ...edge.markerEnd,
       width: 15,
-      color: edge.selected ? EDGE_COLOR_SELECTED : EDGE_COLOR,
+      color: hasErrors ? ERROR_COLOR : primaryColor,
     };
   }
   return edge;

--- a/assets/js/workflow-diagram/types.ts
+++ b/assets/js/workflow-diagram/types.ts
@@ -70,6 +70,7 @@ export type EdgeData = {
   enabled?: boolean;
   placeholder?: boolean;
   condition_type?: string;
+  errors?: object;
 };
 
 export namespace Flow {

--- a/assets/js/workflow-diagram/util/from-workflow.tsx
+++ b/assets/js/workflow-diagram/util/from-workflow.tsx
@@ -108,6 +108,7 @@ const fromWorkflow = (
           condition_type: edge.condition_type,
           // TODO something is up here - ?? true is a hack
           // without it, new edges are marked as disabled
+          errors: edge.errors,
           enabled: edge.enabled ?? true,
           label,
         };

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -601,6 +601,7 @@ defmodule LightningWeb.Components.NewInputs do
   def textarea_element(assigns) do
     ~H"""
     <textarea
+      id={@id}
       name={@name}
       class={[
         "focus:outline focus:outline-2 focus:outline-offset-1 rounded-md shadow-xs text-sm",
@@ -613,7 +614,7 @@ defmodule LightningWeb.Components.NewInputs do
           "border-danger-400 focus:border-danger-400 focus:outline-danger-400",
         @class
       ]}
-      {if(@id, do: Map.merge(%{id: @id}, @rest), else: @rest)}
+      {@rest}
     ><%= Form.normalize_value("textarea", @value) %></textarea>
     """
   end

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -270,22 +270,7 @@ defmodule LightningWeb.Components.NewInputs do
       <.label :if={@label} for={@id}>
         {@label}<span :if={Map.get(@rest, :required, false)} class="text-red-500"> *</span>
       </.label>
-      <textarea
-        id={@id}
-        name={@name}
-        class={[
-          "focus:outline focus:outline-2 focus:outline-offset-1 rounded-md shadow-xs text-sm",
-          "mt-2 block w-full focus:ring-0",
-          "sm:text-sm sm:leading-6",
-          "phx-no-feedback:border-slate-300 phx-no-feedback:focus:border-slate-400 overflow-y-auto",
-          @errors == [] &&
-            "border-slate-300 focus:border-slate-400 focus:outline-indigo-600",
-          @errors != [] && @field && @field.field == @name && @field.errors != [] &&
-            "border-danger-400 focus:border-danger-400 focus:outline-danger-400",
-          @class
-        ]}
-        {@rest}
-      ><%= Form.normalize_value("textarea", @value) %></textarea>
+      <.textarea_element id={@id} name={@name} class={@class} value={@value} {@rest} />
       <.error :for={msg <- @errors} :if={@display_errors}>{msg}</.error>
     </div>
     """
@@ -590,6 +575,46 @@ defmodule LightningWeb.Components.NewInputs do
       ]}
       {@rest}
     />
+    """
+  end
+
+  @doc """
+  Renders a textarea element.
+
+  This function is used internally by `input/1` and generally should not
+  be used directly.
+
+  Look at `input type="textarea"` to see how these values `attr` get populated
+  """
+
+  attr :id, :string, default: nil
+  attr :name, :string, required: true
+  attr :value, :any
+  attr :errors, :list, default: []
+  attr :class, :string, default: ""
+
+  attr :rest, :global,
+    include:
+      ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+              multiple pattern placeholder readonly required rows size step)
+
+  def textarea_element(assigns) do
+    ~H"""
+    <textarea
+      name={@name}
+      class={[
+        "focus:outline focus:outline-2 focus:outline-offset-1 rounded-md shadow-xs text-sm",
+        "mt-2 block w-full focus:ring-0",
+        "sm:text-sm sm:leading-6",
+        "phx-no-feedback:border-slate-300 phx-no-feedback:focus:border-slate-400 overflow-y-auto",
+        @errors == [] &&
+          "border-slate-300 focus:border-slate-400 focus:outline-indigo-600",
+        @errors != [] &&
+          "border-danger-400 focus:border-danger-400 focus:outline-danger-400",
+        @class
+      ]}
+      {if(@id, do: Map.merge(%{id: @id}, @rest), else: @rest)}
+    ><%= Form.normalize_value("textarea", @value) %></textarea>
     """
   end
 

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -121,15 +121,18 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
       can_edit_data_retention={@can_edit_data_retention}
     />
     <div :if={is_nil(@selected_dataclip)} class="grow">
-      <.input
-        type="textarea"
-        field={@form[:body]}
-        disabled={@disabled}
-        class="h-full font-mono proportional-nums text-slate-200 bg-slate-700"
-        stretch={true}
-        phx-debounce="300"
-        phx-hook="BlurDataclipEditor"
-      />
+      <div phx-feedback-for={@form[:body].name} class="h-full">
+        <.errors field={@form[:body]} />
+        <.textarea_element
+          id={@form[:body].id}
+          name={@form[:body].name}
+          value={@form[:body].value}
+          disabled={@disabled}
+          class="h-full font-mono proportional-nums text-slate-200 bg-slate-700"
+          phx-debounce="300"
+          phx-hook="BlurDataclipEditor"
+        />
+      </div>
     </div>
     """
   end

--- a/lib/lightning_web/live/workflow_live/manual_workorder.ex
+++ b/lib/lightning_web/live/workflow_live/manual_workorder.ex
@@ -121,7 +121,7 @@ defmodule LightningWeb.WorkflowLive.ManualWorkorder do
       can_edit_data_retention={@can_edit_data_retention}
     />
     <div :if={is_nil(@selected_dataclip)} class="grow">
-      <div phx-feedback-for={@form[:body].name} class="h-full">
+      <div phx-feedback-for={@form[:body].name} class="h-full flex flex-col">
         <.errors field={@form[:body]} />
         <.textarea_element
           id={@form[:body].id}

--- a/lib/lightning_web/live/workflow_live/workflow_params.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_params.ex
@@ -121,6 +121,7 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParams do
             :enabled,
             :condition_type,
             :condition_label,
+            :condition_expression,
             :target_job_id
           ])
       }


### PR DESCRIPTION
## Description

This PR changes the edge color to red when there is an error
Additionally, it puts the error message at the top of the dataclip input so that it is not hidden by overflow-y.

Closes #2999 

## Validation steps

On any edge connecting jobs in your workflow, change the edge type to be a `JS expression`. This will instantly show an error that the `JS Expression` is required. The color of the edge will change to `red`.
<img width="1440" alt="Screenshot 2025-03-26 at 11 11 43" src="https://github.com/user-attachments/assets/8632fbeb-8cac-404f-b0dd-1e3cbf2a1ec9" />

Open the job inspector modal. In the dataclip input, put in an invalid json, e.g. just an opening brace `{`. You'll notice that the error is shown at the top. Previously this error was added at the bottom and you needed to scroll to view it.
<img width="1440" alt="Screenshot 2025-03-26 at 11 12 13" src="https://github.com/user-attachments/assets/250b5be4-667f-4edf-930c-048fca57b0fb" />


## Additional notes for the reviewer

For the dataclip input, we could also solve it with a fixed height maybe 90%? I just thought it was easier to just put the error at the top instead of wrestling with the layout.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
