### PR TITLE
Unify the sub tabs on the Inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Changed
 
+- Standardize sub-tabs (tabs inside tabs on Inspector)
+  [#3261](https://github.com/OpenFn/lightning/pull/3261)
+
 ### Fixed
 
 - Padding Changes on Project Setup Page

--- a/assets/js/components/Tabs.tsx
+++ b/assets/js/components/Tabs.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+export const iconStyle = 'inline cursor-pointer h-6 w-6 mr-1 hover:text-primary-600';
+
+export type TabSpec = {
+  label: string;
+  id: string;
+  icon: React.JSXElementConstructor<React.SVGAttributes<SVGSVGElement>>;
+};
+
+export type TabsProps = {
+  options: TabSpec[];
+  onSelectionChange?: (newName: string) => void;
+  verticalCollapse: boolean;
+  initialSelection?: String;
+};
+
+export const Tabs = ({
+  options,
+  onSelectionChange,
+  verticalCollapse,
+  initialSelection,
+}: TabsProps) => {
+  const [selected, setSelected] = React.useState(initialSelection);
+
+  const handleSelectionChange = (name: string) => {
+    if (name !== selected) {
+      setSelected(name);
+      onSelectionChange?.(name);
+    }
+  };
+
+  const commonStyle = 'flex';
+  const horizStyle = 'flex-space-x-2 w-full';
+  const vertStyle = 'flex-space-y-2';
+
+  const style: React.CSSProperties = verticalCollapse
+    ? {
+      writingMode: 'vertical-rl',
+      textOrientation: 'mixed',
+    }
+    : {};
+
+  return (
+    <nav
+      className={`${commonStyle} ${verticalCollapse ? vertStyle : horizStyle}`}
+      aria-label="Tabs"
+      style={style}
+    >
+      {options.map(({ label, id, icon }) => {
+        const style =
+          id === selected
+            ? 'bg-primary-50 text-gray-700'
+            : 'text-gray-400 hover:text-gray-700';
+        return (
+          <div
+            key={id}
+            onClick={() => handleSelectionChange(id)}
+            className={`${style} select-none rounded-md px-3 py-2 text-sm font-medium cursor-pointer flex-row whitespace-nowrap`}
+          >
+            {React.createElement(icon, { className: iconStyle })}
+            <span className="align-bottom">{label}</span>
+          </div>
+        );
+      })}
+    </nav>
+  );
+};

--- a/assets/js/components/Tabs.tsx
+++ b/assets/js/components/Tabs.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-export const iconStyle = 'inline cursor-pointer h-4 w-4 hover:text-primary-600';
-
 export type TabSpec = {
   label: string;
   id: string;

--- a/assets/js/components/Tabs.tsx
+++ b/assets/js/components/Tabs.tsx
@@ -11,17 +11,16 @@ export type TabSpec = {
 export type TabsProps = {
   options: TabSpec[];
   onSelectionChange?: (newName: string) => void;
-  verticalCollapse: boolean;
-  initialSelection?: String;
+  verticalCollapse?: boolean; // Made optional since we're using responsive design
+  initialSelection?: string;
 };
 
 export const Tabs = ({
   options,
   onSelectionChange,
-  verticalCollapse,
   initialSelection,
 }: TabsProps) => {
-  const [selected, setSelected] = React.useState(initialSelection);
+  const [selected, setSelected] = React.useState(initialSelection || options[0]?.id);
 
   const handleSelectionChange = (name: string) => {
     if (name !== selected) {
@@ -30,39 +29,69 @@ export const Tabs = ({
     }
   };
 
-  const commonStyle = 'flex';
-  const horizStyle = 'flex-space-x-2 w-full';
-  const vertStyle = 'flex-space-y-2';
-
-  const style: React.CSSProperties = verticalCollapse
-    ? {
-      writingMode: 'vertical-rl',
-      textOrientation: 'mixed',
-    }
-    : {};
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    handleSelectionChange(event.target.value);
+  };
 
   return (
-    <nav
-      className={`${commonStyle} ${verticalCollapse ? vertStyle : horizStyle}`}
-      aria-label="Tabs"
-      style={style}
-    >
-      {options.map(({ label, id, icon }) => {
-        const style =
-          id === selected
-            ? 'bg-primary-50 text-gray-700'
-            : 'text-gray-400 hover:text-gray-700';
-        return (
-          <div
-            key={id}
-            onClick={() => handleSelectionChange(id)}
-            className={`${style} select-none rounded-md px-3 py-2 text-sm font-medium cursor-pointer flex-row whitespace-nowrap`}
-          >
-            {React.createElement(icon, { className: iconStyle })}
-            <span className="align-bottom">{label}</span>
-          </div>
-        );
-      })}
-    </nav>
+    <div className="w-full">
+      {/* Mobile dropdown */}
+      <div className="grid grid-cols-1 sm:hidden">
+        <select
+          aria-label="Select a tab"
+          className="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pr-8 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+          value={selected}
+          onChange={handleSelectChange}
+        >
+          {options.map(({ label, id }) => (
+            <option key={id} value={id}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <svg
+          className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end fill-gray-500"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+
+      {/* Desktop tabs */}
+      <div className="hidden sm:block">
+        <div className="border-b border-gray-200">
+          <nav className="-mb-px flex" aria-label="Tabs">
+            {options.map(({ label, id, icon }) => {
+              const isSelected = id === selected;
+              const widthClass = `w-1/${options.length}`;
+
+              return (
+                <button
+                  key={id}
+                  onClick={() => handleSelectionChange(id)}
+                  className={`${widthClass} border-b-2 px-1 py-4 text-center text-sm font-medium flex items-center justify-center ${
+                    isSelected
+                      ? 'border-indigo-500 text-indigo-600'
+                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                  }`}
+                  aria-current={isSelected ? 'page' : undefined}
+                >
+                  {React.createElement(icon, { 
+                    className: 'inline h-5 w-5 mr-2' 
+                  })}
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+    </div>
   );
 };

--- a/assets/js/components/Tabs.tsx
+++ b/assets/js/components/Tabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-export const iconStyle = 'inline cursor-pointer h-6 w-6 mr-1 hover:text-primary-600';
+export const iconStyle =
+  'inline cursor-pointer h-6 w-6 mr-1 hover:text-primary-600';
 
 export type TabSpec = {
   label: string;
@@ -20,7 +21,9 @@ export const Tabs = ({
   onSelectionChange,
   initialSelection,
 }: TabsProps) => {
-  const [selected, setSelected] = React.useState(initialSelection || options[0]?.id);
+  const [selected, setSelected] = React.useState(
+    initialSelection || options[0]?.id
+  );
 
   const handleSelectionChange = (name: string) => {
     if (name !== selected) {
@@ -29,68 +32,33 @@ export const Tabs = ({
     }
   };
 
-  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    handleSelectionChange(event.target.value);
-  };
-
   return (
-    <div className="w-full">
-      {/* Mobile dropdown */}
-      <div className="grid grid-cols-1 sm:hidden">
-        <select
-          aria-label="Select a tab"
-          className="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pr-8 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
-          value={selected}
-          onChange={handleSelectChange}
-        >
-          {options.map(({ label, id }) => (
-            <option key={id} value={id}>
-              {label}
-            </option>
-          ))}
-        </select>
-        <svg
-          className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end fill-gray-500"
-          viewBox="0 0 16 16"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            fillRule="evenodd"
-            d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </div>
+    <div className="w-full mb-2">
+      <div className="border-b border-gray-200">
+        <nav className="-mb-px flex" aria-label="Tabs">
+          {options.map(({ label, id, icon }) => {
+            const isSelected = id === selected;
+            const widthClass = `w-1/${options.length}`;
 
-      {/* Desktop tabs */}
-      <div className="hidden sm:block">
-        <div className="border-b border-gray-200">
-          <nav className="-mb-px flex" aria-label="Tabs">
-            {options.map(({ label, id, icon }) => {
-              const isSelected = id === selected;
-              const widthClass = `w-1/${options.length}`;
-
-              return (
-                <button
-                  key={id}
-                  onClick={() => handleSelectionChange(id)}
-                  className={`${widthClass} border-b-2 px-1 py-4 text-center text-sm font-medium flex items-center justify-center ${
-                    isSelected
-                      ? 'border-indigo-500 text-indigo-600'
-                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                  }`}
-                  aria-current={isSelected ? 'page' : undefined}
-                >
-                  {React.createElement(icon, { 
-                    className: 'inline h-5 w-5 mr-2' 
-                  })}
-                  <span>{label}</span>
-                </button>
-              );
-            })}
-          </nav>
-        </div>
+            return (
+              <button
+                key={id}
+                onClick={() => handleSelectionChange(id)}
+                className={`${widthClass} border-b-2 px-1 py-4 text-center text-sm font-medium flex items-center justify-center ${
+                  isSelected
+                    ? 'border-indigo-500 text-indigo-600'
+                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                }`}
+                aria-current={isSelected ? 'page' : undefined}
+              >
+                {React.createElement(icon, {
+                  className: 'inline h-5 w-5 mr-2',
+                })}
+                <span>{label}</span>
+              </button>
+            );
+          })}
+        </nav>
       </div>
     </div>
   );

--- a/assets/js/components/Tabs.tsx
+++ b/assets/js/components/Tabs.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-export const iconStyle =
-  'inline cursor-pointer h-6 w-6 mr-1 hover:text-primary-600';
+export const iconStyle = 'inline cursor-pointer h-4 w-4 hover:text-primary-600';
 
 export type TabSpec = {
   label: string;
@@ -12,54 +11,136 @@ export type TabSpec = {
 export type TabsProps = {
   options: TabSpec[];
   onSelectionChange?: (newName: string) => void;
-  verticalCollapse?: boolean; // Made optional since we're using responsive design
+  collapsedVertical?: boolean; // New prop for collapsed state
   initialSelection?: string;
 };
 
 export const Tabs = ({
   options,
   onSelectionChange,
+  collapsedVertical = false,
   initialSelection,
 }: TabsProps) => {
   const [selected, setSelected] = React.useState(
     initialSelection || options[0]?.id
   );
+  const [useDropdown, setUseDropdown] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleSelectionChange = (name: string) => {
-    if (name !== selected) {
-      setSelected(name);
-      onSelectionChange?.(name);
-    }
+    setSelected(name);
+    onSelectionChange?.(name);
   };
 
-  return (
-    <div className="w-full mb-2">
-      <div className="border-b border-gray-200">
-        <nav className="-mb-px flex" aria-label="Tabs">
-          {options.map(({ label, id, icon }) => {
-            const isSelected = id === selected;
-            const widthClass = `w-1/${options.length}`;
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    handleSelectionChange(event.target.value);
+  };
 
-            return (
-              <button
-                key={id}
-                onClick={() => handleSelectionChange(id)}
-                className={`${widthClass} border-b-2 px-1 py-4 text-center text-sm font-medium flex items-center justify-center ${
-                  isSelected
-                    ? 'border-indigo-500 text-indigo-600'
-                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                }`}
-                aria-current={isSelected ? 'page' : undefined}
-              >
-                {React.createElement(icon, {
-                  className: 'inline h-5 w-5 mr-2',
-                })}
-                <span>{label}</span>
-              </button>
-            );
-          })}
-        </nav>
+  // Monitor container width to determine if dropdown should be used
+  React.useEffect(() => {
+    if (!containerRef.current) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        const containerWidth = entry.contentRect.width;
+        // Rough calculation: each tab needs about 120px minimum
+        const minWidthNeeded = options.length * 120;
+        setUseDropdown(containerWidth < minWidthNeeded);
+      }
+    });
+
+    observer.observe(containerRef.current);
+
+    return () => observer.disconnect();
+  }, [options.length]);
+
+  if (collapsedVertical) {
+    return (
+      <div className="h-full w-12">
+        <div className="bg-slate-100 p-1 rounded-lg h-full">
+          <nav className="flex flex-col gap-1 h-full" aria-label="Tabs">
+            {options.map(({ label, id, icon }) => {
+              const isSelected = id === selected;
+
+              return (
+                <button
+                  key={id}
+                  onClick={() => handleSelectionChange(id)}
+                  className={`flex-1 rounded-md px-2 py-3 text-sm font-medium flex flex-col items-center justify-center transition-all duration-200 ${
+                    isSelected
+                      ? 'bg-white text-indigo-600'
+                      : 'text-gray-500 hover:text-gray-700 hover:bg-slate-50'
+                  }`}
+                  aria-current={isSelected ? 'page' : undefined}
+                  style={{
+                    writingMode: 'vertical-rl',
+                    textOrientation: 'mixed',
+                  }}
+                >
+                  {React.createElement(icon, {
+                    className: 'inline h-4 w-4 mb-1',
+                  })}
+                  <span className="text-xs transform rotate-180 whitespace-nowrap">
+                    {label}
+                  </span>
+                </button>
+              );
+            })}
+          </nav>
+        </div>
       </div>
+    );
+  }
+
+  // Responsive layout with dropdown for narrow containers
+  return (
+    <div className="w-full" ref={containerRef}>
+      {useDropdown ? (
+        // Mobile/narrow dropdown
+        <div className="grid grid-cols-1">
+          <select
+            aria-label="Select a tab"
+            className="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pr-8 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+            value={selected}
+            onChange={handleSelectChange}
+          >
+            {options.map(({ label, id }) => (
+              <option key={id} value={id}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : (
+        // Wide container tabs - pill style
+        <div className="bg-slate-100 p-1 rounded-lg">
+          <nav className="flex gap-1" aria-label="Tabs">
+            {options.map(({ label, id, icon }) => {
+              const isSelected = id === selected;
+              const widthClass = `flex-1`;
+
+              return (
+                <button
+                  key={id}
+                  onClick={() => handleSelectionChange(id)}
+                  className={`${widthClass} rounded-md px-3 py-2 text-sm font-medium flex items-center justify-center transition-all duration-200 ${
+                    isSelected
+                      ? 'bg-white text-indigo-600'
+                      : 'text-gray-500 hover:text-gray-700 hover:bg-slate-50'
+                  }`}
+                  aria-current={isSelected ? 'page' : undefined}
+                >
+                  {React.createElement(icon, {
+                    className: 'inline h-5 w-5 mr-2',
+                  })}
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+      )}
     </div>
   );
 };

--- a/assets/js/job-editor/JobEditorComponent.tsx
+++ b/assets/js/job-editor/JobEditorComponent.tsx
@@ -118,7 +118,7 @@ export default ({
             />
             {/* Floating controls in top right corner */}
             {showPanel && (
-              <div className="absolute top-0 left-0 bg-white rounded-lg shadow-sm border border-gray-200 p-1 flex space-x-1 z-20">
+              <div className="absolute top-2 left-1/2 transform -translate-x-1/2 bg-white rounded-lg border border-2 border-gray-200 p-1 flex space-x-1 z-20">
                 <ViewColumnsIcon
                   className={`${iconStyle} ${!vertical ? 'rotate-90' : ''}`}
                   onClick={toggleOrientiation}

--- a/assets/js/job-editor/JobEditorComponent.tsx
+++ b/assets/js/job-editor/JobEditorComponent.tsx
@@ -25,9 +25,9 @@ const persistedSettings = localStorage.getItem('lightning.job-editor.settings');
 const settings = persistedSettings
   ? JSON.parse(persistedSettings)
   : {
-    [SettingsKeys.ORIENTATION]: 'h',
-    [SettingsKeys.SHOW_PANEL]: false,
-  };
+      [SettingsKeys.ORIENTATION]: 'h',
+      [SettingsKeys.SHOW_PANEL]: false,
+    };
 
 const persistSettings = () =>
   localStorage.setItem(
@@ -102,50 +102,41 @@ export default ({
           />
         </div>
         <div
-          className={`${showPanel ? 'flex flex-1 flex-col z-10 overflow-hidden' : ''
-            } ${vertical ? 'pt-2' : 'pl-2'} bg-white`}
+          className={`${
+            showPanel ? 'flex flex-col flex-1 z-10 overflow-hidden' : ''
+          } ${vertical ? 'pt-2' : 'pl-2'} bg-white`}
         >
-          <div
-            className={[
-              'flex',
-              !vertical && !showPanel
-                ? 'flex-col-reverse items-center'
-                : 'flex-row',
-              'w-full',
-              'justify-items-end',
-              'items-center',
-              'sticky',
-            ].join(' ')}
-          >
+          <div className={`relative flex`}>
             <Tabs
               options={[
                 { label: 'Docs', id: 'docs', icon: DocumentTextIcon },
-                { label: 'Metadata', id: 'metadata', icon: SparklesIcon }, // TODO if active, colour it
+                { label: 'Metadata', id: 'metadata', icon: SparklesIcon },
               ]}
               initialSelection={selectedTab}
               onSelectionChange={handleSelectionChange}
-              verticalCollapse={!vertical && !showPanel}
+              collapsedVertical={!vertical && !showPanel}
             />
-            <div
-              className={`flex select-none flex-1 text-right ${!showPanel && !vertical ? 'flex-col-reverse' : 'flex-row'
-                }`}
-            >
-              <ViewColumnsIcon
-                className={`${iconStyle} ${!vertical ? 'rotate-90' : ''}`}
-                onClick={toggleOrientiation}
-                title="Toggle panel orientation"
-              />
-              <CollapseIcon
-                className={iconStyle}
-                onClick={toggleShowPanel}
-                title="Collapse panel"
-              />
-            </div>
+            {/* Floating controls in top right corner */}
+            {showPanel && (
+              <div className="absolute top-0 left-0 bg-white rounded-lg shadow-sm border border-gray-200 p-1 flex space-x-1 z-20">
+                <ViewColumnsIcon
+                  className={`${iconStyle} ${!vertical ? 'rotate-90' : ''}`}
+                  onClick={toggleOrientiation}
+                  title="Toggle panel orientation"
+                />
+                <CollapseIcon
+                  className={iconStyle}
+                  onClick={toggleShowPanel}
+                  title="Collapse panel"
+                />
+              </div>
+            )}
           </div>
           {showPanel && (
             <div
-              className={`flex flex-1 ${vertical ? 'overflow-auto' : 'overflow-hidden'
-                }`}
+              className={`flex flex-1 mt-1 ${
+                vertical ? 'overflow-auto' : 'overflow-hidden'
+              }`}
             >
               {selectedTab === 'docs' && <Docs adaptor={adaptor} />}
               {selectedTab === 'metadata' && (

--- a/assets/js/job-editor/JobEditorComponent.tsx
+++ b/assets/js/job-editor/JobEditorComponent.tsx
@@ -127,7 +127,7 @@ export default ({
               verticalCollapse={!vertical && !showPanel}
             />
             <div
-              className={`flex select-none flex-1 text-right py-2 ${!showPanel && !vertical ? 'flex-col-reverse' : 'flex-row'
+              className={`flex select-none flex-1 text-right ${!showPanel && !vertical ? 'flex-col-reverse' : 'flex-row'
                 }`}
             >
               <ViewColumnsIcon

--- a/assets/js/job-editor/JobEditorComponent.tsx
+++ b/assets/js/job-editor/JobEditorComponent.tsx
@@ -12,6 +12,7 @@ import {
 import Docs from '../adaptor-docs/Docs';
 import Editor from '../editor/Editor';
 import Metadata from '../metadata-explorer/Explorer';
+import { Tabs, iconStyle } from '../components/Tabs';
 
 enum SettingsKeys {
   ORIENTATION = 'lightning.job-editor.orientation',
@@ -33,73 +34,6 @@ const persistSettings = () =>
     'lightning.job-editor.settings',
     JSON.stringify(settings)
   );
-
-const iconStyle = 'inline cursor-pointer h-6 w-6 mr-1 hover:text-primary-600';
-
-type TabSpec = {
-  label: string;
-  id: string;
-  icon: React.JSXElementConstructor<React.SVGAttributes<SVGSVGElement>>;
-};
-
-type TabsProps = {
-  options: TabSpec[];
-  onSelectionChange?: (newName: string) => void;
-  verticalCollapse: boolean;
-  initialSelection?: String;
-};
-
-const Tabs = ({
-  options,
-  onSelectionChange,
-  verticalCollapse,
-  initialSelection,
-}: TabsProps) => {
-  const [selected, setSelected] = useState(initialSelection);
-
-  const handleSelectionChange = (name: string) => {
-    if (name !== selected) {
-      setSelected(name);
-      onSelectionChange?.(name);
-    }
-  };
-
-  const commonStyle = 'flex';
-  const horizStyle = 'flex-space-x-2 w-full';
-  const vertStyle = 'flex-space-y-2';
-
-  const style: React.CSSProperties = verticalCollapse
-    ? {
-      writingMode: 'vertical-rl',
-      textOrientation: 'mixed',
-    }
-    : {};
-
-  return (
-    <nav
-      className={`${commonStyle} ${verticalCollapse ? vertStyle : horizStyle}`}
-      aria-label="Tabs"
-      style={style}
-    >
-      {options.map(({ label, id, icon }) => {
-        const style =
-          id === selected
-            ? 'bg-primary-50 text-gray-700'
-            : 'text-gray-400 hover:text-gray-700';
-        return (
-          <div
-            key={id}
-            onClick={() => handleSelectionChange(id)}
-            className={`${style} select-none rounded-md px-3 py-2 text-sm font-medium cursor-pointer flex-row whitespace-nowrap`}
-          >
-            {React.createElement(icon, { className: iconStyle })}
-            <span className="align-bottom">{label}</span>
-          </div>
-        );
-      })}
-    </nav>
-  );
-};
 
 type JobEditorComponentProps = {
   adaptor: string;

--- a/assets/js/job-editor/JobEditorComponent.tsx
+++ b/assets/js/job-editor/JobEditorComponent.tsx
@@ -12,7 +12,7 @@ import {
 import Docs from '../adaptor-docs/Docs';
 import Editor from '../editor/Editor';
 import Metadata from '../metadata-explorer/Explorer';
-import { Tabs, iconStyle } from '../components/Tabs';
+import { Tabs } from '../components/Tabs';
 
 enum SettingsKeys {
   ORIENTATION = 'lightning.job-editor.orientation',
@@ -34,6 +34,8 @@ const persistSettings = () =>
     'lightning.job-editor.settings',
     JSON.stringify(settings)
   );
+
+const iconStyle = 'inline cursor-pointer h-5 w-5 ml-1 hover:text-primary-600';
 
 type JobEditorComponentProps = {
   adaptor: string;
@@ -118,7 +120,7 @@ export default ({
             />
             {/* Floating controls in top right corner */}
             {showPanel && (
-              <div className="absolute top-2 left-1/2 transform -translate-x-1/2 bg-white rounded-lg border border-2 border-gray-200 p-1 flex space-x-1 z-20">
+              <div className="bg-white rounded-lg p-1 flex space-x-1 z-20 items-center">
                 <ViewColumnsIcon
                   className={`${iconStyle} ${!vertical ? 'rotate-90' : ''}`}
                   onClick={toggleOrientiation}

--- a/assets/js/job-editor/JobEditorComponent.tsx
+++ b/assets/js/job-editor/JobEditorComponent.tsx
@@ -113,6 +113,7 @@ export default ({
                 : 'flex-row',
               'w-full',
               'justify-items-end',
+              'items-center',
               'sticky',
             ].join(' ')}
           >

--- a/assets/js/manual-run-panel/ManualRunPanel.tsx
+++ b/assets/js/manual-run-panel/ManualRunPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from '@heroicons/react/24/outline';
 import React from 'react';
 import constructQuery from '../utils/constructQuery';
+import { Tabs } from '../components/Tabs';
 import { type Dataclip, FilterTypes, SeletableOptions } from './types';
 import CustomView from './views/CustomView';
 import EmptyView from './views/EmptyView';
@@ -13,6 +14,7 @@ import ExistingView from './views/ExistingView';
 import SelectedClipView from './views/SelectedClipView';
 import alterURLParams from '../utils/alterURLParams';
 import useQuery from '../hooks/useQuery';
+
 interface ManualRunPanelProps {
   job_id: string;
   selected_dataclip_id: string | null;
@@ -175,6 +177,13 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
     handleSearchSumbit();
   }, [selectedClipType, selectedDates]);
 
+  const handleTabSelectionChange = React.useCallback((newSelection: string) => {
+    const option = Number(newSelection) as SeletableOptions;
+    navigate(alterURLParams({ active_panel: option.toString() }).toString());
+    pushManualChange(option);
+    setSelectedOption(option);
+  }, [navigate, pushManualChange]);
+
   const innerView = React.useMemo(() => {
     switch (selectedOption) {
       case SeletableOptions.EXISTING:
@@ -215,18 +224,6 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
     handleSearchSumbit,
   ]);
 
-  const getActive = (v: SeletableOptions) => {
-    if (selectedOption === v)
-      return ' border-primary-600 text-primary-600 bg-slate-100';
-    return '';
-  };
-
-  const selectOptionHandler = (option: SeletableOptions) => () => {
-    navigate(alterURLParams({ active_panel: option.toString() }).toString());
-    pushManualChange(option)
-    setSelectedOption(option);
-  };
-
   return (
     <>
       <form ref={formRef} id="manual_run_form"></form>
@@ -241,45 +238,16 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
         <div className="grow overflow-auto no-scrollbar -mt-2">
           <div className="flex flex-col gap-2 h-full">
             <div className="flex md:gap-2 sm:gap-1 justify-center flex-wrap">
-              <button
-                type="button"
-                onClick={selectOptionHandler(SeletableOptions.EMPTY)}
-                className={
-                  'border text-sm rounded-md px-3 py-1 flex justify-center items-center gap-1 hover:bg-slate-100 hover:border-primary-300 group' +
-                  getActive(SeletableOptions.EMPTY)
-                }
-              >
-                <DocumentIcon
-                  className={`text-gray-600 w-4 h-4 group-hover:scale-110 group-hover:text-primary-600`}
-                />
-                Empty
-              </button>
-              <button
-                type="button"
-                onClick={selectOptionHandler(SeletableOptions.CUSTOM)}
-                className={
-                  'border text-sm rounded-md px-3 py-1 flex justify-center items-center gap-1 hover:bg-slate-100 hover:border-primary-300 group' +
-                  getActive(SeletableOptions.CUSTOM)
-                }
-              >
-                <PencilSquareIcon
-                  className={`text-gray-600 w-4 h-4 group-hover:scale-110 group-hover:text-primary-600`}
-                />
-                Custom
-              </button>
-              <button
-                type="button"
-                onClick={selectOptionHandler(SeletableOptions.EXISTING)}
-                className={
-                  'border text-sm rounded-md px-3 py-1 flex justify-center items-center gap-1 hover:bg-slate-100 hover:border-primary-300 group' +
-                  getActive(SeletableOptions.EXISTING)
-                }
-              >
-                <QueueListIcon
-                  className={`text-gray-600 w-4 h-4 group-hover:scale-110 group-hover:text-primary-600`}
-                />
-                Existing
-              </button>
+              <Tabs
+                options={[
+                  { label: 'Empty', id: SeletableOptions.EMPTY.toString(), icon: DocumentIcon },
+                  { label: 'Custom', id: SeletableOptions.CUSTOM.toString(), icon: PencilSquareIcon },
+                  { label: 'Existing', id: SeletableOptions.EXISTING.toString(), icon: QueueListIcon },
+                ]}
+                initialSelection={selectedOption.toString()}
+                onSelectionChange={handleTabSelectionChange}
+                verticalCollapse={false}
+              />
             </div>
             {innerView}
           </div>

--- a/assets/js/manual-run-panel/ManualRunPanel.tsx
+++ b/assets/js/manual-run-panel/ManualRunPanel.tsx
@@ -237,7 +237,7 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
       ) : (
         <div className="grow overflow-auto no-scrollbar">
           <div className="flex flex-col h-full">
-            <div className="flex justify-center flex-wrap">
+            <div className="flex justify-center flex-wrap mb-1">
               <Tabs
                 options={[
                   { label: 'Empty', id: SeletableOptions.EMPTY.toString(), icon: DocumentIcon },

--- a/assets/js/manual-run-panel/ManualRunPanel.tsx
+++ b/assets/js/manual-run-panel/ManualRunPanel.tsx
@@ -235,9 +235,9 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
           }}
         />
       ) : (
-        <div className="grow overflow-auto no-scrollbar -mt-2">
-          <div className="flex flex-col gap-2 h-full">
-            <div className="flex md:gap-2 sm:gap-1 justify-center flex-wrap">
+        <div className="grow overflow-auto no-scrollbar">
+          <div className="flex flex-col h-full">
+            <div className="flex justify-center flex-wrap">
               <Tabs
                 options={[
                   { label: 'Empty', id: SeletableOptions.EMPTY.toString(), icon: DocumentIcon },

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -253,7 +253,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
                     default_hash="manual"
                   >
                     <:panel hash="manual" class="overflow-auto h-full">
-                      <div class="grow flex flex-col gap-4 p-2 min-h-0 h-full">
+                      <div class="grow flex flex-col p-2 min-h-0 h-full">
                         <.ManualRunPanel
                           :if={@selection_mode === "expand"}
                           job_id={@selected_job.id}


### PR DESCRIPTION
## Description

This PR standardizes the sub-tabs in the Inspector

## Validation steps

1. Go to the inspector and play around with the Input panel and the docs/metadata pane inside the Editor panel.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
