### PR TITLE
Do not validate edge js condition expression in lightning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 - Report AI Assistant errors to Sentry
   [#3010](https://github.com/OpenFn/lightning/issues/3010)
+- Do not validate edge js condition expression
+  [#3028](https://github.com/OpenFn/lightning/issues/3028)
 
 ### Fixed
 

--- a/lib/lightning/workflows/edge.ex
+++ b/lib/lightning/workflows/edge.ex
@@ -146,19 +146,9 @@ defmodule Lightning.Workflows.Edge do
   defp validate_condition_expression(%{valid?: false} = changeset), do: changeset
 
   defp validate_condition_expression(changeset) do
-    js_expr = get_field(changeset, :condition_expression)
-
-    if String.match?(js_expr, ~r/(import\b|require\b|process\b|await\b|eval\b)/) do
-      add_error(
-        changeset,
-        :condition_expression,
-        "contains unacceptable words"
-      )
-    else
-      changeset
-      |> validate_length(:condition_label, max: 255)
-      |> validate_length(:condition_expression, max: 255)
-    end
+    changeset
+    |> validate_length(:condition_label, max: 255)
+    |> validate_length(:condition_expression, max: 255)
   end
 
   defp validate_different_nodes(changeset) do

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -554,7 +554,7 @@ defmodule LightningWeb.WorkflowLive.Components do
               name="hero-exclamation-circle-solid"
               class="size-5 text-yellow-600"
               phx-hook="Tooltip"
-              aria-label="Warning: Your expression contains potentially unsafe functions (eval, require, import, process, await) that may cause your workflow to fail"
+              aria-label="Warning: this expression appears to contain unsafe functions (eval, require, import, process, await) that may cause your workflow to fail"
             />
           </.label>
           <.input
@@ -598,7 +598,10 @@ defmodule LightningWeb.WorkflowLive.Components do
   end
 
   defp js_expression_safe?(js_expr) do
-    !String.match?(js_expr, ~r/(import\b|require\b|process\b|await\b|eval\b)/)
+    !String.match?(
+      js_expr,
+      ~r/(\bimport\b|\brequire\b|\bprocess\b|\bawait\b|\beval\b)/
+    )
   end
 
   slot :inner_block, required: true

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -548,6 +548,14 @@ defmodule LightningWeb.WorkflowLive.Components do
         <div>
           <.label>
             JS Expression
+            <.icon
+              :if={!js_expression_safe?(@form[:condition_expression].value)}
+              id="edge-js-expression-unsafe-warning"
+              name="hero-exclamation-circle-solid"
+              class="size-5 text-yellow-600"
+              phx-hook="Tooltip"
+              aria-label="Warning: Your expression contains potentially unsafe functions (eval, require, import, process, await) that may cause your workflow to fail"
+            />
           </.label>
           <.input
             type="textarea"
@@ -587,6 +595,10 @@ defmodule LightningWeb.WorkflowLive.Components do
       <% end %>
     </div>
     """
+  end
+
+  defp js_expression_safe?(js_expr) do
+    !String.match?(js_expr, ~r/(import\b|require\b|process\b|await\b|eval\b)/)
   end
 
   slot :inner_block, required: true

--- a/test/lightning/workflows/edge_test.exs
+++ b/test/lightning/workflows/edge_test.exs
@@ -307,9 +307,11 @@ defmodule Lightning.Workflows.EdgeTest do
           )
         )
 
-      assert changeset.errors == [
+      refute changeset.errors == [
                condition_expression: {"contains unacceptable words", []}
              ]
+
+      assert Enum.empty?(changeset.errors)
 
       changeset =
         Edge.changeset(
@@ -333,9 +335,11 @@ defmodule Lightning.Workflows.EdgeTest do
           )
         )
 
-      assert changeset.errors == [
+      refute changeset.errors == [
                condition_expression: {"contains unacceptable words", []}
              ]
+
+      assert Enum.empty?(changeset.errors)
 
       changeset =
         Edge.changeset(
@@ -347,9 +351,11 @@ defmodule Lightning.Workflows.EdgeTest do
           )
         )
 
-      assert changeset.errors == [
+      refute changeset.errors == [
                condition_expression: {"contains unacceptable words", []}
              ]
+
+      assert Enum.empty?(changeset.errors)
 
       changeset =
         Edge.changeset(
@@ -364,7 +370,7 @@ defmodule Lightning.Workflows.EdgeTest do
       assert Enum.empty?(changeset.errors)
     end
 
-    test "requires JS expression to have neither import or require statements" do
+    test "allows JS expression to have import or require statements" do
       edge = %Edge{
         id: Ecto.UUID.generate(),
         workflow_id: Ecto.UUID.generate(),
@@ -387,9 +393,11 @@ defmodule Lightning.Workflows.EdgeTest do
           )
         )
 
-      assert changeset.errors == [
+      refute changeset.errors == [
                condition_expression: {"contains unacceptable words", []}
              ]
+
+      assert Enum.empty?(changeset.errors)
 
       changeset =
         Edge.changeset(
@@ -401,9 +409,11 @@ defmodule Lightning.Workflows.EdgeTest do
           )
         )
 
-      assert changeset.errors == [
+      refute changeset.errors == [
                condition_expression: {"contains unacceptable words", []}
              ]
+
+      assert Enum.empty?(changeset.errors)
     end
   end
 end

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1655,7 +1655,7 @@ defmodule LightningWeb.WorkflowLive.EditTest do
         )
 
       warning_text =
-        "Your expression contains potentially unsafe functions (eval, require, import, process, await) that may cause your workflow to fail"
+        "Warning: this expression appears to contain unsafe functions (eval, require, import, process, await) that may cause your workflow to fail"
 
       edge_to_edit = Enum.at(workflow.edges, 1)
       view |> select_node(edge_to_edit)

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1642,6 +1642,54 @@ defmodule LightningWeb.WorkflowLive.EditTest do
                )
     end
 
+    test "displays warning when js expression contains unwanted words", %{
+      conn: conn,
+      project: project,
+      workflow: workflow
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/w/#{workflow.id}",
+          on_error: :raise
+        )
+
+      warning_text =
+        "Your expression contains potentially unsafe functions (eval, require, import, process, await) that may cause your workflow to fail"
+
+      edge_to_edit = Enum.at(workflow.edges, 1)
+      view |> select_node(edge_to_edit)
+
+      # change to js_expression
+      html =
+        view
+        |> form("#workflow-form", %{
+          "workflow" => %{
+            "edges" => %{"1" => %{"condition_type" => "js_expression"}}
+          }
+        })
+        |> render_change()
+
+      assert html =~ "Matches a Javascript Expression"
+      refute html =~ warning_text
+
+      html =
+        view
+        |> form("#workflow-form", %{
+          "workflow" => %{
+            "edges" => %{
+              "1" => %{
+                "condition_label" => "My JS Expression",
+                "condition_expression" => "eval"
+              }
+            }
+          }
+        })
+        |> render_change()
+
+      assert html =~ warning_text
+    end
+
     @tag role: :editor
     test "can delete a job", %{conn: conn, project: project, workflow: workflow} do
       {:ok, view, _html} =


### PR DESCRIPTION
## Description

This PR removes the edge validation on js conditions, instead it adds a warning in the UI
<img width="309" alt="Screenshot 2025-06-10 at 11 34 14" src="https://github.com/user-attachments/assets/eb568601-e43a-4405-99ce-25855ec6d5b7" />


Closes #3028

## Validation steps

1. Open a workflow
2. Click on an edge connecting 2 jobs
3. Change the edge condition to `Matches a JS Expression`
4. In the JS Expression, type in `eval`. Notice that a warning circle appears. When you hover it, a tooltip appears with a message: `Your expression contains potentially unsafe functions (eval, require, import, process, await) that may cause your workflow to fail`


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
