### PR TITLE
fix: version mismatch banner flashes while switching

### DIFF
--- a/assets/js/collaborative-editor/hooks/useVersionMismatch.ts
+++ b/assets/js/collaborative-editor/hooks/useVersionMismatch.ts
@@ -9,11 +9,12 @@
  * This prevents confusion when the workflow structure has changed since the run executed.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { useHistory } from './useHistory';
 import { useLatestSnapshotLockVersion } from './useSessionContext';
 import { useWorkflowState } from './useWorkflow';
+import { useURLState } from '#/react/lib/use-url-state';
 
 interface VersionMismatch {
   runVersion: number;
@@ -23,9 +24,15 @@ interface VersionMismatch {
 export function useVersionMismatch(
   selectedRunId: string | null
 ): VersionMismatch | null {
+  const { params } = useURLState();
   const history = useHistory();
   const workflow = useWorkflowState(state => state.workflow);
   const latestSnapshotLockVersion = useLatestSnapshotLockVersion();
+  const currVersion = params['v'] ? Number(params['v']) : null;
+
+  // in the process of switching version
+  const switching =
+    currVersion !== null && currVersion !== workflow?.lock_version;
 
   return useMemo(() => {
     if (
@@ -44,9 +51,7 @@ export function useVersionMismatch(
       wo.runs.some(run => run.id === selectedRunId)
     );
 
-    if (!selectedWorkOrder) {
-      return null;
-    }
+    if (!selectedWorkOrder || switching) return null;
 
     // Show warning when viewing a different version than the run used
     const runUsedDifferentVersion =


### PR DESCRIPTION
## Description

This PR resolves an issue where the version mismatch banner flashes while switching between runs

Closes #4230 

## Validation steps

1. On the canvas, try switching between several runs on the mini history panel
2. does the version mismatch banner below the mini history show up? (we expect a no)

## Additional notes for the reviewer


## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
