### PR TITLE
Sandbox merge UI update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ and this project adheres to
 
 - Worker plan payload now includes `project_id` so workers can scope callbacks
   (e.g. the collections API) to the project that owns the run.
-- bumped local worker to 1.24.0
+- Bumped local worker to 1.24.0
+- Updated the Merge Sandbox UI to be cleaner, clearer, and only include changed
+  workflows by default [#4651](https://github.com/OpenFn/lightning/issues/4651)
 
 ### Fixed
 

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -952,6 +952,8 @@ defmodule Lightning.Projects.MergeProjects do
   sandbox was forked. Specifically, a workflow has diverged if the target's current HEAD
   version is not present in the sandbox's version history.
 
+  Arguments can be reversed to get changes in a sandbox against main.
+
   ## Parameters
     * `source_project` - The sandbox project
     * `target_project` - The target project to compare against

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -246,9 +246,6 @@ defmodule Lightning.Projects.Sandboxes do
   @doc """
   Deletes a sandbox and all its descendant projects.
 
-  **Warning**: This permanently removes the sandbox and any nested sandboxes
-  within it. This action cannot be undone.
-
   ## Parameters
   * `sandbox` - Sandbox project to delete (or sandbox ID as string)
   * `actor` - User performing the deletion (needs `:owner` or `:admin` role on sandbox)

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -268,41 +268,6 @@ defmodule LightningWeb.SandboxLive.Components do
             will be lost.
           </p>
 
-          <%= if @descendant_count > 1 do %>
-            <Common.alert
-              id="merge-descendants-alert"
-              type="warning"
-              header="Child sandboxes will be closed"
-            >
-              <:message>
-                <p class="mb-2">
-                  The following {@descendant_count} sandboxes will be permanently closed:
-                </p>
-                <ul class="list-disc list-inside space-y-1 ml-2 mb-3">
-                  <li :for={descendant <- @descendants}>
-                    {descendant.name}
-                  </li>
-                </ul>
-                <p>
-                  Consider merging child sandboxes into
-                  <strong>{@sandbox.name}</strong>
-                  first to preserve their work before merging up.
-                </p>
-              </:message>
-            </Common.alert>
-          <% end %>
-
-          <%= if @descendant_count == 1 do %>
-            <Common.alert id="merge-single-descendant-alert" type="warning">
-              <:message>
-                <strong>{List.first(@descendants).name}</strong>
-                will also be closed. Consider merging it into
-                <strong>{@sandbox.name}</strong>
-                first to preserve its work.
-              </:message>
-            </Common.alert>
-          <% end %>
-
           <div class="border border-gray-200 rounded-md overflow-hidden">
             <div class="flex items-center justify-between px-3 py-2 bg-gray-50 border-b border-gray-200">
               <span class="text-sm font-medium text-gray-700">
@@ -372,6 +337,13 @@ defmodule LightningWeb.SandboxLive.Components do
           >
             <:message>
               This action cannot be undone.
+              <div :if={@descendant_count == 1} class="mt-2">
+                Child sandbox <strong>{List.first(@descendants).name}</strong>
+                will also be permanently closed.
+              </div>
+              <div :if={@descendant_count > 1} class="mt-2">
+                Its {@descendant_count} child sandboxes will also be permanently closed.
+              </div>
             </:message>
           </Common.alert>
 

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -221,7 +221,7 @@ defmodule LightningWeb.SandboxLive.Components do
     >
       <:title>
         <div class="flex items-start justify-between">
-          <span class="font-bold">Merge</span>
+          <span class="font-bold">Merge Sandbox</span>
           <button
             type="button"
             class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
@@ -258,7 +258,7 @@ defmodule LightningWeb.SandboxLive.Components do
             </div>
           </div>
 
-          <p class="text-gray-700">
+          <p class="text-xs text-gray-700">
             This will overwrite the selected workflows in
             <strong>
               {get_selected_target_label(
@@ -266,22 +266,24 @@ defmodule LightningWeb.SandboxLive.Components do
                 @merge_form[:target_id].value
               )}
             </strong>
-            with the versions from <strong>{@sandbox.name}</strong>,
+            with the versions from sandbox <strong>{@sandbox.name}</strong>,
             then delete <strong>{@sandbox.name}</strong>
+            <%= if @descendant_count == 0 do %>
+              .
+            <% end %>
             <%= if @descendant_count == 1 do %>
-              and its child sandbox <strong>{List.first(@descendants).name}</strong>
+              and its child sandbox <strong>{List.first(@descendants).name}.</strong>
             <% end %>
             <%= if @descendant_count > 1 do %>
-              and its {@descendant_count} child sandboxes
-            <% end %>.
-            Any changes in
+              and its {@descendant_count} child sandboxes.
+            <% end %>
+            Any conflicting changes in
             <strong>
               {get_selected_target_label(
                 @target_options,
                 @merge_form[:target_id].value
               )}
             </strong>
-            that conflict with <strong>{@sandbox.name}</strong>
             will be lost.
           </p>
 
@@ -377,11 +379,10 @@ defmodule LightningWeb.SandboxLive.Components do
           <Common.alert
             id="merge-beta-warning"
             type="danger"
-            header="This action cannot be undone"
+            header="After merging this sandbox will be deleted"
           >
             <:message>
-              Sandbox merging is in beta. For production projects, use the CLI to merge locally and preview changes first.
-              Collection names will be synced: new collections are added (empty) to the target, and collections missing from the sandbox are removed from the target. Collection data is never merged.
+              This action cannot be undone.
             </:message>
           </Common.alert>
 

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -208,6 +208,13 @@ defmodule LightningWeb.SandboxLive.Components do
       assigns
       |> assign(:merge_form, to_form(assigns.changeset, as: :merge))
       |> assign(:descendant_count, length(assigns.descendants))
+      |> assign(
+        :select_all_state,
+        merge_select_all_state(
+          assigns.selected_workflow_ids,
+          assigns.source_workflows
+        )
+      )
 
     ~H"""
     <.modal
@@ -269,20 +276,27 @@ defmodule LightningWeb.SandboxLive.Components do
           </p>
 
           <div class="border border-gray-200 rounded-md overflow-hidden">
-            <div class="flex items-center justify-between px-3 py-2 bg-gray-50 border-b border-gray-200">
+            <label class={[
+              "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
+              @select_all_state == :empty && "cursor-default",
+              @select_all_state != :empty && "cursor-pointer"
+            ]}>
+              <input
+                type="checkbox"
+                id="merge-select-all-workflows"
+                phx-hook="CheckboxIndeterminate"
+                phx-click="toggle-all-workflows"
+                disabled={@select_all_state == :empty}
+                checked={@select_all_state == :all}
+                class={[
+                  "h-4 w-4 rounded border-gray-300 text-indigo-600",
+                  @select_all_state == :partial && "indeterminate"
+                ]}
+              />
               <span class="text-sm font-medium text-gray-700">
                 Workflows to merge
               </span>
-              <button
-                type="button"
-                class="text-sm text-indigo-600 hover:text-indigo-500"
-                phx-click="toggle-all-workflows"
-              >
-                {if MapSet.size(@selected_workflow_ids) == length(@source_workflows),
-                  do: "Deselect all",
-                  else: "Select all"}
-              </button>
-            </div>
+            </label>
             <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
               <li
                 :for={wf <- @source_workflows}
@@ -387,6 +401,16 @@ defmodule LightningWeb.SandboxLive.Components do
 
   defp descendant_suffix(assigns) do
     ~H[{" "}and its {@count} child sandboxes.]
+  end
+
+  defp merge_select_all_state(_selected, []), do: :empty
+
+  defp merge_select_all_state(selected, workflows) do
+    case MapSet.size(selected) do
+      0 -> :none
+      n when n == length(workflows) -> :all
+      _ -> :partial
+    end
   end
 
   attr :id, :string, required: true

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -258,32 +258,13 @@ defmodule LightningWeb.SandboxLive.Components do
             </div>
           </div>
 
-          <p class="text-xs text-gray-700">
+          <p class="text-xs text-gray-700" phx-no-format>
             This will overwrite the selected workflows in
-            <strong>
-              {get_selected_target_label(
-                @target_options,
-                @merge_form[:target_id].value
-              )}
-            </strong>
+            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             with the versions from sandbox <strong>{@sandbox.name}</strong>,
-            then delete <strong>{@sandbox.name}</strong>
-            <%= if @descendant_count == 0 do %>
-              .
-            <% end %>
-            <%= if @descendant_count == 1 do %>
-              and its child sandbox <strong>{List.first(@descendants).name}.</strong>
-            <% end %>
-            <%= if @descendant_count > 1 do %>
-              and its {@descendant_count} child sandboxes.
-            <% end %>
+            then delete <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} />
             Any conflicting changes in
-            <strong>
-              {get_selected_target_label(
-                @target_options,
-                @merge_form[:target_id].value
-              )}
-            </strong>
+            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             will be lost.
           </p>
 
@@ -363,7 +344,8 @@ defmodule LightningWeb.SandboxLive.Components do
                   class="flex items-center gap-1 text-xs text-amber-600"
                   title="This workflow was modified in the target project - this change will be lost"
                 >
-                  ⚠️ <strong>Diverged</strong>
+                  <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
+                  <strong>Diverged</strong>
                 </span>
                 <span
                   :if={wf.is_new}
@@ -416,6 +398,23 @@ defmodule LightningWeb.SandboxLive.Components do
       </.form>
     </.modal>
     """
+  end
+
+  # Caller sits in a phx-no-format <p> so no whitespace leaks between
+  # </strong> and this tag; ~H[...] + {" "} preserve the conditional leading
+  # space that heredoc ~H""" would strip.
+  attr :count, :integer, required: true
+  attr :descendants, :list, required: true
+
+  defp descendant_suffix(%{count: 0} = assigns), do: ~H[.]
+
+  defp descendant_suffix(%{count: 1} = assigns) do
+    assigns = assign(assigns, :name, List.first(assigns.descendants).name)
+    ~H[{" "}and its child sandbox <strong>{@name}</strong>.]
+  end
+
+  defp descendant_suffix(assigns) do
+    ~H[{" "}and its {@count} child sandboxes.]
   end
 
   attr :id, :string, required: true

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -352,11 +352,18 @@ defmodule LightningWeb.SandboxLive.Components do
                 />
                 <span class="flex-1 text-sm text-gray-800">{wf.name}</span>
                 <span
