### PR TITLE
Persist worker name on claimed run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 - When claiming a run, a worker name can optionally be provided to the
   adaptor that is responsible for claiming runs.
   [#3079](https://github.com/OpenFn/lightning/issues/3079)
+- Persist worker name provided by worker when claiming a run.
+  [#3079](https://github.com/OpenFn/lightning/issues/3079)
 
 ### Changed
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
         "@eslint/js": "^9.21.0",
-        "@openfn/ws-worker": "^1.13.0",
+        "@openfn/ws-worker": "^1.13.2",
         "@total-typescript/ts-reset": "^0.6.1",
         "@tsconfig/node-lts": "^22.0.1",
         "@tsconfig/recommended": "^1.0.8",
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "20.17.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
-      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "version": "20.17.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
+      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1298,14 +1298,14 @@
       }
     },
     "node_modules/@openfn/compiler": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@openfn/compiler/-/compiler-1.0.2.tgz",
-      "integrity": "sha512-43nsoBApUYY5vHdo1tqNSbbva6rn3Cmb0blmSvpQhdMdUCdxx7XFnvTYUTcVVRTEJvxZcOptL28IdT/gidfrBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@openfn/compiler/-/compiler-1.0.3.tgz",
+      "integrity": "sha512-NVn+pgmPgzkKGeGqVaqDnMml2DR/uerM5oiZdJDsY+KyqnYkx3wh2CzSTnrYZfohK/tfJltHCPhszi/co6GseQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@openfn/describe-package": "0.1.4",
-        "@openfn/lexicon": "^1.2.0",
+        "@openfn/lexicon": "^1.2.1",
         "@openfn/logger": "1.0.5",
         "acorn": "^8.8.0",
         "ast-types": "^0.14.2",
@@ -1331,15 +1331,15 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-1.6.2.tgz",
-      "integrity": "sha512-O/OdojQeOSyMfMMNbPxY6dw30nfXSef89elpSpajz8jgMBrMDl9Ug+k1MWZpH+P4DueHBWZ3zoDDrvMrBpEIyw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-1.6.3.tgz",
+      "integrity": "sha512-f+LuHNvYfaXQMg5fFAHaTw9BE+NTcrmf0NDJabumnOhLxng4JU4+VqX3iEBWPR379AOkG8wX2eQxIlz8WH/kNA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@openfn/compiler": "1.0.2",
+        "@openfn/compiler": "1.0.3",
         "@openfn/language-common": "2.0.0-rc3",
-        "@openfn/lexicon": "^1.2.0",
+        "@openfn/lexicon": "^1.2.1",
         "@openfn/logger": "1.0.5",
         "@openfn/runtime": "1.6.4",
         "fast-safe-stringify": "^2.1.1"
@@ -1353,9 +1353,9 @@
       "license": "LGPL-3.0-or-later"
     },
     "node_modules/@openfn/lexicon": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@openfn/lexicon/-/lexicon-1.2.0.tgz",
-      "integrity": "sha512-uNB7wekwDAWk+aM+bBl8jZRGG0gqZjl2uzkSjqD8oBwromne7FHig8VmgokMDRwgw37LlqG+23aBcp/8hSICXw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@openfn/lexicon/-/lexicon-1.2.1.tgz",
+      "integrity": "sha512-3WMfBicsVg34YLxDKap5PqNrudxUhB5M6jxALa2dQ8bqJp6iGgPLjnCueQWJS4BVimAdyuU0pTkP4NYKaD3Vtg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1412,15 +1412,15 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-1.13.0.tgz",
-      "integrity": "sha512-ntJWP6ydGT1RGj5ftcQvzwhw68LuqJh1uU9nvA9nwnm2vfAAaA66DEbi+rmJ9mpDbv3qy/sBNVOwHAiCrmS4CA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-1.13.2.tgz",
+      "integrity": "sha512-3fxUeaGPWtsdvyhFM5FU3C7CcZQLorF1qs1Kdjf4TotERWkSQ/O8YbjCEF7qQ6FSWOOvO04kqJqbhPEfQQ1wxg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@koa/router": "^12.0.0",
-        "@openfn/engine-multi": "1.6.2",
-        "@openfn/lexicon": "^1.2.0",
+        "@openfn/engine-multi": "1.6.3",
+        "@openfn/lexicon": "^1.2.1",
         "@openfn/logger": "1.0.5",
         "@openfn/runtime": "1.6.4",
         "@sentry/node": "^9.5.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
     "@eslint/js": "^9.21.0",
-    "@openfn/ws-worker": "^1.13.0",
+    "@openfn/ws-worker": "^1.13.2",
     "@total-typescript/ts-reset": "^0.6.1",
     "@tsconfig/node-lts": "^22.0.1",
     "@tsconfig/recommended": "^1.0.8",

--- a/lib/lightning/extensions/run_queue.ex
+++ b/lib/lightning/extensions/run_queue.ex
@@ -13,7 +13,7 @@ defmodule Lightning.Extensions.RunQueue do
               | {:error, Ecto.Multi.name(), any(),
                  %{required(Ecto.Multi.name()) => any()}}
 
-  @callback claim(demand :: non_neg_integer()) ::
+  @callback claim(demand :: non_neg_integer(), worker_name :: String.t()) ::
               {:ok, [Lightning.Run.t()]}
 
   @callback dequeue(run :: Lightning.Run.t()) ::

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -40,8 +40,8 @@ defmodule Lightning.Runs do
   # all implementation should default to 1.
   # """
   @impl Lightning.Extensions.RunQueue
-  def claim(demand \\ 1) do
-    RunQueue.claim(demand)
+  def claim(demand \\ 1, worker_name) do
+    RunQueue.claim(demand, worker_name)
   end
 
   # @doc """

--- a/lib/lightning/services/run_queue.ex
+++ b/lib/lightning/services/run_queue.ex
@@ -17,8 +17,8 @@ defmodule Lightning.Services.RunQueue do
   end
 
   @impl true
-  def claim(demand) do
-    adapter().claim(demand)
+  def claim(demand, worker_name) do
+    adapter().claim(demand, worker_name)
   end
 
   @impl true

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -20,8 +20,12 @@ defmodule LightningWeb.WorkerChannel do
   end
 
   @impl true
-  def handle_in("claim", %{"demand" => demand}, socket) do
-    case Runs.claim(demand) do
+  def handle_in(
+        "claim",
+        %{"demand" => demand, "worker_name" => worker_name},
+        socket
+      ) do
+    case Runs.claim(demand, sanitise_worker_name(worker_name)) do
       {:ok, runs} ->
         runs =
           runs
@@ -42,6 +46,10 @@ defmodule LightningWeb.WorkerChannel do
         {:reply, {:error, LightningWeb.ChangesetJSON.errors(changeset)}, socket}
     end
   end
+
+  defp sanitise_worker_name(""), do: nil
+
+  defp sanitise_worker_name(worker_name), do: worker_name
 
   defp run_options(run) do
     Ecto.assoc(run, :workflow)

--- a/test/lightning/services/run_queue_test.exs
+++ b/test/lightning/services/run_queue_test.exs
@@ -1,0 +1,36 @@
+defmodule Lightning.Services.RunQueueTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Repo
+  alias Lightning.Services.RunQueue
+  alias Lightning.WorkOrders
+
+  describe "claim/2" do
+    test "persists the worker name when claiming a run" do
+      worker_name = "my.worker.name"
+
+      project1 = insert(:project)
+
+      %{triggers: [trigger1]} =
+        workflow1 =
+        insert(:simple_workflow, project: project1) |> with_snapshot()
+
+      {:ok, %{runs: [run1]}} =
+        WorkOrders.create_for(trigger1,
+          workflow: workflow1,
+          dataclip: params_with_assocs(:dataclip)
+        )
+
+      {:ok, %{runs: [run2]}} =
+        WorkOrders.create_for(trigger1,
+          workflow: workflow1,
+          dataclip: params_with_assocs(:dataclip)
+        )
+
+      RunQueue.claim(2, worker_name)
+
+      assert %{worker_name: ^worker_name} = Repo.reload!(run1)
+      assert %{worker_name: ^worker_name} = Repo.reload!(run2)
+    end
+  end
+end


### PR DESCRIPTION
## Description

When the latest version of the worker claims a run, it will provide an additional field named `worker_name` - this change persists that against the run being claimed, so that it can be used for monitoring and debugging.

Closes #3079 

## Validation steps

- Start lightning
- Enqueue a new work order using the webhook, and make a note of the `work_order_id`.
- In IEx:

```
alias Lightning.Repo
alias Lightning.Run
import Ecto.Query

work_order_id = "..." # as noted above

query = from r in Run, where: r.work_order_id == ^work_order_id, order_by: [desc: :inserted_at], limit: 1

%Run{worker_name: nil} = Repo.one!(query)
```

- Stop Lighting
- Start Lightning with `WORKER_NAME=funky_chicken`
- Enqueue a new work order and make a note of the `work_order_id`
- In IEx:

```
alias Lightning.Repo
alias Lightning.Run
import Ecto.Query

work_order_id = "..." # as noted above

query = from r in Run, where: r.work_order_id == ^work_order_id, order_by: [desc: :inserted_at], limit: 1

%Run{worker_name: "funky_chicken"} = Repo.one!(query)
```


## Additional notes for the reviewer

In 2021, Sony Music bought the rights for all of Bruce Springsteen's music for an estimated 500 million USD.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
