### PR TITLE
Fix error messages in forms not appearing when LastPass enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Handling of CLI error messages when fetching metadata via an adaptor
   [#3367](https://github.com/OpenFn/lightning/issues/3367)
+- Error messages in forms not appearing when LastPass enabled
+  [#3402](https://github.com/OpenFn/lightning/issues/3402)
 
 ## [v2.13.5] 2025-07-11
 

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -908,14 +908,19 @@ defmodule LightningWeb.Components.NewInputs do
       <small :if={@sublabel} class="mb-2 block text-xs text-gray-600">
         {@sublabel}
       </small>
-      <.input_element
-        type={@type}
-        name={@name}
-        id={@id}
-        class={@class}
-        value={Form.normalize_value(@type, @value)}
-        {@rest}
-      />
+      <div>
+        <%!--  This input is wrapped in a div on its own intentionally because of LastPass  --%>
+        <%!-- LastPass adds it's icon next to inputs and that affects error messages.   --%>
+        <%!-- See: https://github.com/OpenFn/lightning/issues/3402 --%>
+        <.input_element
+          type={@type}
+          name={@name}
+          id={@id}
+          class={@class}
+          value={Form.normalize_value(@type, @value)}
+          {@rest}
+        />
+      </div>
       <div :if={Enum.any?(@errors) and @display_errors} class="error-space">
         <.error :for={msg <- @errors}>{msg}</.error>
       </div>

--- a/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
+++ b/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
@@ -161,7 +161,9 @@ defmodule LightningWeb.CredentialLive.TransferCredentialModal do
             class="w-full"
             phx-target={@myself}
             phx-blur="check-user-access"
+            display_errors={false}
           />
+          <.errors field={@f[:email]} />
         </div>
       </div>
     </div>

--- a/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
+++ b/lib/lightning_web/live/credential_live/transfer_credential_modal.ex
@@ -161,9 +161,7 @@ defmodule LightningWeb.CredentialLive.TransferCredentialModal do
             class="w-full"
             phx-target={@myself}
             phx-blur="check-user-access"
-            display_errors={false}
           />
-          <.errors field={@f[:email]} />
         </div>
       </div>
     </div>

--- a/test/support/workflow_live_helpers.ex
+++ b/test/support/workflow_live_helpers.ex
@@ -327,7 +327,7 @@ defmodule Lightning.WorkflowLive.Helpers do
 
     view
     |> element(
-      ~s{input[name='workflow[jobs][#{idx}][#{field}]'] ~ .error-space [data-tag="error_message"]},
+      ~s{div[phx-feedback-for="workflow[jobs][#{idx}][#{field}]"] .error-space [data-tag="error_message"]},
       error
     )
     |> has_element?()


### PR DESCRIPTION
## Description

This PR fixes an issue where error messages were not being displayed in email form fields when LastPass is enabled. 
LastPass adds its icon immediately next to the form input and we also have liveview form errors being displayed at the place.

Closes #3402

## Validation steps

1. Go to Credentials page and click to transfer a credential
2. Key in a nonextsitent user email address e.g. `nonexistent@gmail.com` and press the transfer button
3. You'll see an error message: `User does not exist`

## Additional notes for the reviewer

Initially, I only applied this change to the credential transfer form, https://github.com/OpenFn/lightning/commit/1c1d8350f6aaec37007de8d7a4b60da075fe2784, but then I made it a global change for future email fields.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
