### PR TITLE
refactor: consolidate run and work order state definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to
 
 ### Changed
 
+- Consolidated run and work order state definitions into single source of truth
+  by adding `Run.active_states/0`, `WorkOrder.states/0`, and
+  `WorkOrder.active_states/0` and replacing all hardcoded state lists across the
+  codebase
+  [#4589](https://github.com/OpenFn/lightning/issues/4589)
+
 ### Fixed
 
 ## [2.16.7] - 2026-06-04

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -11,6 +11,8 @@ defmodule Lightning.DashboardStats do
   alias Lightning.Workflows.Workflow
   alias Lightning.WorkOrder
 
+  @wo_active WorkOrder.active_states()
+  @run_active Run.active_states()
   @days_back 30
 
   defmodule WorkflowStats do
@@ -58,7 +60,10 @@ defmodule Lightning.DashboardStats do
     last_workorders = batch_get_last_workorders(workflow_ids)
 
     last_failed_workorders =
-      batch_get_last_workorders(workflow_ids, [:pending, :running, :success])
+      batch_get_last_workorders(
+        workflow_ids,
+        WorkOrder.active_states() ++ [:success]
+      )
 
     Enum.map(workflows, fn workflow ->
       wf_id = workflow.id
@@ -238,7 +243,7 @@ defmodule Lightning.DashboardStats do
       {:success, cnt}, acc ->
         %{acc | success: cnt}
 
-      {state, cnt}, acc when state in [:pending, :running] ->
+      {state, cnt}, acc when state in @wo_active ->
         Map.update!(acc, :pending, &(&1 + cnt))
 
       {_other, cnt}, acc ->
@@ -260,7 +265,7 @@ defmodule Lightning.DashboardStats do
       {:success, cnt}, acc ->
         %{acc | success: cnt}
 
-      {state, cnt}, acc when state in [:available, :claimed, :started] ->
+      {state, cnt}, acc when state in @run_active ->
         Map.update!(acc, :pending, &(&1 + cnt))
 
       {_other, cnt}, acc ->
@@ -342,7 +347,7 @@ defmodule Lightning.DashboardStats do
           :success ->
             %{current | success: cnt}
 
-          s when s in [:pending, :running] ->
+          s when s in @wo_active ->
             Map.update!(current, :pending, &(&1 + cnt))
 
           _ ->
@@ -370,7 +375,7 @@ defmodule Lightning.DashboardStats do
           :success ->
             %{current | success: cnt}
 
-          s when s in [:available, :claimed, :started] ->
+          s when s in @run_active ->
             Map.update!(current, :pending, &(&1 + cnt))
 
           _ ->

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -60,10 +60,7 @@ defmodule Lightning.DashboardStats do
     last_workorders = batch_get_last_workorders(workflow_ids)
 
     last_failed_workorders =
-      batch_get_last_workorders(
-        workflow_ids,
-        WorkOrder.active_states() ++ [:success]
-      )
+      batch_get_last_workorders(workflow_ids, @wo_active ++ [:success])
 
     Enum.map(workflows, fn workflow ->
       wf_id = workflow.id

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -206,7 +206,7 @@ defmodule Lightning.DashboardStats do
   end
 
   defp get_last_failed_workorder(workflow, %{state: :success}) do
-    excluded_states = [:pending, :running, :success]
+    excluded_states = @wo_active ++ [:success]
     get_last_workorder(workflow, excluded_states)
   end
 

--- a/lib/lightning/runs/prom_ex_plugin/impeded_project_helper.ex
+++ b/lib/lightning/runs/prom_ex_plugin/impeded_project_helper.ex
@@ -25,9 +25,11 @@ defmodule Lightning.Runs.PromExPlugin.ImpededProjectHelper do
         select: w.workflow_id,
         distinct: true
 
+    in_progress = Lightning.Run.active_states() -- [:available]
+
     in_progress_runs_query =
       from r in Lightning.Run,
-        where: r.state in [:claimed, :started],
+        where: r.state in ^in_progress,
         join: w in assoc(r, :work_order),
         group_by: w.workflow_id,
         select: %{workflow_id: w.workflow_id, count: count(r.id)}

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -231,7 +231,7 @@ defmodule Lightning.Runs.Query do
     # Step 1: Rank runs within each workflow by priority and insertion time
     ranked_runs_query =
       from(r in Run,
-        where: r.state in [:available, :claimed, :started],
+        where: r.state in ^Run.active_states(),
         join: wo in assoc(r, :work_order),
         join: w in assoc(wo, :workflow),
         join: p in assoc(w, :project)

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -41,6 +41,8 @@ defmodule Lightning.Run do
              :final_dataclip_id
            ]}
 
+  @active_states [:available, :claimed, :started]
+
   @final_states [
     :success,
     :failed,
@@ -68,7 +70,7 @@ defmodule Lightning.Run do
 
   These are all non-final states: available, claimed, and started.
   """
-  def active_states, do: [:available, :claimed, :started]
+  def active_states, do: @active_states
 
   @doc """
   Returns the list of failure states for a run.

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -53,7 +53,7 @@ defmodule Lightning.Run do
     :lost
   ]
 
-  @states [:available, :claimed, :started] ++ @final_states
+  @states @active_states ++ @final_states
 
   @doc """
   Returns all possible states for a run.

--- a/lib/lightning/runs/run.ex
+++ b/lib/lightning/runs/run.ex
@@ -64,6 +64,13 @@ defmodule Lightning.Run do
   def final_states, do: @final_states
 
   @doc """
+  Returns the list of active (in-progress) states for a run.
+
+  These are all non-final states: available, claimed, and started.
+  """
+  def active_states, do: [:available, :claimed, :started]
+
+  @doc """
   Returns the list of failure states for a run.
 
   These are all final states except :success.

--- a/lib/lightning/workorders/search_params.ex
+++ b/lib/lightning/workorders/search_params.ex
@@ -21,7 +21,8 @@ defmodule Lightning.WorkOrders.SearchParams do
              :sort_direction
            ]}
 
