### PR TITLE
Fix Paddings in Settings Page

### DIFF
--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -284,44 +284,47 @@ defmodule LightningWeb.LayoutComponents do
 
   def section_header(assigns) do
     ~H"""
-    <div class="flex justify-between content-center pb-4">
-      <div class="leading-loose">
-        <h6 class="font-medium text-black">{@title}</h6>
-        <small class="block text-xs text-gray-600">
-          {@subtitle}
-        </small>
-        <%= if !@can_perform_action do %>
-          <.permissions_message section={@permissions_message} />
-        <% end %>
-      </div>
-      <%= if @action_button_text || @options do %>
-        <div class="sm:block" aria-hidden="true">
-          <%= if @options do %>
-            <LightningWeb.Components.Credentials.options_menu_button
-              id={@action_button_id}
-              options={@options}
-              disabled={@action_button_disabled}
-            >
-              {@action_button_text || "Add new"}
-            </LightningWeb.Components.Credentials.options_menu_button>
-          <% else %>
-            <.button
-              :if={@action_button_id}
-              id={@action_button_id}
-              type="button"
-              theme="primary"
-              size="lg"
-              phx-click={@action_button_click}
-              phx-value-action={@action_button_value_action}
-              phx-target={@action_button_target}
-              disabled={@action_button_disabled}
-              tooltip={@action_button_tooltip}
-            >
-              {@action_button_text}
-            </.button>
+    <div>
+      <div class="flex justify-between content-center">
+        <div>
+          <h6 class="font-medium text-black">{@title}</h6>
+          <small class="block my-1 text-xs text-gray-600">
+            {@subtitle}
+          </small>
+          <%= if !@can_perform_action do %>
+            <.permissions_message section={@permissions_message} />
           <% end %>
         </div>
-      <% end %>
+        <%= if @action_button_text || @options do %>
+          <div class="sm:block" aria-hidden="true">
+            <%= if @options do %>
+              <LightningWeb.Components.Credentials.options_menu_button
+                id={@action_button_id}
+                options={@options}
+                disabled={@action_button_disabled}
+              >
+                {@action_button_text || "Add new"}
+              </LightningWeb.Components.Credentials.options_menu_button>
+            <% else %>
+              <.button
+                :if={@action_button_id}
+                id={@action_button_id}
+                type="button"
+                theme="primary"
+                size="lg"
+                phx-click={@action_button_click}
+                phx-value-action={@action_button_value_action}
+                phx-target={@action_button_target}
+                disabled={@action_button_disabled}
+                tooltip={@action_button_tooltip}
+              >
+                {@action_button_text}
+              </.button>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+      <LightningWeb.LayoutComponents.spacer />
     </div>
     """
   end
@@ -333,6 +336,38 @@ defmodule LightningWeb.LayoutComponents do
     <small class="mt-2 text-red-700">
       Role based permissions: You cannot modify this project's {@section}
     </small>
+    """
+  end
+
+  def spacer(assigns) do
+    assigns = assign_new(assigns, :vertical, fn -> true end)
+    assigns = assign_new(assigns, :horizontal, fn -> false end)
+    assigns = assign_new(assigns, :size, fn -> "2" end)
+    assigns = assign_new(assigns, :vertical_size, fn -> assigns.size end)
+    assigns = assign_new(assigns, :horizontal_size, fn -> assigns.size end)
+    assigns = assign_new(assigns, :responsive, fn -> true end)
+
+    vertical_class =
+      if assigns.vertical, do: "py-#{assigns.vertical_size}", else: ""
+
+    horizontal_class =
+      if assigns.horizontal, do: "px-#{assigns.horizontal_size}", else: ""
+
+    responsive_class = if assigns.responsive, do: "hidden sm:block", else: ""
+
+    assigns =
+      assign(
+        assigns,
+        :classes,
+        [responsive_class, vertical_class, horizontal_class]
+        |> Enum.filter(&(&1 != ""))
+        |> Enum.join(" ")
+      )
+
+    ~H"""
+    <div class={@classes} aria-hidden="true">
+      <div></div>
+    </div>
     """
   end
 end

--- a/lib/lightning_web/live/job_live/cron_setup_component.ex
+++ b/lib/lightning_web/live/job_live/cron_setup_component.ex
@@ -93,9 +93,7 @@ defmodule LightningWeb.JobLive.CronSetupComponent do
           </div>
         <% end %>
       </div>
-      <div class="hidden sm:block" aria-hidden="true">
-        <div class="py-2"></div>
-      </div>
+      <LightningWeb.LayoutComponents.spacer />
       <div class="col-span-4 @md:col-span-4">
         <Form.text_field field={:cron_expression} form={@form} disabled={@disabled} />
       </div>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -54,7 +54,7 @@
         <.icon name="hero-folder-arrow-down" class="h-5 w-5 inline-block mr-2" />
         <span class="inline-block align-middle">History Exports</span>
       </:tab>
-      <:panel hash="project" class="">
+      <:panel hash="project">
         <.section_header
           title="Project setup"
           subtitle="Projects are isolated workspaces that contain workflows, accessible to certain users."
@@ -77,6 +77,7 @@
             phx-change="validate"
             phx-submit="save"
           >
+            <LightningWeb.LayoutComponents.spacer />
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
                 <.input
@@ -87,6 +88,7 @@
                 />
               </div>
             </div>
+            <LightningWeb.LayoutComponents.spacer />
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
                 <.input
@@ -101,6 +103,7 @@
                 </small>
               </div>
             </div>
+            <LightningWeb.LayoutComponents.spacer />
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
                 <.button
@@ -115,6 +118,8 @@
             </div>
           </.form>
         </div>
+        <LightningWeb.LayoutComponents.spacer />
+
         <div class="bg-white p-4 rounded-md">
           <div>
             <h6 class="font-medium text-black">
@@ -140,16 +145,7 @@
             phx-change="validate"
             phx-submit="save"
           >
-            <div class="grid grid-cols gap-6">
-              <div class="md:col-span-2">
-                <.input type="hidden" field={f[:name]} />
-              </div>
-            </div>
-            <div class="grid grid-cols gap-6">
-              <div class="md:col-span-2">
-                <.input type="hidden" field={f[:description]} />
-              </div>
-            </div>
+            <LightningWeb.LayoutComponents.spacer />
             <div class="grid grid-cols md:col-span-2">
               <div class="flex items-center gap-x-4 justify-between">
                 <.live_component
@@ -181,6 +177,7 @@
                 </:message>
               </Common.alert>
             </div>
+            <LightningWeb.LayoutComponents.spacer />
             <div class="grid grid-cols gap-6">
               <div class="md:col-span-2">
                 <.button
@@ -197,6 +194,7 @@
             </div>
           </.form>
         </div>
+        <LightningWeb.LayoutComponents.spacer />
 
         <div class="bg-white p-4 rounded-md">
           <div>
@@ -204,29 +202,26 @@
             <p class="block my-1 text-xs text-gray-600">
               Export your project as code, to save this version or edit your project locally.
             </p>
-            <div class="my-2">
-              <.button_link
-                theme="primary"
-                href={~p"/download/yaml?id=#{@project.id}"}
-                target="_blank"
-              >
-                Export project
-              </.button_link>
-            </div>
-
-            <%!--  --%>
+            <LightningWeb.LayoutComponents.spacer />
+            <.button_link
+              theme="primary"
+              href={~p"/download/yaml?id=#{@project.id}"}
+              target="_blank"
+            >
+              Export project
+            </.button_link>
           </div>
         </div>
         <%= if @can_delete_project do %>
+          <LightningWeb.LayoutComponents.spacer />
+
           <div class="bg-white p-4 rounded-md">
             <div>
               <h6 class="font-medium text-black">The danger zone</h6>
               <small class="block my-1 text-xs text-gray-600">
                 Deleting your project is irreversible
               </small>
-              <div class="hidden sm:block" aria-hidden="true">
-                <div class="py-2"></div>
-              </div>
+              <LightningWeb.LayoutComponents.spacer />
               <.button_link
                 theme="danger"
                 navigate={

--- a/lib/lightning_web/live/user_live/form_component.html.heex
+++ b/lib/lightning_web/live/user_live/form_component.html.heex
@@ -14,9 +14,7 @@
       </div>
     </div>
 
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
+    <LightningWeb.LayoutComponents.spacer />
 
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
@@ -25,9 +23,7 @@
       </div>
     </div>
 
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
+    <LightningWeb.LayoutComponents.spacer />
 
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
@@ -36,9 +32,7 @@
       </div>
     </div>
 
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
+    <LightningWeb.LayoutComponents.spacer />
 
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
@@ -47,9 +41,7 @@
       </div>
     </div>
 
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
+    <LightningWeb.LayoutComponents.spacer />
 
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
@@ -62,9 +54,7 @@
       </div>
     </div>
 
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
+    <LightningWeb.LayoutComponents.spacer />
 
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
@@ -91,9 +81,7 @@
       </div>
     </div>
 
-    <div class="hidden sm:block" aria-hidden="true">
-      <div class="py-2"></div>
-    </div>
+    <LightningWeb.LayoutComponents.spacer />
 
     <%= if @action in [:edit] do %>
       <%= if @role == :user do %>
@@ -105,9 +93,7 @@
         </div>
       <% end %>
 
-      <div class="hidden sm:block" aria-hidden="true">
-        <div class="py-2"></div>
-      </div>
+      <LightningWeb.LayoutComponents.spacer />
 
       <div class="flex items-start">
         <div class="flex items-center h-5">
@@ -122,9 +108,7 @@
         </div>
       </div>
 
-      <div class="hidden sm:block" aria-hidden="true">
-        <div class="py-2"></div>
-      </div>
+      <LightningWeb.LayoutComponents.spacer />
     <% end %>
 
     <div>

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -331,9 +331,7 @@ defmodule LightningWeb.WorkflowLive.Components do
       />
       <%= case @type do %>
         <% :cron -> %>
-          <div class="hidden sm:block" aria-hidden="true">
-            <div class="py-2"></div>
-          </div>
+          <LightningWeb.LayoutComponents.spacer />
           <.live_component
             id="cron-setup-component"
             form={@form}
@@ -342,9 +340,7 @@ defmodule LightningWeb.WorkflowLive.Components do
             disabled={@disabled}
           />
         <% :kafka -> %>
-          <div class="hidden sm:block" aria-hidden="true">
-            <div class="py-2"></div>
-          </div>
+          <LightningWeb.LayoutComponents.spacer />
           <.live_component
             id="kafka-setup-component"
             form={@form}


### PR DESCRIPTION
## Description

This PR fix a regression on the settings page where all paddings between sections were broken

Closes #3257 

## Validation steps

1. Go to the settings page
2. Note how paddings are back to normal

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
