### PR TITLE
feat: render WorkflowEditor via a portal inside WorkflowStore

### DIFF
--- a/assets/js/react/lib/with-props.tsx
+++ b/assets/js/react/lib/with-props.tsx
@@ -18,7 +18,7 @@ interface ActionProps {
   navigate: (path: string) => void,
 }
 
-export type WithActionProps<T = Record<string, unknown>> = React.FunctionComponent<ActionProps & T>;
+export type WithActionProps<T = Record<string, unknown>> = React.FunctionComponent<React.PropsWithChildren<ActionProps & T>>;
 
 /**
  * Use [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore)

--- a/assets/js/workflow-store/WorkflowStore.tsx
+++ b/assets/js/workflow-store/WorkflowStore.tsx
@@ -118,5 +118,5 @@ export const WorkflowStore: WithActionProps = (props) => {
     });
   }, [props, setDisabled])
 
-  return <></>
+  return <>{props.children}</>
 }

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -174,7 +174,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
         </LayoutComponents.header>
       </:header>
 
-      <.WorkflowStore />
+      <.WorkflowStore react-id="workflow-mount" />
       <div class="relative h-full flex" id={"workflow-edit-#{@workflow.id}"}>
         <div class="flex-none" id="job-editor-pane">
           <div
@@ -347,8 +347,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             </LightningWeb.WorkflowLive.JobView.job_edit_view>
           </div>
         </div>
-
-        <.WorkflowEditor />
+        <.WorkflowEditor react-portal-target="workflow-mount" />
         <.live_component
           :if={@selected_job}
           id="new-credential-modal"


### PR DESCRIPTION
## Description
Renders our WorkflowEditor via WorkflowStore ensuring that we have a single react tree. 

<img width="696" alt="Screenshot 2025-04-19 at 7 43 56 AM" src="https://github.com/user-attachments/assets/1a9b6295-4427-4940-bd23-c0303a94d187" />


**Note**: There was actually no issue with the existing implementation. Any component that is going to be used for portaling needs to render its children because the portaled components come in as children to the component. @stuartc @josephjclark  

Closes ##3120

## Validation steps

1. Install the React Devtool if you already don't have it
2. Open the workflowEditor for a workflow. 
3. Open your browser devTool then to the React Components tab. 
4. Check whether there's a single react tree where WorkflowEditor is a descendant of WorkflowStore

## Additional notes for the reviewer

None. 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
