### PR TITLE
Press control+e to open IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Press `Control-E` (or `⌘+E`) to open the IDE when a job/step is selected
+  [#3890](https://github.com/OpenFn/lightning/issues/3890)
 - Drag-to-connect nodes on workflow canvas - users can now drag from the plus
   button on a node and drop it onto another node to create connections
   [#3825](https://github.com/OpenFn/lightning/issues/3825)

--- a/assets/js/collaborative-editor/components/WorkflowEditor.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowEditor.tsx
@@ -231,6 +231,27 @@ export function WorkflowEditor({
     ]
   );
 
+  // Handle Ctrl/Cmd+E to open IDE for selected job
+  useHotkeys(
+    "ctrl+e,meta+e",
+    event => {
+      event.preventDefault();
+
+      // Only work if a job is selected
+      if (currentNode.type !== "job" || !currentNode.node) {
+        return;
+      }
+
+      // Open IDE by setting editor=open in URL
+      updateSearchParams({ editor: "open" });
+    },
+    {
+      enabled: !isIDEOpen, // Disable when IDE is already open
+      enableOnFormTags: true, // Allow in form fields, like Cmd+Enter
+    },
+    [currentNode, isIDEOpen, updateSearchParams]
+  );
+
   return (
     <div className="relative flex h-full w-full">
       {/* Canvas and Inspector - hidden when IDE open */}


### PR DESCRIPTION
## Description

This PR closes #3890, letting users open the IDE from a selected step by pressing control + E (instead of clicking "Edit")

## Validation steps

1. Select a step
2. Press control+e

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
