### PR TITLE
Allow metrics to be injected from another app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
   [#2284](https://github.com/OpenFn/lightning/issues/2284)
 - Enable Support User and adds audit trail for MFA.
   [#3072](https://github.com/OpenFn/lightning/issues/3072)
+- Make provision for the inclusion of 'external' metrics.
+  [#3096] (https://github.com/OpenFn/lightning/issues/3096])
+- Introduce 'seeding' of PromEx event metrics
+  [#3096] (https://github.com/OpenFn/lightning/issues/3096])
 
 ### Changed
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -36,7 +36,8 @@ config :lightning, Lightning.Extensions,
   run_queue: Lightning.Extensions.FifoRunQueue,
   account_hook: Lightning.Extensions.AccountHook,
   collection_hook: Lightning.Extensions.CollectionHook,
-  project_hook: Lightning.Extensions.ProjectHook
+  project_hook: Lightning.Extensions.ProjectHook,
+  external_metrics: Lightning.Extensions.ExternalMetrics
 
 config :lightning, Lightning.Extensions.Routing,
   session_opts: [on_mount: LightningWeb.InitAssigns],

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -168,6 +168,12 @@ defmodule Lightning.Application do
     state
   end
 
+  @impl true
+  def start_phase(:seed_prom_ex_telemetry, :normal, _) do
+    Lightning.PromEx.seed_event_metrics()
+    :ok
+  end
+
   def oban_opts do
     opts = Application.get_env(:lightning, Oban)
 

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -294,6 +294,12 @@ defmodule Lightning.Config do
     def gdpr_preferences do
       Application.get_env(:lightning, :gdpr_preferences)
     end
+
+    @impl true
+    def external_metrics_module do
+      Application.get_env(:lightning, Lightning.Extensions, [])
+      |> Keyword.get(:external_metrics)
+    end
   end
 
   @callback apollo(key :: atom() | nil) :: map()
@@ -340,6 +346,7 @@ defmodule Lightning.Config do
   @callback book_demo_openfn_workflow_url() :: String.t()
   @callback gdpr_banner() :: map() | false
   @callback gdpr_preferences() :: map() | false
+  @callback external_metrics_module() :: module() | nil
 
   @doc """
   Returns the configuration for the `Lightning.AdaptorRegistry` service
@@ -536,6 +543,10 @@ defmodule Lightning.Config do
 
   def gdpr_preferences do
     impl().gdpr_preferences()
+  end
+
+  def external_metrics_module do
+    impl().external_metrics_module()
   end
 
   defp impl do

--- a/lib/lightning/extensions/external_metrics.ex
+++ b/lib/lightning/extensions/external_metrics.ex
@@ -1,0 +1,11 @@
+defmodule Lightning.Extensions.ExternalMetrics do
+  @moduledoc """
+  Placeholder that wll be replaced by another module configured to inject
+  external metrics.
+  """
+  @spec plugins :: [any()]
+  def plugins, do: []
+
+  @spec seed_event_metrics :: any()
+  def seed_event_metrics, do: nil
+end

--- a/lib/lightning/prom_ex.ex
+++ b/lib/lightning/prom_ex.ex
@@ -73,6 +73,8 @@ defmodule Lightning.PromEx do
         :run_queue_metrics_period_seconds
       ]
 
+    external_plugins = Lightning.Config.external_metrics_module().plugins()
+
     [
       # PromEx built in plugins
       Plugins.Application,
@@ -89,7 +91,11 @@ defmodule Lightning.PromEx do
         run_performance_age_seconds: run_performance_age_seconds,
         stalled_run_threshold_seconds: stalled_run_threshold_seconds
       }
-    ]
+    ] ++ external_plugins
+  end
+
+  def seed_event_metrics do
+    Lightning.Config.external_metrics_module().seed_event_metrics()
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,8 @@ defmodule Lightning.MixProject do
   def application do
     [
       mod: {Lightning.Application, [:timex]},
-      extra_applications: [:logger, :runtime_tools, :os_mon, :scrivener]
+      extra_applications: [:logger, :runtime_tools, :os_mon, :scrivener],
+      start_phases: [seed_prom_ex_telemetry: []]
     ]
   end
 

--- a/test/lightning/config_test.exs
+++ b/test/lightning/config_test.exs
@@ -42,6 +42,17 @@ defmodule Lightning.Configtest do
 
       assert expected == actual
     end
+
+    test "returns module responsible for injecting external metric plugins" do
+      expected =
+        extract_from_config(Lightning.Extensions, :external_metrics)
+
+      refute expected == nil
+
+      actual = API.external_metrics_module()
+
+      assert expected == actual
+    end
   end
 
   defp extract_from_config(config, key) do

--- a/test/lightning/extensions/external_metrics_test.exs
+++ b/test/lightning/extensions/external_metrics_test.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Extensions.ExternalMetricsTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Extensions.ExternalMetrics
+
+  test "returns an empty list " do
+    assert ExternalMetrics.plugins() == []
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,7 +50,8 @@ Application.put_env(:lightning, Lightning.Extensions,
   run_queue: Lightning.Extensions.FifoRunQueue,
   account_hook: Lightning.Extensions.MockAccountHook,
   collection_hook: Lightning.Extensions.MockCollectionHook,
-  project_hook: Lightning.Extensions.MockProjectHook
+  project_hook: Lightning.Extensions.MockProjectHook,
+  external_metrics: Lightning.Extensions.ExternalMetrics
 )
 
 ExUnit.start()


### PR DESCRIPTION
## Description

Adds functionality to allow another application to inject custom metrics to be exposed via PromEx by introducing a stub object that can be replaced.

Closes #3096 

## Validation steps

- Enable Promex by ensuring that `PROMEX_ENABLED=true`, `PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED`=no` and `PROMEX_ENDPOINT_SCHEME=http`.
- Browse to the [metrics page](http://localhost:4000/metrics) - if you see a listing of assorted metrics, then things are working.

## Additional notes for the reviewer

In 1929, JM Barrie granted the rights to Peter Pan to the Great Ormond Street Hospital in London. In 1987, the British Parliament passed a law granting these rights in perpetuity (within the UK) as copyright usually expires a certain number of years after the author's death.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
