### PR TITLE
Display OAuth Clients Owners Emails

### DIFF
--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -443,6 +443,7 @@ defmodule LightningWeb.Components.Credentials do
   attr :id, :string, required: true
   attr :clients, :list, required: true
   attr :title, :string, required: true
+  attr :show_owner, :boolean, default: false
 
   slot :actions,
     doc: "the slot for showing user actions in the last table column"
@@ -462,6 +463,7 @@ defmodule LightningWeb.Components.Credentials do
         <.table id={"#{@id}-table"}>
           <.tr>
             <.th>Name</.th>
+            <.th :if={@show_owner}>Owner</.th>
             <.th>Projects With Access</.th>
             <.th>Authorization URL</.th>
             <.th><span class="sr-only">Actions</span></.th>
@@ -473,6 +475,9 @@ defmodule LightningWeb.Components.Credentials do
             class="hover:bg-gray-100 transition-colors duration-200"
           >
             <.td class="break-words max-w-[15rem]">{client.name}</.td>
+            <.td :if={@show_owner} class="break-words max-w-[15rem]">
+              {if client.global, do: "GLOBAL", else: client.user.email}
+            </.td>
             <.td class="break-words max-w-[20rem]">
               <%= for project_name <- client.project_names do %>
                 <span class="inline-flex items-center rounded-md bg-primary-50 p-1 my-0.5 text-xs font-medium ring-1 ring-inset ring-gray-500/10">

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -322,6 +322,7 @@
           id="oauth-clients"
           title="OAuth Clients"
           clients={@oauth_clients}
+          show_owner={true}
         >
           <:empty_state>
             <button


### PR DESCRIPTION
## Description

This PR add a new **Owner** column in the OAuth clients table in the projects OAuth clients page. The owner column will display the email of the owner of the client when the client is not global and the word "GLOBAL" when the client is global. This new column is not added in the user OAuth clients page. 

Closes #2900 

## Validation steps

1. Make sure you have a global OAuth client and a non global one
2. Visit the OAuth clients table in the projects settings page
3. Notice the new **Owner** column in that table and notice it's value to be **GLOBAL** if the client is global and the owner's email if the client is not global
4. Visit the OAuth clients table in the users oauth clients (/credentials) page
5. Notice how the **Owner** column is not present

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
