### PR TITLE
Broadcast `work-available` to worker when runs are enqueued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Broadcast work-available to worker when runs are enqueued
+  [#2934](https://github.com/OpenFn/lightning/issues/2934)
+
 ### Changed
 
 - Update Elixir to 1.18.3 [#2748](https://github.com/OpenFn/lightning/pull/2748)

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -121,6 +121,7 @@ defmodule Lightning.Application do
         auth_providers_cache_childspec,
         # Start the Endpoint (http/https)
         LightningWeb.Endpoint,
+        LightningWeb.WorkAvailable,
         Lightning.Workflows.Presence,
         adaptor_registry_childspec,
         adaptor_service_childspec,

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -50,6 +50,8 @@ defmodule Lightning.Projects do
     ]
   end
 
+  defdelegate subscribe, to: Events
+
   def get_projects_overview(user, opts \\ [])
 
   def get_projects_overview(%User{id: user_id, support_user: true}, opts) do

--- a/lib/lightning_web/channels/work_available.ex
+++ b/lib/lightning_web/channels/work_available.ex
@@ -1,0 +1,77 @@
+defmodule LightningWeb.WorkAvailable do
+  @moduledoc """
+  Updates workers in the `worker:queue` channnel when there are runs to be executed
+  """
+
+  defmodule State do
+    @moduledoc false
+    defstruct [:debounce_time_ms, :debounce_timer_ref]
+  end
+
+  use GenServer
+
+  alias Lightning.Projects
+  alias Lightning.WorkOrders
+
+  @debounce_time_ms 500
+
+  def start_link(opts) do
+    {name, _rest} = Keyword.pop(opts, :name, __MODULE__)
+
+    {debounce_time_ms, _rest} =
+      Keyword.pop(opts, :debounce_time_ms, @debounce_time_ms)
+
+    state = %State{debounce_time_ms: debounce_time_ms}
+
+    GenServer.start_link(__MODULE__, state, name: name)
+  end
+
+  @impl true
+  def init(state) do
+    {:ok, state, {:continue, :subscribe}}
+  end
+
+  @impl true
+  def handle_continue(:subscribe, state) do
+    # subscribe to run created events
+    Projects.list_projects()
+    |> Enum.each(fn project -> WorkOrders.subscribe(project.id) end)
+
+    # subscribe to project created events
+    Projects.subscribe()
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:notify_work_available, %State{} = state) do
+    LightningWeb.Endpoint.broadcast("worker:queue", "work-available", %{})
+
+    {:noreply, %{state | debounce_timer_ref: nil}}
+  end
+
+  def handle_info(%Projects.Events.ProjectCreated{project: project}, state) do
+    WorkOrders.subscribe(project.id)
+
+    {:noreply, state}
+  end
+
+  def handle_info(%WorkOrders.Events.RunCreated{}, %State{} = state) do
+    {:noreply, maybe_start_debounce_timer(state)}
+  end
+
+  def handle_info(_other_events, state) do
+    {:noreply, state}
+  end
+
+  defp maybe_start_debounce_timer(%State{} = state) do
+    if is_nil(state.debounce_timer_ref) do
+      {:ok, ref} =
+        :timer.send_after(state.debounce_time_ms, self(), :notify_work_available)
+
+      %{state | debounce_timer_ref: ref}
+    else
+      state
+    end
+  end
+end

--- a/test/lightning_web/channels/work_available_test.exs
+++ b/test/lightning_web/channels/work_available_test.exs
@@ -1,0 +1,109 @@
+defmodule LightningWeb.WorkAvailableTest do
+  use LightningWeb.ChannelCase, async: false
+
+  import Lightning.Factories
+
+  alias Lightning.Projects
+  alias Lightning.WorkOrders
+  alias Lightning.Workers
+
+  # this ensures the WorkAvailable server inherits the mox stubs
+  setup :set_mox_from_context
+
+  setup do
+    stub_with(
+      Lightning.Extensions.MockProjectHook,
+      Lightning.Extensions.ProjectHook
+    )
+
+    {:ok, bearer, claims} =
+      Workers.WorkerToken.generate_and_sign(
+        %{},
+        Lightning.Config.worker_token_signer()
+      )
+
+    socket =
+      LightningWeb.WorkerSocket
+      |> socket("socket_id", %{token: bearer, claims: claims})
+
+    {:ok, _, socket} =
+      socket |> subscribe_and_join(LightningWeb.WorkerChannel, "worker:queue")
+
+    %{socket: socket}
+  end
+
+  test "message is sent when a run from an existing project is created",
+       %{test: test} do
+    # project is created before starting the server
+    project = insert(:project)
+
+    %{triggers: [trigger]} =
+      workflow = insert(:simple_workflow, project: project) |> with_snapshot()
+
+    start_supervised!(
+      {LightningWeb.WorkAvailable, [name: test, debounce_time_ms: 0]}
+    )
+
+    {:ok, %{runs: [_run]}} =
+      WorkOrders.create_for(trigger,
+        workflow: workflow,
+        dataclip: params_with_assocs(:dataclip)
+      )
+
+    assert_push "work-available", %{}
+  end
+
+  test "message is sent out when a run from a new project is created",
+       %{test: test} do
+    start_supervised!(
+      {LightningWeb.WorkAvailable, [name: test, debounce_time_ms: 0]}
+    )
+
+    user = insert(:user)
+
+    # We're creating a project after starting the server
+    {:ok, project} =
+      Projects.create_project(%{
+        name: "some-random-project",
+        project_users: [%{role: :owner, user_id: user.id}]
+      })
+
+    %{triggers: [trigger]} =
+      workflow = insert(:simple_workflow, project: project) |> with_snapshot()
+
+    {:ok, %{runs: [_run]}} =
+      WorkOrders.create_for(trigger,
+        workflow: workflow,
+        dataclip: params_with_assocs(:dataclip)
+      )
+
+    assert_push "work-available", %{}
+  end
+
+  test "message is sent out within the specified debounce time once even if multiple runs are created",
+       %{test: test} do
+    project = insert(:project)
+
+    %{triggers: [trigger]} =
+      workflow = insert(:simple_workflow, project: project) |> with_snapshot()
+
+    debounce_time = 50
+
+    start_supervised!(
+      {LightningWeb.WorkAvailable, [name: test, debounce_time_ms: debounce_time]}
+    )
+
+    for _i <- 1..10 do
+      {:ok, %{runs: [_run]}} =
+        WorkOrders.create_for(trigger,
+          workflow: workflow,
+          dataclip: params_with_assocs(:dataclip)
+        )
+    end
+
+    assert_push "work-available", %{}
+
+    # no other message out
+    refute_push "work-available", %{}, debounce_time + 5
+  end
+end


### PR DESCRIPTION
## Description

This PR sends out `work-available` to workers when new runs have been created

Closes #2934 

## Validation steps

Hmm, not quite sure

## Additional notes for the reviewer

The tests are `sync: false` because I kept running into problems with `Ecto.Adaptor.Sandbox`. The Genserver accesses the db when started and it seemed not use the shared mode.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
