### PR TITLE
fix run channel crashes when `run"updated`  is pushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   [#4084](https://github.com/OpenFn/lightning/issues/4084)
 - Fix flickering of canvas and job editor
   [#4095](https://github.com/OpenFn/lightning/issues/4095)
+- Run channel crashes when sending `run:updated` event
+  [#4093](https://github.com/OpenFn/lightning/issues/4093)
 
 ## [2.15.0-pre1] - 2025-11-27
 

--- a/assets/js/collaborative-editor/stores/createHistoryStore.ts
+++ b/assets/js/collaborative-editor/stores/createHistoryStore.ts
@@ -90,6 +90,7 @@ import { channelRequest } from '../hooks/useChannel';
 import {
   type HistoryState,
   type HistoryStore,
+  type RunDetail,
   type RunStepsData,
   type RunSummary,
   type StepDetail,

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -262,6 +262,7 @@ defmodule LightningWeb.RunChannel do
   # Forward PubSub events to browser clients
   @impl true
   def handle_info(%Runs.Events.RunUpdated{run: run}, socket) do
+    run = Repo.preload(run, :steps)
     push(socket, "run:updated", %{run: run})
     {:noreply, socket}
   end


### PR DESCRIPTION
## Description

The run channel was crashing because `:steps` wasn't preloaded. This PR preloads it before pushing the run to the client

Closes #4093

## Validation steps

1. In the collab editor, open the IDE for a job and run. 
2. You should see no error being logged in the server. Previously, you would see this:

```
RuntimeError: cannot encode association :steps from Lightning.Run to JSON because the association was not loaded.

You can either preload the association:

    Repo.preload(Lightning.Run, :steps)

Or choose to not encode the association when converting the struct to JSON by explicitly listing the JSON fields in your schema:
```


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
