### PR TITLE
3226 reduce lost runs cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   [#2905](https://github.com/OpenFn/lightning/issues/2905)
 - Make the chunk size for deleting expired activty configurable via ENV
   [#3181](https://github.com/OpenFn/lightning/pull/3181)
+- Reduce the cardinality of `lightning_run_lost_count`.
+  [#3226](https://github.com/OpenFn/lightning/issues/3226)
 
 ### Fixed
 

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -294,7 +294,7 @@ defmodule Lightning.Runs do
 
   @spec mark_run_lost(Lightning.Run.t()) ::
           {:ok, any()} | {:error, any()}
-  def mark_run_lost(%Run{worker_name: worker_name} = run) do
+  def mark_run_lost(%Run{} = run) do
     error_type =
       case run.state do
         :claimed -> "LostAfterClaim"
@@ -302,7 +302,7 @@ defmodule Lightning.Runs do
         _other -> "UnknownReason"
       end
 
-    PromExPlugin.fire_lost_run_event(worker_name, run.state)
+    PromExPlugin.fire_lost_run_event()
 
     Logger.warning(fn ->
       "Detected lost run with reason #{error_type}: #{inspect(run)}"

--- a/lib/lightning/runs/prom_ex_plugin.ex
+++ b/lib/lightning/runs/prom_ex_plugin.ex
@@ -53,29 +53,22 @@ defmodule Lightning.Runs.PromExPlugin do
           Metrics.counter(
             @lost_run_event ++ [:count],
             description: "A counter of lost runs.",
-            tags: [:seed_event, :state, :worker_name]
+            tags: []
           )
         ]
       )
     ]
   end
 
-  def seed_event_metrics, do: fire_lost_run_event(nil, nil, true)
+  def seed_event_metrics, do: fire_lost_run_event()
 
-  def fire_lost_run_event(worker_name, state, seed_event \\ false) do
+  def fire_lost_run_event do
     :telemetry.execute(
       @lost_run_event,
       %{count: 1},
-      %{
-        seed_event: seed_event,
-        state: state |> nil_to_na() |> to_string(),
-        worker_name: worker_name |> nil_to_na()
-      }
+      %{}
     )
   end
-
-  defp nil_to_na(nil), do: "n/a"
-  defp nil_to_na(value), do: value
 
   @impl true
   def polling_metrics(opts) do

--- a/test/lightning/prom_ex_test.exs
+++ b/test/lightning/prom_ex_test.exs
@@ -98,7 +98,7 @@ defmodule Lightning.PromExTest do
       ^lost_runs_count_event,
       ^ref,
       %{count: 1},
-      %{seed_event: true}
+      %{}
     }
   end
 

--- a/test/lightning/runs/prom_ex_plugin_test.exs
+++ b/test/lightning/runs/prom_ex_plugin_test.exs
@@ -62,7 +62,7 @@ defmodule Lightning.Runs.PromExPluginText do
 
       assert metric.description == "A counter of lost runs."
       assert metric.event_name == [:lightning, :run, :lost]
-      assert metric.tags == [:seed_event, :state, :worker_name]
+      assert metric.tags == []
     end
 
     def find_event_metric(metrics, metric_name) do
@@ -602,7 +602,7 @@ defmodule Lightning.Runs.PromExPluginText do
         ^event,
         ^ref,
         %{count: 1},
-        %{seed_event: true, state: "n/a", worker_name: "n/a"}
+        %{}
       }
     end
   end
@@ -615,111 +615,21 @@ defmodule Lightning.Runs.PromExPluginText do
 
       %{
         event: event,
-        ref: ref,
-        state: :claimed,
-        state_as_string: "claimed",
-        worker_name: "worker_1"
+        ref: ref
       }
     end
 
-    test "defaults to a non-seed event", %{
+    test "fires a lost run event", %{
       event: event,
-      ref: ref,
-      state: state,
-      state_as_string: state_as_string,
-      worker_name: worker_name
+      ref: ref
     } do
-      Lightning.Runs.PromExPlugin.fire_lost_run_event(worker_name, state)
+      Lightning.Runs.PromExPlugin.fire_lost_run_event()
 
       assert_received {
         ^event,
         ^ref,
         %{count: 1},
-        %{seed_event: false, state: ^state_as_string, worker_name: ^worker_name}
-      }
-    end
-
-    test "can set a seed event", %{
-      event: event,
-      ref: ref,
-      state: state,
-      state_as_string: state_as_string,
-      worker_name: worker_name
-    } do
-      Lightning.Runs.PromExPlugin.fire_lost_run_event(worker_name, state, true)
-
-      assert_received {
-        ^event,
-        ^ref,
-        %{count: 1},
-        %{seed_event: true, state: ^state_as_string, worker_name: ^worker_name}
-      }
-    end
-
-    test "can set a non-seed event", %{
-      event: event,
-      ref: ref,
-      state: state,
-      state_as_string: state_as_string,
-      worker_name: worker_name
-    } do
-      Lightning.Runs.PromExPlugin.fire_lost_run_event(worker_name, state, false)
-
-      assert_received {
-        ^event,
-        ^ref,
-        %{count: 1},
-        %{seed_event: false, state: ^state_as_string, worker_name: ^worker_name}
-      }
-    end
-
-    test "converts a nil worker name", %{
-      event: event,
-      ref: ref,
-      state: state,
-      state_as_string: state_as_string
-    } do
-      Lightning.Runs.PromExPlugin.fire_lost_run_event(nil, state)
-
-      assert_received {
-        ^event,
-        ^ref,
-        %{count: 1},
-        %{seed_event: false, state: ^state_as_string, worker_name: "n/a"}
-      }
-    end
-
-    test "converts a nil state", %{
-      event: event,
-      ref: ref,
-      worker_name: worker_name
-    } do
-      Lightning.Runs.PromExPlugin.fire_lost_run_event(worker_name, nil)
-
-      assert_received {
-        ^event,
-        ^ref,
-        %{count: 1},
-        %{seed_event: false, state: "n/a", worker_name: ^worker_name}
-      }
-    end
-
-    test "accepts a state that is a string", %{
-      event: event,
-      ref: ref,
-      state_as_string: state_as_string,
-      worker_name: worker_name
-    } do
-      Lightning.Runs.PromExPlugin.fire_lost_run_event(
-        worker_name,
-        state_as_string
-      )
-
-      assert_received {
-        ^event,
-        ^ref,
-        %{count: 1},
-        %{seed_event: false, state: ^state_as_string, worker_name: ^worker_name}
+        %{}
       }
     end
   end

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -969,7 +969,7 @@ defmodule Lightning.RunsTest do
         ^lost_run_event,
         ^ref,
         %{count: 1},
-        %{seed_event: false, state: "started", worker_name: ^worker_name}
+        %{}
       }
     end
   end


### PR DESCRIPTION
## Description

This removes all the labels ('tags') on the `run_lost_count` metric to reduce cardinality of the metric as the high-cardinality and low-frequency of these events creates undesirable behaviour when ingested by GMP (full details in issue).

Closes #3226 

## Validation steps

- Start Lightning with `PROMEX_ENABLED=true`, `PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=no` and `PROMEX_ENDPOINT_SCHEME=http`.
- Browse to the [metrics endpoint](http://localhost:4000/metrics).
- Search for `lightning_run_lost_count` - it should have a value of 1:

![image](https://github.com/user-attachments/assets/5970a147-0249-4a3c-8e2e-539159cd98f4)

- From an IEx session, run `Lightning.Runs.PromExPlugin.fire_lost_run_event` a few times.
- Refresh the metrics endpoint - `lightning_run_lost_count` should have incremented by the number of times, you executed the above instruction:

![image](https://github.com/user-attachments/assets/85a316bc-d728-44c6-a37f-02664f5599be)


## Additional notes for the reviewer

The compass, gunpowder, papermaking and printing are collectively known as 'The Four Great Inventions' and all originated from Ancient China.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
