### PR TITLE
Fix AI Assistant Z Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to
 
 ### Fixed
 
+## [v2.14.4] - 2025-09-09
+
+### Fixed
+
+- Fix Workflow AI Assistant apearing above inspector panel
+  [#3567](https://github.com/OpenFn/lightning/issues/3567)
+
 ## [v2.14.3] - 2025-08-29
 
 ## [v2.14.3-pre1] - 2025-08-22
@@ -39,8 +46,8 @@ and this project adheres to
 - Add test gauge metric that can be used to set arbitrary values for the
   purposes of triggering behaviour in metric consumers.
   [3510](https://github.com/OpenFn/lightning/issues/3510)
-- Add test gauge metric that can be used to set arbitrary values for the purposes
-  of triggering behaviour in metric consumers.
+- Add test gauge metric that can be used to set arbitrary values for the
+  purposes of triggering behaviour in metric consumers.
   [#3510](https://github.com/OpenFn/lightning/issues/3510)
 - Possibly temporary plumbing to allow the use of libcluster_postgres as an
   additional mechanism for discovering Erlang nodes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 ### Fixed
 
+## [v2.14.3] - 2025-08-29
+
 ## [v2.14.3-pre1] - 2025-08-22
 
 ### Fixed

--- a/lib/lightning_web/live/workflow_live/workflow_ai_chat_component.ex
+++ b/lib/lightning_web/live/workflow_live/workflow_ai_chat_component.ex
@@ -132,7 +132,7 @@ defmodule LightningWeb.WorkflowLive.WorkflowAiChatComponent do
     <div
       id={@id}
       phx-hook="TemplateToWorkflow"
-      class="absolute inset-y-0 left-0 w-[30%] max-w-[30%] z-20 -translate-x-full z-50"
+      class="absolute inset-y-0 left-0 w-[30%] max-w-[30%] z-40 -translate-x-full"
       phx-mounted={slide_in()}
       phx-remove={slide_out()}
     >

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lightning.MixProject do
   def project do
     [
       app: :lightning,
-      version: "2.14.3-pre1",
+      version: "2.14.3",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lightning.MixProject do
   def project do
     [
       app: :lightning,
-      version: "2.14.3",
+      version: "2.14.4",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [


### PR DESCRIPTION
## Description

This PR moves the workflow AI Assistant below the job inspector panel by reducing it's z-index value.

Closes #3567

## Validation steps

### Before this PR

1. Go to workflow canvas
2. Open the workflow AI Assistant
3. Now open the job inspector
4. See the workflow AI Assistant still appearing on top of the job inspector

### With this PR

1. Go to workflow canvas
2. Open the workflow AI Assistant
3. Now open the job inspector
4. You won't see the workflow AI Assistant anymore

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR