### PR TITLE
same search

### DIFF
--- a/lib/lightning_web/live/workflow_live/new_manual_run.ex
+++ b/lib/lightning_web/live/workflow_live/new_manual_run.ex
@@ -110,11 +110,10 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
   end
 
   defp parse_id_prefix(text) do
-    with {_num, ""} <- Integer.parse(text, 16),
-         0 <- rem(String.length(text), 2) do
+    if String.match?(text, ~r/^[0-9a-fA-F]+$/) do
       {:ok, {:id_prefix, text}}
     else
-      _invalid -> {:error, :invalid_uuid}
+      {:error, :invalid_uuid}
     end
   end
 end


### PR DESCRIPTION
@doc-han , can you test this out and let me know if the dataclip UUID search is behaving the way you'd expect now?

cc @stuartc , if you have more context on why Roger set up the search differently from the partial UUID search on the history page, please let me know! this is basically a copy paste from how we search for runs, steps, and workorders by parts of their UUIDs.