### PR TITLE
fix #3605

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix canvas "lockup" after AI chat errors, prevent sending empty message to AI
+  [3605](https://github.com/OpenFn/lightning/issues/3605)
 - Fixed GDPR Compliance component
   [#3611](https://github.com/OpenFn/lightning/issues/3611)
 - Fixed vertical alignment in breadcrumbs

--- a/lib/lightning_web/live/ai_assistant/mode_behavior.ex
+++ b/lib/lightning_web/live/ai_assistant/mode_behavior.ex
@@ -233,11 +233,15 @@ defmodule LightningWeb.Live.AiAssistant.ModeBehavior do
           field :content, :string
         end
 
-        def changeset(params) do
+        @doc false
+        def changeset(params \\ %{}) do
           %__MODULE__{}
           |> cast(params, [:content])
+          |> validate_required([:content], message: "Please enter a message before sending")
+          |> validate_length(:content, min: 1, message: "Please enter a message before sending")
         end
 
+        @doc false
         def extract_options(_changeset), do: []
       end
 

--- a/lib/lightning_web/live/ai_assistant/modes/job_code.ex
+++ b/lib/lightning_web/live/ai_assistant/modes/job_code.ex
@@ -40,6 +40,8 @@ defmodule LightningWeb.Live.AiAssistant.Modes.JobCode do
     def changeset(params) do
       %__MODULE__{}
       |> cast(params, [:content])
+      |> validate_required([:content], message: "Please enter a message before sending")
+      |> validate_length(:content, min: 1, message: "Please enter a message before sending")
       |> cast_embed(:options, with: &options_changeset/2)
     end
 


### PR DESCRIPTION
## Description

This PR fixes #3605 

## Validation steps

1. Open the AI chat on an existing workflow
2. Try to send without any text.
3. Note the send button is grey
4. Note that you can still attempt to send via command+enter
5. Note that the error message indicates you need to enter some text
6. Note that the canvas doesn't freeze up

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
