### PR TITLE
Fix bootstrap script

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -5,12 +5,15 @@ set -euo pipefail
 
 trap 'echo "❌ Script interrupted at line $LINENO"; exit 1' ERR INT
 
-# Global environment facts
-declare -g OS ARCH
-declare -g HAS_RUST HAS_HOMEBREW
-declare -g HOMEBREW_PACKAGES_INSTALLED
-declare -A MISSING_SYSTEM_DEPS
-declare -A MISSING_BREW_PACKAGES
+# Global environment facts (no declare -g needed at global scope)
+OS=""
+ARCH=""
+HAS_RUST=""
+HAS_HOMEBREW=""
+HOMEBREW_PACKAGES_INSTALLED=""
+# Use regular arrays instead of associative arrays
+MISSING_SYSTEM_DEPS=()
+MISSING_BREW_PACKAGES=()
 
 # Function to gather environment facts
 gather_environment_facts() {
@@ -25,7 +28,7 @@ gather_environment_facts() {
   if command -v node &>/dev/null; then
     echo "✅ Node.js: $(node --version)"
   else
-    MISSING_SYSTEM_DEPS[node]="Node.js"
+    MISSING_SYSTEM_DEPS+=("Node.js")
   fi
 
   if command -v elixir &>/dev/null; then
@@ -33,7 +36,7 @@ gather_environment_facts() {
     elixir_version="$(elixir --version 2>/dev/null | head -1 || echo "version unknown")"
     echo "✅ Elixir: $elixir_version"
   else
-    MISSING_SYSTEM_DEPS[elixir]="Elixir"
+    MISSING_SYSTEM_DEPS+=("Elixir")
   fi
 
   if command -v rustc &>/dev/null; then
@@ -41,7 +44,7 @@ gather_environment_facts() {
     echo "✅ Rust: $(rustc --version)"
   else
     HAS_RUST=false
-    MISSING_BREW_PACKAGES[rust]="Rust"
+    MISSING_BREW_PACKAGES+=("rust")
   fi
 
   # Check Homebrew availability
@@ -57,13 +60,14 @@ gather_environment_facts() {
 
   # Check Homebrew packages if available
   if [[ "$HAS_HOMEBREW" == true ]]; then
-    local -ra required_brew_packages=(libsodium cmake)
+    local required_brew_packages
+    required_brew_packages=(libsodium cmake)
 
     for package in "${required_brew_packages[@]}"; do
       if echo "$HOMEBREW_PACKAGES_INSTALLED" | grep -q "^$package$"; then
         echo "✅ $package (via Homebrew)"
       else
-        MISSING_BREW_PACKAGES[$package]="$package"
+        MISSING_BREW_PACKAGES+=("$package")
       fi
     done
 
@@ -71,8 +75,14 @@ gather_environment_facts() {
     if [[ "$HAS_RUST" == false ]]; then
       if echo "$HOMEBREW_PACKAGES_INSTALLED" | grep -q "^rust$"; then
         echo "✅ Rust (via Homebrew)"
-        # Remove from missing since it's available via homebrew
-        unset 'MISSING_BREW_PACKAGES[rust]'
+        # Remove rust from missing packages (need to rebuild array)
+        local new_missing=()
+        for pkg in "${MISSING_BREW_PACKAGES[@]}"; do
+          if [[ "$pkg" != "rust" ]]; then
+            new_missing+=("$pkg")
+          fi
+        done
+        MISSING_BREW_PACKAGES=("${new_missing[@]}")
       fi
     fi
   fi
@@ -88,7 +98,7 @@ check_environment_status() {
   local has_installable_missing=false
 
   # Check critical system dependencies
-  if [[ -v MISSING_SYSTEM_DEPS ]] && ((${#MISSING_SYSTEM_DEPS[@]} > 0)); then
+  if [[ ${#MISSING_SYSTEM_DEPS[@]} -gt 0 ]]; then
     echo "❌ Missing critical system dependencies:"
     for dep in "${MISSING_SYSTEM_DEPS[@]}"; do
       echo "   - $dep"
@@ -97,17 +107,17 @@ check_environment_status() {
   fi
 
   # Check installable homebrew dependencies
-  if [[ -v MISSING_BREW_PACKAGES ]] && ((${#MISSING_BREW_PACKAGES[@]} > 0)); then
+  if [[ ${#MISSING_BREW_PACKAGES[@]} -gt 0 ]]; then
     if [[ "$HAS_HOMEBREW" == true ]]; then
       echo "📦 Missing Homebrew packages (will install):"
-      for package in "${!MISSING_BREW_PACKAGES[@]}"; do
-        echo "   - ${MISSING_BREW_PACKAGES[$package]}"
+      for package in "${MISSING_BREW_PACKAGES[@]}"; do
+        echo "   - $package"
       done
       has_installable_missing=true
     else
       echo "❌ Homebrew not available, cannot install:"
-      for package in "${!MISSING_BREW_PACKAGES[@]}"; do
-        echo "   - ${MISSING_BREW_PACKAGES[$package]}"
+      for package in "${MISSING_BREW_PACKAGES[@]}"; do
+        echo "   - $package"
       done
       has_critical_missing=true
     fi
@@ -129,11 +139,9 @@ check_environment_status() {
 
 # Function to install missing homebrew packages
 install_missing_homebrew_packages() {
-  if [[ -v MISSING_BREW_PACKAGES ]] && ((${#MISSING_BREW_PACKAGES[@]} > 0)) && [[ "$HAS_HOMEBREW" == true ]]; then
-    local packages_to_install=("${!MISSING_BREW_PACKAGES[@]}")
-
-    echo "📦 Installing missing Homebrew packages: ${packages_to_install[*]}"
-    if brew install "${packages_to_install[@]}"; then
+  if [[ ${#MISSING_BREW_PACKAGES[@]} -gt 0 ]] && [[ "$HAS_HOMEBREW" == true ]]; then
+    echo "📦 Installing missing Homebrew packages: ${MISSING_BREW_PACKAGES[*]}"
+    if brew install "${MISSING_BREW_PACKAGES[@]}"; then
       echo "✅ All missing packages have been installed"
     else
       echo "❌ Failed to install some packages"
@@ -145,7 +153,7 @@ install_missing_homebrew_packages() {
 
 # Function to set environment variables
 setup_environment_variables() {
-  if [[ "$OS" == "Darwin" && "$ARCH" == "arm64" ]]; then
+  if [[ "$OS" == "Darwin" ]]; then
     # Check if libsodium is available (either already installed or just installed)
     if echo "$HOMEBREW_PACKAGES_INSTALLED" | grep -q "^libsodium$" || brew list libsodium &>/dev/null; then
       export CPATH=/opt/homebrew/include

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -5,26 +5,31 @@ set -euo pipefail
 
 trap 'echo "❌ Script interrupted at line $LINENO"; exit 1' ERR INT
 
-# Global environment facts (no declare -g needed at global scope)
 OS=""
 ARCH=""
 HAS_RUST=""
 HAS_HOMEBREW=""
 HOMEBREW_PACKAGES_INSTALLED=""
-# Use regular arrays instead of associative arrays
+HOMEBREW_PREFIX=""
 MISSING_SYSTEM_DEPS=()
 MISSING_BREW_PACKAGES=()
 
-# Function to gather environment facts
 gather_environment_facts() {
   echo "🔍 Gathering environment information..."
 
-  # System information
   OS="$(uname)"
   ARCH="$(uname -m)"
   echo "Platform: $OS $ARCH"
 
-  # Check system commands
+  if [[ "$OS" == "Darwin" ]]; then
+    if [[ "$ARCH" == "arm64" ]]; then
+      HOMEBREW_PREFIX="/opt/homebrew"
+    else
+      HOMEBREW_PREFIX="/usr/local"
+    fi
+    echo "Homebrew prefix: $HOMEBREW_PREFIX"
+  fi
+
   if command -v node &>/dev/null; then
     echo "✅ Node.js: $(node --version)"
   else
@@ -47,18 +52,15 @@ gather_environment_facts() {
     MISSING_BREW_PACKAGES+=("rust")
   fi
 
-  # Check Homebrew availability
   if command -v brew &>/dev/null; then
     HAS_HOMEBREW=true
     echo "✅ Homebrew: $(brew --version | head -1)"
 
-    # Get installed packages once
     HOMEBREW_PACKAGES_INSTALLED="$(brew list -1 2>/dev/null || true)"
   else
     HAS_HOMEBREW=false
   fi
 
-  # Check Homebrew packages if available
   if [[ "$HAS_HOMEBREW" == true ]]; then
     local required_brew_packages
     required_brew_packages=(libsodium cmake)
@@ -71,11 +73,9 @@ gather_environment_facts() {
       fi
     done
 
-    # Add rust to missing brew packages if not installed via system
     if [[ "$HAS_RUST" == false ]]; then
       if echo "$HOMEBREW_PACKAGES_INSTALLED" | grep -q "^rust$"; then
         echo "✅ Rust (via Homebrew)"
-        # Remove rust from missing packages (need to rebuild array)
         local new_missing=()
         for pkg in "${MISSING_BREW_PACKAGES[@]}"; do
           if [[ "$pkg" != "rust" ]]; then
@@ -87,26 +87,49 @@ gather_environment_facts() {
     fi
   fi
 
+  if [[ "$OS" == "Darwin" ]]; then
+    if xcode-select -p &>/dev/null; then
+      echo "✅ Xcode Command Line Tools: $(xcode-select -p)"
+    else
+      echo "❌ Xcode Command Line Tools not installed"
+      MISSING_SYSTEM_DEPS+=("Xcode Command Line Tools")
+    fi
+
+    if echo '#include <cstddef>' | clang++ -x c++ -c - &>/dev/null; then
+      echo "✅ C++ standard library headers found"
+    else
+      echo "⚠️  C++ headers not accessible - this often requires reinstalling Command Line Tools"
+      echo ""
+      echo "   Try these solutions in order:"
+      echo "   1. Reset Xcode path: sudo xcode-select --reset"
+      echo "   2. If that doesn't work, completely reinstall CLT:"
+      echo "      sudo rm -rf /Library/Developer/CommandLineTools"
+      echo "      xcode-select --install"
+      echo ""
+      echo "   Note: The reinstall can take 10-15 minutes to download and install."
+    fi
+  fi
+
   echo ""
 }
 
-# Function to display environment status and exit if critical dependencies missing
 check_environment_status() {
   echo "📋 Environment Status Summary:"
 
   local has_critical_missing=false
   local has_installable_missing=false
 
-  # Check critical system dependencies
   if [[ ${#MISSING_SYSTEM_DEPS[@]} -gt 0 ]]; then
     echo "❌ Missing critical system dependencies:"
     for dep in "${MISSING_SYSTEM_DEPS[@]}"; do
       echo "   - $dep"
+      if [[ "$dep" == "Xcode Command Line Tools" ]]; then
+        echo "     Run: xcode-select --install"
+      fi
     done
     has_critical_missing=true
   fi
 
-  # Check installable homebrew dependencies
   if [[ ${#MISSING_BREW_PACKAGES[@]} -gt 0 ]]; then
     if [[ "$HAS_HOMEBREW" == true ]]; then
       echo "📦 Missing Homebrew packages (will install):"
@@ -123,7 +146,6 @@ check_environment_status() {
     fi
   fi
 
-  # Exit if critical dependencies missing
   if [[ "$has_critical_missing" == true ]]; then
     echo ""
     echo "❌ Critical dependencies are missing. Please install them manually and re-run this script."
@@ -137,7 +159,6 @@ check_environment_status() {
   echo ""
 }
 
-# Function to install missing homebrew packages
 install_missing_homebrew_packages() {
   if [[ ${#MISSING_BREW_PACKAGES[@]} -gt 0 ]] && [[ "$HAS_HOMEBREW" == true ]]; then
     echo "📦 Installing missing Homebrew packages: ${MISSING_BREW_PACKAGES[*]}"
@@ -151,19 +172,26 @@ install_missing_homebrew_packages() {
   fi
 }
 
-# Function to set environment variables
 setup_environment_variables() {
   if [[ "$OS" == "Darwin" ]]; then
-    # Check if libsodium is available (either already installed or just installed)
     if echo "$HOMEBREW_PACKAGES_INSTALLED" | grep -q "^libsodium$" || brew list libsodium &>/dev/null; then
-      export CPATH=/opt/homebrew/include
-      export LIBRARY_PATH=/opt/homebrew/lib
-      echo "🔧 Set environment variables for libsodium"
+      export CPATH="$HOMEBREW_PREFIX/include"
+      export LIBRARY_PATH="$HOMEBREW_PREFIX/lib"
+      echo "🔧 Set environment variables for libsodium (using $HOMEBREW_PREFIX)"
+    fi
+
+    if command -v xcrun &>/dev/null; then
+      local sdk_path
+      sdk_path=$(xcrun --show-sdk-path 2>/dev/null || echo "")
+      if [[ -n "$sdk_path" ]]; then
+        export SDKROOT="$sdk_path"
+        export CPATH="$CPATH:$SDKROOT/usr/include"
+        echo "🔧 Set SDKROOT to $SDKROOT"
+      fi
     fi
   fi
 }
 
-# Main execution flow
 main() {
   gather_environment_facts
   check_environment_status
@@ -188,8 +216,7 @@ main() {
   #
   # You can try renaming `deps/rambo/priv/rambo-mac` to `deps/rambo/priv/rambo`.
 
-  # Compile platform-specific dependencies
-  if [[ "$OS" == "Darwin" && "$ARCH" == "arm64" ]]; then
+  if [[ "$OS" == "Darwin" ]]; then
     echo "🔨 Compiling platform-specific dependencies..."
     mix compile.rambo
   fi


### PR DESCRIPTION
## Description
This PR fixes the bootstrap script to support both older Bash versions (3.1+) and Intel Macs, addressing compatibility issues that were preventing team members from setting up the development environment.

The original script used Bash 4.2+ features (`declare -g`, `declare -A`) and had hardcoded ARM64-specific paths, causing failures on:
- macOS with default Bash 3.2
- Intel Macs (x86_64 architecture)
- Systems with C++ header/Xcode CLT issues

Changes made:
- Removed Bash 4.2+ specific syntax (`declare -g` and associative arrays)
- Added dynamic Homebrew path detection for Intel vs ARM Macs
- Added Xcode Command Line Tools validation and repair instructions
- Extended platform-specific compilation to both architectures
- Improved error messages and diagnostic output

## Validation steps
1. Test on Intel Mac:
   - Run `./bin/bootstrap` on an Intel Mac (x86_64)
   - Verify Homebrew packages install to `/usr/local`
   - Confirm all dependencies install successfully

2. Test on Apple Silicon Mac:
   - Run `./bin/bootstrap` on M1/M2/M3 Mac
   - Verify Homebrew packages install to `/opt/homebrew`
   - Confirm all dependencies install successfully

3. Test with older Bash:
   - Run `bash --version` to confirm version 3.2.x
   - Execute script and verify no syntax errors

4. Test C++ header detection:
   - If headers are missing, verify helpful error messages appear
   - Follow the suggested fix commands and re-run

## Additional notes for the reviewer
1. The script now requires Bash 3.1+ (2005) instead of 4.2+ (2011), making it compatible with macOS's default Bash 3.2
2. The `HOMEBREW_PREFIX` variable dynamically adjusts based on architecture
3. The C++ header check now includes instructions for completely removing and reinstalling Xcode CLT when needed
4. All array operations have been converted from associative to regular arrays

## AI Usage
Please disclose how you've used AI in this work (it's cool, we just want to know!):
- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [x] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist
- [x] I have performed a **self-review** of my code.
- [x] I have implemented and/or tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR