### PR TITLE
Allow generic credentials for HTTP adaptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to
 
 ### Fixed
 
-- Fixed bug where generic credential types couldn't be selected with the HTTP
-  adaptor [#4284](https://github.com/OpenFn/lightning/issues/4284)
+- Fixed bug where Oauth credentials and raw credentials couldn't be selected
+  with the HTTP adaptor [#4284](https://github.com/OpenFn/lightning/issues/4284)
 
 ## [2.15.6] - 2025-12-24
 

--- a/assets/js/collaborative-editor/components/ConfigureAdaptorModal.tsx
+++ b/assets/js/collaborative-editor/components/ConfigureAdaptorModal.tsx
@@ -155,6 +155,10 @@ export function ConfigureAdaptorModal({
         // Exact schema match
         if (c.schema === adaptorName) return true;
 
+        // For HTTP adaptor, all OAuth credentials are considered matching
+        // (OAuth can be used for authenticated API calls via HTTP)
+        if (adaptorName === 'http' && c.schema === 'oauth') return true;
+
         // Smart OAuth matching: if credential is OAuth, check oauth_client_name
         if (c.schema === 'oauth' && c.oauth_client_name) {
           // Normalize both strings: lowercase, remove spaces/hyphens/underscores

--- a/assets/test/collaborative-editor/components/ConfigureAdaptorModal.test.tsx
+++ b/assets/test/collaborative-editor/components/ConfigureAdaptorModal.test.tsx
@@ -804,6 +804,28 @@ describe('ConfigureAdaptorModal', () => {
       expect(screen.getByText('Raw Generic Credential')).toBeInTheDocument();
     });
 
+    it('shows OAuth credentials in schema-matched section when HTTP adaptor is selected', () => {
+      // The mock data already includes an OAuth credential: 'My Salesforce OAuth'
+      // When HTTP adaptor is selected, all OAuth credentials should appear as matching
+
+      renderWithProviders(
+        <ConfigureAdaptorModal
+          {...defaultProps}
+          currentAdaptor="@openfn/language-http"
+        />
+      );
+
+      // HTTP adaptor should show HTTP credential in schema-matched section
+      expect(screen.getByText('HTTP API Key')).toBeInTheDocument();
+
+      // OAuth credential should also appear in schema-matched section for HTTP adaptor
+      expect(screen.getByText('My Salesforce OAuth')).toBeInTheDocument();
+
+      // Both should be radio buttons in the main view (not in "Other credentials")
+      const radioButtons = screen.getAllByRole('radio');
+      expect(radioButtons.length).toBe(2); // HTTP + OAuth
+    });
+
     it('shows empty state when no credentials exist at all', () => {
       // Create a mock store context with no credentials
       const emptyCredentialSnapshot = {


### PR DESCRIPTION
## Description

This PR closes #4284 , a bug where generic credential types couldn't be used with the HTTP adaptor.

## Validation steps

  1. Create a raw credential in a project
  2. Create a new HTTP credential in a project
  3. Create an HTTP step in a workflow
  4. Open "Configure connection" modal for the HTTP step
  5. Click "Other credentials" link
  6. Verify the raw credential appears under "Generic Credentials" section
  7. Verify the http credential appears in the main schema-matched view (not duplicated)

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to know!):

- [x] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed a **self-review** of my code.
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
