### PR TITLE
fix: presence of run data between switching & closing

### DIFF
--- a/assets/js/collaborative-editor/components/ide/FullScreenIDE.tsx
+++ b/assets/js/collaborative-editor/components/ide/FullScreenIDE.tsx
@@ -188,6 +188,9 @@ export function FullScreenIDE({
     setManuallyUnselectedDataclip(dataclip === null);
   }, []);
 
+  // Declaratively connect to run channel when runIdFromURL changes
+  const { run: currentRun, clearRun } = useFollowRun(runIdFromURL);
+
   const handleRunSubmitted = useCallback(
     (runId: string, dataclip?: Dataclip) => {
       setFollowRunId(runId);
@@ -210,6 +213,7 @@ export function FullScreenIDE({
 
   const handleClearFollowRun = useCallback(() => {
     setFollowRunId(null);
+    clearRun(); // call clear run for the history store
     updateSearchParams({ run: null });
     // Reset input state when unloading a run
     setSelectedDataclipState(null);
@@ -217,7 +221,7 @@ export function FullScreenIDE({
     setCustomBody('');
     setManuallyUnselectedDataclip(false);
     setRightPanelSubState('landing');
-  }, [updateSearchParams]);
+  }, [updateSearchParams, clearRun]);
 
   const handleNavigateToHistory = useCallback(() => {
     setRightPanelSubState('history');
@@ -280,9 +284,6 @@ export function FullScreenIDE({
     }
     return null;
   }, [selectedRunId, history]);
-
-  // Declaratively connect to run channel when runIdFromURL changes
-  const currentRun = useFollowRun(runIdFromURL);
 
   // Check if the currently selected job matches the loaded run
   const jobMatchesRun = useJobMatchesRun(currentJob?.id || null);

--- a/assets/js/collaborative-editor/hooks/useHistory.ts
+++ b/assets/js/collaborative-editor/hooks/useHistory.ts
@@ -11,6 +11,7 @@ import {
   useMemo,
   useEffect,
   useId,
+  useCallback,
 } from 'react';
 
 import _logger from '#/utils/logger';
@@ -131,7 +132,7 @@ export const useHistoryCommands = () => {
  * const runId = useRunIdFromURL(); // string | null
  * const run = useFollowRun(runId); // Automatic connect/disconnect
  */
-export const useFollowRun = (runId: string | null): RunDetail | null => {
+export const useFollowRun = (runId: string | null) => {
   const historyStore: HistoryStore = useHistoryStore();
   const run = useActiveRun();
 
@@ -140,16 +141,15 @@ export const useFollowRun = (runId: string | null): RunDetail | null => {
       // Connect to run when runId provided
       historyStore._viewRun(runId);
     }
+  }, [runId]);
 
-    return () => {
-      // Disconnect on unmount or when runId changes
-      if (runId) {
-        historyStore._closeRunViewer();
-      }
-    };
-  }, [runId, historyStore]);
+  // whether a run should be cleared can't be handled well in this useEffect. the user
+  // of the useEffect should determine that.
+  const clearRun = useCallback(() => {
+    historyStore._closeRunViewer();
+  }, []);
 
-  return run;
+  return { run, clearRun };
 };
 
 /**

--- a/assets/js/collaborative-editor/stores/createHistoryStore.ts
+++ b/assets/js/collaborative-editor/stores/createHistoryStore.ts
@@ -773,7 +773,7 @@ export const createHistoryStore = (): HistoryStore => {
 
     // GUARD 2: Disconnect only if switching to DIFFERENT run
     if (state.activeRunChannel && state.activeRunId !== runId) {
-      _closeRunViewer();
+      _switchingFromRun();
     }
 
     if (!_channelProvider?.socket) {
@@ -874,6 +874,22 @@ export const createHistoryStore = (): HistoryStore => {
     });
   };
 
+  const _switchingFromRun = () => {
+    // Leave the curren run channel before switch happens
+    if (state.activeRunChannel) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      (state.activeRunChannel as any).leave();
+    }
+
+    state = produce(state, draft => {
+      // only clear the necessary run stuff before switching
+      draft.activeRunChannel = null;
+      draft.activeRunId = null;
+      draft.activeRunError = null;
+    });
+    notify('_switchingFromRun');
+  };
+
   /**
    * Disconnect from active run and clean up channel
    */
@@ -952,6 +968,7 @@ export const createHistoryStore = (): HistoryStore => {
     _connectChannel,
     _viewRun,
     _closeRunViewer,
+    _switchingFromRun,
     _setActiveRunForTesting,
   };
 };

--- a/assets/js/collaborative-editor/types/history.ts
+++ b/assets/js/collaborative-editor/types/history.ts
@@ -247,6 +247,7 @@ interface HistoryStoreInternals {
   _connectChannel: (provider: PhoenixChannelProvider) => () => void;
   _viewRun: (runId: string) => void;
   _closeRunViewer: () => void;
+  _switchingFromRun: () => void;
   _setActiveRunForTesting: (run: RunDetail) => void;
 }
 


### PR DESCRIPTION
## Description

This PR better resolves the state of run data when you're switching between runs or you have a run deselected

Closes #__

## Validation steps

1. *(How can a reviewer validate your work?)*

## Additional notes for the reviewer

1. *(Is there anything else the reviewer should know or look out for?)*

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
