### PR TITLE
fix github sync modal in the workflow editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix save and sync not working in the workflow editor
+  [#3177](https://github.com/OpenFn/lightning/issues/3177)
+
 ## [v2.12.1] - 2025-04-29
 
 ### Changed

--- a/assets/js/hooks/KeyHandlers.ts
+++ b/assets/js/hooks/KeyHandlers.ts
@@ -290,7 +290,8 @@ export const InspectorSaveViaCtrlS = createKeyCombinationHook(
  */
 export const OpenSyncModalViaCtrlShiftS = createKeyCombinationHook(
   isCtrlOrMetaShiftS,
-  clickAction
+  clickAction,
+  PRIORITY.HIGH
 );
 
 /**

--- a/lib/lightning_web/live/workflow_live/github_sync_modal.ex
+++ b/lib/lightning_web/live/workflow_live/github_sync_modal.ex
@@ -25,7 +25,7 @@ defmodule LightningWeb.WorkflowLive.GithubSyncModal do
   @impl true
   def render(assigns) do
     ~H"""
-    <div>
+    <form id={@id <> "-form"} phx-submit="save">
       <.modal
         id={@id}
         show={true}
@@ -160,7 +160,6 @@ defmodule LightningWeb.WorkflowLive.GithubSyncModal do
             <.button
               id={"submit-btn-#{@id}"}
               type="submit"
-              form="workflow-form"
               disabled={!@verify_connection.ok?}
             >
               Save and sync
@@ -175,7 +174,7 @@ defmodule LightningWeb.WorkflowLive.GithubSyncModal do
           </div>
         </:footer>
       </.modal>
-    </div>
+    </form>
     """
   end
 end

--- a/lib/lightning_web/live/workflow_live/github_sync_modal.ex
+++ b/lib/lightning_web/live/workflow_live/github_sync_modal.ex
@@ -25,7 +25,7 @@ defmodule LightningWeb.WorkflowLive.GithubSyncModal do
   @impl true
   def render(assigns) do
     ~H"""
-    <form id={@id <> "-form"} phx-submit="save">
+    <form id={@id <> "-form"} phx-submit="save-and-sync">
       <.modal
         id={@id}
         show={true}

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2569,6 +2569,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
       refute has_element?(view, "#github-sync-modal")
       render_hook(view, "toggle_github_sync_modal")
       assert has_element?(view, "#github-sync-modal")
+      # modal form exists
+      assert view |> has_element?("form#github-sync-modal-form")
       assert render_async(view) =~ "Save and sync changes to GitHub"
 
       expect_create_installation_token(repo_connection.github_installation_id)

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -2579,7 +2579,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       # submit form
       view
-      |> render_hook("save", %{
+      |> form("#github-sync-modal-form")
+      |> render_submit(%{
         "github_sync" => %{"commit_message" => "some message"}
       })
 
@@ -2667,7 +2668,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       # submit form
       view
-      |> form("#workflow-form")
+      |> form("#github-sync-modal-form")
       |> render_submit(%{"github_sync" => %{"commit_message" => "some message"}})
 
       assert_patched(


### PR DESCRIPTION
## Description

This PR fixes the bug on the github sync modal in the workflow editor. The problem was that the modal was embedded inside the `#workflow-form`, which was always present. This PR creates a stand alone form for the github sync modal.

This PR also increases the priority of the `CtrlShiftS` binding. It was being overridden by `CtrlS`.

Closes #3177

## Validation steps

You need to have Github setup to validate this locally. Check the docs for the needed env vars: https://github.com/OpenFn/lightning/blob/main/DEPLOYMENT.md#github 

In the workflow editor, press `CtrlShiftS` or `CmdShiftS` if you're on mac. The github sync modal will appear.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
