### PR TITLE
3532 remove noop link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ and this project adheres to
   [#3387](https://github.com/OpenFn/lightning/issues/3387)
 - Add test gauge metric that can be used to set arbitrary values for the purposes
   of triggering behaviour in metric consumers.
-  [3510](https://github.com/OpenFn/lightning/issues/3510)
+  [#3510](https://github.com/OpenFn/lightning/issues/3510)
 - Possibly temporary plumbing to allow the use of libcluster_postgres as an
   additional mechanism for discovering Erlang nodes.
-  [3482](https://github.com/OpenFn/lightning/issues/3482)
+  [#3482](https://github.com/OpenFn/lightning/issues/3482)
+- Remove redundant 'preconnect' link
+  [#3532](https://github.com/OpenFn/lightning/issues/3532)
 
 ### Changed
 

--- a/lib/lightning_web/components/layouts/root.html.heex
+++ b/lib/lightning_web/components/layouts/root.html.heex
@@ -5,7 +5,6 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="//" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
## Description

This PR removes a redundant 'preconnect' link. As it was connecting to the serving host, it would have no effect as the browser would already have a connection open. Removing this as it triggers some pen testing tools.

Closes #3532 

## Validation steps

As this link was a no-op... I guess if Lightning runs locally, then we call it  a win?

## Additional notes for the reviewer

During the cold war, Radio Free Europe used to transmit from Portugal to countries behind the Iron Curtain. These signals were jammed by transmitters in the Soviet Union. However, because short-wave radio transmissions can be bounced off the ionosphere during daylight, there would be a window each afternoon where the Soviet jammers would be ineffective as they would be in darkness while Europe still had sunlight. There were local jammers as well, but these were largely located in large urban centres.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
