### PR TITLE
Fix search input in history page getting cleared when you click to filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Search input in run history is cleared when you click on the filter buttons
+  [#1951](https://github.com/OpenFn/lightning/issues/1951)
+
 ## [v2.13.0] - 2025-06-04
 
 ## [v2.13.0-pre2] - 2025-06-04

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -466,9 +466,13 @@
                   >
                     <div class="relative rounded-md shadow-xs flex grow">
                       <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                        <Heroicons.magnifying_glass class="h-5 w-5 text-gray-400" />
+                        <.icon
+                          name="hero-magnifying-glass"
+                          class="h-5 w-5 text-gray-400"
+                        />
                       </div>
                       <.input
+                        id="run-search-form-search-term"
                         type="text"
                         field={f[:search_term]}
                         placeholder="Search"
@@ -477,6 +481,7 @@
                           JS.show(to: "#clear_search_button")
                           |> JS.show(to: "#search_button_group")
                         }
+                        onchange="document.getElementById('run-toggle-form-search-term').value = this.value"
                       />
 
                       <div class="absolute inset-y-0 right-0 flex items-center pr-3">
@@ -492,7 +497,10 @@
                             |> JS.hide(to: "#clear_search_button")
                           }
                         >
-                          <Heroicons.x_mark class="h-5 w-5 text-gray-400" />
+                          <.icon
+                            name="hero-x-mark"
+                            class="h-5 w-5 text-gray-400"
+                          />
                         </a>
                       </div>
                     </div>
@@ -506,6 +514,11 @@
                       class="isolate inline-flex rounded-md shadow-xs"
                       id="run-toggle-form"
                     >
+                      <.input
+                        id="run-toggle-form-search-term"
+                        type="hidden"
+                        field={f[:search_term]}
+                      />
                       <%= for {search_field, index} <- Enum.with_index(@search_fields) do %>
                         <.checkbox_element
                           id={f[search_field.id].id}


### PR DESCRIPTION
## Description

This PR makes it such that when you click on the filter buttons after typing, the search term isn't cleared.

Closes #1951 

## Validation steps

On the history page:

1. Type on the search box. Do not hit enter / submit
2. Click on the toggle buttons next to the search box
3. Notice that the search term isn't cleared and is part of the search filter

## Additional notes for the reviewer

This is hacky but necessary given the caveats:
- We don’t want to search work orders every time the user types in the search box because the query is expensive
- On the other hand, when the user toggles on the buttons next to the search box, we want an instant search/result

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
