### PR TITLE
don't use Logger and Shell IO in tests

### DIFF
--- a/lib/lightning/collaboration/document_supervisor.ex
+++ b/lib/lightning/collaboration/document_supervisor.ex
@@ -102,7 +102,7 @@ defmodule Lightning.Collaboration.DocumentSupervisor do
       try do
         GenServer.stop(state.shared_doc_pid, :normal, 5000)
       catch
-        :exit, {:noproc, _} -> :ok
+        :exit, _ -> :ok
       end
     end
 
@@ -115,7 +115,7 @@ defmodule Lightning.Collaboration.DocumentSupervisor do
       try do
         GenServer.stop(state.persistence_writer_pid, :normal, 5000)
       catch
-        :exit, {:noproc, _} -> :ok
+        :exit, _ -> :ok
       end
     end
 

--- a/test/lightning/download_adaptor_registry_test.exs
+++ b/test/lightning/download_adaptor_registry_test.exs
@@ -1,6 +1,7 @@
 defmodule Lightning.DownloadAdaptorRegistryCacheTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
   import Mox
   import Tesla.Test
 
@@ -28,7 +29,9 @@ defmodule Lightning.DownloadAdaptorRegistryCacheTest do
       file_path = Path.join([tmp_dir, "cache.json"])
       refute File.exists?(file_path)
 
-      DownloadAdaptorRegistryCache.run(["--path", file_path])
+      capture_io(fn ->
+        DownloadAdaptorRegistryCache.run(["--path", file_path])
+      end)
 
       refute File.exists?(file_path)
     end
@@ -58,7 +61,9 @@ defmodule Lightning.DownloadAdaptorRegistryCacheTest do
       file_path = Path.join([tmp_dir, "cache.json"])
       refute File.exists?(file_path)
 
-      DownloadAdaptorRegistryCache.run(["--path", file_path])
+      capture_io(fn ->
+        DownloadAdaptorRegistryCache.run(["--path", file_path])
+      end)
 
       assert File.exists?(file_path)
     end

--- a/test/lightning/install_schemas_test.exs
+++ b/test/lightning/install_schemas_test.exs
@@ -2,6 +2,7 @@ defmodule Lightning.InstallSchemasTest do
   use ExUnit.Case, async: false
   use Mimic
 
+  import ExUnit.CaptureIO
   import ExUnit.CaptureLog
   require Logger
 
@@ -76,7 +77,9 @@ defmodule Lightning.InstallSchemasTest do
 
       # |> expect(:binwrite, fn _, ~s({"name": "language-common"}) -> nil end)
 
-      InstallSchemas.run([])
+      capture_io(fn ->
+        InstallSchemas.run([])
+      end)
     end
 
     test "run fail" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,7 +16,10 @@ Mimic.copy(Mix.Tasks.Lightning.InstallSchemas)
 # Other ExUnit configuration can be found in `config/runtime.exs`,
 # for example to change the `assert_receive` timeout, configure it using the
 # `ASSERT_RECEIVE_TIMEOUT` environment variable.
-ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
+ExUnit.configure(
+  formatters: [JUnitFormatter, ExUnit.CLIFormatter],
+  capture_log: true
+)
 
 Mox.defmock(Lightning.Extensions.MockRateLimiter,
   for: Lightning.Extensions.RateLimiting


### PR DESCRIPTION
This PR makes your tests look like this! 🤩  No extra logs, but you still see the errors/failed tests. 👍 

<img width="1798" height="972" alt="image" src="https://github.com/user-attachments/assets/67dd3b43-9da8-4d3f-b1ad-18f8226a948d" />

It also makes one small change to the DocumentSupervisor:

### Safely catch all exit reasons in DocumentSupervisor.terminate/2

  #### Problem
  During shutdown, `GenServer.stop/3` can raise various exit signals depending on race conditions:
  - `{:noproc, _}` - process already gone
  - `{:normal, _}` - process exiting while we stop it
  - `{:shutdown, _}` - process shutting down
  - Other exit reasons during concurrent termination

  Previously we only caught `{:noproc, _}`, allowing other exit signals to escape and log errors despite `capture_log: true`.

  #### Solution
  Changed from `catch :exit, {:noproc, _} -> :ok` to `catch :exit, _ -> :ok` for both child processes.

  #### Why this is safe

  1. **Narrow scope**: The try/catch wraps only the `GenServer.stop/3` call, not arbitrary code
  2. **Shutdown context**: We're in `terminate/2` - the supervisor is already terminating
  3. **Best-effort cleanup**: During shutdown, we attempt graceful stops but don't care if processes are already gone
  4. **Race conditions expected**: Child processes may exit between our monitor check and stop call
  5. **No error masking**: Any legitimate errors would have already been surfaced by the monitor's `:DOWN` message in
  `handle_info/2`

  This is a cleanup operation where "process already stopped" (regardless of how) is the desired outcome.

## Validation steps

1. Run the tests! Notice how you only see things you _want_ to see.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
