### PR TITLE
Default adaptor version

### DIFF
--- a/lib/lightning_web.ex
+++ b/lib/lightning_web.ex
@@ -120,7 +120,6 @@ defmodule LightningWeb do
       import LightningWeb.Gettext
 
       import PetalComponents.Avatar
-      import PetalComponents.Badge
       import PetalComponents.Card
       import PetalComponents.Dropdown
       import PetalComponents.Typography

--- a/lib/lightning_web/components/icons.ex
+++ b/lib/lightning_web/components/icons.ex
@@ -22,7 +22,7 @@ defmodule LightningWeb.Components.Icons do
       <.icon name="hero-play-circle" class="ml-1 w-3 h-3 animate-spin" />
   """
   attr :name, :string, required: true
-  attr :class, :string, default: nil
+  attr :class, :any, default: nil
   attr :naked, :boolean, default: false
   attr :rest, :global
 

--- a/lib/lightning_web/components/pills.ex
+++ b/lib/lightning_web/components/pills.ex
@@ -4,14 +4,68 @@ defmodule LightningWeb.Components.Pills do
   """
   use Phoenix.Component
 
+  @doc """
+  Renders a pill with a color.
+
+  ## Example
+
+  ```
+  <.pill color="red">
+    Red pill
+  </.pill>
+
+  ## Colors
+
+  - `gray` **default**
+  - `red`
+  - `yellow`
+  - `green`
+  - `blue`
+  - `indigo`
+  - `purple`
+  - `pink`
+  """
+  attr :color, :string,
+    default: "gray",
+    values: [
+      "gray",
+      "red",
+      "yellow",
+      "green",
+      "blue",
+      "indigo",
+      "purple",
+      "pink"
+    ]
+
   slot :inner_block, required: true
+  attr :rest, :global
 
   def pill(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        class:
+          case assigns[:color] do
+            "gray" -> "bg-gray-100 text-gray-600"
+            "red" -> "bg-red-100 text-red-700"
+            "yellow" -> "bg-yellow-100 text-yellow-800"
+            "green" -> "bg-green-100 text-green-700"
+            "blue" -> "bg-blue-100 text-blue-700"
+            "indigo" -> "bg-indigo-100 text-indigo-700"
+            "purple" -> "bg-purple-100 text-purple-700"
+            "pink" -> "bg-pink-100 text-pink-700"
+          end
+      )
+
     ~H"""
-    <span class={~w[
-      my-auto whitespace-nowrap rounded-full
-      py-2 px-4 text-center align-baseline text-xs font-medium leading-none
-    ]}>
+    <span
+      class={[
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        @class
+      ]}
+      {@rest}
+    >
       {render_slot(@inner_block)}
     </span>
     """

--- a/lib/lightning_web/live/audit_live/index.ex
+++ b/lib/lightning_web/live/audit_live/index.ex
@@ -5,6 +5,7 @@ defmodule LightningWeb.AuditLive.Index do
   use LightningWeb, :live_view
 
   import PetalComponents.Table
+  import PetalComponents.Badge
 
   alias Lightning.Auditing
   alias Lightning.Policies.Permissions

--- a/lib/lightning_web/live/components/form.ex
+++ b/lib/lightning_web/live/components/form.ex
@@ -417,8 +417,7 @@ defmodule LightningWeb.Components.Form do
       rounded-md
       border-secondary-300
       shadow-xs
-      text-md
-      font-medium
+      sm:text-sm
       focus:border-primary-300
       focus:ring
       focus:ring-primary-200/50

--- a/test/lightning_web/live/job_live/adaptor_picker_test.exs
+++ b/test/lightning_web/live/job_live/adaptor_picker_test.exs
@@ -1,0 +1,54 @@
+defmodule LightningWeb.JobLive.AdaptorPickerTest do
+  use LightningWeb.ConnCase, async: true
+
+  alias LightningWeb.JobLive.AdaptorPicker
+
+  describe "get_adaptor_version_options/1" do
+    test "returns sorted versions with latest option when adaptor exists" do
+      adaptor_name = "@openfn/language-common"
+
+      {module_name, version, adaptor_names, versions} =
+        AdaptorPicker.get_adaptor_version_options(adaptor_name)
+
+      assert module_name == adaptor_name
+      assert version == nil
+      assert {"common", adaptor_name} in adaptor_names
+
+      # Check that versions are properly formatted and ordered
+      latest_version = List.first(versions)
+
+      assert match?(
+               [key: "latest " <> _, value: "@openfn/language-common@latest"],
+               latest_version
+             )
+
+      # Get all non-latest versions
+      [_latest | specific_versions] = versions
+
+      # Verify versions are in descending order
+      version_numbers =
+        Enum.map(specific_versions, fn [key: version, value: _] ->
+          Version.parse!(version)
+        end)
+
+      assert version_numbers == Enum.sort(version_numbers, :desc)
+    end
+
+    test "handles adaptor with specific version" do
+      adaptor_name = "@openfn/language-common@1.6.2"
+
+      {module_name, version, adaptor_names, versions} =
+        AdaptorPicker.get_adaptor_version_options(adaptor_name)
+
+      assert module_name == "@openfn/language-common"
+      assert version == "1.6.2"
+      assert {"common", "@openfn/language-common"} in adaptor_names
+
+      # Verify the specific version is in the list
+      assert Enum.any?(versions, fn
+               [key: "1.6.2", value: "@openfn/language-common@1.6.2"] -> true
+               _ -> false
+             end)
+    end
+  end
+end


### PR DESCRIPTION
## Description

When selecting a new adaptor, default to using the latest specific version number
instead of @latest. The @latest option remains available but requires explicit
opt-in and displays a warning pill about potential breaking changes.

Closes https://github.com/OpenFn/lightning/issues/2843

<img width="584" alt="Screenshot 2025-03-27 at 10 26 56" src="https://github.com/user-attachments/assets/f24a7311-9f69-4736-b2cb-3269a54d4c25" />

## Additional notes for the reviewer

This does not change the default adaptor version when creating a new job or workflow, that is controlled by the workflow store/front end right now - so is arguably out of scope for now.

However as mentioned above, when changing the adaptor itself in the form; the latest version is selected (but not `@latest`).

This supercedes #3042.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
