### PR TITLE
feat: hide mini-history on new page

### DIFF
--- a/assets/js/workflow-diagram/WorkflowDiagram.tsx
+++ b/assets/js/workflow-diagram/WorkflowDiagram.tsx
@@ -590,15 +590,18 @@ export default function WorkflowDiagram(props: WorkflowDiagramProps) {
         liveAction={props.liveAction}
         drawerWidth={drawerWidth}
       />
-      <MiniHistory
-        collapsed={!runSteps.start_from}
-        history={someHistory}
-        selectRunHandler={onRunChange}
-        onCollapseHistory={onCollapseHistory}
-        drawerWidth={drawerWidth}
-        hasSnapshotMismatch={hasSnapshotMismatch}
-        missingNodeCount={missingNodeCount}
-      />
+      {
+        props.liveAction === 'edit' ?
+          <MiniHistory
+            collapsed={!runSteps.start_from}
+            history={someHistory}
+            selectRunHandler={onRunChange}
+            onCollapseHistory={onCollapseHistory}
+            drawerWidth={drawerWidth}
+            hasSnapshotMismatch={hasSnapshotMismatch}
+            missingNodeCount={missingNodeCount}
+          /> : null
+      }
     </ReactFlowProvider>
   );
 }


### PR DESCRIPTION
## Description

When on the new page for creating a new workflow, you shouldn't see the mini history panel. 

<img width="1366" height="725" alt="Screenshot 2025-08-19 at 9 35 40 AM" src="https://github.com/user-attachments/assets/35f02231-431c-46b1-91a3-aeeb32d20105" />

Closes #3529 



## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
