### PR TITLE
Adjust flash messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 
 ### Changed
 
+- Adjusted flash messages
 - Updated dependencies [#3086](https://github.com/OpenFn/lightning/pull/3086):
   - `phoenix` from 1.7.20 to 1.7.21
   - `phoenix_live_view` from 1.0.5 to 1.0.9

--- a/lib/lightning_web/live/collection_live/index.ex
+++ b/lib/lightning_web/live/collection_live/index.ex
@@ -57,7 +57,7 @@ defmodule LightningWeb.CollectionLive.Index do
       {:ok, _collection} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Collection deleted successfully!")
+         |> put_flash(:info, "Collection deleted")
          |> push_navigate(to: ~p"/settings/collections")}
 
       {:error, reason} ->

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -78,7 +78,7 @@ defmodule LightningWeb.CredentialLive.Index do
 
     {:noreply,
      socket
-     |> put_flash(:info, "Oauth client deleted successfully!")
+     |> put_flash(:info, "Oauth client deleted")
      |> assign(:oauth_clients, list_clients(socket.assigns.current_user))
      |> push_patch(to: ~p"/credentials")}
   end

--- a/lib/lightning_web/live/profile_live/mfa_component.ex
+++ b/lib/lightning_web/live/profile_live/mfa_component.ex
@@ -57,7 +57,7 @@ defmodule LightningWeb.ProfileLive.MfaComponent do
       {:ok, _totp} ->
         {:noreply,
          socket
-         |> put_flash(:info, "MFA Setup successfully!")
+         |> put_flash(:info, "MFA Setup")
          |> maybe_redirect_to_backup_codes()}
 
       {:error, changeset} ->
@@ -72,7 +72,7 @@ defmodule LightningWeb.ProfileLive.MfaComponent do
       {:ok, _totp} ->
         {:noreply,
          socket
-         |> put_flash(:info, "MFA Disabled successfully!")
+         |> put_flash(:info, "MFA Disabled")
          |> push_navigate(to: ~p"/profile")}
 
       {:error, _reason} ->

--- a/lib/lightning_web/live/project_live/collections_component.ex
+++ b/lib/lightning_web/live/project_live/collections_component.ex
@@ -80,7 +80,7 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
         {:ok, _collection} ->
           {:noreply,
            socket
-           |> put_flash(:info, "Collection deleted successfully!")
+           |> put_flash(:info, "Collection deleted")
            |> push_navigate(to: socket.assigns.return_to)}
 
         {:error, _reason} ->
@@ -115,7 +115,7 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
     |> case do
       {:ok, _collection} ->
         socket
-        |> put_flash(:info, "Collection created successfully!")
+        |> put_flash(:info, "Collection created")
         |> push_navigate(to: socket.assigns.return_to)
 
       {:error, :exceeds_limit, %{text: error_msg}} ->
@@ -136,7 +136,7 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
     case Collections.update_collection(socket.assigns.collection, params) do
       {:ok, _collection} ->
         socket
-        |> put_flash(:info, "Collection updated successfully!")
+        |> put_flash(:info, "Collection updated")
         |> push_navigate(to: socket.assigns.return_to)
 
       {:error, changeset} ->

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -227,7 +227,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
          ) do
       :ok ->
         socket
-        |> put_flash(:info, "Connection made successfully!")
+        |> put_flash(:info, "Connected to GitHub")
         |> push_navigate(
           to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
         )
@@ -261,7 +261,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
     case VersionControl.initiate_sync(repo_connection, commit_message) do
       :ok ->
         socket
