### PR TITLE
Fix Monaco editor visibility in manual run CustomView

### DIFF
--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -460,7 +460,7 @@ export function ManualRunPanel({
   ) : (
     <div
       className={cn(
-        'flex flex-col overflow-hidden',
+        'flex flex-col overflow-hidden h-full',
         renderMode === RENDER_MODES.EMBEDDED ? 'h-full mt-2' : 'flex-1 mt-4'
       )}
     >

--- a/assets/js/manual-run-panel/views/CustomView.tsx
+++ b/assets/js/manual-run-panel/views/CustomView.tsx
@@ -1,18 +1,18 @@
-import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import React from "react";
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+import React from 'react';
 
-import { cn } from "#/utils/cn";
+import { cn } from '#/utils/cn';
 
-import { MonacoEditor } from "../../monaco";
-import FileUploader from "../FileUploader";
+import { MonacoEditor } from '../../monaco';
+import FileUploader from '../FileUploader';
 
-const iconStyle = "h-4 w-4 text-grey-400";
+const iconStyle = 'h-4 w-4 text-grey-400';
 
 const CustomView: React.FC<{
   pushEvent: (event: string, data: any) => void;
-  renderMode?: "standalone" | "embedded";
-}> = ({ pushEvent, renderMode = "standalone" }) => {
-  const [editorValue, setEditorValue] = React.useState("");
+  renderMode?: 'standalone' | 'embedded';
+}> = ({ pushEvent, renderMode = 'standalone' }) => {
+  const [editorValue, setEditorValue] = React.useState('');
 
   async function uploadFiles(f: File[]) {
     if (f.length) {
@@ -33,17 +33,17 @@ const CustomView: React.FC<{
     try {
       const parsed = JSON.parse(editorValue);
       if (Array.isArray(parsed))
-        return { success: false, message: "Must be an object" };
+        return { success: false, message: 'Must be an object' };
       return { success: true };
     } catch (e) {
-      return { success: false, message: "Invalid JSON format" };
+      return { success: false, message: 'Invalid JSON format' };
     }
   }, [editorValue]);
 
   const handleEditorChange = React.useCallback(
     (value: string) => {
       setEditorValue(value);
-      pushEvent("manual_run_change", {
+      pushEvent('manual_run_change', {
         manual: {
           body: value,
           dataclip_id: null,
@@ -56,12 +56,12 @@ const CustomView: React.FC<{
   return (
     <div
       className={cn(
-        "h-full flex flex-col pb-6",
-        renderMode === "embedded" ? "pt-2" : "px-3 pt-3"
+        'h-full flex flex-col',
+        renderMode === 'embedded' ? 'pt-2' : 'pt-3'
       )}
     >
-      <div className={cn(renderMode === "embedded" && "px-3")}>
-        <FileUploader count={1} formats={["json"]} onUpload={uploadFiles} />
+      <div className="px-3">
+        <FileUploader count={1} formats={['json']} onUpload={uploadFiles} />
         <div className="relative">
           <div
             className="absolute inset-0 flex items-center"
@@ -70,14 +70,14 @@ const CustomView: React.FC<{
             <div className="w-full border-t border-gray-300"></div>
           </div>
           <div className="relative flex justify-center">
-            <span className="bg-white px-2 text-sm text-gray-500">OR</span>
+            <span className="bg-white px-2 text-sm text-gray-500 py-2">OR</span>
           </div>
         </div>
       </div>
       <div className="relative h-full flex flex-col overflow-hidden">
         {!isEmpty && !jsonParseResult.success ? (
           <div className="text-red-700 text-sm flex gap-1 mb-1 items-center">
-            <InformationCircleIcon className={iconStyle} />{" "}
+            <InformationCircleIcon className={iconStyle} />{' '}
             {jsonParseResult.message}
           </div>
         ) : null}
@@ -95,13 +95,13 @@ const CustomView: React.FC<{
               scrollBeyondLastLine: false,
               overviewRulerLanes: 0,
               overviewRulerBorder: false,
-              fontFamily: "Fira Code VF",
+              fontFamily: 'Fira Code VF',
               fontSize: 14,
               fontLigatures: true,
               minimap: {
                 enabled: false,
               },
-              wordWrap: "on",
+              wordWrap: 'on',
             }}
           />
         </div>


### PR DESCRIPTION
The Monaco editor in the CustomView tab of the manual run panel was collapsed and not taking up proper vertical space. This was caused by incorrect flexbox layout and padding configuration.

Changes:
- Remove pb-6 from CustomView root container that was preventing proper height calculation
- Simplify padding logic by always applying px-3 to FileUploader container instead of conditional renderMode-based padding
- Add py-2 to OR divider span for proper vertical spacing between file upload area and editor
- Add h-full to ManualRunPanel tab content container to ensure proper height propagation
- Standardize quotes to single quotes for consistency

The editor now properly expands to fill available space below the file upload area and OR divider in standalone mode.

One of the bugs raised in #3940 

## Validation steps

1. Go to collab editor
2. Click on a node
3. Click Run
4. Close and then click Custom in the tabs - you should see Monaco editor
<img width="1168" height="617" alt="image" src="https://github.com/user-attachments/assets/3007e6f9-18f9-46ed-9d08-b9e8225c33db" />


## Additional notes for the reviewer

I have also made sure this hasn't broken when in Full IDE too.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
