### PR TITLE
Clarify collection name uniqueness

### DIFF
--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -532,8 +532,8 @@ defmodule LightningWeb.Components.NewInputs do
     ~H"""
     <div phx-feedback-for={@name}>
       <.label :if={@label} for={@id} class="mb-2">
-        {@label}
-        <span :if={Map.get(@rest, :required, false)} class="text-red-500"> *</span>
+        {@label}<span :if={Map.get(@rest, :required, false)} class="text-red-500"> *</span>
+        <.tooltip_for_label :if={@tooltip} id={"#{@id}-tooltip"} tooltip={@tooltip} />
       </.label>
       <.input_element
         type={@type}

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -139,6 +139,7 @@ defmodule LightningWeb.Components.NewInputs do
   attr :id, :any, default: nil
   attr :name, :any
   attr :label, :string, default: nil
+  attr :sublabel, :string, default: nil
   attr :value, :any
 
   attr :type, :string,
@@ -532,9 +533,12 @@ defmodule LightningWeb.Components.NewInputs do
     ~H"""
     <div phx-feedback-for={@name}>
       <.label :if={@label} for={@id} class="mb-2">
-        {@label}<span :if={Map.get(@rest, :required, false)} class="text-red-500"> *</span>
-        <.tooltip_for_label :if={@tooltip} id={"#{@id}-tooltip"} tooltip={@tooltip} />
+        {@label}
+        <span :if={Map.get(@rest, :required, false)} class="text-red-500"> *</span>
       </.label>
+      <small :if={@sublabel} class="mb-2 block text-xs text-gray-600">
+        {@sublabel}
+      </small>
       <.input_element
         type={@type}
         name={@name}

--- a/lib/lightning_web/live/book_demo_banner.ex
+++ b/lib/lightning_web/live/book_demo_banner.ex
@@ -178,7 +178,7 @@ defmodule LightningWeb.BookDemoBanner do
                   Schedule a call
                 </button>
                 <button
-                  id="cancel-credential-type-picker"
+                  id="cancel-demo-booking"
                   type="button"
                   phx-click={hide_modal("#{@id}-modal")}
                   class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -140,6 +140,7 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
                 value={@name}
                 label="Name"
                 required="true"
+                tooltip="Collection names are instance wide unique. They are used in URLs and as a title."
               />
               <.input type="hidden" field={f[:name]} />
               <small class="mt-2 block text-xs text-gray-600">

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -103,7 +103,7 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
   def render(assigns) do
     ~H"""
     <div class="text-xs">
-      <.modal id={@id} width="xl:min-w-1/3 min-w-1/2 max-w-full">
+      <.modal id={@id} width="xl:min-w-1/3 min-w-1/2 max-w-1/2">
         <:title>
           <div class="flex justify-between">
             <span class="font-bold">
@@ -139,13 +139,13 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
                 field={f[:raw_name]}
                 value={@name}
                 label="Name"
+                sublabel="Collection names must be unique across all projects within this instance. They are used in URLs and as titles, so duplicates are not allowed."
                 required="true"
-                tooltip="Collection names are instance wide unique. They are used in URLs and as a title."
               />
               <.input type="hidden" field={f[:name]} />
               <small class="mt-2 block text-xs text-gray-600">
                 <%= if to_string(f[:name].value) != "" do %>
-                  Your collection will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
+                  This collection will be named <span class="font-mono border rounded-md p-1 bg-yellow-100 border-slate-300">
       <%= @name %></span>.
                 <% end %>
               </small>


### PR DESCRIPTION
## Description

This PR adds an explanatory sublabel to the collection name input to clarify that collection names must be unique across all projects within an instance. This helps users understand why a name might be marked as "already taken."

Closes #2964 

## Validation steps

1. Go to the collection creation form.
2. Confirm that a small text explaining name uniqueness appears below the name input.

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
