### PR TITLE
feat: clean UI for rendering errors & allow re-renders

### DIFF
--- a/assets/js/react/components/Fallback.tsx
+++ b/assets/js/react/components/Fallback.tsx
@@ -2,11 +2,37 @@ import type { FallbackProps } from 'react-error-boundary';
 
 export type { FallbackProps };
 
-export const Fallback = ({ error }: FallbackProps) => (
-  <div role="alert">
-    <p>Something went wrong:</p>
-    <pre style={{ color: 'red' }}>
-      {error instanceof Error ? error.message : String(error)}
-    </pre>
-  </div>
-);
+const renderStyle = "border border-gray-300 bg-[repeating-linear-gradient(45deg,theme(colors.gray.200)_0_12px,theme(colors.gray.100)_12px_24px)] dark:border-gray-600 dark:bg-[repeating-linear-gradient(45deg,theme(colors.gray.700)_0_12px,theme(colors.gray.800)_12px_24px)]"
+
+export const Fallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return <>
+    <div className={'w-full h-full ' + renderStyle}>
+    </div>
+    <div role="alert" className='z-50 fixed top-0 right-0 bottom-0 left-0 flex items-center justify-center bg-red-100/50'>
+      <div className='bg-white rounded-lg p-4 w-[512px] h-auto shadow'>
+        <h2 className='text-xl mb-3 flex items-center gap-2'> <span className='hero-exclamation-circle text-yellow-500 size-6'></span> Rendering Error</h2>
+        <p>An error occurred while rendering this part of the application.</p>
+        <p>You can either re-render the content or reload the entire page. </p>
+        <pre className={'rounded p-1 text-red-400 my-4 py-4 text-sm overflow-auto font-mono font-semibold' + renderStyle}>
+          {error instanceof Error ? error.message : String(error)}
+        </pre>
+        <div className="mt-2 flex gap-2">
+          <button
+            type="button"
+            className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 bg-primary-600 hover:bg-primary-500 text-white disabled:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 px-2 py-1 flex items-center gap-1"
+            onClick={resetErrorBoundary}
+          >
+            <span className="hero-tv w-4 h-4"></span>  Re-render
+          </button>
+          <button
+            type="button"
+            className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 bg-primary-600 hover:bg-primary-500 text-white disabled:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 px-2 py-1 flex items-center gap-1"
+            onClick={() => { window.location.reload() }}
+          >
+            <span className="hero-arrow-path w-4 h-4"></span>  Reload
+          </button>
+        </div>
+      </div>
+    </div >
+  </>
+}

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1314,7 +1314,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     <div
       id={"selected-template-label-#{@template.id}"}
       phx-mounted={fade_in()}
-      class="absolute z-[9999] m-4 opacity-75 bg-white/100 border border-gray-200 rounded-lg p-6"
+      class="absolute z-40 m-4 opacity-75 bg-white/100 border border-gray-200 rounded-lg p-6"
     >
       <div class="flex items-start gap-3 opacity-100">
         <div class="flex-shrink-0">


### PR DESCRIPTION
## Description
Whenever we have an Error somewhere in react, we now show a beautiful UI and also allow the user to recover from the error.
<img width="1731" height="900" alt="Screenshot 2025-08-21 at 5 57 10 AM" src="https://github.com/user-attachments/assets/46fa145a-87bc-4bf8-b9da-ac5172068d4f" />

Closes #3239 

## Validation steps
Currently on main, switching between templates pretty quick breaks the app. Goodluck on recovering from it.

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