+                  :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
+                  class="flex items-center gap-1 text-xs text-green-600"
+                  title="This workflow has been modified in the sandbox"
+                >
+                  Changed
+                </span>
+                <span
                   :if={wf.is_diverged}
                   class="flex items-center gap-1 text-xs text-amber-600"
-                  title="This workflow has been modified in the target since this sandbox was created"
+                  title="This workflow was modified in the target project - this change will be lost"
                 >
-                  Target modified
+                  ⚠️ <strong>Diverged</strong>
                 </span>
                 <span
                   :if={wf.is_new}
@@ -387,7 +394,14 @@ defmodule LightningWeb.SandboxLive.Components do
           </Common.alert>
 
           <.modal_footer>
-            <.button theme="primary" type="submit">
+            <.button
+              theme="primary"
+              type="submit"
+              disabled={MapSet.size(@selected_workflow_ids) == 0}
+              tooltip={
+                MapSet.size(@selected_workflow_ids) == 0 && "No workflows selected"
+              }
+            >
               Merge
             </.button>
             <.button

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -385,8 +385,8 @@ defmodule LightningWeb.SandboxLive.Components do
 
           <Common.alert
             id="merge-beta-warning"
-            type="danger"
-            header="After merging this sandbox will be deleted"
+            type="warning"
+            header="This sandbox will be deleted after merging"
           >
             <:message>
               This action cannot be undone.

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -14,7 +14,7 @@ defmodule LightningWeb.SandboxLive.Index do
   require Logger
 
   defmodule MergeWorkflow do
-    defstruct [:id, :name, :is_diverged, :is_new, :is_deleted]
+    defstruct [:id, :name, :is_changed, :is_diverged, :is_new, :is_deleted]
   end
 
   on_mount {LightningWeb.Hooks, :project_scope}
@@ -200,29 +200,39 @@ defmodule LightningWeb.SandboxLive.Index do
               target_id: default_target && default_target.value
             })
 
+          target_id = default_target && default_target.value
+
           diverged_workflows =
             get_diverged_workflows(
               sandbox,
-              default_target && default_target.value,
+              target_id,
               socket.assigns.workspace_projects
             )
 
           target_project =
             Enum.find(
               socket.assigns.workspace_projects,
-              fn project ->
-                project.id == (default_target && default_target.value)
-              end
+              fn project -> project.id == target_id end
+            )
+
+          sandbox_changed_workflows =
+            get_changed_workflows(
+              sandbox,
+              target_project
             )
 
           source_workflows =
             build_merge_workflow_list(
               sandbox,
               diverged_workflows,
+              sandbox_changed_workflows,
               target_project
             )
 
-          selected_ids = MapSet.new(source_workflows, fn wf -> wf.id end)
+          selected_ids =
+            source_workflows
+            |> Enum.filter(fn wf -> wf.is_changed end)
+            |> MapSet.new(fn wf -> wf.id end)
 
           {:noreply,
            socket
@@ -296,26 +306,40 @@ defmodule LightningWeb.SandboxLive.Index do
         project.id == target_id
       end)
 
+    sandbox_changed_workflows =
+      get_changed_workflows(
+        socket.assigns.merge_source_sandbox,
+        target_project
+      )
+
     source_workflows =
       if target_project do
         build_merge_workflow_list(
           socket.assigns.merge_source_sandbox,
           diverged_workflows,
+          sandbox_changed_workflows,
           target_project
         )
       else
         socket.assigns.merge_source_workflows
       end
 
-    all_ids = MapSet.new(source_workflows, fn wf -> wf.id end)
-
     prev_ids =
       MapSet.new(socket.assigns.merge_source_workflows, fn wf -> wf.id end)
+
+    all_ids = MapSet.new(source_workflows, fn wf -> wf.id end)
+
+    added_changed_ids =
+      source_workflows
+      |> Enum.filter(fn wf ->
+        wf.is_changed and not MapSet.member?(prev_ids, wf.id)
+      end)
+      |> MapSet.new(fn wf -> wf.id end)
 
     selected_ids =
       socket.assigns.merge_selected_workflow_ids
       |> MapSet.intersection(all_ids)
-      |> MapSet.union(MapSet.difference(all_ids, prev_ids))
+      |> MapSet.union(added_changed_ids)
 
     {:noreply,
      socket
@@ -682,7 +706,12 @@ defmodule LightningWeb.SandboxLive.Index do
     Enum.find(workspace_projects, fn project -> project.id == target_id end)
   end
 
-  defp build_merge_workflow_list(source, _diverged_names, nil) do
+  defp build_merge_workflow_list(
+         source,
+         _diverged_names,
+         _sandbox_changed_names,
+         nil
+       ) do
     source
     |> Repo.preload(:workflows)
     |> Map.get(:workflows, [])
@@ -690,6 +719,7 @@ defmodule LightningWeb.SandboxLive.Index do
       %MergeWorkflow{
         id: wf.id,
         name: wf.name,
+        is_changed: true,
         is_diverged: false,
         is_new: true,
         is_deleted: false
@@ -698,7 +728,12 @@ defmodule LightningWeb.SandboxLive.Index do
     |> Enum.sort_by(fn wf -> wf.name end)
   end
 
-  defp build_merge_workflow_list(source, diverged_names, target_project) do
+  defp build_merge_workflow_list(
+         source,
+         diverged_names,
+         sandbox_changed_names,
+         target_project
+       ) do
     target_workflows =
       target_project
       |> Repo.preload(:workflows)
@@ -707,6 +742,7 @@ defmodule LightningWeb.SandboxLive.Index do
     target_workflow_names = MapSet.new(target_workflows, fn wf -> wf.name end)
 
     diverged_set = MapSet.new(diverged_names)
+    sandbox_changed_set = MapSet.new(sandbox_changed_names)
 
     source_workflows =
       source
@@ -717,11 +753,14 @@ defmodule LightningWeb.SandboxLive.Index do
 
     source_entries =
       Enum.map(source_workflows, fn wf ->
+        is_new = not MapSet.member?(target_workflow_names, wf.name)
+
         %MergeWorkflow{
           id: wf.id,
           name: wf.name,
+          is_changed: is_new or MapSet.member?(sandbox_changed_set, wf.name),
           is_diverged: MapSet.member?(diverged_set, wf.name),
-          is_new: not MapSet.member?(target_workflow_names, wf.name),
+          is_new: is_new,
           is_deleted: false
         }
       end)
@@ -733,6 +772,7 @@ defmodule LightningWeb.SandboxLive.Index do
         %MergeWorkflow{
           id: wf.id,
           name: wf.name,
+          is_changed: true,
           is_diverged: false,
           is_new: false,
           is_deleted: true
@@ -778,6 +818,12 @@ defmodule LightningWeb.SandboxLive.Index do
     else
       _ -> []
     end
+  end
+
+  defp get_changed_workflows(source, target_project) do
+    if target_project,
+      do: MergeProjects.diverged_workflows(target_project, source),
+      else: []
   end
 
   defp perform_merge(

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -202,24 +202,19 @@ defmodule LightningWeb.SandboxLive.Index do
 
           target_id = default_target && default_target.value
 
-          diverged_workflows =
-            get_diverged_workflows(
-              sandbox,
-              target_id,
-              socket.assigns.workspace_projects
-            )
-
           target_project =
             Enum.find(
               socket.assigns.workspace_projects,
               fn project -> project.id == target_id end
             )
 
+          {sandbox, target_project} =
+            preload_merge_projects(sandbox, target_project)
+
+          diverged_workflows = get_diverged_workflows(sandbox, target_project)
+
           sandbox_changed_workflows =
-            get_changed_workflows(
-              sandbox,
-              target_project
-            )
+            get_changed_workflows(sandbox, target_project)
 
           source_workflows =
             build_merge_workflow_list(
@@ -294,28 +289,22 @@ defmodule LightningWeb.SandboxLive.Index do
       ) do
     merge_changeset = merge_changeset(%{target_id: target_id})
 
-    diverged_workflows =
-      get_diverged_workflows(
-        socket.assigns.merge_source_sandbox,
-        target_id,
-        socket.assigns.workspace_projects
-      )
-
     target_project =
       Enum.find(socket.assigns.workspace_projects, fn project ->
         project.id == target_id
       end)
 
-    sandbox_changed_workflows =
-      get_changed_workflows(
-        socket.assigns.merge_source_sandbox,
-        target_project
-      )
+    {sandbox, target_project} =
+      preload_merge_projects(socket.assigns.merge_source_sandbox, target_project)
+
+    diverged_workflows = get_diverged_workflows(sandbox, target_project)
+
+    sandbox_changed_workflows = get_changed_workflows(sandbox, target_project)
 
     source_workflows =
       if target_project do
         build_merge_workflow_list(
-          socket.assigns.merge_source_sandbox,
+          sandbox,
           diverged_workflows,
           sandbox_changed_workflows,
           target_project
@@ -810,20 +799,22 @@ defmodule LightningWeb.SandboxLive.Index do
     end
   end
 
-  defp get_diverged_workflows(source, target_id, workspace_projects) do
-    with true <- !is_nil(target_id),
-         target_project when not is_nil(target_project) <-
-           Enum.find(workspace_projects, &(&1.id == target_id)) do
-      MergeProjects.diverged_workflows(source, target_project)
-    else
-      _ -> []
-    end
+  defp preload_merge_projects(source, nil),
+    do: {Repo.preload(source, :workflows), nil}
+
+  defp preload_merge_projects(source, target),
+    do: {Repo.preload(source, :workflows), Repo.preload(target, :workflows)}
+
+  defp get_diverged_workflows(_source, nil), do: []
+
+  defp get_diverged_workflows(source, target_project) do
+    MergeProjects.diverged_workflows(source, target_project)
   end
 
+  defp get_changed_workflows(_source, nil), do: []
+
   defp get_changed_workflows(source, target_project) do
-    if target_project,
-      do: MergeProjects.diverged_workflows(target_project, source),
-      else: []
+    MergeProjects.diverged_workflows(target_project, source)
   end
 
   defp perform_merge(

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2728,12 +2728,60 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       beta_data = Enum.find(assigns.merge_source_workflows, &(&1.name == "Beta"))
 
-      assert %{is_diverged: true, is_new: false} = alpha_data
-      assert %{is_diverged: false, is_new: true} = beta_data
+      assert %{is_diverged: true, is_new: false, is_changed: true} = alpha_data
+      assert %{is_diverged: false, is_new: true, is_changed: true} = beta_data
 
-      # All workflows selected by default and IDs match
+      # Changed workflows selected by default and IDs match
       assert MapSet.member?(assigns.merge_selected_workflow_ids, alpha_data.id)
       assert MapSet.member?(assigns.merge_selected_workflow_ids, beta_data.id)
+    end
+
+    test "unchanged workflows are not pre-selected by default",
+         %{conn: conn, parent: parent, sandbox: sandbox} do
+      shared_hash = "cccccc222222"
+
+      parent_wf = insert(:workflow, project: parent, name: "Unchanged")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(parent_wf, shared_hash, "app")
+
+      sandbox_wf = insert(:workflow, project: sandbox, name: "Unchanged")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(sandbox_wf, shared_hash, "app")
+
+      changed_sandbox_wf = insert(:workflow, project: sandbox, name: "Changed")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          changed_sandbox_wf,
+          "dddddd333333",
+          "app"
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      unchanged_data =
+        Enum.find(assigns.merge_source_workflows, &(&1.name == "Unchanged"))
+
+      changed_data =
+        Enum.find(assigns.merge_source_workflows, &(&1.name == "Changed"))
+
+      assert %{is_changed: false} = unchanged_data
+      assert %{is_changed: true} = changed_data
+
+      refute MapSet.member?(
+               assigns.merge_selected_workflow_ids,
+               unchanged_data.id
+             )
+
+      assert MapSet.member?(assigns.merge_selected_workflow_ids, changed_data.id)
     end
 
     test "target-only workflows appear in list with is_deleted flag and badge",
@@ -2805,6 +2853,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> render_click()
 
       assert html =~ "Diverged"
+      assert html =~ "Changed"
       assert html =~ "New"
       assert html =~ "Diverged Flow"
       assert html =~ "New Flow"

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2126,7 +2126,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         view
         |> render_click("open-merge-modal", %{"id" => sandbox.id})
 
-      assert html =~ "Target modified"
+      assert html =~ "Diverged"
       assert html =~ "Test Workflow"
     end
   end
@@ -2513,7 +2513,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       # Assert per-row divergence indicators are present
-      assert html =~ "Target modified"
+      assert html =~ "Diverged"
 
       # Assert workflow names are listed in the workflow list
       assert html =~ "Payment Processing"
@@ -2556,7 +2556,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute html =~ "Target project has diverged"
 
       # Matching Workflow appears in the workflow list (not as a diverged workflow)
-      refute html =~ "Target modified"
+      refute html =~ "Diverged"
     end
 
     test "updates diverged workflow list when changing merge target", %{
@@ -2625,7 +2625,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert html =~ "Parent Workflow"
       assert html =~ "Sibling Workflow"
       # Parent Workflow is diverged (different hash in parent), Sibling is new
-      assert html =~ "Target modified"
+      assert html =~ "Diverged"
 
       assigns = :sys.get_state(view.pid).socket.assigns
 
@@ -2804,7 +2804,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> element("#branch-rewire-sandbox-#{sandbox.id} button")
         |> render_click()
 
-      assert html =~ "Target modified"
+      assert html =~ "Diverged"
       assert html =~ "New"
       assert html =~ "Diverged Flow"
       assert html =~ "New Flow"

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2947,6 +2947,62 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert MapSet.size(assigns3.merge_selected_workflow_ids) == 2
     end
 
+    test "select-all checkbox reflects :all, :none, and :partial states", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      wf1 = insert(:workflow, project: sandbox, name: "Flow A")
+      _wf2 = insert(:workflow, project: sandbox, name: "Flow B")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      # Both workflows start pre-selected (both are :new → :is_changed). :all.
+      html = render(view)
+
+      assert html =~
+               ~r/id="merge-select-all-workflows"[^>]*checked[^>]*>/
+
+      refute html =~
+               ~r/id="merge-select-all-workflows"[^>]*indeterminate[^>]*>/
+
+      # Deselect all. :none.
+      render_click(view, "toggle-all-workflows", %{})
+      html = render(view)
+
+      refute html =~ ~r/id="merge-select-all-workflows"[^>]*checked[^>]*>/
+      refute html =~ ~r/id="merge-select-all-workflows"[^>]*indeterminate/
+
+      # Select just one workflow. :partial.
+      render_click(view, "toggle-workflow", %{"id" => wf1.id})
+      html = render(view)
+
+      refute html =~ ~r/id="merge-select-all-workflows"[^>]*checked[^>]*>/
+      assert html =~ ~r/id="merge-select-all-workflows"[^>]*indeterminate/
+    end
+
+    test "select-all checkbox is disabled when there are no workflows", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      html = render(view)
+
+      assert html =~ ~r/id="merge-select-all-workflows"[^>]*disabled/
+      refute html =~ ~r/id="merge-select-all-workflows"[^>]*checked[^>]*>/
+      refute html =~ ~r/id="merge-select-all-workflows"[^>]*indeterminate/
+    end
+
     test "changing merge target recomputes workflow divergence and new status",
          %{
            conn: conn,

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -953,8 +953,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       assert html =~ great_grandchild.name
-      assert html =~ "will also be closed"
-      assert html =~ "Consider merging it into"
+      assert html =~ "will also be permanently closed"
     end
 
     test "merge modal shows multiple descendants warning with full list", %{
@@ -970,13 +969,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "Child sandboxes will be closed"
-      assert html =~ "2 sandboxes will be permanently closed"
-
-      assert html =~ "grandchild1"
-      assert html =~ "grandchild2"
-
-      assert html =~ "Consider merging child sandboxes into"
+      assert html =~ "child sandboxes will also be permanently closed"
       assert html =~ child1.name
     end
 
@@ -1245,10 +1238,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "sandboxes will be permanently closed"
-      assert html =~ "grandchild1"
-      assert html =~ "grandchild2"
-      assert html =~ "3 sandboxes will be permanently closed"
+      assert html =~ "child sandboxes will also be permanently closed"
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1164,23 +1164,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
-    test "merge modal shows beta warning", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      view
-      |> element("#branch-rewire-sandbox-#{child1.id} button")
-      |> render_click()
-
-      html = render(view)
-
-      assert html =~ "This action cannot be undone"
-      assert html =~ "use the CLI to merge locally"
-    end
-
     test "descendants are calculated correctly for deep nesting", %{
       conn: conn,
       root: root,
@@ -1861,6 +1844,8 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         target_job: job1
       )
 
+      with_version(parent_workflow)
+
       # Create sandbox from parent (at this point, parent only has job1)
       sandbox = insert(:project, name: "Sandbox", parent: parent)
 
@@ -1870,6 +1855,8 @@ defmodule LightningWeb.SandboxLive.IndexTest do
           name: "Main Workflow",
           lock_version: parent_workflow.lock_version
         )
+
+      with_version(sandbox_workflow)
 
       sandbox_job1 =
         insert(:job,

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -980,6 +980,65 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert html =~ child1.name
     end
 
+    test "merge sentence: leaf sandbox has no gap before period", %{
+      conn: conn,
+      root: root,
+      child2: child2
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{child2.id} button")
+      |> render_click()
+
+      html = render(view)
+
+      refute html =~ ~r{<strong>child2</strong>\s+\.},
+             "visible space between sandbox name and period for leaf sandbox"
+
+      assert html =~ "<strong>child2</strong>."
+
+      refute html =~ "phx-no-format",
+             "formatter directive leaked into rendered HTML"
+    end
+
+    test "merge sentence: single descendant has space and bolded child name",
+         %{conn: conn, root: root, grandchild1: grandchild1, user: user} do
+      _great =
+        insert(:project,
+          name: "great-grandchild",
+          parent: grandchild1,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{grandchild1.id} button")
+      |> render_click()
+
+      html = render(view)
+
+      assert html =~
+               "<strong>grandchild1</strong> and its child sandbox <strong>great-grandchild</strong>."
+    end
+
+    test "merge sentence: multiple descendants mentions count", %{
+      conn: conn,
+      root: root,
+      child1: child1
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{child1.id} button")
+      |> render_click()
+
+      html = render(view)
+
+      assert html =~ "<strong>child1</strong> and its 2 child sandboxes."
+    end
+
     test "merge modal shows correct dropdown options", %{
       conn: conn,
       root: root,


### PR DESCRIPTION
## Description

* Made the wordy description of what's happening smaller - users can still find it but it's de-emphasized. The UI tells you what is happening
* Simplify the warning message at the bottom and change it from an error UI to a warning UI
* Changed workflows show a green "Changed" badge in the workflow list
* Strengthen the warnining on diverged workflows
* Workflows changed in the sandbox are now pre-selected by default when opening the merge modal
* Merge button is disabled with a tooltip when no workflows are selected

New UI:

<img width="599" height="569" alt="image" src="https://github.com/user-attachments/assets/3ec37ca3-7566-4c55-8980-b2b1ba7b32f1" />

Closes #4651

## Validation steps

1. Test the following states for a workflow in a sandbox:
  a. Change the workflow in the sandbox (a  green change badge)
  b. Change the workflow in the main project (an amber diverge badge)
  c. Remove a workflow in the sandbox (a  red Removed badge)
  d. Add workflow from the project
2. Validate that the changes actually happened as expected on merge
3. Should be able to toggle changes in the UI
4. Unmodified workflows are deselected in the UI by default


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
