### PR TITLE
Halve the default chunk size, make configurable, delete more frequently

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,6 +175,9 @@
 # If not provided, PURGE_DELETED_AFTER_DAYS defaults to 7. Set to 0 to never purge deleted records.
 # PURGE_DELETED_AFTER_DAYS=7
 
+# If not provided, ACTIVITY_CLEANUP_CHUNK_SIZE defaults to 500.
+# ACTIVITY_CLEANUP_CHUNK_SIZE=500
+
 # To use https://plausible.io/ analytics, provide the SRC for your script and
 # your data-domain below.
 # PLAUSIBLE_SRC=https://plausible.io/js/script.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Make the chunk size for deleting expired activty configurable via ENV
+  [#3181](https://github.com/OpenFn/lightning/pull/3181)
+
 ### Fixed
 
 ## [v2.12.2] - 2025-05-01
@@ -28,7 +31,7 @@ and this project adheres to
 - Tweak language on webhook auth method modal and list action
   [#3166](https://github.com/OpenFn/lightning/pull/3166)
 - Re-order nightly cron jobs to reduce acute stress on db
-  [3179](https://github.com/OpenFn/lightning/pull/3179)
+  [#3179](https://github.com/OpenFn/lightning/pull/3179)
 
 ### Fixed
 

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -425,6 +425,14 @@ defmodule Lightning.Config do
     impl().purge_deleted_after_days()
   end
 
+  def activity_cleanup_chunk_size do
+    impl().activity_cleanup_chunk_size()
+  end
+
+  def default_ecto_database_timeout do
+    impl().default_ecto_database_timeout()
+  end
+
   def check_flag?(flag) do
     impl().check_flag?(flag)
   end

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -93,6 +93,11 @@ defmodule Lightning.Config do
     end
 
     @impl true
+    def activity_cleanup_chunk_size do
+      Application.get_env(:lightning, :activity_cleanup_chunk_size)
+    end
+
+    @impl true
     def get_extension_mod(key) do
       AdapterHelper.adapter(key)
     end
@@ -324,6 +329,7 @@ defmodule Lightning.Config do
   @callback promex_metrics_endpoint_scheme() :: String.t()
   @callback promex_metrics_endpoint_token() :: String.t()
   @callback purge_deleted_after_days() :: integer()
+  @callback activity_cleanup_chunk_size() :: integer()
   @callback repo_connection_token_signer() :: Joken.Signer.t()
   @callback reset_password_token_validity_in_days() :: integer()
   @callback run_token_signer() :: Joken.Signer.t()

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -98,6 +98,11 @@ defmodule Lightning.Config do
     end
 
     @impl true
+    def default_ecto_database_timeout do
+      Application.get_env(:lightning, Lightning.Repo) |> Keyword.get(:timeout)
+    end
+
+    @impl true
     def get_extension_mod(key) do
       AdapterHelper.adapter(key)
     end
@@ -330,6 +335,7 @@ defmodule Lightning.Config do
   @callback promex_metrics_endpoint_token() :: String.t()
   @callback purge_deleted_after_days() :: integer()
   @callback activity_cleanup_chunk_size() :: integer()
+  @callback default_ecto_database_timeout() :: integer()
   @callback repo_connection_token_signer() :: Joken.Signer.t()
   @callback reset_password_token_validity_in_days() :: integer()
   @callback run_token_signer() :: Joken.Signer.t()

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -211,6 +211,14 @@ defmodule Lightning.Config.Bootstrap do
              Utils.get_env([:lightning, :purge_deleted_after_days], 7)
            )
 
+    config :lightning,
+           :activity_cleanup_chunk_size,
+           env!(
+             "ACTIVITY_CLEANUP_CHUNK_SIZE",
+             :integer,
+             Utils.get_env([:lightning, :activity_cleanup_chunk_size], 500)
+           )
+
     base_cron = [
       {"* * * * *", Lightning.Workflows.Scheduler},
       {"* * * * *", ObanPruner},

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -229,7 +229,7 @@ defmodule Lightning.Config.Bootstrap do
        args: %{"type" => "weekly_project_digest"}},
       {"0 10 1 * *", Lightning.DigestEmailWorker,
        args: %{"type" => "monthly_project_digest"}},
-      {"30 1 * * *", Lightning.Projects, args: %{"type" => "data_retention"}},
+      {"*/15 * * * *", Lightning.Projects, args: %{"type" => "data_retention"}},
       {"*/10 * * * *", Lightning.KafkaTriggers.DuplicateTrackingCleanupWorker}
     ]
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -889,7 +889,7 @@ defmodule Lightning.Projects do
       project
       |> project_workorders_query()
       |> delete_workorders_history(
-        Lightning.Config.activity_cleanup_chunk_size(),
+        Config.activity_cleanup_chunk_size(),
         period_days
       )
 
@@ -909,7 +909,7 @@ defmodule Lightning.Projects do
 
     delete_dataclips(
       dataclips_query,
-      Lightning.Config.activity_cleanup_chunk_size()
+      Config.activity_cleanup_chunk_size()
     )
 
     :ok

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -887,7 +887,7 @@ defmodule Lightning.Projects do
     :ok =
       project
       |> project_workorders_query()
-      |> delete_workorders_history(1000, period_days)
+      |> delete_workorders_history(500, period_days)
 
     dataclips_query =
       from d in Dataclip,

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -13,6 +13,7 @@ defmodule Lightning.Projects do
   alias Lightning.Accounts.User
   alias Lightning.Accounts.UserNotifier
   alias Lightning.Accounts.UserToken
+  alias Lightning.Config
   alias Lightning.ExportUtils
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Step
@@ -887,7 +888,10 @@ defmodule Lightning.Projects do
     :ok =
       project
       |> project_workorders_query()
-      |> delete_workorders_history(500, period_days)
+      |> delete_workorders_history(
+        Lightning.Config.activity_cleanup_chunk_size(),
+        period_days
+      )
 
     dataclips_query =
       from d in Dataclip,
@@ -903,7 +907,10 @@ defmodule Lightning.Projects do
         where: is_nil(wo.id) and is_nil(r.id) and is_nil(s.id),
         select: d.id
 
-    delete_dataclips(dataclips_query, 1000)
+    delete_dataclips(
+      dataclips_query,
+      Lightning.Config.activity_cleanup_chunk_size()
+    )
 
     :ok
   end
@@ -955,7 +962,7 @@ defmodule Lightning.Projects do
           {_count, _} =
             Repo.delete_all(workorders_delete_query, returning: false)
         end,
-        timeout: 50_000
+        timeout: Config.default_ecto_database_timeout() * 3
       )
     end
 
@@ -1019,7 +1026,7 @@ defmodule Lightning.Projects do
       {_count, _dataclips} =
         Repo.delete_all(dataclips_delete_query,
           returning: false,
-          timeout: 20_000
+          timeout: Config.default_ecto_database_timeout() * 2
         )
     end
 


### PR DESCRIPTION
@jyeshe , how does this look?

1. We say we don't keep data for more than 7 days, but when we only run once a day we could actually keep data for 7 days and 23 hours! This is fixed by running it every 15 min.
2. We shrink the chunk size by default from 1000 to 500
3. We make the chunk size configurable via ENV