### PR TITLE
Add adaptor icons to collaborative editor minimap

### DIFF
--- a/assets/js/collaborative-editor/components/diagram/WorkflowDiagram.tsx
+++ b/assets/js/collaborative-editor/components/diagram/WorkflowDiagram.tsx
@@ -912,7 +912,9 @@ export default function WorkflowDiagram(props: WorkflowDiagramProps) {
             zoomable
             pannable
             className="border-2 border-gray-200"
-            nodeComponent={MiniMapNode}
+            nodeComponent={props => (
+              <MiniMapNode {...props} jobs={jobs} triggers={triggers} />
+            )}
           />
         </ReactFlow>
       </ReactFlowProvider>

--- a/assets/js/workflow-diagram/components/MiniMapNode.tsx
+++ b/assets/js/workflow-diagram/components/MiniMapNode.tsx
@@ -1,14 +1,14 @@
-import { ClockIcon, GlobeAltIcon } from "@heroicons/react/24/outline";
-import type { MiniMapNodeProps } from "@xyflow/react";
-import { memo } from "react";
+import { ClockIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import type { MiniMapNodeProps } from '@xyflow/react';
+import { memo } from 'react';
 
-import { useWorkflowStore } from "../../workflow-store/store";
-import useAdaptorIcons from "../useAdaptorIcons";
-import getAdaptorName from "../util/get-adaptor-name";
+import { useWorkflowStore } from '../../workflow-store/store';
+import useAdaptorIcons from '../useAdaptorIcons';
+import getAdaptorName from '../util/get-adaptor-name';
 
 type Trigger = {
   id: string;
-  type: "webhook" | "cron";
+  type: 'webhook' | 'cron' | 'kafka';
 };
 
 type Job = {
@@ -16,15 +16,44 @@ type Job = {
   adaptor?: string;
 };
 
-const MinimapNode = ({
+/**
+ * MiniMap node renderer for workflow diagrams.
+ *
+ * This component is shared between Phoenix LiveView and Collaborative Editor:
+ * - Phoenix LiveView: Uses Zustand store (no props needed)
+ * - Collaborative Editor: Pass jobs/triggers as props
+ *
+ * @param jobs - Optional jobs array (falls back to useWorkflowStore if not
+ *   provided)
+ * @param triggers - Optional triggers array (falls back to useWorkflowStore
+ *   if not provided)
+ *
+ * @example
+ * // Phoenix LiveView usage (store-based)
+ * <MiniMap nodeComponent={MiniMapNode} />
+ *
+ * @example
+ * // Collaborative Editor usage (props-based)
+ * <MiniMap
+ *   nodeComponent={(props) => (
+ *     <MiniMapNode {...props} jobs={jobs} triggers={triggers} />
+ *   )}
+ * />
+ */
+const MiniMapNode = ({
   x,
   y,
   width: _width,
   height: _height,
   id,
   selected: _selected,
-}: MiniMapNodeProps) => {
-  const { triggers, jobs } = useWorkflowStore();
+  jobs: propJobs,
+  triggers: propTriggers,
+}: MiniMapNodeProps & { jobs?: Job[]; triggers?: Trigger[] }) => {
+  // Fallback to store when props not provided (Phoenix LiveView pattern)
+  const storeData = useWorkflowStore();
+  const jobs = propJobs ?? storeData.jobs;
+  const triggers = propTriggers ?? storeData.triggers;
   const adaptorIconsData = useAdaptorIcons();
 
   // Check if this node is a trigger by looking it up in the triggers array
@@ -35,7 +64,7 @@ const MinimapNode = ({
   if (isTrigger) {
     // Use the same icons as the main Trigger component
     const icon =
-      trigger.type === "webhook" ? (
+      trigger.type === 'webhook' ? (
         <GlobeAltIcon className="w-full h-full text-gray-500" />
       ) : (
         <ClockIcon className="w-full h-full text-gray-500" />
@@ -86,4 +115,4 @@ const MinimapNode = ({
   );
 };
 
-export default memo(MinimapNode);
+export default memo(MiniMapNode);


### PR DESCRIPTION
## Description

This PR updates `MiniMapNode` to accept jobs and triggers as optional props, falling back to `useWorkflowStore` when not provided. This enables the collaborative editor to pass workflow data explicitly while maintaining backward compatibility with Phoenix LiveView.

Changes:
- Add optional jobs/triggers props to `MiniMapNode` with store fallback for LiveView
- Rename `MinimapNode` to `MiniMapNode` for consistency
- Add JSDoc documentation explaining dual usage pattern
- Include kafka trigger type for type compatibility
- Pass jobs/triggers to `MiniMap` in collaborative editor

Closes #3812

## Validation steps

1. Go to collaborative editor and check that the minimap has adaptor icons
<img width="2622" height="1636" alt="image" src="https://github.com/user-attachments/assets/fa25fa1a-f03b-414d-95e7-ec037fb564df" />

2. Make sure the original LiveView implementation minimap isn't broken (they share the same component)

## Additional notes for the reviewer

The `MiniMapNode` component is shared by both Phoenix LiveView and collaborative editor, as it's passed into `@xyflow/react`'s `MiniMap` component

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
