### PR TITLE
fix: esc key always closing IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix ESC key closing IDE when pressed on adaptor modal
+  [#3978](https://github.com/OpenFn/lightning/issues/3978)
 - Fix run/save-and-run keystroke mapping for canvas & IDE
   [#3902](https://github.com/OpenFn/lightning/issues/3902) &
   [#3903](https://github.com/OpenFn/lightning/issues/3903)

--- a/assets/js/collaborative-editor/components/AdaptorSelectionModal.tsx
+++ b/assets/js/collaborative-editor/components/AdaptorSelectionModal.tsx
@@ -1,14 +1,14 @@
-import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
-import { useEffect, useMemo, useState } from "react";
-import { useHotkeysContext } from "react-hotkeys-hook";
+import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
+import { useEffect, useMemo, useState } from 'react';
+import { useHotkeysContext } from 'react-hotkeys-hook';
 
-import { HOTKEY_SCOPES } from "../constants/hotkeys";
-import { useAdaptors } from "../hooks/useAdaptors";
-import type { Adaptor } from "../types/adaptor";
-import { getAdaptorDisplayName } from "../utils/adaptorUtils";
+import { HOTKEY_SCOPES } from '../constants/hotkeys';
+import { useAdaptors } from '../hooks/useAdaptors';
+import type { Adaptor } from '../types/adaptor';
+import { getAdaptorDisplayName } from '../utils/adaptorUtils';
 
-import { AdaptorIcon } from "./AdaptorIcon";
-import { ListRow, ListSection, SearchableList } from "./SearchableList";
+import { AdaptorIcon } from './AdaptorIcon';
+import { ListRow, ListSection, SearchableList } from './SearchableList';
 
 interface AdaptorSelectionModalProps {
   isOpen: boolean;
@@ -28,7 +28,7 @@ export function AdaptorSelectionModal({
   projectAdaptors = [],
 }: AdaptorSelectionModalProps) {
   const allAdaptors = useAdaptors();
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState('');
   const [focusedIndex, setFocusedIndex] = useState<number>(0);
 
   // Keyboard scope management
@@ -38,6 +38,7 @@ export function AdaptorSelectionModal({
     if (isOpen) {
       enableScope(HOTKEY_SCOPES.MODAL);
       disableScope(HOTKEY_SCOPES.PANEL);
+      disableScope(HOTKEY_SCOPES.RUN_PANEL);
     } else {
       disableScope(HOTKEY_SCOPES.MODAL);
       enableScope(HOTKEY_SCOPES.PANEL);
@@ -51,7 +52,7 @@ export function AdaptorSelectionModal({
   // Reset state when modal closes
   useEffect(() => {
     if (!isOpen) {
-      setSearchQuery("");
+      setSearchQuery('');
       setFocusedIndex(0);
     }
   }, [isOpen]);
@@ -62,7 +63,7 @@ export function AdaptorSelectionModal({
   }, [searchQuery]);
 
   const httpAdaptor = useMemo(
-    () => allAdaptors.find(a => a.name.includes("language-http")),
+    () => allAdaptors.find(a => a.name.includes('language-http')),
     [allAdaptors]
   );
 
@@ -161,15 +162,15 @@ export function AdaptorSelectionModal({
     if (totalItems === 0) return;
 
     switch (e.key) {
-      case "ArrowDown":
+      case 'ArrowDown':
         e.preventDefault();
         setFocusedIndex(prev => (prev + 1) % totalItems);
         break;
-      case "ArrowUp":
+      case 'ArrowUp':
         e.preventDefault();
         setFocusedIndex(prev => (prev - 1 + totalItems) % totalItems);
         break;
-      case "Enter": {
+      case 'Enter': {
         e.preventDefault();
         const focusedAdaptor = allVisibleAdaptors[focusedIndex];
         handleRowClick(focusedAdaptor);
@@ -234,7 +235,7 @@ export function AdaptorSelectionModal({
                   {showingHttpFallback && (
                     <div className="mb-4 px-3 py-4 bg-blue-50 rounded-lg border border-blue-100">
                       <p className="text-sm text-gray-700 mb-1">
-                        <span className="font-medium">No adaptor found</span>{" "}
+                        <span className="font-medium">No adaptor found</span>{' '}
                         for "{searchQuery}"
                       </p>
                       <p className="text-sm text-gray-600">
@@ -264,8 +265,8 @@ export function AdaptorSelectionModal({
                     <ListSection
                       title={
                         filteredProjectAdaptors.length > 0
-                          ? "All adaptors"
-                          : "Available adaptors"
+                          ? 'All adaptors'
+                          : 'Available adaptors'
                       }
                     >
                       {filteredAllAdaptors.map(adaptor => (

--- a/assets/js/collaborative-editor/components/AlertDialog.tsx
+++ b/assets/js/collaborative-editor/components/AlertDialog.tsx
@@ -3,11 +3,11 @@ import {
   DialogBackdrop,
   DialogPanel,
   DialogTitle,
-} from "@headlessui/react";
-import { useEffect } from "react";
-import { useHotkeysContext } from "react-hotkeys-hook";
+} from '@headlessui/react';
+import { useEffect } from 'react';
+import { useHotkeysContext } from 'react-hotkeys-hook';
 
-import { HOTKEY_SCOPES } from "#/collaborative-editor/constants/hotkeys";
+import { HOTKEY_SCOPES } from '#/collaborative-editor/constants/hotkeys';
 
 interface AlertDialogProps {
   isOpen: boolean;
@@ -17,7 +17,7 @@ interface AlertDialogProps {
   description: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  variant?: "danger" | "primary";
+  variant?: 'danger' | 'primary';
 }
 
 /**
@@ -43,33 +43,28 @@ export function AlertDialog({
   onConfirm,
   title,
   description,
-  confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
-  variant = "primary",
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'primary',
 }: AlertDialogProps) {
   const confirmButtonClass =
-    variant === "danger"
-      ? "bg-red-600 hover:bg-red-500 focus-visible:outline-red-600"
-      : "bg-primary-600 hover:bg-primary-500 focus-visible:outline-primary-600";
+    variant === 'danger'
+      ? 'bg-red-600 hover:bg-red-500 focus-visible:outline-red-600'
+      : 'bg-primary-600 hover:bg-primary-500 focus-visible:outline-primary-600';
 
   // Use HotkeysContext to control keyboard scope precedence
   const { enableScope, disableScope } = useHotkeysContext();
 
-  // When modal opens, take control by disabling panel scope
-  // When modal closes, give control back by re-enabling panel scope
-  // This prevents Inspector's Escape handler from conflicting with
-  // HeadlessUI's native Escape handling without Inspector needing
-  // to know about modals.
   useEffect(() => {
     if (isOpen) {
       enableScope(HOTKEY_SCOPES.MODAL);
       disableScope(HOTKEY_SCOPES.PANEL);
+      disableScope(HOTKEY_SCOPES.RUN_PANEL);
     } else {
       disableScope(HOTKEY_SCOPES.MODAL);
       enableScope(HOTKEY_SCOPES.PANEL);
     }
 
-    // Cleanup: ensure modal scope is disabled when unmounted
     return () => {
       disableScope(HOTKEY_SCOPES.MODAL);
     };

--- a/assets/js/collaborative-editor/components/ConfigureAdaptorModal.tsx
+++ b/assets/js/collaborative-editor/components/ConfigureAdaptorModal.tsx
@@ -72,6 +72,7 @@ export function ConfigureAdaptorModal({
     if (isOpen) {
       enableScope(HOTKEY_SCOPES.MODAL);
       disableScope(HOTKEY_SCOPES.PANEL);
+      disableScope(HOTKEY_SCOPES.RUN_PANEL);
     } else {
       disableScope(HOTKEY_SCOPES.MODAL);
       enableScope(HOTKEY_SCOPES.PANEL);

--- a/assets/js/collaborative-editor/components/GitHubSyncModal.tsx
+++ b/assets/js/collaborative-editor/components/GitHubSyncModal.tsx
@@ -52,18 +52,16 @@ export function GitHubSyncModal() {
   // Use HotkeysContext to control keyboard scope precedence
   const { enableScope, disableScope } = useHotkeysContext();
 
-  // When modal opens, take control by disabling panel scope
-  // When modal closes, give control back by re-enabling panel scope
   useEffect(() => {
     if (isOpen) {
       enableScope(HOTKEY_SCOPES.MODAL);
       disableScope(HOTKEY_SCOPES.PANEL);
+      disableScope(HOTKEY_SCOPES.RUN_PANEL);
     } else {
       disableScope(HOTKEY_SCOPES.MODAL);
       enableScope(HOTKEY_SCOPES.PANEL);
     }
 
-    // Cleanup: ensure modal scope is disabled when unmounted
     return () => {
       disableScope(HOTKEY_SCOPES.MODAL);
     };

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -427,7 +427,11 @@ export function ManualRunPanel({
     () => {
       onClose();
     },
-    { enabled: true, enableOnFormTags: true },
+    {
+      enabled: true,
+      scopes: [HOTKEY_SCOPES.RUN_PANEL],
+      enableOnFormTags: true,
+    },
     [onClose]
   );
 

--- a/assets/js/collaborative-editor/components/ide/FullScreenIDE.tsx
+++ b/assets/js/collaborative-editor/components/ide/FullScreenIDE.tsx
@@ -520,11 +520,12 @@ export function FullScreenIDE({
       }
     },
     {
-      enabled: true,
+      enabled:
+        !isConfigureModalOpen && !isAdaptorPickerOpen && !isCredentialModalOpen,
       scopes: [HOTKEY_SCOPES.IDE],
       enableOnFormTags: true,
     },
-    [onClose]
+    [onClose, isConfigureModalOpen, isAdaptorPickerOpen, isCredentialModalOpen]
   );
 
   useHotkeys(

--- a/assets/js/collaborative-editor/components/inspector/WebhookAuthMethodModal.tsx
+++ b/assets/js/collaborative-editor/components/inspector/WebhookAuthMethodModal.tsx
@@ -49,6 +49,7 @@ export function WebhookAuthMethodModal({
   useEffect(() => {
     enableScope(HOTKEY_SCOPES.MODAL);
     disableScope(HOTKEY_SCOPES.PANEL);
+    disableScope(HOTKEY_SCOPES.RUN_PANEL);
 
     return () => {
       disableScope(HOTKEY_SCOPES.MODAL);


### PR DESCRIPTION
## Description

This PR fixes ESC key behavior in the IDE to prevent closing the IDE or panels when pressed on modals.

Closes #3978

## Validation steps

1. Open IDE and click adaptor configuration → Press ESC → Only modal closes
2. Open IDE → Open adaptor picker → Press ESC → Only modal closes  
3. Open IDE without modal → Press ESC → IDE closes (expected)
4. Open IDE → Expand left panel → Open adaptor modal → Press ESC → Modal closes, panel stays open

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR