### PR TITLE
remove 'nothing yet' string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@ and this project adheres to
 
 - AI Assistant: add metadata column to chat sessions
   [#3054](https://github.com/OpenFn/lightning/issues/3054)
-  
+
 ### Changed
+
+- Replaced "Nothing yet" with "Waiting for Worker" in the Inpsector while
+  waiting for a run to start
 
 ### Fixed
 
@@ -48,8 +51,8 @@ and this project adheres to
   [#3096](https://github.com/OpenFn/lightning/issues/3096)
 - Introduce 'seeding' of PromEx event metrics
   [#3096](https://github.com/OpenFn/lightning/issues/3096)
-- When claiming a run, a worker name can optionally be provided to the
-  adaptor that is responsible for claiming runs.
+- When claiming a run, a worker name can optionally be provided to the adaptor
+  that is responsible for claiming runs.
   [#3079](https://github.com/OpenFn/lightning/issues/3079)
 - Persist worker name provided by worker when claiming a run.
   [#3079](https://github.com/OpenFn/lightning/issues/3079)

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -99,7 +99,7 @@ defmodule LightningWeb.Components.Viewers do
               class="relative text-xs @md:text-base p-12 text-center bg-slate-700 font-mono text-gray-200"
             >
               <.text_ping_loader>
-                Nothing yet
+                Waiting for worker...
               </.text_ping_loader>
             </div>
             <div id={"#{@id}-viewer"} class="hidden absolute inset-0 rounded-md">
@@ -265,7 +265,7 @@ defmodule LightningWeb.Components.Viewers do
         class="relative rounded-md text-xs @md:text-base p-12 text-center bg-slate-700 font-mono text-gray-200"
       >
         <.text_ping_loader>
-          Nothing yet
+          Waiting for worker...
         </.text_ping_loader>
       </div>
 

--- a/test/lightning_web/live/components/viewer_test.exs
+++ b/test/lightning_web/live/components/viewer_test.exs
@@ -78,7 +78,7 @@ defmodule LightningWeb.Components.ViewerTest do
         )
 
       assert html =~ "No input state could be saved for this run."
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       refute html =~ "data for this step has not been retained"
       refute html =~ "this policy\n      </a>\n      for future runs"
       refute html =~ "test@email.com"
@@ -96,7 +96,7 @@ defmodule LightningWeb.Components.ViewerTest do
           can_edit_data_retention: true
         )
 
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       assert html =~ "data for this step has not been retained"
       assert html =~ "this policy\n      </a>\n      for future runs"
       refute html =~ "test@email.com"
@@ -114,7 +114,7 @@ defmodule LightningWeb.Components.ViewerTest do
           can_edit_data_retention: false
         )
 
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       assert html =~ "data for this step has not been retained"
       refute html =~ "this policy\n      </a>\n      for future runs"
       assert html =~ "test@email.com"
@@ -132,7 +132,7 @@ defmodule LightningWeb.Components.ViewerTest do
           can_edit_data_retention: false
         )
 
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       assert html =~ "data for this step has not been retained in accordance"
 
       # running step always shows the pending state
@@ -148,7 +148,7 @@ defmodule LightningWeb.Components.ViewerTest do
           can_edit_data_retention: true
         )
 
-      assert html =~ "Nothing yet"
+      assert html =~ "Waiting for worker..."
       refute html =~ "data for this step has not been retained"
       refute html =~ "this policy\n      </a>\n      for future runs"
       refute html =~ "test@email.com"
@@ -168,7 +168,7 @@ defmodule LightningWeb.Components.ViewerTest do
           can_edit_data_retention: true
         )
 
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       assert html =~ "data for this step has not been retained"
       assert html =~ "this policy\n      </a>\n      for future runs"
       refute html =~ "test@email.com"

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -1655,13 +1655,13 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       # input panel shows correct information
       html = run_view |> element("div#input-panel") |> render()
 
-      assert html =~ "Nothing yet"
+      assert html =~ "Waiting for worker..."
       refute html =~ "No input/output available. This step was never started."
 
       # output panel shows correct information
       html = run_view |> element("div#output-panel") |> render()
 
-      assert html =~ "Nothing yet"
+      assert html =~ "Waiting for worker..."
       refute html =~ "No input/output available. This step was never started."
 
       # let's subscribe to events to make sure we're in sync with liveview
@@ -1702,12 +1702,12 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
 
       # input panel shows correct information
       html = run_view |> element("div#input-panel") |> render()
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       assert html =~ "No input/output available. This step was never started."
 
       # output panel shows correct information
       html = run_view |> element("div#output-panel") |> render()
-      refute html =~ "Nothing yet"
+      refute html =~ "Waiting for worker..."
       assert html =~ "No input/output available. This step was never started."
     end
   end


### PR DESCRIPTION
## Description

I want to improve this situation a little bit

![image](https://github.com/user-attachments/assets/b7682eb7-f5b1-431b-b260-cc43a2c8fb40)

The "nothing yet" string is very unhelpful for users

I also want to ensure that when you search for "waiting for worker" on the docsite, you get a bit more detail. Stay tuned for that.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
