### PR TITLE
Fix: generate workflow YAML on page load

### DIFF
--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -236,7 +236,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             ai_assistant_component_id={@workflow_ai_assistant_id}
             module={LightningWeb.WorkflowLive.WorkflowAiChatComponent}
             workflow={@workflow}
-            workflow_code={@workflow_code_with_ids}
+            workflow_code={@workflow_code_with_ids |> dbg()}
             project={@project}
             base_url={@base_url}
             query_params={@query_params}
@@ -3098,6 +3098,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     |> assign(show_workflow_ai_chat: show_workflow_ai_chat)
     |> assign_changeset(changeset)
     |> maybe_disable_canvas()
+    |> generate_workflow_code()
   end
 
   defp apply_query_params(socket, params) do


### PR DESCRIPTION
## Description

This PR fixes a regression where the YAML view/code panel did not generate on first load of the Workflow editor. We now push the `"generate_workflow_code"` event from `assign_workflow/3` so the client builds the YAML immediately for:

* Existing workflows (on first mount), and
* Newly created workflows (after the initial save on `/w/new`).

This was affecting prod and staging.

Closes #3536

## Validation steps

1. **Existing workflow**

   * Navigate to `/projects/:project_id/w/:workflow_id?v=:lock_version`.
   * Open “View as YAML”.
   * Correct YAML appears without any additional interaction.
   
2. **New workflow**

   * Go to `/projects/:project_id/w/new`.
   * Choose any template, click **Continue/Save** so a workflow is created.
   * Open “View as YAML”.
   * Correct YAML appears.

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

* [ ] Code generation (copilot but not intellisense)
* [ ] Learning or fact checking
* [ ] Strategy / design
* [ ] Optimisation / refactoring
* [ ] Translation / spellchecking / doc gen
* [ ] Other
* [x] I have not used AI

## Pre-submission checklist

* [x] I have performed a **self-review** of my code.
* [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
* [ ] I have updated the **changelog**.
* [x] I have ticked a box in "AI usage" in this PR
