### PR TITLE
Adds padding to INPUT panel content in collaborative editor

### DIFF
--- a/assets/js/collaborative-editor/components/manual-run/SelectedDataclipView.tsx
+++ b/assets/js/collaborative-editor/components/manual-run/SelectedDataclipView.tsx
@@ -41,7 +41,7 @@ export function SelectedDataclipView({
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between pb-4">
+      <div className="flex items-center justify-between pb-4 px-3">
         <div className="flex-1">
           {isEditingName ? (
             <div className="flex gap-2">

--- a/assets/js/manual-run-panel/FileUploader.tsx
+++ b/assets/js/manual-run-panel/FileUploader.tsx
@@ -1,5 +1,11 @@
-import { CloudArrowUpIcon, InformationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  CloudArrowUpIcon,
+  InformationCircleIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import React, { type ChangeEvent } from "react";
+
+import { cn } from "#/utils/cn";
 
 interface FileUploader {
   onUpload: (files: File[]) => void;
@@ -7,16 +13,12 @@ interface FileUploader {
   formats: string[];
 }
 
-const FileUploader: React.FC<FileUploader> = ({
-  onUpload,
-  count,
-  formats
-}) => {
+const FileUploader: React.FC<FileUploader> = ({ onUpload, count, formats }) => {
   const dropContainer = React.useRef<HTMLDivElement | null>(null);
   const [dragging, setDragging] = React.useState(false);
   const fileRef = React.useRef<HTMLInputElement | null>(null);
   const [issue, setIssue] = React.useState("");
-  const timeout = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const timeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const setVanishingIssue = (issue: string) => {
     setIssue(issue);
@@ -25,37 +27,43 @@ const FileUploader: React.FC<FileUploader> = ({
       setIssue("");
       timeout.current = null;
     }, 3500); // wait 3.5secs
-  }
-  const handleDrop = React.useCallback((type?: string) => (e: DragEvent | ChangeEvent) => {
-    let files: File[] = [];
+  };
+  const handleDrop = React.useCallback(
+    (type?: string) => (e: DragEvent | ChangeEvent) => {
+      let files: File[] = [];
 
-    if (type === "inputFile" && "target" in e) {
-      const inputEl = e.target as HTMLInputElement;
-      if (inputEl.files) files = Array.from(inputEl.files);
-    } else if ("dataTransfer" in e) {
-      e.preventDefault();
-      e.stopPropagation();
-      setDragging(false);
-      files = Array.from(e.dataTransfer?.files || []);
-    }
+      if (type === "inputFile" && "target" in e) {
+        const inputEl = e.target as HTMLInputElement;
+        if (inputEl.files) files = Array.from(inputEl.files);
+      } else if ("dataTransfer" in e) {
+        e.preventDefault();
+        e.stopPropagation();
+        setDragging(false);
+        files = Array.from(e.dataTransfer?.files || []);
+      }
 
-    const allFilesValid = files.every((file) =>
-      formats.some((format) => file.type.toLowerCase().endsWith(`/${format.toLowerCase()}`))
-    );
+      const allFilesValid = files.every(file =>
+        formats.some(format =>
+          file.type.toLowerCase().endsWith(`/${format.toLowerCase()}`)
+        )
+      );
 
-    if (!allFilesValid) {
-      setVanishingIssue(`Invalid file format. Please only upload: ${formats.join(", ").toUpperCase()}`);
-      return;
-    }
+      if (!allFilesValid) {
+        setVanishingIssue(
+          `Invalid file format. Please only upload: ${formats.join(", ").toUpperCase()}`
+        );
+        return;
+      }
 
-    if (files.length > count) {
-      setVanishingIssue(`Only ${count} files can be uploaded`)
-      return;
-    } else {
-      onUpload(files);
-    }
-
-  }, [count, formats, onUpload])
+      if (files.length > count) {
+        setVanishingIssue(`Only ${count} files can be uploaded`);
+        return;
+      } else {
+        onUpload(files);
+      }
+    },
+    [count, formats, onUpload]
+  );
 
   React.useEffect(() => {
     const handleDragOver = (e: DragEvent) => {
@@ -90,8 +98,12 @@ const FileUploader: React.FC<FileUploader> = ({
     <>
       <div
         ref={dropContainer}
-        className={`${dragging ? "border border-blue-400 bg-blue-100" : "border-dashed border-gray-300"
-          } mt-2 flex justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 transition-colors duration-200 ease-in-out`}
+        className={cn(
+          "mt-2 flex justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 transition-colors duration-200 ease-in-out",
+          dragging
+            ? "border border-blue-400 bg-blue-100"
+            : "border-dashed border-gray-300"
+        )}
       >
         <div className="flex flex-col items-center">
           <CloudArrowUpIcon className="mx-auto size-10 text-gray-300" />
@@ -107,22 +119,36 @@ const FileUploader: React.FC<FileUploader> = ({
                 multiple
                 accept={formats.map(f => `.${f}`).join(",")}
                 className="opacity-0 hidden"
-                onChange={(e) => { handleDrop("inputFile")(e) }}
+                onChange={e => {
+                  handleDrop("inputFile")(e);
+                }}
               />
               <span>Upload a file</span>
             </label>
             <p className="pl-1">or drag and drop</p>
           </div>
-          <p className="text-xs/5 text-gray-600">{formats.join(", ").toUpperCase()}, up to 8MB</p>
+          <p className="text-xs/5 text-gray-600">
+            {formats.join(", ").toUpperCase()}, up to 8MB
+          </p>
         </div>
       </div>
 
-      {issue ? <div className="text-red-700 bg-red-200 px-2 py-1 rounded-lg text-sm flex gap-1 mb-1 justify-between items-center">
-        <div className="flex gap-1 items-center"><InformationCircleIcon className="size-4" />{issue}</div>
-        <XMarkIcon onClick={() => { setIssue("") }} className="size-4 hover:bg-red-700 hover:text-red-50 rounded cursor-pointer" />
-      </div> : null}
+      {issue ? (
+        <div className="text-red-700 bg-red-200 px-2 py-1 rounded-lg text-sm flex gap-1 mb-1 justify-between items-center">
+          <div className="flex gap-1 items-center">
+            <InformationCircleIcon className="size-4" />
+            {issue}
+          </div>
+          <XMarkIcon
+            onClick={() => {
+              setIssue("");
+            }}
+            className="size-4 hover:bg-red-700 hover:text-red-50 rounded cursor-pointer"
+          />
+        </div>
+      ) : null}
     </>
   );
-}
+};
 
-export default FileUploader
+export default FileUploader;

--- a/assets/js/manual-run-panel/views/CustomView.tsx
+++ b/assets/js/manual-run-panel/views/CustomView.tsx
@@ -1,14 +1,15 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import React from "react";
+
 import { MonacoEditor } from "../../monaco";
 import FileUploader from "../FileUploader";
 
-const iconStyle = 'h-4 w-4 text-grey-400';
+const iconStyle = "h-4 w-4 text-grey-400";
 
 const CustomView: React.FC<{
   pushEvent: (event: string, data: any) => void;
 }> = ({ pushEvent }) => {
-  const [editorValue, setEditorValue] = React.useState('');
+  const [editorValue, setEditorValue] = React.useState("");
 
   async function uploadFiles(f: File[]) {
     if (f.length) {
@@ -28,17 +29,18 @@ const CustomView: React.FC<{
   const jsonParseResult = React.useMemo(() => {
     try {
       const parsed = JSON.parse(editorValue);
-      if (Array.isArray(parsed)) return { success: false, message: "Must be an object" }
-      return { success: true }
+      if (Array.isArray(parsed))
+        return { success: false, message: "Must be an object" };
+      return { success: true };
     } catch (e) {
-      return { success: false, message: "Invalid JSON format" }
+      return { success: false, message: "Invalid JSON format" };
     }
   }, [editorValue]);
 
   const handleEditorChange = React.useCallback(
     (value: string) => {
       setEditorValue(value);
-      pushEvent('manual_run_change', {
+      pushEvent("manual_run_change", {
         manual: {
           body: value,
           dataclip_id: null,
@@ -48,52 +50,53 @@ const CustomView: React.FC<{
     [pushEvent]
   );
 
-  return <>
-    <FileUploader count={1} formats={["json"]} onUpload={uploadFiles} />
-    <div className="relative">
-      <div className="absolute inset-0 flex items-center" aria-hidden="true">
-        <div className="w-full border-t border-gray-300"></div>
+  return (
+    <>
+      <div className="px-3">
+        <FileUploader count={1} formats={["json"]} onUpload={uploadFiles} />
       </div>
-      <div className="relative flex justify-center">
-        <span className="bg-white px-2 text-sm text-gray-500">OR</span>
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center" aria-hidden="true">
+          <div className="w-full border-t border-gray-300"></div>
+        </div>
+        <div className="relative flex justify-center">
+          <span className="bg-white px-2 text-sm text-gray-500">OR</span>
+        </div>
       </div>
-    </div>
-    <div className="relative h-full flex flex-col overflow-hidden">
-      {
-        !isEmpty && !jsonParseResult.success ?
-          (
-            <div className="text-red-700 text-sm flex gap-1 mb-1 items-center">
-              <InformationCircleIcon className={iconStyle} />{' '}
-              {jsonParseResult.message}
-            </div>
-          ) : null
-      }
-      <div className="overflow-hidden flex-1">
-        <MonacoEditor
-          defaultLanguage="json"
-          theme="default"
-          value={editorValue}
-          onChange={handleEditorChange}
-          loading={<div>Loading...</div>}
-          options={{
-            readOnly: false,
-            lineNumbersMinChars: 3,
-            tabSize: 2,
-            scrollBeyondLastLine: false,
-            overviewRulerLanes: 0,
-            overviewRulerBorder: false,
-            fontFamily: 'Fira Code VF',
-            fontSize: 14,
-            fontLigatures: true,
-            minimap: {
-              enabled: false,
-            },
-            wordWrap: 'on',
-          }}
-        />
+      <div className="relative h-full flex flex-col overflow-hidden">
+        {!isEmpty && !jsonParseResult.success ? (
+          <div className="text-red-700 text-sm flex gap-1 mb-1 items-center">
+            <InformationCircleIcon className={iconStyle} />{" "}
+            {jsonParseResult.message}
+          </div>
+        ) : null}
+        <div className="overflow-hidden flex-1">
+          <MonacoEditor
+            defaultLanguage="json"
+            theme="default"
+            value={editorValue}
+            onChange={handleEditorChange}
+            loading={<div>Loading...</div>}
+            options={{
+              readOnly: false,
+              lineNumbersMinChars: 3,
+              tabSize: 2,
+              scrollBeyondLastLine: false,
+              overviewRulerLanes: 0,
+              overviewRulerBorder: false,
+              fontFamily: "Fira Code VF",
+              fontSize: 14,
+              fontLigatures: true,
+              minimap: {
+                enabled: false,
+              },
+              wordWrap: "on",
+            }}
+          />
+        </div>
       </div>
-    </div>
-  </>
+    </>
+  );
 };
 
 export default CustomView;

--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -94,7 +94,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
   };
 
   return (
-    <div className="mt-2 flex flex-col gap-3">
+    <div className="mt-2 flex flex-col gap-3 px-3">
       <div>
         <div className="flex items-center gap-2">
           {/* Search input + button group */}


### PR DESCRIPTION
## Description

Improves spacing and visual consistency in the collaborative editor's INPUT panel by adding horizontal padding to content areas. Also refactors FileUploader to use the cn utility for better conditional class handling.

- Add px-3 padding to ExistingView container for better spacing
- Add px-3 padding to FileUploader wrapper in CustomView
- Add px-3 padding to SelectedDataclipView header
- Refactor FileUploader to use cn utility instead of template literals

### Screenshots of fix

Padding now applied `px-3`: 

<img width="1812" height="868" alt="image" src="https://github.com/user-attachments/assets/7af51573-9d20-44af-990e-50aa8a9ef1fe" />
<img width="1808" height="990" alt="image" src="https://github.com/user-attachments/assets/883233d4-622e-42b1-82e6-8eef1c369877" />
<img width="1820" height="968" alt="image" src="https://github.com/user-attachments/assets/f083cf23-6725-41cf-a162-48591e68fc6e" />


## Validation steps

1. Go to collaborative editor
2. Click "Edit" 
3. Verify that padding is consistent on "INPUT" panel for different views

## Additional notes for the reviewer

I tidied up and adding `cn` function to `FileUploader`

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
