### PR TITLE
feat(docker-dev): disable git_hooks auto-install to fix deps compile

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -47,6 +47,10 @@ RUN mix local.hex --force && \
 ARG MIX_ENV="dev"
 ENV MIX_ENV=${MIX_ENV}
 
+# Disable git hook auto-install inside Docker builds to avoid
+# compiling the :git_hooks dependency failing without a full .git repo.
+ENV GIT_HOOKS_AUTO_INSTALL=false
+
 COPY mix.* ./
 RUN mix deps.get --only $MIX_ENV
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -132,7 +132,12 @@ config :lightning, :is_resettable_demo, true
 config :lightning, :apollo, endpoint: "http://localhost:3000", timeout: 30_000
 
 config :git_hooks,
-  auto_install: true,
+  # In local dev (with a real .git repo) we auto-install hooks.
+  # In Docker builds the .git directory is not present (or incomplete),
+  # so skip auto-install to avoid compile-time failures.
+  auto_install:
+    System.get_env("GIT_HOOKS_AUTO_INSTALL", "true") == "true" and
+      File.exists?(".git/config"),
   verbose: true,
   hooks: [
     pre_commit: [


### PR DESCRIPTION
## Description

  This PR fixes Docker dev builds failing at mix deps.compile due to :git_hooks trying to auto-install hooks when .git is not present in the Docker build context.

  - Gate git_hooks auto-install behind an env var and the presence of a real Git repo.
  - Disable auto-install in Dockerfile-dev to ensure clean builds.
  - Local development keeps auto-install enabled as before.

  Changes:

  - config/dev.exs:line 134
      - auto_install: System.get_env("GIT_HOOKS_AUTO_INSTALL", "true") == "true" and File.exists?(".git/config")
  - Dockerfile-dev:line 52
      - ENV GIT_HOOKS_AUTO_INSTALL=false

  ## Validation steps

  1. Build the dev image:
      - docker compose build
  2. Run migrations (should succeed without the previous error):
      - docker compose run --rm web mix ecto.migrate
  3. Verify local hooks still work (outside Docker):
      - Make a small change to a .ex or .ts file, then git add -A && git commit -m "test hooks"
      - Expect pre-commit formatting/conflict checks to run.
  4. Optional: Confirm no change to prod image behavior (no use of git_hooks in prod).

  ## Additional notes for the reviewer

  1. No production impact; this only affects the dev image.
  2. The env var allows re-enabling in environments with a real .git:
      - GIT_HOOKS_AUTO_INSTALL=true (still requires .git/config to exist).
  3. The failure I hit was: “could not compile dependency :git_hooks” during RUN mix deps.compile in Dockerfile-dev.

  Files touched:

  - config/dev.exs:134-141
  - Dockerfile-dev:50-55

  ## AI Usage

  Please disclose how you've used AI in this work (it's cool, we just want to know!):

  - [ ] Strategy / design
  - [x] Translation / spellchecking / doc gen
  - [x] Code generation ()
  - [ ] Learning or fact checking
  - [ ] Optimisation / refactoring
  - [ ] Other
  - [ ] I have not used AI