### PR TITLE
Fix metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,14 @@ and this project adheres to
 
 ### Fixed
 
+- Fix magic metadata [#3134](https://github.com/OpenFn/lightning/issues/3134)
+
 ## [v2.12.3-pre] - 2025-05-29
 
 ### Added
 
 - Added a custom metric to track projects that could benefit from additional
-  worker pods.
-  [#3189](https://github.com/OpenFn/lightning/issues/3189)
+  worker pods. [#3189](https://github.com/OpenFn/lightning/issues/3189)
 - Add a test metric that can be used to test external infrastructure (e.g.
   alerting) in a deployed Lightning instance.
   [#3229](https://github.com/OpenFn/lightning/issues/3229)
@@ -39,8 +40,7 @@ and this project adheres to
 - Update Elixir to 1.18.3 [#2748](https://github.com/OpenFn/lightning/pull/2748)
 - Standardized table components across the application
   [#2905](https://github.com/OpenFn/lightning/issues/2905)
-- Standardize buttons
-  [#3093](https://github.com/OpenFn/lightning/issues/3093)
+- Standardize buttons [#3093](https://github.com/OpenFn/lightning/issues/3093)
 - Make the chunk size for deleting expired activty configurable via ENV
   [#3181](https://github.com/OpenFn/lightning/pull/3181)
 - Reduce the cardinality of `lightning_run_lost_count`.

--- a/lib/lightning/cli.ex
+++ b/lib/lightning/cli.ex
@@ -66,7 +66,7 @@ defmodule Lightning.CLI do
     def get_messages(%__MODULE__{logs: logs}) do
       logs
       |> Enum.reduce([], fn l, messages ->
-        if Map.keys(l) == ["message"] do
+        if Map.has_key?(l, "message") do
           messages ++ l["message"]
         else
           messages

--- a/lib/lightning/metadata_service.ex
+++ b/lib/lightning/metadata_service.ex
@@ -113,7 +113,7 @@ defmodule Lightning.MetadataService do
     path =
       result
       |> CLI.Result.get_messages()
-      |> List.first()
+      |> List.last()
 
     cond do
       path ->


### PR DESCRIPTION
There's an issue right now where Metadata doesn't load for adaptors that support it.

Fixes #3134 

The fix makes little sense to me. Claude did this for me.

## Repro steps

- Create a credential like this for DHIS2:
```
baseUrl: https://play.im.dhis2.org/stable-2-41-3-1
user: admin
password: district
```
- Create a dhis2 step
- In the Inspector, click on Metadata
- Stuff should be populated there (on production, it'll say something like "metadata not available for this adaptor")

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
