### PR TITLE
Allow users to import workflows from base templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to
 
 - AI Assistant: add metadata column to chat sessions
   [#3054](https://github.com/OpenFn/lightning/issues/3054)
-  
+- Allow users to create workflows from base templates
+  [#3110](https://github.com/OpenFn/lightning/issues/3110)
+
 ### Changed
 
 ### Fixed

--- a/assets/js/hooks/FileDropzone.ts
+++ b/assets/js/hooks/FileDropzone.ts
@@ -1,0 +1,95 @@
+interface FileDropzoneHook {
+  el: HTMLElement;
+  destroy?: () => void;
+  mounted(): void;
+  destroyed(): void;
+}
+
+const FileDropzone = {
+  mounted() {
+    const dropzone = this.el;
+    const targetSelector = dropzone.dataset['target'];
+    if (!targetSelector) {
+      console.error('No target selector specified');
+      return;
+    }
+    
+    const fileInput = document.querySelector<HTMLInputElement>(targetSelector);
+
+    if (!fileInput) {
+      console.error('Target file input not found:', targetSelector);
+      return;
+    }
+
+    const highlight = () => {
+      dropzone.classList.add('border-indigo-600', 'bg-indigo-50/50');
+      dropzone.classList.remove('border-gray-900/25');
+    };
+
+    const unhighlight = () => {
+      dropzone.classList.remove('border-indigo-600', 'bg-indigo-50/50');
+      dropzone.classList.add('border-gray-900/25');
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      unhighlight();
+
+      const dt = e.dataTransfer;
+      if (!dt?.files) return;
+      
+      const files = dt.files;
+      if (files.length > 0) {
+        const file = files[0];
+        if (!file) return;
+        
+        // Check if file is yaml/yml
+        if (file.name.match(/\.(ya?ml)$/i)) {
+          // Create a new FileList-like object
+          const dataTransfer = new DataTransfer();
+          dataTransfer.items.add(file);
+          fileInput.files = dataTransfer.files;
+          
+          // Trigger change event to notify any listeners
+          fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+        } else {
+          console.error('Invalid file type. Please upload a YAML file.');
+        }
+      }
+    };
+
+    const handleDragEvent = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      highlight();
+    };
+
+    const handleDragLeave = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      unhighlight();
+    };
+
+    dropzone.addEventListener('dragenter', handleDragEvent);
+    dropzone.addEventListener('dragover', handleDragEvent);
+    dropzone.addEventListener('dragleave', handleDragLeave);
+    dropzone.addEventListener('drop', handleDrop);
+
+    // Cleanup
+    this.destroy = () => {
+      dropzone.removeEventListener('dragenter', handleDragEvent);
+      dropzone.removeEventListener('dragover', handleDragEvent);
+      dropzone.removeEventListener('dragleave', handleDragLeave);
+      dropzone.removeEventListener('drop', handleDrop);
+    };
+  },
+
+  destroyed() {
+    if (this.destroy) {
+      this.destroy();
+    }
+  }
+} as FileDropzoneHook;
+
+export default FileDropzone; 

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -7,6 +7,7 @@ import type { PhoenixHook } from './PhoenixHook';
 import LogLineHighlight from './LogLineHighlight';
 import WorkflowToYAML from '../yaml/WorkflowToYAML';
 import YAMLToWorkflow from '../yaml/YAMLToWorkflow';
+import TemplateToWorkflow from '../yaml/TemplateToWorkflow';
 import ElapsedIndicator from './ElapsedIndicator';
 import {
   TabbedContainer,
@@ -28,6 +29,7 @@ export {
   LogLineHighlight,
   WorkflowToYAML,
   YAMLToWorkflow,
+  TemplateToWorkflow,
   ElapsedIndicator,
   TabbedContainer,
   TabbedSelector,

--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -25,6 +25,8 @@ import {
   CloseNodePanelViaEscape,
 } from './KeyHandlers';
 
+import FileDropzone from "./FileDropzone";
+
 export {
   LogLineHighlight,
   WorkflowToYAML,
@@ -41,6 +43,7 @@ export {
   AltRunViaCtrlShiftEnter,
   CloseInspectorPanelViaEscape,
   CloseNodePanelViaEscape,
+  FileDropzone,
 };
 
 export { ReactComponent } from '#/react/hooks';

--- a/assets/js/workflow-editor/index.ts
+++ b/assets/js/workflow-editor/index.ts
@@ -1,15 +1,12 @@
 // Hook for Workflow Editor Component
-import { DEFAULT_TEXT } from '../editor/Editor';
 import type { PhoenixHook } from '../hooks/PhoenixHook';
 import type { Lightning } from '../workflow-diagram/types';
-import { randomUUID } from '../common';
 import type { mount } from './component';
 import {
   type Patch,
   type PendingAction,
   type WorkflowProps,
   createWorkflowStore,
-  type ChangeArgs,
 } from './store';
 
 export type WorkflowEditorEntrypoint = PhoenixHook<
@@ -39,33 +36,6 @@ export type WorkflowEditorEntrypoint = PhoenixHook<
   },
   { baseUrl?: string | undefined }
 >;
-
-const createNewWorkflow = (): Required<ChangeArgs> => {
-  const triggers = [
-    {
-      id: randomUUID(),
-      type: 'webhook' as 'webhook',
-    },
-  ];
-  const jobs = [
-    {
-      id: randomUUID(),
-      name: 'New job',
-      adaptor: '@openfn/language-common@latest',
-      body: DEFAULT_TEXT,
-    },
-  ];
-
-  const edges = [
-    {
-      id: randomUUID(),
-      source_trigger_id: triggers[0].id,
-      target_job_id: jobs[0].id,
-      condition_type: 'always',
-    },
-  ];
-  return { triggers, jobs, edges };
-};
 
 // To support temporary workflow editor metrics submissions to Lightning
 // server.
@@ -248,12 +218,6 @@ export default {
     workflow_params: WorkflowProps;
   }) {
     this.workflowStore.setState(_state => payload);
-
-    if (!payload.triggers.length && !payload.jobs.length) {
-      // Create a placeholder chart and push it back up to the server
-      const diff = createNewWorkflow();
-      this.workflowStore.getState().add(diff);
-    }
 
     this.maybeMountComponent();
     let end = new Date();

--- a/assets/js/yaml/TemplateToWorkflow.ts
+++ b/assets/js/yaml/TemplateToWorkflow.ts
@@ -1,0 +1,16 @@
+import type { PhoenixHook } from '../hooks/PhoenixHook';
+import { parseWorkflowTemplate, convertWorkflowSpecToState } from './util';
+
+const TemplateToWorkflow = {
+  mounted() {
+    this.handleEvent('template_selected', (payload: { template: string }) => {
+      const workflowSpec = parseWorkflowTemplate(payload.template);
+      const workflowState = convertWorkflowSpecToState(workflowSpec);
+      this.pushEventTo(this.el, 'template-parsed', {
+        workflow: workflowState,
+      });
+    });
+  },
+} as PhoenixHook;
+
+export default TemplateToWorkflow;

--- a/assets/js/yaml/YAMLToWorkflow.ts
+++ b/assets/js/yaml/YAMLToWorkflow.ts
@@ -1,10 +1,6 @@
 import type { PhoenixHook } from '../hooks/PhoenixHook';
 import type { WorkflowSpec, WorkflowState } from './types';
-import {
-  parseWorkflowYAML,
-  convertWorkflowSpecToState,
-  defaultWorkflowState,
-} from './util';
+import { parseWorkflowYAML, convertWorkflowSpecToState } from './util';
 
 function transformServerErrors(
   errors: Record<string, any>,
@@ -75,13 +71,6 @@ const YAMLToWorkflow = {
       this.validateYAML(yamlString);
     });
   },
-  destroyed() {
-    // reset server state
-    this.updateServerState(defaultWorkflowState());
-  },
-  updateServerState(state: WorkflowState) {
-    this.pushEvent('validate', { workflow: state });
-  },
   validateYAML(workflowYAML: string) {
     this.errorEl.classList.add('hidden');
     this.errorEl.textContent = '';
@@ -100,8 +89,6 @@ const YAMLToWorkflow = {
             const errors = transformServerErrors(response['errors']);
             this.errorEl.textContent = errors[0];
             this.errorEl.classList.remove('hidden');
-          } else {
-            this.updateServerState(this.workflowState);
           }
         }
       );

--- a/assets/js/yaml/util.ts
+++ b/assets/js/yaml/util.ts
@@ -17,38 +17,6 @@ const hyphenate = (str: string) => {
   return str.replace(/\s+/g, '-');
 };
 
-export const defaultWorkflowState = (): WorkflowState => {
-  const trigger: StateTrigger = {
-    id: randomUUID(),
-    type: 'webhook',
-    enabled: true,
-  };
-
-  // intentionally left out adaptor because of the @latest stuff
-  const job: StateJob = {
-    id: randomUUID(),
-    name: 'New Job',
-    body: '// job body here',
-  };
-
-  const edge: StateEdge = {
-    id: randomUUID(),
-    source_trigger_id: trigger.id,
-    target_job_id: job.id,
-    enabled: true,
-    condition_type: 'always',
-  };
-
-  const workflowState: WorkflowState = {
-    name: '',
-    jobs: [job],
-    edges: [edge],
-    triggers: [trigger],
-  };
-
-  return workflowState;
-};
-
 export const convertWorkflowStateToSpec = (
   workflowState: WorkflowState
 ): WorkflowSpec => {
@@ -233,6 +201,12 @@ export const parseWorkflowYAML = (yamlString: string): WorkflowSpec => {
     },
     {}
   );
+
+  return parsedYAML as WorkflowSpec;
+};
+
+export const parseWorkflowTemplate = (code: string): WorkflowSpec => {
+  const parsedYAML = YAML.parse(code);
 
   return parsedYAML as WorkflowSpec;
 };

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -99,7 +99,7 @@ defmodule LightningWeb.LayoutComponents do
         }
       }
     />
-    <div class="flex-none bg-white shadow-xs">
+    <div class="flex-none bg-white shadow-xs border-b border-gray-200">
       <div class={[@title_class, @title_height]}>
         <%= if @current_user do %>
           <nav class="flex" aria-label="Breadcrumb">

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -177,7 +177,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
           :if={@show_new_workflow_panel}
           id="new-workflow-panel"
           module={LightningWeb.WorkflowLive.NewWorkflowComponent}
-          workflow_form={@workflow_form}
+          workflow={@workflow}
           project_id={@project.id}
         />
         <div class="relative h-full flex grow" id={"workflow-edit-#{@workflow.id}"}>

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -272,7 +272,12 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
       data-error-el="workflow-errors"
       class="flex flex-col gap-3 h-full"
     >
-      <div class="mt-2 flex justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10">
+      <div
+        id="workflow-dropzone"
+        phx-hook="FileDropzone"
+        class="mt-2 flex justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 transition-colors duration-200 ease-in-out"
+        data-target="#workflow-file"
+      >
         <div class="text-center">
           <Heroicons.cloud_arrow_up class="mx-auto size-10 text-gray-300" />
           <div class="mt-4 flex text-sm/6 text-gray-600">
@@ -290,7 +295,6 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
                 phx-update="ignore"
               />
             </label>
-            <%!-- TODO - add drag and drop --%>
             <p class="pl-1">or drag and drop</p>
           </div>
           <p class="text-xs/5 text-gray-600">YML or YAML, up to 8MB</p>

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -160,7 +160,7 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
             phx-value-method="import"
             phx-target={@myself}
           >
-            <.icon name="hero-document-plus" class="size-5" /> Import
+            <.icon name="hero-document" class="size-5" /> Import
           </.button>
           <.button
             id="toggle_new_workflow_panel_btn"
@@ -272,14 +272,15 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
       data-error-el="workflow-errors"
       class="flex flex-col gap-3 h-full"
     >
-      <div class="flex justify-center rounded-lg border border-dashed border-gray-900/25 px-4 py-6">
+      <div class="mt-2 flex justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10">
         <div class="text-center">
-          <div class="flex text-sm/6 text-gray-600">
+          <Heroicons.cloud_arrow_up class="mx-auto size-10 text-gray-300" />
+          <div class="mt-4 flex text-sm/6 text-gray-600">
             <label
               for="workflow-file"
-              class="relative cursor-pointer rounded-md bg-white font-semibold text-indigo-600 focus-within:ring-2 focus-within:ring-indigo-600 focus-within:ring-offset-2 focus-within:outline-hidden hover:text-indigo-500"
+              class="relative cursor-pointer rounded-md bg-white font-semibold text-indigo-600 focus-within:outline-none focus-within:ring-offset-2 hover:text-indigo-500"
             >
-              <span>Upload a YAML file</span>
+              <span>Upload a file</span>
               <input
                 id="workflow-file"
                 name="workflow-file"
@@ -289,8 +290,10 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
                 phx-update="ignore"
               />
             </label>
+            <%!-- TODO - add drag and drop --%>
+            <p class="pl-1">or drag and drop</p>
           </div>
-          <p class="text-xs/5 text-gray-600">Accepts .yml and .yaml files</p>
+          <p class="text-xs/5 text-gray-600">YML or YAML, up to 8MB</p>
         </div>
       </div>
       <div class="relative">

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -293,7 +293,7 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
           <div class="mt-4 flex text-sm/6 text-gray-600">
             <label
               for="workflow-file"
-              class="relative cursor-pointer rounded-md bg-white font-semibold text-indigo-600 focus-within:outline-none focus-within:ring-offset-2 hover:text-indigo-500"
+              class="relative cursor-pointer rounded-md font-semibold text-indigo-600 focus-within:outline-none focus-within:ring-offset-2 hover:text-indigo-500"
             >
               <span>Upload a file</span>
               <input

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -141,8 +141,8 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
         </div>
         <div class="px-4 py-4 sm:p-3 flex flex-row justify-center gap-3 h-max">
           <.button
-            id="move-back-to-templates-btn"
             :if={@selected_method == "import"}
+            id="move-back-to-templates-btn"
             type="button"
             variant="secondary"
             phx-click="choose-another-method"
@@ -152,8 +152,8 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
             Back
           </.button>
           <.button
-            id="import-workflow-btn"
             :if={@selected_method != "import"}
+            id="import-workflow-btn"
             type="button"
             class="inline-flex gap-x-1.5"
             phx-click="choose-another-method"

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -119,7 +119,7 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
     ~H"""
     <div id={@id} class="w-1/3">
       <div class="divide-y divide-gray-200 bg-white h-full flex flex-col">
-        <div class="flex px-4 py-5 sm:px-6">
+        <div class="flex px-4 py-5 sm:px-6 border-b border-gray-200">
           <div class="grow font-bold">
             Create workflow
           </div>
@@ -138,6 +138,37 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
             changeset={@changeset}
             myself={@myself}
           />
+        </div>
+        <div class="px-4 py-4 sm:p-3 flex flex-row justify-center gap-3 h-max">
+          <.button
+            id="move-back-to-templates-btn"
+            :if={@selected_method == "import"}
+            type="button"
+            variant="secondary"
+            phx-click="choose-another-method"
+            phx-value-method="template"
+            phx-target={@myself}
+          >
+            Back
+          </.button>
+          <.button
+            id="import-workflow-btn"
+            :if={@selected_method != "import"}
+            type="button"
+            class="inline-flex gap-x-1.5"
+            phx-click="choose-another-method"
+            phx-value-method="import"
+            phx-target={@myself}
+          >
+            <.icon name="hero-document-plus" class="size-5" /> Import
+          </.button>
+          <.button
+            id="toggle_new_workflow_panel_btn"
+            type="button"
+            phx-click="toggle_new_workflow_panel"
+          >
+            Get started
+          </.button>
         </div>
       </div>
     </div>
@@ -224,26 +255,6 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
           </div>
         </fieldset>
       </.form>
-
-      <div class="flex flex-row justify-center gap-3 h-max">
-        <.button
-          id="import-workflow-btn"
-          type="button"
-          class="inline-flex gap-x-1.5"
-          phx-click="choose-another-method"
-          phx-value-method="import"
-          phx-target={@myself}
-        >
-          <.icon name="hero-document-plus" class="size-5" /> Import
-        </.button>
-        <.button
-          id="toggle_new_workflow_panel_btn"
-          type="button"
-          phx-click="toggle_new_workflow_panel"
-        >
-          Get started
-        </.button>
-      </div>
     </div>
     """
   end
@@ -304,26 +315,6 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
           class="font-mono proportional-nums text-slate-200 bg-slate-700 resize-none text-nowrap overflow-x-auto flex-grow"
           placeholder="Paste your YAML content here"
         />
-      </div>
-      <div class="flex flex-row justify-center gap-3 h-max">
-        <.button
-          id="move-back-to-templates-btn"
-          type="button"
-          variant="secondary"
-          phx-click="choose-another-method"
-          phx-value-method="template"
-          phx-target={@myself}
-        >
-          Back
-        </.button>
-        <.button
-          id="toggle_new_workflow_panel_btn"
-          type="button"
-          phx-click="toggle_new_workflow_panel"
-          disabled={!@changeset.valid?}
-        >
-          Continue
-        </.button>
       </div>
     </div>
     """

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -6,20 +6,27 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
   alias LightningWeb.API.ProvisioningJSON
 
   @impl true
+  def mount(socket) do
+    {:ok,
+     socket
+     |> assign(selected_method: "template")
+     |> apply_selected_method()}
+  end
+
+  @impl true
   def update(assigns, socket) do
     {:ok,
      socket
      |> assign(assigns)
-     |> assign_new(:workflow, fn -> %Workflow{project_id: assigns.project_id} end)
      |> assign_new(:changeset, fn %{workflow: workflow} ->
        Workflow.changeset(workflow, %{})
-     end)
-     |> assign_new(:selected_method, fn -> "scratch" end)}
+     end)}
   end
 
   @impl true
   def handle_event("choose-another-method", %{"method" => method}, socket) do
-    {:noreply, assign(socket, selected_method: method)}
+    {:noreply,
+     socket |> assign(selected_method: method) |> apply_selected_method()}
   end
 
   def handle_event("validate-parsed-workflow", %{"workflow" => params}, socket) do
@@ -27,6 +34,8 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
 
     response =
       if changeset.valid? do
+        update_parent_form(params)
+
         %{}
       else
         ProvisioningJSON.error(%{changeset: changeset})
@@ -35,21 +44,93 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
     {:reply, response, assign(socket, changeset: changeset)}
   end
 
+  def handle_event("template-parsed", %{"workflow" => params}, socket) do
+    given_workflow_name =
+      Ecto.Changeset.get_field(socket.assigns.workflow_name_changeset, :name)
+
+    template_workflow_name = "Copy of #{socket.assigns.selected_template.name}"
+
+    params =
+      Map.put(params, "name", given_workflow_name || template_workflow_name)
+
+    update_parent_form(params)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("validate-name", %{"workflow" => params}, socket) do
+    update_parent_form(params)
+
+    {:noreply,
+     socket
+     |> assign(workflow_name_changeset: workflow_name_changeset(params))}
+  end
+
+  def handle_event("select-template", %{"template_id" => template_id}, socket) do
+    template =
+      Enum.find(socket.assigns.templates, fn template ->
+        template.id == template_id
+      end)
+
+    {:noreply,
+     socket
+     |> assign(selected_template: template)
+     |> push_selected_template_code()}
+  end
+
+  defp apply_selected_method(socket) do
+    case socket.assigns.selected_method do
+      "template" ->
+        base_templates = base_templates()
+        default_template = hd(base_templates)
+
+        socket
+        |> assign(
+          workflow_name_changeset: workflow_name_changeset(%{}),
+          selected_template: default_template,
+          templates: base_templates
+        )
+        |> push_selected_template_code()
+
+      "import" ->
+        changeset = Workflow.changeset(socket.assigns.workflow, %{})
+        assign(socket, changeset: changeset)
+    end
+  end
+
+  defp workflow_name_changeset(params) do
+    {%{name: nil}, %{name: :string}}
+    |> Ecto.Changeset.cast(params, [:name])
+  end
+
+  defp update_parent_form(params) do
+    send(self(), {"form_changed", %{"workflow" => params}})
+    :ok
+  end
+
+  defp push_selected_template_code(socket) do
+    push_event(socket, "template_selected", %{
+      template: socket.assigns.selected_template.code
+    })
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
     <div id={@id} class="w-1/3">
-      <div class="divide-y divide-gray-200 bg-white rounded-lg">
+      <div class="divide-y divide-gray-200 bg-white h-full flex flex-col">
         <div class="flex px-4 py-5 sm:px-6">
           <div class="grow font-bold">
             Create workflow
           </div>
         </div>
-        <div class="px-4 py-5 sm:p-6">
-          <.create_workflow_from_scratch
-            :if={@selected_method == "scratch"}
-            workflow_form={@workflow_form}
+        <div class="px-4 py-5 sm:p-6 flex-grow">
+          <.create_workflow_from_template
+            :if={@selected_method == "template"}
             myself={@myself}
+            templates={@templates}
+            selected_template={@selected_template}
+            workflow_name_changeset={@workflow_name_changeset}
           />
 
           <.create_workflow_via_import
@@ -63,51 +144,106 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
     """
   end
 
