### PR TITLE
it's ok to not have a filter

### DIFF
--- a/lib/lightning_web/live/workflow_live/new_manual_run.ex
+++ b/lib/lightning_web/live/workflow_live/new_manual_run.ex
@@ -56,10 +56,11 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
       params,
       [:before, :after, :type, :query]
     )
-    |> Lightning.Validators.validate_one_required(
-      [:query, :before, :after, :type],
-      "at least one filter is required"
-    )
+    # TODO - figure out why this was added.
+    # |> Lightning.Validators.validate_one_required(
+    #   [:query, :before, :after, :type],
+    #   "at least one filter is required"
+    # )
     |> then(fn changeset ->
       query = Ecto.Changeset.get_field(changeset, :query)
 


### PR DESCRIPTION
not sure if this is the fix, but it seems to highlight and solve the problem here: since https://github.com/OpenFn/lightning/commit/214e8363f4ba0fb8ab01072e7b6ce3f19da09ddc, when no filters are added, we see zero results instead of all the results