### PR TITLE
Upgrade Ecto from v3.11 to v3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to
 
 ### Changed
 
+- Upgrade Ecto from v3.11 to v3.13
+  [#3448](https://github.com/OpenFn/lightning/pull/3448)
+
 ### Fixed
 
 - Fixed bug that prevented HTTP credentials from loading, now allow JSON objects

--- a/mix.exs
+++ b/mix.exs
@@ -82,7 +82,7 @@ defmodule Lightning.MixProject do
       {:dialyxir, "~> 1.4.5", only: [:test, :dev], runtime: false},
       {:ecto_enum, "~> 1.4"},
       {:ecto_psql_extras, "~> 0.8.2"},
-      {:ecto_sql, "~> 3.11"},
+      {:ecto_sql, "~> 3.13"},
       {:esbuild, "~> 0.9", runtime: Mix.env() == :dev},
       {:ex_doc, "~> 0.28", only: :dev, runtime: false},
       {:ex_json_schema, "~> 0.9.1"},


### PR DESCRIPTION
## Description

This PR upgrades the version of Ecto to v3.13 to allow the support of `Repo.transact/1`.

## Validation steps

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
