### PR TITLE
Free node positioning fixes

### DIFF
--- a/assets/js/workflow-diagram/layout.ts
+++ b/assets/js/workflow-diagram/layout.ts
@@ -126,6 +126,7 @@ const calculateLayout = async (
     autofit = fitTargets;
   }
 
+  console.log({ newModel });
   // If the old model had no positions, this is a first load and we should not animate
   if (hasOldPositions && duration) {
     await animate(model, newModel, update, flow, { duration, autofit });

--- a/assets/js/workflow-diagram/util/update-selection.ts
+++ b/assets/js/workflow-diagram/util/update-selection.ts
@@ -1,3 +1,5 @@
+// TODO: delete me
+
 import { getConnectedEdges } from '@xyflow/react';
 import { sortOrderForSvg, styleItem } from '../styles';
 import type { Flow } from '../types';


### PR DESCRIPTION
This PR attempts to fix logic and behaviour of the free node positioning PR.

The base PR has a fundamental problem in how positions are loaded and tracked.  There are just too many `positions` coming from too many places.

The logic now is:

- If `positions` for a workflow is null, we auto layout
- If `positions` is set, then we manually layout
- The last known positions are always cached, so that we can tell if something changed

I'm also noticing that the selection logic keeps triggering race conditions which cause problems in the workflow. Since we've had a request recently to remove the neighbour selection behaviour, I've just cut this code out. At the time of writing some code still needs deleting (you'll see it in the diff). If we decide we actually want to keep this code I'll need to rethink how that stuff works.

This needs testing really thoroughly - but I think it's OK?

Note that there is an existing bug on selection #3300 . This exists in production too and no-one else has complained. Not going to fix it here.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
