### PR TITLE
Fix Cmd+Enter / Cmd+Shift+Enter keybindings in Monaco instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to
 
 ### Fixed
 
+- Cmd+Enter and Cmd+Shift+Enter keyboard shortcuts not working when typing in
+  Monaco code editors [#3903](https://github.com/OpenFn/lightning/issues/3903)
+
 ## [2.14.14-pre1] - 2025-10-30
 
 ### Added

--- a/assets/js/collaborative-editor/components/CollaborativeMonaco.tsx
+++ b/assets/js/collaborative-editor/components/CollaborativeMonaco.tsx
@@ -51,6 +51,45 @@ export function CollaborativeMonaco({
       const language = getLanguageFromAdaptor(adaptor);
       monaco.editor.setModelLanguage(editor.getModel()!, language);
 
+      // Cmd+Enter: Run or Retry
+      editor.addAction({
+        id: 'workflow-run-shortcut',
+        label: 'Run Workflow',
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+        run: () => {
+          const event = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            code: 'Enter',
+            metaKey: true,
+            ctrlKey: true,
+            bubbles: true,
+            cancelable: true,
+          });
+          document.dispatchEvent(event);
+        },
+      });
+
+      // Cmd+Shift+Enter: Force new work order
+      editor.addAction({
+        id: 'workflow-force-run-shortcut',
+        label: 'Force New Workflow Run',
+        keybindings: [
+          monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+        ],
+        run: () => {
+          const event = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            code: 'Enter',
+            metaKey: true,
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+          });
+          document.dispatchEvent(event);
+        },
+      });
+
       // Create initial binding if ytext and awareness are available
       if (ytext && awareness) {
         logger.log("🔄 Creating initial Monaco binding on mount");

--- a/assets/js/monaco/index.tsx
+++ b/assets/js/monaco/index.tsx
@@ -83,6 +83,46 @@ export const MonacoEditor = ({
         ctxKey.reset();
       });
     }
+
+    // Cmd+Enter: Run or Retry
+    editor.addAction({
+      id: 'workflow-run-shortcut',
+      label: 'Run Workflow',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+      run: () => {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Enter',
+          code: 'Enter',
+          metaKey: true,
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        });
+        document.dispatchEvent(event);
+      },
+    });
+
+    // Cmd+Shift+Enter: Force new work order
+    editor.addAction({
+      id: 'workflow-force-run-shortcut',
+      label: 'Force New Workflow Run',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+      ],
+      run: () => {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Enter',
+          code: 'Enter',
+          metaKey: true,
+          ctrlKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        });
+        document.dispatchEvent(event);
+      },
+    });
+
     setTheme(monaco);
     onMount(editor, monaco);
   }, []);


### PR DESCRIPTION
## Description

This PR **fixes** the Cmd+Enter and Cmd+Shift+Enter keyboard shortcuts not working when typing in Monaco code editors. Previously, these shortcuts only worked when Monaco did not have focus.

The issue was that Monaco's default keybindings (specifically `insertLineAfter` for Cmd+Enter) were consuming the keyboard events before react-hotkeys-hook could intercept them. The fix overrides Monaco's default actions and dispatches synthetic keyboard events that bubble up to the application's hotkey handlers.

Closes #3903

## Validation steps

1. **Test Cmd+Enter in FullScreenIDE job editor:**
   - Open a workflow in the collaborative editor
   - Click "Edit" on a job to open the FullScreenIDE
   - Start typing in the Monaco code editor
   - Press Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) while typing
   - Verify the workflow run is triggered

2. **Test Cmd+Shift+Enter in FullScreenIDE job editor:**
   - Same setup as above
   - While following a run with retry available, press Cmd+Shift+Enter
   - Verify it forces a new work order instead of retry

3. **Test Cmd+Enter in ManualRunPanel custom input:**
   - Open the Manual Run panel
   - Switch to the "Custom" tab
   - Start typing JSON in the Monaco editor
   - Press Cmd+Enter while typing
   - Verify the workflow run is triggered

4. **Test Cmd+Shift+Enter in ManualRunPanel custom input:**
   - Same setup as above
   - Press Cmd+Shift+Enter while typing
   - Verify it forces a new work order

5. **Verify existing functionality still works:**
   - Test that Cmd+S (save) still works in Monaco
   - Test that the shortcuts work when Monaco does NOT have focus

## Additional notes for the reviewer

The fix adds Monaco actions in both `CollaborativeMonaco.tsx` (used in FullScreenIDE) and `monaco/index.tsx` (used in ManualRunPanel and other places). Both use the same pattern of dispatching synthetic keyboard events.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR