### PR TITLE
Consider manual runs when determining next run input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to
 
 ### Fixed
 
+- Consider manual runs for "next cron run input" via the
+  `last_run_final_dataclip` function
+  [#4584](https://github.com/OpenFn/lightning/issues/4584)
 - Proper warn & error for exceeding max dataclip size
   [#4524](https://github.com/OpenFn/lightning/issues/4524)
 - Copying api tokens doesn't work on unsecure non-localhost contexts

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -229,14 +229,16 @@ defmodule Lightning.Invocation do
   end
 
   @doc """
-  Returns the final dataclip from the last successful run for a trigger.
-  Used when cron_cursor_job_id is nil (use final run state).
+  Returns the final dataclip from the last successful run for a trigger's
+  workflow. Used when cron_cursor_job_id is nil (use final run state).
+
+  Scopes by workflow (not trigger) so that manual runs are also considered.
   """
-  def last_run_final_dataclip(%Trigger{id: trigger_id}) do
+  def last_run_final_dataclip(%Trigger{workflow_id: workflow_id}) do
     from(r in Run,
       join: wo in assoc(r, :work_order),
       join: d in assoc(r, :final_dataclip),
-      where: wo.trigger_id == ^trigger_id,
+      where: wo.workflow_id == ^workflow_id,
       where: r.state == :success,
       where: is_nil(d.wiped_at),
       order_by: [desc: r.finished_at],

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -714,6 +714,115 @@ defmodule Lightning.InvocationTest do
       assert result.id == final_dataclip.id
     end
 
+    test "returns the final dataclip from a manual run (no trigger on work order)" do
+      project = insert(:project)
+
+      %{workflow: workflow, trigger: trigger, snapshot: snapshot} =
+        build_workflow(project: project)
+
+      dataclip = insert(:dataclip, project: project)
+
+      final_dataclip =
+        insert(:dataclip,
+          project: project,
+          body: %{"manual_final" => "state"},
+          type: :step_result
+        )
+
+      [job] = workflow.jobs
+
+      # Manual run: work order has no trigger, run has starting_job instead
+      wo =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: nil,
+          dataclip: dataclip,
+          snapshot: snapshot
+        )
+
+      insert(:run,
+        work_order: wo,
+        dataclip: dataclip,
+        starting_job: job,
+        snapshot: snapshot,
+        state: :success,
+        finished_at: DateTime.utc_now(),
+        final_dataclip: final_dataclip
+      )
+
+      result = Invocation.get_next_cron_run_dataclip(trigger)
+      assert result.id == final_dataclip.id
+    end
+
+    test "prefers the most recent successful run regardless of trigger" do
+      project = insert(:project)
+
+      %{workflow: workflow, trigger: trigger, snapshot: snapshot} =
+        build_workflow(project: project)
+
+      [job] = workflow.jobs
+
+      old_dataclip = insert(:dataclip, project: project)
+
+      old_final =
+        insert(:dataclip,
+          project: project,
+          body: %{"old" => "state"},
+          type: :step_result
+        )
+
+      # Older cron-triggered run
+      old_wo =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: old_dataclip,
+          snapshot: snapshot
+        )
+
+      insert(:run,
+        work_order: old_wo,
+        dataclip: old_dataclip,
+        starting_trigger: trigger,
+        snapshot: snapshot,
+        state: :success,
+        finished_at: ~U[2025-01-01 00:00:00Z],
+        final_dataclip: old_final
+      )
+
+      # Newer manual run
+      new_dataclip = insert(:dataclip, project: project)
+
+      new_final =
+        insert(:dataclip,
+          project: project,
+          body: %{"new" => "state"},
+          type: :step_result
+        )
+
+      new_wo =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: nil,
+          dataclip: new_dataclip,
+          snapshot: snapshot
+        )
+
+      insert(:run,
+        work_order: new_wo,
+        dataclip: new_dataclip,
+        starting_job: job,
+        snapshot: snapshot,
+        state: :success,
+        finished_at: ~U[2025-06-01 00:00:00Z],
+        final_dataclip: new_final
+      )
+
+      # Should use the newer manual run's final dataclip
+      result = Invocation.get_next_cron_run_dataclip(trigger)
+      assert result.id == new_final.id
+    end
+
     test "skips wiped dataclips and returns nil" do
       project = insert(:project)
 


### PR DESCRIPTION
## Description

This PR closes #4584 .

Cron-triggered workflow runs were ignoring manual run outputs when determining the next input state.

`last_run_final_dataclip/1` filtered by `wo.trigger_id`, which excluded manual runs (whose work orders have `trigger_id = nil`).

Changed the filter to scope by `wo.workflow_id` instead, so the most recent successful run is used regardless of how it was triggered. While you could argue that we _shouldn't_ consider manual runs when calculating the next input state for a scheduled run, this isn't how we do it when using the "single step" option, so we should keep it the same for "Final run state" option.

<img width="495" height="269" alt="image" src="https://github.com/user-attachments/assets/a14c16d2-5b6d-4ee2-91eb-7798812dd161" />


## Validation steps

1. Create a workflow with a cron trigger and at least one job
2. Run the workflow via the cron trigger (or wait for it to fire) — confirm it succeeds
3. Manually run the same workflow using "Empty input" — confirm it succeeds
4. Wait for (or trigger) the next cron execution
5. Verify the new cron run's input dataclip is the final_dataclip from the manual run (step 3), not the older cron run (step 2)

## Additional notes for the reviewer

1. The cron_cursor_job_id path (last_successful_step_dataclip/1) was already unscoped by trigger and did not have this bug — only the cron_cursor_job_id = nil path was affected.
2. Two new test cases added in invocation_test.exs: one for manual runs being picked up, one for recency ordering across trigger types.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