-        |> put_flash(:info, "Github sync initiated successfully!")
+        |> put_flash(:info, "Github sync initiated")
         |> push_navigate(
           to: ~p"/projects/#{socket.assigns.project}/settings#vcs"
         )

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -435,7 +435,7 @@ defmodule LightningWeb.ProjectLive.Settings do
 
     {:noreply,
      socket
-     |> put_flash(:info, "Oauth client deleted successfully!")
+     |> put_flash(:info, "Oauth client deleted")
      |> assign(
        :oauth_clients,
        list_clients(assigns.project)
@@ -453,7 +453,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       {:ok, %Credential{}} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Credential deleted successfully!")
+         |> put_flash(:info, "Credential deleted")
          |> assign(
            :credentials,
            list_credentials(assigns.project)
@@ -480,7 +480,7 @@ defmodule LightningWeb.ProjectLive.Settings do
 
       {:noreply,
        socket
-       |> put_flash(:info, "Collaborator removed successfully!")
+       |> put_flash(:info, "Collaborator removed")
        |> push_navigate(
          to: ~p"/projects/#{assigns.project}/settings#collaboration"
        )}

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -130,7 +130,7 @@ defmodule LightningWeb.WorkflowLive.Index do
       {:ok, _workflow} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Workflow updated successfully!")
+         |> put_flash(:info, "Workflow updated")
          |> push_patch(to: ~p"/projects/#{project_id}/w")}
 
       {:error, _changeset} ->

--- a/test/lightning_web/live/collection_live_test.exs
+++ b/test/lightning_web/live/collection_live_test.exs
@@ -75,7 +75,7 @@ defmodule LightningWeb.CollectionLiveTest do
         |> render_click()
         |> follow_redirect(conn, ~p"/settings/collections")
 
-      assert html =~ "Collection deleted successfully"
+      assert html =~ "Collection deleted"
 
       refute has_element?(view, "tr#collections-table-row-#{collection.id}")
     end

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -303,7 +303,7 @@ defmodule LightningWeb.CredentialLiveTest do
 
       view
       |> element("#delete_credential_#{credential.id}_modal_confirm_button")
-      |> render_click() =~ "Credential deleted successfully!"
+      |> render_click() =~ "Credential deleted"
 
       {:ok, _view, html} =
         live(conn, ~p"/projects/#{project}/settings#credentials",

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -336,7 +336,7 @@ defmodule LightningWeb.ProfileLiveTest do
           )
         )
 
-      assert flash["info"] == "MFA Setup successfully!"
+      assert flash["info"] == "MFA Setup"
     end
   end
 
@@ -377,7 +377,7 @@ defmodule LightningWeb.ProfileLiveTest do
       result = view |> element("#disable_mfa_button") |> render_click()
 
       {:ok, view, html} = follow_redirect(result, conn)
-      assert html =~ "MFA Disabled successfully!"
+      assert html =~ "MFA Disabled"
 
       refute render(view) =~
                "You have configured an authentication app to get two-factor authentication codes"
@@ -404,7 +404,7 @@ defmodule LightningWeb.ProfileLiveTest do
       |> render_submit()
 
       flash = assert_redirected(view, Routes.profile_edit_path(conn, :edit))
-      assert flash["info"] == "MFA Setup successfully!"
+      assert flash["info"] == "MFA Setup"
     end
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -4374,7 +4374,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
         flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
 
-        assert flash["info"] == "Connection made"
+        assert flash["info"] == "Connected to GitHub"
       end
     end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -2845,7 +2845,7 @@ defmodule LightningWeb.ProjectLiveTest do
             ~p"/projects/#{project}/settings#collaboration"
           )
 
-        assert flash["info"] == "Collaborator removed successfully!"
+        assert flash["info"] == "Collaborator removed"
 
         # project user is removed
         refute Repo.get(Lightning.Projects.ProjectUser, project_user.id)
@@ -4374,7 +4374,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
         flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
 
-        assert flash["info"] == "Connection made successfully!"
+        assert flash["info"] == "Connection made"
       end
     end
 
@@ -4968,7 +4968,7 @@ defmodule LightningWeb.ProjectLiveTest do
 
         flash = assert_redirected(view, ~p"/projects/#{project.id}/settings#vcs")
 
-        assert flash["info"] == "Github sync initiated successfully!"
+        assert flash["info"] == "Github sync initiated"
       end
     end
 
@@ -5262,7 +5262,7 @@ defmodule LightningWeb.ProjectLiveTest do
             ~p"/projects/#{project.id}/settings#collections"
           )
 
-        assert flash["info"] == "Collection created successfully!"
+        assert flash["info"] == "Collection created"
 
         # collection now exists
         assert Lightning.Repo.get_by(Lightning.Collections.Collection,
@@ -5450,7 +5450,7 @@ defmodule LightningWeb.ProjectLiveTest do
             ~p"/projects/#{project.id}/settings#collections"
           )
 
-        assert flash["info"] == "Collection updated successfully!"
+        assert flash["info"] == "Collection updated"
 
         assert Lightning.Repo.get_by(Lightning.Collections.Collection,
                  project_id: project.id,
@@ -5536,7 +5536,7 @@ defmodule LightningWeb.ProjectLiveTest do
             ~p"/projects/#{project.id}/settings#collections"
           )
 
-        assert flash["info"] == "Collection deleted successfully!"
+        assert flash["info"] == "Collection deleted"
 
         # collection does not exist
         refute Lightning.Repo.get(

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -309,7 +309,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
         assert view
                |> element("#toggle-control-#{workflow.id}")
                |> render_click() =~
-                 "Workflow updated successfully!"
+                 "Workflow updated"
 
         assert view
                |> has_element?(


### PR DESCRIPTION
A tiny PR to adjust the flash messages that users see.

Sometimes we send messages to the user in little popup flash messages, giving them important feedback about what they've done

![image](https://github.com/user-attachments/assets/a437d429-fb51-420a-b953-7e1b357e0f38)

I have issues with "successfully"

When we say "The workflow saved successfully", it's actually quite scary to me. It feels like saving a workflow is a big huge resource-intensive operation, like we've received your request and are going to roll up our sleeves and really get to work on this.

Saying we did something "successfully" also implies that the thing you did may be _unsuccessful_, which makes me as a user lose some confidence in the project.

It's also just redundant. When I tell you I've saved the project, obviously I mean I've saved it _successfully_. Imagine me telling my boss "Oh yeah I completed that issue... UNSUCCESSFULLY!".

Ok, rant over.

Also, some of these messages include an exclamation mark, which is just a bit unprofessional

By the way, I've done some testing on workflow save and it looks like if there WAS an error, we don't actually tell the user. It's way more important to do this the other way around - to assume the save completed but scream at the user if it did not. I'm going to raise an issue for this.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
