### PR TITLE
Adds helper function to create lastest snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Add helper function to create latest snapshot
+  [#3099](https://github.com/OpenFn/lightning/issues/3099)
 - Restart the credential setup from selecting the credential type
   [#2284](https://github.com/OpenFn/lightning/issues/2284)
 - Enable Support User and adds audit trail for MFA.

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -536,8 +536,19 @@ defmodule Lightning.Workflows do
     |> Repo.exists?()
   end
 
-  def maybe_create_latest_snaphost(
-        %{
+  @doc """
+  Creates a latest snapshot for the given workflow if one does not already exist
+  for the current lock_version. Returns {:ok, snapshot} if a snapshot exists or is created.
+
+  > #### Note {: .info}
+  >
+  > In normal situations this function is not needed as the snapshot is created
+  > when the workflow is saved.
+  """
+  @spec maybe_create_latest_snapshot(Workflow.t()) ::
+          {:ok, Snapshot.t()} | {:error, Ecto.Changeset.t(Snapshot.t())}
+  def maybe_create_latest_snapshot(
+        %Workflow{
           id: workflow_id,
           lock_version: lock_version,
           updated_at: updated_at,

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -446,15 +446,29 @@ defmodule Lightning.WorkflowsTest do
       assert %Ecto.Changeset{} = Workflows.change_workflow(workflow)
     end
 
-    test "maybe_create_latest_snaphost/1 creates snapshot if missing latest" do
+    test "maybe_create_latest_snapshot/1 creates snapshot if missing latest" do
       workflow =
         insert(:simple_workflow, lock_version: 2, updated_at: DateTime.utc_now())
 
+      refute Snapshot.get_current_for(workflow)
+
       assert capture_log(fn ->
                assert {:ok, %Snapshot{lock_version: 2}} =
-                        Workflows.maybe_create_latest_snaphost(workflow)
+                        Workflows.maybe_create_latest_snapshot(workflow)
              end) =~
                "Created latest snapshot for #{workflow.id} (last_update: #{workflow.updated_at})"
+    end
+
+    test "maybe_create_latest_snapshot/1 does not create snapshot if latest exists" do
+      {:ok, workflow} =
+        insert(:simple_workflow)
+        |> Workflows.change_workflow(%{name: "some-updated-name"})
+        |> Workflows.save_workflow(insert(:user))
+
+      %{lock_version: lock_version} = Snapshot.get_current_for(workflow)
+
+      assert {:ok, %Snapshot{lock_version: ^lock_version}} =
+               Workflows.maybe_create_latest_snapshot(workflow)
     end
   end
 


### PR DESCRIPTION
## Description

This PR adds a helper function to create latest snapshot due to a gap when snapshots weren't created in from a version with partial implementation.

Closes #3099 

## Validation steps

1. Via test case as on the latest code a snapshot is part of the workflow save.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
