### PR TITLE
partial string (not prefix) search for dataclip name

### DIFF
--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -104,7 +104,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
                 }}
                 type="text"
                 className="focus:outline focus:outline-2 focus:-outline-offset-2 focus:ring-0  disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 border-slate-300 focus:border-slate-400 focus:outline-indigo-600 block w-full rounded-md border-0 py-1.5 pl-10 pr-20 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400  focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                placeholder="Search by name or UUID (starts with)"
+                placeholder="Search names or UUID prefixes"
               />
               <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
                 <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -875,7 +875,7 @@ defmodule Lightning.Invocation do
       {:exclude_id, exclude_id} ->
         dataclip.id != exclude_id
 
-      {:name_prefix, name} ->
+      {:name_part, name} ->
         String.starts_with?(
           String.downcase(dataclip.name),
           String.downcase(name)
@@ -916,8 +916,8 @@ defmodule Lightning.Invocation do
       {:exclude_id, exclude_id}, dynamic ->
         dynamic([d], ^dynamic and d.id != ^exclude_id)
 
-      {:name_prefix, name}, dynamic ->
-        dynamic([d], ^dynamic and ilike(d.name, ^"#{name}%"))
+      {:name_part, name}, dynamic ->
+        dynamic([d], ^dynamic and ilike(d.name, ^"%#{name}%"))
 
       {:named_only, true}, dynamic ->
         dynamic([d], ^dynamic and not is_nil(d.name))

--- a/lib/lightning_web/live/workflow_live/new_manual_run.ex
+++ b/lib/lightning_web/live/workflow_live/new_manual_run.ex
@@ -54,7 +54,7 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
          query: :string,
          id: Ecto.UUID,
          id_prefix: :string,
-         name_prefix: :string,
+         name_part: :string,
          named_only: :boolean
        }},
       params,
@@ -76,7 +76,7 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
           |> Ecto.Changeset.put_change(:id_prefix, query)
 
         true ->
-          Ecto.Changeset.put_change(changeset, :name_prefix, query)
+          Ecto.Changeset.put_change(changeset, :name_part, query)
       end
     end)
     |> Ecto.Changeset.delete_change(:query)

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -485,7 +485,7 @@ defmodule Lightning.InvocationTest do
         [named_dataclip],
         Invocation.list_dataclips_for_job(
           job1,
-          %{name_prefix: "my"},
+          %{name_part: "my"},
           limit: 10
         )
       )
@@ -495,7 +495,7 @@ defmodule Lightning.InvocationTest do
         [named_dataclip],
         Invocation.list_dataclips_for_job(
           job1,
-          %{name_prefix: "MY"},
+          %{name_part: "MY"},
           limit: 10
         )
       )
@@ -505,7 +505,7 @@ defmodule Lightning.InvocationTest do
         [other_named_dataclip],
         Invocation.list_dataclips_for_job(
           job1,
-          %{name_prefix: "anoth"},
+          %{name_part: "anoth"},
           limit: 10
         )
       )
@@ -514,7 +514,7 @@ defmodule Lightning.InvocationTest do
       assert [] =
                Invocation.list_dataclips_for_job(
                  job1,
-                 %{name_prefix: "nonexistent"},
+                 %{name_part: "nonexistent"},
                  limit: 10
                )
     end

--- a/test/lightning_web/live/workflow_live/new_manual_run_test.exs
+++ b/test/lightning_web/live/workflow_live/new_manual_run_test.exs
@@ -26,12 +26,12 @@ defmodule LightningWeb.WorkflowLive.NewManualRunTest do
     assert {:ok, %{id: ^uuid}} =
              NewManualRun.get_dataclips_filters("query=#{uuid}")
 
-    assert {:ok, %{name_prefix: "1z"}} =
+    assert {:ok, %{name_part: "1z"}} =
              NewManualRun.get_dataclips_filters("query=1z")
 
     invalid_uuid = "#{uuid}z"
 
-    assert {:ok, %{name_prefix: ^invalid_uuid}} =
+    assert {:ok, %{name_part: ^invalid_uuid}} =
              NewManualRun.get_dataclips_filters("query=#{invalid_uuid}"),
            "Invalid uuids are treated as name prefixes"
 


### PR DESCRIPTION
hey @midigofrank , the name search shouldn't just be prefix, that's only for performance on the UUIDs.

this is the concept i'm looking for, but the implementation isn't quite right. can you check it out? (or re-do these changes on your own branch to allow partial string search on dataclip names?)