-  attr :workflow_form, :map, required: true
+  attr :workflow_name_changeset, :map, required: true
+  attr :selected_template, :map, required: true
+  attr :templates, :list, required: true
   attr :myself, :any, required: true
 
-  defp create_workflow_from_scratch(assigns) do
+  defp create_workflow_from_template(assigns) do
     ~H"""
-    <div class="flex flex-col gap-3">
+    <div
+      id="create-workflow-from-template"
+      phx-hook="TemplateToWorkflow"
+      class="flex flex-col gap-3 h-full"
+    >
       <.form
         :let={f}
+        as={:workflow}
         id="new-workflow-name-form"
-        for={@workflow_form}
-        phx-change="validate"
-      >
-        <.input
-          type="text"
-          field={f[:name]}
-          label="How do you want to name your workflow?"
-        />
-      </.form>
-      <.button
-        id="toggle_new_workflow_panel_btn"
-        type="button"
-        class="w-full"
-        phx-click="toggle_new_workflow_panel"
-        disabled={!@workflow_form.source.valid?}
-      >
-        Continue
-      </.button>
-      <div class="relative">
-        <div class="absolute inset-0 flex items-center" aria-hidden="true">
-          <div class="w-full border-t border-gray-300"></div>
-        </div>
-        <div class="relative flex justify-center">
-          <span class="bg-white px-2 text-sm text-gray-500">OR</span>
-        </div>
-      </div>
-      <.button
-        id="import-workflow-btn"
-        type="button"
-        class="w-full inline-flex gap-x-1.5"
-        phx-click="choose-another-method"
-        phx-value-method="import"
+        phx-change="validate-name"
         phx-target={@myself}
+        phx-debounce="300"
+        for={@workflow_name_changeset}
       >
-        <.icon name="hero-document-plus" class="size-5" /> Import
-      </.button>
+        <div class="grid grid-cols-1">
+          <.input_element
+            type="text"
+            name={f[:name].name}
+            placeholder="Describe your workflow in a few words here"
+            class="col-start-1 row-start-1 block w-full text-gray-900 placeholder:text-gray-400 py-1.5 pr-3 pl-10"
+            value={f[:name].value}
+          />
+          <.icon
+            name="hero-magnifying-glass"
+            class="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-gray-400 sm:size-4"
+          />
+        </div>
+      </.form>
+      <.form
+        id="choose-workflow-template-form"
+        phx-change="select-template"
+        phx-target={@myself}
+        for={to_form(%{})}
+        class="flex-grow"
+      >
+        <fieldset>
+          <div class="grid grid-cols-1 gap-y-6 sm:grid-cols-2 sm:gap-x-4 overflow-y-auto">
+            <label
+              :for={template <- @templates}
+              id={"template-label-#{template.id}"}
+              phx-hook="Tooltip"
+              aria-label={template.description}
+              data-selected={"#{template.id == @selected_template.id}"}
+              for={"template-input-#{template.id}"}
+              class={[
+                "flex cursor-pointer rounded-lg border bg-white p-4 shadow-xs focus:outline-hidden max-h-32 overflow-hidden text-ellipsis",
+                if(template.id == @selected_template.id,
+                  do: "border-indigo-600 border-2 ring-indigo-600",
+                  else: "border-gray-300"
+                )
+              ]}
+            >
+              <input
+                id={"template-input-#{template.id}"}
+                type="radio"
+                name="template_id"
+                value={template.id}
+                class="sr-only"
+              />
+              <span class="flex flex-1">
+                <span class="flex flex-col">
+                  <span class="block text-sm font-medium text-gray-900">
+                    {template.name}
+                  </span>
+                  <span class="mt-1 flex items-center text-sm text-gray-500">
+                    {template.description}
+                  </span>
+                </span>
+              </span>
+            </label>
+          </div>
+        </fieldset>
+      </.form>
+
+      <div class="flex flex-row justify-center gap-3 h-max">
+        <.button
+          id="import-workflow-btn"
+          type="button"
+          class="inline-flex gap-x-1.5"
+          phx-click="choose-another-method"
+          phx-value-method="import"
+          phx-target={@myself}
+        >
+          <.icon name="hero-document-plus" class="size-5" /> Import
+        </.button>
+        <.button
+          id="toggle_new_workflow_panel_btn"
+          type="button"
+          phx-click="toggle_new_workflow_panel"
+        >
+          Get started
+        </.button>
+      </div>
     </div>
     """
   end
@@ -123,9 +259,9 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
       data-file-input-el="workflow-file"
       data-viewer-el="workflow-code-viewer"
       data-error-el="workflow-errors"
-      class="flex flex-col gap-3"
+      class="flex flex-col gap-3 h-full"
     >
-      <div class="flex justify-center rounded-lg border border-dashed border-gray-900/25 px-4 py-2">
+      <div class="flex justify-center rounded-lg border border-dashed border-gray-900/25 px-4 py-6">
         <div class="text-center">
           <div class="flex text-sm/6 text-gray-600">
             <label
@@ -154,7 +290,7 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
           <span class="bg-white px-2 text-sm text-gray-500">OR</span>
         </div>
       </div>
-      <div>
+      <div class="flex-grow flex flex-col">
         <div
           id="workflow-errors"
           class="error-space mb-1 text-xs text-danger-600 hidden"
@@ -165,18 +301,17 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
           phx-update="ignore"
           name="workflow-code"
           value=""
-          rows="13"
-          class="font-mono proportional-nums text-slate-200 bg-slate-700 resize-none text-nowrap overflow-x-auto"
+          class="font-mono proportional-nums text-slate-200 bg-slate-700 resize-none text-nowrap overflow-x-auto flex-grow"
           placeholder="Paste your YAML content here"
         />
       </div>
-      <div class="flex flex-row justify-end gap-3">
+      <div class="flex flex-row justify-center gap-3 h-max">
         <.button
-          id="move-back-to-scratch-btn"
+          id="move-back-to-templates-btn"
           type="button"
           variant="secondary"
           phx-click="choose-another-method"
-          phx-value-method="scratch"
+          phx-value-method="template"
           phx-target={@myself}
         >
           Back
@@ -192,5 +327,59 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
       </div>
     </div>
     """
+  end
+
+  defp base_templates do
+    [
+      %{
+        id: "base-webhook-template",
+        name: "base-webhook",
+        description: "webhook triggered workflow",
+        code: """
+        jobs:
+          New-job:
+            name: New job
+            adaptor: "@openfn/language-common@latest"
+            body: |
+              // Check out the Job Writing Guide for help getting started:
+              // https://docs.openfn.org/documentation/jobs/job-writing-guide
+        triggers:
+          webhook:
+            type: webhook
+            enabled: false
+        edges:
+          webhook->New-job:
+            source_trigger: webhook
+            target_job: New-job
+            condition_type: always
+            enabled: true
+        """
+      },
+      %{
+        id: "base-cron-template",
+        name: "base-cron",
+        description: "cron triggered workflow",
+        code: """
+        jobs:
+          New-job:
+            name: New job
+            adaptor: "@openfn/language-common@latest"
+            body: |
+              // Check out the Job Writing Guide for help getting started:
+              // https://docs.openfn.org/documentation/jobs/job-writing-guide
+        triggers:
+          cron:
+            type: cron
+            cron_expression: 0 * * * *
+            enabled: false
+        edges:
+          cron->New-job:
+            source_trigger: cron
+            target_job: New-job
+            condition_type: always
+            enabled: true
+        """
+      }
+    ]
   end
 end

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -141,17 +141,6 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
         </div>
         <div class="px-4 py-4 sm:p-3 flex flex-row justify-center gap-3 h-max">
           <.button
-            :if={@selected_method == "import"}
-            id="move-back-to-templates-btn"
-            type="button"
-            variant="secondary"
-            phx-click="choose-another-method"
-            phx-value-method="template"
-            phx-target={@myself}
-          >
-            Back
-          </.button>
-          <.button
             :if={@selected_method != "import"}
             id="import-workflow-btn"
             type="button"
@@ -163,9 +152,30 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
             <.icon name="hero-document" class="size-5" /> Import
           </.button>
           <.button
+            :if={@selected_method != "import"}
             id="toggle_new_workflow_panel_btn"
             type="button"
             phx-click="toggle_new_workflow_panel"
+          >
+            Get started
+          </.button>
+          <.button
+            :if={@selected_method == "import"}
+            id="move-back-to-templates-btn"
+            type="button"
+            variant="secondary"
+            phx-click="choose-another-method"
+            phx-value-method="template"
+            phx-target={@myself}
+          >
+            Back
+          </.button>
+          <.button
+            :if={@selected_method == "import"}
+            id="toggle_new_workflow_panel_btn"
+            type="button"
+            phx-click="toggle_new_workflow_panel"
+            disabled={!@changeset.valid?}
           >
             Get started
           </.button>

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -325,13 +325,25 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert has_element?(view, "form#choose-workflow-template-form")
 
       # the base webhook template is selected by default
-      template_name = "base-webhook"
+      assert view
+             |> element(
+               "form#choose-workflow-template-form label[data-selected='true']"
+             )
+             |> render() =~ "base-webhook"
+
+      # lets select the cron one
+      template_id = "base-cron-template"
+      cron_template_name = "base-cron"
+
+      view
+      |> form("#choose-workflow-template-form", %{template_id: template_id})
+      |> render_change()
 
       assert view
              |> element(
                "form#choose-workflow-template-form label[data-selected='true']"
              )
-             |> render() =~ template_name
+             |> render() =~ cron_template_name
 
       # lets dummy send the content or base template
       job_id = Ecto.UUID.generate()
@@ -365,7 +377,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       click_save(view)
 
-      expected_workflow_name = "Copy of #{template_name}"
+      expected_workflow_name = "Copy of #{cron_template_name}"
 
       assert Lightning.Repo.exists?(
                from w in Workflow,

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -399,12 +399,12 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       assert has_element?(view, "form#new-workflow-name-form")
       assert has_element?(view, "form#choose-workflow-template-form")
 
-      refute html =~ "Upload a YAML file"
+      refute html =~ "Upload a file"
 
       # click to go to import page
       html = view |> element("#import-workflow-btn") |> render_click()
 
-      assert html =~ "Upload a YAML file"
+      assert html =~ "Upload a file"
       refute html =~ "Describe your workflow in a few words here"
       refute has_element?(view, "form#new-workflow-name-form")
       refute has_element?(view, "form#choose-workflow-template-form")

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -351,7 +351,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       {:ok, view, html} = live(conn, ~p"/projects/#{project.id}/w/new")
 
       assert html =~ "Create workflow"
-      assert html =~ "How do you want to name your workflow?"
+      assert html =~ "Describe your workflow in a few words here"
       assert has_element?(view, "form#new-workflow-name-form")
 
       view
@@ -364,7 +364,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       html = render(view)
 
       refute html =~ "Create workflow"
-      refute html =~ "How do you want to name your workflow?"
+      refute html =~ "Describe your workflow in a few words here"
       refute has_element?(view, "form#new-workflow-name-form")
     end
 

--- a/test/lightning_web/live/workflow_live/new_workflow_component_test.exs
+++ b/test/lightning_web/live/workflow_live/new_workflow_component_test.exs
@@ -1,0 +1,99 @@
+defmodule LightningWeb.WorkflowLive.NewWorkflowComponentTest do
+  use LightningWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_user
+  setup :create_project_for_current_user
+
+  describe "workflow creation methods" do
+    test "displays template and import options", %{conn: conn, project: project} do
+      {:ok, view, html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      # Initial state should show template selection
+      assert html =~ "Create workflow"
+      assert view |> element("#create-workflow-from-template") |> has_element?()
+      assert view |> element("#import-workflow-btn") |> has_element?()
+      refute view |> element("#workflow-importer") |> has_element?()
+    end
+
+    test "switches to import view when import button is clicked", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      # Click import button
+      html = view |> element("#import-workflow-btn") |> render_click()
+
+      # Should now show the import view
+      assert html =~ "Upload a file"
+      assert html =~ "or drag and drop"
+      assert view |> element("#workflow-importer") |> has_element?()
+      assert view |> element("#workflow-dropzone") |> has_element?()
+      assert view |> element("#workflow-file") |> has_element?()
+    end
+
+    test "can switch back to template view from import view", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      # Switch to import view
+      view |> element("#import-workflow-btn") |> render_click()
+
+      # Click back button
+      html = view |> element("#move-back-to-templates-btn") |> render_click()
+
+      # Should show template selection again
+      assert html =~ "Create workflow"
+      assert view |> element("#create-workflow-from-template") |> has_element?()
+      refute view |> element("#workflow-importer") |> has_element?()
+    end
+  end
+
+  describe "template selection" do
+    test "displays available templates", %{conn: conn, project: project} do
+      {:ok, view, html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      assert html =~ "base-webhook"
+      assert html =~ "webhook triggered workflow"
+      assert html =~ "base-cron"
+      assert html =~ "cron triggered workflow"
+
+      # Template selection form should be present
+      assert view |> element("#choose-workflow-template-form") |> has_element?()
+    end
+
+    test "allows template selection", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      # Select a template
+      assert view |> element("#template-input-base-webhook-template") |> has_element?()
+      assert view |> element("#template-input-base-cron-template") |> has_element?()
+    end
+  end
+
+  describe "workflow import" do
+    test "shows file upload interface", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      # Switch to import view
+      html = view |> element("#import-workflow-btn") |> render_click()
+
+      # Verify upload interface elements
+      assert html =~ "Upload a file"
+      assert html =~ "or drag and drop"
+      assert html =~ "YML or YAML, up to 8MB"
+      assert view |> element("#workflow-dropzone") |> has_element?()
+      assert view |> element("#workflow-file") |> has_element?()
+    end
+
+    test "dropzone has proper attributes for drag and drop", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
+
+      # Switch to import view
+      view |> element("#import-workflow-btn") |> render_click()
+
+      # Verify dropzone has necessary attributes for the JavaScript hook
+      assert view
+             |> element("#workflow-dropzone[phx-hook='FileDropzone'][data-target='#workflow-file']")
+             |> has_element?()
+    end
+  end
+end

--- a/test/lightning_web/live/workflow_live/new_workflow_component_test.exs
+++ b/test/lightning_web/live/workflow_live/new_workflow_component_test.exs
@@ -17,7 +17,10 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponentTest do
       refute view |> element("#workflow-importer") |> has_element?()
     end
 
-    test "switches to import view when import button is clicked", %{conn: conn, project: project} do
+    test "switches to import view when import button is clicked", %{
+      conn: conn,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
 
       # Click import button
@@ -31,7 +34,10 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponentTest do
       assert view |> element("#workflow-file") |> has_element?()
     end
 
-    test "can switch back to template view from import view", %{conn: conn, project: project} do
+    test "can switch back to template view from import view", %{
+      conn: conn,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
 
       # Switch to import view
@@ -64,8 +70,13 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponentTest do
       {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
 
       # Select a template
-      assert view |> element("#template-input-base-webhook-template") |> has_element?()
-      assert view |> element("#template-input-base-cron-template") |> has_element?()
+      assert view
+             |> element("#template-input-base-webhook-template")
+             |> has_element?()
+
+      assert view
+             |> element("#template-input-base-cron-template")
+             |> has_element?()
     end
   end
 
@@ -84,7 +95,10 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponentTest do
       assert view |> element("#workflow-file") |> has_element?()
     end
 
-    test "dropzone has proper attributes for drag and drop", %{conn: conn, project: project} do
+    test "dropzone has proper attributes for drag and drop", %{
+      conn: conn,
+      project: project
+    } do
       {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w/new")
 
       # Switch to import view
@@ -92,7 +106,9 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponentTest do
 
       # Verify dropzone has necessary attributes for the JavaScript hook
       assert view
-             |> element("#workflow-dropzone[phx-hook='FileDropzone'][data-target='#workflow-file']")
+             |> element(
+               "#workflow-dropzone[phx-hook='FileDropzone'][data-target='#workflow-file']"
+             )
              |> has_element?()
     end
   end


### PR DESCRIPTION
## Description

This PR defines 2 templates which the user can choose from when creating a workflow, one for `webhook` trigger and another for `cron` trigger. 
The default trigger workflow that was getting rendered initially when you create a workflow is what has been saved as base webhook template.

Closes #3110

## Validation steps

1. Click to create a workflow. 
2. Pick between the base-webhook and base-cron trigger
3. When you describe your workflow in the search input, that is what is used as the workflow name. If you don't put in the name, the workflow name will be picked as `Copy of {template name}`

## Additional notes for the reviewer

 I have removed the `default workflow` from the js land that was used to load the editor. This is because currently liveview provides the templates, including the default one.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
