### PR TITLE
Standardize modals and tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to
   [#3360](https://github.com/OpenFn/lightning/pull/3360)
 - Fix text content overflowing in credential modal
   [#3280](https://github.com/OpenFn/lightning/pull/3280)
+- Fix tables UI broken
+  [#3324](https://github.com/OpenFn/lightning/issues/3324)
 
 ## [2.13.3] 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,15 @@ and this project adheres to
 
 ### Changed
 
+- Standardize modal footers and paddings
+  [#3277](https://github.com/OpenFn/lightning/issues/3277)
+
 ### Fixed
+
+- Fix text content overflowing in credential modal
+  [#3280](https://github.com/OpenFn/lightning/pull/3280)
+- Fix tables UI broken
+  [#3324](https://github.com/OpenFn/lightning/issues/3324)
 
 ## [v2.13.4-pre] - 2025-07-04
 
@@ -37,8 +45,6 @@ and this project adheres to
   [#3334](https://github.com/OpenFn/lightning/issues/3334)
 - Improve error message when credential fails during runs
   [#3332](https://github.com/OpenFn/lightning/issues/3332)
-- Standardize modal footers and paddings
-  [#3277](https://github.com/OpenFn/lightning/issues/3277)
 
 ### Fixed
 
@@ -50,10 +56,6 @@ and this project adheres to
   [#3352](https://github.com/OpenFn/lightning/pull/3352)
 - Fixes import of workflow YML for a manual laid out workflow.
   [#3360](https://github.com/OpenFn/lightning/pull/3360)
-- Fix text content overflowing in credential modal
-  [#3280](https://github.com/OpenFn/lightning/pull/3280)
-- Fix tables UI broken
-  [#3324](https://github.com/OpenFn/lightning/issues/3324)
 
 ## [v2.13.3] 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
   [#3334](https://github.com/OpenFn/lightning/issues/3334)
 - Improve error message when credential fails during runs
   [#3332](https://github.com/OpenFn/lightning/issues/3332)
+- Standardize modal footers and paddings
+  [#3277](https://github.com/OpenFn/lightning/issues/3277)
 
 ### Fixed
 
@@ -36,6 +38,8 @@ and this project adheres to
   [#3352](https://github.com/OpenFn/lightning/pull/3352)
 - Fixes import of workflow YML for a manual laid out workflow.
   [#3360](https://github.com/OpenFn/lightning/pull/3360)
+- Fix text content overflowing in credential modal
+  [#3280](https://github.com/OpenFn/lightning/pull/3280)
 
 ## [2.13.3] 2025-06-26
 

--- a/lib/lightning_web/components/table.ex
+++ b/lib/lightning_web/components/table.ex
@@ -258,17 +258,11 @@ defmodule LightningWeb.Components.Table do
   slot :inner_block, required: true
   attr :class, :string, default: nil
   attr :id, :string, default: nil
-  attr :colspan, :integer, default: nil
-  attr :rowspan, :integer, default: nil
+  attr :rest, :global, include: ~w(colspan rowspan)
 
   def td(assigns) do
     ~H"""
-    <td
-      id={@id}
-      colspan={@colspan}
-      rowspan={@rowspan}
-      class={["text-sm text-gray-500", @class]}
-    >
+    <td id={@id} class={["text-sm text-gray-500", @class]} {@rest}>
       {render_slot(@inner_block)}
     </td>
     """

--- a/lib/lightning_web/components/table.ex
+++ b/lib/lightning_web/components/table.ex
@@ -92,10 +92,7 @@ defmodule LightningWeb.Components.Table do
 
   def table(assigns) do
     ~H"""
-    <div
-      id={@id}
-      class="overflow-hidden shadow ring-1 ring-black/5 sm:rounded-lg bg-gray-50"
-    >
+    <div id={@id} class="shadow ring-1 ring-black/5 sm:rounded-lg bg-gray-50">
       <table class={["min-w-full", @divide && "divide-y divide-gray-200"]}>
         <thead>{render_slot(@header)}</thead>
         <tbody class={[

--- a/lib/lightning_web/components/table.ex
+++ b/lib/lightning_web/components/table.ex
@@ -250,7 +250,7 @@ defmodule LightningWeb.Components.Table do
   ## Example
 
   ```elixir
-  <.td class="break-words max-w-[25rem]">
+  <.td class="wrap-break-word max-w-[25rem]">
     {user.name}
   </.td>
   ```

--- a/lib/lightning_web/components/table.ex
+++ b/lib/lightning_web/components/table.ex
@@ -270,7 +270,7 @@ defmodule LightningWeb.Components.Table do
       id={@id}
       colspan={@colspan}
       rowspan={@rowspan}
-      class={["text-sm text-gray-500 whitespace-nowrap", @class]}
+      class={["text-sm text-gray-500", @class]}
     >
       {render_slot(@inner_block)}
     </td>

--- a/lib/lightning_web/live/collection_live/collection_creation_modal.ex
+++ b/lib/lightning_web/live/collection_live/collection_creation_modal.ex
@@ -120,7 +120,7 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
               aria-label={gettext("close")}
             >
               <span class="sr-only">Close</span>
-              <Heroicons.x_mark solid class="h-5 w-5 stroke-current" />
+              <.icon name="hero-x-mark-solid" class="h-5 w-5 stroke-current" />
             </button>
           </div>
         </:title>
@@ -160,27 +160,25 @@ defmodule LightningWeb.CollectionLive.CollectionCreationModal do
               />
             </div>
           </div>
-          <.modal_footer class="mt-6">
-            <div class="sm:flex sm:flex-row-reverse gap-3">
-              <.button
-                id={"save-collection-#{@collection.id || "new"}"}
-                type="submit"
-                theme="primary"
-                disabled={!@changeset.valid?}
-                phx-target={@myself}
-              >
-                Save
-              </.button>
-              <.button
-                id={"cancel-collection-creation-#{@collection.id || "new"}"}
-                type="button"
-                phx-click="close_modal"
-                phx-target={@myself}
-                theme="secondary"
-              >
-                Cancel
-              </.button>
-            </div>
+          <.modal_footer>
+            <.button
+              id={"save-collection-#{@collection.id || "new"}"}
+              type="submit"
+              theme="primary"
+              disabled={!@changeset.valid?}
+              phx-target={@myself}
+            >
+              Save
+            </.button>
+            <.button
+              id={"cancel-collection-creation-#{@collection.id || "new"}"}
+              type="button"
+              phx-click="close_modal"
+              phx-target={@myself}
+              theme="secondary"
+            >
+              Cancel
+            </.button>
           </.modal_footer>
         </.form>
       </.modal>

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -22,7 +22,7 @@ defmodule LightningWeb.CollectionLive.Components do
           </button>
         </div>
       </:title>
-      <div class="text-left text-wrap">
+      <div>
         <p class="text-sm text-gray-500">
           Are you sure you want to delete the collection
           <span class="font-medium">{@collection.name}</span>

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -98,13 +98,13 @@ defmodule LightningWeb.CollectionLive.Components do
           <:body>
             <%= for collection <- @collections do %>
               <.tr id={"collections-table-row-#{collection.id}"}>
-                <.td class="break-words max-w-[15rem] text-gray-800">
+                <.td class="wrap-break-word max-w-[15rem] text-gray-800">
                   {collection.name}
                 </.td>
-                <.td class="break-words max-w-[25rem]">
+                <.td class="wrap-break-word max-w-[25rem]">
                   {collection.project.name}
                 </.td>
-                <.td class="break-words max-w-[25rem]">
+                <.td class="wrap-break-word max-w-[25rem]">
                   {div(collection.byte_size_sum, 1_000_000)}
                 </.td>
                 <.td>

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -30,7 +30,7 @@ defmodule LightningWeb.CollectionLive.Components do
           If you wish to proceed with this action, click on the delete button. To cancel click on the cancel button.<br /><br />
         </p>
       </div>
-      <div class="flex flex-row-reverse gap-4 mt-2">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -44,7 +44,7 @@ defmodule LightningWeb.CollectionLive.Components do
         <.button type="button" phx-click={hide_modal(@id)} theme="secondary">
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -506,8 +506,8 @@ defmodule LightningWeb.Components.Common do
 
   def sortable_table_header(assigns) do
     ~H"""
-    <.link class="group inline-flex cursor-pointer" {@rest}>
-      {render_slot(@inner_block)}
+    <.link class="group inline-flex cursor-pointer items-center" {@rest}>
+      <span>{render_slot(@inner_block)}</span>
       <span class={[
         "ml-2 flex-none rounded",
         if(@active,

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -524,4 +524,45 @@ defmodule LightningWeb.Components.Common do
     </.link>
     """
   end
+
+  attr :id, :string, required: true
+
+  attr :button_theme, :string, default: "primary"
+  slot :button, required: true
+
+  slot :options, required: true
+
+  def simple_dropdown(assigns) do
+    ~H"""
+    <div id={@id} class="relative inline-block">
+      <div>
+        <.button
+          theme={@button_theme}
+          phx-click={show_dropdown("#{@id}-menu")}
+          class="relative inline-flex items-center"
+          aria-expanded="true"
+          aria-haspopup="true"
+        >
+          {render_slot(@button)}
+          <.icon name="hero-chevron-down" class="ml-1 h-5 w-5" />
+        </.button>
+      </div>
+      <div
+        class="hidden absolute right-0 z-40 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none"
+        role="menu"
+        aria-orientation="vertical"
+        tabindex="-1"
+        phx-click-away={hide_dropdown("#{@id}-menu")}
+        id={"#{@id}-menu"}
+      >
+        <div
+          class="py-1 text-sm text-gray-700 *:block *:px-4 *:py-2 *:hover:bg-gray-100"
+          role="none"
+        >
+          {render_slot(@options)}
+        </div>
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/lightning_web/live/components/credential_deletion_modal.ex
+++ b/lib/lightning_web/live/components/credential_deletion_modal.ex
@@ -86,8 +86,8 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
             </button>
           </div>
         </:title>
-        <div class="">
-          <p class="">
+        <div class="text-sm text-gray-500">
+          <p>
             This credential has been used in workflow runs that
             are still monitored in at least one project's audit trail. The
             credential will be made unavailable for future use immediately and
@@ -99,8 +99,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
             Contact your instance administrator for more details.
           </p>
         </div>
-        <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-        <div class="flex flex-row-reverse gap-4">
+        <.modal_footer>
           <.button
             type="button"
             phx-click="close_modal"
@@ -109,7 +108,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
           >
             Ok, understood
           </.button>
-        </div>
+        </.modal_footer>
       </.modal>
     </div>
     """
@@ -137,7 +136,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
             </button>
           </div>
         </:title>
-        <div class="">
+        <div class="text-sm text-gray-500">
           <p class="">
             Deleting this credential will immediately remove it from all jobs and
             projects. If you later restore it, you will need to re-share it with
@@ -153,8 +152,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
             runs have been purged.
           </p>
         </div>
-        <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-        <div class="flex flex-row-reverse gap-4">
+        <.modal_footer>
           <.button
             id={"user-#{@id}_confirm_button"}
             type="button"
@@ -174,7 +172,7 @@ defmodule LightningWeb.Components.CredentialDeletionModal do
           >
             Cancel
           </.button>
-        </div>
+        </.modal_footer>
       </.modal>
     </div>
     """

--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -2,6 +2,7 @@ defmodule LightningWeb.Components.Credentials do
   @moduledoc false
   use LightningWeb, :component
 
+  alias LightningWeb.Components.Common
   alias LightningWeb.CredentialLive.JsonSchemaBodyComponent
   alias LightningWeb.CredentialLive.RawBodyComponent
 
@@ -235,49 +236,27 @@ defmodule LightningWeb.Components.Credentials do
 
   def options_menu_button(assigns) do
     ~H"""
-    <div id={@id} class="inline-flex rounded-md shadow-xs">
-      <.button
-        type="button"
-        theme="primary"
-        phx-click={show_dropdown("menu")}
-        class="relative inline-flex items-center"
-        aria-expanded="true"
-        aria-haspopup="true"
-        disabled={@disabled}
-      >
+    <Common.simple_dropdown id={@id}>
+      <:button>
         {render_slot(@inner_block)}
-        <.icon name="hero-chevron-down" class="ml-1 h-5 w-5" />
-      </.button>
-      <div class="relative -ml-px block">
-        <div
-          class="hidden absolute right-0 z-10 -mr-1 mt-12 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none"
-          role="menu"
-          aria-orientation="vertical"
-          aria-labelledby="option-menu-button"
+      </:button>
+      <:options>
+        <a
+          :for={%{name: name, id: id, target: target} = option <- @options}
+          href="#"
+          role="menuitem"
           tabindex="-1"
-          phx-click-away={hide_dropdown("menu")}
-          id="menu"
+          id={id}
+          phx-click={show_modal(target)}
+          disabled={@disabled}
         >
-          <div class="py-1" role="none">
-            <a
-              :for={%{name: name, id: id, target: target} = option <- @options}
-              href="#"
-              class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100"
-              role="menuitem"
-              tabindex="-1"
-              id={id}
-              phx-click={show_modal(target)}
-              disabled={@disabled}
-            >
-              {name}<span
-                :if={Map.get(option, :badge)}
-                class="ml-2 inline-flex items-center rounded-md bg-gray-50 px-1.5 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
-              ><%= Map.get(option, :badge) %></span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
+          {name}<span
+            :if={Map.get(option, :badge)}
+            class="ml-2 inline-flex items-center rounded-md bg-gray-50 px-1.5 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
+          ><%= Map.get(option, :badge) %></span>
+        </a>
+      </:options>
+    </Common.simple_dropdown>
     """
   end
 end

--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -25,7 +25,7 @@ defmodule LightningWeb.Components.Credentials do
           </button>
         </div>
       </:title>
-      <div class="text-left text-wrap">
+      <div>
         <p class="text-sm text-gray-500">
           You are about the delete the credential "{@credential.name}" which may be used in other projects. All jobs using this credential will fail.
           <br /><br />Do you want to proceed with this action?
@@ -70,7 +70,7 @@ defmodule LightningWeb.Components.Credentials do
           </button>
         </div>
       </:title>
-      <div class="text-left text-wrap">
+      <div>
         <p class="text-sm text-gray-500">
           You are about the delete the Oauth client "{@client.name}" which may be used in other projects. All jobs dependent on this client will fail.
           <br /><br />Do you want to proceed with this action?

--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -28,11 +28,10 @@ defmodule LightningWeb.Components.Credentials do
       <div class="text-left text-wrap">
         <p class="text-sm text-gray-500">
           You are about the delete the credential "{@credential.name}" which may be used in other projects. All jobs using this credential will fail.
-          <br />Do you want to proceed with this action?
+          <br /><br />Do you want to proceed with this action?
         </p>
       </div>
-      <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-      <div class="flex flex-row-reverse gap-4">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -46,7 +45,7 @@ defmodule LightningWeb.Components.Credentials do
         <.button type="button" phx-click={hide_modal(@id)} theme="secondary">
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end
@@ -77,8 +76,7 @@ defmodule LightningWeb.Components.Credentials do
           <br /><br />Do you want to proceed with this action?
         </p>
       </div>
-      <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-      <div class="flex flex-row-reverse gap-4">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -92,7 +90,7 @@ defmodule LightningWeb.Components.Credentials do
         <.button type="button" phx-click={hide_modal(@id)} theme="secondary">
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -143,20 +143,20 @@ defmodule LightningWeb.Components.DataTables do
           <:body>
             <%= for client <- @clients do %>
               <.tr id={"#{@id}-#{client.id}"}>
-                <.td class="max-w-[15rem]">
+                <.td class="wrap-break-word max-w-[15rem]">
                   {client.name}
                 </.td>
-                <.td :if={@show_owner} class="break-words max-w-[15rem]">
+                <.td :if={@show_owner} class="wrap-break-word max-w-[15rem]">
                   {if client.global, do: "GLOBAL", else: client.user.email}
                 </.td>
-                <.td class="break-words max-w-[20rem]">
+                <.td class="wrap-break-word max-w-[20rem]">
                   <%= for project_name <- client.project_names do %>
                     <span class="inline-flex items-center rounded-md bg-primary-50 p-1 my-0.5 text-xs font-medium ring-1 ring-inset ring-gray-500/10">
                       {project_name}
                     </span>
                   <% end %>
                 </.td>
-                <.td class="break-words max-w-[18rem]">
+                <.td class="wrap-break-word max-w-[18rem]">
                   {client.authorization_endpoint}
                 </.td>
                 <.td>

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -65,22 +65,22 @@ defmodule LightningWeb.Components.DataTables do
                     <% end %>
                   </div>
                 </.td>
-                <.td class="break-words max-w-[10rem] border-">
+                <.td class="wrap-break-word max-w-[10rem] border-">
                   {credential_type(credential)}
                 </.td>
-                <.td :if={@show_owner} class="break-words max-w-[15rem]">
+                <.td :if={@show_owner} class="wrap-break-word max-w-[15rem]">
                   <div class="flex-auto items-center">
                     {credential.user.email}
                   </div>
                 </.td>
-                <.td class="break-words max-w-[25rem]">
+                <.td class="wrap-break-word max-w-[25rem]">
                   <%= for project_name <- credential.project_names do %>
                     <span class="inline-flex items-center rounded-md bg-primary-50 p-1 my-0.5 text-xs font-medium ring-1 ring-inset ring-gray-500/10">
                       {project_name}
                     </span>
                   <% end %>
                 </.td>
-                <.td class="break-words max-w-[5rem]">
+                <.td class="wrap-break-word max-w-[5rem]">
                   <%= if credential.production do %>
                     <div class="flex">
                       <.icon

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -49,9 +49,15 @@ defmodule LightningWeb.Components.DataTables do
           <:body>
             <%= for credential <- @credentials do %>
               <.tr id={"#{@id}-#{credential.id}"}>
-                <.td class="break-words max-w-[15rem]">
-                  <div class="flex-auto items-center">
-                    {credential.name}
+                <.td class="max-w-[15rem]">
+                  <div class="flex items-center truncate">
+                    <Common.wrapper_tooltip
+                      id={"credential-name-#{credential.id}"}
+                      tooltip={credential.name}
+                    >
+                      {credential.name}
+                    </Common.wrapper_tooltip>
+
                     <%= if missing_oauth_client?(credential) do %>
                       <span
                         id={"#{credential.id}-client-not-found-tooltip"}
@@ -82,13 +88,17 @@ defmodule LightningWeb.Components.DataTables do
                 <.td class="break-words max-w-[5rem]">
                   <%= if credential.production do %>
                     <div class="flex">
-                      <Heroicons.exclamation_triangle class="w-5 h-5 text-secondary-500" />
-                      &nbsp;Production
+                      <.icon
+                        name="hero-exclamation-triangle"
+                        class="w-5 h-5 text-secondary-500"
+                      /> &nbsp;Production
                     </div>
                   <% end %>
                 </.td>
-                <.td class="flex justify-end py-0.5">
-                  {render_slot(@actions, credential)}
+                <.td>
+                  <div class="flex justify-end items-center">
+                    {render_slot(@actions, credential)}
+                  </div>
                 </.td>
               </.tr>
             <% end %>
@@ -138,8 +148,13 @@ defmodule LightningWeb.Components.DataTables do
           <:body>
             <%= for client <- @clients do %>
               <.tr id={"#{@id}-#{client.id}"}>
-                <.td class="break-words max-w-[15rem]">
-                  {client.name}
+                <.td class="truncate max-w-[15rem]">
+                  <Common.wrapper_tooltip
+                    id={"oauth-client-name-#{client.id}"}
+                    tooltip={client.name}
+                  >
+                    {client.name}
+                  </Common.wrapper_tooltip>
                 </.td>
                 <.td :if={@show_owner} class="break-words max-w-[15rem]">
                   {if client.global, do: "GLOBAL", else: client.user.email}
@@ -151,11 +166,18 @@ defmodule LightningWeb.Components.DataTables do
                     </span>
                   <% end %>
                 </.td>
-                <.td class="break-words max-w-[21rem]">
-                  {client.authorization_endpoint}
+                <.td class="break-words max-w-[18rem]">
+                  <Common.wrapper_tooltip
+                    id={"oauth-client-endpoint-#{client.id}"}
+                    tooltip={client.authorization_endpoint}
+                  >
+                    {client.authorization_endpoint}
+                  </Common.wrapper_tooltip>
                 </.td>
-                <.td class="flex justify-end py-0.5">
-                  {render_slot(@actions, client)}
+                <.td>
+                  <div class="flex justify-end items-center">
+                    {render_slot(@actions, client)}
+                  </div>
                 </.td>
               </.tr>
             <% end %>

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -50,13 +50,8 @@ defmodule LightningWeb.Components.DataTables do
             <%= for credential <- @credentials do %>
               <.tr id={"#{@id}-#{credential.id}"}>
                 <.td class="max-w-[15rem]">
-                  <div class="flex items-center truncate">
-                    <Common.wrapper_tooltip
-                      id={"credential-name-#{credential.id}"}
-                      tooltip={credential.name}
-                    >
-                      {credential.name}
-                    </Common.wrapper_tooltip>
+                  <div class="flex items-center">
+                    {credential.name}
 
                     <%= if missing_oauth_client?(credential) do %>
                       <span
@@ -148,13 +143,8 @@ defmodule LightningWeb.Components.DataTables do
           <:body>
             <%= for client <- @clients do %>
               <.tr id={"#{@id}-#{client.id}"}>
-                <.td class="truncate max-w-[15rem]">
-                  <Common.wrapper_tooltip
-                    id={"oauth-client-name-#{client.id}"}
-                    tooltip={client.name}
-                  >
-                    {client.name}
-                  </Common.wrapper_tooltip>
+                <.td class="max-w-[15rem]">
+                  {client.name}
                 </.td>
                 <.td :if={@show_owner} class="break-words max-w-[15rem]">
                   {if client.global, do: "GLOBAL", else: client.user.email}
@@ -167,12 +157,7 @@ defmodule LightningWeb.Components.DataTables do
                   <% end %>
                 </.td>
                 <.td class="break-words max-w-[18rem]">
-                  <Common.wrapper_tooltip
-                    id={"oauth-client-endpoint-#{client.id}"}
-                    tooltip={client.authorization_endpoint}
-                  >
-                    {client.authorization_endpoint}
-                  </Common.wrapper_tooltip>
+                  {client.authorization_endpoint}
                 </.td>
                 <.td>
                   <div class="flex justify-end items-center">

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -87,7 +87,7 @@ defmodule LightningWeb.Components.DataTables do
                     </div>
                   <% end %>
                 </.td>
-                <.td class="text-right py-0.5">
+                <.td class="flex justify-end py-0.5">
                   {render_slot(@actions, credential)}
                 </.td>
               </.tr>
@@ -154,7 +154,7 @@ defmodule LightningWeb.Components.DataTables do
                 <.td class="break-words max-w-[21rem]">
                   {client.authorization_endpoint}
                 </.td>
-                <.td class="text-right py-0.5">
+                <.td class="flex justify-end py-0.5">
                   {render_slot(@actions, client)}
                 </.td>
               </.tr>
@@ -224,7 +224,7 @@ defmodule LightningWeb.Components.DataTables do
                   {file.created_by.first_name <> " " <> file.created_by.last_name}
                 </.td>
                 <.td>{format_export_status(file.status)}</.td>
-                <.td class="text-right py-0.5">
+                <.td class="flex justify-end py-0.5">
                   {render_slot(@actions, file)}
                 </.td>
               </.tr>
@@ -271,7 +271,7 @@ defmodule LightningWeb.Components.DataTables do
               <.tr id={"collection-row-#{collection.id}"}>
                 <.td>{collection.name}</.td>
                 <.td>{div(collection.byte_size_sum, 1_000_000)}</.td>
-                <.td class="text-right py-0.5">
+                <.td class="flex justify-end py-0.5">
                   {render_slot(@actions, collection)}
                 </.td>
               </.tr>
@@ -334,7 +334,7 @@ defmodule LightningWeb.Components.DataTables do
                 <.td>
                   <.digest current_user={@current_user} project_user={project_user} />
                 </.td>
-                <.td class="text-right py-0.5">
+                <.td class="flex justify-end py-0.5">
                   {render_slot(@actions, project_user)}
                 </.td>
               </.tr>

--- a/lib/lightning_web/live/components/modal.ex
+++ b/lib/lightning_web/live/components/modal.ex
@@ -11,7 +11,6 @@ defmodule LightningWeb.Components.Modal do
 
   attr :id, :string, required: true
   attr :show, :boolean, default: false
-  attr :with_frame, :boolean, default: true
   attr :position, :string, default: "fixed inset-0"
   attr :width, :string, default: "max-w-3xl"
   attr :close_on_click_away, :boolean, default: true
@@ -72,11 +71,10 @@ defmodule LightningWeb.Components.Modal do
               }
               class={[
                 "hidden relative rounded-xl transition",
-                @with_frame &&
-                  "bg-white py-[24px] shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10"
+                "bg-white py-[24px] shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10"
               ]}
             >
-              <header :if={@title != [] && @with_frame} class="pl-[24px] pr-[24px]">
+              <header :if={@title != []} class="pl-[24px] pr-[24px]">
                 <h1
                   id={"#{@id}-title"}
                   class="text-lg font-semibold leading-5 text-zinc-800"
@@ -89,16 +87,13 @@ defmodule LightningWeb.Components.Modal do
                   </p>
                 <% end %>
               </header>
-              <div
-                :if={@title != [] && @with_frame}
-                class="flex-grow bg-gray-100 h-0.5 my-[16px]"
-              >
+              <div :if={@title != []} class="flex-grow bg-gray-100 h-0.5 my-[16px]">
               </div>
-              <section class={if(@with_frame, do: "pl-[24px] pr-[24px]", else: "")}>
+              <section class="pl-[24px] pr-[24px]">
                 {render_slot(@inner_block)}
               </section>
               <%= for footer <- @footer do %>
-                <.modal_footer :if={@with_frame} class={footer |> Map.get(:class)}>
+                <.modal_footer {if(footer[:class], do: [class: footer[:class], else: []])}>
                   {render_slot(footer)}
                 </.modal_footer>
               <% end %>
@@ -110,12 +105,12 @@ defmodule LightningWeb.Components.Modal do
     """
   end
 
-  attr :class, :any, default: ""
+  attr :class, :any, default: "sm:flex sm:flex-row-reverse gap-3"
   slot :inner_block, required: true
 
   def modal_footer(assigns) do
     ~H"""
-    <div class="flex-grow bg-gray-100 h-0.5 mt-[16px]"></div>
+    <div class="mt-[16px]"></div>
     <footer class={@class}>
       {render_slot(@inner_block)}
     </footer>

--- a/lib/lightning_web/live/components/modal.ex
+++ b/lib/lightning_web/live/components/modal.ex
@@ -93,7 +93,7 @@ defmodule LightningWeb.Components.Modal do
                 {render_slot(@inner_block)}
               </section>
               <%= for footer <- @footer do %>
-                <.modal_footer {if(footer[:class], do: [class: footer[:class], else: []])}>
+                <.modal_footer {if(footer[:class], do: [class: footer[:class]], else: [])}>
                   {render_slot(footer)}
                 </.modal_footer>
               <% end %>

--- a/lib/lightning_web/live/components/project_deletion_modal.ex
+++ b/lib/lightning_web/live/components/project_deletion_modal.ex
@@ -131,8 +131,7 @@ defmodule LightningWeb.Components.ProjectDeletionModal do
             <.input type="hidden" field={f[:id]} />
             <.input type="hidden" field={f[:name]} />
           </div>
-          <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-          <div class="flex flex-row-reverse gap-4">
+          <.modal_footer>
             <.button
               id={"project-#{@id}_confirm_button"}
               type="submit"
@@ -150,7 +149,7 @@ defmodule LightningWeb.Components.ProjectDeletionModal do
             >
               Cancel
             </.button>
-          </div>
+          </.modal_footer>
         </.form>
       </.modal>
     </div>

--- a/lib/lightning_web/live/components/token_deletion_modal.ex
+++ b/lib/lightning_web/live/components/token_deletion_modal.ex
@@ -61,8 +61,7 @@ defmodule LightningWeb.Components.TokenDeletionModal do
             Are you sure you want to delete this token?
           </p>
         </div>
-        <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-        <div class="flex flex-row-reverse gap-4">
+        <.modal_footer>
           <.button
             id={"delete-token-#{@id}_confirm_button"}
             type="button"
@@ -82,7 +81,7 @@ defmodule LightningWeb.Components.TokenDeletionModal do
           >
             Cancel
           </.button>
-        </div>
+        </.modal_footer>
       </.modal>
     </div>
     """

--- a/lib/lightning_web/live/components/user_deletion_modal.ex
+++ b/lib/lightning_web/live/components/user_deletion_modal.ex
@@ -111,8 +111,7 @@ defmodule LightningWeb.Components.UserDeletionModal do
             <br /><br />Audit trails are removed on a project-basis and may be controlled by the project owner or a superuser.
           </p>
         </div>
-        <div class="flex-grow bg-gray-100 h-0.5 my-[16px]"></div>
-        <div class="flex flex-row-reverse gap-4">
+        <.modal_footer>
           <button
             type="button"
             phx-click="close_modal"
@@ -121,7 +120,7 @@ defmodule LightningWeb.Components.UserDeletionModal do
           >
             Cancel
           </button>
-        </div>
+        </.modal_footer>
       </.modal>
     </div>
     """

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -224,7 +224,7 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
             </button>
           </div>
         </:title>
-        <div class="container mx-auto px-4">
+        <div class="container mx-auto">
           <.form
             id="credential-schema-picker"
             for={@schema_selection_form}
@@ -256,26 +256,24 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
             </div>
           </.form>
         </div>
-        <.modal_footer class="mt-6 mx-6">
-          <div class="sm:flex sm:flex-row-reverse gap-3">
-            <.button
-              type="submit"
-              theme="primary"
-              disabled={!@schema}
-              phx-click="change_page"
-              phx-target={@myself}
-            >
-              Configure credential
-            </.button>
-            <.button
-              id="cancel-credential-type-picker"
-              type="button"
-              phx-click={hide_modal(@id) |> JS.push("reset_state", target: @myself)}
-              theme="secondary"
-            >
-              Cancel
-            </.button>
-          </div>
+        <.modal_footer>
+          <.button
+            type="submit"
+            theme="primary"
+            disabled={!@schema}
+            phx-click="change_page"
+            phx-target={@myself}
+          >
+            Configure credential
+          </.button>
+          <.button
+            id="cancel-credential-type-picker"
+            type="button"
+            phx-click={hide_modal(@id) |> JS.push("reset_state", target: @myself)}
+            theme="secondary"
+          >
+            Cancel
+          </.button>
         </.modal_footer>
       </.modal>
     </div>
@@ -355,7 +353,7 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
             form={f}
             type={@schema}
           >
-            <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
+            <div class="space-y-6 bg-white py-5">
               <fieldset>
                 <div class="space-y-4">
                   <div>
@@ -411,26 +409,22 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
               </div>
             </div>
           </LightningWeb.Components.Credentials.form_component>
-          <.modal_footer class="mt-6 mx-6">
-            <div class="sm:flex sm:flex-row-reverse gap-3">
-              <.button
-                id={"save-credential-button-#{@credential.id || "new"}"}
-                type="submit"
-                theme="primary"
-                disabled={!@changeset.valid? or @scopes_changed or @sandbox_changed}
-              >
-                Save
-              </.button>
-              <.button
-                type="button"
-                phx-click={
-                  hide_modal(@id) |> JS.push("reset_state", target: @myself)
-                }
-                theme="secondary"
-              >
-                Cancel
-              </.button>
-            </div>
+          <.modal_footer>
+            <.button
+              id={"save-credential-button-#{@credential.id || "new"}"}
+              type="submit"
+              theme="primary"
+              disabled={!@changeset.valid? or @scopes_changed or @sandbox_changed}
+            >
+              Save
+            </.button>
+            <.button
+              type="button"
+              phx-click={hide_modal(@id) |> JS.push("reset_state", target: @myself)}
+              theme="secondary"
+            >
+              Cancel
+            </.button>
           </.modal_footer>
         </.form>
       </.modal>

--- a/lib/lightning_web/live/credential_live/generic_oauth_component.ex
+++ b/lib/lightning_web/live/credential_live/generic_oauth_component.ex
@@ -556,7 +556,7 @@ defmodule LightningWeb.CredentialLive.GenericOauthComponent do
         phx-change="validate"
         phx-submit="save"
       >
-        <div class="bg-white px-4">
+        <div class="bg-white">
           <div class="space-y-4">
             <div>
               <NewInputs.input
@@ -642,31 +642,25 @@ defmodule LightningWeb.CredentialLive.GenericOauthComponent do
           </div>
         </div>
 
-        <.modal_footer class="mt-6 mx-4">
-          <div class="flex justify-between items-center">
-            <div class="flex-1 w-1/2">
-              <div class="sm:flex sm:flex-row-reverse gap-3">
-                <.button
-                  id={"save-credential-button-#{@credential.id || "new"}"}
-                  type="submit"
-                  theme="primary"
-                  disabled={
-                    !@changeset.valid? || @scopes_changed ||
-                      @oauth_progress == :error
-                  }
-                >
-                  Save
-                </.button>
-                <.button
-                  type="button"
-                  phx-click={JS.navigate(@return_to)}
-                  theme="secondary"
-                >
-                  Cancel
-                </.button>
-              </div>
-            </div>
-          </div>
+        <.modal_footer>
+          <.button
+            id={"save-credential-button-#{@credential.id || "new"}"}
+            type="submit"
+            theme="primary"
+            disabled={
+              !@changeset.valid? || @scopes_changed ||
+                @oauth_progress == :error
+            }
+          >
+            Save
+          </.button>
+          <.button
+            type="button"
+            phx-click={JS.navigate(@return_to)}
+            theme="secondary"
+          >
+            Cancel
+          </.button>
         </.modal_footer>
       </.form>
     </div>

--- a/lib/lightning_web/live/credential_live/index.ex
+++ b/lib/lightning_web/live/credential_live/index.ex
@@ -8,6 +8,7 @@ defmodule LightningWeb.CredentialLive.Index do
 
   alias Lightning.Credentials
   alias Lightning.OauthClients
+  alias LightningWeb.Components.Common
 
   on_mount {LightningWeb.Hooks, :assign_projects}
 
@@ -119,41 +120,30 @@ defmodule LightningWeb.CredentialLive.Index do
   end
 
   def delete_action(assigns) do
-    if assigns.credential.scheduled_deletion do
-      ~H"""
-      <span>
-        <.link
-          id={"cancel-deletion-#{@credential.id}"}
-          class="table-action"
-          href="#"
-          phx-click="cancel_deletion"
-          phx-value-id={@credential.id}
-        >
-          Cancel deletion
-        </.link>
-      </span>
-      <span>
-        <.link
-          id={"delete-now-#{@credential.id}"}
-          class="table-action"
-          navigate={~p"/credentials/#{@credential.id}/delete"}
-        >
-          Delete now
-        </.link>
-      </span>
-      """
-    else
-      ~H"""
-      <span>
-        <.link
-          id={"delete-#{@credential.id}"}
-          class="table-action"
-          navigate={~p"/credentials/#{@credential.id}/delete"}
-        >
-          Delete
-        </.link>
-      </span>
-      """
-    end
+    ~H"""
+    <%= if @credential.scheduled_deletion do %>
+      <.link
+        id={"cancel-deletion-#{@credential.id}"}
+        href="#"
+        phx-click="cancel_deletion"
+        phx-value-id={@credential.id}
+      >
+        Cancel deletion
+      </.link>
+      <.link
+        id={"delete-now-#{@credential.id}"}
+        navigate={~p"/credentials/#{@credential.id}/delete"}
+      >
+        Delete now
+      </.link>
+    <% else %>
+      <.link
+        id={"delete-#{@credential.id}"}
+        navigate={~p"/credentials/#{@credential.id}/delete"}
+      >
+        Delete
+      </.link>
+    <% end %>
+    """
   end
 end

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -48,23 +48,30 @@
         </:empty_state>
         <:actions :let={client}>
           <div :if={can_edit?(client, @current_user)}>
-            <span>
-              <.link
-                class="table-action"
-                phx-click={show_modal("edit-oauth-client-#{client.id}-modal")}
-              >
-                Edit
-              </.link>
-            </span>
-            <span>
-              <.link
-                id={"delete-oauth-client-#{client.id}-button"}
-                class="table-action"
-                phx-click={show_modal("delete_oauth_client_#{client.id}_modal")}
-              >
-                Delete
-              </.link>
-            </span>
+            <Common.simple_dropdown
+              id={"oauth-client-actions-#{client.id}-dropdown"}
+              button_theme="secondary"
+            >
+              <:button>
+                Actions
+              </:button>
+
+              <:options>
+                <.link phx-click={
+                  show_modal("edit-oauth-client-#{client.id}-modal")
+                }>
+                  Edit
+                </.link>
+                <.link
+                  id={"delete-oauth-client-#{client.id}-button"}
+                  phx-click={
+                    show_modal("delete_oauth_client_#{client.id}_modal")
+                  }
+                >
+                  Delete
+                </.link>
+              </:options>
+            </Common.simple_dropdown>
 
             <LightningWeb.Components.Credentials.delete_oauth_client_modal
               :if={can_edit?(client, @current_user)}

--- a/lib/lightning_web/live/credential_live/index.html.heex
+++ b/lib/lightning_web/live/credential_live/index.html.heex
@@ -102,32 +102,35 @@
         </:empty_state>
         <:actions :let={credential}>
           <div :if={can_edit?(credential, @current_user)}>
-            <span>
-              <.link
-                class="table-action"
-                phx-click={
+            <Common.simple_dropdown
+              id={"credential-actions-#{credential.id}-dropdown"}
+              button_theme="secondary"
+            >
+              <:button>
+                Actions
+              </:button>
+              <:options>
+                <.link phx-click={
                   show_modal("transfer-credential-#{credential.id}-modal")
-                }
-              >
-                <%= case credential.transfer_status do %>
-                  <% :pending -> %>
-                    Revoke Transfer
-                  <% :completed -> %>
-                    Transfer
-                  <% nil -> %>
-                    Transfer
-                <% end %>
-              </.link>
-            </span>
-            <span>
-              <.link
-                class="table-action"
-                phx-click={show_modal("edit-credential-#{credential.id}-modal")}
-              >
-                Edit
-              </.link>
-            </span>
-            <.delete_action socket={@socket} credential={credential} />
+                }>
+                  <%= case credential.transfer_status do %>
+                    <% :pending -> %>
+                      Revoke Transfer
+                    <% :completed -> %>
+                      Transfer
+                    <% nil -> %>
+                      Transfer
+                  <% end %>
+                </.link>
+                <.link phx-click={
+                  show_modal("edit-credential-#{credential.id}-modal")
+                }>
+                  Edit
+                </.link>
+                <.delete_action socket={@socket} credential={credential} />
+              </:options>
+            </Common.simple_dropdown>
+
             <.live_component
               id={"edit-credential-#{credential.id}-modal"}
               module={LightningWeb.CredentialLive.CredentialFormComponent}

--- a/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
+++ b/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
@@ -361,7 +361,7 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
           phx-change="validate"
           phx-submit="save"
         >
-          <div class="space-y-6 bg-white px-4 px-6 sm:px-6">
+          <div class="space-y-6 bg-white">
             <div class="space-y-4">
               <div>
                 <NewInputs.input
@@ -509,20 +509,18 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
               </fieldset>
             </div>
           </div>
-          <.modal_footer class="mt-6 mx-6">
-            <div class="sm:flex sm:flex-row-reverse gap-3">
-              <.button type="submit" theme="primary" disabled={!@changeset.valid?}>
-                <%= case @action do %>
-                  <% :edit -> %>
-                    Save Changes
-                  <% :new -> %>
-                    Add OAuth Client
-                <% end %>
-              </.button>
-              <.button_link type="button" navigate={@return_to} theme="secondary">
-                Cancel
-              </.button_link>
-            </div>
+          <.modal_footer>
+            <.button type="submit" theme="primary" disabled={!@changeset.valid?}>
+              <%= case @action do %>
+                <% :edit -> %>
+                  Save Changes
+                <% :new -> %>
+                  Add OAuth Client
+              <% end %>
+            </.button>
+            <.button_link type="button" navigate={@return_to} theme="secondary">
+              Cancel
+            </.button_link>
           </.modal_footer>
         </.form>
       </.modal>

--- a/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
+++ b/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
@@ -126,7 +126,7 @@ defmodule LightningWeb.CredentialLive.TransferCredentialModal do
           </div>
         </:title>
         <:subtitle>
-          <span class="text-xs text-left text-wrap">
+          <span class="text-xs">
             <.modal_subtitle {assigns} />
           </span>
         </:subtitle>

--- a/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
+++ b/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
@@ -191,7 +191,7 @@ defmodule LightningWeb.CredentialLive.TransferCredentialModal do
 
   defp form_footer(assigns) do
     ~H"""
-    <.modal_footer class="mt-6">
+    <.modal_footer>
       <.footer_buttons {assigns} />
     </.modal_footer>
     """
@@ -216,52 +216,48 @@ defmodule LightningWeb.CredentialLive.TransferCredentialModal do
 
   defp footer_buttons(%{revoke_transfer: true} = assigns) do
     ~H"""
-    <div class="flex flex-row-reverse gap-4">
-      <.button
-        id={"#{@id}-revoke-button"}
-        type="button"
-        theme="primary"
-        phx-click="revoke-transfer"
-        phx-target={@myself}
-        phx-disable-with="Revoking..."
-      >
-        Revoke
-      </.button>
-      <.button
-        id={"#{@id}-cancel-button"}
-        type="button"
-        phx-target={@myself}
-        phx-click="close-modal"
-        theme="secondary"
-      >
-        Cancel
-      </.button>
-    </div>
+    <.button
+      id={"#{@id}-revoke-button"}
+      type="button"
+      theme="primary"
+      phx-click="revoke-transfer"
+      phx-target={@myself}
+      phx-disable-with="Revoking..."
+    >
+      Revoke
+    </.button>
+    <.button
+      id={"#{@id}-cancel-button"}
+      type="button"
+      phx-target={@myself}
+      phx-click="close-modal"
+      theme="secondary"
+    >
+      Cancel
+    </.button>
     """
   end
 
   defp footer_buttons(assigns) do
     ~H"""
-    <div class="flex flex-row-reverse gap-4">
-      <.button
-        id={"#{@id}-submit-button"}
-        type="submit"
-        theme="primary"
-        phx-disable-with="Transferring..."
-        disabled={!@changeset.valid?}
-      >
-        Transfer
-      </.button>
-      <.button
-        id={"#{@id}-cancel-button"}
-        type="button"
-        phx-target={@myself}
-        phx-click="close-modal"
-        theme="secondary"
-      >
-        Cancel
-      </.button>
-    </div>
+    <.button
+      id={"#{@id}-submit-button"}
+      type="submit"
+      theme="primary"
+      phx-disable-with="Transferring..."
+      disabled={!@changeset.valid?}
+    >
+      Transfer
+    </.button>
+    <.button
+      id={"#{@id}-cancel-button"}
+      type="button"
+      phx-target={@myself}
+      phx-click="close-modal"
+      theme="secondary"
+    >
+      Cancel
+    </.button>
     """
   end
 

--- a/lib/lightning_web/live/dashboard_live/components.ex
+++ b/lib/lightning_web/live/dashboard_live/components.ex
@@ -116,13 +116,13 @@ defmodule LightningWeb.DashboardLive.Components do
                 <.td>
                   {project.name}
                 </.td>
-                <.td class="break-words max-w-[25rem]">
+                <.td class="wrap-break-word max-w-[25rem]">
                   {String.capitalize(to_string(project.role))}
                 </.td>
-                <.td class="break-words max-w-[10rem]">
+                <.td class="wrap-break-word max-w-[10rem]">
                   {project.workflows_count}
                 </.td>
-                <.td class="break-words max-w-[5rem]">
+                <.td class="wrap-break-word max-w-[5rem]">
                   <.link
                     class="link"
                     href={~p"/projects/#{project.id}/settings#collaboration"}

--- a/lib/lightning_web/live/dashboard_live/project_creation_modal.ex
+++ b/lib/lightning_web/live/dashboard_live/project_creation_modal.ex
@@ -123,26 +123,24 @@ defmodule LightningWeb.DashboardLive.ProjectCreationModal do
               </small>
             </div>
           </div>
-          <.modal_footer class="mt-6 mx-6">
-            <div class="sm:flex sm:flex-row-reverse gap-3">
-              <.button
-                type="submit"
-                theme="primary"
-                disabled={!@changeset.valid?}
-                phx-target={@myself}
-              >
-                Create project
-              </.button>
-              <.button
-                id="cancel-project-creation"
-                theme="secondary"
-                type="button"
-                phx-click="close_modal"
-                phx-target={@myself}
-              >
-                Cancel
-              </.button>
-            </div>
+          <.modal_footer>
+            <.button
+              type="submit"
+              theme="primary"
+              disabled={!@changeset.valid?}
+              phx-target={@myself}
+            >
+              Create project
+            </.button>
+            <.button
+              id="cancel-project-creation"
+              theme="secondary"
+              type="button"
+              phx-click="close_modal"
+              phx-target={@myself}
+            >
+              Cancel
+            </.button>
           </.modal_footer>
         </.form>
       </.modal>

--- a/lib/lightning_web/live/profile_live/github_component.ex
+++ b/lib/lightning_web/live/profile_live/github_component.ex
@@ -114,7 +114,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
         You are about to disconnect your OpenFn account from GitHub.
         Until you reconnect, you will not be able to set up or modify version control for your projects.
       </p>
-      <div class="flex flex-row-reverse gap-4 mx-6 mt-2">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -128,7 +128,7 @@ defmodule LightningWeb.ProfileLive.GithubComponent do
         <.button type="button" phx-click={hide_modal(@id)} theme="secondary">
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end

--- a/lib/lightning_web/live/project_live/collections_component.ex
+++ b/lib/lightning_web/live/project_live/collections_component.ex
@@ -291,26 +291,24 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
             </small>
           </div>
         </div>
-        <.modal_footer class="mt-6">
-          <div class="sm:flex sm:flex-row-reverse gap-3">
-            <.button
-              id={"submit-btn-#{@id}"}
-              type="submit"
-              theme="primary"
-              disabled={!@changeset.valid?}
-            >
-              Save
-            </.button>
-            <.button
-              id={"cancel-btn-#{@id}"}
-              type="button"
-              phx-click="reset_action"
-              phx-target={@myself}
-              theme="secondary"
-            >
-              Cancel
-            </.button>
-          </div>
+        <.modal_footer>
+          <.button
+            id={"submit-btn-#{@id}"}
+            type="submit"
+            theme="primary"
+            disabled={!@changeset.valid?}
+          >
+            Save
+          </.button>
+          <.button
+            id={"cancel-btn-#{@id}"}
+            type="button"
+            phx-click="reset_action"
+            phx-target={@myself}
+            theme="secondary"
+          >
+            Cancel
+          </.button>
         </.modal_footer>
       </.form>
     </.modal>
@@ -350,7 +348,7 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
           If you wish to proceed with this action, click on the delete button. To cancel click on the cancel button.<br /><br />
         </p>
       </div>
-      <div class="flex flex-row-reverse gap-4 mt-2">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -370,7 +368,7 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
         >
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -556,7 +556,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
           Until you reconnect, you will not be able to sync this project to Github.
         </p>
       </div>
-      <div class="flex flex-row-reverse gap-4 mx-6 mt-2">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -570,7 +570,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
         <.button type="button" phx-click={hide_modal(@id)} theme="secondary">
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end
@@ -608,10 +608,10 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
         phx-submit="reconnect"
         phx-target={@myself}
       >
-        <div class="px-6">
+        <div>
           <.sync_order_radio form={f} />
         </div>
-        <div class="px-6">
+        <div>
           <.accept_checkbox
             project={@project}
             form={f}
@@ -623,7 +623,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
             }
           />
         </div>
-        <div class="flex flex-row-reverse gap-4 mx-6 mt-2">
+        <.modal_footer>
           <.button
             id="reconnect-project-button"
             type="submit"
@@ -632,7 +632,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
           >
             Reconnect
           </.button>
-        </div>
+        </.modal_footer>
       </.form>
     </.modal>
     """

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -161,42 +161,32 @@ defmodule LightningWeb.ProjectLive.Index do
   end
 
   def delete_action(assigns) do
-    if assigns.project.scheduled_deletion do
-      ~H"""
-      <span>
-        <.link
-          id={"cancel-deletion-#{@project.id}"}
-          href="#"
-          class="table-action"
-          phx-click="cancel_deletion"
-          phx-value-id={@project.id}
-        >
-          Cancel deletion
-        </.link>
-      </span>
-      <span>
-        <.link
-          id={"delete-now-#{@project.id}"}
-          class="table-action"
-          navigate={~p"/settings/projects/#{@project.id}/delete"}
-        >
-          Delete now
-        </.link>
-      </span>
-      """
-    else
-      ~H"""
-      <span>
-        <.link
-          id={"delete-#{@project.id}"}
-          class="table-action"
-          navigate={Routes.project_index_path(@socket, :delete, @project)}
-        >
-          Delete
-        </.link>
-      </span>
-      """
-    end
+    ~H"""
+    <%= if assigns.project.scheduled_deletion do %>
+      <.link
+        id={"cancel-deletion-#{@project.id}"}
+        href="#"
+        phx-click="cancel_deletion"
+        phx-value-id={@project.id}
+      >
+        Cancel deletion
+      </.link>
+
+      <.link
+        id={"delete-now-#{@project.id}"}
+        navigate={~p"/settings/projects/#{@project.id}/delete"}
+      >
+        Delete now
+      </.link>
+    <% else %>
+      <.link
+        id={"delete-#{@project.id}"}
+        navigate={Routes.project_index_path(@socket, :delete, @project)}
+      >
+        Delete
+      </.link>
+    <% end %>
+    """
   end
 
   defp list_projects(filter, sort_key, sort_direction) do
@@ -223,7 +213,7 @@ defmodule LightningWeb.ProjectLive.Index do
   def get_project_owner_name(project) do
     case Enum.find(project.project_users, fn pu -> pu.role == :owner end) do
       %{user: user} when not is_nil(user) ->
-        "#{user.first_name || ""} #{user.last_name || ""}" |> String.trim()
+        String.trim("#{user.first_name} #{user.last_name}")
 
       _ ->
         ""

--- a/lib/lightning_web/live/project_live/index.ex
+++ b/lib/lightning_web/live/project_live/index.ex
@@ -162,7 +162,7 @@ defmodule LightningWeb.ProjectLive.Index do
 
   def delete_action(assigns) do
     ~H"""
-    <%= if assigns.project.scheduled_deletion do %>
+    <%= if @project.scheduled_deletion do %>
       <.link
         id={"cancel-deletion-#{@project.id}"}
         href="#"

--- a/lib/lightning_web/live/project_live/index.html.heex
+++ b/lib/lightning_web/live/project_live/index.html.heex
@@ -53,7 +53,7 @@
               <.td>{project.inserted_at}</.td>
               <.td>{project.description}</.td>
               <.td>{project.scheduled_deletion}</.td>
-              <.td class="text-right py-0.5">
+              <.td class="flex justify-end py-0.5">
                 <span>
                   <.link
                     class="table-action"

--- a/lib/lightning_web/live/project_live/index.html.heex
+++ b/lib/lightning_web/live/project_live/index.html.heex
@@ -88,12 +88,12 @@
         <:body>
           <%= for project <- @projects do %>
             <.tr id={"project-row-#{project.id}"}>
-              <.td>{project.name}</.td>
+              <.td class="max-w-80">{project.name}</.td>
               <.td>{Calendar.strftime(project.inserted_at, "%d %b  %H:%M")}</.td>
-              <.td class="max-w-64 overflow-hidden whitespace-nowrap text-ellipsis">
+              <.td class="max-w-80">
                 {project.description}
               </.td>
-              <.td class="max-w-48 overflow-hidden text-ellipsis">
+              <.td class="max-w-64 wrap-break-word">
                 <%= case get_project_owner_name(project) do %>
                   <% "" -> %>
                     <span>No owner</span>
@@ -105,24 +105,26 @@
                 {project.scheduled_deletion &&
                   Calendar.strftime(project.scheduled_deletion, "%d %b  %H:%M")}
               </.td>
-              <.td class="flex justify-end py-0.5">
-                <Common.simple_dropdown
-                  id={"project-actions-#{project.id}-dropdown"}
-                  button_theme="secondary"
-                >
-                  <:button>
-                    Actions
-                  </:button>
+              <.td class="py-0.5">
+                <div class="flex justify-end">
+                  <Common.simple_dropdown
+                    id={"project-actions-#{project.id}-dropdown"}
+                    button_theme="secondary"
+                  >
+                    <:button>
+                      Actions
+                    </:button>
 
-                  <:options>
-                    <.link navigate={
-                      Routes.project_index_path(@socket, :edit, project.id)
-                    }>
-                      Edit
-                    </.link>
-                    <.delete_action socket={@socket} project={project} />
-                  </:options>
-                </Common.simple_dropdown>
+                    <:options>
+                      <.link navigate={
+                        Routes.project_index_path(@socket, :edit, project.id)
+                      }>
+                        Edit
+                      </.link>
+                      <.delete_action socket={@socket} project={project} />
+                    </:options>
+                  </Common.simple_dropdown>
+                </div>
               </.td>
             </.tr>
           <% end %>

--- a/lib/lightning_web/live/project_live/index.html.heex
+++ b/lib/lightning_web/live/project_live/index.html.heex
@@ -89,29 +89,40 @@
           <%= for project <- @projects do %>
             <.tr id={"project-row-#{project.id}"}>
               <.td>{project.name}</.td>
-              <.td>{project.inserted_at}</.td>
-              <.td>{project.description}</.td>
-              <.td>
+              <.td>{Calendar.strftime(project.inserted_at, "%d %b  %H:%M")}</.td>
+              <.td class="max-w-64 overflow-hidden whitespace-nowrap text-ellipsis">
+                {project.description}
+              </.td>
+              <.td class="max-w-48 overflow-hidden text-ellipsis">
                 <%= case get_project_owner_name(project) do %>
                   <% "" -> %>
-                    <span class="text-gray-400">No owner</span>
+                    <span>No owner</span>
                   <% owner_name -> %>
-                    {owner_name}
+                    <span>{owner_name}</span>
                 <% end %>
               </.td>
-              <.td>{project.scheduled_deletion}</.td>
+              <.td>
+                {project.scheduled_deletion &&
+                  Calendar.strftime(project.scheduled_deletion, "%d %b  %H:%M")}
+              </.td>
               <.td class="flex justify-end py-0.5">
-                <span>
-                  <.link
-                    class="table-action"
-                    navigate={
+                <Common.simple_dropdown
+                  id={"project-actions-#{project.id}-dropdown"}
+                  button_theme="secondary"
+                >
+                  <:button>
+                    Actions
+                  </:button>
+
+                  <:options>
+                    <.link navigate={
                       Routes.project_index_path(@socket, :edit, project.id)
-                    }
-                  >
-                    Edit
-                  </.link>
-                  <.delete_action socket={@socket} project={project} />
-                </span>
+                    }>
+                      Edit
+                    </.link>
+                    <.delete_action socket={@socket} project={project} />
+                  </:options>
+                </Common.simple_dropdown>
               </.td>
             </.tr>
           <% end %>

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -606,7 +606,7 @@ defmodule LightningWeb.ProjectLive.Settings do
           </button>
         </div>
       </:title>
-      <div class="text-left text-wrap">
+      <div>
         <p class="text-sm text-gray-500">
           Are you sure you want to remove "{@project_user.user.first_name} {@project_user.user.last_name}" from this project? {@access_text}{@credentials_text}.
           <br /> Do you wish to proceed with this action?

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -612,7 +612,7 @@ defmodule LightningWeb.ProjectLive.Settings do
           <br /> Do you wish to proceed with this action?
         </p>
       </div>
-      <div class="flex flex-row-reverse gap-4 mt-4">
+      <.modal_footer>
         <.button
           id={"#{@id}_confirm_button"}
           type="button"
@@ -626,7 +626,7 @@ defmodule LightningWeb.ProjectLive.Settings do
         <.button type="button" phx-click={hide_modal(@id)} theme="secondary">
           Cancel
         </.button>
-      </div>
+      </.modal_footer>
     </.modal>
     """
   end

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -282,27 +282,30 @@
             </:empty_state>
             <:actions :let={client}>
               <div :if={can_edit?(client, @current_user)}>
-                <span>
-                  <.link
-                    class="table-action"
-                    phx-click={
+                <Common.simple_dropdown
+                  id={"oauth-client-actions-#{client.id}-dropdown"}
+                  button_theme="secondary"
+                >
+                  <:button>
+                    Actions
+                  </:button>
+
+                  <:options>
+                    <.link phx-click={
                       show_modal("edit-oauth-client-#{client.id}-modal")
-                    }
-                  >
-                    Edit
-                  </.link>
-                </span>
-                <span>
-                  <.link
-                    id={"delete-oauth-client-#{client.id}-button"}
-                    class="table-action"
-                    phx-click={
-                      show_modal("delete_oauth_client_#{client.id}_modal")
-                    }
-                  >
-                    Delete
-                  </.link>
-                </span>
+                    }>
+                      Edit
+                    </.link>
+                    <.link
+                      id={"delete-oauth-client-#{client.id}-button"}
+                      phx-click={
+                        show_modal("delete_oauth_client_#{client.id}_modal")
+                      }
+                    >
+                      Delete
+                    </.link>
+                  </:options>
+                </Common.simple_dropdown>
               </div>
               <.live_component
                 id={"edit-oauth-client-#{client.id}-modal"}

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -340,43 +340,39 @@
             </:empty_state>
             <:actions :let={credential}>
               <div :if={can_edit?(credential, @current_user)}>
-                <span>
-                  <.link
-                    class="table-action"
-                    phx-click={
+                <Common.simple_dropdown
+                  id={"credential-actions-#{credential.id}-dropdown"}
+                  button_theme="secondary"
+                >
+                  <:button>
+                    Actions
+                  </:button>
+                  <:options>
+                    <.link phx-click={
                       show_modal("transfer-credential-#{credential.id}-modal")
-                    }
-                  >
-                    <%= case credential.transfer_status do %>
-                      <% :pending -> %>
-                        Revoke Transfer
-                      <% :completed -> %>
-                        Transfer
-                      <% nil -> %>
-                        Transfer
-                    <% end %>
-                  </.link>
-                </span>
-                <span>
-                  <.link
-                    class="table-action"
-                    phx-click={
+                    }>
+                      <%= case credential.transfer_status do %>
+                        <% :pending -> %>
+                          Revoke Transfer
+                        <% :completed -> %>
+                          Transfer
+                        <% nil -> %>
+                          Transfer
+                      <% end %>
+                    </.link>
+                    <.link phx-click={
                       show_modal("edit-credential-#{credential.id}-modal")
-                    }
-                  >
-                    Edit
-                  </.link>
-                </span>
-                <span>
-                  <.link
-                    class="table-action"
-                    phx-click={
+                    }>
+                      Edit
+                    </.link>
+                    <.link phx-click={
                       show_modal("delete_credential_#{credential.id}_modal")
-                    }
-                  >
-                    Delete
-                  </.link>
-                </span>
+                    }>
+                      Delete
+                    </.link>
+                  </:options>
+                </Common.simple_dropdown>
+
                 <.live_component
                   id={"edit-credential-#{credential.id}-modal"}
                   module={LightningWeb.CredentialLive.CredentialFormComponent}

--- a/lib/lightning_web/live/run_live/export_confirmation_modal.ex
+++ b/lib/lightning_web/live/run_live/export_confirmation_modal.ex
@@ -30,25 +30,23 @@ defmodule LightningWeb.RunLive.ExportConfirmationModal do
           Exporting history will download all {@count_work_orders} work orders and associated runs, steps, and I/O data clips that match your query.<br />
           The export will happen in the background and you'll receive an email when it is complete.
         </div>
-        <.modal_footer class="mt-6 mx-6">
-          <div class="sm:flex sm:flex-row-reverse gap-3">
-            <.button
-              id="confirm-export"
-              type="button"
-              theme="primary"
-              phx-click="confirm-export"
-            >
-              Export history
-            </.button>
-            <.button
-              id="cancel-export"
-              type="button"
-              phx-click="close-export-modal"
-              theme="secondary"
-            >
-              Cancel
-            </.button>
-          </div>
+        <.modal_footer>
+          <.button
+            id="confirm-export"
+            type="button"
+            theme="primary"
+            phx-click="confirm-export"
+          >
+            Export history
+          </.button>
+          <.button
+            id="cancel-export"
+            type="button"
+            phx-click="close-export-modal"
+            theme="secondary"
+          >
+            Cancel
+          </.button>
         </.modal_footer>
       </.modal>
     </div>

--- a/lib/lightning_web/live/user_live/components.ex
+++ b/lib/lightning_web/live/user_live/components.ex
@@ -104,36 +104,59 @@ defmodule LightningWeb.UserLive.Components do
       <:body>
         <%= for user <- @users do %>
           <.tr id={"user-#{user.id}"}>
-            <.td>{user.first_name}</.td>
-            <.td>{user.last_name}</.td>
-            <.td>{user.email}</.td>
+            <.td
+              class="overflow-hidden text-ellipsis max-w-40"
+              title={user.first_name}
+            >
+              {user.first_name}
+            </.td>
+            <.td
+              class="overflow-hidden text-ellipsis max-w-40"
+              title={user.last_name}
+            >
+              {user.last_name}
+            </.td>
+            <.td class="max-w-48 overflow-hidden text-ellipsis" title={user.email}>
+              {user.email}
+            </.td>
             <.td>{user.role}</.td>
             <.td>
-              <%= if !user.disabled do %>
-                <Heroicons.check_circle solid class="w-6 h-6 text-gray-500" />
-              <% end %>
+              <.icon
+                :if={!user.disabled}
+                name="hero-check-circle-solid"
+                class="w-6 h-6 text-gray-500"
+              />
             </.td>
             <.td>
-              <%= if user.support_user do %>
-                <div class="content-center">
-                  <Heroicons.check_circle solid class="w-6 h-6 text-gray-500" />
-                </div>
-              <% end %>
-            </.td>
-            <.td>{user.scheduled_deletion}</.td>
-            <.td class="py-0.5">
-              <span>
-                <.link
-                  class="table-action"
-                  navigate={Routes.user_edit_path(@socket, :edit, user)}
-                >
-                  Edit
-                </.link>
-              </span>
-              <.delete_action
-                user={user}
-                delete_url={Routes.user_index_path(@socket, :delete, user)}
+              <.icon
+                :if={user.support_user}
+                name="hero-check-circle-solid"
+                class="w-6 h-6 text-gray-500"
               />
+            </.td>
+            <.td>
+              {user.scheduled_deletion &&
+                Calendar.strftime(user.scheduled_deletion, "%d %b  %H:%M")}
+            </.td>
+            <.td class="py-0.5">
+              <Common.simple_dropdown
+                id={"user-actions-#{user.id}-dropdown"}
+                button_theme="secondary"
+              >
+                <:button>
+                  Actions
+                </:button>
+
+                <:options>
+                  <.link navigate={Routes.user_edit_path(@socket, :edit, user)}>
+                    Edit
+                  </.link>
+                  <.delete_action
+                    user={user}
+                    delete_url={Routes.user_index_path(@socket, :delete, user)}
+                  />
+                </:options>
+              </Common.simple_dropdown>
             </.td>
           </.tr>
         <% end %>
@@ -155,14 +178,14 @@ defmodule LightningWeb.UserLive.Components do
   defp delete_action(%{user: %{role: :superuser}} = assigns) do
     if assigns.user.scheduled_deletion do
       ~H"""
-      <.cancel_deletion user={@user} /> |
-      <span id={"delete-now-#{@user.id}"} class="table-action-disabled">
+      <.cancel_deletion user={@user} />
+      <span id={"delete-now-#{@user.id}"} class="cursor-not-allowed">
         Delete now
       </span>
       """
     else
       ~H"""
-      <span id={"delete-#{@user.id}"} class="table-action-disabled">
+      <span id={"delete-#{@user.id}"} class="cursor-not-allowed">
         Delete
       </span>
       """
@@ -172,41 +195,30 @@ defmodule LightningWeb.UserLive.Components do
   defp delete_action(%{user: %{role: :user}} = assigns) do
     if assigns.user.scheduled_deletion do
       ~H"""
-      <.cancel_deletion user={@user} /> |
-      <span>
-        <.link
-          id={"delete-now-#{@user.id}"}
-          class="table-action"
-          navigate={@delete_url}
-        >
-          Delete now
-        </.link>
-      </span>
+      <.cancel_deletion user={@user} />
+      <.link id={"delete-now-#{@user.id}"} navigate={@delete_url}>
+        Delete now
+      </.link>
       """
     else
       ~H"""
-      <span>
-        <.link id={"delete-#{@user.id}"} class="table-action" navigate={@delete_url}>
-          Delete
-        </.link>
-      </span>
+      <.link id={"delete-#{@user.id}"} navigate={@delete_url}>
+        Delete
+      </.link>
       """
     end
   end
 
   defp cancel_deletion(assigns) do
     ~H"""
-    <span>
-      <.link
-        id={"cancel-deletion-#{@user.id}"}
-        href="#"
-        phx-click="cancel_deletion"
-        phx-value-id={@user.id}
-        class="table-action"
-      >
-        Cancel deletion
-      </.link>
-    </span>
+    <.link
+      id={"cancel-deletion-#{@user.id}"}
+      href="#"
+      phx-click="cancel_deletion"
+      phx-value-id={@user.id}
+    >
+      Cancel deletion
+    </.link>
     """
   end
 end

--- a/lib/lightning_web/live/user_live/components.ex
+++ b/lib/lightning_web/live/user_live/components.ex
@@ -104,19 +104,13 @@ defmodule LightningWeb.UserLive.Components do
       <:body>
         <%= for user <- @users do %>
           <.tr id={"user-#{user.id}"}>
-            <.td
-              class="overflow-hidden text-ellipsis max-w-40"
-              title={user.first_name}
-            >
+            <.td class="max-w-40 wrap-break-word" title={user.first_name}>
               {user.first_name}
             </.td>
-            <.td
-              class="overflow-hidden text-ellipsis max-w-40"
-              title={user.last_name}
-            >
+            <.td class="max-w-40 wrap-break-word" title={user.last_name}>
               {user.last_name}
             </.td>
-            <.td class="max-w-48 overflow-hidden text-ellipsis" title={user.email}>
+            <.td class="max-w-48 wrap-break-word" title={user.email}>
               {user.email}
             </.td>
             <.td>{user.role}</.td>

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -169,7 +169,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
                 class="hover:bg-gray-100 transition-colors duration-200"
                 onclick={JS.navigate(~p"/projects/#{@project.id}/w/#{workflow.id}")}
               >
-                <.td class="break-words max-w-[15rem]">
+                <.td class="wrap-break-word max-w-[15rem]">
                   <div
                     phx-click={
                       JS.navigate(~p"/projects/#{@project.id}/w/#{workflow.id}")
@@ -183,14 +183,14 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
                     />
                   </div>
                 </.td>
-                <.td class="break-words max-w-[15rem]">
+                <.td class="wrap-break-word max-w-[15rem]">
                   <.state_card
                     state={workflow.last_workorder.state}
                     timestamp={workflow.last_workorder.updated_at}
                     period={@period}
                   />
                 </.td>
-                <.td class="break-words max-w-[10rem]">
+                <.td class="wrap-break-word max-w-[10rem]">
                   <div>
                     <%= if workflow.workorders_count > 0 do %>
                       <div class="text-indigo-700 text-lg">
@@ -217,7 +217,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
                     <% end %>
                   </div>
                 </.td>
-                <.td class="break-words max-w-[15rem]">
+                <.td class="wrap-break-word max-w-[15rem]">
                   <div>
                     <%= if workflow.failed_workorders_count > 0 do %>
                       <div class="text-indigo-700 text-lg">

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -269,8 +269,10 @@ defmodule LightningWeb.UserLiveTest do
 
       assert html =~ "Users"
 
-      refute html =~
-               "#{DateTime.utc_now() |> Timex.shift(days: 7) |> Map.fetch!(:year)}"
+      formated_deletion_date =
+        DateTime.utc_now() |> Timex.shift(days: 7) |> Calendar.strftime("%d %b")
+
+      refute html =~ formated_deletion_date
 
       {:ok, form_live, _} =
         index_live
@@ -302,8 +304,7 @@ defmodule LightningWeb.UserLiveTest do
         to: Swoosh.Email.Recipient.format(user)
       )
 
-      assert html =~
-               "#{DateTime.utc_now() |> Timex.shift(days: 7) |> Map.fetch!(:year)}"
+      assert html =~ formated_deletion_date
     end
 
     test "disables the delete link for listed superusers", %{
@@ -315,14 +316,14 @@ defmodule LightningWeb.UserLiveTest do
       assert(
         index_live
         |> has_element?(
-          "span#delete-#{user.id}.table-action-disabled",
+          "span#delete-#{user.id}.cursor-not-allowed",
           "Delete"
         )
       )
 
       refute(
         index_live
-        |> has_element?("a#delete-#{user.id}.table-action", "Delete")
+        |> has_element?("a#delete-#{user.id}", "Delete")
       )
     end
 
@@ -382,7 +383,7 @@ defmodule LightningWeb.UserLiveTest do
 
       assert index_live
              |> has_element?(
-               "a#cancel-deletion-#{user.id}.table-action",
+               "a#cancel-deletion-#{user.id}",
                "Cancel deletion"
              )
     end
@@ -429,7 +430,7 @@ defmodule LightningWeb.UserLiveTest do
       assert(
         index_live
         |> has_element?(
-          "span#delete-now-#{user.id}.table-action-disabled",
+          "span#delete-now-#{user.id}.cursor-not-allowed",
           "Delete now"
         )
       )
@@ -437,7 +438,7 @@ defmodule LightningWeb.UserLiveTest do
       refute(
         index_live
         |> has_element?(
-          "a#delete-now-#{user.id}.table-action",
+          "a#delete-now-#{user.id}",
           "Delete now"
         )
       )


### PR DESCRIPTION
## Description

This PR updates all modals with a standardized footer and padding. 

- [x] **Collection Live Components**
  - [x] `CollectionLive.CollectionCreationModal` - Create/Edit Collection modal
  - [x] `CollectionLive.Components` - Confirm collection deletion modal
- [x] **Credential Components**
  - [x] `Components.CredentialDeletionModal` - Credential marked for deletion modal
  - [x] `Components.CredentialDeletionModal` - Delete credential modal
  - [x] `Components.Credentials` - Delete Credential modal
  - [x] `Components.Credentials` - Delete OAuth Client modal
  - [x] `CredentialLive.CredentialFormComponent` - Credential type picker modal
  - [x] `CredentialLive.CredentialFormComponent` - Credential form modal (two instances)
  - [x] `CredentialLive.OauthClientFormComponent` - OAuth client form modal
  - [x] `CredentialLive.TransferCredentialModal` - Transfer credential modal
- [x] **Project Components**
  - [x] `Components.ProjectDeletionModal` - Delete project modal
  - [x] `DashboardLive.ProjectCreationModal` - Create a new project modal
  - [x] `ProjectLive.CollectionsComponent` - Collection form modal
  - [x] `ProjectLive.CollectionsComponent` - Delete collection modal
  - [x] `ProjectLive.Settings` - Confirm user removal modal
- [x] **User Components**
  - [x] `Components.UserDeletionModal` - Delete user modal (two instances)
  - [x] `Components.TokenDeletionModal` - Delete API Access Token modal
- [x] **GitHub Integration Components**
  - [x] `ProfileLive.GithubComponent` - Confirm GitHub disconnection modal
  - [x] `ProjectLive.GithubSyncComponent` - Confirm connection removal modal
  - [x] `ProjectLive.GithubSyncComponent` - Reconnect to GitHub modal
- [x] **Run Components**
  - [x] `RunLive.ExportConfirmationModal` - Confirm history export modal

Closes #3277 
Closes #3324

## Validation steps

The modals listed above are all the modals in the app.  If you don't see one in this list please let me know.

The credentials table has also been updated to have the actions inside a dropdown
<img width="1249" alt="Screenshot 2025-07-01 at 17 37 55" src="https://github.com/user-attachments/assets/304158d7-fd66-485a-b8be-160cc366f451" />


## Additional notes for the reviewer

The following stylings on tables have been removed because they were affecting the modals:
- `overflow-hidden` (indirectly affecting the actions dropdown inn credentials tables)
- `whitespace-nowrap` (texts were not getting wrapped in some modals)
- `text-left` . 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
