### PR TITLE
Comment out esbuild runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to
 
 ### Fixed
 
-## [v2.11.1-pre.0] - 2025-03-26
+## [v2.11.1-pre.1] - 2025-03-26
 
 ### Added
 

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -643,10 +643,13 @@ defmodule Lightning.Config.Bootstrap do
 
     setup_storage()
 
-    entry_points = React.get_entry_points(:lightning)
+    # Commenting this out because the React modules aren't being used in prod
+    # Utils.get_env([:esbuild, :default, :args]) returns nil in prod
+    # We should have uncomment it when we have a proper fix
+    # entry_points = React.get_entry_points(:lightning)
 
-    config :esbuild, :default,
-      args: Utils.get_env([:esbuild, :default, :args]) ++ entry_points
+    # config :esbuild, :default,
+    #   args: Utils.get_env([:esbuild, :default, :args]) ++ entry_points
 
     :ok
   end


### PR DESCRIPTION
## Description

This PR does a temporary fix for a config issue regarding esbuild. 
`Utils.get_env([:esbuild, :default, :args])` is returning `nil`. 
This is just a temporary fix.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
