### PR TITLE
QA: Fix AI Assistant message status not updating on Apollo timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix Oban crash when Apollo times out
+  [#3497](https://github.com/OpenFn/lightning/issues/3497)
+
 ## [v2.14.1-pre1] - 2025-08-07
 
 ### Fixed

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -505,10 +505,7 @@ defmodule Lightning.AiAssistant do
       if message.role == :user && message.status == :pending do
         Oban.insert(
           Lightning.Oban,
-          MessageProcessor.new(%{
-            message_id: message.id,
-            session_id: session.id
-          })
+          MessageProcessor.new(%{message_id: message.id})
         )
       else
         {:ok, nil}
@@ -688,10 +685,7 @@ defmodule Lightning.AiAssistant do
     )
     |> Multi.insert(
       :oban_job,
-      MessageProcessor.new(%{
-        message_id: message.id,
-        session_id: message.chat_session_id
-      })
+      MessageProcessor.new(%{message_id: message.id})
     )
     |> Repo.transaction()
     |> case do

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -70,7 +70,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   @impl Oban.Worker
   @spec timeout(Oban.Job.t()) :: pos_integer()
   def timeout(_job) do
-    apollo_timeout_ms = Lightning.Config.apollo(:timeout)
+    apollo_timeout_ms = Lightning.Config.apollo(:timeout) || 30_000
     buffer_ms = round(apollo_timeout_ms * @timeout_buffer_percentage / 100)
     apollo_timeout_ms + max(buffer_ms, @minimum_buffer_ms)
   end

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -221,4 +221,140 @@ defmodule Lightning.AiAssistant.MessageProcessor do
       _ -> nil
     end)
   end
+
+  @doc """
+  Handles exceptions for `ai_assistant` Oban jobs.
+
+  ## Parameters
+    * `measure` — A map containing job execution metrics (`duration`, `memory`, `reductions`).
+    * `meta` — A map containing job metadata (`job`, `error`, `stacktrace`, etc.).
+  """
+  def handle_ai_assistant_exception(measure, meta) do
+    job = meta.job
+    error = meta.error
+    timeout? = Map.get(error, :reason) == :timeout
+
+    Logger.error(~s"""
+    AI Assistant exception:
+    Worker: #{job.worker}
+    Type: #{if timeout?, do: "Timeout", else: "Error"}
+    Args: #{inspect(job.args)}
+    Error: #{inspect(error)}
+    Duration: #{measure.duration / 1_000_000}ms
+    """)
+
+    ChatMessage
+    |> Repo.get!(job.args["message_id"])
+    |> case do
+      %ChatMessage{id: message_id, status: status} = message
+      when status in [:pending, :processing] ->
+        Logger.info(
+          "[AI Assistant] Updating message #{message_id} to error status after exception"
+        )
+
+        {:ok, _updated_session, _updated_message} =
+          update_message_status(message, :error)
+
+      %ChatMessage{id: message_id, status: status} ->
+        Logger.debug(
+          "[AI Assistant] Message #{message_id} already has status: #{status}, skipping cleanup"
+        )
+    end
+
+    context = %{
+      worker: job.worker,
+      args: job.args,
+      queue: job.queue,
+      job_id: job.id,
+      duration_ms: measure.duration / 1_000_000,
+      memory: measure.memory,
+      reductions: measure.reductions
+    }
+
+    if timeout? do
+      Lightning.Sentry.capture_message("AI Assistant Timeout: #{job.worker}",
+        level: :warning,
+        extra: Map.merge(context, %{error: inspect(error)}),
+        tags: %{
+          type: "ai_timeout",
+          queue: "ai_assistant",
+          worker: job.worker
+        }
+      )
+    else
+      Lightning.Sentry.capture_exception(error,
+        stacktrace: meta.stacktrace,
+        extra: context,
+        tags: %{
+          type: "ai_error",
+          queue: "ai_assistant",
+          worker: job.worker
+        }
+      )
+    end
+  end
+
+  @doc """
+  Handles `:stop` events for `ai_assistant` Oban jobs.
+
+  This function is invoked when a job in the `ai_assistant` queue stops with a non-success state
+  (e.g., `:discard`, `:cancelled`, or other custom stop reasons).
+
+  Jobs with the `:success` state are ignored.
+
+  ## Parameters
+    * `measure` — A map containing job execution metrics (`duration`, `memory`, `reductions`).
+    * `meta` — A map containing job metadata (`job`, `state`, etc.).
+  """
+  def handle_ai_assistant_stop(measure, meta) do
+    case meta.state do
+      :success ->
+        :ok
+
+      other ->
+        Logger.error("""
+        AI Assistant stop (non-success):
+        Worker: #{meta.job.worker}
+        State: #{inspect(other)}
+        Args: #{inspect(meta.job.args)}
+        Duration: #{measure.duration / 1_000_000}ms
+        """)
+
+        ChatMessage
+        |> Repo.get!(meta.job.args["message_id"])
+        |> case do
+          %ChatMessage{id: message_id, status: status} = message
+          when status in [:pending, :processing] ->
+            Logger.info(
+              "[AI Assistant] Updating message #{message_id} to error status after stop=#{other}"
+            )
+
+            {:ok, _sess, _msg} = update_message_status(message, :error)
+
+          _ ->
+            :ok
+        end
+
+        Lightning.Sentry.capture_message(
+          "AI Assistant Stop (#{other}): #{meta.job.worker}",
+          level: :warning,
+          extra: %{
+            worker: meta.job.worker,
+            args: meta.job.args,
+            job_id: meta.job.id,
+            queue: meta.job.queue,
+            state: other,
+            duration_ms: measure.duration / 1_000_000,
+            memory: measure.memory,
+            reductions: measure.reductions
+          },
+          tags: %{
+            type: "ai_stop",
+            queue: "ai_assistant",
+            worker: meta.job.worker,
+            state: other
+          }
+        )
+    end
+  end
 end

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -345,6 +345,11 @@ defmodule Lightning.Config do
     end
 
     defp metrics_config, do: Application.get_env(:lightning, :metrics)
+
+    @impl true
+    def sentry do
+      Application.get_env(:lightning, :sentry, Sentry)
+    end
   end
 
   @callback apollo(key :: atom() | nil) :: map()
@@ -400,6 +405,7 @@ defmodule Lightning.Config do
   @callback external_metrics_module() :: module() | nil
   @callback ai_assistant_modes() :: %{atom() => module()}
   @callback per_workflow_claim_limit() :: pos_integer()
+  @callback sentry() :: module()
 
   @doc """
   Returns the configuration for the `Lightning.AdaptorRegistry` service
@@ -632,6 +638,10 @@ defmodule Lightning.Config do
 
   def per_workflow_claim_limit do
     impl().per_workflow_claim_limit()
+  end
+
+  def sentry do
+    impl().sentry()
   end
 
   defp impl do

--- a/lib/lightning/oban_manager.ex
+++ b/lib/lightning/oban_manager.ex
@@ -2,7 +2,20 @@ defmodule Lightning.ObanManager do
   @moduledoc """
   The Oban Manager
   """
+  alias Lightning.AiAssistant.ChatMessage
+  alias Lightning.AiAssistant.MessageProcessor
+  alias Lightning.Repo
+
   require Logger
+
+  def handle_event(
+        [:oban, :job, :exception],
+        measure,
+        %{job: %{queue: "ai_assistant"}} = meta,
+        _pid
+      ) do
+    handle_ai_assistant_exception(measure, meta)
+  end
 
   def handle_event([:oban, :job, :exception], measure, meta, _pid) do
     Logger.error(~s"""
@@ -33,6 +46,74 @@ defmodule Lightning.ObanManager do
         stacktrace: meta.stacktrace,
         extra: context,
         tags: %{type: "oban"}
+      )
+    end
+  end
+
+  defp handle_ai_assistant_exception(measure, meta) do
+    job = meta.job
+    error = meta.error
+    timeout? = Map.get(error, :reason) == :timeout
+
+    Logger.error(~s"""
+    AI Assistant exception:
+    Worker: #{job.worker}
+    Type: #{if timeout?, do: "Timeout", else: "Error"}
+    Args: #{inspect(job.args)}
+    Error: #{inspect(error)}
+    Duration: #{measure.duration / 1_000_000}ms
+    """)
+
+    ChatMessage
+    |> Repo.get!(job.args["message_id"])
+    |> case do
+      %ChatMessage{id: message_id, status: status} = message
+      when status in [:pending, :processing] ->
+        Logger.info(
+          "[AI Assistant] Updating message #{message_id} to error status after exception"
+        )
+
+        {:ok, _updated_session, _updated_message} =
+          MessageProcessor.update_message_status(
+            message,
+            :error
+          )
+
+      %ChatMessage{id: message_id, status: status} ->
+        Logger.debug(
+          "[AI Assistant] Message #{message_id} already has status: #{status}, skipping cleanup"
+        )
+    end
+
+    context = %{
+      worker: job.worker,
+      args: job.args,
+      queue: job.queue,
+      job_id: job.id,
+      duration_ms: measure.duration / 1_000_000,
+      memory: measure.memory,
+      reductions: measure.reductions
+    }
+
+    if timeout? do
+      Sentry.capture_message("AI Assistant Timeout: #{job.worker}",
+        level: :warning,
+        extra: Map.merge(context, %{error: inspect(error)}),
+        tags: %{
+          type: "ai_timeout",
+          queue: "ai_assistant",
+          worker: job.worker
+        }
+      )
+    else
+      Sentry.capture_exception(error,
+        stacktrace: meta.stacktrace,
+        extra: context,
+        tags: %{
+          type: "ai_error",
+          queue: "ai_assistant",
+          worker: job.worker
+        }
       )
     end
   end

--- a/lib/lightning/oban_manager.ex
+++ b/lib/lightning/oban_manager.ex
@@ -2,9 +2,7 @@ defmodule Lightning.ObanManager do
   @moduledoc """
   The Oban Manager
   """
-  alias Lightning.AiAssistant.ChatMessage
   alias Lightning.AiAssistant.MessageProcessor
-  alias Lightning.Repo
 
   require Logger
 
@@ -14,7 +12,7 @@ defmodule Lightning.ObanManager do
         %{job: %{queue: "ai_assistant"}} = meta,
         _pid
       ) do
-    handle_ai_assistant_exception(measure, meta)
+    MessageProcessor.handle_ai_assistant_exception(measure, meta)
   end
 
   def handle_event([:oban, :job, :exception], measure, meta, _pid) do
@@ -56,126 +54,8 @@ defmodule Lightning.ObanManager do
         %{job: %{queue: "ai_assistant"}} = meta,
         _pid
       ) do
-    handle_ai_assistant_stop(measure, meta)
+    MessageProcessor.handle_ai_assistant_stop(measure, meta)
   end
 
   def handle_event([:oban, :job, :stop], _measure, _meta, _pid), do: :ok
