### PR TITLE
Tests: Fix locale-dependent date test in SelectedDataclipView

### DIFF
--- a/assets/test/collaborative-editor/components/manual-run/SelectedDataclipView.test.tsx
+++ b/assets/test/collaborative-editor/components/manual-run/SelectedDataclipView.test.tsx
@@ -60,7 +60,12 @@ describe('SelectedDataclipView', () => {
 
       expect(screen.getByText('Test Dataclip')).toBeInTheDocument();
       expect(screen.getByText('http request')).toBeInTheDocument();
-      expect(screen.getByText('1/15/2024')).toBeInTheDocument();
+
+      // Calculate expected date string for the current locale
+      const expectedDate = new Date(
+        '2024-01-15T10:30:00Z'
+      ).toLocaleDateString();
+      expect(screen.getByText(expectedDate)).toBeInTheDocument();
     });
 
     test("renders 'Unnamed' when dataclip has no name", () => {


### PR DESCRIPTION
## Description

The `SelectedDataclipView` test was failing in non-US locales (ie, me using a computer with UK date format) because it hardcoded the expected date format as "1/15/2024" (en-US). Systems using other locales (e.g., en-GB) format the same date as "15/01/2024", causing the test to fail.

Calculate the expected date string dynamically using `toLocaleDateString()` to match the actual rendered output, ensuring the test passes regardless of the system's locale settings.

## Validation steps

1. Run the tests and check they pass

## Additional notes for the reviewer

1. This is just a test improvement, so I haven't added anything to the changelog
2. This test has failed for me locally always, I'm only raising the PR now

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
