### PR TITLE
use started_at, fallback to claimed_at

### DIFF
--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -40,12 +40,20 @@ defmodule Lightning.Runs.Query do
       where: r.state not in ^final_states,
       where:
         fragment(
-          "? + ((? ->> 'run_timeout_ms')::int + ?) * '1 millisecond'::interval < ?",
+          "COALESCE(?, ?) + ((? ->> 'run_timeout_ms')::int + ?) * '1 millisecond'::interval < ?",
+          r.started_at,
           r.claimed_at,
           r.options,
           ^grace_period_ms,
           ^now
-        ) or (is_nil(r.options) and r.claimed_at < ^fallback_oldest_claim)
+        ) or
+          (is_nil(r.options) and
+             fragment(
+               "COALESCE(?, ?) < ?",
+               r.started_at,
+               r.claimed_at,
+               ^fallback_oldest_claim
+             ))
     )
   end
 


### PR DESCRIPTION
## Description

This PR *[adds/changes/fixes]... (A description of your work goes here.)*

Closes #__

## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
