### PR TITLE
Add conditional padding to INPUT selector in embedded mode

### DIFF
--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -400,6 +400,7 @@ export function ManualRunPanel({
       onNameChange={handleDataclipNameChange}
       canEdit={canEditDataclip}
       isNextCronRun={nextCronRunDataclipId === selectedDataclip.id}
+      renderMode={renderMode}
     />
   ) : (
     <div className="flex flex-col h-full overflow-hidden">
@@ -429,6 +430,7 @@ export function ManualRunPanel({
               handleCustomBodyChange(data.manual.body);
             }
           }}
+          renderMode={renderMode}
         />
       )}
       {selectedTab === "existing" && (
@@ -449,6 +451,7 @@ export function ManualRunPanel({
           fixedHeight={true}
           currentRunDataclip={currentRunDataclip}
           nextCronRunDataclipId={nextCronRunDataclipId}
+          renderMode={renderMode}
         />
       )}
     </div>

--- a/assets/js/collaborative-editor/components/manual-run/SelectedDataclipView.tsx
+++ b/assets/js/collaborative-editor/components/manual-run/SelectedDataclipView.tsx
@@ -1,6 +1,8 @@
 import { CheckIcon, PencilIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useCallback, useState } from "react";
 
+import { cn } from "#/utils/cn";
+
 import { DataclipViewer } from "../../../react/components/DataclipViewer";
 import type { Dataclip } from "../../api/dataclips";
 import { Button } from "../Button";
@@ -11,6 +13,7 @@ interface SelectedDataclipViewProps {
   onNameChange: (dataclipId: string, name: string | null) => Promise<void>;
   canEdit: boolean;
   isNextCronRun: boolean;
+  renderMode?: "standalone" | "embedded";
 }
 
 export function SelectedDataclipView({
@@ -19,6 +22,7 @@ export function SelectedDataclipView({
   onNameChange,
   canEdit,
   isNextCronRun,
+  renderMode = "standalone",
 }: SelectedDataclipViewProps) {
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState(dataclip.name || "");
@@ -41,7 +45,12 @@ export function SelectedDataclipView({
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between pb-4">
+      <div
+        className={cn(
+          "flex items-center justify-between pb-4",
+          renderMode === "embedded" && "px-3"
+        )}
+      >
         <div className="flex-1">
           {isEditingName ? (
             <div className="flex gap-2">
@@ -117,7 +126,12 @@ export function SelectedDataclipView({
 
       {/* Next Cron Run Warning */}
       {isNextCronRun && (
-        <div className="alert-warning flex flex-col gap-1 px-3 py-2 rounded-md border mb-4">
+        <div
+          className={cn(
+            "alert-warning flex flex-col gap-1 px-3 py-2 rounded-md border mb-4",
+            renderMode === "embedded" && "mx-3"
+          )}
+        >
           <span className="text-sm font-medium">
             Default Next Input for Cron
           </span>

--- a/assets/js/manual-run-panel/views/CustomView.tsx
+++ b/assets/js/manual-run-panel/views/CustomView.tsx
@@ -1,14 +1,18 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import React from "react";
+
+import { cn } from "#/utils/cn";
+
 import { MonacoEditor } from "../../monaco";
 import FileUploader from "../FileUploader";
 
-const iconStyle = 'h-4 w-4 text-grey-400';
+const iconStyle = "h-4 w-4 text-grey-400";
 
 const CustomView: React.FC<{
   pushEvent: (event: string, data: any) => void;
-}> = ({ pushEvent }) => {
-  const [editorValue, setEditorValue] = React.useState('');
+  renderMode?: "standalone" | "embedded";
+}> = ({ pushEvent, renderMode = "standalone" }) => {
+  const [editorValue, setEditorValue] = React.useState("");
 
   async function uploadFiles(f: File[]) {
     if (f.length) {
@@ -28,17 +32,18 @@ const CustomView: React.FC<{
   const jsonParseResult = React.useMemo(() => {
     try {
       const parsed = JSON.parse(editorValue);
-      if (Array.isArray(parsed)) return { success: false, message: "Must be an object" }
-      return { success: true }
+      if (Array.isArray(parsed))
+        return { success: false, message: "Must be an object" };
+      return { success: true };
     } catch (e) {
-      return { success: false, message: "Invalid JSON format" }
+      return { success: false, message: "Invalid JSON format" };
     }
   }, [editorValue]);
 
   const handleEditorChange = React.useCallback(
     (value: string) => {
       setEditorValue(value);
-      pushEvent('manual_run_change', {
+      pushEvent("manual_run_change", {
         manual: {
           body: value,
           dataclip_id: null,
@@ -48,52 +53,56 @@ const CustomView: React.FC<{
     [pushEvent]
   );
 
-  return <>
-    <FileUploader count={1} formats={["json"]} onUpload={uploadFiles} />
-    <div className="relative">
-      <div className="absolute inset-0 flex items-center" aria-hidden="true">
-        <div className="w-full border-t border-gray-300"></div>
+  return (
+    <>
+      <div className={cn(renderMode === "embedded" && "px-3")}>
+        <FileUploader count={1} formats={["json"]} onUpload={uploadFiles} />
+        <div className="relative">
+          <div
+            className="absolute inset-0 flex items-center"
+            aria-hidden="true"
+          >
+            <div className="w-full border-t border-gray-300"></div>
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-white px-2 text-sm text-gray-500">OR</span>
+          </div>
+        </div>
       </div>
-      <div className="relative flex justify-center">
-        <span className="bg-white px-2 text-sm text-gray-500">OR</span>
+      <div className="relative h-full flex flex-col overflow-hidden">
+        {!isEmpty && !jsonParseResult.success ? (
+          <div className="text-red-700 text-sm flex gap-1 mb-1 items-center">
+            <InformationCircleIcon className={iconStyle} />{" "}
+            {jsonParseResult.message}
+          </div>
+        ) : null}
+        <div className="overflow-hidden flex-1">
+          <MonacoEditor
+            defaultLanguage="json"
+            theme="default"
+            value={editorValue}
+            onChange={handleEditorChange}
+            loading={<div>Loading...</div>}
+            options={{
+              readOnly: false,
+              lineNumbersMinChars: 3,
+              tabSize: 2,
+              scrollBeyondLastLine: false,
+              overviewRulerLanes: 0,
+              overviewRulerBorder: false,
+              fontFamily: "Fira Code VF",
+              fontSize: 14,
+              fontLigatures: true,
+              minimap: {
+                enabled: false,
+              },
+              wordWrap: "on",
+            }}
+          />
+        </div>
       </div>
-    </div>
-    <div className="relative h-full flex flex-col overflow-hidden">
-      {
-        !isEmpty && !jsonParseResult.success ?
-          (
-            <div className="text-red-700 text-sm flex gap-1 mb-1 items-center">
-              <InformationCircleIcon className={iconStyle} />{' '}
-              {jsonParseResult.message}
-            </div>
-          ) : null
-      }
-      <div className="overflow-hidden flex-1">
-        <MonacoEditor
-          defaultLanguage="json"
-          theme="default"
-          value={editorValue}
-          onChange={handleEditorChange}
-          loading={<div>Loading...</div>}
-          options={{
-            readOnly: false,
-            lineNumbersMinChars: 3,
-            tabSize: 2,
-            scrollBeyondLastLine: false,
-            overviewRulerLanes: 0,
-            overviewRulerBorder: false,
-            fontFamily: 'Fira Code VF',
-            fontSize: 14,
-            fontLigatures: true,
-            minimap: {
-              enabled: false,
-            },
-            wordWrap: 'on',
-          }}
-        />
-      </div>
-    </div>
-  </>
+    </>
+  );
 };
 
 export default CustomView;

--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -7,6 +7,7 @@ import {
 import React, { type KeyboardEvent } from "react";
 
 import useOutsideClick from "#/hooks/useOutsideClick";
+import { cn } from "#/utils/cn";
 import formatDate from "#/utils/formatDate";
 import truncateUid from "#/utils/truncateUID";
 
@@ -37,6 +38,7 @@ interface ExistingViewProps {
   fixedHeight: boolean;
   currentRunDataclip?: Dataclip | null;
   nextCronRunDataclipId?: string | null;
+  renderMode?: "standalone" | "embedded";
 }
 
 const ExistingView: React.FC<ExistingViewProps> = ({
@@ -56,6 +58,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
   fixedHeight,
   currentRunDataclip,
   nextCronRunDataclipId,
+  renderMode = "standalone",
 }) => {
   const [typesOpen, setTypesOpen] = React.useState(false);
   const [dateOpen, setDateOpen] = React.useState(false);
@@ -94,7 +97,12 @@ const ExistingView: React.FC<ExistingViewProps> = ({
   };
 
   return (
-    <div className="mt-2 flex flex-col gap-3">
+    <div
+      className={cn(
+        "mt-2 flex flex-col gap-3",
+        renderMode === "embedded" && "px-3"
+      )}
+    >
       <div>
         <div className="flex items-center gap-2">
           {/* Search input + button group */}


### PR DESCRIPTION
## Description

Passes `renderMode` prop to input view components (`SelectedDataclipView`, `CustomView`, `ExistingView`) to apply `px-3` padding only in embedded mode (IDE). This aligns content with the INPUT label while avoiding double padding in standalone mode where InspectorLayout already provides padding.

Code viewers (DataclipViewer, Monaco editor) remain full-width without padding for optimal visibility.

Closes #3883

## Validation steps

**Embedded Mode (IDE)**
1. Open a workflow and click "Edit" on a job node
2. Check the INPUT selector - content should align with the "INPUT" label
3. Switch between Empty/Custom/Existing tabs - headers/controls should have padding
4. Verify code viewers (Monaco editor, DataclipViewer) remain full-width

**Standalone Mode (Run Panel)**
1. Click "Run" button from workflow toolbar
2. Check all tabs (Empty/Custom/Existing) - should use panel's existing padding
3. Verify no double padding or cramped layout

**Expected Behavior**
- IDE mode: `px-3` padding applied to headers/controls
- Run panel mode: No additional padding (uses InspectorLayout padding)
- Code viewers: Always full-width in both modes

## Additional notes for the reviewer

I tried to do this more simply, but applying padding in `FullScreenIDE` component, but this then meant that the code editor section had padding, and looked bad. So in the end went with a solution where components have a `renderMode` prop that applies padding conditionally.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
