### PR TITLE
Don't match non-webhook triggers via webhook URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Prevent requests to webhook URLs from matching non-webhook triggers
+  [#3453](https://github.com/OpenFn/lightning/issues/3453)
+
 ## [v2.13.6] - 2025-07-24
 
 ### Added

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -452,7 +452,7 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
-  Gets a Single Edge by it's webhook trigger.
+  Gets a single Webhook Trigger by its `custom_path` or `id`.
   """
   def get_webhook_trigger(path, opts \\ []) when is_binary(path) do
     preloads = opts |> Keyword.get(:include, [])
@@ -463,36 +463,8 @@ defmodule Lightning.Workflows do
           "coalesce(?, ?)",
           t.custom_path,
           type(t.id, :string)
-        ) == ^path,
+        ) == ^path and t.type == :webhook,
       preload: ^preloads
-    )
-    |> Repo.one()
-  end
-
-  @doc """
-  Gets a single `Trigger` by its `custom_path` or `id`.
-
-  ## Parameters
-  - `path`: A binary string representing the `custom_path` or `id` of the trigger.
-
-  ## Returns
-  - Returns a `Trigger` struct if a trigger is found.
-  - Returns `nil` if no trigger is found for the given `path`.
-
-  ## Examples
-
-  ```
-  Lightning.Workflows.get_trigger_by_webhook("some_path_or_id")
-  # => %Trigger{id: 1, custom_path: "some_path_or_id", ...}
-
-  Lightning.Workflows.get_trigger_by_webhook("non_existent_path_or_id")
-  # => nil
-  ```
-  """
-  def get_trigger_by_webhook(path) when is_binary(path) do
-    from(t in Trigger,
-      where:
-        fragment("coalesce(?, ?)", t.custom_path, type(t.id, :string)) == ^path
     )
     |> Repo.one()
   end

--- a/test/lightning_web/controllers/webhooks_controller_test.exs
+++ b/test/lightning_web/controllers/webhooks_controller_test.exs
@@ -103,6 +103,28 @@ defmodule LightningWeb.WebhooksControllerTest do
              }
     end
 
+    test "returns 404 when trigger does not exist for GET request", %{conn: conn} do
+      non_existent_trigger_id = Ecto.UUID.generate()
+
+      conn = get(conn, "/i/#{non_existent_trigger_id}")
+
+      assert json_response(conn, 404) == %{"error" => "Webhook not found"}
+    end
+
+    test "returns 404 when trigger exists but is of type cron", %{conn: conn} do
+      %{triggers: [trigger = %{id: trigger_id}]} =
+        insert(:simple_workflow) |> Lightning.Repo.preload(:triggers)
+
+      # Change the trigger type to cron
+
+      Ecto.Changeset.change(trigger, type: :cron)
+      |> Lightning.Repo.update!()
+
+      conn = get(conn, "/i/#{trigger_id}")
+
+      assert json_response(conn, 404) == %{"error" => "Webhook not found"}
+    end
+
     test "creates a pending workorder with a valid trigger", %{conn: conn} do
       %{triggers: [%{id: trigger_id}]} =
         insert(:simple_workflow)


### PR DESCRIPTION
## Description

This PR fixes #3453 

## Validation steps

1. Create a webhook trigger and ensure you can curl to it to start a workflow run
2. Change to a cron trigger and ensure that when you try to curl to it, you get a 404

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
