### PR TITLE
Refactor supeuser user settings page

### DIFF
--- a/lib/lightning_web/live/user_live/index.ex
+++ b/lib/lightning_web/live/user_live/index.ex
@@ -4,31 +4,9 @@ defmodule LightningWeb.UserLive.Index do
   """
   use LightningWeb, :live_view
 
-  import LightningWeb.UserLive.Components
-  alias LightningWeb.Live.Helpers.TableHelpers
-
   alias Lightning.Accounts
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.Users
-
-  # Configuration for user table sorting
-  defp user_sort_map do
-    %{
-      "first_name" => :first_name,
-      "last_name" => :last_name,
-      "email" => :email,
-      "role" => fn user -> to_string(user.role) end,
-      "enabled" => fn user -> !user.disabled end,
-      "support_user" => :support_user,
-      "scheduled_deletion" => fn user ->
-        user.scheduled_deletion || ~U[9999-12-31 23:59:59Z]
-      end
-    }
-  end
-
-  defp user_search_fields do
-    [:first_name, :last_name, :email, fn user -> to_string(user.role) end]
-  end
 
   @impl true
   def mount(_params, _session, socket) do
@@ -39,11 +17,7 @@ defmodule LightningWeb.UserLive.Index do
     if can_access_admin_space do
       socket =
         assign(socket,
-          users: list_users("", "email", "asc"),
-          active_menu_item: :users,
-          sort_key: "email",
-          sort_direction: "asc",
-          filter: ""
+          active_menu_item: :users
         )
 
       {:ok, socket, layout: {LightningWeb.Layouts, :settings}}
@@ -89,58 +63,5 @@ defmodule LightningWeb.UserLive.Index do
          socket
          |> put_flash(:error, "Cancel user deletion failed")}
     end
-  end
-
-  def handle_event("sort", %{"by" => sort_key}, socket) do
-    {sort_key, sort_direction} =
-      TableHelpers.toggle_sort_direction(
-        socket.assigns.sort_direction,
-        socket.assigns.sort_key,
-        sort_key
-      )
-
-    users = list_users(socket.assigns.filter, sort_key, sort_direction)
-
-    {:noreply,
-     assign(socket,
-       users: users,
-       sort_key: sort_key,
-       sort_direction: sort_direction
-     )}
-  end
-
-  def handle_event("filter", %{"value" => filter}, socket) do
-    users =
-      list_users(filter, socket.assigns.sort_key, socket.assigns.sort_direction)
-
-    {:noreply,
-     assign(socket,
-       users: users,
-       filter: filter
-     )}
-  end
-
-  def handle_event("clear_filter", _params, socket) do
-    users =
-      list_users("", socket.assigns.sort_key, socket.assigns.sort_direction)
-
-    {:noreply,
-     assign(socket,
-       users: users,
-       filter: ""
-     )}
-  end
-
-  defp list_users(filter, sort_key, sort_direction) do
-    users = Accounts.list_users()
-
-    TableHelpers.filter_and_sort(
-      users,
-      filter,
-      user_search_fields(),
-      sort_key,
-      sort_direction,
-      user_sort_map()
-    )
   end
 end

--- a/lib/lightning_web/live/user_live/index.html.heex
+++ b/lib/lightning_web/live/user_live/index.html.heex
@@ -18,6 +18,7 @@
       module={LightningWeb.UserLive.TableComponent}
       delete_user={assigns[:delete_user]}
       live_action={@live_action}
+      user_deletion_modal={LightningWeb.Components.UserDeletionModal}
     />
   </LayoutComponents.centered>
 </LayoutComponents.page_content>

--- a/lib/lightning_web/live/user_live/index.html.heex
+++ b/lib/lightning_web/live/user_live/index.html.heex
@@ -13,14 +13,11 @@
     </LayoutComponents.header>
   </:header>
   <LayoutComponents.centered>
-    <.users_table
-      socket={@socket}
-      live_action={@live_action}
+    <.live_component
+      id="users-table-live-component"
+      module={LightningWeb.UserLive.TableComponent}
       delete_user={assigns[:delete_user]}
-      users={@users}
-      sort_key={@sort_key}
-      sort_direction={@sort_direction}
-      filter={@filter}
+      live_action={@live_action}
     />
   </LayoutComponents.centered>
 </LayoutComponents.page_content>

--- a/lib/lightning_web/live/user_live/table_component.ex
+++ b/lib/lightning_web/live/user_live/table_component.ex
@@ -1,0 +1,116 @@
+defmodule LightningWeb.UserLive.TableComponent do
+  @moduledoc false
+
+  use LightningWeb, :live_component
+  import LightningWeb.UserLive.Components
+
+  alias Lightning.Accounts
+  alias LightningWeb.Live.Helpers.TableHelpers
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.users_table
+        socket={@socket}
+        target={@myself}
+        live_action={@live_action}
+        delete_user={assigns[:delete_user]}
+        users={@users}
+        sort_key={@sort_key}
+        sort_direction={@sort_direction}
+        filter={@filter}
+      />
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     assign(socket,
+       users: list_users("", "email", "asc"),
+       sort_key: "email",
+       sort_direction: "asc",
+       filter: ""
+     )}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok, assign(socket, assigns)}
+  end
+
+  @impl true
+  def handle_event("sort", %{"by" => sort_key}, socket) do
+    {sort_key, sort_direction} =
+      TableHelpers.toggle_sort_direction(
+        socket.assigns.sort_direction,
+        socket.assigns.sort_key,
+        sort_key
+      )
+
+    users = list_users(socket.assigns.filter, sort_key, sort_direction)
+
+    {:noreply,
+     assign(socket,
+       users: users,
+       sort_key: sort_key,
+       sort_direction: sort_direction
+     )}
+  end
+
+  def handle_event("filter", %{"value" => filter}, socket) do
+    users =
+      list_users(filter, socket.assigns.sort_key, socket.assigns.sort_direction)
+
+    {:noreply,
+     assign(socket,
+       users: users,
+       filter: filter
+     )}
+  end
+
+  def handle_event("clear_filter", _params, socket) do
+    users =
+      list_users("", socket.assigns.sort_key, socket.assigns.sort_direction)
+
+    {:noreply,
+     assign(socket,
+       users: users,
+       filter: ""
+     )}
+  end
+
+  defp list_users(filter, sort_key, sort_direction) do
+    users = Accounts.list_users()
+
+    TableHelpers.filter_and_sort(
+      users,
+      filter,
+      user_search_fields(),
+      sort_key,
+      sort_direction,
+      user_sort_map()
+    )
+  end
+
+  # Configuration for user table sorting
+  defp user_sort_map do
+    %{
+      "first_name" => :first_name,
+      "last_name" => :last_name,
+      "email" => :email,
+      "role" => fn user -> to_string(user.role) end,
+      "enabled" => fn user -> !user.disabled end,
+      "support_user" => :support_user,
+      "scheduled_deletion" => fn user ->
+        user.scheduled_deletion || ~U[9999-12-31 23:59:59Z]
+      end
+    }
+  end
+
+  defp user_search_fields do
+    [:first_name, :last_name, :email, fn user -> to_string(user.role) end]
+  end
+end

--- a/lib/lightning_web/live/user_live/table_component.ex
+++ b/lib/lightning_web/live/user_live/table_component.ex
@@ -20,6 +20,7 @@ defmodule LightningWeb.UserLive.TableComponent do
         sort_key={@sort_key}
         sort_direction={@sort_direction}
         filter={@filter}
+        user_deletion_modal={@user_deletion_modal}
       />
     </div>
     """

--- a/test/lightning_web/live/user_live_test.exs
+++ b/test/lightning_web/live/user_live_test.exs
@@ -606,7 +606,8 @@ defmodule LightningWeb.UserLiveTest do
 
       # Clear filter
       index_live
-      |> render_click("clear_filter")
+      |> element("#clear_filter_button")
+      |> render_click()
 
       html = render(index_live)
       assert html =~ "alice@example.com"


### PR DESCRIPTION
## Description

This PR moves the user table into a livecomponent which can reused

Related to #3354

## Validation steps

1. Log In as a superuser and go to the admin settings
2. Open users
3. Try searching and sorting. Everything should still work


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
