### PR TITLE
Start data retention purge at 130am

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 - Tweak language on webhook auth method modal and list action
   [#3166](https://github.com/OpenFn/lightning/pull/3166)
+- Stagger nightly data retention purge to reduce acute stress on db
+  [3179](https://github.com/OpenFn/lightning/pull/3179)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to
 
 - Tweak language on webhook auth method modal and list action
   [#3166](https://github.com/OpenFn/lightning/pull/3166)
-- Stagger nightly data retention purge to reduce acute stress on db
+- Re-order nightly cron jobs to reduce acute stress on db
   [3179](https://github.com/OpenFn/lightning/pull/3179)
 
 ### Fixed

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -221,7 +221,7 @@ defmodule Lightning.Config.Bootstrap do
        args: %{"type" => "weekly_project_digest"}},
       {"0 10 1 * *", Lightning.DigestEmailWorker,
        args: %{"type" => "monthly_project_digest"}},
-      {"1 2 * * *", Lightning.Projects, args: %{"type" => "data_retention"}},
+      {"30 1 * * *", Lightning.Projects, args: %{"type" => "data_retention"}},
       {"*/10 * * * *", Lightning.KafkaTriggers.DuplicateTrackingCleanupWorker}
     ]
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -163,12 +163,7 @@ defmodule Lightning.Projects do
     jobs =
       list_projects_having_history_retention()
       |> Enum.map(fn project ->
-        delay = :rand.uniform(7_200) - 1
-
-        new(%{project_id: project.id, type: "data_retention"},
-          max_attempts: 3,
-          schedule_in: delay
-        )
+        new(%{project_id: project.id, type: "data_retention"}, max_attempts: 3)
       end)
 
     Oban.insert_all(Lightning.Oban, jobs)

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -163,7 +163,12 @@ defmodule Lightning.Projects do
     jobs =
       list_projects_having_history_retention()
       |> Enum.map(fn project ->
-        new(%{project_id: project.id, type: "data_retention"}, max_attempts: 3)
+        delay = :rand.uniform(7_200) - 1
+
+        new(%{project_id: project.id, type: "data_retention"},
+          max_attempts: 3,
+          schedule_in: delay
+        )
       end)
 
     Oban.insert_all(Lightning.Oban, jobs)


### PR DESCRIPTION
This staggers the data retention purge over a 2 hour period between 2am and 4am UTC.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
