### PR TITLE
Fix Exception while cleaning up old document updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 
 ### Fixed
 
+- Exception when cleaning up old persisted documents
+  [#3932](https://github.com/OpenFn/lightning/issues/3932)
+
 ## [2.14.14-pre2] - 2025-11-04
 
 ### Added

--- a/lib/lightning/collaboration/persistence_writer.ex
+++ b/lib/lightning/collaboration/persistence_writer.ex
@@ -381,7 +381,8 @@ defmodule Lightning.Collaboration.PersistenceWriter do
     latest_checkpoint =
       Repo.one(
         from d in DocumentState,
-          where: d.document_name == ^document_name and d.version == "checkpoint",
+          where:
+            d.document_name == ^document_name and d.version == ^"checkpoint",
           order_by: [desc: d.inserted_at],
           limit: 1
       )
@@ -396,7 +397,7 @@ defmodule Lightning.Collaboration.PersistenceWriter do
         from d in DocumentState,
           where:
             d.document_name == ^document_name and
-              d.version == "update" and
+              d.version == ^"update" and
               d.inserted_at > ^checkpoint_time,
           order_by: [asc: d.inserted_at]
       )
@@ -439,7 +440,8 @@ defmodule Lightning.Collaboration.PersistenceWriter do
     latest_checkpoint =
       Repo.one(
         from d in DocumentState,
-          where: d.document_name == ^document_name and d.version == "checkpoint",
+          where:
+            d.document_name == ^document_name and d.version == ^"checkpoint",
           order_by: [desc: d.inserted_at],
           limit: 1
       )
@@ -454,7 +456,7 @@ defmodule Lightning.Collaboration.PersistenceWriter do
           from d in DocumentState,
             where:
               d.document_name == ^document_name and
-                d.version == "update" and
+                d.version == ^"update" and
                 d.inserted_at < ^latest_checkpoint.inserted_at and
                 d.inserted_at < ^cutoff_time
         )


### PR DESCRIPTION
## Description

This PR fixes the exception that was occurring when cleaning up old document updates. The exceptions were being caused by `Ecto.Query` typing.

Closes #3932



## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
