### PR TITLE
Sandbox-aware Project Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to
   is ambiguous across projects, the API returns 409 with guidance to add
   `?project_id=`. Existing unscoped calls keep working for unambiguous names.
   [#3548](https://github.com/OpenFn/lightning/issues/3548)
+- Sandbox-aware Project Settings page. Each tab shows a banner explaining how
+  changes will (or will not) flow on merge: Local (sandbox-only), Editable
+  (syncs on merge), or Inherited (read-only, managed in the parent). The Sandbox
+  Identity panel links back to the parent project, the MFA toggle is read-only,
+  webhook authentication methods are managed from the parent project, and parent
+  project admins cannot be removed from a sandbox. The danger zone inside a
+  sandbox now deletes the sandbox through `Sandboxes.delete_sandbox/2` (matching
+  the Sandboxes page behaviour).
+  [#3398](https://github.com/OpenFn/lightning/issues/3398)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to
   `x-api-version: 2` header. V1 continues to work and returns 409 when a name is
   ambiguous across projects.
   [#3548](https://github.com/OpenFn/lightning/issues/3548)
+- Sandbox-aware Project Settings page. Each tab shows a banner explaining how
+  changes will (or will not) flow on merge: Local (sandbox-only), Editable
+  (syncs on merge), or Inherited (read-only, managed in the parent). The Sandbox
+  Identity panel links back to the parent project, the MFA toggle is read-only,
+  webhook security is unavailable in V1, and parent project admins cannot be
+  removed from a sandbox.
+  [#3398](https://github.com/OpenFn/lightning/issues/3398)
 
 ### Changed
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -574,6 +574,15 @@ defmodule Lightning.Projects do
       %{user_id: user_id, project_id: project_id} =
       Repo.preload(project_user, [:user, :project])
 
+    if Project.sandbox?(project_user.project) and
+         Lightning.Projects.Sandboxes.parent_admin?(
+           project_user.project,
+           project_user.user
+         ) do
+      raise ArgumentError,
+            "Cannot remove a parent project admin from a sandbox"
+    end
+
     Repo.transaction(fn ->
       from(pc in Lightning.Projects.ProjectCredential,
         join: c in Lightning.Credentials.Credential,

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -319,7 +319,10 @@ defmodule Lightning.Projects do
       ** (Ecto.NoResultsError)
 
   """
-  def get_project_user!(id), do: Repo.get!(ProjectUser, id)
+  def get_project_user!(id, opts \\ []) do
+    include = Keyword.get(opts, :include, [])
+    ProjectUser |> Repo.get!(id) |> Repo.preload(include)
+  end
 
   @spec get_project_user(Ecto.UUID.t()) :: ProjectUser.t() | nil
   def get_project_user(id) when is_binary(id), do: Repo.get(ProjectUser, id)

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -319,7 +319,10 @@ defmodule Lightning.Projects do
       ** (Ecto.NoResultsError)
 
   """
-  def get_project_user!(id), do: Repo.get!(ProjectUser, id)
+  def get_project_user!(id, opts \\ []) do
+    include = Keyword.get(opts, :include, [])
+    ProjectUser |> Repo.get!(id) |> Repo.preload(include)
+  end
 
   @spec get_project_user(Ecto.UUID.t()) :: ProjectUser.t() | nil
   def get_project_user(id) when is_binary(id), do: Repo.get(ProjectUser, id)
@@ -573,6 +576,15 @@ defmodule Lightning.Projects do
     project_user =
       %{user_id: user_id, project_id: project_id} =
       Repo.preload(project_user, [:user, :project])
+
+    if Project.sandbox?(project_user.project) and
+         Lightning.Projects.Sandboxes.parent_admin?(
+           project_user.project,
+           project_user.user
+         ) do
+      raise ArgumentError,
+            "Cannot remove a parent project admin from a sandbox"
+    end
 
     Repo.transaction(fn ->
       from(pc in Lightning.Projects.ProjectCredential,

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -210,6 +210,35 @@ defmodule Lightning.Projects.Sandboxes do
   end
 
   @doc """
+  Returns `true` when `user` has an `:admin` or `:owner` role on any ancestor
+  of `project`, walking the parent chain.
+
+  Used to enforce the parent-admin floor rule: a user who is admin/owner on
+  any ancestor project cannot be removed from, or downgraded within, a
+  sandbox descended from that project.
+  """
+  @spec parent_admin?(Project.t(), User.t()) :: boolean()
+  def parent_admin?(%Project{} = project, %User{} = user) do
+    project
+    |> ancestors()
+    |> Enum.any?(fn ancestor ->
+      Lightning.Projects.get_project_user_role(user, ancestor) in [
+        :admin,
+        :owner
+      ]
+    end)
+  end
+
+  defp ancestors(%Project{parent_id: nil}), do: []
+
+  defp ancestors(%Project{parent_id: parent_id}) do
+    case Lightning.Projects.get_project(parent_id) do
+      nil -> []
+      %Project{} = parent -> [parent | ancestors(parent)]
+    end
+  end
+
+  @doc """
   Deletes a sandbox and all its descendant projects.
 
   **Warning**: This permanently removes the sandbox and any nested sandboxes

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -232,10 +232,8 @@ defmodule Lightning.Projects.Sandboxes do
   defp ancestors(%Project{parent_id: nil}), do: []
 
   defp ancestors(%Project{parent_id: parent_id}) do
-    case Lightning.Projects.get_project(parent_id) do
-      nil -> []
-      %Project{} = parent -> [parent | ancestors(parent)]
-    end
+    parent = Lightning.Projects.get_project!(parent_id)
+    [parent | ancestors(parent)]
   end
 
   @doc """

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -215,6 +215,35 @@ defmodule Lightning.Projects.Sandboxes do
   end
 
   @doc """
+  Returns `true` when `user` has an `:admin` or `:owner` role on any ancestor
+  of `project`, walking the parent chain.
+
+  Used to enforce the parent-admin floor rule: a user who is admin/owner on
+  any ancestor project cannot be removed from, or downgraded within, a
+  sandbox descended from that project.
+  """
+  @spec parent_admin?(Project.t(), User.t()) :: boolean()
+  def parent_admin?(%Project{} = project, %User{} = user) do
+    project
+    |> ancestors()
+    |> Enum.any?(fn ancestor ->
+      Lightning.Projects.get_project_user_role(user, ancestor) in [
+        :admin,
+        :owner
+      ]
+    end)
+  end
+
+  defp ancestors(%Project{parent_id: nil}), do: []
+
+  defp ancestors(%Project{parent_id: parent_id}) do
+    case Lightning.Projects.get_project(parent_id) do
+      nil -> []
+      %Project{} = parent -> [parent | ancestors(parent)]
+    end
+  end
+
+  @doc """
   Deletes a sandbox and all its descendant projects.
 
   **Warning**: This permanently removes the sandbox and any nested sandboxes

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -232,8 +232,10 @@ defmodule Lightning.Projects.Sandboxes do
   defp ancestors(%Project{parent_id: nil}), do: []
 
   defp ancestors(%Project{parent_id: parent_id}) do
-    parent = Lightning.Projects.get_project!(parent_id)
-    [parent | ancestors(parent)]
+    case Lightning.Projects.get_project(parent_id) do
+      nil -> []
+      %Project{} = parent -> [parent | ancestors(parent)]
+    end
   end
 
   @doc """

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -388,7 +388,7 @@ defmodule LightningWeb.LayoutComponents do
 
   attr :title, :string, required: true
   attr :subtitle, :string, required: true
-  attr :permissions_message, :string, required: true
+  attr :permissions_message, :string, default: nil
   attr :can_perform_action, :boolean, default: true
   attr :action_button_text, :string, default: nil
   attr :action_button_click, :any, default: nil
@@ -409,7 +409,7 @@ defmodule LightningWeb.LayoutComponents do
         <small class="block my-1 text-xs text-gray-600">
           {@subtitle}
         </small>
-        <%= if !@can_perform_action do %>
+        <%= if !@can_perform_action and @permissions_message do %>
           <.permissions_message section={@permissions_message} />
         <% end %>
       </div>

--- a/lib/lightning_web/components/sandbox_settings_banner.ex
+++ b/lib/lightning_web/components/sandbox_settings_banner.ex
@@ -1,0 +1,71 @@
+defmodule LightningWeb.Components.SandboxSettingsBanner do
+  @moduledoc """
+  Banner shown at the top of a Project Settings tab when the project is a
+  sandbox, communicating how changes on that tab will (or will not) flow
+  to the parent project on merge.
+
+  Three variants:
+
+    * `:local` — changes apply only to this sandbox and do not sync on merge
+    * `:editable` — changes will sync to the parent on merge
+    * `:inherited` — settings are read-only, managed in the parent project
+
+  ## Examples
+
+      <.sandbox_settings_banner variant={:local} />
+
+      <.sandbox_settings_banner
+        variant={:inherited}
+        parent_project={@parent_project}
+      />
+  """
+  use LightningWeb, :component
+
+  alias LightningWeb.Components.Common
+
+  attr :variant, :atom, required: true, values: [:local, :editable, :inherited]
+  attr :id, :string, required: true
+  attr :parent_project, :map, default: nil
+
+  def sandbox_settings_banner(%{variant: :local} = assigns) do
+    ~H"""
+    <Common.alert id={@id} type="info" class="border border-blue-200">
+      <:message>
+        Changes you make here only apply to this sandbox and do not sync to the parent project on merge.
+      </:message>
+    </Common.alert>
+    """
+  end
+
+  def sandbox_settings_banner(%{variant: :editable} = assigns) do
+    ~H"""
+    <Common.alert id={@id} type="success" class="border border-green-200">
+      <:message>
+        Changes you make here will sync to the parent project on merge.
+      </:message>
+    </Common.alert>
+    """
+  end
+
+  def sandbox_settings_banner(%{variant: :inherited} = assigns) do
+    ~H"""
+    <Common.alert id={@id} type="warning" class="border border-yellow-200">
+      <:message>
+        These settings are inherited from the parent project
+        <.parent_link :if={@parent_project} project={@parent_project} />and cannot be changed here.
+      </:message>
+    </Common.alert>
+    """
+  end
+
+  attr :project, :map, required: true
+
+  defp parent_link(assigns) do
+    ~H"""
+    (<.link
+      navigate={~p"/projects/#{@project.id}/settings"}
+      class="font-medium underline"
+    >{@project.name}</.link>)
+    """
+  end
+end

--- a/lib/lightning_web/components/sandbox_settings_banner.ex
+++ b/lib/lightning_web/components/sandbox_settings_banner.ex
@@ -1,0 +1,71 @@
+defmodule LightningWeb.Components.SandboxSettingsBanner do
+  @moduledoc """
+  Banner shown at the top of a Project Settings tab when the project is a
+  sandbox, communicating how changes on that tab will (or will not) flow
+  to the parent project on merge.
+
+  Three variants:
+
+    * `:local` — changes apply only to this sandbox and do not sync on merge
+    * `:editable` — changes will sync to the parent on merge
+    * `:inherited` — settings are read-only, managed in the parent project
+
+  ## Examples
+
+      <.sandbox_settings_banner variant={:local} />
+
+      <.sandbox_settings_banner
+        variant={:inherited}
+        parent_project={@parent_project}
+      />
+  """
+  use LightningWeb, :component
+
+  alias LightningWeb.Components.Common
+
+  attr :variant, :atom, required: true, values: [:local, :editable, :inherited]
+  attr :id, :string, required: true
+  attr :parent_project, :map, default: nil
+
+  def sandbox_settings_banner(%{variant: :local} = assigns) do
+    ~H"""
+    <Common.alert id={@id} type="info">
+      <:message>
+        Changes you make here only apply to this sandbox and won't sync to the parent project on merge.
+      </:message>
+    </Common.alert>
+    """
+  end
+
+  def sandbox_settings_banner(%{variant: :editable} = assigns) do
+    ~H"""
+    <Common.alert id={@id} type="success">
+      <:message>
+        Changes you make here will sync to the parent project on merge.
+      </:message>
+    </Common.alert>
+    """
+  end
+
+  def sandbox_settings_banner(%{variant: :inherited} = assigns) do
+    ~H"""
+    <Common.alert id={@id} type="warning">
+      <:message>
+        These settings are inherited from the parent project
+        <.parent_link :if={@parent_project} project={@parent_project} />and can't be changed here.
+      </:message>
+    </Common.alert>
+    """
+  end
+
+  attr :project, :map, required: true
+
+  defp parent_link(assigns) do
+    ~H"""
+    (<.link
+      navigate={~p"/projects/#{@project.id}/settings"}
+      class="font-medium underline"
+    >{@project.name}</.link>)
+    """
+  end
+end

--- a/lib/lightning_web/components/sandbox_settings_banner.ex
+++ b/lib/lightning_web/components/sandbox_settings_banner.ex
@@ -29,7 +29,7 @@ defmodule LightningWeb.Components.SandboxSettingsBanner do
 
   def sandbox_settings_banner(%{variant: :local} = assigns) do
     ~H"""
-    <Common.alert id={@id} type="info" class="border border-blue-200">
+    <Common.alert id={@id} type="info" class="border border-blue-300">
       <:message>
         Changes you make here only apply to this sandbox and do not sync to the parent project on merge.
       </:message>
@@ -39,7 +39,7 @@ defmodule LightningWeb.Components.SandboxSettingsBanner do
 
   def sandbox_settings_banner(%{variant: :editable} = assigns) do
     ~H"""
-    <Common.alert id={@id} type="success" class="border border-green-200">
+    <Common.alert id={@id} type="success" class="border border-green-400">
       <:message>
         Changes you make here will sync to the parent project on merge.
       </:message>
@@ -49,7 +49,7 @@ defmodule LightningWeb.Components.SandboxSettingsBanner do
 
   def sandbox_settings_banner(%{variant: :inherited} = assigns) do
     ~H"""
-    <Common.alert id={@id} type="warning" class="border border-yellow-200">
+    <Common.alert id={@id} type="warning" class="border border-yellow-300">
       <:message>
         These settings are inherited from the parent project
         <.parent_link :if={@parent_project} project={@parent_project} />and cannot be changed here.

--- a/lib/lightning_web/live/project_live/collections_component.ex
+++ b/lib/lightning_web/live/project_live/collections_component.ex
@@ -3,6 +3,7 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
 
   use LightningWeb, :live_component
 
+  import LightningWeb.Components.SandboxSettingsBanner
   import LightningWeb.LayoutComponents
 
   alias Lightning.Collections
@@ -30,9 +31,9 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
           collections: _,
           return_to: _,
           project: _,
+          sandbox?: _,
           current_user: _
-        } =
-          assigns,
+        } = assigns,
         socket
       ) do
     {:ok,
@@ -266,6 +267,11 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
         action_button_target={@myself}
         action_button_disabled={!@can_create_collection}
         action_button_id="open-create-collection-modal-button"
+      />
+      <.sandbox_settings_banner
+        :if={@sandbox?}
+        id="sandbox-banner-collections"
+        variant={:editable}
       />
 
       <.form_modal_component

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -6,6 +6,7 @@ defmodule LightningWeb.ProjectLive.Settings do
 
   import LightningWeb.LayoutComponents
 
+  alias Lightning.Accounts.User
   alias Lightning.Collections
   alias Lightning.Credentials
   alias Lightning.Helpers
@@ -17,6 +18,8 @@ defmodule LightningWeb.ProjectLive.Settings do
   alias Lightning.VersionControl
   alias Lightning.WebhookAuthMethods
   alias LightningWeb.Components.GithubComponents
+
+  import LightningWeb.Components.SandboxSettingsBanner
 
   require Logger
 
@@ -33,6 +36,10 @@ defmodule LightningWeb.ProjectLive.Settings do
     if connected?(socket) do
       VersionControl.subscribe(current_user)
     end
+
+    project = Lightning.Repo.preload(project, :parent)
+    sandbox? = Project.sandbox?(project)
+    parent_project = if sandbox?, do: project.parent
 
     project_user = Projects.get_project_user(project, current_user)
 
@@ -126,6 +133,8 @@ defmodule LightningWeb.ProjectLive.Settings do
        current_user: socket.assigns.current_user,
        github_enabled: VersionControl.github_enabled?(),
        name: project.name,
+       parent_project: parent_project,
+       project: project,
        project_changeset:
          Project.form_changeset(project, %{raw_name: project.name}),
        project_files: project_files,
@@ -133,6 +142,7 @@ defmodule LightningWeb.ProjectLive.Settings do
        project_user: project_user,
        project_users: [],
        projects: projects,
+       sandbox?: sandbox?,
        selected_credential_type: nil,
        show_collaborators_modal: false,
        show_invite_collaborators_modal: false,
@@ -463,7 +473,9 @@ defmodule LightningWeb.ProjectLive.Settings do
     if user_removable?(
          project_user,
          assigns.current_user,
-         assigns.can_remove_project_user
+         assigns.can_remove_project_user,
+         assigns.project,
+         assigns.sandbox?
        ) do
       Projects.delete_project_user!(project_user)
 
@@ -637,7 +649,13 @@ defmodule LightningWeb.ProjectLive.Settings do
     """
   end
 
-  defp remove_user_tooltip(project_user, current_user, can_remove_project_user) do
+  defp remove_user_tooltip(
+         project_user,
+         current_user,
+         can_remove_project_user,
+         project,
+         sandbox?
+       ) do
     cond do
       !can_remove_project_user ->
         "You do not have permission to remove a user"
@@ -648,14 +666,34 @@ defmodule LightningWeb.ProjectLive.Settings do
       project_user.role == :owner ->
         "You cannot remove an owner"
 
+      sandbox? and parent_admin?(project, project_user) ->
+        "Cannot remove a user who is admin or owner on the parent project"
+
       true ->
         ""
     end
   end
 
-  defp user_removable?(project_user, current_user, can_remove_project_user) do
+  defp user_removable?(
+         project_user,
+         current_user,
+         can_remove_project_user,
+         project,
+         sandbox?
+       ) do
     can_remove_project_user and project_user.role != :owner and
-      project_user.user_id != current_user.id
+      project_user.user_id != current_user.id and
+      not (sandbox? and parent_admin?(project, project_user))
+  end
+
+  defp parent_admin?(project, %{user: %User{} = user}),
+    do: Lightning.Projects.Sandboxes.parent_admin?(project, user)
+
+  defp parent_admin?(project, %{user_id: user_id}) do
+    case Lightning.Accounts.get_user(user_id) do
+      %User{} = user -> Lightning.Projects.Sandboxes.parent_admin?(project, user)
+      nil -> false
+    end
   end
 
   defp user_has_valid_oauth_token(user) do

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -4,8 +4,10 @@ defmodule LightningWeb.ProjectLive.Settings do
   """
   use LightningWeb, :live_view
 
+  import LightningWeb.Components.SandboxSettingsBanner
   import LightningWeb.LayoutComponents
 
+  alias Lightning.Accounts.User
   alias Lightning.Collections
   alias Lightning.Credentials
   alias Lightning.Helpers
@@ -14,6 +16,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   alias Lightning.Projects.Project
   alias Lightning.Projects.ProjectLimiter
   alias Lightning.Projects.ProjectUser
+  alias Lightning.Projects.Sandboxes
   alias Lightning.VersionControl
   alias Lightning.WebhookAuthMethods
   alias LightningWeb.Components.GithubComponents
@@ -33,6 +36,11 @@ defmodule LightningWeb.ProjectLive.Settings do
     if connected?(socket) do
       VersionControl.subscribe(current_user)
     end
+
+    project = Lightning.Repo.preload(project, :parent)
+    sandbox? = Project.sandbox?(project)
+    parent_project = if sandbox?, do: project.parent
+    root_project = if sandbox?, do: Projects.root_of(project)
 
     project_user = Projects.get_project_user(project, current_user)
 
@@ -126,6 +134,9 @@ defmodule LightningWeb.ProjectLive.Settings do
        current_user: socket.assigns.current_user,
        github_enabled: VersionControl.github_enabled?(),
        name: project.name,
+       parent_project: parent_project,
+       root_project: root_project,
+       project: project,
        project_changeset:
          Project.form_changeset(project, %{raw_name: project.name}),
        project_files: project_files,
@@ -133,6 +144,7 @@ defmodule LightningWeb.ProjectLive.Settings do
        project_user: project_user,
        project_users: [],
        projects: projects,
+       sandbox?: sandbox?,
        selected_credential_type: nil,
        show_collaborators_modal: false,
        show_invite_collaborators_modal: false,
@@ -179,13 +191,39 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   defp apply_action(socket, :delete, %{"project_id" => id}) do
-    if socket.assigns.can_delete_project do
-      socket |> assign(:page_title, "Project settings")
-    else
-      socket
-      |> put_flash(:error, "You are not authorize to perform this action")
-      |> push_patch(to: ~p"/projects/#{id}/settings")
+    cond do
+      not socket.assigns.can_delete_project ->
+        socket
+        |> put_flash(:error, "You are not authorize to perform this action")
+        |> push_patch(to: ~p"/projects/#{id}/settings")
+
+      socket.assigns.sandbox? ->
+        socket
+        |> assign(:page_title, "Project settings")
+        |> assign(
+          :confirm_delete_changeset,
+          sandbox_confirm_changeset(socket.assigns.project)
+        )
+        |> assign(:confirm_delete_input, "")
+
+      true ->
+        assign(socket, :page_title, "Project settings")
     end
+  end
+
+  defp sandbox_confirm_changeset(sandbox, params \\ %{}) do
+    types = %{name: :string}
+
+    {%{name: ""}, types}
+    |> Ecto.Changeset.cast(params, Map.keys(types))
+    |> Ecto.Changeset.validate_required([:name])
+    |> Ecto.Changeset.validate_change(:name, fn :name, value ->
+      if value == sandbox.name do
+        []
+      else
+        [name: "does not match the sandbox name"]
+      end
+    end)
   end
 
   @impl true
@@ -338,6 +376,75 @@ defmodule LightningWeb.ProjectLive.Settings do
     |> noreply()
   end
 
+  def handle_event("close-delete-modal", _params, socket) do
+    socket
+    |> push_navigate(to: ~p"/projects/#{socket.assigns.project.id}/settings")
+    |> noreply()
+  end
+
+  def handle_event("confirm-delete-validate", params, socket) do
+    confirm_params = params["confirm"] || %{}
+
+    changeset =
+      sandbox_confirm_changeset(socket.assigns.project, confirm_params)
+      |> Map.put(:action, :validate)
+
+    socket
+    |> assign(:confirm_delete_changeset, changeset)
+    |> assign(:confirm_delete_input, String.trim(confirm_params["name"] || ""))
+    |> noreply()
+  end
+
+  def handle_event("confirm-delete", params, socket) do
+    confirm_params = params["confirm"] || %{}
+
+    changeset =
+      sandbox_confirm_changeset(socket.assigns.project, confirm_params)
+      |> Map.put(:action, :validate)
+
+    if changeset.valid? do
+      case Lightning.Projects.Sandboxes.delete_sandbox(
+             socket.assigns.project,
+             socket.assigns.current_user
+           ) do
+        {:ok, deleted} ->
+          socket
+          |> put_flash(
+            :info,
+            "Sandbox #{deleted.name} and all its associated descendants deleted"
+          )
+          |> push_navigate(to: ~p"/projects/#{socket.assigns.root_project.id}/w")
+          |> noreply()
+
+        {:error, :unauthorized} ->
+          socket
+          |> put_flash(
+            :error,
+            "You don't have permission to delete this sandbox"
+          )
+          |> push_navigate(
+            to: ~p"/projects/#{socket.assigns.project.id}/settings"
+          )
+          |> noreply()
+
+        {:error, _reason} ->
+          socket
+          |> put_flash(
+            :error,
+            "Could not delete sandbox. Please try again later."
+          )
+          |> push_navigate(
+            to: ~p"/projects/#{socket.assigns.project.id}/settings"
+          )
+          |> noreply()
+      end
+    else
+      socket
+      |> assign(:confirm_delete_changeset, changeset)
+      |> noreply()
+    end
+  end
+
   def handle_event(
         "show_modal",
         %{"target" => "new_webhook_auth_method"},
@@ -458,12 +565,14 @@ defmodule LightningWeb.ProjectLive.Settings do
         %{"project_user_id" => project_user_id},
         %{assigns: assigns} = socket
       ) do
-    project_user = Projects.get_project_user!(project_user_id)
+    project_user = Projects.get_project_user!(project_user_id, include: :user)
 
     if user_removable?(
          project_user,
          assigns.current_user,
-         assigns.can_remove_project_user
+         assigns.can_remove_project_user,
+         assigns.project,
+         assigns.sandbox?
        ) do
       Projects.delete_project_user!(project_user)
 
@@ -637,7 +746,13 @@ defmodule LightningWeb.ProjectLive.Settings do
     """
   end
 
-  defp remove_user_tooltip(project_user, current_user, can_remove_project_user) do
+  defp remove_user_tooltip(
+         project_user,
+         current_user,
+         can_remove_project_user,
+         project,
+         sandbox?
+       ) do
     cond do
       !can_remove_project_user ->
         "You do not have permission to remove a user"
@@ -648,15 +763,28 @@ defmodule LightningWeb.ProjectLive.Settings do
       project_user.role == :owner ->
         "You cannot remove an owner"
 
+      sandbox? and parent_admin?(project, project_user) ->
+        "Cannot remove a user who is admin or owner on the parent project"
+
       true ->
         ""
     end
   end
 
-  defp user_removable?(project_user, current_user, can_remove_project_user) do
+  defp user_removable?(
+         project_user,
+         current_user,
+         can_remove_project_user,
+         project,
+         sandbox?
+       ) do
     can_remove_project_user and project_user.role != :owner and
-      project_user.user_id != current_user.id
+      project_user.user_id != current_user.id and
+      not (sandbox? and parent_admin?(project, project_user))
   end
+
+  defp parent_admin?(project, %{user: %User{} = user}),
+    do: Sandboxes.parent_admin?(project, user)
 
   defp user_has_valid_oauth_token(user) do
     VersionControl.oauth_token_valid?(user.github_oauth_token)

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -17,6 +17,7 @@ defmodule LightningWeb.ProjectLive.Settings do
   alias Lightning.Projects.ProjectLimiter
   alias Lightning.Projects.ProjectUser
   alias Lightning.Projects.Sandboxes
+  alias Lightning.Repo
   alias Lightning.VersionControl
   alias Lightning.WebhookAuthMethods
   alias LightningWeb.Components.GithubComponents
@@ -468,7 +469,8 @@ defmodule LightningWeb.ProjectLive.Settings do
         %{"project_user_id" => project_user_id},
         %{assigns: assigns} = socket
       ) do
-    project_user = Projects.get_project_user!(project_user_id)
+    project_user =
+      Projects.get_project_user!(project_user_id) |> Repo.preload(:user)
 
     if user_removable?(
          project_user,

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -7,7 +7,6 @@ defmodule LightningWeb.ProjectLive.Settings do
   import LightningWeb.Components.SandboxSettingsBanner
   import LightningWeb.LayoutComponents
 
-  alias Lightning.Accounts
   alias Lightning.Accounts.User
   alias Lightning.Collections
   alias Lightning.Credentials
@@ -689,13 +688,6 @@ defmodule LightningWeb.ProjectLive.Settings do
 
   defp parent_admin?(project, %{user: %User{} = user}),
     do: Sandboxes.parent_admin?(project, user)
-
-  defp parent_admin?(project, %{user_id: user_id}) do
-    case Accounts.get_user(user_id) do
-      %User{} = user -> Sandboxes.parent_admin?(project, user)
-      nil -> false
-    end
-  end
 
   defp user_has_valid_oauth_token(user) do
     VersionControl.oauth_token_valid?(user.github_oauth_token)

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -4,8 +4,10 @@ defmodule LightningWeb.ProjectLive.Settings do
   """
   use LightningWeb, :live_view
 
+  import LightningWeb.Components.SandboxSettingsBanner
   import LightningWeb.LayoutComponents
 
+  alias Lightning.Accounts
   alias Lightning.Accounts.User
   alias Lightning.Collections
   alias Lightning.Credentials
@@ -15,11 +17,10 @@ defmodule LightningWeb.ProjectLive.Settings do
   alias Lightning.Projects.Project
   alias Lightning.Projects.ProjectLimiter
   alias Lightning.Projects.ProjectUser
+  alias Lightning.Projects.Sandboxes
   alias Lightning.VersionControl
   alias Lightning.WebhookAuthMethods
   alias LightningWeb.Components.GithubComponents
-
-  import LightningWeb.Components.SandboxSettingsBanner
 
   require Logger
 
@@ -687,11 +688,11 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   defp parent_admin?(project, %{user: %User{} = user}),
-    do: Lightning.Projects.Sandboxes.parent_admin?(project, user)
+    do: Sandboxes.parent_admin?(project, user)
 
   defp parent_admin?(project, %{user_id: user_id}) do
-    case Lightning.Accounts.get_user(user_id) do
-      %User{} = user -> Lightning.Projects.Sandboxes.parent_admin?(project, user)
+    case Accounts.get_user(user_id) do
+      %User{} = user -> Sandboxes.parent_admin?(project, user)
       nil -> false
     end
   end

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -17,7 +17,6 @@ defmodule LightningWeb.ProjectLive.Settings do
   alias Lightning.Projects.ProjectLimiter
   alias Lightning.Projects.ProjectUser
   alias Lightning.Projects.Sandboxes
-  alias Lightning.Repo
   alias Lightning.VersionControl
   alias Lightning.WebhookAuthMethods
   alias LightningWeb.Components.GithubComponents
@@ -469,8 +468,7 @@ defmodule LightningWeb.ProjectLive.Settings do
         %{"project_user_id" => project_user_id},
         %{assigns: assigns} = socket
       ) do
-    project_user =
-      Projects.get_project_user!(project_user_id) |> Repo.preload(:user)
+    project_user = Projects.get_project_user!(project_user_id, include: :user)
 
     if user_removable?(
          project_user,

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -62,9 +62,20 @@
         <span class="inline-block align-middle">History Exports</span>
       </:tab>
       <:panel hash="project" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-project"
+          variant={:local}
+        />
         <.section_header
-          title="Project setup"
-          subtitle="Projects are isolated workspaces that contain workflows, accessible to certain users."
+          title={if @sandbox?, do: "Sandbox setup", else: "Project setup"}
+          subtitle={
+            if @sandbox?,
+              do:
+                "Sandboxes are isolated copies of a project for safe experimentation.",
+              else:
+                "Projects are isolated workspaces that contain workflows, accessible to certain users."
+          }
           permissions_message="basic settings, but you can export a copy."
           can_perform_action={@can_edit_project}
         />
@@ -72,10 +83,22 @@
           <div class="bg-white p-4 rounded-md space-y-4">
             <div>
               <h6 class="font-medium text-black">
-                Project Identity
+                {if @sandbox?, do: "Sandbox Identity", else: "Project Identity"}
               </h6>
               <small class="block my-1 text-xs text-gray-600">
-                This metadata helps you identify the types of workflows managed in this project and the people that have access.
+                <%= if @sandbox? do %>
+                  Identifies this sandbox within the parent project.
+                  <span :if={@parent_project}>
+                    Parent project: <.link
+                      navigate={~p"/projects/#{@parent_project.id}/settings"}
+                      class="font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {@parent_project.name}
+                    </.link>.
+                  </span>
+                <% else %>
+                  This metadata helps you identify the types of workflows managed in this project and the people that have access.
+                <% end %>
               </small>
             </div>
             <.form
@@ -233,7 +256,7 @@
               Export project
             </.button_link>
           </div>
-          <%= if @can_delete_project do %>
+          <%= if @can_delete_project and not @sandbox? do %>
             <div class="bg-white p-4 rounded-md space-y-4">
               <div>
                 <h6 class="font-medium text-black">The danger zone</h6>
@@ -268,6 +291,11 @@
         </div>
       </:panel>
       <:panel hash="credentials" class="space-y-4 block">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-credentials"
+          variant={:editable}
+        />
         <.section_header
           title="Project credentials"
           subtitle="Manage OAuth 2.0 Clients and Credentials accessible to this project."
@@ -315,6 +343,11 @@
         />
       </:panel>
       <:panel hash="collections" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-collections"
+          variant={:editable}
+        />
         <.live_component
           module={LightningWeb.ProjectLive.CollectionsComponent}
           id="collections"
@@ -325,171 +358,198 @@
         />
       </:panel>
       <:panel hash="webhook_security" class="space-y-4">
-        <.section_header
-          title="Webhook security"
-          subtitle="Webhook authentication methods that are used with the starting trigger in workflows."
-          permissions_message="webhook auth methods."
-          can_perform_action={@can_write_webhook_auth_method}
-          action_button_text="New auth method"
-          action_button_click={
-            JS.push("show_modal", value: %{target: "new_webhook_auth_method"})
-          }
-          action_button_disabled={!@can_write_webhook_auth_method}
-          action_button_id="add_new_auth_method"
-        />
-        <.modal
-          :if={
-            @active_modal in [
-              :new_webhook_auth_method,
-              :edit_webhook_auth_method
-            ]
-          }
-          id="webhook_auth_method_modal"
-          width="min-w-1/3 max-w-xl"
-          on_close={JS.push("close_active_modal")}
-          show={true}
-        >
-          <.live_component
-            :if={@active_modal == :new_webhook_auth_method}
-            module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
-            id="new_auth_method"
-            action={:new}
-            current_user={@current_user}
-            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-            trigger={nil}
-            on_close={JS.push("close_active_modal")}
-            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+        <%= if @sandbox? do %>
+          <.section_header
+            title="Webhook security"
+            subtitle="Webhook authentication methods that are used with the starting trigger in workflows."
+            permissions_message="webhook auth methods."
+            can_perform_action={false}
           />
-          <.live_component
-            :if={@active_modal == :edit_webhook_auth_method}
-            module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
-            id={"edit_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
-            action={:edit}
-            current_user={@current_user}
-            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-            trigger={nil}
-            on_close={JS.push("close_active_modal")}
-            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+          <div class="bg-white p-4 rounded-md">
+            <p class="text-sm text-gray-700">
+              Webhook security is not available in sandboxes for now. Manage these methods in the parent project <.link
+                :if={@parent_project}
+                navigate={
+                  ~p"/projects/#{@parent_project.id}/settings#webhook_security"
+                }
+                class="font-medium text-indigo-600 hover:text-indigo-900"
+              >
+                ({@parent_project.name})
+              </.link>.
+            </p>
+          </div>
+        <% else %>
+          <.section_header
+            title="Webhook security"
+            subtitle="Webhook authentication methods that are used with the starting trigger in workflows."
+            permissions_message="webhook auth methods."
+            can_perform_action={@can_write_webhook_auth_method}
+            action_button_text="New auth method"
+            action_button_click={
+              JS.push("show_modal", value: %{target: "new_webhook_auth_method"})
+            }
+            action_button_disabled={!@can_write_webhook_auth_method}
+            action_button_id="add_new_auth_method"
           />
-        </.modal>
-        <.live_component
-          :if={@active_modal == :delete_webhook_auth_method}
-          module={LightningWeb.WorkflowLive.WebhookAuthMethodDeleteModal}
-          id={"delete_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
-          current_user={@current_user}
-          webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-          on_close={JS.push("close_active_modal")}
-          return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
-        />
-        <LightningWeb.WorkflowLive.Components.linked_triggers_for_webhook_auth_method_modal
-          :if={@active_modal == :linked_triggers_for_webhook_auth_method}
-          id={"linked_triggers_for_#{@active_modal_assigns.webhook_auth_method.id}_modal"}
-          webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-          on_close={JS.push("close_active_modal")}
-        />
-        <LightningWeb.WorkflowLive.Components.webhook_auth_methods_table
-          auth_methods={@webhook_auth_methods}
-          current_user={@current_user}
-          return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
-          class="p-2"
-        >
-          <:empty_state>
-            <.empty_state
-              icon="hero-plus-circle"
-              message="No auth methods found."
-              button_text="Create a new auth method"
-              button_id="open-create-auth-method-modal"
-              button_click={
-                JS.push("show_modal",
-                  value: %{target: "new_webhook_auth_method"}
-                )
-              }
-              button_disabled={!@can_write_webhook_auth_method}
+          <.modal
+            :if={
+              @active_modal in [
+                :new_webhook_auth_method,
+                :edit_webhook_auth_method
+              ]
+            }
+            id="webhook_auth_method_modal"
+            width="min-w-1/3 max-w-xl"
+            on_close={JS.push("close_active_modal")}
+            show={true}
+          >
+            <.live_component
+              :if={@active_modal == :new_webhook_auth_method}
+              module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
+              id="new_auth_method"
+              action={:new}
+              current_user={@current_user}
+              webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+              trigger={nil}
+              on_close={JS.push("close_active_modal")}
+              return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
             />
-          </:empty_state>
-          <:linked_triggers :let={auth_method}>
-            <span class="relative font-normal">
-              <a
-                :if={auth_method.triggers != []}
-                id={"display_linked_triggers_link_#{auth_method.id}"}
-                href="#"
-                class="text-indigo-600 hover:text-indigo-900"
-                phx-click={
+            <.live_component
+              :if={@active_modal == :edit_webhook_auth_method}
+              module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
+              id={"edit_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
+              action={:edit}
+              current_user={@current_user}
+              webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+              trigger={nil}
+              on_close={JS.push("close_active_modal")}
+              return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+            />
+          </.modal>
+          <.live_component
+            :if={@active_modal == :delete_webhook_auth_method}
+            module={LightningWeb.WorkflowLive.WebhookAuthMethodDeleteModal}
+            id={"delete_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
+            current_user={@current_user}
+            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+            on_close={JS.push("close_active_modal")}
+            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+          />
+          <LightningWeb.WorkflowLive.Components.linked_triggers_for_webhook_auth_method_modal
+            :if={@active_modal == :linked_triggers_for_webhook_auth_method}
+            id={"linked_triggers_for_#{@active_modal_assigns.webhook_auth_method.id}_modal"}
+            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+            on_close={JS.push("close_active_modal")}
+          />
+          <LightningWeb.WorkflowLive.Components.webhook_auth_methods_table
+            auth_methods={@webhook_auth_methods}
+            current_user={@current_user}
+            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+            class="p-2"
+          >
+            <:empty_state>
+              <.empty_state
+                icon="hero-plus-circle"
+                message="No auth methods found."
+                button_text="Create a new auth method"
+                button_id="open-create-auth-method-modal"
+                button_click={
                   JS.push("show_modal",
-                    value: %{
-                      target: "linked_triggers_for_webhook_auth_method",
-                      id: auth_method.id
-                    }
+                    value: %{target: "new_webhook_auth_method"}
                   )
                 }
-              >
-                {Enum.count(auth_method.triggers)}
-              </a>
-              <span
-                :if={auth_method.triggers == []}
-                class="italic font-normal text-gray-300"
-              >
-                No associated triggers...
+                button_disabled={!@can_write_webhook_auth_method}
+              />
+            </:empty_state>
+            <:linked_triggers :let={auth_method}>
+              <span class="relative font-normal">
+                <a
+                  :if={auth_method.triggers != []}
+                  id={"display_linked_triggers_link_#{auth_method.id}"}
+                  href="#"
+                  class="text-indigo-600 hover:text-indigo-900"
+                  phx-click={
+                    JS.push("show_modal",
+                      value: %{
+                        target: "linked_triggers_for_webhook_auth_method",
+                        id: auth_method.id
+                      }
+                    )
+                  }
+                >
+                  {Enum.count(auth_method.triggers)}
+                </a>
+                <span
+                  :if={auth_method.triggers == []}
+                  class="italic font-normal text-gray-300"
+                >
+                  No associated triggers...
+                </span>
               </span>
-            </span>
-          </:linked_triggers>
-          <:action :let={auth_method}>
-            <%= if @can_write_webhook_auth_method do %>
-              <a
-                id={"edit_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action"
-                phx-click={
-                  JS.push("show_modal",
-                    value: %{
-                      target: "edit_webhook_auth_method",
-                      id: auth_method.id
-                    }
-                  )
-                }
-              >
-                View
-              </a>
-            <% else %>
-              <a
-                id={"edit_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action cursor-not-allowed"
-              >
-                Edit
-              </a>
-            <% end %>
-          </:action>
-          <:action :let={auth_method}>
-            <%= if @can_write_webhook_auth_method do %>
-              <a
-                id={"delete_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action"
-                phx-click={
-                  JS.push("show_modal",
-                    value: %{
-                      target: "delete_webhook_auth_method",
-                      id: auth_method.id
-                    }
-                  )
-                }
-              >
-                Delete
-              </a>
-            <% else %>
-              <a
-                id={"delete_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action cursor-not-allowed"
-              >
-                Delete
-              </a>
-            <% end %>
-          </:action>
-        </LightningWeb.WorkflowLive.Components.webhook_auth_methods_table>
+            </:linked_triggers>
+            <:action :let={auth_method}>
+              <%= if @can_write_webhook_auth_method do %>
+                <a
+                  id={"edit_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action"
+                  phx-click={
+                    JS.push("show_modal",
+                      value: %{
+                        target: "edit_webhook_auth_method",
+                        id: auth_method.id
+                      }
+                    )
+                  }
+                >
+                  View
+                </a>
+              <% else %>
+                <a
+                  id={"edit_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action cursor-not-allowed"
+                >
+                  Edit
+                </a>
+              <% end %>
+            </:action>
+            <:action :let={auth_method}>
+              <%= if @can_write_webhook_auth_method do %>
+                <a
+                  id={"delete_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action"
+                  phx-click={
+                    JS.push("show_modal",
+                      value: %{
+                        target: "delete_webhook_auth_method",
+                        id: auth_method.id
+                      }
+                    )
+                  }
+                >
+                  Delete
+                </a>
+              <% else %>
+                <a
+                  id={"delete_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action cursor-not-allowed"
+                >
+                  Delete
+                </a>
+              <% end %>
+            </:action>
+          </LightningWeb.WorkflowLive.Components.webhook_auth_methods_table>
+        <% end %>
       </:panel>
       <:panel hash="collaboration" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-collaboration"
+          variant={:local}
+        />
         <.section_header
           title="Project collaboration"
           subtitle="View collaborators and manage alert settings for this project."
@@ -547,14 +607,18 @@
                   remove_user_tooltip(
                     project_user,
                     @current_user,
-                    @can_remove_project_user
+                    @can_remove_project_user,
+                    @project,
+                    @sandbox?
                   )
                 }
                 disabled={
                   !user_removable?(
                     project_user,
                     @current_user,
-                    @can_remove_project_user
+                    @can_remove_project_user,
+                    @project,
+                    @sandbox?
                   )
                 }
               >
@@ -580,7 +644,9 @@
               user_removable?(
                 project_user,
                 @current_user,
-                @can_remove_project_user
+                @can_remove_project_user,
+                @project,
+                @sandbox?
               )
             }
             id={"remove_#{project_user.id}_modal"}
@@ -589,11 +655,17 @@
         <% end %>
       </:panel>
       <:panel hash="security" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-security"
+          variant={:inherited}
+          parent_project={@parent_project}
+        />
         <.section_header
           title="Project security"
           subtitle="View and manage security settings for this project."
           permissions_message="multi-factor authentication settings."
-          can_perform_action={@can_edit_project}
+          can_perform_action={@can_edit_project and not @sandbox?}
         />
         <div>
           <%= if assigns[:mfa_banner] do %>
@@ -628,10 +700,10 @@
               <button
                 id="toggle-mfa-switch"
                 type="button"
-                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !@can_edit_project, do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !@can_edit_project or @sandbox?, do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
                 role="switch"
-                disabled={!@can_require_mfa}
-                phx-click="toggle-mfa"
+                disabled={!@can_require_mfa or @sandbox?}
+                phx-click={unless @sandbox?, do: "toggle-mfa"}
                 aria-checked={@project.requires_mfa}
                 aria-labelledby="require-mfa-label"
                 aria-describedby="require-mfa-description"
@@ -658,6 +730,11 @@
         </div>
       </:panel>
       <:panel hash="vcs" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-vcs"
+          variant={:local}
+        />
         <.section_header
           title="Version control"
           subtitle="View or modify external version control settings for this project."
@@ -757,6 +834,11 @@
         </div>
       </:panel>
       <:panel hash="data-storage" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-data-storage"
+          variant={:local}
+        />
         <.section_header
           title="Data storage"
           subtitle="View or modify data storage settings for this project."
@@ -945,6 +1027,11 @@
         </div>
       </:panel>
       <:panel hash="history-exports" class="space-y-4">
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-history-exports"
+          variant={:local}
+        />
         <.section_header
           title="History exports"
           subtitle="View export status and download work order history for this project."

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -87,13 +87,14 @@
               </h6>
               <small class="block my-1 text-xs text-gray-600">
                 <%= if @sandbox? do %>
-                  Identifies this sandbox within its parent: <.link
+                  Identifies this sandbox within its parent:
+                  <.link
                     :if={@parent_project}
                     navigate={~p"/projects/#{@parent_project.id}/settings"}
                     class="font-medium text-indigo-600 hover:text-indigo-900"
                   >
                     {@parent_project.name}
-                  </.link>.
+                  </.link>
                 <% else %>
                   This metadata helps you identify the types of workflows managed in this project and the people that have access.
                 <% end %>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -63,19 +63,40 @@
       </:tab>
       <:panel hash="project" class="space-y-4">
         <.section_header
-          title="Project setup"
-          subtitle="Projects are isolated workspaces that contain workflows, accessible to certain users."
+          title={if @sandbox?, do: "Sandbox setup", else: "Project setup"}
+          subtitle={
+            if @sandbox?,
+              do:
+                "Sandboxes are isolated copies of a project for safe experimentation.",
+              else:
+                "Projects are isolated workspaces that contain workflows, accessible to certain users."
+          }
           permissions_message="basic settings, but you can export a copy."
           can_perform_action={@can_edit_project}
+        />
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-project"
+          variant={:local}
         />
         <div class="space-y-4">
           <div class="bg-white p-4 rounded-md space-y-4">
             <div>
               <h6 class="font-medium text-black">
-                Project Identity
+                {if @sandbox?, do: "Sandbox Identity", else: "Project Identity"}
               </h6>
               <small class="block my-1 text-xs text-gray-600">
-                This metadata helps you identify the types of workflows managed in this project and the people that have access.
+                <%= if @sandbox? do %>
+                  Identifies this sandbox within its parent: <.link
+                    :if={@parent_project}
+                    navigate={~p"/projects/#{@parent_project.id}/settings"}
+                    class="font-medium text-indigo-600 hover:text-indigo-900"
+                  >
+                    {@parent_project.name}
+                  </.link>.
+                <% else %>
+                  This metadata helps you identify the types of workflows managed in this project and the people that have access.
+                <% end %>
               </small>
             </div>
             <.form
@@ -238,7 +259,13 @@
               <div>
                 <h6 class="font-medium text-black">The danger zone</h6>
                 <small class="block my-1 text-xs text-gray-600">
-                  Deleting your project is irreversible
+                  <%= if @sandbox? do %>
+                    Deleting this sandbox is irreversible. It removes every
+                    workflow, trigger, version, keychain clone, and dataclip
+                    that lives only inside it.
+                  <% else %>
+                    Deleting your project is irreversible
+                  <% end %>
                 </small>
               </div>
               <.button_link
@@ -251,12 +278,20 @@
                   )
                 }
               >
-                Delete project
+                {if @sandbox?, do: "Delete sandbox", else: "Delete project"}
               </.button_link>
             </div>
           <% end %>
 
-          <%= if @live_action == :delete and @can_delete_project do %>
+          <%= if @live_action == :delete and @can_delete_project and @sandbox? do %>
+            <LightningWeb.SandboxLive.Components.confirm_delete_modal
+              open?={true}
+              sandbox={Map.put(@project, :is_current, true)}
+              changeset={@confirm_delete_changeset}
+              root_project={@root_project}
+            />
+          <% end %>
+          <%= if @live_action == :delete and @can_delete_project and not @sandbox? do %>
             <.live_component
               module={LightningWeb.Components.ProjectDeletionModal}
               id={@project.id}
@@ -304,6 +339,11 @@
             </Components.Credentials.new_credential_menu_button>
           </:action_button>
         </.section_header>
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-credentials"
+          variant={:editable}
+        />
 
         <Components.Credentials.credentials_index_live_component
           current_user={@current_user}
@@ -321,174 +361,202 @@
           project={@project}
           collections={@collections}
           can_create_collection={@can_create_collection}
+          sandbox?={@sandbox?}
           current_user={@current_user}
           return_to={~p"/projects/#{@project.id}/settings#collections"}
         />
       </:panel>
       <:panel hash="webhook_security" class="space-y-4">
-        <.section_header
-          title="Webhook security"
-          subtitle="Webhook authentication methods that are used with the starting trigger in workflows."
-          permissions_message="webhook auth methods."
-          can_perform_action={@can_write_webhook_auth_method}
-          action_button_text="New auth method"
-          action_button_click={
-            JS.push("show_modal", value: %{target: "new_webhook_auth_method"})
-          }
-          action_button_disabled={!@can_write_webhook_auth_method}
-          action_button_id="add_new_auth_method"
-        />
-        <.modal
-          :if={
-            @active_modal in [
-              :new_webhook_auth_method,
-              :edit_webhook_auth_method
-            ]
-          }
-          id="webhook_auth_method_modal"
-          width="min-w-1/3 max-w-xl"
-          on_close={JS.push("close_active_modal")}
-          show={true}
-        >
-          <.live_component
-            :if={@active_modal == :new_webhook_auth_method}
-            module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
-            id="new_auth_method"
-            action={:new}
-            current_user={@current_user}
-            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-            trigger={nil}
-            on_close={JS.push("close_active_modal")}
-            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+        <%= if @sandbox? do %>
+          <.section_header
+            title="Webhook security"
+            subtitle="Webhook authentication methods that are used with the starting trigger in workflows."
           />
-          <.live_component
-            :if={@active_modal == :edit_webhook_auth_method}
-            module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
-            id={"edit_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
-            action={:edit}
-            current_user={@current_user}
-            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-            trigger={nil}
-            on_close={JS.push("close_active_modal")}
-            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
-          />
-        </.modal>
-        <.live_component
-          :if={@active_modal == :delete_webhook_auth_method}
-          module={LightningWeb.WorkflowLive.WebhookAuthMethodDeleteModal}
-          id={"delete_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
-          current_user={@current_user}
-          webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-          on_close={JS.push("close_active_modal")}
-          return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
-        />
-        <LightningWeb.WorkflowLive.Components.linked_triggers_for_webhook_auth_method_modal
-          :if={@active_modal == :linked_triggers_for_webhook_auth_method}
-          id={"linked_triggers_for_#{@active_modal_assigns.webhook_auth_method.id}_modal"}
-          webhook_auth_method={@active_modal_assigns.webhook_auth_method}
-          on_close={JS.push("close_active_modal")}
-        />
-        <LightningWeb.WorkflowLive.Components.webhook_auth_methods_table
-          auth_methods={@webhook_auth_methods}
-          current_user={@current_user}
-          return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
-          class="p-2"
-        >
-          <:empty_state>
-            <.empty_state
-              icon="hero-plus-circle"
-              message="No auth methods found."
-              button_text="Create a new auth method"
-              button_id="open-create-auth-method-modal"
-              button_click={
-                JS.push("show_modal",
-                  value: %{target: "new_webhook_auth_method"}
-                )
+          <div
+            id="webhook-security-sandbox-notice"
+            class="bg-white p-4 rounded-md"
+          >
+            <h6 class="font-medium text-black">
+              Webhook authentication is managed in the parent project
+            </h6>
+            <small class="block my-1 text-xs text-gray-600">
+              Methods are shared with this sandbox and enforced on its webhook triggers, but can only be created, edited, or deleted from the parent.
+            </small>
+            <.link
+              :if={@parent_project}
+              navigate={
+                ~p"/projects/#{@parent_project.id}/settings#webhook_security"
               }
-              button_disabled={!@can_write_webhook_auth_method}
+              class="mt-2 inline-block text-xs font-medium text-indigo-600 hover:text-indigo-900"
+            >
+              Manage them in the parent project ({@parent_project.name})
+            </.link>
+          </div>
+        <% else %>
+          <.section_header
+            title="Webhook security"
+            subtitle="Webhook authentication methods that are used with the starting trigger in workflows."
+            permissions_message="webhook auth methods."
+            can_perform_action={@can_write_webhook_auth_method}
+            action_button_text="New auth method"
+            action_button_click={
+              JS.push("show_modal", value: %{target: "new_webhook_auth_method"})
+            }
+            action_button_disabled={!@can_write_webhook_auth_method}
+            action_button_id="add_new_auth_method"
+          />
+          <.modal
+            :if={
+              @active_modal in [
+                :new_webhook_auth_method,
+                :edit_webhook_auth_method
+              ]
+            }
+            id="webhook_auth_method_modal"
+            width="min-w-1/3 max-w-xl"
+            on_close={JS.push("close_active_modal")}
+            show={true}
+          >
+            <.live_component
+              :if={@active_modal == :new_webhook_auth_method}
+              module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
+              id="new_auth_method"
+              action={:new}
+              current_user={@current_user}
+              webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+              trigger={nil}
+              on_close={JS.push("close_active_modal")}
+              return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
             />
-          </:empty_state>
-          <:linked_triggers :let={auth_method}>
-            <span class="relative font-normal">
-              <a
-                :if={auth_method.triggers != []}
-                id={"display_linked_triggers_link_#{auth_method.id}"}
-                href="#"
-                class="text-indigo-600 hover:text-indigo-900"
-                phx-click={
+            <.live_component
+              :if={@active_modal == :edit_webhook_auth_method}
+              module={LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent}
+              id={"edit_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
+              action={:edit}
+              current_user={@current_user}
+              webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+              trigger={nil}
+              on_close={JS.push("close_active_modal")}
+              return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+            />
+          </.modal>
+          <.live_component
+            :if={@active_modal == :delete_webhook_auth_method}
+            module={LightningWeb.WorkflowLive.WebhookAuthMethodDeleteModal}
+            id={"delete_auth_method_#{@active_modal_assigns.webhook_auth_method.id}"}
+            current_user={@current_user}
+            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+            on_close={JS.push("close_active_modal")}
+            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+          />
+          <LightningWeb.WorkflowLive.Components.linked_triggers_for_webhook_auth_method_modal
+            :if={@active_modal == :linked_triggers_for_webhook_auth_method}
+            id={"linked_triggers_for_#{@active_modal_assigns.webhook_auth_method.id}_modal"}
+            webhook_auth_method={@active_modal_assigns.webhook_auth_method}
+            on_close={JS.push("close_active_modal")}
+          />
+          <LightningWeb.WorkflowLive.Components.webhook_auth_methods_table
+            auth_methods={@webhook_auth_methods}
+            current_user={@current_user}
+            return_to={~p"/projects/#{@project.id}/settings#webhook_security"}
+            class="p-2"
+          >
+            <:empty_state>
+              <.empty_state
+                icon="hero-plus-circle"
+                message="No auth methods found."
+                button_text="Create a new auth method"
+                button_id="open-create-auth-method-modal"
+                button_click={
                   JS.push("show_modal",
-                    value: %{
-                      target: "linked_triggers_for_webhook_auth_method",
-                      id: auth_method.id
-                    }
+                    value: %{target: "new_webhook_auth_method"}
                   )
                 }
-              >
-                {Enum.count(auth_method.triggers)}
-              </a>
-              <span
-                :if={auth_method.triggers == []}
-                class="italic font-normal text-gray-300"
-              >
-                No associated triggers...
+                button_disabled={!@can_write_webhook_auth_method}
+              />
+            </:empty_state>
+            <:linked_triggers :let={auth_method}>
+              <span class="relative font-normal">
+                <a
+                  :if={auth_method.triggers != []}
+                  id={"display_linked_triggers_link_#{auth_method.id}"}
+                  href="#"
+                  class="text-indigo-600 hover:text-indigo-900"
+                  phx-click={
+                    JS.push("show_modal",
+                      value: %{
+                        target: "linked_triggers_for_webhook_auth_method",
+                        id: auth_method.id
+                      }
+                    )
+                  }
+                >
+                  {Enum.count(auth_method.triggers)}
+                </a>
+                <span
+                  :if={auth_method.triggers == []}
+                  class="italic font-normal text-gray-300"
+                >
+                  No associated triggers...
+                </span>
               </span>
-            </span>
-          </:linked_triggers>
-          <:action :let={auth_method}>
-            <%= if @can_write_webhook_auth_method do %>
-              <a
-                id={"edit_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action"
-                phx-click={
-                  JS.push("show_modal",
-                    value: %{
-                      target: "edit_webhook_auth_method",
-                      id: auth_method.id
-                    }
-                  )
-                }
-              >
-                View
-              </a>
-            <% else %>
-              <a
-                id={"edit_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action cursor-not-allowed"
-              >
-                Edit
-              </a>
-            <% end %>
-          </:action>
-          <:action :let={auth_method}>
-            <%= if @can_write_webhook_auth_method do %>
-              <a
-                id={"delete_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action"
-                phx-click={
-                  JS.push("show_modal",
-                    value: %{
-                      target: "delete_webhook_auth_method",
-                      id: auth_method.id
-                    }
-                  )
-                }
-              >
-                Delete
-              </a>
-            <% else %>
-              <a
-                id={"delete_auth_method_link_#{auth_method.id}"}
-                href="#"
-                class="table-action cursor-not-allowed"
-              >
-                Delete
-              </a>
-            <% end %>
-          </:action>
-        </LightningWeb.WorkflowLive.Components.webhook_auth_methods_table>
+            </:linked_triggers>
+            <:action :let={auth_method}>
+              <%= if @can_write_webhook_auth_method do %>
+                <a
+                  id={"edit_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action"
+                  phx-click={
+                    JS.push("show_modal",
+                      value: %{
+                        target: "edit_webhook_auth_method",
+                        id: auth_method.id
+                      }
+                    )
+                  }
+                >
+                  View
+                </a>
+              <% else %>
+                <a
+                  id={"edit_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action cursor-not-allowed"
+                >
+                  Edit
+                </a>
+              <% end %>
+            </:action>
+            <:action :let={auth_method}>
+              <%= if @can_write_webhook_auth_method do %>
+                <a
+                  id={"delete_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action"
+                  phx-click={
+                    JS.push("show_modal",
+                      value: %{
+                        target: "delete_webhook_auth_method",
+                        id: auth_method.id
+                      }
+                    )
+                  }
+                >
+                  Delete
+                </a>
+              <% else %>
+                <a
+                  id={"delete_auth_method_link_#{auth_method.id}"}
+                  href="#"
+                  class="table-action cursor-not-allowed"
+                >
+                  Delete
+                </a>
+              <% end %>
+            </:action>
+          </LightningWeb.WorkflowLive.Components.webhook_auth_methods_table>
+        <% end %>
       </:panel>
       <:panel hash="collaboration" class="space-y-4">
         <.section_header
@@ -509,6 +577,11 @@
             )
           }
           action_button_id="show_collaborators_modal_button"
+        />
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-collaboration"
+          variant={:local}
         />
         <.support_access_toggle
           can_edit_project={@can_edit_project}
@@ -548,14 +621,18 @@
                   remove_user_tooltip(
                     project_user,
                     @current_user,
-                    @can_remove_project_user
+                    @can_remove_project_user,
+                    @project,
+                    @sandbox?
                   )
                 }
                 disabled={
                   !user_removable?(
                     project_user,
                     @current_user,
-                    @can_remove_project_user
+                    @can_remove_project_user,
+                    @project,
+                    @sandbox?
                   )
                 }
               >
@@ -581,7 +658,9 @@
               user_removable?(
                 project_user,
                 @current_user,
-                @can_remove_project_user
+                @can_remove_project_user,
+                @project,
+                @sandbox?
               )
             }
             id={"remove_#{project_user.id}_modal"}
@@ -593,8 +672,16 @@
         <.section_header
           title="Project security"
           subtitle="View and manage security settings for this project."
-          permissions_message="multi-factor authentication settings."
+          permissions_message={
+            unless @sandbox?, do: "multi-factor authentication settings."
+          }
           can_perform_action={@can_edit_project}
+        />
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-security"
+          variant={:inherited}
+          parent_project={@parent_project}
         />
         <div>
           <%= if assigns[:mfa_banner] do %>
@@ -629,10 +716,10 @@
               <button
                 id="toggle-mfa-switch"
                 type="button"
-                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !@can_edit_project, do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
+                class={"#{if @project.requires_mfa, do: "bg-indigo-600", else: "bg-gray-200"} #{if !@can_edit_project or @sandbox?, do: "cursor-not-allowed opacity-50", else: "cursor-pointer"} relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"}
                 role="switch"
-                disabled={!@can_require_mfa}
-                phx-click="toggle-mfa"
+                disabled={!@can_require_mfa or @sandbox?}
+                phx-click={unless @sandbox?, do: "toggle-mfa"}
                 aria-checked={@project.requires_mfa}
                 aria-labelledby="require-mfa-label"
                 aria-describedby="require-mfa-description"
@@ -664,6 +751,11 @@
           subtitle="View or modify external version control settings for this project."
           permissions_message={"version control configuration#{@can_initiate_github_sync && " but you can initiate a sync." || "."}"}
           can_perform_action={@can_install_github}
+        />
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-vcs"
+          variant={:local}
         />
         <div>
           <%= if assigns[:github_banner] do %>
@@ -763,6 +855,11 @@
           subtitle="View or modify data storage settings for this project."
           permissions_message="data storage settings."
           can_perform_action={@can_edit_data_retention}
+        />
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-data-storage"
+          variant={:local}
         />
         <div class="bg-white p-4 rounded-md">
           <.form
@@ -951,6 +1048,11 @@
           subtitle="View export status and download work order history for this project."
           permissions_message="history exports."
           can_perform_action={true}
+        />
+        <.sandbox_settings_banner
+          :if={@sandbox?}
+          id="sandbox-banner-history-exports"
+          variant={:local}
         />
         <LightningWeb.Components.DataTables.history_exports_table
           id="project_users_table"

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -170,7 +170,6 @@ defmodule LightningWeb.SandboxLive.Components do
             autocomplete="off"
             required
           />
-          <.errors field={@confirm_form[:name]} />
 
           <.modal_footer>
             <.button

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -834,6 +834,118 @@ defmodule Lightning.Projects.SandboxesTest do
     end
   end
 
+  # These tests document that the merge pipeline does not propagate
+  # project-level Local or Inherited fields from sandbox to parent. They
+  # guard against future changes to MergeProjects or Provisioner that
+  # could accidentally start syncing these fields.
+  describe "merge/4 does not propagate Local/Inherited fields" do
+    setup do
+      actor = insert(:user)
+
+      parent =
+        insert(:project,
+          name: "parent",
+          description: "parent description",
+          requires_mfa: false,
+          concurrency: 5,
+          retention_policy: :retain_all,
+          history_retention_period: 30,
+          dataclip_retention_period: 30
+        )
+
+      ensure_member!(parent, actor, :owner)
+      insert(:simple_workflow, project: parent)
+
+      sandbox =
+        insert(:project,
+          name: "sandbox",
+          description: "sandbox description",
+          parent: parent,
+          requires_mfa: true,
+          concurrency: 1,
+          retention_policy: :erase_all,
+          history_retention_period: 7,
+          dataclip_retention_period: nil,
+          project_users: [%{user: actor, role: :owner}]
+        )
+
+      insert(:simple_workflow, project: sandbox)
+      {:ok, actor: actor, parent: parent, sandbox: sandbox}
+    end
+
+    test "requires_mfa stays at parent's value", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      assert Repo.reload(parent).requires_mfa == false
+    end
+
+    test "concurrency stays at parent's value", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      assert Repo.reload(parent).concurrency == 5
+    end
+
+    test "retention settings stay at parent's values", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      reloaded = Repo.reload(parent)
+      assert reloaded.retention_policy == :retain_all
+      assert reloaded.history_retention_period == 30
+      assert reloaded.dataclip_retention_period == 30
+    end
+
+    test "name and description stay at parent's values", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      reloaded = Repo.reload(parent)
+      assert reloaded.name == "parent"
+      assert reloaded.description == "parent description"
+    end
+
+    test "collaborators are not synced from sandbox to parent", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      sandbox_only_user = insert(:user)
+
+      insert(:project_user,
+        project: sandbox,
+        user: sandbox_only_user,
+        role: :editor
+      )
+
+      parent_user_ids_before =
+        parent.id
+        |> Lightning.Projects.get_project_users!()
+        |> Enum.map(& &1.user_id)
+
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+
+      parent_user_ids_after =
+        parent.id
+        |> Lightning.Projects.get_project_users!()
+        |> Enum.map(& &1.user_id)
+
+      refute sandbox_only_user.id in parent_user_ids_after
+
+      assert Enum.sort(parent_user_ids_before) ==
+               Enum.sort(parent_user_ids_after)
+    end
+  end
+
   describe "keychains" do
     test "clones only used keychains and rewires jobs to cloned keychains" do
       %{

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -769,6 +769,118 @@ defmodule Lightning.Projects.SandboxesTest do
     end
   end
 
+  # These tests document that the merge pipeline does not propagate
+  # project-level Local or Inherited fields from sandbox to parent. They
+  # guard against future changes to MergeProjects or Provisioner that
+  # could accidentally start syncing these fields.
+  describe "merge/4 does not propagate Local/Inherited fields" do
+    setup do
+      actor = insert(:user)
+
+      parent =
+        insert(:project,
+          name: "parent",
+          description: "parent description",
+          requires_mfa: false,
+          concurrency: 5,
+          retention_policy: :retain_all,
+          history_retention_period: 30,
+          dataclip_retention_period: 30
+        )
+
+      ensure_member!(parent, actor, :owner)
+      insert(:simple_workflow, project: parent)
+
+      sandbox =
+        insert(:project,
+          name: "sandbox",
+          description: "sandbox description",
+          parent: parent,
+          requires_mfa: true,
+          concurrency: 1,
+          retention_policy: :erase_all,
+          history_retention_period: 7,
+          dataclip_retention_period: nil,
+          project_users: [%{user: actor, role: :owner}]
+        )
+
+      insert(:simple_workflow, project: sandbox)
+      {:ok, actor: actor, parent: parent, sandbox: sandbox}
+    end
+
+    test "requires_mfa stays at parent's value", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      assert Repo.reload(parent).requires_mfa == false
+    end
+
+    test "concurrency stays at parent's value", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      assert Repo.reload(parent).concurrency == 5
+    end
+
+    test "retention settings stay at parent's values", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      reloaded = Repo.reload(parent)
+      assert reloaded.retention_policy == :retain_all
+      assert reloaded.history_retention_period == 30
+      assert reloaded.dataclip_retention_period == 30
+    end
+
+    test "name and description stay at parent's values", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+      reloaded = Repo.reload(parent)
+      assert reloaded.name == "parent"
+      assert reloaded.description == "parent description"
+    end
+
+    test "collaborators are not synced from sandbox to parent", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      sandbox_only_user = insert(:user)
+
+      insert(:project_user,
+        project: sandbox,
+        user: sandbox_only_user,
+        role: :editor
+      )
+
+      parent_user_ids_before =
+        parent.id
+        |> Lightning.Projects.get_project_users!()
+        |> Enum.map(& &1.user_id)
+
+      {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+
+      parent_user_ids_after =
+        parent.id
+        |> Lightning.Projects.get_project_users!()
+        |> Enum.map(& &1.user_id)
+
+      refute sandbox_only_user.id in parent_user_ids_after
+
+      assert Enum.sort(parent_user_ids_before) ==
+               Enum.sort(parent_user_ids_after)
+    end
+  end
+
   describe "keychains" do
     test "clones only used keychains and rewires jobs to cloned keychains" do
       %{

--- a/test/lightning_web/live/project_live/sandbox_settings_test.exs
+++ b/test/lightning_web/live/project_live/sandbox_settings_test.exs
@@ -1,0 +1,292 @@
+defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
+  use LightningWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Lightning.Factories
+
+  alias Lightning.Projects
+  alias Lightning.Projects.Sandboxes
+
+  setup :stub_usage_limiter_ok
+  setup :register_and_log_in_user
+
+  defp setup_parent_and_sandbox(%{user: user}) do
+    parent =
+      insert(:project,
+        name: "parent-project",
+        project_users: [%{user: user, role: :owner}]
+      )
+
+    sandbox =
+      insert(:project,
+        name: "sandbox-test",
+        parent: parent,
+        project_users: [%{user: user, role: :owner}]
+      )
+
+    {:ok, parent: parent, sandbox: sandbox}
+  end
+
+  describe "non-sandbox project (parent project)" do
+    setup [:setup_parent_and_sandbox]
+
+    test "does not show any sandbox banners", %{conn: conn, parent: parent} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+
+      refute html =~ "sandbox-banner-"
+    end
+
+    test "shows 'Project Identity' header on project tab", %{
+      conn: conn,
+      parent: parent
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+      assert html =~ "Project Identity"
+      refute html =~ "Sandbox Identity"
+    end
+
+    test "shows the danger zone delete button", %{conn: conn, parent: parent} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+      assert html =~ "The danger zone"
+      assert html =~ "Delete project"
+    end
+
+    test "shows webhook auth methods table on webhook_security tab", %{
+      conn: conn,
+      parent: parent
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+      refute html =~ "Webhook security is not available in sandboxes"
+    end
+  end
+
+  describe "sandbox project" do
+    setup [:setup_parent_and_sandbox]
+
+    test "shows Editable banner on credentials and collections tabs", %{
+      conn: conn,
+      sandbox: sandbox
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ ~s(id="sandbox-banner-credentials")
+      assert html =~ ~s(id="sandbox-banner-collections")
+
+      assert html =~
+               "Changes you make here will sync to the parent project on merge."
+    end
+
+    test "shows Local banner on project, collaboration, vcs, data-storage, history-exports tabs",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      for tab <- ~w(project collaboration vcs data-storage history-exports) do
+        assert html =~ ~s(id="sandbox-banner-#{tab}")
+      end
+
+      assert html =~
+               "Changes you make here only apply to this sandbox and won&#39;t sync"
+    end
+
+    test "shows Inherited banner on security tab", %{
+      conn: conn,
+      sandbox: sandbox
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ ~s(id="sandbox-banner-security")
+      assert html =~ "These settings are inherited from the parent project"
+    end
+
+    test "shows 'Sandbox Identity' header instead of 'Project Identity'", %{
+      conn: conn,
+      sandbox: sandbox
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ "Sandbox Identity"
+      assert html =~ "Sandbox setup"
+      assert html =~ "Parent project:"
+      assert html =~ "parent-project"
+    end
+
+    test "hides the danger zone delete button", %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      refute html =~ "The danger zone"
+      refute html =~ "Delete project"
+    end
+
+    test "shows webhook security explanatory message instead of auth methods",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ "Webhook security is not available in sandboxes for now"
+    end
+
+    test "MFA toggle is disabled in sandbox", %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+      html = render(view)
+
+      assert html =~ ~s(id="toggle-mfa-switch")
+      assert html =~ ~s(disabled)
+      assert html =~ "cursor-not-allowed"
+    end
+  end
+
+  describe "Sandboxes.parent_admin?/2" do
+    test "returns true when user is admin on direct parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [%{user: user, role: :admin}])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      assert Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns true when user is owner on direct parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [%{user: user, role: :owner}])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      assert Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns false when user is editor on parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [%{user: user, role: :editor}])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      refute Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns false when user has no role on parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      refute Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "walks the chain — admin on grandparent counts" do
+      user = insert(:user)
+
+      grandparent =
+        insert(:project, project_users: [%{user: user, role: :admin}])
+
+      parent = insert(:project, parent: grandparent, project_users: [])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      assert Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns false for projects with no parent" do
+      user = insert(:user)
+      project = insert(:project, project_users: [%{user: user, role: :admin}])
+
+      refute Sandboxes.parent_admin?(project, user)
+    end
+  end
+
+  describe "delete_project_user! parent admin protection" do
+    test "raises when removing a parent admin from a sandbox" do
+      admin = insert(:user)
+      other = insert(:user)
+
+      parent =
+        insert(:project,
+          project_users: [
+            %{user: admin, role: :admin},
+            %{user: other, role: :owner}
+          ]
+        )
+
+      sandbox =
+        insert(:project,
+          parent: parent,
+          project_users: [
+            %{user: admin, role: :editor},
+            %{user: other, role: :owner}
+          ]
+        )
+
+      sandbox_pu = Projects.get_project_user(sandbox, admin)
+
+      assert_raise ArgumentError,
+                   ~r/Cannot remove a parent project admin/,
+                   fn ->
+                     Projects.delete_project_user!(sandbox_pu)
+                   end
+    end
+
+    test "allows removing a non-parent-admin from a sandbox" do
+      regular = insert(:user)
+      owner = insert(:user)
+
+      parent =
+        insert(:project, project_users: [%{user: owner, role: :owner}])
+
+      sandbox =
+        insert(:project,
+          parent: parent,
+          project_users: [
+            %{user: regular, role: :editor},
+            %{user: owner, role: :owner}
+          ]
+        )
+
+      sandbox_pu = Projects.get_project_user(sandbox, regular)
+
+      assert %Lightning.Projects.ProjectUser{} =
+               Projects.delete_project_user!(sandbox_pu)
+    end
+
+    test "allows removing any user from a non-sandbox project" do
+      admin = insert(:user)
+      other = insert(:user)
+
+      project =
+        insert(:project,
+          project_users: [
+            %{user: admin, role: :admin},
+            %{user: other, role: :owner}
+          ]
+        )
+
+      pu = Projects.get_project_user(project, admin)
+
+      assert %Lightning.Projects.ProjectUser{} =
+               Projects.delete_project_user!(pu)
+    end
+  end
+
+  describe "Remove Collaborator UI guard for parent admins" do
+    test "Remove button is disabled for a parent admin in sandbox", %{
+      conn: conn,
+      user: user
+    } do
+      parent_admin = insert(:user, email: "parent-admin@example.com")
+
+      parent =
+        insert(:project,
+          project_users: [
+            %{user: user, role: :owner},
+            %{user: parent_admin, role: :admin}
+          ]
+        )
+
+      sandbox =
+        insert(:project,
+          parent: parent,
+          project_users: [
+            %{user: user, role: :owner},
+            %{user: parent_admin, role: :editor}
+          ]
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~
+               "Cannot remove a user who is admin or owner on the parent project"
+    end
+  end
+end

--- a/test/lightning_web/live/project_live/sandbox_settings_test.exs
+++ b/test/lightning_web/live/project_live/sandbox_settings_test.exs
@@ -185,6 +185,19 @@ defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
 
       refute Sandboxes.parent_admin?(project, user)
     end
+
+    test "returns false when parent_id points to a deleted project" do
+      # Race condition: in-memory sandbox struct has a parent_id that
+      # was nilified in the database after we loaded the struct (because
+      # the parent project was deleted). The function should treat the
+      # missing ancestor as no ancestor, not crash.
+      user = insert(:user)
+      sandbox = insert(:project)
+      stale_parent_id = Ecto.UUID.generate()
+      stale_sandbox = %{sandbox | parent_id: stale_parent_id}
+
+      refute Sandboxes.parent_admin?(stale_sandbox, user)
+    end
   end
 
   describe "delete_project_user! parent admin protection" do

--- a/test/lightning_web/live/project_live/sandbox_settings_test.exs
+++ b/test/lightning_web/live/project_live/sandbox_settings_test.exs
@@ -1,0 +1,419 @@
+defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
+  use LightningWeb.ConnCase, async: true
+  use Mimic
+
+  import Phoenix.LiveViewTest
+  import Lightning.Factories
+
+  alias Lightning.Projects
+  alias Lightning.Projects.Sandboxes
+
+  setup :stub_usage_limiter_ok
+  setup :register_and_log_in_user
+
+  setup do
+    Mimic.copy(Lightning.Projects.Sandboxes)
+    :ok
+  end
+
+  defp setup_parent_and_sandbox(%{user: user}) do
+    parent =
+      insert(:project,
+        name: "parent-project",
+        project_users: [%{user: user, role: :owner}]
+      )
+
+    sandbox =
+      insert(:project,
+        name: "sandbox-test",
+        parent: parent,
+        project_users: [%{user: user, role: :owner}]
+      )
+
+    {:ok, parent: parent, sandbox: sandbox}
+  end
+
+  describe "non-sandbox project (parent project)" do
+    setup [:setup_parent_and_sandbox]
+
+    test "does not show any sandbox banners", %{conn: conn, parent: parent} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+
+      refute html =~ "sandbox-banner-"
+    end
+
+    test "shows 'Project Identity' header on project tab", %{
+      conn: conn,
+      parent: parent
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+      assert html =~ "Project Identity"
+      refute html =~ "Sandbox Identity"
+    end
+
+    test "shows the danger zone delete button", %{conn: conn, parent: parent} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+      assert html =~ "The danger zone"
+      assert html =~ "Delete project"
+    end
+
+    test "shows webhook auth methods table on webhook_security tab", %{
+      conn: conn,
+      parent: parent
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/settings")
+      refute html =~ "Webhook authentication is managed in the parent project"
+    end
+  end
+
+  describe "sandbox project" do
+    setup [:setup_parent_and_sandbox]
+
+    test "shows Editable banner on credentials and collections tabs", %{
+      conn: conn,
+      sandbox: sandbox
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ ~s(id="sandbox-banner-credentials")
+      assert html =~ ~s(id="sandbox-banner-collections")
+
+      assert html =~
+               "Changes you make here will sync to the parent project on merge."
+    end
+
+    test "shows Local banner on project, collaboration, vcs, data-storage, history-exports tabs",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      for tab <- ~w(project collaboration vcs data-storage history-exports) do
+        assert html =~ ~s(id="sandbox-banner-#{tab}")
+      end
+
+      assert html =~
+               "Changes you make here only apply to this sandbox and do not sync"
+    end
+
+    test "shows Inherited banner on security tab", %{
+      conn: conn,
+      sandbox: sandbox
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ ~s(id="sandbox-banner-security")
+      assert html =~ "These settings are inherited from the parent project"
+    end
+
+    test "shows 'Sandbox Identity' header instead of 'Project Identity'", %{
+      conn: conn,
+      sandbox: sandbox
+    } do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ "Sandbox Identity"
+      assert html =~ "Sandbox setup"
+      assert html =~ "Identifies this sandbox within its parent:"
+      assert html =~ "parent-project"
+    end
+
+    test "shows the danger zone delete button", %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ "The danger zone"
+      assert html =~ "Delete sandbox"
+      refute html =~ "Delete project"
+    end
+
+    test "delete sandbox flow calls delete_sandbox and redirects to root project",
+         %{conn: conn, sandbox: sandbox, parent: parent} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      view
+      |> form("#confirm-delete-sandbox form",
+        confirm: %{name: sandbox.name}
+      )
+      |> render_submit()
+
+      flash = assert_redirected(view, ~p"/projects/#{parent.id}/w")
+      assert flash["info"] =~ "and all its associated descendants deleted"
+      assert is_nil(Lightning.Projects.get_project(sandbox.id))
+    end
+
+    test "confirm-delete-validate marks the form invalid for a wrong name",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      html =
+        view
+        |> form("#confirm-delete-sandbox form", confirm: %{name: "wrong"})
+        |> render_change()
+
+      assert html =~ "does not match the sandbox name"
+      # Sandbox was not deleted
+      assert Lightning.Projects.get_project(sandbox.id)
+    end
+
+    test "submitting the confirm form with a wrong name does not delete and re-renders errors",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      html =
+        view
+        |> form("#confirm-delete-sandbox form", confirm: %{name: "wrong"})
+        |> render_submit()
+
+      assert html =~ "does not match the sandbox name"
+      assert Lightning.Projects.get_project(sandbox.id)
+    end
+
+    test "close button navigates back to the settings index",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      view
+      |> element("#confirm-delete-sandbox button[aria-label='Close']")
+      |> render_click()
+
+      assert_redirected(view, ~p"/projects/#{sandbox.id}/settings")
+    end
+
+    test "unauthorized sandbox delete surfaces an error and returns to settings",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      # Simulate an authorization mismatch by stubbing the sandbox delete call
+      # to return :unauthorized while the settings page's own can_delete_project
+      # gate allowed us through.
+      Mimic.expect(Lightning.Projects.Sandboxes, :delete_sandbox, fn _, _ ->
+        {:error, :unauthorized}
+      end)
+
+      view
+      |> form("#confirm-delete-sandbox form",
+        confirm: %{name: sandbox.name}
+      )
+      |> render_submit()
+
+      flash = assert_redirected(view, ~p"/projects/#{sandbox.id}/settings")
+      assert flash["error"] =~ "permission to delete this sandbox"
+      assert Lightning.Projects.get_project(sandbox.id)
+    end
+
+    test "unexpected sandbox delete error surfaces a generic error",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      Mimic.expect(Lightning.Projects.Sandboxes, :delete_sandbox, fn _, _ ->
+        {:error, :boom}
+      end)
+
+      view
+      |> form("#confirm-delete-sandbox form",
+        confirm: %{name: sandbox.name}
+      )
+      |> render_submit()
+
+      flash = assert_redirected(view, ~p"/projects/#{sandbox.id}/settings")
+      assert flash["error"] =~ "Could not delete sandbox"
+      assert Lightning.Projects.get_project(sandbox.id)
+    end
+
+    test "shows webhook security explanatory message instead of auth methods",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~ "Webhook authentication is managed in the parent project"
+    end
+
+    test "MFA toggle is disabled in sandbox", %{conn: conn, sandbox: sandbox} do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+      html = render(view)
+
+      assert html =~ ~s(id="toggle-mfa-switch")
+      assert html =~ ~s(disabled)
+      assert html =~ "cursor-not-allowed"
+    end
+
+    test "does not show the role permissions message on webhook_security or security tabs",
+         %{conn: conn, sandbox: sandbox} do
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      refute html =~ "Role based permissions: You cannot modify"
+    end
+  end
+
+  describe "Sandboxes.parent_admin?/2" do
+    test "returns true when user is admin on direct parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [%{user: user, role: :admin}])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      assert Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns true when user is owner on direct parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [%{user: user, role: :owner}])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      assert Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns false when user is editor on parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [%{user: user, role: :editor}])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      refute Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns false when user has no role on parent" do
+      user = insert(:user)
+      parent = insert(:project, project_users: [])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      refute Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "walks the chain — admin on grandparent counts" do
+      user = insert(:user)
+
+      grandparent =
+        insert(:project, project_users: [%{user: user, role: :admin}])
+
+      parent = insert(:project, parent: grandparent, project_users: [])
+      sandbox = insert(:project, parent: parent, project_users: [])
+
+      assert Sandboxes.parent_admin?(sandbox, user)
+    end
+
+    test "returns false for projects with no parent" do
+      user = insert(:user)
+      project = insert(:project, project_users: [%{user: user, role: :admin}])
+
+      refute Sandboxes.parent_admin?(project, user)
+    end
+
+    test "returns false when parent_id points to a deleted project" do
+      # Race condition: in-memory sandbox struct has a parent_id that
+      # was nilified in the database after we loaded the struct (because
+      # the parent project was deleted). The function should treat the
+      # missing ancestor as no ancestor, not crash.
+      user = insert(:user)
+      sandbox = insert(:project)
+      stale_parent_id = Ecto.UUID.generate()
+      stale_sandbox = %{sandbox | parent_id: stale_parent_id}
+
+      refute Sandboxes.parent_admin?(stale_sandbox, user)
+    end
+  end
+
+  describe "delete_project_user! parent admin protection" do
+    test "raises when removing a parent admin from a sandbox" do
+      admin = insert(:user)
+      other = insert(:user)
+
+      parent =
+        insert(:project,
+          project_users: [
+            %{user: admin, role: :admin},
+            %{user: other, role: :owner}
+          ]
+        )
+
+      sandbox =
+        insert(:project,
+          parent: parent,
+          project_users: [
+            %{user: admin, role: :editor},
+            %{user: other, role: :owner}
+          ]
+        )
+
+      sandbox_pu = Projects.get_project_user(sandbox, admin)
+
+      assert_raise ArgumentError,
+                   ~r/Cannot remove a parent project admin/,
+                   fn ->
+                     Projects.delete_project_user!(sandbox_pu)
+                   end
+    end
+
+    test "allows removing a non-parent-admin from a sandbox" do
+      regular = insert(:user)
+      owner = insert(:user)
+
+      parent =
+        insert(:project, project_users: [%{user: owner, role: :owner}])
+
+      sandbox =
+        insert(:project,
+          parent: parent,
+          project_users: [
+            %{user: regular, role: :editor},
+            %{user: owner, role: :owner}
+          ]
+        )
+
+      sandbox_pu = Projects.get_project_user(sandbox, regular)
+
+      assert %Lightning.Projects.ProjectUser{} =
+               Projects.delete_project_user!(sandbox_pu)
+    end
+
+    test "allows removing any user from a non-sandbox project" do
+      admin = insert(:user)
+      other = insert(:user)
+
+      project =
+        insert(:project,
+          project_users: [
+            %{user: admin, role: :admin},
+            %{user: other, role: :owner}
+          ]
+        )
+
+      pu = Projects.get_project_user(project, admin)
+
+      assert %Lightning.Projects.ProjectUser{} =
+               Projects.delete_project_user!(pu)
+    end
+  end
+
+  describe "Remove Collaborator UI guard for parent admins" do
+    test "Remove button is disabled for a parent admin in sandbox", %{
+      conn: conn,
+      user: user
+    } do
+      parent_admin = insert(:user, email: "parent-admin@example.com")
+
+      parent =
+        insert(:project,
+          project_users: [
+            %{user: user, role: :owner},
+            %{user: parent_admin, role: :admin}
+          ]
+        )
+
+      sandbox =
+        insert(:project,
+          parent: parent,
+          project_users: [
+            %{user: user, role: :owner},
+            %{user: parent_admin, role: :editor}
+          ]
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{sandbox.id}/settings")
+
+      assert html =~
+               "Cannot remove a user who is admin or owner on the parent project"
+    end
+  end
+end


### PR DESCRIPTION
## Description

This implements the per-page approach we agreed on in #3398. The Project Settings page now behaves differently when you're inside a sandbox: each tab tells you whether your changes will sync on merge, and the UI for some tabs changes shape to match what makes sense for a sandbox (no Delete button, MFA read-only, webhook security managed at the parent level, etc.).

The categorization, agreed in the issue thread:

| Tab | Category | What it means |
|---|---|---|
| `project` | Local | Editable but does not sync on merge. Sandbox Identity panel with a link to the parent. Delete button hidden (sandboxes are deleted from the sandboxes UI). |
| `credentials` | Editable | Editable, will sync on merge. |
| `collections` | Editable | Editable, will sync on merge (handled in #4613). |
| `webhook_security` | Inherited | Auth methods are shared with the sandbox and enforced on its webhook triggers, but can only be created, edited, or deleted from the parent project. |
| `collaboration` | Local | Editable but does not sync on merge. Adds a parent admin floor rule (see below). |
| `security` (MFA) | Inherited | Read-only, value cloned from parent at provision time, MFA toggle disabled. |
| `vcs` | Local | Editable but does not sync on merge. |
| `data-storage` | Local | Editable but does not sync on merge. |
| `history-exports` | Local | Action button stays, banner explains scope. |

A few things worth knowing about how this is implemented, because they affected the scope:

**The merge layer is already protective.** I started worrying that "Local" and "Inherited" were just UI promises and that a user changing data retention in a sandbox would actually push that value back to the parent on merge. After tracing through `MergeProjects.merge_project/3` and `Provisioner.import_document/4`, that turns out not to be the case. The merge document only takes `[:name, :description, :env, :color]` from the **target** (not the source), and the provisioner only casts `[:id, :name, :description]` on the project itself. Project-level fields like `requires_mfa`, `concurrency`, `retention_policy`, `history_retention_period`, `dataclip_retention_period` aren't in the cast list, so they never propagate. Webhook auth methods, project_users, and the GitHub repo connection aren't in the merge document at all. I added regression tests in `sandboxes_test.exs` to lock this in so a future change to MergeProjects or the Provisioner doesn't accidentally start syncing them.

**The parent admin floor rule is enforced server-side, not just in the UI.** A user who is admin or owner on any ancestor project (walking the parent chain, so admin on grandparent counts) cannot be removed from a sandbox. The UI disables the Remove button with a tooltip explaining why, but `Projects.delete_project_user!/1` also raises an `ArgumentError` if you try to do it directly, so a curl bypass or a future code path can't get around it. There's a unit test covering both paths.

**Webhook auth methods stay enforced but can't be managed from the sandbox.** Auth methods flow down from the parent and are still applied to the sandbox's webhook triggers, but the sandbox UI points users back to the parent for create/edit/delete. The tab is still present so users can find it; the panel renders a notice and a link to the parent project's webhook security tab instead of the full management table.

Closes #3398

## Validation steps

### Setup

1. Create a project called **Cat Shelter Registry**.
2. In **Project Settings**, set MFA to required on the Security tab and change History Retention to 7 days under Data Storage. We'll use these later to confirm they don't get overwritten.
3. On the **Collaboration** tab, add a teammate as `admin` on this project.
4. Go to **Sandboxes** and create a sandbox called **sandbox-test**. Open it.

You're now inside the sandbox. Every test below happens from here unless I say otherwise.

### 1. Sandbox Setup tab (Local)

Navigate to **Project Settings** in the sandbox. The first tab should be **Setup**.

What you should see:

- A blue banner at the top: *"Changes you make here only apply to this sandbox and do not sync to the parent project on merge."*
- The section title says **Sandbox setup**
- The first card is **Sandbox Identity**
- Below the description, a line: *"Identifies this sandbox within its parent: [Cat Shelter Registry]"* with the parent name as a link
- The Export project button is still there
- The danger zone at the bottom reads **"The danger zone"** with a **Delete sandbox** button. Clicking it opens a confirmation modal that requires typing the sandbox name; submitting calls `Sandboxes.delete_sandbox/2` and redirects to the root project's workflows page with the flash *"Sandbox <name> and all its associated descendants deleted"*

### 2. Credentials and Collections (Editable)

These are the two tabs where changes flow back. We'll create one of each in the sandbox now and confirm in step 7 that they show up in the parent after merge.

**Credentials**

1. Click the **Credentials** tab. You should see a green banner: *"Changes you make here will sync to the parent project on merge."*
2. Click **New credential**, pick any type (raw JSON is quickest), and create a credential called **sandbox-only-credential**.
3. In another browser tab, open the parent project (**Cat Shelter Registry**) → Credentials. Confirm **sandbox-only-credential** is **not there yet** — it lives only in the sandbox until merge.

**Collections**

1. Click the **Collections** tab. Same green banner.
2. Click **New collection**, name it **sandbox-only-collection**, and save.
3. In the parent project's Collections tab, confirm **sandbox-only-collection** is **not there yet**.

### 3. Webhook Security (managed in parent)

Click **Webhook Security**. Instead of the usual auth methods table, you should see a notice that reads something like:

> *Webhook authentication is managed in the parent project. Methods are shared with this sandbox and enforced on its webhook triggers, but can only be created, edited, or deleted from the parent.*

Followed by a link: *"Manage them in the parent project ([Cat Shelter Registry])"* pointing back to the parent's webhook security tab.

### 4. Collaboration and the parent admin floor rule

Click **Collaboration**. You should see a Local banner.

The collaborators table shows the current sandbox members. The teammate you added as admin in step 3 of Setup should also be listed (they were inherited when the sandbox was provisioned).

Now hover over the **Remove Collaborator** button next to that admin. The button should be **disabled**, and the tooltip should read:

> *Cannot remove a user who is admin or owner on the parent project*

For comparison, add another teammate to the **sandbox** as `editor` (not admin on the parent). Their Remove button should be enabled normally.

### 5. Security tab (Inherited)

Click **Security**. You should see:

- A yellow banner: *"These settings are inherited from the parent project ([Cat Shelter Registry]) and cannot be changed here."*
- The MFA toggle is visible but **disabled** (cursor shows `not-allowed` on hover, the switch reflects the parent's value)
- Clicking the toggle does nothing

The value you see should match what you set on the parent in step 2 of Setup.

### 6. The other Local tabs

Click through **Sync to GitHub**, **Data Storage**, **History Exports**. Each should show the blue Local banner at the top. The forms remain editable. This is intentional: you can change these in the sandbox to support sandbox-specific workflows, but the values do not sync back.

### 7. Merge: what flows back, what doesn't

This is the part that worried me when I started, so worth confirming hands-on.

Still in the sandbox:

1. Go to **Data Storage** and change History Retention to 90 days (or anything different from the parent's 7).
2. Go to **Setup** and change Project Concurrency to 1.
3. Open the parent project's settings briefly and note the starting values — History Retention 7 days, MFA required, no concurrency override.
4. From the Sandboxes page, **merge** the sandbox into the parent.
5. Open the parent project (**Cat Shelter Registry**) and walk through each tab.

**Credentials (Editable — should sync):**
- **sandbox-only-credential** should now appear in the parent's Credentials tab.

**Collections (Editable — should sync):**
- **sandbox-only-collection** should now appear in the parent's Collections tab (per #4613).

**Setup (Local — should not sync):**
- Project name and description unchanged.
- Concurrency unchanged (didn't become 1).

**Data Storage (Local — should not sync):**
- History Retention is still 7 days (didn't change to 90).
- I/O retention / policy unchanged.

**Security (Inherited — should not sync):**
- MFA is still required (didn't get unset).

Editable categories flow back, Local and Inherited categories don't. That asymmetry is what `sandboxes_test.exs` locks in at the merge-document/provisioner level.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR