### PR TITLE
Collaborative Editor: fix placeholder confirmation with Y.Doc store

### DIFF
--- a/assets/js/collaborative-editor/components/diagram/CollaborativeWorkflowDiagram.tsx
+++ b/assets/js/collaborative-editor/components/diagram/CollaborativeWorkflowDiagram.tsx
@@ -4,6 +4,7 @@
  */
 
 import { ReactFlowProvider } from "@xyflow/react";
+import { useRef } from "react";
 
 import { useNodeSelection, useWorkflowState } from "../../hooks/useWorkflow";
 
@@ -21,6 +22,9 @@ export function CollaborativeWorkflowDiagram({
   const workflow = useWorkflowState(state => state.workflow);
   const { currentNode, selectNode } = useNodeSelection();
 
+  // Create container ref for event delegation
+  const containerRef = useRef<HTMLDivElement>(null);
+
   // Don't render if no workflow data yet
   if (!workflow) {
     return (
@@ -33,7 +37,7 @@ export function CollaborativeWorkflowDiagram({
   }
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={className}>
       <ReactFlowProvider>
         <CollaborativeWorkflowDiagramImpl
           selection={currentNode.id}
@@ -41,6 +45,7 @@ export function CollaborativeWorkflowDiagram({
           forceFit={true}
           showAiAssistant={false}
           inspectorId={inspectorId}
+          containerEl={containerRef.current}
         />
       </ReactFlowProvider>
     </div>

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -466,6 +466,25 @@ export const createWorkflowStore = () => {
     }
   };
 
+  const addEdge = (edge: Partial<Session.Edge>) => {
+    if (!ydoc || !edge.id || !edge.target_job_id) return;
+
+    const edgesArray = ydoc.getArray("edges");
+    const edgeMap = new Y.Map();
+
+    ydoc.transact(() => {
+      edgeMap.set("id", edge.id);
+      edgeMap.set("source_job_id", edge.source_job_id || null);
+      edgeMap.set("source_trigger_id", edge.source_trigger_id || null);
+      edgeMap.set("target_job_id", edge.target_job_id);
+      edgeMap.set("condition_type", edge.condition_type || "on_job_success");
+      edgeMap.set("condition_label", edge.condition_label || null);
+      edgeMap.set("condition_expression", edge.condition_expression || null);
+      edgeMap.set("enabled", edge.enabled !== undefined ? edge.enabled : true);
+      edgesArray.push([edgeMap]);
+    });
+  };
+
   const updateTrigger = (id: string, updates: Partial<Session.Trigger>) => {
     if (!ydoc) return;
 
@@ -754,6 +773,7 @@ export const createWorkflowStore = () => {
     updateJobBody,
     addJob,
     removeJob,
+    addEdge,
     updateTrigger,
     setEnabled,
     getJobBodyYText,


### PR DESCRIPTION
## Description

This PR fixes placeholder node confirmation in the collaborative editor to work with the Y.Doc workflow store.

When a user adds a node and types a name to confirm it, the placeholder is now converted to a real job with its edge properly created in Y.Doc, matching the original editor's behavior.

Closes #3764

## Validation steps

1. Open a workflow in the collaborative editor
2. Click the "+" handle on any job node to add a placeholder
3. Type a name and press Enter to confirm
4. Verify the placeholder converts to a real job
5. Verify the edge connects properly
6. Verify the position is preserved in manual layout mode

## Additional notes for the reviewer

The fix adds:
- Custom `commit-placeholder` event handler that uses `workflowStore` methods
- New `addEdge()` method in `createWorkflowStore` for programmatic edge creation
- Container ref plumbing for event delegation
- ReactFlow instance null checks for safety

The original editor uses a legacy store callback (`addTo(toWorkflow(...))`), but the collaborative editor needs to call Y.Doc store methods directly (`addJob()`, `addEdge()`, `updatePosition()`).

## AI Usage

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR