### PR TITLE
send project_id to worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to
 
 ### Changed
 
+- Worker plan payload now includes `project_id` so workers can scope callbacks
+  (e.g. the collections API) to the project that owns the run.
+
 ### Fixed
 
 ## [2.16.2] - 2026-04-20

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -84,7 +84,7 @@ defmodule Lightning.Runs do
     Multi.new()
     |> Multi.one(
       :__pre_check_run__,
-      get_query(id, include: [snapshot: [jobs: :credential]])
+      get_query(id, include: [snapshot: [:workflow, jobs: :credential]])
     )
     |> Multi.merge(fn %{__pre_check_run__: run} ->
       Multi.new() |> Multi.put(:run, run)

--- a/lib/lightning_web/channels/run_with_options.ex
+++ b/lib/lightning_web/channels/run_with_options.ex
@@ -21,6 +21,7 @@ defmodule LightningWeb.RunWithOptions do
   def render(%Run{} = run) do
     %{
       "id" => run.id,
+      "project_id" => run.snapshot.workflow.project_id,
       "triggers" => run.snapshot.triggers |> Enum.map(&render/1),
       "jobs" => run.snapshot.jobs |> Enum.map(&render/1),
       "edges" => run.snapshot.edges |> Enum.map(&render/1),

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -163,6 +163,7 @@ defmodule LightningWeb.RunChannelTest do
 
       assert payload == %{
                "id" => id,
+               "project_id" => workflow.project_id,
                "triggers" => triggers,
                "jobs" => jobs,
                "edges" => edges,
@@ -221,6 +222,7 @@ defmodule LightningWeb.RunChannelTest do
 
       assert payload == %{
                "id" => id,
+               "project_id" => workflow.project_id,
                "triggers" => triggers,
                "jobs" => jobs,
                "edges" => edges,

--- a/test/lightning_web/channels/run_with_options_test.exs
+++ b/test/lightning_web/channels/run_with_options_test.exs
@@ -38,6 +38,7 @@ defmodule LightningWeb.RunWithOptionsTest do
             }
           ],
           "id" => run.id,
+          "project_id" => workflow.project_id,
           "jobs" => [
             %{
               "adaptor" => "@openfn/language-common@1.6.2",
@@ -87,6 +88,7 @@ defmodule LightningWeb.RunWithOptionsTest do
             }
           ],
           "id" => run.id,
+          "project_id" => workflow.project_id,
           "jobs" => [
             %{
               "adaptor" => "@openfn/language-common@1.6.2",


### PR DESCRIPTION
## Description

Workers need `project_id` to scope callbacks (e.g. the new collections API) to the project that owns the run they're executing. This adds `project_id` to the plan payload sent by the run channel.

Derived from `run.snapshot.workflow.project_id` inside `RunWithOptions.render/1` rather than threaded through as a new arg, so `render/1` stays a pure projection of its input and stays symmetrical with the sibling clauses for triggers, jobs, and edges. `Runs.get_for_worker/1` preloads `:workflow` on the snapshot so the value is always hydrated at render time.

## Validation steps

Pick whichever fits. Option 1 is a 30-second sanity check. Option 2 is the full roundtrip through a real worker if you want to see it live. Both options cover both regular projects and sandboxes, because those are the two cases worth confirming — the sandbox case is the whole reason this change exists (so the worker can scope collections-in-sandboxes calls to the sandbox, not its parent).

### Option 1: IEx one-liner (quickest)

Start Lightning in dev, open the IEx prompt, and paste the snippet twice — once for a run in a regular project, once for a run in a sandbox.

```elixir
run =
  Lightning.Repo.get!(Lightning.Runs.Run, "<run-id>")
  |> Lightning.Runs.get_for_worker()

LightningWeb.RunWithOptions.render(run)
```

For each run, confirm in the returned map:

- `"project_id"` is present at the top level.
- Its value matches `run.snapshot.workflow.project_id`.

Specifically:

- **Regular project run** — `project_id` should equal the project ID shown in the UI.
- **Sandbox run** — `project_id` should equal the **sandbox's** project ID, not the parent project's. The sandbox has its own UUID; that's the one the worker needs.

If the dev DB has no runs yet, trigger the workflows from the UI so there's a row of each kind to fetch.

### Option 2: End-to-end through a real worker

Lightning's dev mode auto-starts an embedded ws-worker (see `Lightning.Runtime.RuntimeManager`), so you don't need to launch one separately.

1. Start Lightning:
   ```bash
   iex -S mix phx.server
   ```
   Wait for the log line `Starting runtime with opts: [...]` — that's the worker coming up inside Lightning's supervision tree. Both Lightning logs and worker logs print to this same terminal.

2. In the Lightning UI, open a workflow in a **regular project** and click **Run** (or send a webhook, or wait for a cron to fire).

3. In the terminal, watch for the channel lifecycle lines. They look roughly like this:
   ```
   [debug] JOINED worker:queue ...
   [debug] JOINED run:<run-id> ...
   [debug] HANDLE IN "fetch:plan" ...
   [debug] Replied in ...
   ```

4. The worker now has the plan. Confirm it contains `project_id` using IEx in the same session:
   ```elixir
   run = Lightning.Runs.get_for_worker("<run-id-from-the-logs>")
   LightningWeb.RunWithOptions.render(run) |> Map.get("project_id")
   # => the regular project's UUID
   ```

5. Repeat steps 2–4 from **inside a sandbox** — open a sandbox in the UI, run one of its workflows, and confirm the returned `project_id` is the **sandbox's** UUID (not the parent project's).

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (N/A — no authz surface)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR