### PR TITLE
Delay purge user having project file(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to
 
 ### Fixed
 
+- Delay purge user having project file(s)
+  [#2919](https://github.com/OpenFn/lightning/issues/2919)
+
 ## [v2.12.2] - 2025-05-01
 
 ### Changed

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -18,7 +18,7 @@ defmodule Lightning.Accounts do
   alias Lightning.Accounts.UserToken
   alias Lightning.Accounts.UserTOTP
   alias Lightning.Credentials
-  alias Lightning.Projects.File
+  alias Lightning.Projects
   alias Lightning.Repo
   alias Lightning.Services.AccountHook
 
@@ -69,28 +69,24 @@ defmodule Lightning.Accounts do
   """
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"type" => "purge_deleted"}}) do
-    users_with_activities =
-      from(run in Lightning.Run,
-        join: user in User,
-        on: run.created_by_id == user.id,
-        select: user.id,
-        distinct: true
-      )
-
-    users_with_files =
-      from(file in File,
-        join: user in User,
-        on: file.created_by_id == user.id,
-        select: user.id,
-        distinct: true
-      )
-
     users_to_delete =
       from(u in User,
+        as: :user,
+        where: u.scheduled_deletion <= ago(0, "second"),
         where:
-          u.scheduled_deletion <= ago(0, "second") and
-            u.id not in subquery(users_with_activities) and
-            u.id not in subquery(users_with_files)
+          not exists(
+            from(r in Lightning.Run,
+              where: parent_as(:user).id == r.created_by_id,
+              select: 1
+            )
+          ),
+        where:
+          not exists(
+            from(f in Projects.File,
+              where: parent_as(:user).id == f.created_by_id,
+              select: 1
+            )
+          )
       )
       |> Repo.all()
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -891,7 +891,9 @@ defmodule Lightning.Projects do
       )
       |> Repo.all()
       |> Enum.each(fn %{path: object_path} = project_file ->
-        with {:ok, _res} <- Lightning.Storage.delete(object_path) do
+        result = Lightning.Storage.delete(object_path)
+
+        if match?({:ok, _res}, result) or match?({:error, %{status: 404}}, result) do
           Repo.delete(project_file)
         end
       end)

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -893,7 +893,8 @@ defmodule Lightning.Projects do
       |> Enum.each(fn %{path: object_path} = project_file ->
         result = Lightning.Storage.delete(object_path)
 
-        if match?({:ok, _res}, result) or match?({:error, %{status: 404}}, result) do
+        if match?({:ok, _res}, result) or
+             match?({:error, %{status: 404}}, result) do
           Repo.delete(project_file)
         end
       end)

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -17,9 +17,9 @@ defmodule Lightning.Projects do
   alias Lightning.ExportUtils
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Step
+  alias Lightning.Projects
   alias Lightning.Projects.Audit
   alias Lightning.Projects.Events
-  alias Lightning.Projects.File
   alias Lightning.Projects.Project
   alias Lightning.Projects.ProjectCredential
   alias Lightning.Projects.ProjectUser
@@ -885,7 +885,7 @@ defmodule Lightning.Projects do
          history_retention_period: period
        }) do
     if not is_nil(period) do
-      from(f in File,
+      from(f in Projects.File,
         where:
           f.project_id == ^project_id and f.inserted_at < ago(^period, "day")
       )
@@ -1194,7 +1194,7 @@ defmodule Lightning.Projects do
   def list_project_files(%Project{id: project_id}, opts \\ []) do
     sort_order = Keyword.get(opts, :sort, :desc)
 
-    from(pf in File,
+    from(pf in Projects.File,
       where: pf.project_id == ^project_id,
       order_by: [{^sort_order, pf.inserted_at}],
       preload: [:created_by]

--- a/lib/lightning/storage.ex
+++ b/lib/lightning/storage.ex
@@ -13,6 +13,11 @@ defmodule Lightning.Storage do
   end
 
   @impl true
+  def delete(path) do
+    adapter().delete(path)
+  end
+
+  @impl true
   def get_url(path) do
     adapter().get_url(path)
   end

--- a/lib/lightning/storage/backend.ex
+++ b/lib/lightning/storage/backend.ex
@@ -4,5 +4,8 @@ defmodule Lightning.Storage.Backend do
   """
   @callback store(source :: String.t(), dest :: String.t()) ::
               {:ok, any()} | {:error, any()}
+
+  @callback delete(object_path :: String.t()) :: {:ok, any()} | {:error, any()}
+
   @callback get_url(String.t()) :: {:ok, String.t()} | {:error, any()}
 end

--- a/lib/lightning/storage/gcs.ex
+++ b/lib/lightning/storage/gcs.ex
@@ -41,6 +41,15 @@ defmodule Lightning.Storage.GCS do
   end
 
   @impl true
+  def delete(object_path) do
+    Objects.storage_objects_delete(
+      conn(),
+      bucket!(),
+      object_path
+    )
+  end
+
+  @impl true
   def get_url(path) do
     client =
       Lightning.Config.google(:credentials)

--- a/lib/lightning/storage/local.ex
+++ b/lib/lightning/storage/local.ex
@@ -31,13 +31,24 @@ defmodule Lightning.Storage.Local do
 
   @impl true
   def store(source_path, destination_path) do
-    destination_path = Path.join(storage_dir!(), destination_path)
-    destination_dir = Path.dirname(destination_path)
-    File.mkdir_p!(destination_dir)
+    write_path =
+      Path.join(storage_dir!(), destination_path)
+      |> tap(fn path ->
+        path
+        |> Path.dirname()
+        |> File.mkdir_p!()
+      end)
 
-    File.cp!(source_path, destination_path)
+    File.cp!(source_path, write_path)
 
-    {:ok, Path.basename(destination_path)}
+    {:ok, destination_path}
+  end
+
+  @impl true
+  def delete(object_path) do
+    local_path = Path.join(storage_dir!(), object_path)
+
+    with :ok <- File.rm(local_path), do: {:ok, nil}
   end
 
   @impl true

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -6,7 +6,6 @@ defmodule Lightning.WebAndWorkerTest do
   import Lightning.Factories
   import Mox
 
-  alias Lightning.Run
   alias Lightning.Runs
   alias Lightning.Runs.Events
   alias Lightning.Invocation
@@ -14,8 +13,6 @@ defmodule Lightning.WebAndWorkerTest do
   alias Lightning.Runtime.RuntimeManager
   alias Lightning.WorkOrders
   alias Lightning.Workflows.Snapshot
-
-  require Run
 
   setup :set_mox_from_context
   setup :verify_on_exit!

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1477,9 +1477,16 @@ defmodule Lightning.ProjectsTest do
 
       more_days_ago = Date.utc_today() |> Date.add(-8)
 
+      File.write!("ficheiro", "some-content")
+      on_exit(fn -> File.rm!("ficheiro") end)
+
+      {:ok, path} =
+        Lightning.Storage.store("ficheiro", "/bucket_subdir/ficheiro")
+
       project_file1 =
         insert(:project_file,
           project: project,
+          path: path,
           inserted_at: DateTime.new!(more_days_ago, ~T[00:00:00])
         )
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1470,6 +1470,27 @@ defmodule Lightning.ProjectsTest do
       assert dataclip.body === %{"team" => "senegal"}
       assert is_nil(dataclip.wiped_at)
     end
+
+    test "deletes project files past the retention period" do
+      project =
+        insert(:project, history_retention_period: 7)
+
+      more_days_ago = Date.utc_today() |> Date.add(-8)
+
+      project_file1 =
+        insert(:project_file,
+          project: project,
+          inserted_at: DateTime.new!(more_days_ago, ~T[00:00:00])
+        )
+
+      project_file2 =
+        insert(:project_file, project: project)
+
+      :ok = Projects.perform(%Oban.Job{args: %{"type" => "data_retention"}})
+
+      refute Repo.get(Projects.File, project_file1.id)
+      assert Repo.get(Projects.File, project_file2.id)
+    end
   end
 
   describe "invite_collaborators/3" do

--- a/test/lightning/usage_tracking/run_service_test.exs
+++ b/test/lightning/usage_tracking/run_service_test.exs
@@ -1,10 +1,7 @@
 defmodule Lightning.UsageTracking.RunServiceTest do
   use Lightning.DataCase, async: true
 
-  alias Lightning.Run
   alias Lightning.UsageTracking.RunService
-
-  require Run
 
   @date ~D[2024-02-05]
   @finished_at ~U[2024-02-05 12:11:10Z]


### PR DESCRIPTION
## Description

This PR changes the `purge-user` to postpone it for users having a project file. The project file is retained until the `history_retention_period` and after it's deleted the user will be deleted on the next scheduled job.

Closes #2919 

## Validation steps

* The real validation will be on Staging with GCS and there is a test cases for delaying the purging of a user with a project file and another for deleting the file on storage and on database when file expires.  

Without the same value as staging locally you can try to:
1. Create a work orders export
2. Try to purge this user 
3. When cron job runs it won't delete the user
4. Set the project file inserted_at to a expired date
5. Force the project "data_retention" job to run
6. It deletes the file (and the database record)
7. Force the accounts "purge_user" job to run
8. It deletes the user   

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
