### PR TITLE
Bump local worker to 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 
 ### Changed
 
+- bumped local worker to 1.24.0
+
 ### Fixed
 
 ## [2.16.2] - 2026-04-20

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -59,7 +59,7 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
         "@eslint/js": "^9.21.0",
-        "@openfn/ws-worker": "^1.23.7",
+        "@openfn/ws-worker": "^1.24.0",
         "@playwright/test": "^1.55.0",
         "@redux-devtools/extension": "^3.3.0",
         "@testing-library/jest-dom": "^6.9.0",
@@ -2250,9 +2250,9 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-1.11.1.tgz",
-      "integrity": "sha512-n1sBXs/XDyt5HymKscQblXCoTLcWrm2H3ZmOJmCY54HL08hKIYlJ9y8sJBmdJJ+2n5Lae+qRlJSLVZs7l9Dd8A==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-1.11.2.tgz",
+      "integrity": "sha512-s18b5KfRmBgmi7NO/JwxedvJ9p5D+fJhEOI1Mi4W+8RDA/PbvApKAFvVfUL7lnKK7uwONge+M2EWCdC5CEhYWg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2260,7 +2260,7 @@
         "@openfn/language-common": "3.2.3",
         "@openfn/lexicon": "^1.4.2",
         "@openfn/logger": "1.1.2",
-        "@openfn/runtime": "1.9.0",
+        "@openfn/runtime": "1.9.1",
         "fast-safe-stringify": "^2.1.1",
         "json-stream-stringify": "^3.1.6"
       }
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/@openfn/lexicon": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@openfn/lexicon/-/lexicon-1.4.2.tgz",
-      "integrity": "sha512-v72JjlhMu/B0ql2rn/m0x38txtygT0TXKba/xgazEa5tKcnyOIf6RBh+UmOMeiCj05AQ4iuPcNk6WADGmpuvpA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@openfn/lexicon/-/lexicon-1.5.0.tgz",
+      "integrity": "sha512-mIlQs0DEHqAUZjxHsOjuKAw6AtEtPxdjMDotiDzLOskg+UztbZLbc63FGG8IN5CfCti8ajzSnqRFmE+0Kg8zAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2327,9 +2327,9 @@
       }
     },
     "node_modules/@openfn/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-z/Mtggsx5EWT9OwyD+O1gdvWvdBEMct+/SPeiDtkElTXX/IhonxfqVQtT2uTIbmQjQOyfQ2+iZr2AZpkCiUB4A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@openfn/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-mGdJ0KVNX7iGBhghu/A6L5hUspUcY5oiv8T35jD+H3egZ/V86qK6mlveV9sjQNXX7bnLHsj3ArdGc2iOYNPxSA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2341,18 +2341,18 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "1.23.7",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-1.23.7.tgz",
-      "integrity": "sha512-0AOE8+F9qtlV5Mneg6KhunLfeotJPHmC2i53Tr8zWIEoWp5/05A6McL6slJ1YWY9F+VQ06VJuE+YOGiHDHbFrw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-1.24.0.tgz",
+      "integrity": "sha512-VTRqkKXr9EwfaC4Fqd2T9EWLdBsXXKnRze3D5Qmv1mutRndtygwcsm7xN13jkiQO3GGjK9qx/iacrpH5q+yatw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@koa/bodyparser": "^6.1.0",
         "@koa/router": "^15.4.0",
-        "@openfn/engine-multi": "1.11.1",
-        "@openfn/lexicon": "^1.4.2",
+        "@openfn/engine-multi": "1.11.2",
+        "@openfn/lexicon": "^1.5.0",
         "@openfn/logger": "1.1.2",
-        "@openfn/runtime": "1.9.0",
+        "@openfn/runtime": "1.9.1",
         "@sentry/node": "^10.44.0",
         "@types/koa-logger": "^3.1.5",
         "@types/ws": "^8.18.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
     "@eslint/js": "^9.21.0",
-    "@openfn/ws-worker": "^1.23.8",
+    "@openfn/ws-worker": "^1.24.0",
     "@playwright/test": "^1.55.0",
     "@redux-devtools/extension": "^3.3.0",
     "@testing-library/jest-dom": "^6.9.0",

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -268,7 +268,7 @@ defmodule Lightning.WebAndWorkerTest do
 
       version_logs = pick_out_version_logs(run)
       assert version_logs["@openfn/language-http"] =~ "3.1.12"
-      assert version_logs["worker"] =~ "1.23"
+      assert version_logs["worker"] =~ "1.24"
       assert version_logs["node.js"] =~ "22.12"
       assert version_logs["@openfn/language-common"] == "3.0.2"
 


### PR DESCRIPTION
Supports handling of `project_id` for collections