### PR TITLE
AI Assistant fails to send job context in subsequent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- AI Assistant fails to send job context in subsequent messages
+[#3329](https://github.com/OpenFn/lightning/issues/3329)
+
 ## [v2.13.2] - 2025-06-18
 
 ⚠️️ Please note that **this version fixes an issue that caused premature run

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -596,17 +596,6 @@ defmodule Lightning.AiAssistantTest do
       assert "is invalid" in errors_on(changeset).status
     end
 
-    test "handles non-existent session", %{
-      user: user
-    } do
-      message = insert(:chat_message, content: "test", role: :user, user: user)
-      session = build(:chat_session, id: Ecto.UUID.generate())
-
-      assert_raise Ecto.NoResultsError, fn ->
-        AiAssistant.update_message_status(session, message, :success)
-      end
-    end
-
     test "updates message status for session with multiple messages", %{
       user: user,
       workflow: %{jobs: [job_1 | _]}

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -109,7 +109,6 @@ defmodule Lightning.AiAssistantTest do
       end)
 
       {:ok, updated_session} = AiAssistant.query(session, message_content)
-      dbg(updated_session)
       assert updated_session.expression == job_expression
       assert updated_session.adaptor == adaptor
 


### PR DESCRIPTION
## Description

This PR ensures that the session context is mantained when updating the message status

Closes #3329

## Validation steps
Send a message to the assistant asking for your job code.
**Before:**
<img width="486" alt="Screenshot 2025-06-20 at 12 37 36" src="https://github.com/user-attachments/assets/8d6281ea-e9fc-49be-bd70-12427871230d" />

**After:**
<img width="486" alt="Screenshot 2025-06-20 at 15 18 49" src="https://github.com/user-attachments/assets/7d434f85-c97b-4ad1-8946-9d733cd50809" />


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