-  @statuses ~w(pending running success failed crashed killed cancelled lost exception rejected)
+  @statuses Lightning.WorkOrder.states()
+           |> Enum.map(&Atom.to_string/1)
   @statuses_set MapSet.new(@statuses)
   @search_fields ~w(id body log dataclip_name)
 

--- a/lib/lightning/workorders/search_params.ex
+++ b/lib/lightning/workorders/search_params.ex
@@ -22,7 +22,7 @@ defmodule Lightning.WorkOrders.SearchParams do
            ]}
 
   @statuses Lightning.WorkOrder.states()
-           |> Enum.map(&Atom.to_string/1)
+            |> Enum.map(&Atom.to_string/1)
   @statuses_set MapSet.new(@statuses)
   @search_fields ~w(id body log dataclip_name)
 

--- a/lib/lightning/workorders/workorder.ex
+++ b/lib/lightning/workorders/workorder.ex
@@ -21,8 +21,10 @@ defmodule Lightning.WorkOrder do
           workflow: Workflow.t() | Ecto.Association.NotLoaded.t()
         }
 
+  @active_states [:pending, :running]
+
   @state_values Enum.concat(
-                  [:rejected, :pending, :running],
+                  [:rejected | @active_states],
                   Run.final_states()
                 )
 
@@ -30,6 +32,11 @@ defmodule Lightning.WorkOrder do
   Returns all possible states for a work order.
   """
   def states, do: @state_values
+
+  @doc """
+  Returns the list of active (in-progress) work order states.
+  """
+  def active_states, do: @active_states
 
   @derive {Jason.Encoder,
            only: [

--- a/lib/lightning_web/live/run_live/workorder_component.ex
+++ b/lib/lightning_web/live/run_live/workorder_component.ex
@@ -5,6 +5,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
   use LightningWeb, :live_component
 
   import LightningWeb.RunLive.Components
+  alias Lightning.WorkOrder
   alias Phoenix.LiveView.JS
 
   @impl true
@@ -261,7 +262,7 @@ defmodule LightningWeb.RunLive.WorkOrderComponent do
                   <.icon name="hero-x-mark-mini" class="h-4 w-4" />
                 </button>
               <% end %>
-              <%= if @work_order.state not in [:pending, :running] do %>
+              <%= if @work_order.state not in WorkOrder.active_states() do %>
                 <%= if wo_dataclip_available?(@work_order) and @can_run_workflow do %>
                   <button
                     type="button"

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -4,6 +4,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
 
   alias Lightning.DashboardStats.ProjectMetrics
   alias Lightning.Projects.Project
+  alias Lightning.WorkOrder
   alias Lightning.WorkOrders.SearchParams
   alias LightningWeb.Components.Common
   alias LightningWeb.WorkflowLive.Helpers
@@ -455,7 +456,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
     <div>
       <div class="flex items-center gap-x-2">
         <span class="relative inline-flex h-2 w-2">
-          <%= if @state in [:pending, :running] do %>
+          <%= if @state in WorkOrder.active_states() do %>
             <span class={[
               "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
               @dot_color

--- a/test/lightning/digest_email_worker_test.exs
+++ b/test/lightning/digest_email_worker_test.exs
@@ -153,7 +153,7 @@ defmodule Lightning.DigestEmailWorkerTest do
       workflow = insert(:simple_workflow, project: project)
 
       # Create workorders in non-final states (these should not be counted as failed)
-      create_runs(workflow, [:pending, :running])
+      create_runs(workflow, Lightning.WorkOrder.active_states())
 
       # Create one actual failed run for comparison
       create_runs(workflow, [:failed])

--- a/test/lightning/janitor_test.exs
+++ b/test/lightning/janitor_test.exs
@@ -161,7 +161,7 @@ defmodule Lightning.JanitorTest do
 
       unfinished_runs_with_unfinished_steps =
         Enum.map(
-          [:available, :claimed, :started],
+          Lightning.Run.active_states(),
           fn state ->
             insert(:run,
               work_order: work_order,


### PR DESCRIPTION
## Description

This PR establishes a single source of truth for run and work order state groupings by adding named public functions on the schema modules and replacing all hardcoded state lists throughout the codebase.

**New functions:**
- `Run.active_states/0` → `[:available, :claimed, :started]`
- `WorkOrder.states/0` → all valid work order states
- `WorkOrder.active_states/0` → `[:pending, :running]`

**Replaced hardcoded lists in:**
- `lib/lightning/dashboard_stats.ex` (4 occurrences across `count_workorders`, `count_runs`, `batch_count_workorders`, `batch_count_runs`, and the `batch_get_last_workorders` excluded-states argument)
- `lib/lightning/runs/query.ex` (`workflow_limited_runs/1`)
- `lib/lightning/runs/prom_ex_plugin/impeded_project_helper.ex` (derived from `Run.active_states/0 -- [:available]`)
- `lib/lightning_web/live/workflow_live/dashboard_components.ex` (status dot animation)
- `lib/lightning/workorders/search_params.ex` (`@statuses` now derived from `WorkOrder.states/0`)
- `test/lightning/janitor_test.exs` and `test/lightning/digest_email_worker_test.exs`

Closes #4589

## Validation steps

1. Run the full test suite: `mix test` — all existing tests should pass without assertion changes.
2. Verify no remaining hardcoded `[:available, :claimed, :started]` or `[:pending, :running]` lists in `lib/` (outside schema modules): `grep -rn "\[:available, :claimed, :started\]\|\[:pending, :running\]" lib/`
3. Verify the dashboard still renders correctly with the status dot animation for pending/running work orders.

## Additional notes for the reviewer

1. Guard clauses in `dashboard_stats.ex` use module attributes (`@wo_active`, `@run_active`) which are evaluated at compile time from the function calls — this is the standard Elixir pattern for using dynamic values in guards.
2. The `impeded_project_helper.ex` intentionally used `[:claimed, :started]` (not `[:available, :claimed, :started]`) because it counts runs actively consuming concurrency slots. This is preserved as `Run.active_states() -- [:available]`.
3. Frontend TypeScript state definitions in `types/history.ts` and `useRunRetry.ts` are excluded from this change per the issue's explicit scoping.

## AI Usage

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR