### PR TITLE
3070 lost run counter 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Custom metrics to track lost runs.
+  [#3070](https://github.com/OpenFn/lightning/issues/3070)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/prom_ex.ex
+++ b/lib/lightning/prom_ex.ex
@@ -96,6 +96,8 @@ defmodule Lightning.PromEx do
 
   def seed_event_metrics do
     Lightning.Config.external_metrics_module().seed_event_metrics()
+
+    Lightning.Runs.PromExPlugin.seed_event_metrics()
   end
 
   @impl true

--- a/lib/lightning/runs/prom_ex_plugin.ex
+++ b/lib/lightning/runs/prom_ex_plugin.ex
@@ -58,6 +58,17 @@ defmodule Lightning.Runs.PromExPlugin do
     ]
   end
 
+  def seed_event_metrics do
+    :telemetry.execute(
+      [:lightning, :run, :lost],
+      %{count: 1},
+      %{
+        seed_event: true,
+        worker_name: "n/a"
+      }
+    )
+  end
+
   @impl true
   def polling_metrics(opts) do
     {:ok, stalled_run_threshold_seconds} =

--- a/lib/lightning/runs/prom_ex_plugin.ex
+++ b/lib/lightning/runs/prom_ex_plugin.ex
@@ -11,6 +11,7 @@ defmodule Lightning.Runs.PromExPlugin do
 
   alias Lightning.Repo
   alias Lightning.Run
+  alias Telemetry.Metrics
 
   require Run
 
@@ -21,33 +22,40 @@ defmodule Lightning.Runs.PromExPlugin do
 
   @impl true
   def event_metrics(_opts) do
-    Event.build(
-      :rory_test,
-      [
-        distribution(
-          [:lightning, :run, :queue, :delay, :milliseconds],
-          event_name: [:domain, :run, :queue],
-          measurement: :delay,
-          description: "Queue delay for runs",
-          reporter_options: [
-            buckets: [
-              100,
-              200,
-              400,
-              800,
-              1_500,
-              5_000,
-              15_000,
-              30_000,
-              50_000,
-              100_000
-            ]
-          ],
-          tags: [],
-          unit: :millisecond
-        )
-      ]
-    )
+    [
+      Event.build(
+        :lightning_run_event_metrics,
+        [
+          distribution(
+            [:lightning, :run, :queue, :delay, :milliseconds],
+            event_name: [:domain, :run, :queue],
+            measurement: :delay,
+            description: "Queue delay for runs",
+            reporter_options: [
+              buckets: [
+                100,
+                200,
+                400,
+                800,
+                1_500,
+                5_000,
+                15_000,
+                30_000,
+                50_000,
+                100_000
+              ]
+            ],
+            tags: [],
+            unit: :millisecond
+          ),
+          Metrics.counter(
+            [:lightning, :run, :lost, :count],
+            description: "A counter of lost runs.",
+            tags: [:seed_event, :worker_name]
+          )
+        ]
+      )
+    ]
   end
 
   @impl true

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -88,7 +88,7 @@ defmodule Lightning.PromExTest do
       ^lost_runs_count_event,
       ^ref,
       %{count: 1},
-      %{seed_event: true, state: "n/a", worker_name: "n/a"}
+      %{seed_event: true}
     }
   end
 

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -83,12 +83,13 @@ defmodule Lightning.PromExTest do
     Lightning.PromEx.seed_event_metrics()
 
     assert_received {^test_event, ^ref, %{count: 42}, %{}}
+
     assert_received {
-                      ^lost_runs_count_event,
-                      ^ref,
-                      %{count: 1},
-                      %{seed_event: true, worker_name: "n/a"}
-                    }
+      ^lost_runs_count_event,
+      ^ref,
+      %{count: 1},
+      %{seed_event: true, state: "n/a", worker_name: "n/a"}
+    }
   end
 
   defp update_promex_config(overrides) do

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -68,7 +68,7 @@ defmodule Lightning.PromExTest do
       Lightning.PromExTest.ExternalMetrics
     end)
 
-    lost_runs_count_event = [:lightning, :run, :lost, :count]
+    lost_runs_count_event = [:lightning, :run, :lost]
     test_event = [:promex, :test, :event]
 
     ref =

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -68,13 +68,27 @@ defmodule Lightning.PromExTest do
       Lightning.PromExTest.ExternalMetrics
     end)
 
-    event = [:promex, :test, :event]
+    lost_runs_count_event = [:lightning, :run, :lost, :count]
+    test_event = [:promex, :test, :event]
 
-    ref = :telemetry_test.attach_event_handlers(self(), [event])
+    ref =
+      :telemetry_test.attach_event_handlers(
+        self(),
+        [
+          lost_runs_count_event,
+          test_event
+        ]
+      )
 
     Lightning.PromEx.seed_event_metrics()
 
-    assert_received {^event, ^ref, %{count: 42}, %{}}
+    assert_received {^test_event, ^ref, %{count: 42}, %{}}
+    assert_received {
+                      ^lost_runs_count_event,
+                      ^ref,
+                      %{count: 1},
+                      %{seed_event: true, worker_name: "n/a"}
+                    }
   end
 
   defp update_promex_config(overrides) do

--- a/test/lightning/runs/prom_ex_plugin_test.exs
+++ b/test/lightning/runs/prom_ex_plugin_test.exs
@@ -562,6 +562,22 @@ defmodule Lightning.Runs.PromExPluginText do
     end
   end
 
+  describe "seed_event_metrics/0" do
+    test "seeds the lost runs counter" do
+      event = [:lightning, :run, :lost]
+
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      Lightning.Runs.PromExPlugin.seed_event_metrics()
+
+      assert_received {
+        ^event,
+        ^ref,
+        %{count: 1},
+        %{seed_event: true, worker_name: "n/a"}
+      }
+    end
+  end
   defp available_run(now, time_offset) do
     insert(
       :run,


### PR DESCRIPTION
## Description

This exposes a custom metric to track when runs are marked as lost.

Closes #3070 

## Validation steps

- Start Lighting with `WORKER_NAME=funky_chicken` 
- Browse to the [metrics page](http://localhost:4000/metrics) and you should see that the counter has been seeded:

![Screenshot From 2025-04-16 18-33-49](https://github.com/user-attachments/assets/b09acec5-0190-4a52-a1c8-602359da892d)


- Use curl to enqueue a work order - make a note of the work order id
- In IEx, find the run and mark it as lost (the code will not be happy with this ham-fisted approach but it will suffice to trigger the event).

```
alias Lightning.Repo
alias Lightning.Run
import Ecto.Query

work_order_id = "..." # As noted above

query = from r in Run, where: r.work_order_id == ^work_order_id, order_by: [desc: :inserted_at], limit: 1

run = Repo.one!(query)

Lightning.Runs.mark_run_lost(run)
```
- If you now go to the metrics page, you will see the event triggered for the lost run.

![Screenshot From 2025-04-16 18-35-04](https://github.com/user-attachments/assets/2d3f1d07-ec1c-4f58-8779-915e5244c502)


## Additional notes for the reviewer

James Doohan, who played Scotty in the original Star Trek series landed at Juno beach on D-Day. That night, he was hit by 6 bullets, one of which severed the middle finger of his right hand. Another bullet was stopped by a cigarette case he was carrying in his chest pocket.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
