### PR TITLE
Fix collaborative_editor_url incorrectly mapping trigger/edge s param to job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,9 @@ and this project adheres to
 
 ### Fixed
 
+- Fix `collaborative_editor_url/2` incorrectly mapping trigger/edge selections
+  to `job` param when switching from legacy to collaborative editor
+  [#4375](https://github.com/OpenFn/lightning/issues/4375)
 - Consider manual runs for "next cron run input" via the
   `last_run_final_dataclip` function
   [#4584](https://github.com/OpenFn/lightning/issues/4584)

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1644,7 +1644,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
       })
 
     collaborative_url =
-      Helpers.collaborative_editor_url(params, socket.assigns.live_action)
+      Helpers.collaborative_editor_url(params, socket.assigns.live_action, socket.assigns)
 
     {:noreply, push_navigate(socket, to: collaborative_url)}
   end

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -1644,7 +1644,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
       })
 
     collaborative_url =
-      Helpers.collaborative_editor_url(params, socket.assigns.live_action, socket.assigns)
+      Helpers.collaborative_editor_url(
+        params,
+        socket.assigns.live_action,
+        socket.assigns
+      )
 
     {:noreply, push_navigate(socket, to: collaborative_url)}
   end

--- a/lib/lightning_web/live/workflow_live/helpers.ex
+++ b/lib/lightning_web/live/workflow_live/helpers.ex
@@ -417,12 +417,12 @@ defmodule LightningWeb.WorkflowLive.Helpers do
       "/projects/proj-1/w/wf-1?custom=value&job=job-123&v=42"
 
   """
-  def collaborative_editor_url(params, live_action) do
+  def collaborative_editor_url(params, live_action, assigns \\ %{}) do
     collaborative_params =
       params
       |> Map.drop(["id", "project_id"])
       |> Enum.reduce(%{}, fn {key, value}, acc ->
-        convert_param(key, value, acc, params)
+        convert_param(key, value, acc, assigns)
       end)
 
     base_url = collaborative_base_url(params, live_action)

--- a/test/lightning_web/live/workflow_live/helpers_test.exs
+++ b/test/lightning_web/live/workflow_live/helpers_test.exs
@@ -78,6 +78,45 @@ defmodule LightningWeb.WorkflowLive.HelpersTest do
       assert result == "/projects/proj-1/w/wf-1?job=unknown-id"
     end
 
+    test "maps 's' to 'trigger' when assigns identify it as a trigger" do
+      params = %{
+        "s" => "trigger-xyz",
+        "project_id" => "proj-1",
+        "id" => "wf-1"
+      }
+
+      assigns = %{selected_trigger: %{id: "trigger-xyz"}}
+
+      result = Helpers.collaborative_editor_url(params, :edit, assigns)
+      assert result == "/projects/proj-1/w/wf-1?trigger=trigger-xyz"
+    end
+
+    test "maps 's' to 'edge' when assigns identify it as an edge" do
+      params = %{
+        "s" => "edge-123",
+        "project_id" => "proj-1",
+        "id" => "wf-1"
+      }
+
+      assigns = %{selected_edge: %{id: "edge-123"}}
+
+      result = Helpers.collaborative_editor_url(params, :edit, assigns)
+      assert result == "/projects/proj-1/w/wf-1?edge=edge-123"
+    end
+
+    test "maps 's' to 'job' when assigns identify it as a job" do
+      params = %{
+        "s" => "job-abc",
+        "project_id" => "proj-1",
+        "id" => "wf-1"
+      }
+
+      assigns = %{selected_job: %{id: "job-abc"}}
+
+      result = Helpers.collaborative_editor_url(params, :edit, assigns)
+      assert result == "/projects/proj-1/w/wf-1?job=job-abc"
+    end
+
     test "converts 'm=expand' to 'panel=editor'" do
       params = %{
         "m" => "expand",


### PR DESCRIPTION
## Summary

Closes #4375

When a user switches from the legacy editor to the collaborative editor,
the `s` query param (selected node) is converted to the appropriate collab
param (`job=`, `trigger=`, or `edge=`). The conversion depends on
`determine_selection_type/2`, which pattern-matches on atom-keyed socket
assigns (`selected_trigger`, `selected_job`, `selected_edge`).

The bug: `collaborative_editor_url/2` was passing the URL params map
(string-keyed) as the 4th argument to `convert_param`, not socket assigns.
Since the URL params never contain `:selected_trigger` etc., the cond always
fell through to the default `"job"` case - so triggers and edges were always
mapped to `job=` instead of `trigger=` or `edge=`.

### Changes

- `collaborative_editor_url/3` now takes an optional `assigns` arg (defaults
  to `%{}` for backward compat) and passes it to `convert_param` instead of
  the URL params map
- `edit.ex` now passes `socket.assigns` when calling `collaborative_editor_url`
  from the `switch_to_collab_editor` event handler
- Three new tests cover the fixed trigger/edge/job resolution with assigns

## Checklist

- [x] I have added tests to cover my changes
- [x] I have used an AI assistant (Claude Code) to help produce this code