### PR TITLE
fixes scrolling bug on templates picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Allow scrolling in the template grid
+  [#3284](https://github.com/OpenFn/lightning/issues/3284)
+
 ## [v2.13.0] - 2025-06-04
 
 ## [v2.13.0-pre2] - 2025-06-04

--- a/lib/lightning_web/live/workflow_live/new_workflow_component.ex
+++ b/lib/lightning_web/live/workflow_live/new_workflow_component.ex
@@ -485,8 +485,8 @@ defmodule LightningWeb.WorkflowLive.NewWorkflowComponent do
         for={to_form(%{})}
         class="flex-grow overflow-hidden flex flex-col"
       >
-        <fieldset class="overflow-auto flex-grow">
-          <div class="grid lg:grid-cols-1 xl:grid-cols-2 gap-2">
+        <fieldset class="overflow-y-auto flex-grow min-h-0 h-0">
+          <div class="grid lg:grid-cols-1 xl:grid-cols-2 gap-2 pb-4">
             <label
               :for={template <- @base_templates}
               id={"template-label-#{template.id}"}


### PR DESCRIPTION
## Description

This PR fixes #3284 , allowing the template grid to scroll.

## Validation steps

1. Go to templates
2. Sroll!

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
