### PR TITLE
Enable credential transfer in projects credentials table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Enable Credential Transfer In Projects Credentials Table
+  [#2978](https://github.com/OpenFn/lightning/issues/2978)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/accounts/user_notifier.ex
+++ b/lib/lightning/accounts/user_notifier.ex
@@ -423,20 +423,25 @@ defmodule Lightning.Accounts.UserNotifier do
         credential,
         token
       ) do
-    validity_days = Lightning.Config.credential_transfer_token_validity_in_days()
-    validity_text = format_validity_period(validity_days)
+    validity_text =
+      Lightning.Config.credential_transfer_token_validity_in_days()
+      |> format_validity_period()
 
     confirmation_url =
       url(~p"/credentials/transfer/#{credential.id}/#{receiver.id}/#{token}")
 
-    deliver(owner, "Confirm your credential transfer", """
+    deliver(owner, "Transfer #{credential.name} to #{receiver.first_name}", """
     Hi #{owner.first_name},
 
-    Confirm your credential transfer to #{receiver.first_name} (#{receiver.email}) by visiting the link below:
+    You are about to transfer #{credential.name} to #{receiver.first_name} (#{receiver.email}). Please ignore this email if you have not requested to transfer this credential.
+
+    To confirm this activity, click the link below:
 
     #{confirmation_url}
 
-    Note that this link is only valid for #{validity_text}. If you didn't request this change, please ignore this.
+    Please note:
+    1. Transferring your credentials is irreversible and can impact the security of your projects.
+    2. This link is only valid for #{validity_text}.
 
     OpenFn
     """)
@@ -453,12 +458,10 @@ defmodule Lightning.Accounts.UserNotifier do
       ) do
     credentials_url = url(~p"/credentials")
 
-    deliver(receiver, "You have received a credential", """
-    Hi #{receiver.first_name},
+    deliver(receiver, "A credential has been transferred to you.", """
+    #{owner.first_name} has transferred the credential \"#{credential.name}\" to you. As a credential owner, you can edit the credential details and share the credential with other projects in your OpenFn account.
 
-    #{owner.first_name} has transferred the credential \"#{credential.name}\" to you.
-
-    You can find it in your list of credentials by following this URL: #{credentials_url}
+    See your credential list here: #{credentials_url}
 
     OpenFn
     """)

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -404,6 +404,23 @@
                 <.link
                   class="table-action"
                   phx-click={
+                    show_modal("transfer-credential-#{credential.id}-modal")
+                  }
+                >
+                  <%= case credential.transfer_status do %>
+                    <% :pending -> %>
+                      Revoke Transfer
+                    <% :completed -> %>
+                      Transfer
+                    <% nil -> %>
+                      Transfer
+                  <% end %>
+                </.link>
+              </span>
+              <span>
+                <.link
+                  class="table-action"
+                  phx-click={
                     show_modal("edit-credential-#{credential.id}-modal")
                   }
                 >
@@ -439,6 +456,13 @@
                 :if={credential.user_id == @current_user.id}
                 id={"delete_credential_#{credential.id}_modal"}
                 credential={credential}
+              />
+              <.live_component
+                id={"transfer-credential-#{credential.id}-modal"}
+                module={LightningWeb.CredentialLive.TransferCredentialModal}
+                credential={credential}
+                current_user={@current_user}
+                return_to={~p"/projects/#{@project.id}/settings#credentials"}
               />
             </div>
           </:actions>

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -1012,7 +1012,7 @@ defmodule Lightning.CredentialsTest do
 
         assert_email_sent(
           to: Swoosh.Email.Recipient.format(receiver),
-          subject: "You have received a credential"
+          subject: "A credential has been transferred to you."
         )
       end)
     end

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -2764,7 +2764,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       assert_email_sent(
         to: Swoosh.Email.Recipient.format(credential.user),
-        subject: "Confirm your credential transfer"
+        subject: "Transfer #{credential.name} to #{receiver.first_name}"
       )
 
       assert Repo.get_by(Lightning.Accounts.UserToken,


### PR DESCRIPTION
## Description

This PR enables the credential transfer feature in the projects credentials table and updates the credential transfer emails copies.

Closes #2978 

## Validation steps

1. Visit the projects credentials page in the projects settings area (`/projects/<project_id>/settings#credentials`)
2. See the `Transfer` button in the credentials table action buttons
3. Click on that transfer button to initiate a credential transfer
4. Check the confirmation email sent to the user to confirm that it aligns with the copy proposed in the issue
5. Confirm the transfer thru the email
6. Check the received notifying email to confirm that it aligns with the copy proposed in the issue

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