-
-  defp handle_ai_assistant_exception(measure, meta) do
-    job = meta.job
-    error = meta.error
-    timeout? = Map.get(error, :reason) == :timeout
-
-    Logger.error(~s"""
-    AI Assistant exception:
-    Worker: #{job.worker}
-    Type: #{if timeout?, do: "Timeout", else: "Error"}
-    Args: #{inspect(job.args)}
-    Error: #{inspect(error)}
-    Duration: #{measure.duration / 1_000_000}ms
-    """)
-
-    ChatMessage
-    |> Repo.get!(job.args["message_id"])
-    |> case do
-      %ChatMessage{id: message_id, status: status} = message
-      when status in [:pending, :processing] ->
-        Logger.info(
-          "[AI Assistant] Updating message #{message_id} to error status after exception"
-        )
-
-        {:ok, _updated_session, _updated_message} =
-          MessageProcessor.update_message_status(message, :error)
-
-      %ChatMessage{id: message_id, status: status} ->
-        Logger.debug(
-          "[AI Assistant] Message #{message_id} already has status: #{status}, skipping cleanup"
-        )
-    end
-
-    context = %{
-      worker: job.worker,
-      args: job.args,
-      queue: job.queue,
-      job_id: job.id,
-      duration_ms: measure.duration / 1_000_000,
-      memory: measure.memory,
-      reductions: measure.reductions
-    }
-
-    if timeout? do
-      Lightning.Sentry.capture_message("AI Assistant Timeout: #{job.worker}",
-        level: :warning,
-        extra: Map.merge(context, %{error: inspect(error)}),
-        tags: %{
-          type: "ai_timeout",
-          queue: "ai_assistant",
-          worker: job.worker
-        }
-      )
-    else
-      Lightning.Sentry.capture_exception(error,
-        stacktrace: meta.stacktrace,
-        extra: context,
-        tags: %{
-          type: "ai_error",
-          queue: "ai_assistant",
-          worker: job.worker
-        }
-      )
-    end
-  end
-
-  defp handle_ai_assistant_stop(measure, meta) do
-    case meta.state do
-      :success ->
-        :ok
-
-      other ->
-        Logger.error("""
-        AI Assistant stop (non-success):
-        Worker: #{meta.job.worker}
-        State: #{inspect(other)}
-        Args: #{inspect(meta.job.args)}
-        Duration: #{measure.duration / 1_000_000}ms
-        """)
-
-        ChatMessage
-        |> Repo.get!(meta.job.args["message_id"])
-        |> case do
-          %ChatMessage{id: message_id, status: status} = message
-          when status in [:pending, :processing] ->
-            Logger.info(
-              "[AI Assistant] Updating message #{message_id} to error status after stop=#{other}"
-            )
-
-            {:ok, _sess, _msg} =
-              MessageProcessor.update_message_status(message, :error)
-
-          _ ->
-            :ok
-        end
-
-        Lightning.Sentry.capture_message(
-          "AI Assistant Stop (#{other}): #{meta.job.worker}",
-          level: :warning,
-          extra: %{
-            worker: meta.job.worker,
-            args: meta.job.args,
-            job_id: meta.job.id,
-            queue: meta.job.queue,
-            state: other,
-            duration_ms: measure.duration / 1_000_000,
-            memory: measure.memory,
-            reductions: measure.reductions
-          },
-          tags: %{
-            type: "ai_stop",
-            queue: "ai_assistant",
-            worker: meta.job.worker,
-            state: other
-          }
-        )
-    end
-  end
 end

--- a/lib/lightning/sentry.ex
+++ b/lib/lightning/sentry.ex
@@ -1,0 +1,22 @@
+defmodule Lightning.SentryBehaviour do
+  @moduledoc """
+  Behaviour for our Sentry client.
+  """
+  @callback capture_message(String.t(), keyword()) :: any()
+  @callback capture_exception(Exception.t(), keyword()) :: any()
+end
+
+defmodule Lightning.Sentry do
+  @moduledoc """
+  Runtime proxy around the configured Sentry implementation.
+  """
+  @behaviour Lightning.SentryBehaviour
+
+  defp impl, do: Lightning.Config.sentry()
+
+  @impl true
+  def capture_message(msg, opts), do: impl().capture_message(msg, opts)
+
+  @impl true
+  def capture_exception(err, opts), do: impl().capture_exception(err, opts)
+end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -138,40 +138,40 @@ defmodule LightningWeb.WorkflowLive.Edit do
             Switch to latest version
           </.button>
 
-          <div class="flex flex-row gap-2">
-            <.icon
-              :if={!@can_edit_workflow}
-              name="hero-lock-closed"
-              class="w-5 h-5 place-self-center text-gray-300"
-            />
-            <div class="flex flex-row m-auto gap-2">
-              <.input
-                id="workflow"
-                type="toggle"
-                name="workflow_state"
-                disabled={@sending_ai_message}
-                value={Helpers.workflow_enabled?(@changeset)}
-                tooltip={Helpers.workflow_state_tooltip(@changeset)}
-                on_click="toggle_workflow_state"
+          <.with_changes_indicator
+            :if={@snapshot_version_tag == "latest" && !@show_new_workflow_panel}
+            changeset={@changeset}
+          >
+            <div class="flex flex-row gap-2">
+              <.icon
+                :if={!@can_edit_workflow}
+                name="hero-lock-closed"
+                class="w-5 h-5 place-self-center text-gray-300"
               />
-              <div>
-                <.settings_icon
-                  :if={!@show_new_workflow_panel}
-                  changeset={@changeset}
-                  selection_mode={@selection_mode}
-                  base_url={@base_url}
-                  query_params={@query_params}
-                  show_workflow_ai_chat={@show_workflow_ai_chat}
-                  workflow_chat_session_id={@workflow_chat_session_id}
-                  job_chat_session_id={@job_chat_session_id}
+              <div class="flex flex-row m-auto gap-2">
+                <.input
+                  id="workflow"
+                  type="toggle"
+                  name="workflow_state"
+                  disabled={@sending_ai_message}
+                  value={Helpers.workflow_enabled?(@changeset)}
+                  tooltip={Helpers.workflow_state_tooltip(@changeset)}
+                  on_click="toggle_workflow_state"
                 />
+                <div>
+                  <.settings_icon
+                    :if={!@show_new_workflow_panel}
+                    changeset={@changeset}
+                    selection_mode={@selection_mode}
+                    base_url={@base_url}
+                    query_params={@query_params}
+                    show_workflow_ai_chat={@show_workflow_ai_chat}
+                    workflow_chat_session_id={@workflow_chat_session_id}
+                    job_chat_session_id={@job_chat_session_id}
+                  />
+                </div>
+                <.offline_indicator />
               </div>
-            </div>
-            <.offline_indicator />
-            <.with_changes_indicator
-              :if={@snapshot_version_tag == "latest" && !@show_new_workflow_panel}
-              changeset={@changeset}
-            >
               <.run_workflow_button
                 base_url={@base_url}
                 show_workflow_ai_chat={@show_workflow_ai_chat}
@@ -199,8 +199,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
                 project_repo_connection={@project_repo_connection}
                 dropdown_position={:bottom}
               />
-            </.with_changes_indicator>
-          </div>
+            </div>
+          </.with_changes_indicator>
         </LayoutComponents.header>
       </:header>
       <.WorkflowStore react-id="workflow-mount" />

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -508,10 +508,7 @@ defmodule Lightning.AiAssistantTest do
 
         assert_enqueued(
           worker: Lightning.AiAssistant.MessageProcessor,
-          args: %{
-            "session_id" => session.id,
-            "message_id" => message.id
-          }
+          args: %{"message_id" => message.id}
         )
       end)
     end
@@ -527,10 +524,7 @@ defmodule Lightning.AiAssistantTest do
 
         assert_enqueued(
           worker: Lightning.AiAssistant.MessageProcessor,
-          args: %{
-            "session_id" => session.id,
-            "message_id" => message.id
-          }
+          args: %{"message_id" => message.id}
         )
       end)
     end
@@ -694,10 +688,7 @@ defmodule Lightning.AiAssistantTest do
 
         assert_enqueued(
           worker: Lightning.AiAssistant.MessageProcessor,
-          args: %{
-            "session_id" => session.id,
-            "message_id" => new_message.id
-          }
+          args: %{"message_id" => new_message.id}
         )
       end)
     end
@@ -1067,10 +1058,7 @@ defmodule Lightning.AiAssistantTest do
 
       assert_enqueued(
         worker: Lightning.AiAssistant.MessageProcessor,
-        args: %{
-          "message_id" => message.id,
-          "session_id" => session.id
-        }
+        args: %{"message_id" => message.id}
       )
     end
 
@@ -1422,10 +1410,7 @@ defmodule Lightning.AiAssistantTest do
 
         assert_enqueued(
           worker: Lightning.AiAssistant.MessageProcessor,
-          args: %{
-            "session_id" => session.id,
-            "message_id" => initial_message.id
-          }
+          args: %{"message_id" => initial_message.id}
         )
       end)
     end
@@ -1449,10 +1434,7 @@ defmodule Lightning.AiAssistantTest do
         # Verify the job was enqueued
         assert_enqueued(
           worker: Lightning.AiAssistant.MessageProcessor,
-          args: %{
-            "session_id" => session.id,
-            "message_id" => message.id
-          }
+          args: %{"message_id" => message.id}
         )
       end)
     end

--- a/test/lightning/oban_manager_test.exs
+++ b/test/lightning/oban_manager_test.exs
@@ -1,0 +1,355 @@
+defmodule Lightning.ObanManagerTest do
+  use Lightning.DataCase, async: true
+
+  import ExUnit.CaptureLog
+  import Mox
+
+  alias Lightning.AiAssistant
+  alias Lightning.AiAssistant.ChatMessage
+  alias Lightning.ObanManager
+  alias Lightning.Repo
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    Mox.stub(Lightning.MockConfig, :sentry, fn -> Lightning.MockSentry end)
+    :ok
+  end
+
+  defp ai_setup(_) do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      user = insert(:user)
+      job = insert(:job)
+
+      {:ok, session} =
+        AiAssistant.create_session(job, user, "Test message", meta: %{})
+
+      message = hd(session.messages)
+
+      oban_job = %{
+        id: 123,
+        queue: "ai_assistant",
+        worker: "Lightning.AiAssistant.MessageProcessor",
+        args: %{"message_id" => message.id, "session_id" => session.id}
+      }
+
+      %{
+        session: session,
+        message: message,
+        oban_job: oban_job,
+        user: user,
+        job: job
+      }
+    end)
+  end
+
+  describe "handle_event/4 for AI Assistant queue" do
+    setup :ai_setup
+
+    test "handles timeout exception for pending message", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      {:ok, _} = Repo.update(Ecto.Changeset.change(message, %{status: :pending}))
+
+      error = %Oban.TimeoutError{
+        message:
+          "Lightning.AiAssistant.MessageProcessor timed out after 31000ms",
+        reason: :timeout
+      }
+
+      meta = %{job: oban_job, error: error, stacktrace: []}
+      measure = %{duration: 31_000_000_000, memory: 50_000, reductions: 400_000}
+
+      expect(Lightning.MockSentry, :capture_message, fn msg, opts ->
+        assert msg ==
+                 "AI Assistant Timeout: Lightning.AiAssistant.MessageProcessor"
+
+        assert opts[:level] == :warning
+        assert opts[:tags][:type] == "ai_timeout"
+        :ok
+      end)
+
+      logs =
+        capture_log(fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :exception],
+            measure,
+            meta,
+            self()
+          )
+        end)
+
+      assert logs =~ "AI Assistant exception:"
+      assert logs =~ "Type: Timeout"
+
+      updated_message = Repo.get!(ChatMessage, message.id)
+      assert updated_message.status == :error
+      assert updated_message.processing_completed_at != nil
+    end
+
+    test "handles generic exception for processing message", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      {:ok, _} =
+        Repo.update(Ecto.Changeset.change(message, %{status: :processing}))
+
+      error = %RuntimeError{message: "Something went wrong"}
+
+      meta = %{
+        job: oban_job,
+        error: error,
+        stacktrace: [
+          {Lightning.SomeModule, :some_function, 2,
+           [file: "lib/some_module.ex", line: 42]}
+        ]
+      }
+
+      measure = %{duration: 5_000_000_000, memory: 30_000, reductions: 200_000}
+
+      expect(Lightning.MockSentry, :capture_exception, fn error, opts ->
+        assert %RuntimeError{} = error
+        assert opts[:stacktrace] == meta.stacktrace
+        assert opts[:tags][:type] == "ai_error"
+        :ok
+      end)
+
+      logs =
+        capture_log(fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :exception],
+            measure,
+            meta,
+            self()
+          )
+        end)
+
+      assert logs =~ "AI Assistant exception:"
+      assert logs =~ "Type: Error"
+
+      updated_message = Repo.get!(ChatMessage, message.id)
+      assert updated_message.status == :error
+    end
+
+    test "skips update for already completed message", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      {:ok, _} = Repo.update(Ecto.Changeset.change(message, %{status: :success}))
+
+      error = %Oban.TimeoutError{reason: :timeout}
+      meta = %{job: oban_job, error: error, stacktrace: []}
+      measure = %{duration: 1_000, memory: 1_000, reductions: 1_000}
+
+      expect(Lightning.MockSentry, :capture_message, fn _, _ -> :ok end)
+
+      capture_log(fn ->
+        ObanManager.handle_event(
+          [:oban, :job, :exception],
+          measure,
+          meta,
+          self()
+        )
+      end)
+
+      updated_message = Repo.get!(ChatMessage, message.id)
+      assert updated_message.status == :success
+    end
+  end
+
+  describe "handle_event/4 for other queues" do
+    test "handles timeout for non-AI queue" do
+      oban_job = %{
+        id: 456,
+        queue: "background",
+        worker: "SomeOtherWorker",
+        args: %{}
+      }
+
+      error = %Oban.TimeoutError{reason: :timeout}
+      meta = %{job: oban_job, error: error, stacktrace: []}
+      measure = %{duration: 10_000, memory: 5_000, reductions: 10_000}
+
+      expect(Lightning.MockSentry, :capture_message, fn msg, opts ->
+        assert msg == "Processor Timeout"
+        assert opts[:level] == :warning
+        assert opts[:tags][:type] == "timeout"
+        :ok
+      end)
+
+      logs =
+        capture_log([level: :debug], fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :exception],
+            measure,
+            meta,
+            self()
+          )
+        end)
+
+      assert logs =~ "Oban exception:"
+      assert logs =~ "TimeoutError"
+    end
+
+    test "handles generic exception for non-AI queue" do
+      oban_job = %{
+        id: 789,
+        queue: "workflow_failures",
+        worker: "WorkflowWorker",
+        args: %{"workflow_id" => "123"}
+      }
+
+      error = %ArgumentError{message: "invalid argument"}
+
+      meta = %{
+        job: oban_job,
+        error: error,
+        stacktrace: [{Module, :function, 1, [file: "lib/module.ex", line: 10]}]
+      }
+
+      measure = %{duration: 500, memory: 1_000, reductions: 500}
+
+      expect(Lightning.MockSentry, :capture_exception, fn error, opts ->
+        assert %ArgumentError{} = error
+        assert opts[:stacktrace] == meta.stacktrace
+        assert opts[:tags][:type] == "oban"
+        :ok
+      end)
+
+      logs =
+        capture_log([level: :debug], fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :exception],
+            measure,
+            meta,
+            self()
+          )
+        end)
+
+      assert logs =~ "Oban exception:"
+      assert logs =~ "ArgumentError"
+      refute logs =~ "AI Assistant exception:"
+    end
+  end
+
+  describe "broadcasting" do
+    setup :ai_setup
+
+    test "broadcasts error status update", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      Lightning.subscribe("ai_session:#{message.chat_session_id}")
+
+      {:ok, _} = Repo.update(Ecto.Changeset.change(message, %{status: :pending}))
+
+      error = %Oban.TimeoutError{reason: :timeout}
+      meta = %{job: oban_job, error: error, stacktrace: []}
+      measure = %{duration: 1_000, memory: 1_000, reductions: 1_000}
+
+      expect(Lightning.MockSentry, :capture_message, fn _, _ -> :ok end)
+
+      logs =
+        capture_log([level: :warning], fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :exception],
+            measure,
+            meta,
+            self()
+          )
+        end)
+
+      assert logs =~ "AI Assistant exception:"
+
+      assert_receive {:ai_assistant, :message_status_changed,
+                      %{status: {:error, _}, session_id: _}}
+
+      updated_message = Repo.get!(ChatMessage, message.id)
+      assert updated_message.status == :error
+      assert updated_message.processing_completed_at != nil
+    end
+  end
+
+  describe "handle_event/4 :stop for AI Assistant queue" do
+    setup :ai_setup
+
+    test "no-op on success stop", %{message: message, oban_job: oban_job} do
+      logs =
+        capture_log([level: :warning], fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :stop],
+            %{duration: 1_000, memory: 1_000, reductions: 1_000},
+            %{job: oban_job, state: :success},
+            self()
+          )
+        end)
+
+      refute logs =~ "AI Assistant stop (non-success):"
+
+      reloaded = Repo.get!(ChatMessage, message.id)
+      assert reloaded.status == message.status
+    end
+
+    test "marks message error on non-success stop and broadcasts", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      Lightning.subscribe("ai_session:#{message.chat_session_id}")
+
+      {:ok, _} =
+        Repo.update(Ecto.Changeset.change(message, %{status: :processing}))
+
+      expect(Lightning.MockSentry, :capture_message, fn msg, opts ->
+        assert msg ==
+                 "AI Assistant Stop (discarded): Lightning.AiAssistant.MessageProcessor"
+
+        assert opts[:level] == :warning
+        assert opts[:tags][:type] == "ai_stop"
+        assert opts[:tags][:queue] == "ai_assistant"
+        assert opts[:tags][:worker] == "Lightning.AiAssistant.MessageProcessor"
+        :ok
+      end)
+
+      logs =
+        capture_log([level: :warning], fn ->
+          ObanManager.handle_event(
+            [:oban, :job, :stop],
+            %{duration: 2_000, memory: 2_000, reductions: 2_000},
+            %{job: oban_job, state: :discarded},
+            self()
+          )
+        end)
+
+      assert logs =~ "AI Assistant stop (non-success):"
+
+      assert_receive {:ai_assistant, :message_status_changed,
+                      %{status: {:error, _}, session_id: _}}
+
+      updated = Repo.get!(ChatMessage, message.id)
+      assert updated.status == :error
+      assert updated.processing_completed_at != nil
+    end
+
+    test "ignores stop for non-AI queues" do
+      meta = %{
+        job: %{id: 42, queue: "background", worker: "SomeOther", args: %{}},
+        state: :discarded
+      }
+
+      logs =
+        capture_log([level: :warning], fn ->
+          assert :ok =
+                   ObanManager.handle_event(
+                     [:oban, :job, :stop],
+                     %{duration: 1},
+                     meta,
+                     self()
+                   )
+        end)
+
+      refute logs =~ "AI Assistant stop"
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@
 # Rexbug.start("ExUnit.Server.add_sync_module/_")
 
 Mox.defmock(Lightning.AuthProviders.OauthHTTPClient.Mock, for: Tesla.Adapter)
+Mox.defmock(Lightning.MockSentry, for: Lightning.SentryBehaviour)
 Mox.defmock(Lightning.Tesla.Mock, for: Tesla.Adapter)
 
 :ok = Application.ensure_started(:ex_machina)


### PR DESCRIPTION
## Description
This PR fixes an issue where AI Assistant messages would get stuck in "pending" state when Apollo times out, preventing users from seeing error feedback or retrying.

This PR fixes also a bug in the Workflow Canvas where the users could still enable or disable a workflow when viewing in snapshot mode.

Closes #3497 

@elias-ba believes that #3498 will also be addressed by this PR - I am linking it here but not tagging for closure as it must be verified separately.

## Validation steps
1. **Test Apollo timeout handling:**
   - Temporarily set a very low timeout in MessageProcessor (e.g., `def timeout(_job), do: 10`)
   - Send a message in the AI Assistant
   - Verify the message shows error status in the UI after timeout
   - Verify the retry button appears and works

2. **Test normal flow still works:**
   - Restore normal timeout
   - Send a regular AI message
   - Verify it processes successfully

3. **Test ObanManager safety net:**
   - Check logs for `[AI Assistant] Updating message X to error status after exception`
   - Verify Sentry receives proper "AI Assistant Timeout" events (need to configure Sentry)

4. **Test bug when viewing a snapshot in workflow canvas**
    - Open a snapshot
    - See that workflow enable / disable toggle is not rendered

## Additional notes for the reviewer
1. The core issue was that we were broadcasting stale session data. After updating a message status in the DB, we now reload the session to get fresh data before broadcasting.

2. Added a safety net in `ObanManager` that catches AI assistant queue exceptions and ensures messages don't get stuck in pending state.

3. Fixed the timeout buffer calculation - removed hardcoded `10` that was overriding the dynamic calculation.

4. No database migrations needed - only runtime behavior changes.

## AI Usage
Please disclose how you've used AI in this work (it's cool, we just want to know!):
- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist
- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR