### PR TITLE
Bump CLI to 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 
 ### Changed
 
+- Bump CLI to 1.13.1 [#3351](https://github.com/OpenFn/lightning/issues/3351)
+
 ### Fixed
 
 ## [v2.13.4] - 2025-07-05

--- a/lib/mix/tasks/install_runtime.ex
+++ b/lib/mix/tasks/install_runtime.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Lightning.InstallRuntime do
 
   def packages do
     ~W(
-      @openfn/cli@1.11.5
+      @openfn/cli@1.13.1
       @openfn/language-common@latest
     )
   end


### PR DESCRIPTION
This version of the CLI includes a fix for a bug where the CLI would not properly clean up adaptors that don't support metadata.

re: #3351

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
