### PR TITLE
feat: support v2 sync protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 
 ### Added
 
+- Add support for sync v2 protocol
+  [#4523](https://github.com/OpenFn/lightning/issues/4523)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/version_control/project_repo_connection.ex
+++ b/lib/lightning/version_control/project_repo_connection.ex
@@ -22,6 +22,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     field :branch, :string
     field :access_token, :binary
     field :config_path, :string
+    field :use_yaml_config, :boolean, default: false
     field :accept, :boolean, virtual: true
 
     field :sync_direction, Ecto.Enum,
@@ -56,7 +57,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
   end
 
   @required_fields ~w(github_installation_id repo branch project_id)a
-  @other_fields ~w(config_path)a
+  @other_fields ~w(config_path use_yaml_config)a
 
   def changeset(project_repo_connection, attrs) do
     project_repo_connection
@@ -125,6 +126,14 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
 
   def config_path(repo_connection) do
     repo_connection.config_path ||
-      "./openfn-#{repo_connection.project_id}-config.json"
+      if repo_connection.use_yaml_config do
+        openfn_yaml()
+      else
+        "./openfn-#{repo_connection.project_id}-config.json"
+      end
+  end
+
+  def openfn_yaml do
+    "openfn.yaml"
   end
 end

--- a/lib/lightning/version_control/project_repo_connection.ex
+++ b/lib/lightning/version_control/project_repo_connection.ex
@@ -127,13 +127,13 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
   def config_path(repo_connection) do
     repo_connection.config_path ||
       if repo_connection.sync_version do
-        openfn_yaml()
+        path_to_openfn_yaml()
       else
         "./openfn-#{repo_connection.project_id}-config.json"
       end
   end
 
-  def openfn_yaml do
+  def path_to_openfn_yaml do
     "openfn.yaml"
   end
 end

--- a/lib/lightning/version_control/project_repo_connection.ex
+++ b/lib/lightning/version_control/project_repo_connection.ex
@@ -22,7 +22,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     field :branch, :string
     field :access_token, :binary
     field :config_path, :string
-    field :use_yaml_config, :boolean, default: false
+    field :sync_version, :boolean, default: false
     field :accept, :boolean, virtual: true
 
     field :sync_direction, Ecto.Enum,
@@ -57,7 +57,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
   end
 
   @required_fields ~w(github_installation_id repo branch project_id)a
-  @other_fields ~w(config_path use_yaml_config)a
+  @other_fields ~w(config_path sync_version)a
 
   def changeset(project_repo_connection, attrs) do
     project_repo_connection
@@ -126,7 +126,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
 
   def config_path(repo_connection) do
     repo_connection.config_path ||
-      if repo_connection.use_yaml_config do
+      if repo_connection.sync_version do
         openfn_yaml()
       else
         "./openfn-#{repo_connection.project_id}-config.json"

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -11,7 +11,6 @@ defmodule Lightning.VersionControl do
   alias Ecto.Multi
   alias Lightning.Accounts.User
   alias Lightning.Extensions.UsageLimiting
-  alias Lightning.Projects.Project
   alias Lightning.Repo
   alias Lightning.VersionControl.Audit
   alias Lightning.VersionControl.Events

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -18,8 +18,8 @@ defmodule Lightning.VersionControl do
   alias Lightning.VersionControl.GithubError
   alias Lightning.VersionControl.ProjectRepoConnection
   alias Lightning.VersionControl.VersionControlUsageLimiter
-  alias Lightning.Workflows.Workflow
   alias Lightning.Projects.Project
+  alias Lightning.Workflows.Workflow
 
   require Logger
 

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -575,7 +575,7 @@ defmodule Lightning.VersionControl do
     if is_nil(repo_connection.config_path) do
       content =
         if repo_connection.sync_version do
-          openfn_yaml(repo_connection)
+          path_to_openfn_yaml(repo_connection)
         else
           config_json(repo_connection)
         end
@@ -633,12 +633,12 @@ defmodule Lightning.VersionControl do
     )
   end
 
-  defp openfn_yaml(repo_connection) do
-    project = Repo.get!(Project, repo_connection.project_id)
+  defp path_to_openfn_yaml(repo_connection) do
+    project_id = repo_connection.project_id
 
     """
     project:
-      uuid: #{project.id}
+      uuid: #{project_id}
       endpoint: #{LightningWeb.Endpoint.url()}
     """
   end

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -625,7 +625,7 @@ defmodule Lightning.VersionControl do
   defp config_json(repo_connection) do
     Jason.encode!(
       %{
-        endpoint: "https://2daf-154-160-0-161.ngrok-free.app",
+        endpoint: LightningWeb.Endpoint.url(),
         statePath: "openfn-#{repo_connection.project_id}-state.json",
         specPath: "openfn-#{repo_connection.project_id}-spec.yaml"
       },
@@ -642,7 +642,7 @@ defmodule Lightning.VersionControl do
     """
     project:
       uuid: #{project.id}
-      endpoint: https://2daf-154-160-0-161.ngrok-free.app
+      endpoint: #{LightningWeb.Endpoint.url()}
       alias: #{project.env}
       inserted_at: #{inserted_at}
       updated_at: #{updated_at}

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -636,27 +636,10 @@ defmodule Lightning.VersionControl do
   defp openfn_yaml(repo_connection) do
     project = Repo.get!(Project, repo_connection.project_id)
 
-    inserted_at = DateTime.to_iso8601(project.inserted_at)
-    updated_at = DateTime.to_iso8601(project.updated_at)
-
     """
     project:
       uuid: #{project.id}
       endpoint: #{LightningWeb.Endpoint.url()}
-      alias: #{project.env}
-      inserted_at: #{inserted_at}
-      updated_at: #{updated_at}
-      id: #{project.name}
-      name: #{project.name}
-    workspace:
-      credentials: credentials.yaml
-      dirs:
-        projects: .projects
-        workflows: workflows
-      formats:
-        openfn: yaml
-        project: yaml
-        workflow: yaml
     """
   end
 

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -574,7 +574,7 @@ defmodule Lightning.VersionControl do
   defp maybe_create_config_blob(tesla_client, repo_connection) do
     if is_nil(repo_connection.config_path) do
       content =
-        if repo_connection.use_yaml_config do
+        if repo_connection.sync_version do
           openfn_yaml(repo_connection)
         else
           config_json(repo_connection)

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -11,6 +11,7 @@ defmodule Lightning.VersionControl do
   alias Ecto.Multi
   alias Lightning.Accounts.User
   alias Lightning.Extensions.UsageLimiting
+  alias Lightning.Projects.Project
   alias Lightning.Repo
   alias Lightning.VersionControl.Audit
   alias Lightning.VersionControl.Events
@@ -18,7 +19,6 @@ defmodule Lightning.VersionControl do
   alias Lightning.VersionControl.GithubError
   alias Lightning.VersionControl.ProjectRepoConnection
   alias Lightning.VersionControl.VersionControlUsageLimiter
-  alias Lightning.Projects.Project
   alias Lightning.Workflows.Workflow
 
   require Logger

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -19,6 +19,7 @@ defmodule Lightning.VersionControl do
   alias Lightning.VersionControl.ProjectRepoConnection
   alias Lightning.VersionControl.VersionControlUsageLimiter
   alias Lightning.Workflows.Workflow
+  alias Lightning.Projects.Project
 
   require Logger
 
@@ -572,8 +573,15 @@ defmodule Lightning.VersionControl do
 
   defp maybe_create_config_blob(tesla_client, repo_connection) do
     if is_nil(repo_connection.config_path) do
+      content =
+        if repo_connection.use_yaml_config do
+          openfn_yaml(repo_connection)
+        else
+          config_json(repo_connection)
+        end
+
       GithubClient.create_blob(tesla_client, repo_connection.repo, %{
-        content: config_json(repo_connection)
+        content: content
       })
     else
       {:ok, nil}
@@ -617,12 +625,39 @@ defmodule Lightning.VersionControl do
   defp config_json(repo_connection) do
     Jason.encode!(
       %{
-        endpoint: LightningWeb.Endpoint.url(),
+        endpoint: "https://2daf-154-160-0-161.ngrok-free.app",
         statePath: "openfn-#{repo_connection.project_id}-state.json",
         specPath: "openfn-#{repo_connection.project_id}-spec.yaml"
       },
       pretty: true
     )
+  end
+
+  defp openfn_yaml(repo_connection) do
+    project = Repo.get!(Project, repo_connection.project_id)
+
+    inserted_at = DateTime.to_iso8601(project.inserted_at)
+    updated_at = DateTime.to_iso8601(project.updated_at)
+
+    """
+    project:
+      uuid: #{project.id}
+      endpoint: https://2daf-154-160-0-161.ngrok-free.app
+      alias: #{project.env}
+      inserted_at: #{inserted_at}
+      updated_at: #{updated_at}
+      id: #{project.name}
+      name: #{project.name}
+    workspace:
+      credentials: credentials.yaml
+      dirs:
+        projects: .projects
+        workflows: workflows
+      formats:
+        openfn: yaml
+        project: yaml
+        workflow: yaml
+    """
   end
 
   defp pull_yml_target_path do

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -700,7 +700,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
           <label class="flex items-center gap-3 cursor-pointer">
             <.input
               type="checkbox"
-              field={@form[:use_yaml_config]}
+              field={@form[:sync_version]}
               hidden_input={false}
             />
             <span class="text-sm text-gray-700">
@@ -717,8 +717,8 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
     """
   end
 
-  defp use_yaml_config?(form) do
-    form[:use_yaml_config].value in [true, "true"]
+  defp sync_version?(form) do
+    form[:sync_version].value in [true, "true"]
   end
 
   attr :form, :map, required: true
@@ -844,7 +844,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
   end
 
   defp config_filename(form, project_id) do
-    if use_yaml_config?(form) do
+    if sync_version?(form) do
       ProjectRepoConnection.openfn_yaml()
     else
       "openfn-#{project_id}-config.json"

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -684,6 +684,45 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
   end
 
   attr :form, :map, required: true
+  attr :project_id, :string, required: true
+
+  defp config_format_toggle(assigns) do
+    ~H"""
+    <div class="mt-4">
+      <details class="group">
+        <summary class="cursor-pointer text-sm text-gray-500 hover:text-gray-700 select-none list-none flex items-center gap-1">
+          <.icon
+            name="hero-chevron-right-mini"
+            class="h-4 w-4 transition-transform group-open:rotate-90"
+          /> Advanced: use new YAML config format
+        </summary>
+        <div class="mt-2 ml-5 p-3 bg-gray-50 rounded-md border border-gray-200">
+          <label class="flex items-center gap-3 cursor-pointer">
+            <.input
+              type="checkbox"
+              field={@form[:use_yaml_config]}
+              hidden_input={false}
+            />
+            <span class="text-sm text-gray-700">
+              Use new <code>openfn.yaml</code> format
+              instead of <code>openfn-{@project_id}-config.json</code>
+            </span>
+          </label>
+          <p class="mt-1 ml-6 text-xs text-gray-500">
+            Only enable this if you want to use the new <code>openfn.yaml</code>
+            format instead of the legacy JSON config.
+          </p>
+        </div>
+      </details>
+    </div>
+    """
+  end
+
+  defp use_yaml_config?(form) do
+    form[:use_yaml_config].value in [true, "true"]
+  end
+
+  attr :form, :map, required: true
 
   defp sync_order_radio(assigns) do
     ~H"""
@@ -738,9 +777,9 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
                 Import from GitHub (overwrite this project)
               </label>
               <p id="deploy_first_sync_option_description" class="text-gray-500">
-                If you already have <code>config.json</code>
-                and <code>project.yaml</code>
-                files tracked on GitHub and you want to <b>overwrite</b>
+                If you already have an <code>openfn.yaml</code>
+                (or legacy <code>config.json</code>)
+                tracked on GitHub and you want to <b>overwrite</b>
                 this project on OpenFn, you can choose this advanced option.
               </p>
             </div>
@@ -794,9 +833,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
             <li>
               <.icon name="hero-document-plus" class="h-4 w-4" />
               <code>
-                ./openfn-{@project.id}-config.json -> {@form[
-                  :branch
-                ].value}
+                {config_filename(@form, @project.id)} -> {@form[:branch].value}
               </code>
             </li>
           <% end %>
@@ -805,5 +842,13 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
       </span>
     </div>
     """
+  end
+
+  defp config_filename(form, project_id) do
+    if use_yaml_config?(form) do
+      ProjectRepoConnection.openfn_yaml()
+    else
+      "openfn-#{project_id}-config.json"
+    end
   end
 end

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -705,7 +705,6 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
             />
             <span class="text-sm text-gray-700">
               Use new <code>openfn.yaml</code> format
-              instead of <code>openfn-{@project_id}-config.json</code>
             </span>
           </label>
           <p class="mt-1 ml-6 text-xs text-gray-500">

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -850,7 +850,7 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
 
   defp config_filename(form, project_id) do
     if sync_version?(form) do
-      ProjectRepoConnection.openfn_yaml()
+      ProjectRepoConnection.path_to_openfn_yaml()
     else
       "openfn-#{project_id}-config.json"
     end

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -689,30 +689,35 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
   defp config_format_toggle(assigns) do
     ~H"""
     <div class="mt-4">
-      <details class="group">
-        <summary class="cursor-pointer text-sm text-gray-500 hover:text-gray-700 select-none list-none flex items-center gap-1">
-          <.icon
-            name="hero-chevron-right-mini"
-            class="h-4 w-4 transition-transform group-open:rotate-90"
-          /> Advanced: use new YAML config format
-        </summary>
-        <div class="mt-2 ml-5 p-3 bg-gray-50 rounded-md border border-gray-200">
-          <label class="flex items-center gap-3 cursor-pointer">
-            <.input
-              type="checkbox"
-              field={@form[:sync_version]}
-              hidden_input={false}
-            />
-            <span class="text-sm text-gray-700">
-              Use new <code>openfn.yaml</code> format
-            </span>
-          </label>
-          <p class="mt-1 ml-6 text-xs text-gray-500">
-            Only enable this if you want to use the new <code>openfn.yaml</code>
-            format instead of the legacy JSON config.
-          </p>
-        </div>
-      </details>
+      <button
+        type="button"
+        class="cursor-pointer text-sm text-gray-500 hover:text-gray-700 select-none flex items-center gap-1"
+        phx-click={
+          JS.toggle(to: "#sync-version-content")
+          |> JS.toggle_class("rotate-90", to: "#sync-version-chevron")
+        }
+      >
+        <.icon
+          id="sync-version-chevron"
+          name="hero-chevron-right-mini"
+          class="h-4 w-4 transition-transform"
+        /> Advanced: use new YAML config format
+      </button>
+      <div
+        id="sync-version-content"
+        class="hidden mt-2 ml-5 p-3 bg-gray-50 rounded-md border border-gray-200"
+      >
+        <label class="flex items-center gap-3 cursor-pointer">
+          <.input type="checkbox" field={@form[:sync_version]} hidden_input={false} />
+          <span class="text-sm text-gray-700">
+            Use new <code>openfn.yaml</code> format
+          </span>
+        </label>
+        <p class="mt-1 ml-6 text-xs text-gray-500">
+          Only enable this if you want to use the new <code>openfn.yaml</code>
+          format instead of the legacy JSON config.
+        </p>
+      </div>
     </div>
     """
   end

--- a/lib/lightning_web/live/project_live/github_sync_component.html.heex
+++ b/lib/lightning_web/live/project_live/github_sync_component.html.heex
@@ -237,6 +237,15 @@
           </span>
         </span>
 
+        <span>
+          Sync version:
+          <span class="text-xs font-mono bg-gray-200 rounded-md p-1">
+            {if @project_repo_connection.sync_version,
+              do: "v2 (new)",
+              else: "v1 (legacy)"}
+          </span>
+        </span>
+
         <div class="pt-2">
           <.button
             id="initiate-sync-button"

--- a/lib/lightning_web/live/project_live/github_sync_component.html.heex
+++ b/lib/lightning_web/live/project_live/github_sync_component.html.heex
@@ -145,17 +145,22 @@
         </.input>
       </div>
       <div class="mt-4">
+        <.sync_order_radio form={f} />
+      </div>
+      <div :if={f[:sync_direction].value == :deploy} class="mt-4">
         <.input
           type="text"
           field={f[:config_path]}
-          label={"Path to config #{if f[:sync_direction].value == :deploy, do: "(required)", else: "(optional)"}"}
+          label="Path to config (required)"
           placeholder={"./openfn-#{@project.id}-config.json"}
           class="placeholder:italic placeholder:text-slate-400"
         />
       </div>
-      <div class="mt-4">
-        <.sync_order_radio form={f} />
-      </div>
+      <.config_format_toggle
+        :if={f[:sync_direction].value != :deploy}
+        form={f}
+        project_id={@project.id}
+      />
       <%= if f[:branch].value do %>
         <.accept_checkbox
           project={@project}

--- a/priv/repo/migrations/20260420114808_use_sync_v2.exs
+++ b/priv/repo/migrations/20260420114808_use_sync_v2.exs
@@ -1,0 +1,9 @@
+defmodule Lightning.Repo.Migrations.UseSyncV2 do
+  use Ecto.Migration
+
+  def change do
+    alter table(:project_repo_connections) do
+      add :use_yaml_config, :boolean, null: false, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260420114808_use_sync_v2.exs
+++ b/priv/repo/migrations/20260420114808_use_sync_v2.exs
@@ -3,7 +3,7 @@ defmodule Lightning.Repo.Migrations.UseSyncV2 do
 
   def change do
     alter table(:project_repo_connections) do
-      add :use_yaml_config, :boolean, null: false, default: false
+      add :sync_version, :boolean, null: false, default: false
     end
   end
 end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -651,8 +651,7 @@ defmodule Lightning.VersionControlTest do
     end
 
     defp path_to_config(repo_connection) do
-      repo_connection
-      |> ProjectRepoConnection.config_path()
+      ProjectRepoConnection.openfn_yaml()
       |> Path.relative_to(".")
     end
   end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -617,7 +617,7 @@ defmodule Lightning.VersionControlTest do
                VersionControl.initiate_sync(repo_connection, commit_message)
     end
 
-    test "creates GH workflow dispatch event", %{
+    test "creates GH workflow dispatch event using JSON config (default)", %{
       commit_message: commit_message,
       repo_connection: repo_connection,
       snapshots: [snapshot, other_snapshot]
@@ -644,6 +644,39 @@ defmodule Lightning.VersionControlTest do
       assert :ok = VersionControl.initiate_sync(repo_connection, commit_message)
     end
 
+    test "creates GH workflow dispatch event using YAML config (use_yaml_config: true)",
+         %{
+           commit_message: commit_message,
+           repo_connection: repo_connection,
+           snapshots: [snapshot, other_snapshot]
+         } do
+      yaml_connection =
+        repo_connection
+        |> Ecto.Changeset.change(use_yaml_config: true)
+        |> Lightning.Repo.update!()
+
+      expect_create_installation_token(yaml_connection.github_installation_id)
+      expect_get_repo(yaml_connection.repo)
+
+      expect_create_workflow_dispatch_with_request_body(
+        yaml_connection.repo,
+        "openfn-pull.yml",
+        %{
+          ref: "main",
+          inputs: %{
+            projectId: yaml_connection.project_id,
+            apiSecretName: api_secret_name(yaml_connection),
+            branch: yaml_connection.branch,
+            pathToConfig: path_to_config(yaml_connection),
+            commitMessage: commit_message,
+            snapshots: "#{other_snapshot.id} #{snapshot.id}"
+          }
+        }
+      )
+
+      assert :ok = VersionControl.initiate_sync(yaml_connection, commit_message)
+    end
+
     defp api_secret_name(%{project_id: project_id}) do
       project_id
       |> String.replace("-", "_")
@@ -651,7 +684,7 @@ defmodule Lightning.VersionControlTest do
     end
 
     defp path_to_config(repo_connection) do
-      ProjectRepoConnection.openfn_yaml()
+      ProjectRepoConnection.config_path(repo_connection)
       |> Path.relative_to(".")
     end
   end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -865,6 +865,123 @@ defmodule Lightning.VersionControlTest do
     end
   end
 
+  describe "config file blob content" do
+    setup do
+      Mox.verify_on_exit!()
+
+      project = insert(:project)
+      user = user_with_valid_github_oauth()
+
+      repo = "someaccount/somerepo"
+      branch = "somebranch"
+      installation_id = "1234"
+
+      base_params = %{
+        "project_id" => project.id,
+        "repo" => repo,
+        "branch" => branch,
+        "github_installation_id" => installation_id,
+        "sync_direction" => "pull",
+        "accept" => "true"
+      }
+
+      expected_repo = %{"full_name" => repo, "default_branch" => "main"}
+
+      {:ok,
+       project: project,
+       user: user,
+       repo: repo,
+       branch: branch,
+       installation_id: installation_id,
+       base_params: base_params,
+       expected_repo: expected_repo}
+    end
+
+    defp setup_github_mocks(repo, expected_repo) do
+      expect_get_repo(repo, 200, expected_repo)
+      expect_create_blob(repo)
+      expect_get_commit(repo, expected_repo["default_branch"])
+      expect_create_tree(repo)
+      expect_create_commit(repo)
+      expect_update_ref(repo, expected_repo["default_branch"])
+      expect_create_blob(repo)
+    end
+
+    test "pushes JSON config blob when sync_version is false (default)", %{
+      project: project,
+      user: user,
+      repo: repo,
+      branch: branch,
+      installation_id: installation_id,
+      base_params: base_params,
+      expected_repo: expected_repo
+    } do
+      setup_github_mocks(repo, expected_repo)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://api.github.com/repos/#{repo}/git/blobs"
+        body = Jason.decode!(env.body)
+
+        assert body["content"] =~
+                 "\"statePath\": \"openfn-#{project.id}-state.json\""
+
+        assert body["content"] =~
+                 "\"specPath\": \"openfn-#{project.id}-spec.yaml\""
+
+        {:ok, %Tesla.Env{status: 201, body: %{"sha" => "3a0f8"}}}
+      end)
+
+      secret_name = "OPENFN_#{String.replace(project.id, "-", "_")}_API_KEY"
+      expect_get_commit(repo, branch)
+      expect_create_tree(repo)
+      expect_create_commit(repo)
+      expect_update_ref(repo, branch)
+      expect_get_public_key(repo)
+      expect_create_repo_secret(repo, secret_name)
+      expect_create_installation_token(installation_id)
+      expect_get_repo(repo, 200, expected_repo)
+      expect_create_workflow_dispatch(repo, "openfn-pull.yml")
+
+      assert {:ok, _} =
+               VersionControl.create_github_connection(base_params, user)
+    end
+
+    test "pushes YAML config blob when sync_version is true", %{
+      project: project,
+      user: user,
+      repo: repo,
+      branch: branch,
+      installation_id: installation_id,
+      base_params: base_params,
+      expected_repo: expected_repo
+    } do
+      setup_github_mocks(repo, expected_repo)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://api.github.com/repos/#{repo}/git/blobs"
+        body = Jason.decode!(env.body)
+        assert body["content"] =~ "project:"
+        assert body["content"] =~ "uuid: #{project.id}"
+        assert body["content"] =~ LightningWeb.Endpoint.url()
+        {:ok, %Tesla.Env{status: 201, body: %{"sha" => "3a0f8"}}}
+      end)
+
+      secret_name = "OPENFN_#{String.replace(project.id, "-", "_")}_API_KEY"
+      expect_get_commit(repo, branch)
+      expect_create_tree(repo)
+      expect_create_commit(repo)
+      expect_update_ref(repo, branch)
+      expect_get_public_key(repo)
+      expect_create_repo_secret(repo, secret_name)
+      expect_create_installation_token(installation_id)
+      expect_get_repo(repo, 200, expected_repo)
+      expect_create_workflow_dispatch(repo, "openfn-pull.yml")
+
+      params = Map.put(base_params, "sync_version", "true")
+      assert {:ok, _} = VersionControl.create_github_connection(params, user)
+    end
+  end
+
   defp user_with_valid_github_oauth do
     active_token = %{
       "access_token" => "access-token",

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -644,7 +644,7 @@ defmodule Lightning.VersionControlTest do
       assert :ok = VersionControl.initiate_sync(repo_connection, commit_message)
     end
 
-    test "creates GH workflow dispatch event using YAML config (use_yaml_config: true)",
+    test "creates GH workflow dispatch event using YAML config (sync_version: true)",
          %{
            commit_message: commit_message,
            repo_connection: repo_connection,
@@ -652,7 +652,7 @@ defmodule Lightning.VersionControlTest do
          } do
       yaml_connection =
         repo_connection
-        |> Ecto.Changeset.change(use_yaml_config: true)
+        |> Ecto.Changeset.change(sync_version: true)
         |> Lightning.Repo.update!()
 
       expect_create_installation_token(yaml_connection.github_installation_id)

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2907,6 +2907,72 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert_redirect(view, ~p"/projects/#{parent.id}/w")
     end
 
+    test "commits to GitHub using YAML config when use_yaml_config is true",
+         %{
+           conn: conn,
+           parent: parent,
+           sandbox: sandbox,
+           snapshot: snapshot
+         } do
+      repo_connection =
+        insert(:project_repo_connection,
+          project: parent,
+          repo: "someaccount/somerepo",
+          branch: "main",
+          github_installation_id: "1234",
+          use_yaml_config: true
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      expect_create_installation_token(repo_connection.github_installation_id)
+      expect_get_repo(repo_connection.repo)
+
+      expect_create_workflow_dispatch_with_request_body(
+        repo_connection.repo,
+        "openfn-pull.yml",
+        %{
+          ref: "main",
+          inputs: %{
+            projectId: parent.id,
+            apiSecretName: api_secret_name(parent),
+            branch: repo_connection.branch,
+            pathToConfig: path_to_config(repo_connection),
+            commitMessage: "pre-merge commit",
+            snapshots: "#{snapshot.id}"
+          }
+        }
+      )
+
+      expect_create_installation_token(repo_connection.github_installation_id)
+      expect_get_repo(repo_connection.repo)
+
+      expect_create_workflow_dispatch_with_request_body(
+        repo_connection.repo,
+        "openfn-pull.yml",
+        %{
+          ref: "main",
+          inputs: %{
+            projectId: parent.id,
+            apiSecretName: api_secret_name(parent),
+            branch: repo_connection.branch,
+            pathToConfig: path_to_config(repo_connection),
+            commitMessage: "Merged sandbox #{sandbox.name}"
+          }
+        }
+      )
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      assert_redirect(view, ~p"/projects/#{parent.id}/w")
+    end
+
     test "does not commit to GitHub when project has no GitHub sync configured",
          %{
            conn: conn,
@@ -2937,7 +3003,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
     end
 
     defp path_to_config(repo_connection) do
-      Lightning.VersionControl.ProjectRepoConnection.openfn_yaml()
+      Lightning.VersionControl.ProjectRepoConnection.config_path(repo_connection)
       |> Path.relative_to(".")
     end
   end

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2937,8 +2937,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
     end
 
     defp path_to_config(repo_connection) do
-      repo_connection
-      |> Lightning.VersionControl.ProjectRepoConnection.config_path()
+      Lightning.VersionControl.ProjectRepoConnection.openfn_yaml()
       |> Path.relative_to(".")
     end
   end

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2907,7 +2907,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert_redirect(view, ~p"/projects/#{parent.id}/w")
     end
 
-    test "commits to GitHub using YAML config when use_yaml_config is true",
+    test "commits to GitHub using YAML config when sync_version is true",
          %{
            conn: conn,
            parent: parent,
@@ -2920,7 +2920,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
           repo: "someaccount/somerepo",
           branch: "main",
           github_installation_id: "1234",
-          use_yaml_config: true
+          sync_version: true
         )
 
       {:ok, view, _html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")


### PR DESCRIPTION
## Description

This PR makes sync v2 protocol an option for syncing projects with Github. By default sync will use the old `config.json` style but users can switch to the new `openfn.yaml` style if they prefer.

**Currently defaults to v1 (legacy) but can be switched to v2 (new) style**


<table>
<tbody>
<tr>
    <th colspan='2'>Github Sync Setup Screen</th>
  </tr>
<tr>
    <td colspan='2'>
    <img width="924" height="358" alt="Screenshot 2026-04-20 at 12 06 56 PM" src="https://github.com/user-attachments/assets/18c4840d-2db6-4f67-9afb-d79622334213" />
    </td>
  </tr>
<tr>
    <th>Legacy</th>
    <th>New</th>
  </tr>
  <tr>
    <td>
<img width="578" height="326" alt="Screenshot 2026-04-21 at 6 48 44 AM" src="https://github.com/user-attachments/assets/0554afb7-1776-4121-8db8-b338f9c78657" />
</td>
    <td>
<img width="544" height="314" alt="Screenshot 2026-04-21 at 6 47 58 AM" src="https://github.com/user-attachments/assets/9119c416-31a9-42fb-9156-2c2ce5a8c60e" />
</td>
  </tr>
</tbody>
</table>

Closes #4523 

## Validation steps

1. Try to sync a project with github. connect and select the repo you want to sync with
2. Click on Advanced: Use new `openfn.yaml` format
3. After connecting. sync the project.
4. Check whether your `openfn.yaml` is in github with nicely generated content like the example below

#### Example `openfn.yaml` content
```yaml
project:
  uuid: 43c34b65-50cf-4ec3-b480-32b3b17ac9c0
  endpoint: <your-instance-url>
  alias: 
  inserted_at: 2026-04-13T01:00:00Z
  updated_at: 2026-04-13T04:37:54Z
  id: sync
  name: sync
workspace:
  credentials: credentials.yaml
  dirs:
    projects: .projects
    workflows: workflows
  formats:
    openfn: yaml
    project: yaml
    workflow: yaml
```
## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
