### PR TITLE
workflow presence bug

### DIFF
--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2263,16 +2263,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   def handle_info(%{event: "presence_diff", payload: _diff}, socket) do
-    summary =
-      socket.assigns.workflow
-      |> Presence.list_presences_for()
-      |> Presence.build_presences_summary(socket.assigns)
-
-    {:noreply,
-     socket
-     |> assign(summary)
-     |> maybe_switch_workflow_version()
-     |> maybe_disable_canvas()}
+    {:noreply, update_presence_summary(socket)}
   end
 
   @impl true
@@ -2833,9 +2824,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
         socket.assigns.workflow,
         self()
       )
-    end
 
-    socket
+      update_presence_summary(socket)
+    else
+      socket
+    end
   end
 
   defp initial_presence_summary(current_user) do
@@ -2850,6 +2843,17 @@ defmodule LightningWeb.WorkflowLive.Edit do
       current_user_presence: init_user_presence,
       has_presence_edit_priority: true
     }
+  end
+
+  defp update_presence_summary(socket) do
+    summary =
+      socket.assigns.workflow
+      |> Presence.list_presences_for()
+      |> Presence.build_presences_summary(socket.assigns)
+
+    assign(socket, summary)
+    |> maybe_switch_workflow_version()
+    |> maybe_disable_canvas()
   end
 
   defp view_only_users(project) do


### PR DESCRIPTION
## Description

This PR fixes an intermittent failure where the banner that tells that someone else is already editing the workflow doesn't show.

Closes #3546

## Validation steps

This is a no-op

## Additional notes for the reviewer

We simply update the presence summary every time you check for user presence instead of waiting for the callback

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
