### PR TITLE
Presence to know about worker capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to
 
 ### Added
 
-- SessionContextStore for collaborative workflow editor to provide user, project,
-  and config data to React components via Phoenix Channel
+- Worker "presence" module to track connected workers (and their capacity)
+  across the app. [#3725](https://github.com/OpenFn/lightning/pull/3725)
+- SessionContextStore for collaborative workflow editor to provide user,
+  project, and config data to React components via Phoenix Channel
   [#3624](https://github.com/OpenFn/lightning/issues/3624)
 
 ### Changed

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -134,6 +134,7 @@ defmodule Lightning.Application do
         # Start the Endpoint (http/https)
         LightningWeb.Endpoint,
         Lightning.Workflows.Presence,
+        LightningWeb.WorkerPresence,
         adaptor_registry_childspec,
         adaptor_service_childspec,
         {Lightning.TaskWorker, name: :cli_task_worker},

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -16,8 +16,8 @@ defmodule LightningWeb.WorkerChannel do
   @impl true
   def join("worker:queue", payload, %{assigns: %{claims: claims}} = socket)
       when not is_nil(claims) do
-    # Extract capacity from payload, default to 2 if not provided
-    capacity = Map.get(payload, "capacity", 2)
+    # Extract capacity from payload, default to 1 if not provided
+    capacity = Map.get(payload, "capacity", 1)
 
     # Track this worker's presence with its capacity
     worker_id = "worker-#{inspect(self())}"

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -12,8 +12,15 @@ defmodule LightningWeb.WorkerChannel do
   require Logger
 
   @impl true
-  def join("worker:queue", _payload, %{assigns: %{claims: claims}} = socket)
+  def join("worker:queue", payload, %{assigns: %{claims: claims}} = socket)
       when not is_nil(claims) do
+    # Extract capacity from payload, default to 2 if not provided
+    capacity = Map.get(payload, "capacity", 2)
+
+    # Track this worker's presence with its capacity
+    worker_id = "worker-#{inspect(self())}"
+    {:ok, _ref} = WorkerPresence.track_worker(self(), worker_id, capacity)
+
     # the work_listener_debounce_time assign is meant to be overidden in test mode.
     # a default value is set incase it's nil or not provided
     {:ok, pid} =

--- a/lib/lightning_web/channels/worker_channel.ex
+++ b/lib/lightning_web/channels/worker_channel.ex
@@ -9,6 +9,8 @@ defmodule LightningWeb.WorkerChannel do
   alias Lightning.Services.UsageLimiter
   alias Lightning.Workers
 
+  alias LightningWeb.WorkerPresence
+
   require Logger
 
   @impl true

--- a/lib/lightning_web/worker_presence.ex
+++ b/lib/lightning_web/worker_presence.ex
@@ -49,7 +49,9 @@ defmodule LightningWeb.WorkerPresence do
     |> list()
     |> Enum.reduce(0, fn {_worker_id, %{metas: metas}}, acc ->
       # Sum up capacity from all metas for this worker
-      worker_capacity = Enum.reduce(metas, 0, fn meta, sum -> sum + meta.capacity end)
+      worker_capacity =
+        Enum.reduce(metas, 0, fn meta, sum -> sum + meta.capacity end)
+
       acc + worker_capacity
     end)
   end

--- a/lib/lightning_web/worker_presence.ex
+++ b/lib/lightning_web/worker_presence.ex
@@ -1,0 +1,56 @@
+defmodule LightningWeb.WorkerPresence do
+  @moduledoc """
+  Handles worker presence tracking for connected workers.
+
+  This module leverages Phoenix.Presence to track worker connections,
+  allowing the system to dynamically calculate available worker capacity.
+  """
+  use Phoenix.Presence,
+    otp_app: :lightning,
+    pubsub_server: Lightning.PubSub
+
+  @worker_topic "workers:presence"
+
+  @doc """
+  Tracks a worker's presence when they connect.
+
+  ## Parameters
+
+    - `pid`: The process identifier for the worker's channel.
+    - `worker_id`: A unique identifier for the worker.
+    - `capacity`: The number of concurrent runs this worker can handle.
+
+  ## Examples
+
+      iex> LightningWeb.WorkerPresence.track_worker(self(), "worker-123", 5)
+      {:ok, _ref}
+
+  """
+  def track_worker(pid, worker_id, capacity) do
+    track(pid, @worker_topic, worker_id, %{
+      capacity: capacity,
+      joined_at: System.system_time(:microsecond)
+    })
+  end
+
+  @doc """
+  Calculates the total worker capacity across all connected workers.
+
+  Returns the sum of all worker capacities currently tracked in Presence.
+
+  ## Examples
+
+      iex> LightningWeb.WorkerPresence.total_worker_capacity()
+      10
+
+  """
+  def total_worker_capacity do
+    @worker_topic
+    |> list()
+    |> Enum.reduce(0, fn {_worker_id, %{metas: metas}}, acc ->
+      # Sum up capacity from all metas for this worker
+      worker_capacity = Enum.reduce(metas, 0, fn meta, sum -> sum + meta.capacity end)
+      acc + worker_capacity
+    end)
+  end
+end

--- a/test/lightning_web/channels/worker_channel_test.exs
+++ b/test/lightning_web/channels/worker_channel_test.exs
@@ -41,7 +41,7 @@ defmodule LightningWeb.WorkerChannelTest do
       # Give presence a moment to sync
       Process.sleep(50)
 
-      assert WorkerPresence.total_worker_capacity() == 2
+      assert WorkerPresence.total_worker_capacity() == 1
     end
 
     test "tracks worker presence with custom capacity" do

--- a/test/lightning_web/worker_presence_test.exs
+++ b/test/lightning_web/worker_presence_test.exs
@@ -1,0 +1,92 @@
+defmodule LightningWeb.WorkerPresenceTest do
+  use LightningWeb.ChannelCase, async: false
+
+  alias LightningWeb.WorkerPresence
+
+  describe "track_worker/3" do
+    test "tracks a worker with given capacity" do
+      {:ok, _ref} = WorkerPresence.track_worker(self(), "worker-1", 5)
+
+      # Give presence a moment to sync
+      Process.sleep(50)
+
+      assert WorkerPresence.total_worker_capacity() == 5
+    end
+
+    test "tracks multiple workers with different capacities" do
+      pid1 = spawn(fn -> Process.sleep(1000) end)
+      pid2 = spawn(fn -> Process.sleep(1000) end)
+
+      {:ok, _ref1} = WorkerPresence.track_worker(pid1, "worker-1", 3)
+      {:ok, _ref2} = WorkerPresence.track_worker(pid2, "worker-2", 7)
+
+      # Give presence a moment to sync
+      Process.sleep(50)
+
+      assert WorkerPresence.total_worker_capacity() == 10
+
+      # Clean up
+      Process.exit(pid1, :kill)
+      Process.exit(pid2, :kill)
+    end
+
+    test "handles worker with zero capacity" do
+      {:ok, _ref} = WorkerPresence.track_worker(self(), "worker-1", 0)
+
+      # Give presence a moment to sync
+      Process.sleep(50)
+
+      assert WorkerPresence.total_worker_capacity() == 0
+    end
+  end
+
+  describe "total_worker_capacity/0" do
+    test "returns 0 when no workers are present" do
+      assert WorkerPresence.total_worker_capacity() == 0
+    end
+
+    test "sums capacity across all tracked workers" do
+      pid1 = spawn(fn -> Process.sleep(1000) end)
+      pid2 = spawn(fn -> Process.sleep(1000) end)
+      pid3 = spawn(fn -> Process.sleep(1000) end)
+
+      {:ok, _ref1} = WorkerPresence.track_worker(pid1, "worker-1", 2)
+      {:ok, _ref2} = WorkerPresence.track_worker(pid2, "worker-2", 4)
+      {:ok, _ref3} = WorkerPresence.track_worker(pid3, "worker-3", 6)
+
+      # Give presence a moment to sync
+      Process.sleep(50)
+
+      assert WorkerPresence.total_worker_capacity() == 12
+
+      # Clean up
+      Process.exit(pid1, :kill)
+      Process.exit(pid2, :kill)
+      Process.exit(pid3, :kill)
+    end
+
+    test "updates when workers disconnect" do
+      pid1 = spawn(fn -> Process.sleep(1000) end)
+      pid2 = spawn(fn -> Process.sleep(1000) end)
+
+      {:ok, _ref1} = WorkerPresence.track_worker(pid1, "worker-1", 5)
+      {:ok, _ref2} = WorkerPresence.track_worker(pid2, "worker-2", 3)
+
+      # Give presence a moment to sync
+      Process.sleep(50)
+
+      assert WorkerPresence.total_worker_capacity() == 8
+
+      # Disconnect one worker
+      Process.exit(pid1, :kill)
+
+      # Give presence a moment to sync
+      Process.sleep(50)
+
+      assert WorkerPresence.total_worker_capacity() == 3
+
+      # Clean up
+      Process.exit(pid2, :kill)
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR adds presence so we can know what the total capacity is. Right now, this only allows us to deprecate the `TOTAL_WORKER_CAPACITY` env. Later, we might use this for more information about workers - like how much mem they have, etc.

## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
