### PR TITLE
Handle `error:invalid_grant` explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to
 
 ### Fixed
 
+- Isolate failed to refresh token errors from other oauth errros
+  [#3332](https://github.com/OpenFn/lightning/issues/3332)
+
 ## [v2.13.4] - 2025-07-05
 
 ## [v2.13.4-pre1] - 2025-07-04

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -587,7 +587,7 @@ defmodule LightningWeb.RunChannelTest do
           {:ok,
            %Tesla.Env{
              env
-             | status: 401,
+             | status: 400,
                body: %{"error" => "invalid_grant"}
            }}
       end)


### PR DESCRIPTION
## Description

This PR handles `invalid_grant` oauth errors which ensures oauth refresh errors are not sent to sentry in the run channel

Closes #3334 

## Validation steps

This implementation was based off of the response logged ins sentry: https://openfn.sentry.io/issues/6708827881/events/c4ac54f19bb54d2cb6781b483d8c8c25/


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
