### PR TITLE
Keep hidden secondary buttons from showing up before click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Don't display hidden secondary buttons
+  [#3265](https://github.com/OpenFn/lightning/issues/3265)
+
 ## [v2.13.0-pre] - 2025-06-02
 
 ### Added

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -169,6 +169,11 @@ defmodule LightningWeb.Components.NewInputs do
         [
           # Base classes
           button_base_classes(),
+          # TODO: consider another approach:
+          # https://github.com/OpenFn/lightning/issues/3269
+          # We want a way to style these links as buttons without interfering
+          # with JS.show()—using `inline-block` leads to a Tailwind gotcha.
+          "inline-block",
           # size variants
           button_size_classes(@size),
           # theme variants
@@ -185,7 +190,7 @@ defmodule LightningWeb.Components.NewInputs do
   end
 
   defp button_base_classes do
-    "inline-block rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75"
+    "rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75"
   end
 
   defp button_theme_classes(theme) do


### PR DESCRIPTION
## Description

This PR closes #3265 , but references #3269 . (For later.)

## Validation steps

1. Go to the inspector and see the the hidden secondary buttons stay hidden, but still work when showing them.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [x] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
