### PR TITLE
Add channel proxy mock sink and load test tools

### DIFF
--- a/benchmarking/channels/README.md
+++ b/benchmarking/channels/README.md
@@ -21,10 +21,13 @@ elixir benchmarking/channels/mock_sink.exs
 # Terminal 2 — Lightning (as a named node)
 iex --sname lightning --cookie bench -S mix phx.server
 
-# Terminal 3 — Load test
+# Terminal 3 — Load test (single scenario)
 elixir --sname loadtest --cookie bench \
   benchmarking/channels/load_test.exs \
   --scenario happy_path --concurrency 20 --duration 30
+
+# Or run all scenarios in sequence:
+benchmarking/channels/run_all.sh --duration 30 --concurrency 20
 ```
 
 The load test will automatically create a "load-test" project and channel
@@ -42,32 +45,54 @@ elixir benchmarking/channels/mock_sink.exs [options]
 
 ### Options
 
-| Option              | Default                 | Description                |
-| ------------------- | ----------------------- | -------------------------- |
-| `--port PORT`       | 4001                    | Listen port                |
-| `--mode MODE`       | fixed                   | Response mode (see below)  |
-| `--status CODE`     | 200                     | HTTP status for fixed mode |
-| `--delay MS`        | 0 (fixed), 1000 (delay) | Response delay             |
-| `--body-size BYTES` | 256                     | Response body size         |
+| Option              | Default | Description                |
+| ------------------- | ------- | -------------------------- |
+| `--port PORT`       | 4001    | Listen port                |
+| `--mode MODE`       | fixed   | Response mode (see below)  |
+| `--status CODE`     | 200     | HTTP status for fixed mode |
+| `--body-size BYTES` | 256     | Response body size         |
 
 ### Modes
 
 | Mode        | Behaviour                                                                       |
 | ----------- | ------------------------------------------------------------------------------- |
-| **fixed**   | Returns `--status` after `--delay` with `--body-size` body                      |
-| **delay**   | Returns 200 after `--delay` ms (default 1000ms)                                 |
+| **fixed**   | Returns `--status` with `--body-size` body (respects `?delay=N`)                |
 | **timeout** | Accepts connection, never responds                                              |
 | **auth**    | 401 if no `Authorization` header, 403 if invalid, 200 for `Bearer test-api-key` |
 | **mixed**   | 80% fast 200, 10% slow 200 (2s delay), 10% 503                                  |
+
+### Query Parameters
+
+The mock sink supports per-request overrides via query parameters:
+
+| Parameter          | Description                                     |
+| ------------------ | ----------------------------------------------- |
+| `?response_size=N` | Override `--body-size` for this request (bytes) |
+| `?delay=N`         | Add a response delay for this request (ms)      |
+| `?status=N`        | Override `--status` for this request (e.g. 503) |
+
+This lets the load test control response sizes and delays without restarting the
+sink:
+
+```bash
+# Default body size
+curl http://localhost:4001/test
+
+# Override to 5000 bytes for this request
+curl "http://localhost:4001/test?response_size=5000"
+
+# 500ms delay
+curl "http://localhost:4001/test?delay=500"
+
+# Combine both
+curl "http://localhost:4001/test?delay=500&response_size=5000"
+```
 
 ### Examples
 
 ```bash
 # Default: fast 200 responses
 elixir benchmarking/channels/mock_sink.exs
-
-# Simulate slow upstream (2s delay)
-elixir benchmarking/channels/mock_sink.exs --mode delay --delay 2000
 
 # Simulate flaky upstream
 elixir benchmarking/channels/mock_sink.exs --mode mixed
@@ -77,6 +102,9 @@ elixir benchmarking/channels/mock_sink.exs --body-size 5000000
 
 # Require authentication
 elixir benchmarking/channels/mock_sink.exs --mode auth
+
+# Slow responses via query param (no restart needed)
+curl "http://localhost:4001/test?delay=2000"
 ```
 
 ## Load Test (`load_test.exs`)
@@ -94,18 +122,20 @@ to the Lightning BEAM for channel setup and memory sampling.
 
 ### Options
 
-| Option                 | Default                 | Description                                         |
-| ---------------------- | ----------------------- | --------------------------------------------------- |
-| `--target URL`         | `http://localhost:4000` | Lightning base URL                                  |
-| `--sink URL`           | `http://localhost:4001` | Mock sink URL (for channel creation)                |
-| `--node NODE`          | `lightning@hostname`    | Lightning node name                                 |
-| `--cookie COOKIE`      | —                       | Erlang cookie (also settable via `elixir --cookie`) |
-| `--channel NAME`       | `load-test`             | Channel name to find/create                         |
-| `--scenario NAME`      | `happy_path`            | Test scenario (see below)                           |
-| `--concurrency N`      | 10                      | Concurrent virtual users                            |
-| `--duration SECS`      | 30                      | Test duration                                       |
-| `--payload-size BYTES` | 1024                    | Request body size                                   |
-| `--csv PATH`           | —                       | Optional CSV output file                            |
+| Option                  | Default                 | Description                                          |
+| ----------------------- | ----------------------- | ---------------------------------------------------- |
+| `--target URL`          | `http://localhost:4000` | Lightning base URL                                   |
+| `--sink URL`            | `http://localhost:4001` | Mock sink URL (for channel creation)                 |
+| `--node NODE`           | `lightning@hostname`    | Lightning node name                                  |
+| `--cookie COOKIE`       | —                       | Erlang cookie (also settable via `elixir --cookie`)  |
+| `--channel NAME`        | `load-test`             | Channel name to find/create                          |
+| `--scenario NAME`       | `happy_path`            | Test scenario (see below)                            |
+| `--concurrency N`       | 10                      | Concurrent virtual users                             |
+| `--duration SECS`       | 30                      | Test duration                                        |
+| `--payload-size BYTES`  | 1024                    | Request body size                                    |
+| `--response-size BYTES` | —                       | Response body size override (via `?response_size=N`) |
+| `--delay MS`            | — (slow_sink: 2000)     | Sink response delay (via `?delay=N`)                 |
+| `--csv PATH`            | —                       | Optional CSV output file                             |
 
 ### Scenarios
 
@@ -116,7 +146,8 @@ to the Lightning BEAM for channel setup and memory sampling.
 | **large_payload**  | POST with large request bodies (default 1MB)    | `fixed`               |
 | **large_response** | GET requests with large response bodies         | `fixed --body-size N` |
 | **mixed_methods**  | Rotate through GET, POST, PUT, PATCH, DELETE    | `fixed`               |
-| **slow_sink**      | Measure latency with a slow upstream            | `delay --delay N`     |
+| **slow_sink**      | Measure latency with a slow upstream            | `fixed` + `?delay=N`  |
+| **direct_sink**    | Hit mock sink directly (baseline measurement)   | `fixed` (default)     |
 
 ### Examples
 
@@ -136,11 +167,69 @@ elixir --sname lt --cookie bench \
   benchmarking/channels/load_test.exs \
   --scenario ramp_up --concurrency 50 --duration 60 --csv results.csv
 
-# Slow upstream latency test (start sink with: --mode delay --delay 2000)
+# Slow upstream latency test (delay applied via query param, no sink restart)
 elixir --sname lt --cookie bench \
   benchmarking/channels/load_test.exs \
-  --scenario slow_sink --concurrency 10 --duration 30
+  --scenario slow_sink --delay 2000 --concurrency 10 --duration 30
+
+# Baseline: hit mock sink directly (no Lightning needed, no --sname required)
+elixir benchmarking/channels/load_test.exs \
+  --scenario direct_sink --concurrency 20 --duration 10
+
+# Large response test with explicit response size
+elixir --sname lt --cookie bench \
+  benchmarking/channels/load_test.exs \
+  --scenario large_response --response-size 1048576 --duration 30
 ```
+
+## Run All Scenarios (`run_all.sh`)
+
+Runs all 7 scenarios in sequence, logging output to a timestamped file and
+appending CSV rows for each scenario. Assumes Lightning and mock sink are
+already running. Bails on first failure.
+
+```bash
+benchmarking/channels/run_all.sh [options]
+```
+
+### Options
+
+| Option            | Default | Description           |
+| ----------------- | ------- | --------------------- |
+| `--sname NAME`    | lt      | Erlang short name     |
+| `--cookie COOKIE` | bench   | Erlang cookie         |
+| `--duration SECS` | 30      | Per-scenario duration |
+| `--concurrency N` | 20      | Virtual users         |
+
+### Scenario Order
+
+| #   | Scenario         | Extra flags               |
+| --- | ---------------- | ------------------------- |
+| 1   | `direct_sink`    | (none — baseline)         |
+| 2   | `happy_path`     | (none)                    |
+| 3   | `ramp_up`        | (none)                    |
+| 4   | `large_payload`  | `--payload-size 1048576`  |
+| 5   | `large_response` | `--response-size 1048576` |
+| 6   | `mixed_methods`  | (none)                    |
+| 7   | `slow_sink`      | `--delay 2000`            |
+
+### Examples
+
+```bash
+# Quick smoke test (10s per scenario, 5 VUs)
+benchmarking/channels/run_all.sh --duration 10 --concurrency 5
+
+# Full run with defaults (30s per scenario, 20 VUs)
+benchmarking/channels/run_all.sh
+
+# Custom node/cookie
+benchmarking/channels/run_all.sh --sname mynode --cookie mysecret
+```
+
+Results are written to `benchmarking/channels/results/`:
+
+- `YYYY.MM.DD-HH.MM.log` — full console output
+- `YYYY.MM.DD-HH.MM.csv` — one row per scenario for analysis
 
 ## Interpreting Results
 
@@ -188,3 +277,28 @@ The load test prints a summary like:
 
 - **Error rate** should be 0% for `happy_path` and `large_payload` scenarios.
   Non-zero errors suggest proxy bugs or resource limits.
+
+### Measuring proxy overhead with `direct_sink`
+
+The `direct_sink` scenario hits the mock sink directly, bypassing Lightning
+entirely. This gives a baseline for the test harness + mock sink latency:
+
+```
+proxy_overhead = happy_path_latency - direct_sink_latency
+```
+
+Run both and compare:
+
+```bash
+# Baseline (no Lightning needed)
+elixir benchmarking/channels/load_test.exs \
+  --scenario direct_sink --concurrency 20 --duration 10
+
+# Through proxy
+elixir --sname lt --cookie bench \
+  benchmarking/channels/load_test.exs \
+  --scenario happy_path --concurrency 20 --duration 10
+```
+
+The difference tells you exactly what the proxy pipeline (plugs, DB lookup,
+Weir, second HTTP hop) costs per request.

--- a/benchmarking/channels/results/.gitignore
+++ b/benchmarking/channels/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/benchmarking/channels/run_all.sh
+++ b/benchmarking/channels/run_all.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# benchmarking/channels/run_all.sh
+#
+# Runs all channel proxy load test scenarios in sequence, logging output
+# to a timestamped file. Assumes Lightning and mock sink are already running.
+# Bails on first failure.
+#
+# Usage:
+#   benchmarking/channels/run_all.sh [options]
+#
+# Options:
+#   --sname NAME       Erlang short name (default: lt)
+#   --cookie COOKIE    Erlang cookie (default: bench)
+#   --duration SECS    Per-scenario duration (default: 30)
+#   --concurrency N    Virtual users (default: 20)
+#
+# Examples:
+#   benchmarking/channels/run_all.sh
+#   benchmarking/channels/run_all.sh --duration 60 --concurrency 50
+#   benchmarking/channels/run_all.sh --sname mynode --cookie mysecret
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────
+SNAME="lt"
+COOKIE="bench"
+DURATION=30
+CONCURRENCY=20
+
+# ── Parse args ────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sname)      SNAME="$2";       shift 2 ;;
+    --cookie)     COOKIE="$2";      shift 2 ;;
+    --duration)   DURATION="$2";    shift 2 ;;
+    --concurrency) CONCURRENCY="$2"; shift 2 ;;
+    --help|-h)
+      sed -n '2,/^$/s/^# \?//p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Log setup ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results"
+mkdir -p "$RESULTS_DIR"
+
+TIMESTAMP="$(date +%Y.%m.%d-%H.%M)"
+LOG="$RESULTS_DIR/$TIMESTAMP.log"
+CSV="$RESULTS_DIR/$TIMESTAMP.csv"
+
+# ── Preflight checks ─────────────────────────────────────────────
+echo "=== Channel Proxy Load Test Suite ==="
+echo ""
+echo "  sname:       $SNAME"
+echo "  cookie:      $COOKIE"
+echo "  duration:    ${DURATION}s per scenario"
+echo "  concurrency: $CONCURRENCY VUs"
+echo "  log:         $LOG"
+echo "  csv:         $CSV"
+echo ""
+
+echo -n "Checking mock sink at http://localhost:4001... "
+if curl -sf http://localhost:4001/ > /dev/null 2>&1; then
+  echo "ok"
+else
+  echo "FAILED"
+  echo "error: Mock sink is not reachable at http://localhost:4001" >&2
+  echo "Start it first: elixir benchmarking/channels/mock_sink.exs" >&2
+  exit 1
+fi
+
+echo -n "Checking Lightning at http://localhost:4000... "
+if curl -sf http://localhost:4000/ > /dev/null 2>&1; then
+  echo "ok"
+else
+  echo "FAILED"
+  echo "error: Lightning is not reachable at http://localhost:4000" >&2
+  echo "Start it first: iex --sname lightning --cookie $COOKIE -S mix phx.server" >&2
+  exit 1
+fi
+
+echo ""
+
+# ── Scenario runner ───────────────────────────────────────────────
+SCRIPT="benchmarking/channels/load_test.exs"
+PASS=0
+FAIL=0
+
+run_scenario() {
+  local name="$1"
+  shift
+  local extra_flags=("$@")
+
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" | tee -a "$LOG"
+  echo " Scenario: $name" | tee -a "$LOG"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" | tee -a "$LOG"
+
+  local cmd=(
+    elixir --sname "${SNAME}-${name}" --cookie "$COOKIE"
+    "$SCRIPT"
+    --scenario "$name"
+    --concurrency "$CONCURRENCY"
+    --duration "$DURATION"
+    --csv "$CSV"
+    "${extra_flags[@]}"
+  )
+
+  echo "  ${cmd[*]}" | tee -a "$LOG"
+  echo "" | tee -a "$LOG"
+
+  if "${cmd[@]}" 2>&1 | tee -a "$LOG"; then
+    PASS=$((PASS + 1))
+    echo "" | tee -a "$LOG"
+  else
+    FAIL=$((FAIL + 1))
+    echo "" | tee -a "$LOG"
+    echo "FATAL: scenario '$name' failed (exit $?). Stopping." | tee -a "$LOG"
+    echo ""
+    echo "Results so far: $PASS passed, $FAIL failed"
+    echo "Log: $LOG"
+    echo "CSV: $CSV"
+    exit 1
+  fi
+}
+
+# ── Run scenarios ─────────────────────────────────────────────────
+
+# 1. Baseline — hit mock sink directly (no Lightning, no --sname)
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" | tee -a "$LOG"
+echo " Scenario: direct_sink" | tee -a "$LOG"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" | tee -a "$LOG"
+
+DIRECT_CMD=(
+  elixir "$SCRIPT"
+  --scenario direct_sink
+  --concurrency "$CONCURRENCY"
+  --duration "$DURATION"
+  --csv "$CSV"
+)
+echo "  ${DIRECT_CMD[*]}" | tee -a "$LOG"
+echo "" | tee -a "$LOG"
+
+if "${DIRECT_CMD[@]}" 2>&1 | tee -a "$LOG"; then
+  PASS=$((PASS + 1))
+  echo "" | tee -a "$LOG"
+else
+  FAIL=$((FAIL + 1))
+  echo "" | tee -a "$LOG"
+  echo "FATAL: scenario 'direct_sink' failed. Stopping." | tee -a "$LOG"
+  echo "Log: $LOG"
+  exit 1
+fi
+
+# 2-7. Scenarios that go through Lightning
+run_scenario happy_path
+run_scenario ramp_up
+run_scenario large_payload  --payload-size 1048576
+run_scenario large_response --response-size 1048576
+run_scenario mixed_methods
+run_scenario slow_sink      --delay 2000
+
+# ── Summary ───────────────────────────────────────────────────────
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" | tee -a "$LOG"
+echo " All scenarios complete: $PASS passed, $FAIL failed" | tee -a "$LOG"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" | tee -a "$LOG"
+echo ""
+echo "Log: $LOG"
+echo "CSV: $CSV"


### PR DESCRIPTION
## Description

This PR adds Elixir benchmarking tools for the channel proxy — a mock sink
server and a load test runner. WIP: still needs end-to-end validation and
refinement against a running Lightning instance.

Closes #4409
Closes #4410

## Validation steps

1. `elixir benchmarking/channels/mock_sink.exs --help` — prints usage
2. `elixir --sname lt --cookie test benchmarking/channels/load_test.exs --help` — prints usage
3. See `benchmarking/channels/README.md` for full 3-terminal walkthrough

## Additional notes for the reviewer

1. Both scripts are standalone (`Mix.install`) — no changes to Lightning's deps
2. WIP — needs validation against a running Lightning + mock sink setup and
   possible refinement of scenarios/metrics
3. The load test connects to Lightning via distributed Erlang for channel
   setup and memory sampling

## AI Usage

- [x] I have used Claude Code

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [ ] I have implemented and tested all related **authorization policies**.
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR