### PR TITLE
Reserve scrollbar space on main content area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to
 
 ### Fixed
 
+- Reserve space for the scrollbar on the main content area so page content no
+  longer shifts horizontally when switching between tall and short tabs (e.g. on
+  the Project Settings page).
 - Sandbox merge no longer deletes a workflow that was added to the project after
   the sandbox was branched. Such workflows were never part of the sandbox, so
   they are excluded from the merge screen entirely. Workflows deleted inside the
@@ -745,9 +748,6 @@ Migrations in this release, all in `priv/repo/migrations/`:
 
 - Bump `@openfn/ws-worker` from
   [`1.23.6` to `1.23.8`](https://github.com/OpenFn/kit/blob/@openfn/ws-worker@1.23.8/packages/ws-worker/CHANGELOG.md?plain=1#L3-L16)
-- Reserve space for the scrollbar on the main content area so page content no
-  longer shifts horizontally when switching between tall and short tabs (e.g. on
-  the Project Settings page).
 
 ## [2.16.2-pre] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,9 @@ Migrations in this release, all in `priv/repo/migrations/`:
 
 - Bump `@openfn/ws-worker` from
   [`1.23.6` to `1.23.8`](https://github.com/OpenFn/kit/blob/@openfn/ws-worker@1.23.8/packages/ws-worker/CHANGELOG.md?plain=1#L3-L16)
+- Reserve space for the scrollbar on the main content area so page content no
+  longer shifts horizontally when switching between tall and short tabs (e.g. on
+  the Project Settings page).
 
 ## [2.16.2-pre] - 2026-04-16
 

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -205,7 +205,7 @@ defmodule LightningWeb.LayoutComponents do
       <div class="flex-auto bg-secondary-100 relative">
         <section
           id="inner_content"
-          class="overflow-y-auto [scrollbar-gutter:stable] absolute top-0 bottom-0 left-0 right-0"
+          class="overflow-y-auto [scrollbar-gutter:stable_both-edges] absolute top-0 bottom-0 left-0 right-0"
         >
           {render_slot(@inner_block)}
         </section>

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -205,7 +205,7 @@ defmodule LightningWeb.LayoutComponents do
       <div class="flex-auto bg-secondary-100 relative">
         <section
           id="inner_content"
-          class="overflow-y-auto absolute top-0 bottom-0 left-0 right-0"
+          class="overflow-y-auto [scrollbar-gutter:stable] absolute top-0 bottom-0 left-0 right-0"
         >
           {render_slot(@inner_block)}
         </section>


### PR DESCRIPTION
## Description

This PR fixes a small but visible layout bug: content on every page that uses `page_content` shifts horizontally as the vertical scrollbar toggles on and off. Most obvious on the Project Settings page — switching between tall tabs (Setup) and short ones (Security, Collaboration) makes the page bounce sideways ~15px.

The fix is a single CSS rule on the scrolling element (`#inner_content`):

```
scrollbar-gutter: stable
```

Reserves gutter space whether the scrollbar is currently rendered or not, so content width never changes.

## Validation steps

1. Open a project's Project Settings page.
2. Click the **Setup** tab.
3. Switch to **Security** (a shorter tab), then back to **Setup**.
4. Confirm the content no longer shifts left/right as the scrollbar toggles.
5. Spot check the workflow editor and dashboard pages to confirm nothing else regressed visually.

## Additional notes for the reviewer

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (N/A — pure CSS change)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR