### PR TITLE
3510 test gauge metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 ### Added
 
+- Add test gauge metric that can be used to set arbitrary values for the purposes
+  of triggering behaviour in metric consumers.
+  [3510](https://github.com/OpenFn/lightning/issues/3510)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/prom_ex_test_plugin.ex
+++ b/lib/lightning/prom_ex_test_plugin.ex
@@ -19,6 +19,11 @@ defmodule Lightning.PromExTestPlugin do
             @event_name ++ [:count],
             description:
               "A counter that can be triggered arbitrarily for test purposes."
+          ),
+          Metrics.last_value(
+            @event_name ++ [:last_value],
+            description:
+              "A gauge that can be triggered arbitrarily for test purposes."
           )
         ]
       )
@@ -29,6 +34,14 @@ defmodule Lightning.PromExTestPlugin do
     :telemetry.execute(
       @event_name,
       %{count: 1},
+      %{}
+    )
+  end
+
+  def fire_gauge_event(last_value) do
+    :telemetry.execute(
+      @event_name,
+      %{last_value: last_value},
       %{}
     )
   end


### PR DESCRIPTION
## Description

Certain consumers (such as GKE Autoscaling) require a 'gauge' metric - i.e. a metric that can increase or decrease. Having  a test metric that can be set to arbitrary values is useful for testing things such as autoscaling where it may be quite labour-intensive to produce the conditions necessary to see autoscaling react.

Closes #3510 

## Validation steps

- Start Phoenix locally
- Browse to the [metrics page](http://localhost:4000/metrics). 
- You should not see the metric ``.
- In an IEx session, run  `Lightning.PromExTestPlugin.fire_gauge_event(6000)`
- Refresh the metrics page, adn you should see the below:

<img width="684" height="52" alt="image" src="https://github.com/user-attachments/assets/1b9a213f-1404-4b8c-b3d5-5aaa7a8213c4" />


## Additional notes for the reviewer

Lisa Gerrard is an Australian singer and is known for (amongst other things) performing the Gladiator theme song. The language used in the song is known as an idioglossia - an invented language that is only spoken by 1-2 people.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
