### PR TITLE
Inspector Input panel not showing current run's dataclip for older runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Search input in run history is cleared when you click on the filter buttons
   [#1951](https://github.com/OpenFn/lightning/issues/1951)
+- Fix Inspector Input panel not showing current run's dataclip for older
+  workflow runs [#3288](https://github.com/OpenFn/lightning/issues/3288)
 
 ## [v2.13.0] - 2025-06-04
 

--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -11,7 +11,6 @@ import Pill from '../Pill';
 import DataclipTypePill from '../DataclipTypePill';
 import {
   CalendarDaysIcon,
-  CheckIcon,
   MagnifyingGlassIcon,
   RectangleGroupIcon,
   XMarkIcon,

--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -12,15 +12,12 @@ import DataclipTypePill from '../DataclipTypePill';
 import {
   CalendarDaysIcon,
   CheckIcon,
-  DocumentTextIcon,
   MagnifyingGlassIcon,
   RectangleGroupIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import formatDate from '#/utils/formatDate';
 import truncateUid from '#/utils/truncateUID';
-
-const iconStyle = 'h-4 w-4 text-grey-400';
 
 interface ExistingViewProps {
   dataclips: Dataclip[];
@@ -34,6 +31,7 @@ interface ExistingViewProps {
   selectedDates: { before: string; after: string };
   setSelectedDates: SetDates;
   onSubmit: () => void;
+  currentRunDataclip?: Dataclip | null;
 }
 
 const ExistingView: React.FC<ExistingViewProps> = ({
@@ -48,6 +46,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
   selectedDates,
   setSelectedDates,
   onSubmit,
+  currentRunDataclip,
 }) => {
   const [typesOpen, setTypesOpen] = React.useState(false);
   const [dateOpen, setDateOpen] = React.useState(false);
@@ -68,7 +67,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
       >
         {key}:{' '}
         {(key as FilterTypes) === FilterTypes.DATACLIP_TYPE
-          ? DataclipTypeNames[value]
+          ? DataclipTypeNames[value!]
           : value}{' '}
       </Pill>
     ));
@@ -183,20 +182,18 @@ const ExistingView: React.FC<ExistingViewProps> = ({
                           type === selectedClipType ? '' : type
                         );
                       }}
-                      className={`px-4 py-2 hover:bg-slate-100 cursor-pointer text-nowrap flex items-center gap-2 text-base text-slate-700 ${
+                      className={`px-3 py-2 hover:bg-slate-100 cursor-pointer text-nowrap flex items-center gap-2 text-slate-700 ${
                         type === selectedClipType
                           ? 'bg-blue-200 text-blue-700'
                           : ''
                       }`}
                     >
-                      {' '}
-                      {DataclipTypeNames[type]}{' '}
-                      <CheckIcon
-                        strokeWidth={3}
-                        className={`${iconStyle} ${
+                      <span
+                        className={`hero-check size-4 text-gray-400 ${
                           type !== selectedClipType ? 'invisible' : ''
                         }`}
-                      />{' '}
+                      />
+                      <span className="text-sm">{DataclipTypeNames[type]}</span>
                     </li>
                   );
                 })}
@@ -218,19 +215,31 @@ const ExistingView: React.FC<ExistingViewProps> = ({
         </div>
         {dataclips.length ? (
           dataclips.map(clip => {
+            const isCurrent =
+              currentRunDataclip && clip.id === currentRunDataclip.id;
             return (
               <div
+                key={clip.id}
                 onClick={() => {
                   setSelected(clip);
                 }}
                 className="flex items-center justify-between border rounded-md px-3 py-2 cursor-pointer hover:bg-slate-100 hover:border-primary-600 group"
               >
                 <div className="flex gap-2 items-center text-sm">
-                  <DocumentTextIcon
-                    className={`${iconStyle} group-hover:scale-110 group-hover:text-primary-600 align-middle h-5 w-5`}
-                  />
-                  <span className="font-mono leading-none align-middle relative top-[1px]">{truncateUid(clip.id)}</span>
-                  <span className="align-middle"><DataclipTypePill type={clip.type} size="small" /></span>
+                  {isCurrent ? (
+                    <span
+                      className="hero-star-solid size-4 text-primary-400 group-hover:text-primary-600"
+                      title="Current dataclip for this step"
+                    />
+                  ) : (
+                    <span className="hero-document-text align-middle size-4 group-hover:text-primary-600" />
+                  )}
+                  <span className="font-mono leading-none align-middle relative top-[1px]">
+                    {truncateUid(clip.id)}
+                  </span>
+                  <span className="align-middle">
+                    <DataclipTypePill type={clip.type} size="small" />
+                  </span>
                 </div>
                 <div className="text-xs truncate ml-2">
                   {formatDate(new Date(clip.updated_at))}
@@ -244,7 +253,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
           </div>
         )}
         {dataclips.length ? (
-          <div className="text-center text-sm">
+          <div className="text-center text-sm text-gray-600">
             Search results are limited to the 10 most recent matches for this
             step.
           </div>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1475,6 +1475,18 @@ defmodule LightningWeb.WorkflowLive.Edit do
     end
   end
 
+  def handle_event(
+        "get-run-input-dataclip",
+        %{"run_id" => run_id, "job_id" => job_id},
+        socket
+      ) do
+    Invocation.get_first_dataclip_for_run_and_job(run_id, job_id)
+    |> case do
+      nil -> {:reply, %{dataclip: nil}, socket}
+      dataclip -> {:reply, %{dataclip: dataclip}, socket}
+    end
+  end
+
   def handle_event("switch-version", %{"type" => type}, socket) do
     updated_socket =
       case type do

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -45,7 +45,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
   jsx("assets/js/workflow-store/WorkflowStore.tsx")
 
   attr :job_id, :string
-  attr :selected_dataclip_id, :string, required: false
   jsx("assets/js/manual-run-panel/ManualRunPanel.tsx")
 
   attr :changeset, :map, required: true
@@ -257,7 +256,6 @@ defmodule LightningWeb.WorkflowLive.Edit do
                         <.ManualRunPanel
                           :if={@selection_mode === "expand"}
                           job_id={@selected_job.id}
-                          selected_dataclip_id={@step && @step.input_dataclip_id}
                         />
                       </div>
                     </:panel>


### PR DESCRIPTION
## Description

The Inspector's Input panel fails to load when viewing older workflow runs. Users can see input data in the right-side "Input" tab, but the left-side Input panel appears empty, preventing them from using that data to create new manual runs.

Fixes #3288 

**Root Cause:** The Input panel only searches through the 10 most recent dataclips for a job. When viewing older runs (typically runs 11+), their input data isn't included in this limited search, so the panel can't find and display it.

**Fix:** When viewing a specific run (indicated by the `a` parameter in the URL), the component now:
- Fetches the current run's input dataclip separately via a new `get-run-input-dataclip` event
- Displays it at the top of the dataclip list with a star icon to indicate it's the current run's input
- Automatically selects it if it matches the expected `selected_dataclip_id`
- Prevents duplication by filtering it out of the regular search results

## Validation Steps

1. **Test the original issue:**
   - Open Inspector for a workflow job with >10 runs
   - Navigate to run #11 or later (URL will have `a=<run-id>` parameter)
   - Verify the Input panel now shows the dataclip content with a star icon

2. **Test recent runs still work:**
   - Navigate to runs 1-10 for the same job
   - Verify the Input panel continues to work as before

3. **Test search functionality:**
   - In the Input panel's "Existing" tab, perform searches with filters
   - Verify search results are limited to 10 items and don't include the current run dataclip to avoid duplication

## Additional Notes

I've taken the liberty of changing our UX a bit here, there was no way to unselect and then reselect the current Run/Step input dataclip.

So the change here is that there is a star representing the current Run/Steps input, and it's "pinned" to the top.

<img width="593" alt="image" src="https://github.com/user-attachments/assets/ee9dc519-dcd5-4eea-a7ef-859823fd2e12" />

Feedback welcome.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [x] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
