### PR TITLE
Fix blank modal showing when you click to show webhook auth method password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 
 - Make Collections delete_all idempotent.
   [#3143](https://github.com/OpenFn/lightning/issues/3143)
+- Blank modal showing when you click to show webhook auth method password
+  [#3154](https://github.com/OpenFn/lightning/issues/3154)
 
 ## [v2.12.0] - 2025-04-25
 

--- a/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
+++ b/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
@@ -568,6 +568,7 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
     ~H"""
     <div id={"generic-oauth-scopes-#{@id}"} class="space-y-2 mt-5">
       <NewInputs.input
+        id={@id}
         type="text"
         label={@label}
         field={@field}

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -45,10 +45,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
 
   def handle_event("toggle-2fa", _params, %{assigns: assigns} = socket) do
     {:noreply,
-     assign(socket,
-       show_2fa_options: dbg(!assigns.show_2fa_options),
-       error_msg: nil
-     )}
+     assign(socket, show_2fa_options: !assigns.show_2fa_options, error_msg: nil)}
   end
 
   def handle_event("reauthenticate-user", %{"user" => params}, socket) do

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -353,62 +353,17 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
       phx-target={@myself}
     >
       <div class="ml-[24px] mr-[24px]">
-        <%= case @webhook_auth_method.auth_type do %>
-          <% :basic -> %>
-            <.label for={:name}>Auth method name</.label>
-            <.input type="text" field={f[:name]} required="true" />
+        <.basic_auth_type_form_fields
+          :if={@webhook_auth_method.auth_type == :basic}
+          form={f}
+          {assigns}
+        />
 
-            <div class="hidden sm:block" aria-hidden="true">
-              <div class="py-1"></div>
-            </div>
-
-            <.label for={:username}>Username</.label>
-            <.input
-              type="text"
-              field={f[:username]}
-              required="true"
-              disabled={@action == :edit}
-            />
-
-            <div class="hidden sm:block" aria-hidden="true">
-              <div class="py-1"></div>
-            </div>
-
-            <%= if @action == :edit do %>
-              <div class="mb-3">
-                <label class="block text-sm font-semibold leading-6 text-slate-800">
-                  Password
-                </label>
-                <.maybe_mask_password_field
-                  field={f[:password]}
-                  sudo_mode?={@sudo_mode?}
-                  phx_target={@myself}
-                />
-              </div>
-            <% else %>
-              <.label for={:password}>Password</.label>
-              <.input type="password" field={f[:password]} required="true" />
-
-              <div class="hidden sm:block" aria-hidden="true">
-                <div class="py-1"></div>
-              </div>
-            <% end %>
-          <% :api -> %>
-            <.label for={:name}>Auth method name</.label>
-            <.input type="text" field={f[:name]} required="true" />
-
-            <div class="hidden sm:block" aria-hidden="true">
-              <div class="py-1"></div>
-            </div>
-
-            <.label for={:api_key}>API Key</.label>
-            <.maybe_mask_api_key_field
-              action={@action}
-              field={f[:api_key]}
-              sudo_mode?={@sudo_mode?}
-              phx_target={@myself}
-            />
-        <% end %>
+        <.api_auth_type_form_fields
+          :if={@webhook_auth_method.auth_type == :api}
+          form={f}
+          {assigns}
+        />
       </div>
       <.modal_footer class="mx-6 mt-6">
         <div class="sm:flex sm:flex-row-reverse">
@@ -458,6 +413,72 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
       </button>
       """
     end
+  end
+
+  attr :form, Phoenix.HTML.Form, required: true
+
+  defp basic_auth_type_form_fields(assigns) do
+    ~H"""
+    <.label for={:name}>Auth method name</.label>
+    <.input type="text" field={@form[:name]} required="true" />
+
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-1"></div>
+    </div>
+
+    <.label for={:username}>Username</.label>
+    <.input
+      type="text"
+      field={@form[:username]}
+      required="true"
+      disabled={@action == :edit}
+    />
+
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-1"></div>
+    </div>
+
+    <%= if @action == :edit do %>
+      <div class="mb-3">
+        <label class="block text-sm font-semibold leading-6 text-slate-800">
+          Password
+        </label>
+        <.maybe_mask_password_field
+          field={@form[:password]}
+          sudo_mode?={@sudo_mode?}
+          phx_target={@myself}
+        />
+      </div>
+    <% else %>
+      <.label for={:password}>Password</.label>
+      <.input type="password" field={@form[:password]} required="true" />
+
+      <div class="hidden sm:block" aria-hidden="true">
+        <div class="py-1"></div>
+      </div>
+    <% end %>
+    """
+  end
+
+  attr :form, Phoenix.HTML.Form, required: true
+
+  defp api_auth_type_form_fields(assigns) do
+    ~H"""
+    <.label for={:name}>Auth method name</.label>
+    <.input type="text" field={@form[:name]} required="true" />
+
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-1"></div>
+    </div>
+
+    <.label for={:api_key}>API Key</.label>
+    <.maybe_mask_api_key_field
+      action={@action}
+      field={@form[:api_key]}
+      sudo_mode?={@sudo_mode?}
+      phx_target={@myself}
+    />
+    """
   end
 
   attr :field, :map, required: true

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -45,7 +45,10 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
 
   def handle_event("toggle-2fa", _params, %{assigns: assigns} = socket) do
     {:noreply,
-     assign(socket, show_2fa_options: !assigns.show_2fa_options, error_msg: nil)}
+     assign(socket,
+       show_2fa_options: dbg(!assigns.show_2fa_options),
+       error_msg: nil
+     )}
   end
 
   def handle_event("reauthenticate-user", %{"user" => params}, socket) do
@@ -270,157 +273,163 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
     """
   end
 
-  def render(%{action: :edit, show_2fa_options: true} = assigns) do
+  def render(assigns) do
     ~H"""
-    <div>
-      <.form
-        :let={f}
-        for={%{}}
-        action="#"
-        phx-submit="reauthenticate-user"
-        as={:user}
-        phx-target={@myself}
-        class="mt-2"
-        id="reauthentication-form"
-      >
-        <div class="space-y-4 ml-[24px] mr-[24px]">
-          <p class="font-normal text-sm whitespace-normal">
-            You're required to reauthenticate yourself before viewing the webhook
-            <%= if @webhook_auth_method.auth_type == :basic do %>
-              Password
-            <% else %>
-              API Key
-            <% end %>
-          </p>
-          <%= if @error_msg do %>
-            <div class="alert alert-danger" role="alert">
-              {@error_msg}
-            </div>
-          <% end %>
-
-          <.input type="password" field={f[:password]} label="Password" />
-          <div class="relative">
-            <div class="absolute inset-0 flex items-center" aria-hidden="true">
-              <div class="w-full border-t border-gray-300"></div>
-            </div>
-            <div class="relative flex justify-center">
-              <span class="bg-white px-2 text-sm text-gray-500">OR</span>
-            </div>
-          </div>
-          <.input type="text" field={f[:code]} label="2FA Code" inputmode="numeric" />
-        </div>
-        <.modal_footer class="mx-6 mt-6">
-          <div class="sm:flex sm:flex-row-reverse">
-            <button
-              type="submit"
-              class="inline-flex w-full justify-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 sm:ml-3 sm:w-auto"
-            >
-              Done
-            </button>
-            <button
-              type="button"
-              phx-click="toggle-2fa"
-              phx-target={@myself}
-              class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
-            >
-              Cancel
-            </button>
-          </div>
-        </.modal_footer>
-      </.form>
+    <div id={"write_webhook_auth_method_#{@id}"}>
+      <%= if @action == :edit and @show_2fa_options do %>
+        <.authenticate_user_form {assigns} />
+      <% else %>
+        <.webhook_auth_method_form {assigns} />
+      <% end %>
     </div>
     """
   end
 
-  def render(assigns) do
+  defp authenticate_user_form(assigns) do
     ~H"""
-    <div id={"write_webhook_auth_method_#{@id}"}>
-      <%!-- <%= if @webhook_auth_method.auth_type do %> --%>
-      <.form
-        :let={f}
-        id={"form_#{@id}"}
-        for={@changeset}
-        phx-submit="save"
-        phx-change="validate"
-        phx-target={@myself}
-      >
-        <div class="ml-[24px] mr-[24px]">
-          <%= case @webhook_auth_method.auth_type do %>
-            <% :basic -> %>
-              <.label for={:name}>Auth method name</.label>
-              <.input type="text" field={f[:name]} required="true" />
-
-              <div class="hidden sm:block" aria-hidden="true">
-                <div class="py-1"></div>
-              </div>
-
-              <.label for={:username}>Username</.label>
-              <.input
-                type="text"
-                field={f[:username]}
-                required="true"
-                disabled={@action == :edit}
-              />
-
-              <div class="hidden sm:block" aria-hidden="true">
-                <div class="py-1"></div>
-              </div>
-
-              <%= if @action == :edit do %>
-                <div class="mb-3">
-                  <label class="block text-sm font-semibold leading-6 text-slate-800">
-                    Password
-                  </label>
-                  <.maybe_mask_password_field
-                    field={f[:password]}
-                    sudo_mode?={@sudo_mode?}
-                    phx_target={@myself}
-                  />
-                </div>
-              <% else %>
-                <.label for={:password}>Password</.label>
-                <.input type="password" field={f[:password]} required="true" />
-
-                <div class="hidden sm:block" aria-hidden="true">
-                  <div class="py-1"></div>
-                </div>
-              <% end %>
-            <% :api -> %>
-              <.label for={:name}>Auth method name</.label>
-              <.input type="text" field={f[:name]} required="true" />
-
-              <div class="hidden sm:block" aria-hidden="true">
-                <div class="py-1"></div>
-              </div>
-
-              <.label for={:api_key}>API Key</.label>
-              <.maybe_mask_api_key_field
-                action={@action}
-                field={f[:api_key]}
-                sudo_mode?={@sudo_mode?}
-                phx_target={@myself}
-              />
+    <.form
+      :let={f}
+      for={%{}}
+      action="#"
+      phx-submit="reauthenticate-user"
+      as={:user}
+      phx-target={@myself}
+      class="mt-2"
+      id="reauthentication-form"
+    >
+      <div class="space-y-4 ml-[24px] mr-[24px]">
+        <p class="font-normal text-sm whitespace-normal">
+          You're required to reauthenticate yourself before viewing the webhook
+          <%= if @webhook_auth_method.auth_type == :basic do %>
+            Password
+          <% else %>
+            API Key
           <% end %>
-        </div>
-        <.modal_footer class="mx-6 mt-6">
-          <div class="sm:flex sm:flex-row-reverse">
-            <button
-              type="submit"
-              disabled={!@changeset.valid?}
-              class="inline-flex w-full justify-center rounded-md disabled:bg-primary-300 bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 sm:ml-3 sm:w-auto"
-            >
-              <%= if @action == :new do %>
-                Create auth method
-              <% else %>
-                Save changes
-              <% end %>
-            </button>
-            <.cancel_button return_to={@return_to} />
+        </p>
+        <%= if @error_msg do %>
+          <div class="alert alert-danger" role="alert">
+            {@error_msg}
           </div>
-        </.modal_footer>
-      </.form>
-      <%!-- <% end %> --%>
-    </div>
+        <% end %>
+
+        <.input type="password" field={f[:password]} label="Password" />
+        <div class="relative">
+          <div class="absolute inset-0 flex items-center" aria-hidden="true">
+            <div class="w-full border-t border-gray-300"></div>
+          </div>
+          <div class="relative flex justify-center">
+            <span class="bg-white px-2 text-sm text-gray-500">OR</span>
+          </div>
+        </div>
+        <.input type="text" field={f[:code]} label="2FA Code" inputmode="numeric" />
+      </div>
+      <.modal_footer class="mx-6 mt-6">
+        <div class="sm:flex sm:flex-row-reverse">
+          <button
+            type="submit"
+            class="inline-flex w-full justify-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 sm:ml-3 sm:w-auto"
+          >
+            Done
+          </button>
+          <button
+            type="button"
+            phx-click="toggle-2fa"
+            phx-target={@myself}
+            class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+          >
+            Cancel
+          </button>
+        </div>
+      </.modal_footer>
+    </.form>
+    """
+  end
+
+  defp webhook_auth_method_form(assigns) do
+    ~H"""
+    <.form
+      :let={f}
+      id={"form_#{@id}"}
+      for={@changeset}
+      phx-submit="save"
+      phx-change="validate"
+      phx-target={@myself}
+    >
+      <div class="ml-[24px] mr-[24px]">
+        <%= case @webhook_auth_method.auth_type do %>
+          <% :basic -> %>
+            <.label for={:name}>Auth method name</.label>
+            <.input type="text" field={f[:name]} required="true" />
+
+            <div class="hidden sm:block" aria-hidden="true">
+              <div class="py-1"></div>
+            </div>
+
+            <.label for={:username}>Username</.label>
+            <.input
+              type="text"
+              field={f[:username]}
+              required="true"
+              disabled={@action == :edit}
+            />
+
+            <div class="hidden sm:block" aria-hidden="true">
+              <div class="py-1"></div>
+            </div>
+
+            <%= if @action == :edit do %>
+              <div class="mb-3">
+                <label class="block text-sm font-semibold leading-6 text-slate-800">
+                  Password
+                </label>
+                <.maybe_mask_password_field
+                  field={f[:password]}
+                  sudo_mode?={@sudo_mode?}
+                  phx_target={@myself}
+                />
+              </div>
+            <% else %>
+              <.label for={:password}>Password</.label>
+              <.input type="password" field={f[:password]} required="true" />
+
+              <div class="hidden sm:block" aria-hidden="true">
+                <div class="py-1"></div>
+              </div>
+            <% end %>
+          <% :api -> %>
+            <.label for={:name}>Auth method name</.label>
+            <.input type="text" field={f[:name]} required="true" />
+
+            <div class="hidden sm:block" aria-hidden="true">
+              <div class="py-1"></div>
+            </div>
+
+            <.label for={:api_key}>API Key</.label>
+            <.maybe_mask_api_key_field
+              action={@action}
+              field={f[:api_key]}
+              sudo_mode?={@sudo_mode?}
+              phx_target={@myself}
+            />
+        <% end %>
+      </div>
+      <.modal_footer class="mx-6 mt-6">
+        <div class="sm:flex sm:flex-row-reverse">
+          <button
+            type="submit"
+            disabled={!@changeset.valid?}
+            class="inline-flex w-full justify-center rounded-md disabled:bg-primary-300 bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 sm:ml-3 sm:w-auto"
+          >
+            <%= if @action == :new do %>
+              Create auth method
+            <% else %>
+              Save changes
+            <% end %>
+          </button>
+          <.cancel_button return_to={@return_to} />
+        </div>
+      </.modal_footer>
+    </.form>
     """
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1544,6 +1544,10 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert view |> element("##{modal_id}") |> has_element?()
 
+      # this is to check that the root tag for the live component is mantained
+      root_div = "write_webhook_auth_method_#{modal_id}_#{auth_method.id}"
+      assert has_element?(view, "##{root_div}")
+
       form_id = "form_#{modal_id}_#{auth_method.id}"
 
       assert view |> has_element?("##{form_id}_password_action_button", "Show")
@@ -1556,6 +1560,9 @@ defmodule LightningWeb.ProjectLiveTest do
       view |> element("##{form_id}_password_action_button") |> render_click()
 
       assert view |> has_element?("#reauthentication-form")
+
+      # root html tag in livecomponent is mantained
+      assert has_element?(view, "##{root_div}")
 
       # test wrong password
       refute render(view) =~ "Invalid! Please try again"


### PR DESCRIPTION
## Description

This PR fixes an issue where after clicking to show the password or api key, the modal goes blank. It seems liveview doesn't like changing/replacing of the root html tag, which is what we were doing. 

When you click `show` on the password/api field of the form, the intention is to show you a page to `reauthenticate`. What we were doing previously is matching against the `render/1` function and changing the root html.

Please ignore the large diff, all I have done is moved the 2 `render/ heads` into 2 different function components 

Closes #3154

## Validation steps

1. Go to project settings page and click to add a new webhook auth method under the `Webhook Security` tab. 
2. Click to edit that auth method. A modal will appear. 
3. On the `password/api key` field, click the `show` button. 
4. A form to re-authenticate the user appears. Previously, this blank


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
