### PR TITLE
fix monaco sizing

### DIFF
--- a/assets/js/manual-run-panel/views/CustomView.tsx
+++ b/assets/js/manual-run-panel/views/CustomView.tsx
@@ -58,7 +58,7 @@ const CustomView: React.FC<{
         <span className="bg-white px-2 text-sm text-gray-500">OR</span>
       </div>
     </div>
-    <div className="relative h-full flex flex-col">
+    <div className="relative h-full flex flex-col overflow-hidden">
       {
         !isEmpty && !jsonParseResult.success ?
           (
@@ -68,30 +68,28 @@ const CustomView: React.FC<{
             </div>
           ) : null
       }
-      <div className="grow">
-        <MonacoEditor
-          defaultLanguage="json"
-          theme="default"
-          value={editorValue}
-          onChange={handleEditorChange}
-          loading={<div>Loading...</div>}
-          options={{
-            readOnly: false,
-            lineNumbersMinChars: 3,
-            tabSize: 2,
-            scrollBeyondLastLine: false,
-            overviewRulerLanes: 0,
-            overviewRulerBorder: false,
-            fontFamily: 'Fira Code VF',
-            fontSize: 14,
-            fontLigatures: true,
-            minimap: {
-              enabled: false,
-            },
-            wordWrap: 'on',
-          }}
-        />
-      </div>
+      <MonacoEditor
+        defaultLanguage="json"
+        theme="default"
+        value={editorValue}
+        onChange={handleEditorChange}
+        loading={<div>Loading...</div>}
+        options={{
+          readOnly: false,
+          lineNumbersMinChars: 3,
+          tabSize: 2,
+          scrollBeyondLastLine: false,
+          overviewRulerLanes: 0,
+          overviewRulerBorder: false,
+          fontFamily: 'Fira Code VF',
+          fontSize: 14,
+          fontLigatures: true,
+          minimap: {
+            enabled: false,
+          },
+          wordWrap: 'on',
+        }}
+      />
     </div>
   </>
 };


### PR DESCRIPTION
Fix Monaco so that:
1) Does not infinitely grow
2) Shrinks when its parent panel shrinks

`overflow-hidden` is the thing, because it tells  monaco's parent not to size to its children

I used https://github.com/OpenFn/lightning/pull/2126 as inspiration