### PR TITLE
fix: prevent flaky TemplatePublishPanel tests in CI

### DIFF
--- a/assets/test/collaborative-editor/components/inspector/TemplatePublishPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/TemplatePublishPanel.test.tsx
@@ -231,8 +231,9 @@ describe('TemplatePublishPanel', () => {
       const nameInput = screen.getByLabelText('Name');
       const longName = 'a'.repeat(256);
 
+      // Use paste instead of type to avoid timeout on CI (256 keystrokes is slow)
       await user.clear(nameInput);
-      await user.type(nameInput, longName);
+      await user.paste(longName);
 
       await waitFor(() => {
         expect(
@@ -266,8 +267,8 @@ describe('TemplatePublishPanel', () => {
       render(<TemplatePublishPanel />);
 
       const tagsInput = screen.getByLabelText('Tags');
-      // Use paste for faster execution on CI
-      await user.click(tagsInput);
+      // Use clear + paste to prevent state leak from previous tests
+      await user.clear(tagsInput);
       await user.paste('tag1, tag2 , tag3');
 
       // Tags should be displayed as chips
@@ -310,8 +311,8 @@ describe('TemplatePublishPanel', () => {
       render(<TemplatePublishPanel />);
 
       const tagsInput = screen.getByLabelText('Tags');
-      // Use paste for faster execution on CI
-      await user.click(tagsInput);
+      // Use clear + paste to prevent state leak from previous tests
+      await user.clear(tagsInput);
       await user.paste('tag1,,tag2, ,tag3');
 
       // Only non-empty tags should be displayed


### PR DESCRIPTION
## Description

This PR **fixes** flaky tests in `TemplatePublishPanel.test.tsx` that were causing CI failures.

<img width="1585" height="642" alt="Screenshot 2025-12-15 at 04 06 02" src="https://github.com/user-attachments/assets/d7b494d1-b230-42a9-850b-3ab85b00b141" />

**Root cause:** Two issues with `userEvent`:
1. `user.type()` with 256 characters times out on CI (256 keystrokes is slow)
2. When a test times out mid-typing, keyboard state leaks to subsequent tests

**Solution:**
- Use `paste` instead of `type` for the 256-char input test
- Use `clear` before `paste` in tag tests to reset any leaked state

Closes #4193

## Validation steps

1. Run `npm test -- --run TemplatePublishPanel.test.tsx` locally - all 22 tests should pass
2. CI should no longer fail on these tests

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR