### PR TITLE
Remove Credentials for Collaborators Removed from a Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Remove Credentials for Collaborators Removed from a Project
+  [#2942](https://github.com/OpenFn/lightning/issues/2942)
 - Allow possibility to inject components for implementing GDPR compliance
   [PR#3056](https://github.com/OpenFn/lightning/pull/3056)
 - Change edge color in the workflow when there is an error

--- a/lib/lightning/credentials.ex
+++ b/lib/lightning/credentials.ex
@@ -1614,4 +1614,36 @@ defmodule Lightning.Credentials do
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
   end
+
+  @doc """
+  Returns all credentials owned by a specific user that are also being used in a specific project.
+
+  ## Parameters
+    - `user`: The `User` struct whose credentials we want to find.
+    - `project`: The `Project` struct to check for credential usage.
+
+  ## Returns
+    - A list of `Credential` structs that are owned by the user and used in the project.
+
+  ## Examples
+
+      iex> list_user_credentials_in_project(%User{id: 123}, %Project{id: 456})
+      [%Credential{user_id: 123, ...}, %Credential{user_id: 123, ...}]
+  """
+  @spec list_user_credentials_in_project(User.t(), Project.t()) :: [
+          Credential.t()
+        ]
+  def list_user_credentials_in_project(%User{id: user_id}, %Project{
+        id: project_id
+      }) do
+    query =
+      from c in Credential,
+        join: pc in assoc(c, :project_credentials),
+        on: pc.project_id == ^project_id,
+        where: c.user_id == ^user_id,
+        order_by: [asc: fragment("lower(?)", c.name)],
+        distinct: c.id
+
+    Repo.all(query)
+  end
 end

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -794,6 +794,7 @@ defmodule Lightning.SetupUtils do
       Lightning.Projects.ProjectCredential,
       Lightning.WorkOrder,
       Lightning.Invocation.Step,
+      Lightning.Credentials.OauthToken,
       Lightning.Credentials.Credential,
       Lightning.KafkaTriggers.TriggerKafkaMessageRecord,
       Lightning.Workflows.Job,
@@ -803,6 +804,8 @@ defmodule Lightning.SetupUtils do
       Lightning.Projects.ProjectUser,
       Lightning.Invocation.Dataclip,
       Lightning.Projects.File,
+      Lightning.Projects.ProjectOauthClient,
+      Lightning.Credentials.OauthClient,
       Lightning.Projects.Project
     ])
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -658,9 +658,7 @@ defmodule LightningWeb.ProjectLive.Settings do
           " and their owned credential #{credential.name}"
 
         credentials ->
-          credentials_list =
-            credentials |> Enum.map(& &1.name) |> Enum.join(", ")
-
+          credentials_list = Enum.map_join(credentials, ", ", & &1.name)
           " and their owned credentials #{credentials_list}"
       end
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -643,6 +643,29 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   defp confirm_user_removal_modal(assigns) do
+    user_credentials =
+      get_user_credentials_in_project(
+        assigns.project_user.user,
+        assigns.project_user.project
+      )
+
+    credentials_text =
+      case user_credentials do
+        [] ->
+          ""
+
+        [credential] ->
+          " and their owned credential #{credential.name}"
+
+        credentials ->
+          credentials_list =
+            credentials |> Enum.map(& &1.name) |> Enum.join(", ")
+
+          " and their owned credentials #{credentials_list}"
+      end
+
+    assigns = assign(assigns, :credentials_text, credentials_text)
+
     ~H"""
     <.modal id={@id} width="max-w-md">
       <:title>
@@ -665,7 +688,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       <div class="px-6">
         <p class="text-sm text-gray-500">
           Are you sure you want to remove "{@project_user.user.first_name} {@project_user.user.last_name}" from this project?
-          They will nolonger have access.
+          They will no longer have access{@credentials_text} will be removed from this project.
           Do you wish to proceed with this action?
         </p>
       </div>
@@ -732,5 +755,12 @@ defmodule LightningWeb.ProjectLive.Settings do
     |> Atom.to_string()
     |> String.replace("_", " ")
     |> String.capitalize()
+  end
+
+  defp get_user_credentials_in_project(
+         %User{} = user,
+         %Projects.Project{} = project
+       ) do
+    Credentials.list_user_credentials_in_project(user, project)
   end
 end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -649,19 +649,23 @@ defmodule LightningWeb.ProjectLive.Settings do
         assigns.project_user.project
       )
 
-    credentials_text =
+    {access_text, credentials_text} =
       case user_credentials do
         [] ->
-          ""
+          {"They will no longer have access to this project.", ""}
 
         [credential] ->
-          " and their owned credential #{credential.name}"
+          {"They will no longer have access to this project",
+           " and their owned credential #{credential.name} will be removed from it"}
 
         credentials ->
           credentials_list = Enum.map_join(credentials, ", ", & &1.name)
-          " and their owned credentials #{credentials_list}"
+
+          {"They will no longer have access to this project",
+           " and their owned credentials #{credentials_list} will be removed from it"}
       end
 
+    assigns = assign(assigns, :access_text, access_text)
     assigns = assign(assigns, :credentials_text, credentials_text)
 
     ~H"""
@@ -685,8 +689,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       </:title>
       <div class="px-6">
         <p class="text-sm text-gray-500">
-          Are you sure you want to remove "{@project_user.user.first_name} {@project_user.user.last_name}" from this project?
-          They will no longer have access{@credentials_text} will be removed from this project.
+          Are you sure you want to remove "{@project_user.user.first_name} {@project_user.user.last_name}" from this project? {@access_text}{@credentials_text}.
           Do you wish to proceed with this action?
         </p>
       </div>

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -2241,7 +2241,10 @@ defmodule Lightning.CredentialsTest do
       assert length(user_2_credentials) == 1
       assert Enum.map(user_2_credentials, & &1.id) == [credential_4.id]
 
-      assert Enum.map(user_1_credentials, & &1.name) == ["cred A", "cred B"]
+      user_1_credential_names = Enum.map(user_1_credentials, & &1.name)
+      assert "cred A" in user_1_credential_names
+      assert "cred B" in user_1_credential_names
+      assert length(user_1_credential_names) == 2
     end
 
     test "returns empty list when user has no credentials in project" do

--- a/test/lightning/credentials_test.exs
+++ b/test/lightning/credentials_test.exs
@@ -2196,4 +2196,62 @@ defmodule Lightning.CredentialsTest do
       assert result.id == token.id
     end
   end
+
+  describe "list_user_credentials_in_project/2" do
+    test "returns all credentials owned by a user that are used in a project" do
+      user_1 = insert(:user)
+      user_2 = insert(:user)
+
+      project = insert(:project)
+
+      credential_1 =
+        insert(:credential,
+          user: user_1,
+          name: "cred A",
+          project_credentials: [%{project: project}]
+        )
+
+      credential_2 =
+        insert(:credential,
+          user: user_1,
+          name: "cred B",
+          project_credentials: [%{project: project}]
+        )
+
+      _credential_3 = insert(:credential, user: user_1, name: "cred C")
+
+      credential_4 =
+        insert(:credential,
+          user: user_2,
+          name: "cred D",
+          project_credentials: [%{project: project}]
+        )
+
+      user_1_credentials =
+        Credentials.list_user_credentials_in_project(user_1, project)
+
+      assert length(user_1_credentials) == 2
+
+      assert Enum.map(user_1_credentials, & &1.id) |> Enum.sort() ==
+               [credential_1.id, credential_2.id] |> Enum.sort()
+
+      user_2_credentials =
+        Credentials.list_user_credentials_in_project(user_2, project)
+
+      assert length(user_2_credentials) == 1
+      assert Enum.map(user_2_credentials, & &1.id) == [credential_4.id]
+
+      assert Enum.map(user_1_credentials, & &1.name) == ["cred A", "cred B"]
+    end
+
+    test "returns empty list when user has no credentials in project" do
+      user = insert(:user)
+      project = insert(:project)
+
+      insert(:credential, user: user)
+
+      credentials = Credentials.list_user_credentials_in_project(user, project)
+      assert Enum.empty?(credentials)
+    end
+  end
 end

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2852,6 +2852,64 @@ defmodule LightningWeb.ProjectLiveTest do
              |> element("#failure-alert-status-#{project_user.id}")
              |> render() =~ "Unavailable"
     end
+
+    test "removal confirmation modal shows user's credentials that will be removed",
+         %{
+           conn: conn
+         } do
+      project = insert(:project)
+      {conn, _user} = setup_project_user(conn, project, :admin)
+
+      user_to_remove = insert(:user, first_name: "Amy", last_name: "Admin")
+
+      project_user =
+        insert(:project_user,
+          project: project,
+          user: user_to_remove,
+          role: :viewer
+        )
+
+      credential =
+        insert(:credential,
+          name: "DHIS2 play",
+          user: user_to_remove,
+          project_credentials: [%{project_id: project.id}]
+        )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#collaboration"
+        )
+
+      assert has_element?(view, "#remove_#{project_user.id}_modal")
+
+      modal = element(view, "#remove_#{project_user.id}_modal")
+      modal_html = render(modal)
+
+      assert modal_html =~ credential.name
+      assert modal_html =~ "and their owned credential #{credential.name}"
+
+      credential2 =
+        insert(:credential,
+          name: "PostgreSQL",
+          user: user_to_remove,
+          project_credentials: [%{project_id: project.id}]
+        )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#collaboration"
+        )
+
+      modal = element(view, "#remove_#{project_user.id}_modal")
+      modal_html = render(modal)
+
+      assert modal_html =~ "and their owned credentials"
+      assert modal_html =~ credential.name
+      assert modal_html =~ credential2.name
+    end
   end
 
   describe "project settings:version control" do


### PR DESCRIPTION
## Description

This PR adds functionality to automatically remove a user's credentials from a project when removing that user from the project.

Closes #2942 

## Validation steps

1. Create a project with multiple users
2. Add credentials owned by these users to the project
3. Remove a user from the project
4. Verify that credentials owned by the removed user are no longer available in the project
5. Verify the confirmation dialog shows the correct credentials that will be removed

PS: Demo video available [here](https://www.loom.com/share/8d47e7334ae845318093d206f465b666?sid=824b6f1c-068e-4b89-9308-20319f947f3c)

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
