### PR TITLE
Adjust initial AI streaming status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to
 
 ### Changed
 
+- Set initial streaming status when sending messages to the AI Assistant
+  [#4630](https://github.com/OpenFn/lightning/pull/4630)
+
 ### Fixed
 
 - Prevent crash when an unsupported data type from `credential-schema.json` is

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+const INITIAL_LOADING_STATUSES = [
+  'Thinking about the question...',
+  'Working on it...',
+  'Processing your request...',
+  'Examining your question...',
+  'Taking a look...',
+  'Looking into it...',
+] as const;
+
 import { useURLState } from '../../react/lib/use-url-state';
 import {
   useMonacoRef,
@@ -409,6 +418,11 @@ export function AIAssistantPanelWrapper({
 
         // Mark message as sending in store
         aiStore.setMessageSending();
+        aiStore.setStreamingStatus(
+          INITIAL_LOADING_STATUSES[
+            Math.floor(Math.random() * INITIAL_LOADING_STATUSES.length)
+          ]
+        );
         return;
       }
 
@@ -461,6 +475,11 @@ export function AIAssistantPanelWrapper({
 
       // Update store state and send through registry
       aiStore.setMessageSending();
+      aiStore.setStreamingStatus(
+        INITIAL_LOADING_STATUSES[
+          Math.floor(Math.random() * INITIAL_LOADING_STATUSES.length)
+        ]
+      );
       sendMessageToChannel(content, options);
     },
     [

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -9,6 +9,11 @@ const INITIAL_LOADING_STATUSES = [
   'Looking into it...',
 ] as const;
 
+const getRandomStatus = () =>
+  INITIAL_LOADING_STATUSES[
+    Math.floor(Math.random() * INITIAL_LOADING_STATUSES.length)
+  ];
+
 import { useURLState } from '../../react/lib/use-url-state';
 import {
   useMonacoRef,
@@ -418,11 +423,7 @@ export function AIAssistantPanelWrapper({
 
         // Mark message as sending in store
         aiStore.setMessageSending();
-        aiStore.setStreamingStatus(
-          INITIAL_LOADING_STATUSES[
-            Math.floor(Math.random() * INITIAL_LOADING_STATUSES.length)
-          ]
-        );
+        aiStore.setStreamingStatus(getRandomStatus());
         return;
       }
 
@@ -475,11 +476,7 @@ export function AIAssistantPanelWrapper({
 
       // Update store state and send through registry
       aiStore.setMessageSending();
-      aiStore.setStreamingStatus(
-        INITIAL_LOADING_STATUSES[
-          Math.floor(Math.random() * INITIAL_LOADING_STATUSES.length)
-        ]
-      );
+      aiStore.setStreamingStatus(getRandomStatus());
       sendMessageToChannel(content, options);
     },
     [
@@ -499,6 +496,7 @@ export function AIAssistantPanelWrapper({
   const handleRetryMessage = useCallback(
     (messageId: string) => {
       aiStore.retryMessage(messageId);
+      aiStore.setStreamingStatus(getRandomStatus());
       retryMessageViaChannel(messageId);
     },
     [aiStore, retryMessageViaChannel]

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -773,7 +773,7 @@ export function MessageList({
                 <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
               </div>
               <span className="text-xs text-gray-400 italic">
-                {streamingStatus || 'Generating response...'}
+                {streamingStatus || 'Thinking...'}
               </span>
             </div>
           </div>

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -11,6 +11,15 @@ import { Tooltip } from '../../components/Tooltip';
 
 const STREAMING_MESSAGE_ID = '__streaming__' as const;
 
+const LOADING_STATUSES = [
+  'Thinking about the question...',
+  'Working on it...',
+  'Processing your request...',
+  'Examining your question...',
+  'Taking a look...',
+  'Looking into it...',
+] as const;
+
 const PROSE_CLASSES =
   'text-sm text-gray-700 leading-relaxed prose prose-sm max-w-none prose-headings:font-medium prose-h1:text-lg prose-h1:text-gray-900 prose-h1:mb-3 prose-h2:text-base prose-h2:text-gray-900 prose-h2:mb-2 prose-h2:mt-5 prose-h3:text-sm prose-h3:text-gray-900 prose-h3:mb-2 prose-h3:font-semibold prose-p:mb-3 prose-p:last:mb-0 prose-p:text-gray-700 prose-ul:list-disc prose-ul:pl-5 prose-ul:mb-3 prose-ul:space-y-1 prose-ol:list-decimal prose-ol:pl-5 prose-ol:mb-3 prose-ol:space-y-1 prose-li:text-gray-700 prose-strong:font-medium prose-strong:text-gray-900 prose-em:italic prose-a:text-primary-600 prose-a:hover:text-primary-700 prose-a:underline prose-a:font-normal prose-code:px-1.5 prose-code:py-0.5 prose-code:bg-gray-100 prose-code:text-gray-800 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal prose-pre:rounded-md prose-pre:bg-slate-100 prose-pre:border-2 prose-pre:border-slate-200 prose-pre:text-slate-800 prose-pre:p-4 prose-pre:overflow-x-auto prose-pre:text-xs prose-pre:font-mono prose-pre:mb-4';
 
@@ -416,6 +425,14 @@ export function MessageList({
   const [expandedYaml, setExpandedYaml] = useState<Set<string>>(new Set());
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
 
+  // Pick a new random status each time loading starts so it stays
+  // stable across re-renders within one loading session.
+  const loadingStatus = useMemo(
+    () =>
+      LOADING_STATUSES[Math.floor(Math.random() * LOADING_STATUSES.length)],
+    [isLoading]
+  );
+
   useEffect(() => {
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({
@@ -773,7 +790,7 @@ export function MessageList({
                 <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
               </div>
               <span className="text-xs text-gray-400 italic">
-                {streamingStatus || 'Thinking...'}
+                {streamingStatus || loadingStatus}
               </span>
             </div>
           </div>

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -11,15 +11,6 @@ import { Tooltip } from '../../components/Tooltip';
 
 const STREAMING_MESSAGE_ID = '__streaming__' as const;
 
-const LOADING_STATUSES = [
-  'Thinking about the question...',
-  'Working on it...',
-  'Processing your request...',
-  'Examining your question...',
-  'Taking a look...',
-  'Looking into it...',
-] as const;
-
 const PROSE_CLASSES =
   'text-sm text-gray-700 leading-relaxed prose prose-sm max-w-none prose-headings:font-medium prose-h1:text-lg prose-h1:text-gray-900 prose-h1:mb-3 prose-h2:text-base prose-h2:text-gray-900 prose-h2:mb-2 prose-h2:mt-5 prose-h3:text-sm prose-h3:text-gray-900 prose-h3:mb-2 prose-h3:font-semibold prose-p:mb-3 prose-p:last:mb-0 prose-p:text-gray-700 prose-ul:list-disc prose-ul:pl-5 prose-ul:mb-3 prose-ul:space-y-1 prose-ol:list-decimal prose-ol:pl-5 prose-ol:mb-3 prose-ol:space-y-1 prose-li:text-gray-700 prose-strong:font-medium prose-strong:text-gray-900 prose-em:italic prose-a:text-primary-600 prose-a:hover:text-primary-700 prose-a:underline prose-a:font-normal prose-code:px-1.5 prose-code:py-0.5 prose-code:bg-gray-100 prose-code:text-gray-800 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal prose-pre:rounded-md prose-pre:bg-slate-100 prose-pre:border-2 prose-pre:border-slate-200 prose-pre:text-slate-800 prose-pre:p-4 prose-pre:overflow-x-auto prose-pre:text-xs prose-pre:font-mono prose-pre:mb-4';
 
@@ -425,14 +416,6 @@ export function MessageList({
   const [expandedYaml, setExpandedYaml] = useState<Set<string>>(new Set());
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
 
-  // Pick a new random status each time loading starts so it stays
-  // stable across re-renders within one loading session.
-  const loadingStatus = useMemo(
-    () =>
-      LOADING_STATUSES[Math.floor(Math.random() * LOADING_STATUSES.length)],
-    [isLoading]
-  );
-
   useEffect(() => {
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({
@@ -790,7 +773,7 @@ export function MessageList({
                 <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
               </div>
               <span className="text-xs text-gray-400 italic">
-                {streamingStatus || loadingStatus}
+                {streamingStatus}
               </span>
             </div>
           </div>

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -693,7 +693,7 @@ export class AIChannelRegistry {
 
     const streamingStatusHandler: ChannelCallback = (payload: unknown) => {
       const typedPayload = payload as { text: string };
-      this.store._setStreamingStatus(typedPayload.text);
+      this.store.setStreamingStatus(typedPayload.text);
     };
 
     const streamingChangesHandler: ChannelCallback = (payload: unknown) => {

--- a/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
+++ b/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
@@ -583,11 +583,11 @@ export const createAIAssistantStore = (): AIAssistantStore => {
     notify('_appendStreamingChunk');
   };
 
-  const _setStreamingStatus = (text: string) => {
+  const setStreamingStatus = (text: string) => {
     state = produce(state, draft => {
       draft.streamingStatus = text;
     });
-    notify('_setStreamingStatus');
+    notify('setStreamingStatus');
   };
 
   const _setStreamingChanges = (changes: Record<string, unknown>) => {
@@ -682,7 +682,7 @@ export const createAIAssistantStore = (): AIAssistantStore => {
     _initializeContext,
     _setProcessingState,
     _appendStreamingChunk,
-    _setStreamingStatus,
+    setStreamingStatus,
     _setStreamingChanges,
     _clearStreaming,
     _connectChannel,

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -199,7 +199,7 @@ export interface AIAssistantStore {
   ) => void;
   _setProcessingState: (isProcessing: boolean) => void;
   _appendStreamingChunk: (content: string) => void;
-  _setStreamingStatus: (text: string) => void;
+  setStreamingStatus: (text: string) => void;
   _setStreamingChanges: (changes: Record<string, unknown>) => void;
   _clearStreaming: () => void;
   _connectChannel: (channelProvider: unknown) => () => void;


### PR DESCRIPTION
## Description

This PR changes the initial progress status shown to the user when starting a conversation with the AI assistants from "Generating response..." to "Thinking..." . This change is required because we are adding a more detailed stream of status updates from Apollo, where "Generating response" would feel out of place. https://github.com/OpenFn/apollo/pull/452

## Validation steps

1. Start a conversation with any AI assistant. Check that the first status that gets shown is "Thinking..."
 
## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
