### PR TITLE
feat: before & after commit while merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Sandbox compatibility with github sync(commit before & after merge)
+  [#3957](https://github.com/OpenFn/lightning/issues/3957)
 - Add PromEx plugin to track sandbox-related metrics for Prometheus including
   sandbox lifecycle events and workflow saves by project type
   [#4101](https://github.com/OpenFn/lightning/issues/4101)

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -583,7 +583,7 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp perform_merge(source, target, actor) do
-    maybe_commit_to_github(target, "Before merge: #{source.name}")
+    maybe_commit_to_github(target, "pre-merge commit")
 
     result =
       source
@@ -596,7 +596,7 @@ defmodule LightningWeb.SandboxLive.Index do
 
     case result do
       {:ok, _updated_target} = success ->
-        maybe_commit_to_github(target, "After merge: #{source.name}")
+        maybe_commit_to_github(target, "Merged sandbox #{source.name}")
         success
 
       error ->

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -605,20 +605,9 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp maybe_commit_to_github(project, commit_message) do
-    case VersionControl.get_repo_connection_for_project(project.id) do
-      nil ->
-        :ok
-
-      repo_connection ->
-        case VersionControl.initiate_sync(repo_connection, commit_message) do
-          :ok ->
-            :ok
-
-          {:error, reason} ->
-            require Logger
-            Logger.warning("Failed to sync to GitHub: #{inspect(reason)}")
-            :ok
-        end
+    with %{} = repo_connection <-
+           VersionControl.get_repo_connection_for_project(project.id) do
+      VersionControl.initiate_sync(repo_connection, commit_message)
     end
   end
 

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -5,6 +5,7 @@ defmodule LightningWeb.SandboxLive.Index do
   alias Lightning.Projects
   alias Lightning.Projects.MergeProjects
   alias Lightning.Projects.ProjectLimiter
+  alias Lightning.VersionControl
   alias LightningWeb.SandboxLive.Components
 
   on_mount {LightningWeb.Hooks, :project_scope}
@@ -582,13 +583,43 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp perform_merge(source, target, actor) do
-    source
-    |> MergeProjects.merge_project(target)
-    |> then(
-      &Lightning.Projects.Provisioner.import_document(target, actor, &1,
-        allow_stale: true
+    maybe_commit_to_github(target, "Before merge: #{source.name}")
+
+    result =
+      source
+      |> MergeProjects.merge_project(target)
+      |> then(
+        &Lightning.Projects.Provisioner.import_document(target, actor, &1,
+          allow_stale: true
+        )
       )
-    )
+
+    case result do
+      {:ok, _updated_target} = success ->
+        maybe_commit_to_github(target, "After merge: #{source.name}")
+        success
+
+      error ->
+        error
+    end
+  end
+
+  defp maybe_commit_to_github(project, commit_message) do
+    case VersionControl.get_repo_connection_for_project(project.id) do
+      nil ->
+        :ok
+
+      repo_connection ->
+        case VersionControl.initiate_sync(repo_connection, commit_message) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            require Logger
+            Logger.warning("Failed to sync to GitHub: #{inspect(reason)}")
+            :ok
+        end
+    end
   end
 
   defp handle_merge_result(

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2015,8 +2015,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
             apiSecretName: api_secret_name(parent),
             branch: repo_connection.branch,
             pathToConfig: path_to_config(repo_connection),
-            commitMessage: "Merged sandbox #{sandbox.name}",
-            snapshots: "#{snapshot.id}"
+            commitMessage: "Merged sandbox #{sandbox.name}"
           }
         }
       )
@@ -2037,8 +2036,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
          %{
            conn: conn,
            parent: parent,
-           sandbox: sandbox,
-           user: user
+           sandbox: sandbox
          } do
       # No repo_connection created = no GitHub sync
       # Without a repo_connection, get_repo_connection_for_project returns nil


### PR DESCRIPTION
## Description

This PR makes a github sync(commit) before and after a sandbox merge. This is so we have a checkpoint for the state of a project before and after a merge.

Closes #3957

## Validation steps

1. _(How can a reviewer validate your work?)_

## Additional notes for the reviewer

1. _(Is there anything else the reviewer should know or look out for?)_

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
