### PR TITLE
Restore export history button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
 
 - Fix pagination bar rounding to match table corners
   [#3595](https://github.com/OpenFn/lightning/issues/3595)
+- Restore export history button
+  [#3594](https://github.com/OpenFn/lightning/issues/3594)
 - Wrong timestamp information in mini-history for in-progress runs
   [#3579](https://github.com/OpenFn/lightning/pull/3579)
 

--- a/lib/lightning_web/components/table.ex
+++ b/lib/lightning_web/components/table.ex
@@ -84,6 +84,7 @@ defmodule LightningWeb.Components.Table do
   slot :header
   slot :body
   slot :footer
+  slot :pagination_actions
   attr :class, :string, default: nil
   attr :page, :map, default: nil
   attr :url, :any, default: nil
@@ -111,7 +112,11 @@ defmodule LightningWeb.Components.Table do
             page={@page}
             url={@url}
             rounded="lg"
-          />
+          >
+            <:action>
+              {render_slot(@pagination_actions)}
+            </:action>
+          </LightningWeb.Pagination.pagination_bar>
         </div>
       <% end %>
     </div>

--- a/lib/lightning_web/live/run_live/export_confirmation_modal.ex
+++ b/lib/lightning_web/live/run_live/export_confirmation_modal.ex
@@ -26,7 +26,7 @@ defmodule LightningWeb.RunLive.ExportConfirmationModal do
             </button>
           </div>
         </:title>
-        <div class="container mx-auto px-6 space-y-6 bg-white text-sm text-slate-900">
+        <div class="space-y-6 bg-white text-sm text-slate-900">
           Exporting history will download all {@count_work_orders} work orders and associated runs, steps, and I/O data clips that match your query.<br />
           The export will happen in the background and you'll receive an email when it is complete.
         </div>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -746,6 +746,19 @@
               <% end %>
             </.async_result>
           </:body>
+          <:pagination_actions>
+            <button
+              :if={@page.total_entries > 0}
+              id="export-history-button"
+              type="button"
+              phx-click="show-export-modal"
+              class="icon-button inline-flex items-center"
+              phx-hook="Tooltip"
+              aria-label={"Export all #{@page.total_entries} results matching your query"}
+            >
+              <.icon name="hero-cloud-arrow-down" class="w-5 h-5" />
+            </button>
+          </:pagination_actions>
         </.table>
       </div>
     </div>

--- a/test/lightning_web/live/run_live/index_test.exs
+++ b/test/lightning_web/live/run_live/index_test.exs
@@ -475,4 +475,16 @@ defmodule LightningWeb.RunLive.IndexTest do
                "Rerun #{length(selected_workorders)} selected work orders from selected job"
     end
   end
+
+  describe "Export History" do
+    test "export history button is present", %{conn: conn, project: project} do
+      {:ok, view, _html} =
+        live_async(
+          conn,
+          Routes.project_run_index_path(conn, :index, project.id)
+        )
+
+      assert has_element?(view, "button#export-history-button")
+    end
+  end
 end


### PR DESCRIPTION
## Description

This PR restores the export history button. It was removed in [this commit](https://github.com/OpenFn/lightning/commit/167c825f2a7518cb1413e4bee25288405f082f13#diff-22230f2b83dbb80540c108098f13a1f28165b897fc29bb0065a5e0d78829179bL734-L746) 

Closes #3594

## Validation steps

- Open history page
- You should find the export button at the bottom


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
