### PR TITLE
feat: reset store on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fixes brief flash of previously viewed diagram when switching workflows
+  [#3352](https://github.com/OpenFn/lightning/pull/3352)
+
 ## [2.13.3] 2025-06-26
 
 ## [2.13.3-pre1] 2025-06-26

--- a/assets/js/workflow-store/WorkflowStore.tsx
+++ b/assets/js/workflow-store/WorkflowStore.tsx
@@ -47,6 +47,7 @@ export const WorkflowStore: WithActionProps = props => {
     subscribe,
     setDisabled,
     setForceFit,
+    reset
   } = useWorkflowStore();
 
   const pushPendingChange = React.useCallback(
@@ -152,6 +153,13 @@ export const WorkflowStore: WithActionProps = props => {
       setDisabled(response.disabled);
     });
   }, [props, setDisabled]);
+
+  // clear store when store-component unmounted
+  React.useEffect(() => {
+    return () => {
+      reset();
+    }
+  }, [reset])
 
   return <>{props.children}</>;
 };

--- a/assets/js/workflow-store/store.ts
+++ b/assets/js/workflow-store/store.ts
@@ -42,6 +42,7 @@ export interface WorkflowState extends WorkflowProps {
     replace?: boolean
   ) => void;
   observer: null | ((v: unknown) => void);
+  reset: () => void;
   subscribe: (cb: (v: unknown) => void) => void;
   add: (data: AddArgs) => void;
   updatePositions: (data: Positions | null) => void;
@@ -313,6 +314,9 @@ export const store: WorkflowStore = createStore<WorkflowState>()(
       }));
 
       set(state => applyPatches(state, immerPatches));
+    },
+    reset() {
+      set(DEFAULT_PROPS);
     },
     setDisabled: (value: boolean) => {
       set(state => ({


### PR DESCRIPTION
## Description

This PR resets the store data on unmount. Hence, going into two different workflows wouldn't have any state persisted inbetween.

Closes #3350 

## Validation steps

1. Open workflow1
2. go back to workflows page
3. Open workflow2
4. Do you see workflow1 for a brief second?

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR