### PR TITLE
Retry a followed run from job panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Retry webhook events on transient database connection errors
   [#3097](https://github.com/OpenFn/lightning/issues/3097)
+- Allow users to retry followed runs from the job panel
+  [#3502](https://github.com/OpenFn/lightning/issues/3502)
 
 ### Changed
 

--- a/assets/js/manual-run-panel/ManualRunPanel.tsx
+++ b/assets/js/manual-run-panel/ManualRunPanel.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import constructQuery from '../utils/constructQuery';
 import { Tabs } from '../components/Tabs';
 import { type Dataclip, FilterTypes, SeletableOptions } from './types';
+import type { RunStep } from '../workflow-store/store';
 import CustomView from './views/CustomView';
 import EmptyView from './views/EmptyView';
 import ExistingView from './views/ExistingView';
@@ -18,6 +19,8 @@ import useQuery from '../hooks/useQuery';
 interface ManualRunPanelProps {
   job_id: string;
   fixedHeight: boolean;
+  onRunStepChange?: (runStep: RunStep | null) => void;
+  onDataclipChange?: (dataclip: Dataclip | null) => void;
 }
 
 export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
@@ -44,6 +47,8 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
     job_id,
     navigate,
     fixedHeight = false,
+    onRunStepChange,
+    onDataclipChange,
   } = props;
 
   const [selectedOption, setSelectedOption] = React.useState<SeletableOptions>(
@@ -109,10 +114,17 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
         setSelectedOption(SeletableOptions.EXISTING);
         pushManualChange(SeletableOptions.EXISTING);
       }
+      onDataclipChange?.(dataclip);
       setSelectedDataclip(dataclip);
       setNameError(''); // Clear any existing error when switching dataclips
     },
-    [pushEvent, setSelectedOption, pushManualChange, setSelectedDataclip]
+    [
+      pushEvent,
+      setSelectedOption,
+      pushManualChange,
+      setSelectedDataclip,
+      onDataclipChange,
+    ]
   );
 
   React.useEffect(() => {
@@ -184,21 +196,26 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
   React.useEffect(() => {
     if (runId && job_id) {
       pushEventTo(
-        'get-run-input-dataclip',
+        'get-run-step-and-input-dataclip',
         { run_id: runId, job_id: job_id },
         (response: unknown) => {
-          const typedResponse = response as { dataclip: Dataclip | null };
+          const typedResponse = response as {
+            dataclip: Dataclip | null;
+            run_step: RunStep | null;
+          };
           if (typedResponse.dataclip) {
             setCurrentRunDataclip(typedResponse.dataclip);
             // Auto-select the current run's dataclip when viewing a specific run
             selectDataclipForManualRun(typedResponse.dataclip);
           }
+          onRunStepChange?.(typedResponse.run_step);
         }
       );
     } else {
       setCurrentRunDataclip(null);
+      onRunStepChange?.(null);
     }
-  }, [runId, job_id, pushEventTo, selectDataclipForManualRun]);
+  }, [runId, job_id, pushEventTo, selectDataclipForManualRun, onRunStepChange]);
 
   React.useEffect(() => {
     pushEventTo(

--- a/assets/js/panel/Panel.tsx
+++ b/assets/js/panel/Panel.tsx
@@ -15,7 +15,7 @@ export const Panel: React.FC<PanelProps> = ({
   children,
   footer,
   onClose,
-  onBack
+  onBack,
 }) => {
   return (
     <div
@@ -25,9 +25,10 @@ export const Panel: React.FC<PanelProps> = ({
         <div className="flex px-4 py-5 sm:px-6 gap-2 items-center">
           <div className="flex-none flex items-center">
             <div
-              onClick={() => { onBack(); }}
+              onClick={() => {
+                onBack();
+              }}
               className="justify-center flex items-center hover:text-gray-500 cursor-pointer"
-              id="close-panel"
             >
               <span className="hero-arrow-left h-4 w-4 inline-block" />
             </div>
@@ -35,7 +36,9 @@ export const Panel: React.FC<PanelProps> = ({
           <div className="grow font-bold truncate">{heading}</div>
           <div className="flex-none flex items-center">
             <div
-              onClick={() => { onClose(); }}
+              onClick={() => {
+                onClose();
+              }}
               className="justify-center flex items-center hover:text-gray-500 cursor-pointer"
               id="close-panel"
             >
@@ -44,14 +47,14 @@ export const Panel: React.FC<PanelProps> = ({
           </div>
         </div>
         <div className="px-4 py-5 sm:p-6 grow flex flex-col overflow-visible h-130">
-          <div className="md:gap-4 grow flex flex-col overflow-visible">{children}</div>
+          <div className="md:gap-4 grow flex flex-col overflow-visible">
+            {children}
+          </div>
         </div>
         {footer && (
           <div className="p-3 z-50 bg-white rounded-lg">
             <div className="md:grid md:grid-cols-6 md:gap-4 @container">
-              <div className="col-span-6">
-                {footer}
-              </div>
+              <div className="col-span-6">{footer}</div>
             </div>
           </div>
         )}

--- a/assets/js/panel/panels/WorkflowRunPanel.tsx
+++ b/assets/js/panel/panels/WorkflowRunPanel.tsx
@@ -103,12 +103,12 @@ export const WorkflowRunPanel: WithActionProps<WorkflowRunPanel> = props => {
   }, [pushEvent, manualContent, job_id]);
 
   const shouldShowRetry = React.useMemo(() => {
-    if (!currentRunStep || !currentDataclip || !runId) return false;
+    if (is_edge || !currentRunStep || !currentDataclip || !runId) return false;
     return (
       currentDataclip.wiped_at === null &&
       currentRunStep.input_dataclip_id === currentDataclip.id
     );
-  }, [currentRunStep, runId, currentDataclip]);
+  }, [currentRunStep, runId, currentDataclip, is_edge]);
 
   return (
     <>

--- a/assets/js/panel/panels/WorkflowRunPanel.tsx
+++ b/assets/js/panel/panels/WorkflowRunPanel.tsx
@@ -1,30 +1,52 @@
-import { ManualRunPanel } from "../../manual-run-panel/ManualRunPanel"
-import type { WithActionProps } from "#/react/lib/with-props"
-import { Panel } from "../Panel"
-import React from "react"
-
+import { ManualRunPanel } from '../../manual-run-panel/ManualRunPanel';
+import type { WithActionProps } from '#/react/lib/with-props';
+import { Panel } from '../Panel';
+import type { Dataclip } from '../../manual-run-panel/types';
+import type { RunStep } from '../../workflow-store/store';
+import useQuery from '../../hooks/useQuery';
+import React from 'react';
 
 interface ManualRunBody {
   manual: {
-    body: string | null
-    dataclip_id: string | null
-  }
+    body: string | null;
+    dataclip_id: string | null;
+  };
 }
 
 interface WorkflowRunPanel {
-  job_id: string
-  job_title: string
-  cancel_url: string
-  back_url: string
-  is_edge: boolean
+  job_id: string;
+  job_title: string;
+  cancel_url: string;
+  back_url: string;
+  is_edge: boolean;
 }
 
-export const WorkflowRunPanel: WithActionProps<WorkflowRunPanel> = (props) => {
-  const { job_id, job_title, cancel_url, back_url, is_edge, pushEvent, ...actionProps } = props;
-  const [manualContent, setManualRunContent] = React.useState<ManualRunBody>({ manual: { body: null, dataclip_id: null } })
+export const WorkflowRunPanel: WithActionProps<WorkflowRunPanel> = props => {
+  const {
+    job_id,
+    job_title,
+    cancel_url,
+    back_url,
+    is_edge,
+    pushEvent,
+    ...actionProps
+  } = props;
+  const { a: runId } = useQuery(['a']);
+  const [manualContent, setManualRunContent] = React.useState<ManualRunBody>({
+    manual: { body: null, dataclip_id: null },
+  });
+  const [currentRunStep, setCurrentRunStep] = React.useState<RunStep | null>(
+    null
+  );
+  const [currentDataclip, setCurrentDataclip] = React.useState<Dataclip | null>(
+    null
+  );
 
   const runDisabled = React.useMemo(() => {
-    if (!manualContent.manual.body && !manualContent.manual.dataclip_id) return true;
+    if (currentDataclip && currentDataclip.wiped_at) {
+      return true;
+    } else if (!manualContent.manual.body && !manualContent.manual.dataclip_id)
+      return true;
     else if (manualContent.manual.body) {
       try {
         const parsed = JSON.parse(manualContent.manual.body);
@@ -33,48 +55,137 @@ export const WorkflowRunPanel: WithActionProps<WorkflowRunPanel> = (props) => {
       } catch (e: unknown) {
         return true;
       }
-    } else if (manualContent.manual.dataclip_id)
-      return false;
+    } else if (manualContent.manual.dataclip_id) return false;
     return true;
-  }, [manualContent.manual.body, manualContent.manual.dataclip_id])
+  }, [
+    manualContent.manual.body,
+    manualContent.manual.dataclip_id,
+    currentDataclip,
+  ]);
 
-  const pushEventProxy = React.useCallback((title: string, payload: Record<string, unknown>, cb: unknown) => {
-    // here we intercept manual_run_change events and keep the state local
-    if (title === "manual_run_change") {
-      setManualRunContent(payload as unknown as ManualRunBody);
-      return;
+  const pushEventProxy = React.useCallback(
+    (title: string, payload: Record<string, unknown>, cb: unknown) => {
+      // here we intercept manual_run_change events and keep the state local
+      if (title === 'manual_run_change') {
+        console.log('manual_run_change event received', payload);
+        setManualRunContent(payload as unknown as ManualRunBody);
+        return;
+      }
+      pushEvent(title, payload, cb);
+    },
+    [pushEvent]
+  );
+
+  const handleRunStepChange = React.useCallback((runStep: RunStep | null) => {
+    setCurrentRunStep(runStep);
+  }, []);
+
+  const handleDataclipChange = React.useCallback(
+    (dataclip: Dataclip | null) => {
+      setCurrentDataclip(dataclip);
+    },
+    []
+  );
+
+  const startRetry = React.useCallback(() => {
+    if (runId && currentRunStep) {
+      pushEvent('rerun', {
+        run_id: runId,
+        step_id: currentRunStep.id,
+        via: 'job_panel',
+      });
     }
-    pushEvent(title, payload, cb);
-  }, [pushEvent])
+  }, [pushEvent, runId, currentRunStep]);
 
   const startRun = React.useCallback(() => {
     const from = job_id ? { from_job: job_id } : { from_start: true };
-    pushEvent("manual_run_submit", { ...manualContent, ...from });
-  }, [pushEvent, manualContent, job_id])
+    pushEvent('manual_run_submit', { ...manualContent, ...from });
+  }, [pushEvent, manualContent, job_id]);
 
-  return <>
-    <Panel
-      heading={is_edge ? "Run" : `Run from ${job_title}`}
-      onClose={() => { props.navigate(cancel_url); }}
-      onBack={() => { props.navigate(back_url) }}
-      className="flex flex-col bg-red"
-      footer={
-        <div className="flex justify-end">
-          <button
-            type="button"
-            className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 bg-primary-600 hover:bg-primary-500 text-white disabled:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 px-3 py-2 flex items-center gap-1"
-            disabled={is_edge ? true : runDisabled}
-            onClick={startRun}
-          >
-            <span className="hero-play-solid w-4 h-4"></span>  Run Workflow Now
-          </button>
-        </div>
-      }
-    >
-      {
-        is_edge ? <div className="flex justify-center flex-col items-center self-center">
-          <div>Select a Step or Trigger to start a Run from</div>
-        </div> :
+  const shouldShowRetry = React.useMemo(() => {
+    if (!currentRunStep || !currentDataclip || !runId) return false;
+    return (
+      currentDataclip.wiped_at === null &&
+      currentRunStep.input_dataclip_id === currentDataclip.id
+    );
+  }, [currentRunStep, runId, currentDataclip]);
+
+  return (
+    <>
+      <Panel
+        heading={is_edge ? 'Run' : `Run from ${job_title}`}
+        onClose={() => {
+          props.navigate(cancel_url);
+        }}
+        onBack={() => {
+          props.navigate(back_url);
+        }}
+        className="flex flex-col bg-red"
+        footer={
+          <div className="flex justify-end">
+            {shouldShowRetry ? (
+              <div className="inline-flex rounded-md shadow-xs">
+                <button
+                  type="button"
+                  className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 cursor-pointer disabled:cursor-auto px-3 py-2 bg-primary-600 hover:bg-primary-500 text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 relative inline-flex items-center rounded-r-none"
+                  onClick={startRetry}
+                >
+                  <span className="hero-play-mini w-4 h-4 mr-1"></span> Run
+                  (retry)
+                </button>
+                <div className="relative -ml-px block">
+                  <button
+                    type="button"
+                    className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 cursor-pointer disabled:cursor-auto px-3 py-2 bg-primary-600 hover:bg-primary-500 text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 h-full rounded-l-none pr-1 pl-1"
+                    onClick={() => {
+                      const dropdown = document.getElementById(
+                        'new-work-order-option'
+                      );
+                      if (dropdown) {
+                        dropdown.style.display =
+                          dropdown.style.display === 'none' ? 'block' : 'none';
+                      }
+                    }}
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                  >
+                    <span className="sr-only">Open options</span>
+                    <span className="hero-chevron-down w-4 h-4"></span>
+                  </button>
+                  <div role="menu" aria-orientation="vertical">
+                    <button
+                      id="new-work-order-option"
+                      type="button"
+                      className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 cursor-pointer disabled:cursor-auto px-3 py-2 bg-white hover:bg-gray-50 text-gray-900 ring-1 ring-gray-300 ring-inset hidden absolute right-0 bottom-9 z-10 mb-2 w-max"
+                      style={{ display: 'none' }}
+                      disabled={is_edge ? true : runDisabled}
+                      onClick={startRun}
+                    >
+                      <span className="hero-play-solid w-4 h-4 mr-1"></span> Run
+                      (New Work Order)
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="rounded-md text-sm font-semibold shadow-xs phx-submit-loading:opacity-75 bg-primary-600 hover:bg-primary-500 text-white disabled:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 px-3 py-2 flex items-center gap-1"
+                disabled={is_edge ? true : runDisabled}
+                onClick={startRun}
+              >
+                <span className="hero-play-solid w-4 h-4"></span> Run Workflow
+                Now
+              </button>
+            )}
+          </div>
+        }
+      >
+        {is_edge ? (
+          <div className="flex justify-center flex-col items-center self-center">
+            <div>Select a Step or Trigger to start a Run from</div>
+          </div>
+        ) : (
           <>
             <div className="truncate">Select input to start a run</div>
             <ManualRunPanel
@@ -82,9 +193,12 @@ export const WorkflowRunPanel: WithActionProps<WorkflowRunPanel> = (props) => {
               pushEvent={pushEventProxy}
               job_id={job_id}
               fixedHeight
+              onRunStepChange={handleRunStepChange}
+              onDataclipChange={handleDataclipChange}
             />
           </>
-      }
-    </Panel>
-  </>
-}
+        )}
+      </Panel>
+    </>
+  );
+};

--- a/assets/js/workflow-editor/WorkflowEditor.tsx
+++ b/assets/js/workflow-editor/WorkflowEditor.tsx
@@ -60,6 +60,7 @@ export const WorkflowEditor: WithActionProps<{
       } else {
         console.debug('Selecting', id);
 
+        nextUrl.searchParams.delete('m');
         nextUrl.searchParams.set('s', id);
       }
     }

--- a/assets/js/workflow-editor/WorkflowEditor.tsx
+++ b/assets/js/workflow-editor/WorkflowEditor.tsx
@@ -60,7 +60,6 @@ export const WorkflowEditor: WithActionProps<{
       } else {
         console.debug('Selecting', id);
 
-        nextUrl.searchParams.delete('m');
         nextUrl.searchParams.set('s', id);
       }
     }

--- a/assets/js/workflow-store/store.ts
+++ b/assets/js/workflow-store/store.ts
@@ -38,11 +38,13 @@ export type WorkflowProps = {
 };
 
 export type RunStep = {
+  id: string;
   job_id: Lightning.Job['id'];
   error_type: string;
   exit_reason: 'fail' | 'success' | 'crash' | null;
   started_at: string;
   finished_at: string;
+  input_dataclip_id: string;
   // below don't come from backend
   startNode?: boolean;
   startBy: string;

--- a/lib/lightning/invocation/step.ex
+++ b/lib/lightning/invocation/step.ex
@@ -34,6 +34,17 @@ defmodule Lightning.Invocation.Step do
           exit_reason: String.t() | nil,
           job: Job.t() | Ecto.Association.NotLoaded.t() | nil
         }
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :exit_reason,
+             :error_type,
+             :finished_at,
+             :started_at,
+             :job_id,
+             :input_dataclip_id,
+             :output_dataclip_id
+           ]}
 
   schema "steps" do
     field :exit_reason, :string

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1634,15 +1634,14 @@ defmodule LightningWeb.WorkflowLive.Edit do
   end
 
   def handle_event(
-        "get-run-input-dataclip",
+        "get-run-step-and-input-dataclip",
         %{"run_id" => run_id, "job_id" => job_id},
         socket
       ) do
-    Invocation.get_first_dataclip_for_run_and_job(run_id, job_id)
-    |> case do
-      nil -> {:reply, %{dataclip: nil}, socket}
-      dataclip -> {:reply, %{dataclip: dataclip}, socket}
-    end
+    dataclip = Invocation.get_first_dataclip_for_run_and_job(run_id, job_id)
+    run_step = Invocation.get_first_step_for_run_and_job(run_id, job_id)
+
+    {:reply, %{dataclip: dataclip, run_step: run_step}, socket}
   end
 
   def handle_event(
@@ -2037,10 +2036,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
   # order, just like clicking "rerun from here" on the history page.
   def handle_event(
         "rerun",
-        %{"run_id" => run_id, "step_id" => step_id},
+        %{"run_id" => run_id, "step_id" => step_id} = params,
         socket
       ) do
-    case rerun(socket, run_id, step_id) do
+    case rerun(socket, run_id, step_id, params["via"]) do
       {:ok, socket} ->
         {:noreply, socket}
 
@@ -2325,11 +2324,13 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
   defp format_step(step) do
     %{
+      id: step.id,
       job_id: step.job_id,
       error_type: step.error_type,
       exit_reason: step.exit_reason,
       started_at: step.started_at,
-      finished_at: step.finished_at
+      finished_at: step.finished_at,
+      input_dataclip_id: step.input_dataclip_id
     }
   end
 
@@ -2914,16 +2915,8 @@ defmodule LightningWeb.WorkflowLive.Edit do
         selectable_dataclips =
           Invocation.list_dataclips_for_job(%Job{id: job.id})
 
-        step =
-          assigns[:follow_run] &&
-            Invocation.get_first_step_for_run_and_job(
-              assigns[:follow_run].id,
-              job.id
-            )
-
         socket
         |> assign_manual_run_form(changeset)
-        |> assign(step: step)
         |> assign_dataclips(selectable_dataclips, dataclip)
 
       _ ->
@@ -3412,7 +3405,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
     """
   end
 
-  defp rerun(socket, run_id, step_id) do
+  defp rerun(socket, run_id, step_id, via) do
     %{
       can_run_workflow: can_run_workflow?,
       current_user: current_user,
@@ -3439,15 +3432,19 @@ defmodule LightningWeb.WorkflowLive.Edit do
          {:ok, workflow} <- save_or_get_workflow,
          {:ok, run} <-
            WorkOrders.retry(run_id, step_id, created_by: current_user) do
-      Runs.subscribe(run)
+      if via == "job_panel" do
+        {:ok, push_navigate(socket, to: ~p"/projects/#{project_id}/runs/#{run}")}
+      else
+        Runs.subscribe(run)
 
-      snapshot = Snapshot.get_by_version(workflow.id, workflow.lock_version)
+        snapshot = Snapshot.get_by_version(workflow.id, workflow.lock_version)
 
-      {:ok,
-       socket
-       |> assign_workflow(workflow, snapshot)
-       |> follow_run(run)
-       |> push_event("push-hash", %{"hash" => "log"})}
+        {:ok,
+         socket
+         |> assign_workflow(workflow, snapshot)
+         |> follow_run(run)
+         |> push_event("push-hash", %{"hash" => "log"})}
+      end
     end
   end
 


### PR DESCRIPTION
## Description

This PR allows users to retry a run from the job panel

Closes #3502 

## Validation steps

In order to test this, you will need to have some run history for that workflow

1. In the workflow edit page, open the recent history in the workflow and click on one of the runs in the history
2. You'll see the jobs highlighted with green for successfully run steps and red for failed steps. Choose on of the jobs/steps
3. A job panel appears, at the bottom of the panel, you'll find a `run` button. Click on it
4. A run form appears, at the bottom, you should see a button to `Run (retry)`

## Additional notes for the reviewer

I have added callbacks for passing the `currentDataclip` and `currentStep` to the `WorkflowPanel`.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
