### PR TITLE
fix: flickering of inactive collaborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 ### Fixed
 
+- Fix flickering of active collaborator icons between activity states(active,
+  away, offline) [#3931](https://github.com/OpenFn/lightning/issues/3931)
 - Put close button in top right
   [PR#4037](https://github.com/OpenFn/lightning/pull/4037)
 - Don't grey out in-progress runs

--- a/assets/js/collaborative-editor/components/ActiveCollaborators.tsx
+++ b/assets/js/collaborative-editor/components/ActiveCollaborators.tsx
@@ -4,12 +4,6 @@ import { getAvatarInitials } from '../utils/avatar';
 
 import { Tooltip } from './Tooltip';
 
-function lessthanmin(val: number, mins: number) {
-  const now = Date.now();
-  const threshold = now - mins * 60 * 1000;
-  return val > threshold;
-}
-
 interface ActiveCollaboratorsProps {
   className?: string;
 }
@@ -44,7 +38,7 @@ export function ActiveCollaborators({ className }: ActiveCollaboratorsProps) {
         return (
           <Tooltip key={user.clientId} content={tooltipContent} side="right">
             <div
-              className={`relative inline-flex items-center justify-center rounded-full border-2 ${user.lastSeen && lessthanmin(user.lastSeen, 0.2) ? 'border-green-500' : 'border-gray-500 '}`}
+              className={`relative inline-flex items-center justify-center rounded-full border-2 ${user.lastState === 'active' ? 'border-green-500' : 'border-gray-500 '}`}
             >
               <div
                 className="w-5 h-5 rounded-full flex items-center justify-center font-normal text-[9px] font-semibold text-white cursor-default"

--- a/assets/js/collaborative-editor/components/ActiveCollaborators.tsx
+++ b/assets/js/collaborative-editor/components/ActiveCollaborators.tsx
@@ -1,5 +1,5 @@
 import { cn } from '../../utils/cn';
-import { useAwareness } from '../hooks/useAwareness';
+import { useRemoteUsers } from '../hooks/useAwareness';
 import { getAvatarInitials } from '../utils/avatar';
 
 import { Tooltip } from './Tooltip';
@@ -9,7 +9,7 @@ interface ActiveCollaboratorsProps {
 }
 
 export function ActiveCollaborators({ className }: ActiveCollaboratorsProps) {
-  const remoteUsers = useAwareness({ cached: true });
+  const remoteUsers = useRemoteUsers();
 
   if (remoteUsers.length === 0) {
     return null;

--- a/assets/js/collaborative-editor/components/CollaborationWidget.tsx
+++ b/assets/js/collaborative-editor/components/CollaborationWidget.tsx
@@ -5,7 +5,7 @@
 
 import { useSocket } from '../../react/contexts/SocketProvider';
 import { cn } from '../../utils/cn';
-import { useAwareness } from '../hooks/useAwareness';
+import { useRemoteUsers } from '../hooks/useAwareness';
 import { useSession } from '../hooks/useSession';
 
 export function CollaborationWidget() {
@@ -13,7 +13,7 @@ export function CollaborationWidget() {
   const { isConnected: yjsConnected, isSynced } = useSession();
 
   // Get remote users only (local user is always excluded)
-  const remoteUsers = useAwareness({ cached: true });
+  const remoteUsers = useRemoteUsers();
 
   const getStatusColor = () => {
     if (socketConnected && yjsConnected && isSynced) return 'bg-green-500';

--- a/assets/js/collaborative-editor/contexts/StoreProvider.tsx
+++ b/assets/js/collaborative-editor/contexts/StoreProvider.tsx
@@ -155,6 +155,11 @@ export const StoreProvider = ({ children }: StoreProviderProps) => {
       // Set up last seen timer
       const cleanupTimer = stores.awarenessStore._internal.setupLastSeenTimer();
 
+      // set up activityState handler
+      stores.awarenessStore._internal.initActivityStateChange(state => {
+        session.awareness?.setLocalStateField('lastState', state);
+      });
+
       return cleanupTimer;
     }
     return undefined;

--- a/assets/js/collaborative-editor/types/awareness.ts
+++ b/assets/js/collaborative-editor/types/awareness.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 
 import type { WithSelector } from '../stores/common';
 
+export type ActivityState = 'active' | 'away' | 'idle';
+
 /**
  * User information stored in awareness
  */
@@ -24,6 +26,7 @@ export interface AwarenessUser {
     head: RelativePosition;
   } | null;
   lastSeen?: number;
+  lastState?: ActivityState;
   connectionCount?: number;
 }
 
@@ -115,6 +118,8 @@ export interface AwarenessQueries {
   getRawAwareness: () => Awareness | null;
 }
 
+export type SetStateHandler = (state: ActivityState) => void;
+
 /**
  * Complete awareness store interface following CQS pattern
  */
@@ -128,5 +133,6 @@ export interface AwarenessStore extends AwarenessCommands, AwarenessQueries {
   _internal: {
     handleAwarenessChange: () => void;
     setupLastSeenTimer: () => () => void;
+    initActivityStateChange: (setState: SetStateHandler) => void;
   };
 }

--- a/assets/js/collaborative-editor/utils/visibility.ts
+++ b/assets/js/collaborative-editor/utils/visibility.ts
@@ -1,0 +1,24 @@
+export const getVisibilityProps = () => {
+  if (typeof document.hidden !== 'undefined') {
+    return { hidden: 'hidden', visibilityChange: 'visibilitychange' };
+  }
+
+  if (
+    // @ts-expect-error webkitHidden not defined
+    typeof (document as unknown as Document).webkitHidden !== 'undefined'
+  ) {
+    return {
+      hidden: 'webkitHidden',
+      visibilityChange: 'webkitvisibilitychange',
+    };
+  }
+  // @ts-expect-error mozHidden not defined
+  if (typeof (document as unknown as Document).mozHidden !== 'undefined') {
+    return { hidden: 'mozHidden', visibilityChange: 'mozvisibilitychange' };
+  }
+  // @ts-expect-error msHidden not defined
+  if (typeof (document as unknown as Document).msHidden !== 'undefined') {
+    return { hidden: 'msHidden', visibilityChange: 'msvisibilitychange' };
+  }
+  return null;
+};

--- a/assets/test/collaborative-editor/components/ActiveCollaborators.test.tsx
+++ b/assets/test/collaborative-editor/components/ActiveCollaborators.test.tsx
@@ -433,32 +433,6 @@ describe('ActiveCollaborators - Cache Behavior', () => {
     expect(screen.getByText('JD')).toBeInTheDocument();
   });
 
-  test('cached users appear with their last known state', () => {
-    const now = Date.now();
-    const fiveSecondsAgo = now - 5 * 1000;
-
-    // User active 5 seconds ago
-    mockRemoteUsers = [
-      createMockAwarenessUser({
-        user: {
-          id: 'user-1',
-          name: 'Jane Smith',
-          email: 'jane@example.com',
-          color: '#00ff00',
-        },
-        lastSeen: fiveSecondsAgo,
-      }),
-    ];
-
-    render(<ActiveCollaborators />);
-
-    // Should still show as active (green border) because < 12 seconds
-    expect(screen.getByText('JS')).toBeInTheDocument();
-    expect(screen.getByText('JS').closest('div')?.parentElement).toHaveClass(
-      'border-green-500'
-    );
-  });
-
   test('cached users eventually expire after threshold', () => {
     const now = Date.now();
     const thirtySecondsAgo = now - 30 * 1000; // Well over 12 seconds

--- a/assets/test/collaborative-editor/stores/createAwarenessStore.test.ts
+++ b/assets/test/collaborative-editor/stores/createAwarenessStore.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Awareness } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+
+import { createAwarenessStore } from '../../../js/collaborative-editor/stores/createAwarenessStore';
+import type {
+  ActivityState,
+  LocalUserData,
+} from '../../../js/collaborative-editor/types/awareness';
+
+function createMockLocalUser(
+  overrides: Partial<LocalUserData> = {}
+): LocalUserData {
+  return {
+    id: `user-${Math.random().toString(36).substring(7)}`,
+    name: 'Test User',
+    email: 'test@example.com',
+    color: '#ff0000',
+    ...overrides,
+  };
+}
+
+describe('AwarenessStore - Activity State Tracking', () => {
+  test('tracks lastState field in awareness users', () => {
+    const store = createAwarenessStore();
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const localUser = createMockLocalUser({ id: 'local-user' });
+
+    store.initializeAwareness(awareness, localUser);
+
+    // Add a remote user with lastState
+    const remoteClientId = 123;
+    const states = new Map();
+    states.set(remoteClientId, {
+      user: {
+        id: 'remote-user',
+        name: 'Remote User',
+        email: 'remote@example.com',
+        color: '#00ff00',
+      },
+      lastState: 'active' as ActivityState,
+    });
+
+    awareness.states = states;
+    awareness.emit('change', []);
+
+    const state = store.getSnapshot();
+    const remoteUser = state.users.find(u => u.user.id === 'remote-user');
+
+    expect(remoteUser?.lastState).toBe('active');
+  });
+
+  test('updates user when lastState changes', () => {
+    const store = createAwarenessStore();
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const localUser = createMockLocalUser({ id: 'local-user' });
+
+    store.initializeAwareness(awareness, localUser);
+
+    const remoteClientId = 123;
+
+    // First update - active state
+    const states1 = new Map();
+    states1.set(remoteClientId, {
+      user: {
+        id: 'remote-user',
+        name: 'Remote User',
+        email: 'remote@example.com',
+        color: '#00ff00',
+      },
+      lastState: 'active' as ActivityState,
+    });
+    awareness.states = states1;
+    awareness.emit('change', []);
+
+    const state1 = store.getSnapshot();
+    const user1 = state1.cursorsMap.get(remoteClientId);
+    expect(user1?.lastState).toBe('active');
+
+    // Second update - away state
+    const states2 = new Map();
+    states2.set(remoteClientId, {
+      user: {
+        id: 'remote-user',
+        name: 'Remote User',
+        email: 'remote@example.com',
+        color: '#00ff00',
+      },
+      lastState: 'away' as ActivityState,
+    });
+    awareness.states = states2;
+    awareness.emit('change', []);
+
+    const state2 = store.getSnapshot();
+    const user2 = state2.cursorsMap.get(remoteClientId);
+
+    // Should be different references due to state change
+    expect(user1).not.toBe(user2);
+    expect(user2?.lastState).toBe('away');
+  });
+
+  test('maintains referential stability when lastState unchanged', () => {
+    const store = createAwarenessStore();
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const localUser = createMockLocalUser({ id: 'local-user' });
+
+    store.initializeAwareness(awareness, localUser);
+
+    const remoteClientId = 123;
+    const remoteUserState = {
+      user: {
+        id: 'remote-user',
+        name: 'Remote User',
+        email: 'remote@example.com',
+        color: '#00ff00',
+      },
+      lastState: 'active' as ActivityState,
+    };
+
+    // First update
+    const states1 = new Map();
+    states1.set(remoteClientId, remoteUserState);
+    awareness.states = states1;
+    awareness.emit('change', []);
+
+    const state1 = store.getSnapshot();
+    const user1 = state1.cursorsMap.get(remoteClientId);
+
+    // Second update with same data
+    const states2 = new Map();
+    states2.set(remoteClientId, remoteUserState);
+    awareness.states = states2;
+    awareness.emit('change', []);
+
+    const state2 = store.getSnapshot();
+    const user2 = state2.cursorsMap.get(remoteClientId);
+
+    // Should maintain referential stability (Immer won't create new object)
+    expect(user1).toBe(user2);
+  });
+
+  test('handles undefined lastState gracefully', () => {
+    const store = createAwarenessStore();
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const localUser = createMockLocalUser({ id: 'local-user' });
+
+    store.initializeAwareness(awareness, localUser);
+
+    const remoteClientId = 123;
+    const states = new Map();
+    states.set(remoteClientId, {
+      user: {
+        id: 'remote-user',
+        name: 'Remote User',
+        email: 'remote@example.com',
+        color: '#00ff00',
+      },
+      // lastState intentionally omitted
+    });
+
+    awareness.states = states;
+    awareness.emit('change', []);
+
+    const state = store.getSnapshot();
+    const remoteUser = state.users.find(u => u.user.id === 'remote-user');
+
+    // Should handle missing lastState without errors
+    expect(remoteUser).toBeDefined();
+    expect(remoteUser?.lastState).toBeUndefined();
+  });
+
+  test('supports all activity states: active, away, idle', () => {
+    const store = createAwarenessStore();
+    const ydoc = new Y.Doc();
+    const awareness = new Awareness(ydoc);
+    const localUser = createMockLocalUser({ id: 'local-user' });
+
+    store.initializeAwareness(awareness, localUser);
+
+    const states = new Map();
+    states.set(1, {
+      user: {
+        id: 'user-1',
+        name: 'Active User',
+        email: 'active@example.com',
+        color: '#ff0000',
+      },
+      lastState: 'active' as ActivityState,
+    });
+    states.set(2, {
+      user: {
+        id: 'user-2',
+        name: 'Away User',
+        email: 'away@example.com',
+        color: '#00ff00',
+      },
+      lastState: 'away' as ActivityState,
+    });
+    states.set(3, {
+      user: {
+        id: 'user-3',
+        name: 'Idle User',
+        email: 'idle@example.com',
+        color: '#0000ff',
+      },
+      lastState: 'idle' as ActivityState,
+    });
+
+    awareness.states = states;
+    awareness.emit('change', []);
+
+    const state = store.getSnapshot();
+
+    const activeUser = state.users.find(u => u.user.id === 'user-1');
+    const awayUser = state.users.find(u => u.user.id === 'user-2');
+    const idleUser = state.users.find(u => u.user.id === 'user-3');
+
+    expect(activeUser?.lastState).toBe('active');
+    expect(awayUser?.lastState).toBe('away');
+    expect(idleUser?.lastState).toBe('idle');
+  });
+});
+
+describe('AwarenessStore - Visibility API Integration', () => {
+  test('initActivityStateChange sets up visibility listener', () => {
+    const store = createAwarenessStore();
+    const setStateMock = vi.fn();
+
+    store._internal.initActivityStateChange(setStateMock);
+
+    // Initial call should happen
+    expect(setStateMock).toHaveBeenCalled();
+  });
+
+  test('calls setState with away when document is hidden', () => {
+    const store = createAwarenessStore();
+
+    // Mock document visibility as hidden
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => true,
+    });
+
+    const setStateMock = vi.fn();
+    store._internal.initActivityStateChange(setStateMock);
+
+    // Should be called with 'away' when document is hidden
+    expect(setStateMock).toHaveBeenCalledWith('away');
+  });
+
+  test('calls setState with active when document is visible', () => {
+    const store = createAwarenessStore();
+
+    // Mock document visibility as visible
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => false,
+    });
+
+    const setStateMock = vi.fn();
+    store._internal.initActivityStateChange(setStateMock);
+
+    // Should be called with 'active' when document is visible
+    expect(setStateMock).toHaveBeenCalledWith('active');
+  });
+
+  test('handles missing visibility API gracefully', () => {
+    const store = createAwarenessStore();
+    const setStateMock = vi.fn();
+
+    expect(() => {
+      store._internal.initActivityStateChange(setStateMock);
+    }).not.toThrow();
+  });
+});

--- a/assets/test/collaborative-editor/utils/visibility.test.ts
+++ b/assets/test/collaborative-editor/utils/visibility.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Visibility API Utility Tests
+ *
+ * Tests for the visibility.ts utility that detects Page Visibility API
+ * support across different browser vendors.
+ *
+ * Test categories:
+ * 1. Standard API - Modern browsers with standard implementation
+ * 2. Vendor Prefixes - Legacy browser support (webkit, moz, ms)
+ * 3. No Support - Browsers without Page Visibility API
+ */
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { getVisibilityProps } from '../../../js/collaborative-editor/utils/visibility';
+
+describe('getVisibilityProps - Standard API', () => {
+  beforeEach(() => {
+    // Clean up any vendor prefixes from previous tests
+    // @ts-expect-error - Deleting test properties
+    delete document.webkitHidden;
+    // @ts-expect-error - Deleting test properties
+    delete document.mozHidden;
+    // @ts-expect-error - Deleting test properties
+    delete document.msHidden;
+  });
+
+  test('returns standard properties when document.hidden is supported', () => {
+    // Standard API is already available in modern test environments
+    const result = getVisibilityProps();
+
+    expect(result).toEqual({
+      hidden: 'hidden',
+      visibilityChange: 'visibilitychange',
+    });
+  });
+});
+
+describe('getVisibilityProps - Vendor Prefixes', () => {
+  beforeEach(() => {
+    // Save original property descriptor
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'hidden'
+    );
+
+    // Remove standard property to test vendor prefixes
+    if (originalDescriptor) {
+      Object.defineProperty(Document.prototype, 'hidden', {
+        configurable: true,
+        get: () => undefined,
+      });
+    }
+  });
+
+  test('returns webkit properties when webkitHidden is supported', () => {
+    // Mock webkit prefix
+    Object.defineProperty(document, 'webkitHidden', {
+      configurable: true,
+      value: false,
+    });
+
+    const result = getVisibilityProps();
+
+    expect(result).toEqual({
+      hidden: 'webkitHidden',
+      visibilityChange: 'webkitvisibilitychange',
+    });
+
+    // Cleanup
+    // @ts-expect-error - Deleting test property
+    delete document.webkitHidden;
+  });
+
+  test('returns moz properties when mozHidden is supported', () => {
+    // Mock moz prefix
+    Object.defineProperty(document, 'mozHidden', {
+      configurable: true,
+      value: false,
+    });
+
+    const result = getVisibilityProps();
+
+    expect(result).toEqual({
+      hidden: 'mozHidden',
+      visibilityChange: 'mozvisibilitychange',
+    });
+
+    // Cleanup
+    // @ts-expect-error - Deleting test property
+    delete document.mozHidden;
+  });
+
+  test('returns ms properties when msHidden is supported', () => {
+    // Mock ms prefix
+    Object.defineProperty(document, 'msHidden', {
+      configurable: true,
+      value: false,
+    });
+
+    const result = getVisibilityProps();
+
+    expect(result).toEqual({
+      hidden: 'msHidden',
+      visibilityChange: 'msvisibilitychange',
+    });
+
+    // Cleanup
+    // @ts-expect-error - Deleting test property
+    delete document.msHidden;
+  });
+});
+
+describe('getVisibilityProps - Browser Compatibility', () => {
+  test('returns properties in standard modern browsers', () => {
+    // The function should check in this order:
+    // 1. document.hidden (standard)
+    // 2. document.webkitHidden (webkit)
+    // 3. document.mozHidden (moz)
+    // 4. document.msHidden (ms)
+
+    // Standard should take precedence
+    const result = getVisibilityProps();
+
+    // In modern test/browser environments, standard API is available
+    // So we expect either the standard API or null
+    expect(result === null || result?.hidden === 'hidden').toBe(true);
+  });
+
+  test('returns event name matching the property prefix', () => {
+    const result = getVisibilityProps();
+
+    if (result) {
+      // Event name should match the property prefix
+      if (result.hidden === 'hidden') {
+        expect(result.visibilityChange).toBe('visibilitychange');
+      } else if (result.hidden === 'webkitHidden') {
+        expect(result.visibilityChange).toBe('webkitvisibilitychange');
+      } else if (result.hidden === 'mozHidden') {
+        expect(result.visibilityChange).toBe('mozvisibilitychange');
+      } else if (result.hidden === 'msHidden') {
+        expect(result.visibilityChange).toBe('msvisibilitychange');
+      }
+    }
+  });
+});
+
+describe('getVisibilityProps - Return Type', () => {
+  test('returns object with hidden and visibilityChange properties', () => {
+    const result = getVisibilityProps();
+
+    if (result) {
+      expect(result).toHaveProperty('hidden');
+      expect(result).toHaveProperty('visibilityChange');
+      expect(typeof result.hidden).toBe('string');
+      expect(typeof result.visibilityChange).toBe('string');
+    }
+  });
+
+  test('returns null or object, never undefined', () => {
+    const result = getVisibilityProps();
+
+    expect(result).not.toBe(undefined);
+    expect(result === null || typeof result === 'object').toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Better implements
1. activity state for connected collaborators on a workflow showing their current state being `active`|`away`. also deals with when they switch from the tab and back.
2. maintains our 10s ydoc keep-alive trigger updates using `lastSeen`.

#### What was causing the flickering?
- ydoc requires us to update a user's state within a 30s interval to keep them considered in awareness(being online)
- due to this, we have a `setInterval` which updates the user's `lastSeen` every 10s, just so we are in the 30s interval
- we try to do this all the time but some browsers have a smart way of saving resources which is to throttle JS execution on tabs that aren't active(user has switched away from)
- when this happens, JS timers like `setInterval` start to miss their interval calls. eg. a 10s interval call might be actually triggered after 60s.
- hence, we start missing the 30s requirement by ydoc and then ydoc removes all users who have started missing the time.
- but if a user missed the 30s threshold and got called after 60s due to throttling. it shows a flicker on all other active collaborator. because the user was removed when they missed 30s but got back in awareness when their throttled trigger came in after 60s. 

#### Approach taken
- we keep our 10s interval trigger to ydoc
- we have another field `lastState` controlled by the browser visibility API to track whether a user is `active` or `away`

**How do we smoothing the presence of a user to avoid the flickering?**
- Now, we only cache a user in awareness for 60s when they are `away`. (throttling likely happens to away users)
- If they're away and keep showing up in awareness, we give that precedence over what's in the cache. (probably they're not throttled)
- As soon as they come back to active, we dont wait for TTL of cache but just remove them from cache. (throttling never happens to active users)



Closes #3931 

## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
