### PR TITLE
fix: run duration and status misalignment in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 
 ### Fixed
 
+- Run duration and status alignment drift in history view
+  [#3945](https://github.com/OpenFn/lightning/pull/3945)
 - Shared doc lookup in clustered environments now works across nodes instead of
   only searching locally
   [#3910](https://github.com/OpenFn/lightning/issues/3910)

--- a/lib/lightning_web/live/run_live/components.ex
+++ b/lib/lightning_web/live/run_live/components.ex
@@ -401,7 +401,7 @@ defmodule LightningWeb.RunLive.Components do
       </div>
       <div
         role="cell"
-        class="flex-shrink-0 py-2 px-4 text-right group-hover:bg-white"
+        class="flex-shrink-0 py-2 px-4 text-right group-hover:bg-white min-w-[240px]"
       >
         <div class="flex items-center justify-end gap-3 text-xs text-gray-500">
           <%= if @can_run_workflow && @step.exit_reason do %>
@@ -419,8 +419,10 @@ defmodule LightningWeb.RunLive.Components do
           >
             <.icon naked name="hero-document-magnifying-glass-mini" class="h-5 w-5" />
           </.link>
-          <.elapsed_indicator item={@step} context="list" />
-          <span class="font-mono">
+          <div class="w-16 text-right">
+            <.elapsed_indicator item={@step} context="list" />
+          </div>
+          <span class="font-mono w-24 text-right">
             {@step.exit_reason}{if @step.error_type, do: ":#{@step.error_type}"}
           </span>
         </div>

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -223,7 +223,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
         <.td>
           <Common.datetime datetime={@work_order.last_activity} />
         </.td>
-        <.td class="text-right">
+        <.td class="text-right w-28">
           <LightningWeb.RunLive.Components.elapsed_indicator
             :if={@last_run}
             item={@last_run}
@@ -231,12 +231,12 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
           />
           <span :if={is_nil(@last_run)}>Not started</span>
         </.td>
-        <.td class="text-right">
+        <.td class="text-right w-32">
           <div class="flex items-center justify-end gap-2">
             <.state_pill state={@work_order.state} />
           </div>
         </.td>
-        <.td class="text-right">
+        <.td class="text-right w-20">
           <%= if @work_order.runs !== [] do %>
             <div class="flex items-center justify-end gap-2 pr-2 -mr-3">
               <%= if wo_dataclip_available?(@work_order) and @can_run_workflow do %>
@@ -362,10 +362,12 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
                           <% end %>
                         </div>
                       </div>
-                      <div class="flex-shrink-0 py-2 px-4 text-right">
-                        <div class="flex items-center justify-end gap-4">
-                          <.elapsed_indicator item={run} context="details" />
-                          <span class="font-mono">{run.state}</span>
+                      <div class="flex-shrink-0 py-2 px-4 text-right min-w-[240px]">
+                        <div class="flex items-center justify-end gap-3">
+                          <div class="w-16 text-right">
+                            <.elapsed_indicator item={run} context="details" />
+                          </div>
+                          <span class="font-mono w-24 text-right">{run.state}</span>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Description

This PR **fixes** alignment drift issues in the work order history view. Previously, duration indicators and status text would shift horizontally when values had varying widths (e.g., "1ms" vs "900ms"), creating a visual misalignment.

Closes #3946 

## Validation steps

1. Navigate to a workflow's history page with multiple work orders
2. Expand several work orders to view their runs
3. Observe that duration and status columns maintain consistent alignment regardless of value width
4. Verify that short durations ("1ms") and long durations ("900ms") don't cause horizontal shifts
5. Check that status text ("success", "failed", "killed") stays aligned

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
