### PR TITLE
feat: use formatRelative time formatting for mini-history

### DIFF
--- a/assets/js/hooks/index.ts
+++ b/assets/js/hooks/index.ts
@@ -908,7 +908,7 @@ export const TypewriterHook = {
   },
 };
 
-const relativeLocale = {
+export const relativeLocale = {
   ...enUS,
   formatRelative: (token, date, baseDate, options) => {
     const formatters = {

--- a/assets/js/workflow-diagram/MiniHistory.tsx
+++ b/assets/js/workflow-diagram/MiniHistory.tsx
@@ -1,9 +1,10 @@
+import { relativeLocale } from '../hooks';
 import type {
   WorkflowRunHistory,
   WorkOrderStates,
 } from '#/workflow-store/store';
+import { formatRelative } from 'date-fns';
 import React, { useState } from 'react';
-import formatDate from '../utils/formatDate';
 import { duration } from '../utils/duration';
 import truncateUid from '../utils/truncateUID';
 import { renderIcon } from './components/RunIcons';
@@ -27,6 +28,8 @@ export default function MiniHistory({
 }: MiniHistoryProps) {
   const [expandedWorder, setExpandedWorder] = useState('');
   const [isCollapsed, setIsCollapsed] = useState(collapsed);
+
+  const now = new Date();
 
   // to ensure panel is not collapsed when there's a selected item in history
   // at time this component will be rendered before data reaches store. that makes the panel collapse
@@ -140,7 +143,7 @@ export default function MiniHistory({
                         {truncateUid(workorder.id)}
                       </span>
                       <span className="text-xs text-gray-500 font-mono">
-                        {formatDate(new Date(workorder.last_activity))}
+                        {formatRelative(new Date(workorder.last_activity), now, { locale: relativeLocale })}
                       </span>
                     </div>
                     <StatePill key={workorder.id} state={workorder.state} />
@@ -167,8 +170,9 @@ export default function MiniHistory({
                           </span>
                           <span className="text-gray-500 font-mono">
                             {run.started_at
-                              ? formatDate(new Date(run.started_at))
-                              : formatDate(new Date(run.finished_at))}
+                              ? formatRelative(new Date(run.started_at), now, { locale: relativeLocale })
+                              : formatRelative(new Date(run.finished_at), now, { locale: relativeLocale })
+                            }
                           </span>
                           <span className="text-gray-400 text-xs">
                             {!run.started_at || !run.finished_at


### PR DESCRIPTION
## Description
Attempt to reuse the formatRelative formatting for the mini-history. This PR partially addresses #3499 

<img width="552" height="463" alt="Screenshot 2025-08-08 at 8 14 44 AM" src="https://github.com/user-attachments/assets/d8fda8ac-3c1e-4a81-a347-803ec3f31f49" />

## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
