### PR TITLE
fix: beaker icon appearing active in classical editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix beaker icon appearing active in classical editor
+  [#3988](https://github.com/OpenFn/lightning/issues/3988)
 - Fix ESC key closing IDE when pressed on adaptor modal
   [#3978](https://github.com/OpenFn/lightning/issues/3978)
 - Fix run/save-and-run keystroke mapping for canvas & IDE

--- a/lib/lightning_web/live/workflow_live/job_view.ex
+++ b/lib/lightning_web/live/workflow_live/job_view.ex
@@ -157,7 +157,7 @@ defmodule LightningWeb.WorkflowLive.JobView do
               data-placement="bottom"
               aria-label="Switch to collaborative editor (experimental)"
             >
-              <Heroicons.beaker class="h-4 w-4" solid />
+              <Heroicons.beaker class="h-4 w-4" />
             </.link>
           </div>
           <div class="flex grow items-center justify-end">


### PR DESCRIPTION
## Description

This PR **fixes** a visual regression where the collaborative editor toggle (beaker icon) appeared as solid/filled in the classical editor, incorrectly indicating the collaborative editor was active.

Closes #3988

## Validation steps

1. **Enable experimental features:**
   - Go to user settings and enable experimental features
   - This makes the beaker toggle visible

2. **Verify classical editor shows outline beaker:**
   - Navigate to a workflow
   - Click a job to open the inspector panel
   - Verify the beaker icon in the job inspector header is **outline** (not filled)
   - Also verify the beaker in the main workflow header is **outline** (not filled)
   - Both beakers should be blue/primary colored and appear as outlines

3. **Verify collaborative editor shows solid beaker:**
   - Click either beaker icon to switch to the collaborative editor
   - Once in the collaborative editor, verify the beaker icon is now **solid/filled** (indicating it's active)
 
## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
