### PR TITLE
fix: scope AI chat sessions per user to prevent cross-user access

### DIFF
--- a/lib/lightning_web/controllers/api/ai_assistant_controller.ex
+++ b/lib/lightning_web/controllers/api/ai_assistant_controller.ex
@@ -52,7 +52,7 @@ defmodule LightningWeb.API.AiAssistantController do
         end
 
       %{sessions: sessions, pagination: pagination} =
-        AiAssistant.list_sessions(resource, :desc, opts)
+        AiAssistant.list_sessions(resource, user, :desc, opts)
 
       json(conn, %{
         sessions: AiAssistantJSON.format_sessions(sessions),

--- a/lib/lightning_web/live/ai_assistant/modes/job_code.ex
+++ b/lib/lightning_web/live/ai_assistant/modes/job_code.ex
@@ -110,14 +110,14 @@ defmodule LightningWeb.Live.AiAssistant.Modes.JobCode do
           sessions: [session()],
           pagination: map()
         }
-  def list_sessions(%{selected_job: job}, sort_direction, opts \\ []) do
-    AiAssistant.list_sessions(job, sort_direction, opts)
+  def list_sessions(%{selected_job: job, user: user}, sort_direction, opts \\ []) do
+    AiAssistant.list_sessions(job, user, sort_direction, opts)
   end
 
   @impl true
   @spec more_sessions?(assigns(), integer()) :: boolean()
-  def more_sessions?(%{selected_job: job}, current_count) do
-    AiAssistant.has_more_sessions?(job, current_count)
+  def more_sessions?(%{selected_job: job, user: user}, current_count) do
+    AiAssistant.has_more_sessions?(job, user, current_count)
   end
 
   @impl true

--- a/lib/lightning_web/live/ai_assistant/modes/workflow_template.ex
+++ b/lib/lightning_web/live/ai_assistant/modes/workflow_template.ex
@@ -49,16 +49,20 @@ defmodule LightningWeb.Live.AiAssistant.Modes.WorkflowTemplate do
           sessions: [session()],
           pagination: map()
         }
-  def list_sessions(%{project: project} = assigns, sort_direction, opts \\ []) do
+  def list_sessions(
+        %{project: project, user: user} = assigns,
+        sort_direction,
+        opts \\ []
+      ) do
     workflow = assigns[:workflow]
     opts_with_workflow = Keyword.put_new(opts, :workflow, workflow)
-    AiAssistant.list_sessions(project, sort_direction, opts_with_workflow)
+    AiAssistant.list_sessions(project, user, sort_direction, opts_with_workflow)
   end
 
   @impl true
   @spec more_sessions?(assigns(), integer()) :: boolean()
-  def more_sessions?(%{project: project}, current_count) do
-    AiAssistant.has_more_sessions?(project, current_count)
+  def more_sessions?(%{project: project, user: user}, current_count) do
+    AiAssistant.has_more_sessions?(project, user, current_count)
   end
 
   @impl true

--- a/test/lightning_web/live/ai_assistant_live_test.exs
+++ b/test/lightning_web/live/ai_assistant_live_test.exs
@@ -2001,7 +2001,7 @@ defmodule LightningWeb.AiAssistantLiveTest do
       assert html =~ "Here&#39;s your Salesforce sync workflow:"
 
       workflow_sessions =
-        Lightning.AiAssistant.list_sessions(project, :desc, limit: 5)
+        Lightning.AiAssistant.list_sessions(project, user, :desc, limit: 5)
 
       assert %{sessions: [session | _]} = workflow_sessions
       assert session.session_type == "workflow_template"
@@ -2394,7 +2394,7 @@ defmodule LightningWeb.AiAssistantLiveTest do
       assert has_element?(view, "#new-workflow-panel-assistant")
     end
 
-    test "workflow mode handles concurrent users correctly", %{
+    test "workflow mode isolates sessions per user", %{
       conn: conn,
       project: project
     } do
@@ -2459,11 +2459,12 @@ defmodule LightningWeb.AiAssistantLiveTest do
       html1 = render(view1)
       html2 = render(view2)
 
+      # Each user should only see their own sessions (privacy fix)
       assert html1 =~ "User 1 Workflow"
-      assert html1 =~ "User 2 Workflow"
+      refute html1 =~ "User 2 Workflow"
 
-      assert html2 =~ "User 1 Workflow"
       assert html2 =~ "User 2 Workflow"
+      refute html2 =~ "User 1 Workflow"
     end
   end
 


### PR DESCRIPTION
## Description

This PR **fixes** AI chat session scoping to prevent cross-user access in collaborative editing scenarios. Previously, AI chat sessions were only scoped by job/workflow/project, which meant that two users working on the same job/workflow could see each other's chat sessions and potentially access the same session simultaneously.

Closes #4244

## Validation steps

1. Create a project with two users (both with editor access)
2. Have User A open a job and start an AI chat session
3. Have User B open the same job
4. Verify User B does NOT see User A's chat session in their session list
5. Verify User B cannot join User A's session even if they have the session ID
6. Do the same for workflow chats too

## Additional notes for the reviewer

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR