### PR TITLE
fix z-index of version mismatch modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to
   [#4095](https://github.com/OpenFn/lightning/issues/4095)
 - Run channel crashes when sending `run:updated` event
   [#4093](https://github.com/OpenFn/lightning/issues/4093)
+- Fix Version mismatch modal appears on top of IDE
+  [#4096](https://github.com/OpenFn/lightning/issues/4096)
 
 ## [2.15.0-pre1] - 2025-11-27
 

--- a/assets/js/collaborative-editor/components/diagram/CollaborativeWorkflowDiagram.tsx
+++ b/assets/js/collaborative-editor/components/diagram/CollaborativeWorkflowDiagram.tsx
@@ -151,7 +151,7 @@ export function CollaborativeWorkflowDiagram({
           <VersionMismatchBanner
             runVersion={versionMismatch.runVersion}
             currentVersion={versionMismatch.currentVersion}
-            className="absolute top-4 left-1/2 -translate-x-1/2 z-50 max-w-md"
+            className="absolute top-4 left-1/2 -translate-x-1/2 z-[45] max-w-md"
           />
         )}
 


### PR DESCRIPTION
## Description

This PR fixes the z-index of the version mismatch modal so that it doesn't appear in front if the IDE

Closes #4096 


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [X] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
