### PR TITLE
fix: current run dataclip stuck

### DIFF
--- a/assets/js/manual-run-panel/ManualRunPanel.tsx
+++ b/assets/js/manual-run-panel/ManualRunPanel.tsx
@@ -192,6 +192,9 @@ export const ManualRunPanel: WithActionProps<ManualRunPanelProps> = props => {
             setCurrentRunDataclip(typedResponse.dataclip);
             // Auto-select the current run's dataclip when viewing a specific run
             selectDataclipForManualRun(typedResponse.dataclip);
+          } else {
+            setCurrentRunDataclip(null);
+            selectDataclipForManualRun(null);
           }
         }
       );


### PR DESCRIPTION
## Description

Makes sure current run dataclip isn't stuck when switching between a step that has one and one that doesn't on the history overlay view in the canvas

Closes #3558 

## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
