### PR TITLE
Don't block creation because of workflow limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Standardize sub-tabs (tabs inside tabs on Inspector)
   [#3261](https://github.com/OpenFn/lightning/pull/3261)
+- No longer blocking the "Create new workflow" button based on _active_ workflow
+  limits [#3251](https://github.com/OpenFn/lightning/pull/3251)
 
 ### Fixed
 

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -13,7 +13,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
   attr :period, :string, default: "last 30 days"
   attr :can_create_workflow, :boolean
   attr :can_delete_workflow, :boolean
-  attr :workflow_creation_limit_error, :string
   attr :workflows_stats, :list
   attr :project, :map
   attr :sort_key, :string, default: "name"
@@ -29,7 +28,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
           <.search_workflows_input search_term={@search_term} />
           <.create_workflow_card
             project_id={@project.id}
-            limit_error={@workflow_creation_limit_error}
             can_create_workflow={@can_create_workflow}
           />
         </div>
@@ -350,7 +348,6 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
 
   attr :can_create_workflow, :boolean, required: true
   attr :project_id, :string, required: true
-  attr :limit_error, :string
 
   def create_workflow_card(assigns) do
     assigns =

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -356,10 +356,10 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     assigns =
       assigns
       |> assign_new(:disabled, fn ->
-        !assigns.can_create_workflow or is_binary(assigns.limit_error)
+        !assigns.can_create_workflow
       end)
       |> assign_new(:tooltip, fn ->
-        assigns.limit_error || "You are not authorized to perform this action."
+        "You are not authorized to perform this action."
       end)
 
     ~H"""

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -6,7 +6,6 @@ defmodule LightningWeb.WorkflowLive.Index do
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.ProjectUsers
   alias Lightning.Workflows
-  alias Lightning.Workflows.WorkflowUsageLimiter
   alias LightningWeb.LiveHelpers
   alias LightningWeb.WorkflowLive.DashboardComponents
   alias LightningWeb.WorkflowLive.Helpers
@@ -26,7 +25,7 @@ defmodule LightningWeb.WorkflowLive.Index do
 
   @impl true
   def render(%{project: %{id: project_id}} = assigns) do
-    assigns = check_workflow_and_run_limits(assigns, project_id)
+    assigns = check_run_limits(assigns, project_id)
 
     ~H"""
     <LayoutComponents.page_content>
@@ -49,7 +48,6 @@ defmodule LightningWeb.WorkflowLive.Index do
           period={@dashboard_period}
           can_create_workflow={@can_create_workflow}
           can_delete_workflow={@can_delete_workflow}
-          workflow_creation_limit_error={@workflow_creation_limit_error}
           workflows_stats={@workflows_stats}
           project={@project}
           sort_key={Atom.to_string(@sort_key)}
@@ -277,22 +275,8 @@ defmodule LightningWeb.WorkflowLive.Index do
     end
   end
 
-  defp check_workflow_and_run_limits(assigns, project_id) do
-    assigns
-    |> assign(
-      workflow_creation_limit_error: limit_workflow_creation_error(project_id)
-    )
-    |> LiveHelpers.check_limits(project_id)
-  end
-
-  defp limit_workflow_creation_error(project_id) do
-    case WorkflowUsageLimiter.limit_workflow_creation(project_id) do
-      :ok ->
-        nil
-
-      {:error, _reason, %{text: error_msg}} ->
-        error_msg
-    end
+  defp check_run_limits(assigns, project_id) do
+    LiveHelpers.check_limits(assigns, project_id)
   end
 
   defp to_sort_key("name"), do: :name

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -48,7 +48,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       Mox.expect(
         Lightning.Extensions.MockUsageLimiter,
         :limit_action,
-        2,
+        0,
         fn %{type: :activate_workflow}, %{project_id: ^project_id} ->
           {:error, :too_many_workflows, %{text: error_message}}
         end

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -37,10 +37,11 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       assert html =~ "Some banner text"
     end
 
-    test "renders error tooltip when limit has been reached", %{
-      conn: conn,
-      project: %{id: project_id}
-    } do
+    test "doesn't render error tooltip when limit is reached; we allow create but block save",
+         %{
+           conn: conn,
+           project: %{id: project_id}
+         } do
       Mox.verify_on_exit!()
       error_message = "some funny error message"
 
@@ -55,7 +56,7 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
 
       {:ok, _view, html} = live(conn, ~p"/projects/#{project_id}/w")
 
-      assert html =~ error_message
+      refute html =~ error_message
     end
 
     test "only users with MFA enabled can access workflows for a project with MFA requirement",
@@ -310,7 +311,9 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
                )
       end)
 
-      assert view |> has_element?("#new-workflow-button[type=button][disabled]")
+      # Make sure the new workflow button is enabled, even though the toggles are disabled.
+      assert view |> has_element?("#new-workflow-button[type=button]")
+      refute view |> has_element?("#new-workflow-button[type=button][disabled]")
     end
   end
 


### PR DESCRIPTION
## Description

This PR removes the "disabled" status of "Create new workflow" button when a project is past it's workflow limit. We don't actually have a limit on the total number of workflows in a project, but rather on the number of _active_ workflows. We'd like to still let people create workflows, but if they try to save them as enabled we will them block save and request that they disable before saving.

## Validation steps

1. Attempt to create a new workflow in a lightning instance that is limited by an extension.
2. Note that you _can_ now click the create workflow button, but if you try to save your new workflow when it's _enabled_ you'll get an error. You can then disable and save as normal.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
