### PR TITLE
[draft] Improve keyboard shortcut hint text in GitHub Sync Modal

### DIFF
--- a/assets/js/collaborative-editor/components/GitHubSyncModal.tsx
+++ b/assets/js/collaborative-editor/components/GitHubSyncModal.tsx
@@ -168,7 +168,8 @@ export function GitHubSyncModal() {
                   autoFocus
                 />
                 <p className="mt-2 text-xs text-gray-500 text-left">
-                  Tip: Press Ctrl+Enter (or Cmd+Enter) to save and sync
+                  Tip: Press Ctrl+Enter (or Cmd+Enter) to save and sync after
+                  typing here
                 </p>
               </div>
             </div>

--- a/assets/test/collaborative-editor/components/GitHubSyncModal.test.tsx
+++ b/assets/test/collaborative-editor/components/GitHubSyncModal.test.tsx
@@ -802,7 +802,7 @@ describe('GitHubSyncModal - Keyboard Shortcuts', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Tip: Press Ctrl\+Enter \(or Cmd\+Enter\) to save and sync/i
+          /Tip: Press Ctrl\+Enter \(or Cmd\+Enter\) to save and sync after typing here/i
         )
       ).toBeInTheDocument();
     });


### PR DESCRIPTION
Update the hint text to clarify that Ctrl+Enter (or Cmd+Enter) should be pressed while typing in the commit message textarea. The previous text was ambiguous about when to use the shortcut. Also update the corresponding test to match the new hint text.

Closes #4315 

## Validation steps

1. Go to a workflow with GitHub integrated
2. Click the chevron icon next to Save and click "Save & Sync"
3. Observe the "Tip" help text

## Additional notes for the reviewer

1. When I raised the issue, I thought that the keyboard shortcut was incorrect and that it should refer to the shortcut for Save + Sync (Mod + Shift + S). When implementing and looking at the GitHubSyncModal test, I realised that the keyboard shortcut was correct - it's just that it only works when you are inside the commit message text box. Open to suggestions for better wording.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
