### PR TITLE
Fix users unable to change workflow concurrency settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Authorized users unable to change the workflow concurrency setting
+  [#3459](https://github.com/OpenFn/lightning/issues/3459)
+
 ## [v2.13.6] - 2025-07-24
 
 ### Added

--- a/lib/lightning_web/live/workflow_live/workflow_params.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_params.ex
@@ -86,7 +86,14 @@ defmodule LightningWeb.WorkflowNewLive.WorkflowParams do
   defp to_serializable(%Ecto.Changeset{} = changeset, accessor)
        when is_function(accessor) do
     Map.merge(
-      changeset |> to_serializable([:project_id, :name, :positions]),
+      changeset
+      |> to_serializable([
+        :project_id,
+        :name,
+        :concurrency,
+        :enable_job_logs,
+        :positions
+      ]),
       %{
         jobs:
           changeset

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -1243,8 +1243,11 @@ defmodule LightningWeb.WorkflowLive.EditTest do
              |> form("#workflow-form", %{"workflow" => %{"concurrency" => "5"}})
              |> render_change() =~ "No more than 5 runs at a time"
 
-      assert view |> element("#workflow-form") |> render_submit() =~
-               "Workflow saved"
+      # the current implmentation simply sends `save` the event, it does
+      # not submit the form. I'm mimicking that here
+      assert view |> render_submit("save") =~ "Workflow saved"
+
+      assert Lightning.Repo.reload(workflow).concurrency == 5
 
       assert assert_patch(view) =~
                ~p"/projects/#{project.id}/w/#{workflow.id}?m=settings"
@@ -1371,8 +1374,8 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
         assert workflow.enable_job_logs == true
 
-        # submit the form
-        view |> element("#workflow-form") |> render_submit()
+        # send a save event
+        view |> render_submit("save")
 
         assert assert_patch(view) =~
                  ~p"/projects/#{project.id}/w/#{workflow.id}?m=settings"


### PR DESCRIPTION
## Description

This PR adds `concurrency` and `enable_job_logs` to the workflow params to ensure they're picked by the changeset.

Initially, clicking on `save button` would submit the `#workflow-form`, but currently it doesn't, it only sends the `save` event without any params. The current functionality assumes that all the needed changes have been added to the `Ecto.Changeset`. 

Closes #3459 

## Validation steps

1. Login as a project admin
2. Open the workflow settings panel
3. Update the concurrency and `console.log()` toggle
4. Click the save button
5. The updated values should stick and not get reset.


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
