### PR TITLE
Fix project deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed `purge_deleted` job by ensuring that webhook auth methods are cleaned
+  before related triggers are removed.
+  [#3621](https://github.com/OpenFn/lightning/pull/3621)
 - Fixed GDPR Compliance component
   [#3611](https://github.com/OpenFn/lightning/issues/3611)
 - Fixed vertical alignment in breadcrumbs

--- a/lib/lightning/extensions/project_hook.ex
+++ b/lib/lightning/extensions/project_hook.ex
@@ -37,7 +37,6 @@ defmodule Lightning.Extensions.ProjectHook do
     Repo.delete(project)
   end
 
-
   @spec handle_project_validation(Changeset.t(Project.t())) ::
           Changeset.t(Project.t())
   def handle_project_validation(changeset), do: changeset

--- a/lib/lightning/extensions/project_hook.ex
+++ b/lib/lightning/extensions/project_hook.ex
@@ -9,6 +9,8 @@ defmodule Lightning.Extensions.ProjectHook do
   alias Lightning.Projects.Project
   alias Lightning.Repo
 
+  import Ecto.Query
+
   @spec handle_create_project(map()) ::
           {:ok, Project.t()} | {:error, Changeset.t()}
   def handle_create_project(attrs) do
@@ -27,6 +29,11 @@ defmodule Lightning.Extensions.ProjectHook do
 
     Projects.delete_project_workorders(project)
     Projects.project_jobs_query(project) |> Repo.delete_all()
+
+    # Clean up webhook auth method associations before deleting triggers
+    delete_webhook_auth_method_associations(project)
+    Projects.project_webhook_auth_methods_query(project) |> Repo.delete_all()
+
     Projects.project_triggers_query(project) |> Repo.delete_all()
     Projects.project_workflows_query(project) |> Repo.delete_all()
     Projects.project_users_query(project) |> Repo.delete_all()
@@ -34,6 +41,23 @@ defmodule Lightning.Extensions.ProjectHook do
     Projects.delete_project_dataclips(project)
 
     Repo.delete(project)
+  end
+
+  defp delete_webhook_auth_method_associations(project) do
+    # Get all webhook auth method IDs for this project
+    wam_ids =
+      from(wam in Lightning.Workflows.WebhookAuthMethod,
+        where: wam.project_id == ^project.id,
+        select: wam.id
+      )
+      |> Repo.all()
+      |> Enum.map(&Ecto.UUID.dump!/1)
+
+    # Clean up the many-to-many join table
+    from(j in "trigger_webhook_auth_methods",
+      where: j.webhook_auth_method_id in ^wam_ids
+    )
+    |> Repo.delete_all()
   end
 
   @spec handle_project_validation(Changeset.t(Project.t())) ::

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -682,7 +682,9 @@ defmodule Lightning.Projects do
   end
 
   def project_webhook_auth_methods_query(project) do
-    from(wam in Lightning.Workflows.WebhookAuthMethod, where: wam.project_id == ^project.id)
+    from(wam in Lightning.Workflows.WebhookAuthMethod,
+      where: wam.project_id == ^project.id
+    )
   end
 
   @doc """

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -681,6 +681,10 @@ defmodule Lightning.Projects do
     )
   end
 
+  def project_webhook_auth_methods_query(project) do
+    from(wam in Lightning.Workflows.WebhookAuthMethod, where: wam.project_id == ^project.id)
+  end
+
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking project changes.
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -245,6 +245,7 @@ defmodule Lightning.ProjectsTest do
 
       # Add webhook auth method to test edge case deletion
       wam1 = insert(:webhook_auth_method, project: p1)
+
       t1 =
         t1
         |> Repo.preload(:webhook_auth_methods)


### PR DESCRIPTION
## Description

This PR fixes #3523, allowing projects with webhook auth methods to be deleted

## Validation steps

1. Add a project with webhook auth methods
2. Delete it via Iex (or set it to delete, then modify you DB so the deletion date is passed and trigger the oban job)
3. 

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
