### PR TITLE
Fix channel error handling with optional chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 
 ### Fixed
 
+- Channel error handling crash when error responses don't include expected
+  structure [#3928](https://github.com/OpenFn/lightning/issues/3928)
 - Dataclip body display timing out due to slow credentials query - optimised
   query to leverage indexes better using a self-join
   [#3924](https://github.com/OpenFn/lightning/issues/3924)

--- a/assets/js/collaborative-editor/hooks/useChannel.ts
+++ b/assets/js/collaborative-editor/hooks/useChannel.ts
@@ -1,4 +1,4 @@
-import type { Channel } from "phoenix";
+import type { Channel } from 'phoenix';
 
 /**
  * Channel error response from backend
@@ -16,14 +16,14 @@ export async function channelRequest<T = unknown>(
   return new Promise((resolve, reject) => {
     channel
       .push(message, payload)
-      .receive("ok", (response: T) => {
+      .receive('ok', (response: T) => {
         resolve(response);
       })
-      .receive("error", (error: ChannelError) => {
+      .receive('error', (error: ChannelError) => {
         const errorMessage =
-          error.errors["base"][0] ||
+          error.errors?.['base']?.[0] ||
           Object.values(error.errors || {})[0]?.[0] ||
-          "An error occurred";
+          'An error occurred';
         const customError = new Error(errorMessage) as Error & {
           type?: string;
           errors?: Record<string, string[]>;
@@ -32,8 +32,8 @@ export async function channelRequest<T = unknown>(
         customError.errors = error.errors;
         reject(customError);
       })
-      .receive("timeout", () => {
-        reject(new Error("Request timed out"));
+      .receive('timeout', () => {
+        reject(new Error('Request timed out'));
       });
   });
 }


### PR DESCRIPTION
## Description

This PR fixes a crash in the Phoenix Channel error handling that was preventing UI components from rendering properly.

Closes #3928 

## Validation steps

1. Try to create a new workflow
2. Without saving or doing anything, hit the beaker toggle to switch to collaborative editor
3. Verify the templates panel renders without console errors

## Additional notes for the reviewer

The issue occurred when Phoenix Channel error responses didn't include the expected `errors.base` structure. The fix adds optional chaining to safely access nested error properties, falling back to a generic error message when the expected structure isn't present.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR