### PR TITLE
Rename webhook auth method button and title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Rename webhook auth method button and title.
+  [#3165](https://github.com/OpenFn/lightning/issues/3165)
+
 ### Fixed
 
 - Make Collections delete_all idempotent.

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -612,7 +612,7 @@
                 class="table-action"
                 phx-click={show_modal("edit_auth_#{auth_method.id}_modal")}
               >
-                Edit
+                View
               </a>
               <div class="text-left">
                 <.live_component

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_modal_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_modal_component.ex
@@ -268,7 +268,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodModalComponent do
                       Create an "API token" method
                   <% end %>
                 <% :edit -> %>
-                  Edit webhook auth method
+                  Rename webhook auth method
                 <% :display_triggers -> %>
                   Associated Workflow Triggers
                 <% :delete -> %>

--- a/test/lightning_web/live/workflow_live/trigger_test.exs
+++ b/test/lightning_web/live/workflow_live/trigger_test.exs
@@ -292,7 +292,7 @@ defmodule LightningWeb.WorkflowLive.TriggerTest do
         |> element("#edit_auth_method_link_#{auth_method.id}")
         |> render_click()
 
-      assert html =~ "Edit webhook auth method"
+      assert html =~ "Rename webhook auth method"
 
       new_auth_method_name = Name.generate()
 


### PR DESCRIPTION
## Description

This PR changes the button and the modal title of webhook auth methods.
The button is renamed from `Edit` to `View` once the user can only view the Auth method user and pass of a Basic method (and cannot change the API key of the other method).

It renames also the title of the modal from `Edit webhook auth method` to `Rename webhook auth method` making it clear that the fields are not disabled by chance.

Closes #3164 

## Validation steps

1. Navigate to Settings->Webhook Security
2. Create a new auth method
3. See that the newly created shows an option to View
4. Click on View and see it shows a Rename title.

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
