### PR TITLE
Consideration for the byte search concept

### DIFF
--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -88,7 +88,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
                 }}
                 type="text"
                 className="focus:outline focus:outline-2 focus:-outline-offset-2 focus:ring-0  disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 border-slate-300 focus:border-slate-400 focus:outline-indigo-600 block w-full rounded-md border-0 py-1.5 pl-10 pr-20 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400  focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                placeholder="Search for inputs by UUID"
+                placeholder="Search by UUID (starts with)"
               />
               <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
                 <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
@@ -240,9 +240,12 @@ const ExistingView: React.FC<ExistingViewProps> = ({
             No dataclips match the filter.
           </div>
         )}
-        <div className="text-center text-xs">
-          (Search results are limited to the 10 most recent matches for this step.)
-        </div>
+        {dataclips.length ? (
+          <div className="text-center text-sm">
+            Search results are limited to the 10 most recent matches for this
+            step.
+          </div>
+        ) : null}
       </div>
     </>
   );

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -67,10 +67,16 @@ defmodule Lightning.Invocation do
     filters =
       Enum.reduce(filters, dynamic(true), fn
         {:id, uuid}, dynamic ->
-          dynamic([d], ^dynamic and like(type(d.id, :string), ^"%#{uuid}%"))
+          dynamic([d], ^dynamic and d.id == ^uuid)
 
         {:id_prefix, id_prefix}, dynamic ->
-          dynamic([d], ^dynamic and like(type(d.id, :string), ^"%#{id_prefix}%"))
+          {id_prefix_start, id_prefix_end} =
+            id_prefix_interval(id_prefix)
+
+          dynamic(
+            [d],
+            ^dynamic and d.id > ^id_prefix_start and d.id < ^id_prefix_end
+          )
 
         {:type, type}, dynamic ->
           dynamic([d], ^dynamic and d.type == ^type)
@@ -91,6 +97,7 @@ defmodule Lightning.Invocation do
     |> where([d], ^filters)
     |> then(fn query -> if offset, do: query, else: offset(query, ^offset) end)
     |> Repo.all()
+    |> maybe_filter_uuid_prefix(filters)
   end
 
   @spec get_dataclip_details!(id :: Ecto.UUID.t()) :: Dataclip.t()
@@ -744,5 +751,44 @@ defmodule Lightning.Invocation do
       )
     end)
     |> Repo.transaction()
+  end
+
+  @uuid_binary_size 16
+
+  defp id_prefix_interval(id_prefix) do
+    prefix_bin =
+      id_prefix
+      |> String.to_charlist()
+      |> Enum.chunk_every(2)
+      |> Enum.reduce(<<>>, fn
+        [_single_char], prefix_bin ->
+          prefix_bin
+
+        byte_list, prefix_bin ->
+          byte_int = byte_list |> :binary.list_to_bin() |> String.to_integer(16)
+          prefix_bin <> <<byte_int>>
+      end)
+
+    prefix_size = byte_size(prefix_bin)
+    missing_byte_size = @uuid_binary_size - prefix_size
+
+    {
+      Ecto.UUID.load!(prefix_bin <> :binary.copy(<<0>>, missing_byte_size)),
+      Ecto.UUID.load!(prefix_bin <> :binary.copy(<<255>>, missing_byte_size))
+    }
+  end
+
+  # A pair of hex chars on UUID strings comprise a byte on UUID binary
+  # Searching by prefix with an odd number of chars (not in pairs) requires
+  # additional filtering once you can't filter half of a byte on the database
+  # using > or < operators
+  defp maybe_filter_uuid_prefix(dataclips, filters) do
+    case Map.get(filters, :id_prefix, "") do
+      id_prefix when rem(byte_size(id_prefix), 2) == 1 ->
+        Enum.filter(dataclips, &String.starts_with?(&1.id, id_prefix))
+
+      _ ->
+        dataclips
+    end
   end
 end

--- a/lib/lightning_web/live/workflow_live/new_manual_run.ex
+++ b/lib/lightning_web/live/workflow_live/new_manual_run.ex
@@ -110,10 +110,11 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
   end
 
   defp parse_id_prefix(text) do
-    if String.match?(text, ~r/^[0-9a-fA-F]+$/) do
+    with {_num, ""} <- Integer.parse(text, 16),
+         0 <- rem(String.length(text), 2) do
       {:ok, {:id_prefix, text}}
     else
-      {:error, :invalid_uuid}
+      _invalid -> {:error, :invalid_uuid}
     end
   end
 end

--- a/lib/lightning_web/live/workflow_live/new_manual_run.ex
+++ b/lib/lightning_web/live/workflow_live/new_manual_run.ex
@@ -110,10 +110,8 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
   end
 
   defp parse_id_prefix(text) do
-    with {_num, ""} <- Integer.parse(text, 16),
-         0 <- rem(String.length(text), 2) do
-      {:ok, {:id_prefix, text}}
-    else
+    case Integer.parse(text, 16) do
+      {_num, ""} -> {:ok, {:id_prefix, text}}
       _invalid -> {:error, :invalid_uuid}
     end
   end


### PR DESCRIPTION
@jyeshe , I'm interested in the byte search idea (reverted back to it here) but i'd want to see an implementation where '7d4' doesn't match '7d866f02'.

These "false positives" were enough for me to revert to the standard UUID search we use on the history page (which does partial string matching quite nicely.) Note the failing test here. I created it to help showcase the false positives.

`mix test test/lightning/invocation_test.exs`

I don't think it's high priority right now, but if @theroinaochieng and @stuartc are interested in following this thread when you're back online, they might consider an implementation like this for all of our UUID searching. Note that right now, UUID search on History is, weirdly, only for runs, steps, and work orders. AFAIK there isn't UUID search for data clips, and your implementation here could be a handy way to standardize all that stuff.