### PR TITLE
Allow special characters and non-Latin scripts in job names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to
 
 ### Fixed
 
+- Allow special characters and non-Latin scripts in workflow step names
+  [#4577](https://github.com/OpenFn/lightning/issues/4577)
 - Consider manual runs for "next cron run input" via the
   `last_run_final_dataclip` function
   [#4584](https://github.com/OpenFn/lightning/issues/4584)

--- a/assets/js/collaborative-editor/types/job.ts
+++ b/assets/js/collaborative-editor/types/job.ts
@@ -20,7 +20,6 @@ export const JobSchema = z
       .string()
       .min(1, "Job name can't be blank")
       .max(100, "Job name shouldn't be longer than 100 characters.")
-      .regex(/^[a-zA-Z0-9_\- ]*$/, "Job name can't include special characters.")
       .transform(val => val.trim()), // Auto-trim whitespace like backend
     body: z.string().min(1, "can't be blank"),
     adaptor: adaptorSchema.default('@openfn/language-common@latest'),

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -77,15 +77,6 @@ const PlaceholderJobNode = ({ id, data, selected }: NodeProps<NodeData>) => {
       };
     }
 
-    const regex = /^[a-zA-Z0-9_\- ]*$/;
-    if (!regex.test(name)) {
-      return {
-        isValid: false,
-        message:
-          'Name can only contain alphanumeric characters, underscores, dashes, and spaces.',
-      };
-    }
-
     return {
       isValid: true,
       message: 'Valid name.',

--- a/lib/lightning/workflows/job.ex
+++ b/lib/lightning/workflows/job.ex
@@ -113,9 +113,6 @@ defmodule Lightning.Workflows.Job do
       max: 100,
       message: "job name should be at most %{count} character(s)"
     )
-    |> validate_format(:name, ~r/^[a-zA-Z0-9_\- ]*$/,
-      message: "job name has invalid format"
-    )
   end
 
   defp validate_keychain_credential_project_membership(changeset) do

--- a/test/lightning/workflows/job_test.exs
+++ b/test/lightning/workflows/job_test.exs
@@ -152,11 +152,11 @@ defmodule Lightning.Workflows.JobTest do
       assert errors[:name] == ["job name should be at most 100 character(s)"]
     end
 
-    test "name can't contain non url-safe chars" do
-      ["My project @ OpenFn", "Can't have a / slash"]
+    test "name accepts special characters and non-latin scripts" do
+      ["My project @ OpenFn", "Can't have a / slash", "حساب", "étape 1"]
       |> Enum.each(fn name ->
         errors = Job.changeset(%Job{}, %{name: name}) |> errors_on()
-        assert errors[:name] == ["job name has invalid format"]
+        refute errors[:name]
       end)
     end
 


### PR DESCRIPTION
## Summary

Closes #4577

Workflow step names are stored as labels in YAML exports, not as
identifiers. The existing regex (`/^[a-zA-Z0-9_\- ]*$/`) was unnecessarily
blocking non-English users from entering names in their native scripts
(Arabic, French, Chinese, etc.) or using characters like `@` or `'`.

Removes the character-set restriction from three locations:

- `lib/lightning/workflows/job.ex` - Elixir changeset validation
- `assets/js/workflow-diagram/nodes/PlaceholderJob.tsx` - PlaceholderJob inline validation
- `assets/js/collaborative-editor/types/job.ts` - Zod schema for collaborative editor

The 100-character length limit and blank-name check are preserved.

## Validation steps

1. `mix format`
2. `mix test test/lightning/workflows/job_test.exs --seed 0`

## Checklist

- [x] I have added tests to cover my changes
- [x] I have used Claude Code to help produce this code