### PR TITLE
Update AI Assistant disclaimers with data privacy information

### DIFF
--- a/assets/js/collaborative-editor/components/AIAssistantPanel.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanel.tsx
@@ -506,7 +506,17 @@ export function AIAssistantPanel({
             </h4>
             <p>
               The AI assistant uses Claude by Anthropic, a third-party AI model.
-              Messages are saved on OpenFn and Anthropic servers.
+              Messages are stored on OpenFn servers and temporarily on Anthropic
+              servers (up to 30 days) but are not used to train AI models.{' '}
+              <a
+                href="https://privacy.claude.com/en/collections/10672411-data-handling-retention"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary-600 hover:text-primary-700"
+              >
+                Read more about this here
+              </a>
+              .
             </p>
             <p>
               Although we continuously monitor and improve the model, the

--- a/assets/js/collaborative-editor/components/DisclaimerScreen.tsx
+++ b/assets/js/collaborative-editor/components/DisclaimerScreen.tsx
@@ -57,8 +57,18 @@ export function DisclaimerScreen({
             or sensitive credentials in your messages.
           </p>
           <p className="text-xs text-gray-500">
-            This Assistant uses Claude by Anthropic. Conversations may be stored
-            on OpenFn and Anthropic servers for service improvement.
+            This Assistant uses Claude by Anthropic. Messages are stored on
+            OpenFn servers and temporarily on Anthropic servers (up to 30 days)
+            but are not used to train AI models.{' '}
+            <a
+              href="https://privacy.claude.com/en/collections/10672411-data-handling-retention"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-600 hover:text-indigo-700 underline"
+            >
+              Read more about this here
+            </a>
+            .
           </p>
         </div>
       </div>

--- a/assets/test/collaborative-editor/components/DisclaimerScreen.test.tsx
+++ b/assets/test/collaborative-editor/components/DisclaimerScreen.test.tsx
@@ -54,7 +54,7 @@ describe('DisclaimerScreen', () => {
         screen.getByText(/Do not include real user data/)
       ).toBeInTheDocument();
       expect(
-        screen.getByText(/Conversations may be stored/)
+        screen.getByText(/Messages are stored on OpenFn servers/)
       ).toBeInTheDocument();
     });
 

--- a/lib/lightning_web/live/ai_assistant/component.ex
+++ b/lib/lightning_web/live/ai_assistant/component.ex
@@ -1056,7 +1056,14 @@ defmodule LightningWeb.AiAssistant.Component do
             Using The Assistant Safely
           </h2>
           <p>
-            The AI assistant uses a third-party model to process chat messages. Messages may be saved on OpenFn and Anthropic servers.
+            The AI assistant uses Claude by Anthropic, a third-party AI model.
+            Messages are stored on OpenFn servers and temporarily on Anthropic servers (up to 30 days) but are not used to train AI models. <a
+              href="https://privacy.claude.com/en/collections/10672411-data-handling-retention"
+              target="_blank"
+              class="text-primary-600 hover:text-primary-700"
+            >
+              Read more about this here
+            </a>.
           </p>
           <p>
             Although we are constantly monitoring and improving the performance of the model, the Assistant can


### PR DESCRIPTION
## Description

This PR **updates** the AI Assistant disclaimers across the application with clearer data privacy information.

- Clarify that messages are stored on OpenFn servers and temporarily on Anthropic servers (up to 30 days)
- Add note that data is **not** used to train AI models
- Add link to Anthropic's [data handling & retention documentation](https://privacy.claude.com/en/collections/10672411-data-handling-retention)

## Validation steps

1. Open a workflow in the collaborative editor
2. Press `Cmd+K` to open the AI Assistant
3. If you haven't accepted the disclaimer before, verify the new text: "Messages are stored on OpenFn servers and temporarily on Anthropic servers (up to 30 days) but are not used to train AI models."
4. Click "Read more about this here" and verify it opens Anthropic's data handling page
5. Click the menu button (three dots) → "About the AI Assistant" and verify the About modal has the same updated text and link
6. Test the legacy editor's AI Assistant About page for the same updates

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR