### PR TITLE
fix version display

### DIFF
--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -450,18 +450,22 @@ defmodule LightningWeb.LayoutComponents do
   end
 
   def sidebar_footer(assigns) do
+    label = Lightning.release()[:label]
+    compact? = is_binary(label) and not String.contains?(label, " ")
+    assigns = assign(assigns, :compact_version?, compact?)
+
     ~H"""
     <div class="flex-shrink-0 sidebar-footer flex flex-col border-t border-white/10 pt-3 mt-3">
       <%!-- Expanded branding: centered --%>
-      <div class="sidebar-branding-expanded h-14 text-center">
-        <div class="pt-2 pb-1">
+      <div class="sidebar-branding-expanded h-14 text-center animate-[fade-in-keys_1s_ease-out_forwards]">
+        <div class="pt-2">
           <LightningWeb.Components.Common.openfn_logo class="h-6 primary-light mx-auto" />
         </div>
         <LightningWeb.Components.Common.version_chip />
       </div>
       <%!-- Collapsed branding: centered --%>
-      <div class="sidebar-branding-collapsed hidden h-14 text-center">
-        <div class="pt-2 pb-1">
+      <div class="sidebar-branding-collapsed hidden h-14 text-center animate-[fade-in-keys_1s_ease-out_forwards]">
+        <div class={if @compact_version?, do: "pt-2", else: "pt-0.5"}>
           <LightningWeb.Components.Common.openfn_logo_collapsed class="h-6 primary-light mx-auto" />
         </div>
         <LightningWeb.Components.Common.version_chip />

--- a/lib/lightning_web/live/components/common.ex
+++ b/lib/lightning_web/live/components/common.ex
@@ -310,13 +310,7 @@ defmodule LightningWeb.Components.Common do
         ]}
         title={@message}
       >
-        <%= for {part, index} <- Enum.with_index(String.split(@display, " ")) do %>
-          <%= if index > 0 do %>
-            <br /><span class="text-[0.45rem]">{part}</span>
-          <% else %>
-            {part}
-          <% end %>
-        <% end %>
+        {@display}
       </code>
     </div>
     """


### PR DESCRIPTION
## Description

This PR fixes the version display alignment in the bottom left corner.

## Validation steps

1. Run this (lightning or TB) and check that the version chip is properly aligned, vertically and horizontally.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
