### PR TITLE
Keep secondary button from appearing on page load

### DIFF
--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2998,10 +2998,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
             phx-click="toggle_github_sync_modal"
             theme="secondary"
             class={[
-              "hidden absolute right-0 z-10 w-max",
+              "absolute right-0 z-10 w-max",
               if(@dropdown_position == :top, do: "bottom-9 mb-2"),
               if(@dropdown_position == :bottom, do: "top-9 mt-2")
             ]}
+            style="display: none;"
             disabled={@disabled}
             phx-hook="OpenSyncModalViaCtrlShiftS"
           >


### PR DESCRIPTION
Closes a strange issue (https://github.com/OpenFn/lightning/issues/3265) where the secondary action button was _OPEN_ during page refreshes. (It should only open when you click the action dropdown.)

## Validation steps

1. Go to the Inspector
2. Hard refresh
3. Note that the secondary buttons are not open anymore, but that they work!

## Additional notes for the reviewer

I can't figure out why this `style="display: none;"` works when `hidden` doesn't. And I'm not even entirely sure that the `new_input` standardization of the buttons was the culprit. So strange that it only happens on page load and goes back to what it should be when you click somewhere on the page. Makes me think there's some strange JS going on elsewhere.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
