### PR TITLE
Export RELEASE_NODE for ECS

### DIFF
--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,3 +1,10 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
+
+if [ "$AWS_EXECUTION_ENV" = "AWS_ECS_EC2" ]; then
+  # ECS_EC2 service discovery works similarly to K8S service
+  IP=`echo $HOSTNAME | awk -F '.' '{print $1}' | sed s/ip-// | tr '-' '.'`
+  export RELEASE_NODE="lightning@${IP}"
+fi
+
 PHX_SERVER=true exec ./lightning start


### PR DESCRIPTION
## Description

ECS also provides a service discovery via DNS. By using `Cluster.Strategy.Kubernetes.DNS`, Lightning instances are able to join Erlang cluster (via vendor-free DNS query) to enable the PubSub. It relies on a env var set by AWS themselves (`AWS_EXECUTION_ENV`).

Refs "AWS Lagos dependency for Lightning clustering."

## Validation Steps

1. Set K8S_HEADLESS_SERVICE with the ECS service discovery DNS name
2. Run a task

## Additional notes for the reviewer

- Please notice ECS Tasks don't have user data to initialize this variable and the task IP is different from the container instance.
- There is a similar PR on Thunderbolt: https://github.com/OpenFn/thunderbolt/pull/381

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
