### PR TITLE
Optimize claim query performance

### DIFF
--- a/priv/repo/migrations/20250506111933_add_workflows_indexes.exs
+++ b/priv/repo/migrations/20250506111933_add_workflows_indexes.exs
@@ -1,0 +1,8 @@
+defmodule Lightning.Repo.Migrations.AddWorkflowsIndexes do
+  use Ecto.Migration
+
+  def change do
+    create index(:work_orders, [:snapshot_id])
+    create index(:workflows, [:project_id])
+  end
+end

--- a/priv/repo/migrations/20250506111933_add_workflows_indexes.exs
+++ b/priv/repo/migrations/20250506111933_add_workflows_indexes.exs
@@ -1,8 +1,0 @@
-defmodule Lightning.Repo.Migrations.AddWorkflowsIndexes do
-  use Ecto.Migration
-
-  def change do
-    create index(:work_orders, [:snapshot_id])
-    create index(:workflows, [:project_id])
-  end
-end

--- a/priv/repo/migrations/20250506111934_add_runs_available_covering_index.exs
+++ b/priv/repo/migrations/20250506111934_add_runs_available_covering_index.exs
@@ -1,0 +1,18 @@
+defmodule Lightning.Repo.Migrations.AddRunsAvailableCoveringIndex do
+  use Ecto.Migration
+
+  def change do
+    # TODO - confirm that we have all these...
+    # create index(:work_orders, [:snapshot_id])
+    # create index(:workflows, [:project_id])
+    # create index(:runs, [:state, :inserted_at])
+    # create index(:runs, [:work_order_id])
+    # create index(:work_orders, [:workflow_id, :project_id])
+
+    create index(:runs, [:state, :inserted_at],
+             include: [:work_order_id],
+             where: "state = 'available'",
+             name: :runs_available_covering_idx
+           )
+  end
+end


### PR DESCRIPTION
@stuartc , @jyeshe , here's the concept from Cursor to discuss today

Optimize eligible_for_claim query performance

The query was taking too long with large queues (>1000 runs). Changes:

1. Simplified query structure:
   - Removed expensive window function that was calculating row numbers for all runs
   - Replaced multiple subqueries with a single in-progress count query
   - Eliminated redundant joins and intermediate result sets
   - Maintains strict FIFO ordering by inserted_at across all workflows/projects

2. Added covering index on runs table for available runs:
   - Partial index (WHERE state = 'available')
   - Includes work_order_id to avoid table lookups
   - Ordered by inserted_at for efficient oldest-first retrieval

This ensures runs are processed in strict chronological order while significantly improving query performance.