### PR TITLE
Tell users why they're waiting for runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - AI Assistant: add metadata column to chat sessions
   [#3054](https://github.com/OpenFn/lightning/issues/3054)
+- Added a message to explain to the user why they're waiting for a run
+  [#3131](https://github.com/OpenFn/lightning/issues/3131)
   
 ### Changed
 

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -60,8 +60,8 @@ defmodule LightningWeb.Components.Viewers do
       end)
       |> assign_new(:waiting_message, fn ->
         case assigns[:run_state] do
-          :available -> "Waiting for an available worker"
-          :claimed -> "Creating secure runtime & installing adaptors"
+          :available -> "Waiting for worker..."
+          :claimed -> "Creating runtime & installing adaptors..."
           _any -> "Nothing yet"
         end
       end)

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -58,6 +58,13 @@ defmodule LightningWeb.Components.Viewers do
           "info"
         end
       end)
+      |> assign_new(:waiting_message, fn ->
+        case assigns[:run_state] do
+          :available -> "Waiting for an available worker"
+          :claimed -> "Creating secure runtime & installing adaptors"
+          _any -> "Nothing yet"
+        end
+      end)
 
     ~H"""
     <%= if @run_state in Lightning.Run.final_states() and @logs_empty? do %>
@@ -99,7 +106,7 @@ defmodule LightningWeb.Components.Viewers do
               class="relative text-xs @md:text-base p-12 text-center bg-slate-700 font-mono text-gray-200"
             >
               <.text_ping_loader>
-                Nothing yet
+                {@waiting_message}
               </.text_ping_loader>
             </div>
             <div id={"#{@id}-viewer"} class="hidden absolute inset-0 rounded-md">

--- a/lib/lightning_web/components/viewers.ex
+++ b/lib/lightning_web/components/viewers.ex
@@ -60,8 +60,8 @@ defmodule LightningWeb.Components.Viewers do
       end)
       |> assign_new(:waiting_message, fn ->
         case assigns[:run_state] do
-          :available -> "Waiting for worker..."
-          :claimed -> "Creating runtime & installing adaptors..."
+          :available -> "Waiting for worker"
+          :claimed -> "Creating runtime & installing adaptors"
           _any -> "Nothing yet"
         end
       end)

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -203,6 +203,11 @@ defmodule Lightning.WebAndWorkerTest do
       Events.subscribe(run)
 
       assert_receive %Events.RunUpdated{
+                       run: %{id: ^run_id, state: :started}
+                     },
+                     115_000
+
+      assert_receive %Events.RunUpdated{
                        run: %{id: ^run_id, state: :success}
                      },
                      115_000

--- a/test/lightning_web/live/components/viewer_test.exs
+++ b/test/lightning_web/live/components/viewer_test.exs
@@ -36,6 +36,36 @@ defmodule LightningWeb.Components.ViewerTest do
 
       assert html =~ "No logs were received for this run."
     end
+
+    test "shows 'Waiting for worker...' when run state is :available", %{
+      workflow: %{jobs: [_job | _rest]}
+    } do
+      html =
+        render_component(&Viewers.log_viewer/1,
+          id: "test",
+          logs_empty?: true,
+          selected_step_id: nil,
+          run_state: :available,
+          run_id: "run-id"
+        )
+
+      assert html =~ "Waiting for worker..."
+    end
+
+    test "shows 'Creating runtime & installing adaptors...' when run state is :claimed", %{
+      workflow: %{jobs: [_job | _rest]}
+    } do
+      html =
+        render_component(&Viewers.log_viewer/1,
+          id: "test",
+          logs_empty?: true,
+          selected_step_id: nil,
+          run_state: :claimed,
+          run_id: "run-id"
+        )
+
+      assert html =~ "Creating runtime &amp; installing adaptors..."
+    end
   end
 
   describe "step_dataclip_viewer/1" do

--- a/test/lightning_web/live/components/viewer_test.exs
+++ b/test/lightning_web/live/components/viewer_test.exs
@@ -37,7 +37,7 @@ defmodule LightningWeb.Components.ViewerTest do
       assert html =~ "No logs were received for this run."
     end
 
-    test "shows 'Waiting for worker...' when run state is :available", %{
+    test "shows 'Waiting for worker' when run state is :available", %{
       workflow: %{jobs: [_job | _rest]}
     } do
       html =
@@ -49,10 +49,10 @@ defmodule LightningWeb.Components.ViewerTest do
           run_id: "run-id"
         )
 
-      assert html =~ "Waiting for worker..."
+      assert html =~ "Waiting for worker"
     end
 
-    test "shows 'Creating runtime & installing adaptors...' when run state is :claimed",
+    test "shows 'Creating runtime & installing adaptors' when run state is :claimed",
          %{
            workflow: %{jobs: [_job | _rest]}
          } do
@@ -65,7 +65,7 @@ defmodule LightningWeb.Components.ViewerTest do
           run_id: "run-id"
         )
 
-      assert html =~ "Creating runtime &amp; installing adaptors..."
+      assert html =~ "Creating runtime &amp; installing adaptors"
     end
   end
 

--- a/test/lightning_web/live/components/viewer_test.exs
+++ b/test/lightning_web/live/components/viewer_test.exs
@@ -52,9 +52,10 @@ defmodule LightningWeb.Components.ViewerTest do
       assert html =~ "Waiting for worker..."
     end
 
-    test "shows 'Creating runtime & installing adaptors...' when run state is :claimed", %{
-      workflow: %{jobs: [_job | _rest]}
-    } do
+    test "shows 'Creating runtime & installing adaptors...' when run state is :claimed",
+         %{
+           workflow: %{jobs: [_job | _rest]}
+         } do
       html =
         render_component(&Viewers.log_viewer/1,
           id: "test",

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -1050,7 +1050,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       # the select input now exists
       assert has_element?(view, "select[name='manual[dataclip_id]']")
 
-      # the wiped message is nolonger displayed
+      # the wiped message is no longer displayed
       refute render(form) =~ "data for this step has not been retained"
 
       assert has_element?(view, "textarea[name='manual[body]']")
@@ -1127,7 +1127,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       assert has_element?(view, "textarea[name='manual[body]']"),
              "dataclip body input exists"
 
-      # the wiped message is nolonger displayed
+      # the wiped message is no longer displayed
       refute render(form) =~ "data for this step has not been retained"
 
       # Wait out all the async renders on RunViewerLive, avoiding Postgrex client
@@ -1207,7 +1207,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       assert has_element?(view, "textarea[name='manual[body]']"),
              "dataclip body input exists"
 
-      # the job not run message is nolonger displayed
+      # the job not run message is no longer displayed
       refute render(form) =~ "This job was not/is not yet included in this Run"
 
       # Wait out all the async renders on RunViewerLive, avoiding Postgrex client
@@ -1495,7 +1495,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       # make sure that the event is processed by liveview
       render(view)
 
-      # dataclip body is nolonger present
+      # dataclip body is no longer present
       refute has_element?(
                view,
                "#manual-job-#{job_1.id} [phx-hook='DataclipViewer'][data-id='#{input_dataclip.id}']"
@@ -1694,7 +1694,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
 
       # action button is rendered correctly.
       refute has_element?(view, "button", "Retry from here")
-      refute has_element?(view, "button", "Processing"), "nolonger processing"
+      refute has_element?(view, "button", "Processing"), "no longer processing"
       assert has_element?(view, "button", "Create New Work Order")
 
       # make sure event is processed by the run viewer


### PR DESCRIPTION
## Description

The PR Closes #3131, giving the user a slightly better sense of what's happening when they're waiting for their runs.

## Validation steps

1. Chose a step with an adaptor that you don't have installed
2. Run it!
3. Check the messages.

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
