### PR TITLE
Show who ran runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Show who started each run
+  [#3309](https://github.com/OpenFn/lightning/issues/3309)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -243,7 +243,9 @@ defmodule Lightning.Runs do
         # TODO: remove the requirement for events to be hydrated with a specific
         # set of preloads.
         runs
-        |> Enum.map(fn run -> Repo.preload(run, [:snapshot, :created_by, :starting_trigger]) end)
+        |> Enum.map(fn run ->
+          Repo.preload(run, [:snapshot, :created_by, :starting_trigger])
+        end)
         |> Enum.each(&Events.run_updated/1)
       end
     end)

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -243,7 +243,7 @@ defmodule Lightning.Runs do
         # TODO: remove the requirement for events to be hydrated with a specific
         # set of preloads.
         runs
-        |> Enum.map(fn run -> Repo.preload(run, :snapshot) end)
+        |> Enum.map(fn run -> Repo.preload(run, [:snapshot, :created_by, :starting_trigger]) end)
         |> Enum.each(&Events.run_updated/1)
       end
     end)

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -60,10 +60,20 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                       </.link>
                     </:value>
                   </.list_item>
-                  <%= if run.created_by do %>
+                  <%= if run.created_by || run.starting_trigger do %>
                     <.list_item>
-                      <:label>Created by</:label>
-                      <:value>{run.created_by.email}</:value>
+                      <:label>Started by</:label>
+                      <:value>
+                        <%= cond do %>
+                          <% run.created_by -> %>
+                            {run.created_by.email}
+                          <% run.starting_trigger -> %>
+                            {String.capitalize(
+                              Atom.to_string(run.starting_trigger.type)
+                            )} trigger
+                          <% true -> %>
+                        <% end %>
+                      </:value>
                     </.list_item>
                   <% end %>
                   <.list_item>

--- a/lib/lightning_web/live/run_live/run_viewer_live.ex
+++ b/lib/lightning_web/live/run_live/run_viewer_live.ex
@@ -60,6 +60,12 @@ defmodule LightningWeb.RunLive.RunViewerLive do
                       </.link>
                     </:value>
                   </.list_item>
+                  <%= if run.created_by do %>
+                    <.list_item>
+                      <:label>Created by</:label>
+                      <:value>{run.created_by.email}</:value>
+                    </.list_item>
+                  <% end %>
                   <.list_item>
                     <:label>Started</:label>
                     <:value>

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -112,6 +112,12 @@ defmodule LightningWeb.RunLive.Show do
                     </.link>
                   </:value>
                 </.list_item>
+                <%= if run.created_by do %>
+                  <.list_item>
+                    <:label>Created by</:label>
+                    <:value>{run.created_by.email}</:value>
+                  </.list_item>
+                <% end %>
                 <.list_item>
                   <:label>Started</:label>
                   <:value>

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -112,10 +112,20 @@ defmodule LightningWeb.RunLive.Show do
                     </.link>
                   </:value>
                 </.list_item>
-                <%= if run.created_by do %>
+                <%= if run.created_by || run.starting_trigger do %>
                   <.list_item>
-                    <:label>Created by</:label>
-                    <:value>{run.created_by.email}</:value>
+                    <:label>Started by</:label>
+                    <:value>
+                      <%= cond do %>
+                        <% run.created_by -> %>
+                          {run.created_by.email}
+                        <% run.starting_trigger -> %>
+                          {String.capitalize(
+                            Atom.to_string(run.starting_trigger.type)
+                          )} trigger
+                        <% true -> %>
+                      <% end %>
+                    </:value>
                   </.list_item>
                 <% end %>
                 <.list_item>

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -17,6 +17,7 @@ defmodule LightningWeb.RunLive.Streaming do
     |> start_async(:run, fn ->
       Runs.get(run_id,
         include: [
+          :created_by,
           steps: [:job, snapshot: [triggers: :webhook_auth_methods]],
           workflow: [:project],
           snapshot: [triggers: :webhook_auth_methods]

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -18,6 +18,7 @@ defmodule LightningWeb.RunLive.Streaming do
       Runs.get(run_id,
         include: [
           :created_by,
+          :starting_trigger,
           steps: [:job, snapshot: [triggers: :webhook_auth_methods]],
           workflow: [:project],
           snapshot: [triggers: :webhook_auth_methods]

--- a/test/lightning_web/live/run_live/show_test.exs
+++ b/test/lightning_web/live/run_live/show_test.exs
@@ -55,6 +55,12 @@ defmodule LightningWeb.RunLive.ShowTest do
              |> render_async() =~ "Enqueued",
              "has enqueued state"
 
+      # Check that webhook-triggered run shows "Webhook trigger" as the starter
+      assert view
+             |> element("#run-detail-#{run_id}")
+             |> render_async() =~ "Webhook trigger",
+             "shows webhook trigger as starter"
+
       assert has_element?(
                view,
                "div#log-panel [phx-hook='LogViewer'][data-run-id='#{run_id}']"

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -343,7 +343,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       render_async(run_viewer)
 
       assert run_viewer
-             |> element("li:nth-child(5) dd", "Enqueued")
+             |> element("li:nth-child(6) dd", "Enqueued")
              |> has_element?()
     end
 

--- a/test/lightning_web/live/workflow_live/editor_test.exs
+++ b/test/lightning_web/live/workflow_live/editor_test.exs
@@ -310,7 +310,7 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
              |> has_element?("[data-flash-kind='error']", "Runs limit exceeded")
     end
 
-    test "can run a job", %{conn: conn, project: p, workflow: w} do
+    test "can run a job", %{conn: conn, project: p, workflow: w, user: user} do
       job = w.jobs |> hd
 
       {:ok, view, _html} =
@@ -345,6 +345,10 @@ defmodule LightningWeb.WorkflowLive.EditorTest do
       assert run_viewer
              |> element("li:nth-child(6) dd", "Enqueued")
              |> has_element?()
+
+      # Check that manually triggered run shows the user's email as the starter
+      assert render(run_viewer) =~ user.email,
+             "shows user email as starter for manually triggered run"
     end
 
     @tag skip: "component moved to react"


### PR DESCRIPTION
## Description

This PR fixes #3309 , showing who (or what) was responsible for running a run.

## Validation steps

1. Go to the inspector or the run detail page and look at a run that's been started manually.
2. Go to the inspector or the run detail page and look at a run that's been started by a cron trigger.
3. Go to the inspector or the run detail page and look at a run that's been started by a webhook trigger.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
