### PR TITLE
3079 optionally set worker name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
   [#3096] (https://github.com/OpenFn/lightning/issues/3096])
 - Introduce 'seeding' of PromEx event metrics
   [#3096] (https://github.com/OpenFn/lightning/issues/3096])
+- When claiming a run, a worker name can optionally be provided to the
+  adaptor that is responsible for claiming runs.
+  [#3079](https://github.com/OpenFn/lightning/issues/3079)
 
 ### Changed
 

--- a/lib/lightning/extensions/fifo_run_queue.ex
+++ b/lib/lightning/extensions/fifo_run_queue.ex
@@ -19,12 +19,12 @@ defmodule Lightning.Extensions.FifoRunQueue do
   def enqueue_many(%Multi{} = multi), do: Repo.transaction(multi)
 
   @impl true
-  def claim(demand) do
+  def claim(demand, worker_name \\ nil) do
     fifo_runs_query =
       Query.eligible_for_claim()
       |> prepend_order_by([:priority])
 
-    Queue.claim(demand, fifo_runs_query)
+    Queue.claim(demand, fifo_runs_query, worker_name)
   end
 
   @impl true

--- a/lib/lightning/runs/queue.ex
+++ b/lib/lightning/runs/queue.ex
@@ -6,10 +6,10 @@ defmodule Lightning.Runs.Queue do
 
   alias Lightning.Runs
 
-  @spec claim(non_neg_integer(), Ecto.Query.t()) ::
+  @spec claim(non_neg_integer(), Ecto.Query.t(), String.t() | nil) ::
           {:ok, [Lightning.Run.t()]}
           | {:error, Ecto.Changeset.t(Lightning.Run.t())}
-  def claim(demand, base_query) do
+  def claim(demand, base_query, worker_name \\ nil) do
     subset_query =
       base_query
       |> select([:id])
@@ -34,7 +34,11 @@ defmodule Lightning.Runs.Queue do
       |> select([a, _], a)
 
     case Runs.update_runs(query,
-           set: [state: :claimed, claimed_at: DateTime.utc_now()]
+           set: [
+             state: :claimed,
+             claimed_at: DateTime.utc_now(),
+             worker_name: worker_name
+           ]
          ) do
       {:ok, %{runs: {_, runs}}} ->
         {:ok, runs}

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -84,6 +84,8 @@ defmodule Lightning.Run do
       values: [immediate: 0, normal: 1],
       default: :normal
 
+    field :worker_name, :string
+
     timestamps(type: :utc_datetime_usec)
   end
 

--- a/priv/repo/migrations/20250414111117_add_worker_name_to_runs.exs
+++ b/priv/repo/migrations/20250414111117_add_worker_name_to_runs.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.AddWorkerNameToRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:runs) do
+      add :worker_name, :string, null: true
+    end
+  end
+end

--- a/test/lightning/runs/queue_test.exs
+++ b/test/lightning/runs/queue_test.exs
@@ -1,0 +1,49 @@
+defmodule Lightning.Runs.QueueTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Runs.Query
+  alias Lightning.Runs.Queue
+  alias Lightning.WorkOrders
+
+  setup do
+    project1 = insert(:project)
+
+    %{triggers: [trigger1]} =
+      workflow1 =
+      insert(:simple_workflow, project: project1) |> with_snapshot()
+
+    {:ok, %{runs: [run_1]}} =
+      WorkOrders.create_for(trigger1,
+        workflow: workflow1,
+        dataclip: params_with_assocs(:dataclip)
+      )
+
+    {:ok, %{runs: [run_2]}} =
+      WorkOrders.create_for(trigger1,
+        workflow: workflow1,
+        dataclip: params_with_assocs(:dataclip)
+      )
+
+    %{run_1: run_1, run_2: run_2}
+  end
+
+  test "if worker name is provided, persists it for each claimed run", %{
+    run_1: run_1,
+    run_2: run_2
+  } do
+    Queue.claim(2, Query.eligible_for_claim(), "my.worker.name")
+
+    assert %{worker_name: "my.worker.name"} = Lightning.Repo.reload!(run_1)
+    assert %{worker_name: "my.worker.name"} = Lightning.Repo.reload!(run_2)
+  end
+
+  test "if no worker name is provided, persists nil for each claimed run", %{
+    run_1: run_1,
+    run_2: run_2
+  } do
+    Queue.claim(2, Query.eligible_for_claim())
+
+    assert %{worker_name: nil} = Lightning.Repo.reload!(run_1)
+    assert %{worker_name: nil} = Lightning.Repo.reload!(run_2)
+  end
+end


### PR DESCRIPTION
## Description

This is preparatory work for allowing a Worker to specify a worker name and having Lightning persist that. As the run queue adaptor is different between Lightning and Thunderbolt, the safest approach is to ensure that both adaptors will optionally allow a worker name to be passed in, before modifying the upstream code.

This PR is the Lightning portion of that exercise.

#3079 

## Validation steps

1. *(How can a reviewer validate your work?)*

- Trigger a WorkOrder using `curl` for a workflow that exists on your local machine and make a note of the `work_order_id` returned
- In an IEx session:

```
alias Lightning.Run
alias Lightning.Repo
import Ecto.Query

work_order_id = "..." # As captured when triggering the run

query = from r in Run, where: r.work_order_id == ^work_order_id and r.state == :success

%{worker_name: nil}  = Repo.one!(query)
```
## Additional notes for the reviewer

It is believed that all domestic cats are descendents of the North African wildcat.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
