### PR TITLE
Remove outdated Rambo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,16 +481,6 @@ Install the Rust compiler so a binary can be prepared for you.
 You can resolve this error by installing the Rust compiler using Homebrew. Run
 the following command in your terminal: `brew install rust`
 
-If you have already compiled Rambo explicitly via `mix compile.rambo`, and you
-are still seeing the following error:
-
-```
-sh: /path_to_directory/Lightning/_build/dev/lib/rambo/priv/rambo: No such file or directory
-sh: line 0: exec: /path_to_directory/Lightning/_build/dev/lib/rambo/priv/rambo: cannot execute: No such file or directory
-```
-
-You can try renaming `deps/rambo/priv/rambo-mac` to `deps/rambo/priv/rambo`.
-
 If neither of the approaches above work, please raise an issue.
 
 ## Support

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -49,6 +49,19 @@ if [[ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
         exit 1
       fi
     fi
+
+
+    if brew list rust &>/dev/null; then
+      echo "✅ rust is installed"
+    else
+      echo "❌ rust is not installed"
+      if brew install rust; then
+        echo "✅ rust has been installed"
+      else
+        echo "❌ Failed to install rust"
+        exit 1
+      fi
+    fi
   else
     echo "❌ Homebrew is not installed"
     exit 1
@@ -60,6 +73,15 @@ mix local.rebar --if-missing
 mix deps.get
 mix deps.compile
 
+# <!-- If you have already compiled Rambo explicitly via `mix compile.rambo`, and you
+# are still seeing the following error:
+
+# ```
+# sh: /path_to_directory/Lightning/_build/dev/lib/rambo/priv/rambo: No such file or directory
+# sh: line 0: exec: /path_to_directory/Lightning/_build/dev/lib/rambo/priv/rambo: cannot execute: No such file or directory
+# ```
+
+# You can try renaming `deps/rambo/priv/rambo-mac` to `deps/rambo/priv/rambo`. -->
 if [[ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
   mix compile.rambo
 fi


### PR DESCRIPTION
## Description

This PR *This PR removes outdated Rambo references from the codebase. These instructions were not used anymore and could cause confusion during builds.*

Closes #__

## Validation steps

1. *Confirm the deleted section no longer appears in the docs/code.*

2. *Run the project build to ensure there are no Rambo-related errors or warnings.*

3. *Search the repo (grep -r "rambo" .) to confirm no other stray references remain.*

## Additional notes for the reviewer

1. *This is a cleanup-only change. No functional code paths were altered*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [* ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have ticked a box in "AI usage" in this PR
