### PR TITLE
copy assets should goes first before start compile and run

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -66,7 +66,6 @@ RUN mix lightning.install_adaptor_icons
 COPY bin bin
 
 
-
 ENTRYPOINT ["/app/bin/entrypoint"]
 
 ARG PORT

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -53,6 +53,8 @@ RUN mkdir config
 # to ensure any relevant config change will trigger the dependencies
 # to be re-compiled.
 COPY config config
+COPY assets assets
+RUN npm install --prefix assets
 RUN mix deps.compile
 
 COPY priv priv
@@ -62,8 +64,7 @@ RUN mix lightning.install_schemas
 RUN mix lightning.install_adaptor_icons
 
 COPY bin bin
-COPY assets assets
-RUN npm install --prefix assets
+
 
 
 ENTRYPOINT ["/app/bin/entrypoint"]


### PR DESCRIPTION
The local Docker build was failing while running the command.

`docker compose build && docker compose run --rm web mix ecto.migrate`

[The detailed issue and error are here](https://community.openfn.org/t/openfn-lightning-docker-compose-local-build-failed/955)
