### PR TITLE
Fix Glitching on Template Label Change and Add AI Assistant Disabled Screen

### DIFF
--- a/lib/lightning_web/live/ai_assistant/component.ex
+++ b/lib/lightning_web/live/ai_assistant/component.ex
@@ -32,7 +32,8 @@ defmodule LightningWeb.AiAssistant.Component do
        has_read_disclaimer: false,
        all_sessions: AsyncResult.ok([]),
        form: to_form(%{"content" => nil}),
-       pending_message: AsyncResult.ok(nil)
+       pending_message: AsyncResult.ok(nil),
+       ai_enabled?: AiAssistant.enabled?()
      })
      |> assign_async(:endpoint_available?, fn ->
        {:ok, %{endpoint_available?: AiAssistant.endpoint_available?()}}
@@ -58,10 +59,17 @@ defmodule LightningWeb.AiAssistant.Component do
   def render(assigns) do
     ~H"""
     <div id={@id} class="h-full relative">
-      <%= if !@has_read_disclaimer do %>
-        <.render_onboarding myself={@myself} can_edit_workflow={@can_edit_workflow} />
+      <%= if !@ai_enabled? do %>
+        <.render_ai_not_configured />
       <% else %>
-        <.render_session {assigns} />
+        <%= if !@has_read_disclaimer do %>
+          <.render_onboarding
+            myself={@myself}
+            can_edit_workflow={@can_edit_workflow}
+          />
+        <% else %>
+          <.render_session {assigns} />
+        <% end %>
       <% end %>
     </div>
     """
@@ -373,6 +381,48 @@ defmodule LightningWeb.AiAssistant.Component do
     )
 
     socket
+  end
+
+  defp render_ai_not_configured(assigns) do
+    ~H"""
+    <div class="flex flex-col items-center justify-center h-full">
+      <div class="text-center w-1/2">
+        <div class="mx-auto w-16 h-16 mb-6">
+          <div class="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center">
+            <.icon name="hero-cpu-chip" class="w-8 h-8 text-gray-400" />
+          </div>
+        </div>
+
+        <h3 class="text-lg font-semibold text-gray-900 mb-4">
+          AI Assistant Not Available
+        </h3>
+
+        <p class="text-gray-500 text-sm mb-4">
+          AI Assistant has not been configured for your instance - contact your admin for support.
+        </p>
+
+        <p class="text-gray-500 text-sm mb-6">
+          Try the AI Assistant on OpenFn cloud for free at
+          <a
+            href="https://app.openfn.org"
+            target="_blank"
+            class="text-primary-600 hover:text-primary-700 underline"
+          >
+            app.openfn.org
+          </a>
+        </p>
+
+        <div class="text-xs text-gray-400 space-y-1">
+          <p>To enable AI Assistant, your administrator needs to:</p>
+          <ul class="list-disc list-inside text-left max-w-sm mx-auto mt-2 space-y-1">
+            <li>Configure the Apollo endpoint URL</li>
+            <li>Set up the AI Assistant API key</li>
+            <li>Restart the Lightning application</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    """
   end
 
   defp render_session(assigns) do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -259,61 +259,24 @@ defmodule LightningWeb.WorkflowLive.Edit do
                           job_id={@selected_job.id}
                           selected_dataclip_id={@step && @step.input_dataclip_id}
                         />
-                        <%!-- <LightningWeb.WorkflowLive.ManualWorkorder.component
-                          id={"manual-job-#{@selected_job.id}"}
-                          form={@manual_run_form}
-                          dataclips={@selectable_dataclips}
-                          disabled={
-                            !@can_run_workflow ||
-                              @snapshot_version_tag != "latest"
-                          }
-                          project={@project}
-                          admin_contacts={@admin_contacts}
-                          can_edit_data_retention={@can_edit_data_retention}
-                          follow_run={@follow_run}
-                          step={@step}
-                          show_missing_dataclip_selector={
-                            @show_missing_dataclip_selector
-                          }
-                        /> --%>
                       </div>
                     </:panel>
                     <:panel hash="aichat" class="h-full">
-                      <%= if @ai_assistant_enabled do %>
-                        <div class="grow min-h-0 h-full text-sm">
-                          <.live_component
-                            module={LightningWeb.AiAssistant.Component}
-                            mode={:job}
-                            can_edit_workflow={@can_edit_workflow}
-                            project={@project}
-                            current_user={@current_user}
-                            selected_job={@selected_job}
-                            chat_session_id={@chat_session_id}
-                            query_params={@query_params}
-                            base_url={@base_url}
-                            action={if(@chat_session_id, do: :show, else: :new)}
-                            id={"aichat-#{@selected_job.id}"}
-                          />
-                        </div>
-                      <% else %>
-                        <div class="flex flex-col items-center justify-center h-full">
-                          <div class="text-center w-1/2">
-                            <p class="text-gray-500 text-sm mb-2">
-                              AI Assistant has not been configured for your instance - contact your admin for support.
-                            </p>
-                            <p class="text-gray-500 text-sm mb-2">
-                              Try the AI Assistant on Openfn cloud for free at
-                              <a
-                                href="https://app.openfn.org"
-                                target="_blank"
-                                class="text-primary-600"
-                              >
-                                app.openfn.org
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      <% end %>
+                      <div class="grow min-h-0 h-full text-sm">
+                        <.live_component
+                          module={LightningWeb.AiAssistant.Component}
+                          mode={:job}
+                          can_edit_workflow={@can_edit_workflow}
+                          project={@project}
+                          current_user={@current_user}
+                          selected_job={@selected_job}
+                          chat_session_id={@chat_session_id}
+                          query_params={@query_params}
+                          base_url={@base_url}
+                          action={if(@chat_session_id, do: :show, else: :new)}
+                          id={"aichat-#{@selected_job.id}"}
+                        />
+                      </div>
                     </:panel>
                   </LightningWeb.Components.Tabbed.panels>
                 </.collapsible_panel>
@@ -3132,7 +3095,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
     <div
       id={"selected-template-label-#{@template.id}"}
       phx-mounted={fade_in()}
-      phx-remove={fade_out()}
       class="absolute z-[9999] m-4 opacity-75 bg-white/100 border border-gray-200 rounded-lg p-6"
     >
       <div class="flex items-start gap-3 opacity-100">


### PR DESCRIPTION
## Description

This PR fixes a weird glitching that happens to the template labels when you click on different templates and also adds the AI Assistant disabled screen to the AI Assistant itself so that it's available on all instances of the assistant.

## Validation steps

1. Remove your AI Assistant env variables
2. Visit the Job Mode AI Assistant or the Workflow Mode AI Assistant pages
3. See the same disabled screen appear
4. Click on a template and click to another one and see that no glitch or animation weirdness happen.

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
