### PR TITLE
feat: run from here button text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 - Worker plan payload now includes `project_id` so workers can scope callbacks
   (e.g. the collections API) to the project that owns the run.
 - bumped local worker to 1.24.0
+- Update run text to run from here
+  [#4617](https://github.com/OpenFn/lightning/issues/4617)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to
 - Worker plan payload now includes `project_id` so workers can scope callbacks
   (e.g. the collections API) to the project that owns the run.
 - bumped local worker to 1.24.0
-- Update run text to run from here
+- Update 'Run' button label to 'Run From Here' in the job inspector panel
   [#4617](https://github.com/OpenFn/lightning/issues/4617)
 
 ### Fixed

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -647,7 +647,7 @@ export function ManualRunPanel({
                 void handleRetry().then(ok => ok && closeAfterRun());
               }}
               buttonText={{
-                run: 'Run',
+                run: 'Run From Here',
                 retry: 'Run (Retry)',
                 processing: 'Processing',
               }}

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -8,6 +8,7 @@ interface NewRunButtonProps {
   onClick: () => void;
   disabled?: boolean;
   tooltipSide?: 'top' | 'bottom';
+  text?: string;
 }
 
 /**
@@ -26,6 +27,7 @@ export function NewRunButton({
   onClick,
   disabled: disabledProp,
   tooltipSide = 'bottom',
+  text = 'Run',
 }: NewRunButtonProps) {
   const { canRun, tooltipMessage } = useCanRun();
 
@@ -44,7 +46,7 @@ export function NewRunButton({
         <Button variant="primary" onClick={onClick} disabled={isDisabled}>
           <span className="flex items-center gap-1">
             <span className="hero-play h-4 w-4" />
-            Run
+            {text}
           </span>
         </Button>
       </span>

--- a/assets/js/collaborative-editor/components/inspector/JobInspector.tsx
+++ b/assets/js/collaborative-editor/components/inspector/JobInspector.tsx
@@ -102,6 +102,7 @@ export function JobInspector({
             onClick={() => onOpenRunPanel({ jobId: job.id })}
             tooltipSide="top"
             disabled={isReadOnly}
+            text="Run From Here"
           />
         </>
       }

--- a/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
@@ -592,7 +592,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // Verify Run button is available (shortcuts configured in lines 439-447)
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
     });
 
@@ -618,7 +618,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
 
       // Verify Run button is NOT shown in embedded mode
       // (shortcuts disabled via enabled: renderMode === RENDER_MODES.STANDALONE)
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
     });
 
     test('run button respects canRun guard', async () => {
@@ -644,7 +644,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // Verify Run button is disabled when canRun is false
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).toBeDisabled();
     });
 
@@ -670,7 +670,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // Click Run button
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       act(() => {
         runButton.click();
       });
@@ -709,7 +709,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       // In embedded mode, shortcuts are disabled (enabled: renderMode === STANDALONE)
       // This prevents conflicts with IDE shortcuts
       expect(screen.queryByText('Run from Test Job')).not.toBeInTheDocument();
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
     });
 
     test('standalone mode provides full UI with shortcuts', async () => {
@@ -733,7 +733,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // In standalone mode, full UI is rendered with shortcuts enabled
-      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.getByText('Run From Here')).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /close panel/i })
       ).toBeInTheDocument();
@@ -762,7 +762,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
 
       // useRunRetryShortcuts configured with enabled: renderMode === RENDER_MODES.STANDALONE
       // This ensures shortcuts only work in standalone mode, preventing conflicts with IDE
-      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.getByText('Run From Here')).toBeInTheDocument();
     });
   });
 
@@ -1279,7 +1279,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
         await new Promise(resolve => setTimeout(resolve, 200));
 
         // Click run button to start running
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         act(() => {
           runButton.click();
         });

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -360,7 +360,7 @@ describe('ManualRunPanel', () => {
     });
 
     await waitFor(() => {
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
     });
   });
@@ -560,7 +560,7 @@ describe('ManualRunPanel', () => {
 
     // Run button should be enabled
     await waitFor(() => {
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
     });
   });
@@ -608,7 +608,7 @@ describe('ManualRunPanel', () => {
       ).toBeInTheDocument();
 
       // Should show footer with Run button
-      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.getByText('Run From Here')).toBeInTheDocument();
     });
 
     test('embedded mode shows only content, no header or footer', async () => {
@@ -635,7 +635,7 @@ describe('ManualRunPanel', () => {
       ).not.toBeInTheDocument();
 
       // Should NOT show footer with Run button
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
     });
 
     test('embedded mode with trigger context', async () => {
@@ -735,7 +735,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });
@@ -751,7 +751,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
     });
@@ -802,7 +802,7 @@ describe('ManualRunPanel', () => {
 
       // Run button should still be disabled due to lack of permission
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });
@@ -840,11 +840,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for initial render
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Click Run button
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Verify save was called first, then run
       await waitFor(() => {
@@ -871,10 +871,10 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Save should be called
       await waitFor(() => {
@@ -910,10 +910,10 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Save should be called
       await waitFor(() => {
@@ -954,11 +954,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for initial render
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Click Run button
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Verify saveWorkflow was called with { silent: true }
       await waitFor(() => {
@@ -994,11 +994,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for initial render
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Click Run button - this will start the save
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Button should show "Processing" while submitting
       // Use helper for CSS Grid layout (invisible spacers render same text)
@@ -1050,7 +1050,7 @@ describe('ManualRunPanel', () => {
 
       // Button should be enabled with selected dataclip
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
 
@@ -1073,7 +1073,7 @@ describe('ManualRunPanel', () => {
 
       // Button should now be disabled
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });
@@ -1133,7 +1133,7 @@ describe('ManualRunPanel', () => {
       expect(screen.getByText('Test Dataclip')).toBeInTheDocument();
 
       // Run button should still be disabled
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).toBeDisabled();
     });
 
@@ -1178,7 +1178,7 @@ describe('ManualRunPanel', () => {
 
       // Run button should be enabled on Empty tab
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
     });
@@ -1248,10 +1248,10 @@ describe('ManualRunPanel', () => {
 
       // Footer should be rendered with Run button
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
 
       // The footer button passes showKeyboardShortcuts=true
@@ -1271,7 +1271,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
 
@@ -1309,11 +1309,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for component to load with retryable state
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Footer button should be rendered
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).toBeInTheDocument();
 
       // showKeyboardShortcuts=true is passed, enabling tooltip for main button
@@ -1336,7 +1336,7 @@ describe('ManualRunPanel', () => {
       });
 
       // Footer should NOT be rendered in embedded mode
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
 
       // No tooltip concerns because RunRetryButton is not rendered in footer
     });
@@ -1361,7 +1361,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
     });
@@ -1384,7 +1384,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });

--- a/assets/test/collaborative-editor/components/NewRunButton.test.tsx
+++ b/assets/test/collaborative-editor/components/NewRunButton.test.tsx
@@ -75,6 +75,21 @@ describe('NewRunButton - Disabled Prop', () => {
 
     expect(screen.getByText('Run')).toBeInTheDocument();
   });
+
+  test('button renders with custom text when text prop is provided', () => {
+    const mockOnClick = vi.fn();
+
+    render(
+      <NewRunButton
+        onClick={mockOnClick}
+        disabled={false}
+        text="Run From Here"
+      />
+    );
+
+    expect(screen.getByText('Run From Here')).toBeInTheDocument();
+    expect(screen.queryByText('Run')).not.toBeInTheDocument();
+  });
 });
 
 describe('NewRunButton - Tooltip Positioning', () => {


### PR DESCRIPTION
## Description

This PR updates the wording for "Run" on the jobInspector panel and the run Panel from "Run" to "Run From Here".

Closes #4617

## Validation steps

1. _(How can a reviewer validate your work?)_

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
