### PR TITLE
Set x-content-type-options for static content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
   [#3482](https://github.com/OpenFn/lightning/issues/3482)
 - Remove redundant 'preconnect' link
   [#3532](https://github.com/OpenFn/lightning/issues/3532)
+- Enable X-Content-Type-Options header for static pages.
+  [#3534](https://github.com/OpenFn/lightning/issues/3534)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Enable X-Content-Type-Options header for static pages.
+  [#3534](https://github.com/OpenFn/lightning/issues/3534)
+
 ### Fixed
 
 ## [v2.14.3-pre1] - 2025-08-22
@@ -45,8 +48,6 @@ and this project adheres to
   [#3482](https://github.com/OpenFn/lightning/issues/3482)
 - Remove redundant 'preconnect' link
   [#3532](https://github.com/OpenFn/lightning/issues/3532)
-- Enable X-Content-Type-Options header for static pages.
-  [#3534](https://github.com/OpenFn/lightning/issues/3534)
 
 ### Fixed
 

--- a/lib/lightning_web/endpoint.ex
+++ b/lib/lightning_web/endpoint.ex
@@ -36,7 +36,10 @@ defmodule LightningWeb.Endpoint do
     at: "/",
     from: :lightning,
     gzip: true,
-    only: LightningWeb.static_paths()
+    only: LightningWeb.static_paths(),
+    headers: [
+      {"x-content-type-options", "nosniff"}
+    ]
 
   if Code.ensure_loaded?(Tidewave) do
     plug Tidewave


### PR DESCRIPTION
## Description

This adds the X-Content-Type-Options header to static pages.

Closes #3534 

## Validation steps

- Start Lightning locally
- cURL a static page - e.g. `curl -i localhost:4000/robots.txt`
- You should see `x-content-type-options: nosniff` in the output

## Additional notes for the reviewer

In 1924, two US aircraft completed the first circumnavigation of the world, after a journey that took 175 days. Other countries that made the attempt included the UK, France, Italy, Portugal and Argentina. Despite multiple crashes no participants were killed and the spirit of cooperation was notable with countries helping one another.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
