### PR TITLE
fix: duplicate `isReadOnly` variable blocking es builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
 
 ### Fixed
 
+- Duplicate `isReadOnly` declaration in TriggerForm that was blocking asset builds
+  [#3976](https://github.com/OpenFn/lightning/issues/3976)
 - Run duration and status alignment drift in history view
   [#3945](https://github.com/OpenFn/lightning/pull/3945)
 - Shared doc lookup in clustered environments now works across nodes instead of

--- a/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
+++ b/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
@@ -43,7 +43,6 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
   const sessionContext = useSessionContext();
   const { provider } = useSession();
   const channel = provider?.channel;
-  const { isReadOnly } = useWorkflowReadOnly();
 
   // Get active trigger auth methods from workflow store
   const activeTriggerAuthMethods = useWorkflowState(


### PR DESCRIPTION
## Description

This PR **fixes** a critical build error caused by a duplicate `isReadOnly` variable declaration in `TriggerForm.tsx` that was preventing esbuild from compiling assets.

Closes #3976

## Validation steps

1. Build assets to verify the error is fixed:
   ```bash
   mix esbuild default
   ```
   Should complete successfully without errors.

2. Start Phoenix server and verify assets rebuild automatically:
   ```bash
   iex -S mix phx.server
   ```

3. Make a change to any JS/TS file and verify Phoenix rebuilds assets

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR