### PR TITLE
fix: incorrect field access in create_checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to
 - Fix infinite loading when reopening workflow in collaborative editor due to
   delta updates not being merged with persisted state
   [#4164](https://github.com/OpenFn/lightning/issues/4164)
-- Fix incorrect field access in checkpoint creation that would crash after 500
-  document updates [#4176](https://github.com/OpenFn/lightning/issues/4176)
+- Fix incorrect field access and version type in checkpoint creation that would
+  crash after 500 document updates
+  [#4176](https://github.com/OpenFn/lightning/issues/4176)
 
 ## [2.15.0-pre4] - 2025-12-08
 

--- a/lib/lightning/collaboration/persistence_writer.ex
+++ b/lib/lightning/collaboration/persistence_writer.ex
@@ -429,7 +429,7 @@ defmodule Lightning.Collaboration.PersistenceWriter do
 
       checkpoint = %DocumentState{
         document_name: document_name,
-        version: "checkpoint",
+        version: :checkpoint,
         state_data: checkpoint_data
       }
 


### PR DESCRIPTION
## Description

This PR **fixes** two bugs in `create_checkpoint/1` that would crash the `PersistenceWriter` after 500 document updates:

1. Used `.data` instead of `.state_data` when accessing `DocumentState` records
2. Used string `"checkpoint"` instead of atom `:checkpoint` for the `Ecto.Enum` version field

Closes #4176

## Validation steps

mix test test/lightning/collaboration/document_supervisor_test.exs:818

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR