### PR TITLE
update form field names to match calendly form

### DIFF
--- a/lib/lightning_web/live/book_demo_banner.ex
+++ b/lib/lightning_web/live/book_demo_banner.ex
@@ -16,10 +16,10 @@ defmodule LightningWeb.BookDemoBanner do
     data = %{
       name: "#{user.first_name} #{user.last_name}",
       email: user.email,
-      message: nil
+      a4: nil
     }
 
-    types = %{name: :string, email: :string, message: :string}
+    types = %{name: :string, email: :string, a4: :string}
 
     {data, types}
     |> Ecto.Changeset.cast(params, Map.keys(types))
@@ -161,7 +161,7 @@ defmodule LightningWeb.BookDemoBanner do
             <.input type="text" field={f[:email]} label="Email" required={true} />
             <.input
               type="textarea"
-              field={f[:message]}
+              field={f[:a4]}
               label="What problem are you trying to solve with OpenFn?
           What specific task, process, or program would you like to automate?"
               placeholder="E.g. Every time a new person is registered in my clinic system, I must initiate a mobile money payment to a caregiver. This takes time & money. I'd like to use OpenFn to automate the process."

--- a/test/lightning_web/live/book_demo_banner_test.exs
+++ b/test/lightning_web/live/book_demo_banner_test.exs
@@ -110,7 +110,7 @@ defmodule LightningWeb.BookDemoBannerTest do
       %{
         "name" => "#{user.first_name} #{user.last_name}",
         "email" => user.email,
-        "message" => expected_message
+        "a4" => expected_message
       }
 
     expected_redirect_url =
@@ -135,14 +135,14 @@ defmodule LightningWeb.BookDemoBannerTest do
 
     form = view |> form("#book-demo-banner-modal form")
 
-    assert render_change(form, demo: %{email: nil, message: expected_message}) =~
+    assert render_change(form, demo: %{email: nil, a4: expected_message}) =~
              "This field can&#39;t be blank"
 
     assert render_submit(form) =~ "This field can&#39;t be blank"
 
     assert {:error, {:redirect, %{to: redirect_to}}} =
              render_submit(form,
-               demo: %{email: user.email, message: expected_message}
+               demo: %{email: user.email, a4: expected_message}
              )
 
     assert redirect_to == expected_redirect_url


### PR DESCRIPTION
## Description

This PR updates the book demo form fields to match those used in calendly


## Validation steps

This should be validated from the billing app


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
