### PR TITLE
feat: add run with custom input & run instantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to
 - bumped local worker to 1.24.0
 - Update 'Run' button label to 'Run From Here' in the job inspector panel
   [#4617](https://github.com/OpenFn/lightning/issues/4617)
+- Split run button in the canvas header. one-click runs instantly, dropdown
+  opens run with custom input.
+  [#4615](https://github.com/OpenFn/lightning/issues/4615)
 
 ### Fixed
 

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -1,10 +1,13 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 
 import { useURLState } from '#/react/lib/use-url-state';
 
+import * as dataclipApi from '../api/dataclips';
 import { buildClassicalEditorUrl } from '../../utils/editorUrlConversion';
 import { channelRequest } from '../hooks/useChannel';
+import { StoreContext } from '../contexts/StoreProvider';
+import { notifications } from '../lib/notifications';
 import { useSession } from '../hooks/useSession';
 import {
   useIsNewWorkflow,
@@ -226,6 +229,8 @@ export function Header({
   const limits = useLimits();
   const { isReadOnly } = useWorkflowReadOnly();
   const { hasChanges } = useUnsavedChanges();
+  const storeContext = useContext(StoreContext);
+  const getLimits = storeContext?.sessionContextStore.getLimits;
 
   // Check GitHub sync limit
   const githubSyncLimit = limits.github_sync ?? {
@@ -251,15 +256,42 @@ export function Header({
 
   const showChangeIndicator = hasChanges && canSave && !isNewWorkflow;
 
-  const handleRunClick = useCallback(() => {
-    if (firstTriggerId) {
-      // select the first trigger
-      selectNode(firstTriggerId);
-      // switch panel to run
-      updateSearchParams({
-        panel: 'run',
+  const handleRunClick = useCallback(async () => {
+    if (!firstTriggerId || !projectId || !workflowId) return;
+
+    try {
+      await saveWorkflow({ silent: true });
+      const response = await dataclipApi.submitManualRun({
+        workflowId,
+        projectId,
+        triggerId: firstTriggerId,
       });
-      // Canvas context: open run panel with first trigger
+      notifications.success({
+        title: 'Run started',
+        description: 'Saved latest changes and created new work order',
+      });
+      if (getLimits) void getLimits('new_run');
+      updateSearchParams({ run: response.data.run_id });
+    } catch (error) {
+      notifications.alert({
+        title: 'Failed to submit run',
+        description:
+          error instanceof Error ? error.message : 'An unknown error occurred',
+      });
+    }
+  }, [
+    firstTriggerId,
+    projectId,
+    workflowId,
+    saveWorkflow,
+    getLimits,
+    updateSearchParams,
+  ]);
+
+  const handleRunWithCustomInputClick = useCallback(() => {
+    if (firstTriggerId) {
+      selectNode(firstTriggerId);
+      updateSearchParams({ panel: 'run' });
       openRunPanel({ triggerId: firstTriggerId });
     }
   }, [firstTriggerId, openRunPanel, selectNode, updateSearchParams]);
@@ -398,6 +430,7 @@ export function Header({
               {projectId && workflowId && firstTriggerId && !isNewWorkflow && (
                 <NewRunButton
                   onClick={handleRunClick}
+                  onRunWithCustomInputClick={handleRunWithCustomInputClick}
                   disabled={!canRun || isRunPanelOpen || isIDEOpen}
                 />
               )}

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -1,13 +1,13 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { useURLState } from '#/react/lib/use-url-state';
 
-import * as dataclipApi from '../api/dataclips';
 import { buildClassicalEditorUrl } from '../../utils/editorUrlConversion';
-import { channelRequest } from '../hooks/useChannel';
+import * as dataclipApi from '../api/dataclips';
 import { StoreContext } from '../contexts/StoreProvider';
-import { notifications } from '../lib/notifications';
+import { channelRequest } from '../hooks/useChannel';
+import { useActiveRun } from '../hooks/useHistory';
 import { useSession } from '../hooks/useSession';
 import {
   useIsNewWorkflow,
@@ -32,6 +32,8 @@ import {
   useWorkflowState,
 } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
+import { notifications } from '../lib/notifications';
+import { isFinalState } from '../types/history';
 
 import { ActiveCollaborators } from './ActiveCollaborators';
 import { AIButton } from './AIButton';
@@ -231,6 +233,9 @@ export function Header({
   const { hasChanges } = useUnsavedChanges();
   const storeContext = useContext(StoreContext);
   const getLimits = storeContext?.sessionContextStore.getLimits;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const activeRun = useActiveRun();
+  const runIsProcessing = activeRun ? !isFinalState(activeRun.state) : false;
 
   // Check GitHub sync limit
   const githubSyncLimit = limits.github_sync ?? {
@@ -259,6 +264,7 @@ export function Header({
   const handleRunClick = useCallback(async () => {
     if (!firstTriggerId || !projectId || !workflowId) return;
 
+    setIsSubmitting(true);
     try {
       await saveWorkflow({ silent: true });
       const response = await dataclipApi.submitManualRun({
@@ -278,6 +284,8 @@ export function Header({
         description:
           error instanceof Error ? error.message : 'An unknown error occurred',
       });
+    } finally {
+      setIsSubmitting(false);
     }
   }, [
     firstTriggerId,
@@ -432,6 +440,7 @@ export function Header({
                   onClick={handleRunClick}
                   onRunWithCustomInputClick={handleRunWithCustomInputClick}
                   disabled={!canRun || isRunPanelOpen || isIDEOpen}
+                  isRunning={isSubmitting || runIsProcessing}
                 />
               )}
               <SaveButton

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -60,7 +60,7 @@ export function NewRunButton({
           <Button variant="primary" onClick={onClick} disabled={isDisabled}>
             <span className="flex items-center gap-1">
               {icon}
-              Run
+              {text}
             </span>
           </Button>
         </span>

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -10,14 +10,14 @@ interface NewRunButtonProps {
   onClick: () => void;
   onRunWithCustomInputClick?: () => void;
   disabled?: boolean;
+  isRunning?: boolean;
   tooltipSide?: 'top' | 'bottom';
 }
 
 /**
  * NewRunButton - Standardized button for opening the manual run panel.
  *
- * Displays a play-circle outline icon with "Run" text.
- * Shows keyboard shortcut tooltip when enabled, error message when disabled.
+ * Displays a play icon with "Run" text. Shows a spinner when isRunning=true.
  * When onRunWithCustomInputClick is provided, renders as a split button with a
  * dropdown containing a "Run with custom input" option.
  *
@@ -31,17 +31,24 @@ export function NewRunButton({
   onClick,
   onRunWithCustomInputClick,
   disabled: disabledProp,
+  isRunning = false,
   tooltipSide = 'bottom',
 }: NewRunButtonProps) {
   const { canRun, tooltipMessage } = useCanRun();
 
-  // Disable if parent requests OR if canRun is false
-  const isDisabled = disabledProp || !canRun;
+  // Disable if parent requests, canRun is false, or a run is in progress
+  const isDisabled = disabledProp || !canRun || isRunning;
 
   const tooltip = canRun ? (
     <ShortcutKeys keys={['mod', 'enter']} />
   ) : (
     tooltipMessage
+  );
+
+  const icon = isRunning ? (
+    <span className="hero-arrow-path h-4 w-4 animate-spin" />
+  ) : (
+    <span className="hero-play h-4 w-4" />
   );
 
   if (!onRunWithCustomInputClick) {
@@ -50,7 +57,7 @@ export function NewRunButton({
         <span className="inline-block">
           <Button variant="primary" onClick={onClick} disabled={isDisabled}>
             <span className="flex items-center gap-1">
-              <span className="hero-play h-4 w-4" />
+              {icon}
               Run
             </span>
           </Button>
@@ -75,7 +82,7 @@ export function NewRunButton({
           disabled={isDisabled}
         >
           <span className="flex items-center gap-1">
-            <span className="hero-play h-4 w-4" />
+            {icon}
             Run
           </span>
         </button>

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -1,3 +1,5 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+
 import { useCanRun } from '../hooks/useWorkflow';
 
 import { Button } from './Button';
@@ -6,6 +8,7 @@ import { Tooltip } from './Tooltip';
 
 interface NewRunButtonProps {
   onClick: () => void;
+  onRunWithCustomInputClick?: () => void;
   disabled?: boolean;
   tooltipSide?: 'top' | 'bottom';
 }
@@ -15,6 +18,8 @@ interface NewRunButtonProps {
  *
  * Displays a play-circle outline icon with "Run" text.
  * Shows keyboard shortcut tooltip when enabled, error message when disabled.
+ * When onRunWithCustomInputClick is provided, renders as a split button with a
+ * dropdown containing a "Run with custom input" option.
  *
  * Used in:
  * - Header (canvas)
@@ -24,6 +29,7 @@ interface NewRunButtonProps {
  */
 export function NewRunButton({
   onClick,
+  onRunWithCustomInputClick,
   disabled: disabledProp,
   tooltipSide = 'bottom',
 }: NewRunButtonProps) {
@@ -38,16 +44,77 @@ export function NewRunButton({
     tooltipMessage
   );
 
+  if (!onRunWithCustomInputClick) {
+    return (
+      <Tooltip content={tooltip} side={tooltipSide}>
+        <span className="inline-block">
+          <Button variant="primary" onClick={onClick} disabled={isDisabled}>
+            <span className="flex items-center gap-1">
+              <span className="hero-play h-4 w-4" />
+              Run
+            </span>
+          </Button>
+        </span>
+      </Tooltip>
+    );
+  }
+
   return (
-    <Tooltip content={tooltip} side={tooltipSide}>
-      <span className="inline-block">
-        <Button variant="primary" onClick={onClick} disabled={isDisabled}>
+    <div className="inline-flex rounded-md shadow-xs">
+      <Tooltip content={tooltip} side={tooltipSide}>
+        <button
+          type="button"
+          className="rounded-l-md text-sm font-semibold shadow-xs
+          phx-submit-loading:opacity-75 cursor-pointer
+          disabled:cursor-not-allowed disabled:bg-primary-300 px-3 py-2
+          bg-primary-600 hover:bg-primary-500
+          disabled:hover:bg-primary-300 text-white
+          focus-visible:outline-2 focus-visible:outline-offset-2
+          focus-visible:outline-primary-600 focus:ring-transparent"
+          onClick={onClick}
+          disabled={isDisabled}
+        >
           <span className="flex items-center gap-1">
             <span className="hero-play h-4 w-4" />
             Run
           </span>
-        </Button>
-      </span>
-    </Tooltip>
+        </button>
+      </Tooltip>
+      <Menu as="div" className="relative -ml-px block">
+        <MenuButton
+          disabled={isDisabled}
+          className="h-full rounded-r-md pr-2 pl-2 text-sm font-semibold
+          shadow-xs cursor-pointer disabled:cursor-not-allowed
+          bg-primary-600 hover:bg-primary-500
+          disabled:bg-primary-300 disabled:hover:bg-primary-300 text-white
+          focus-visible:outline-2 focus-visible:outline-offset-2
+          focus-visible:outline-primary-600 focus:ring-transparent"
+        >
+          <span className="sr-only">Open run options</span>
+          <span className="hero-chevron-down w-4 h-4" />
+        </MenuButton>
+        <MenuItems
+          transition
+          className="absolute right-0 z-[100] mt-2 w-max origin-top-right
+          rounded-md bg-white py-1 shadow-lg outline outline-black/5
+          transition data-closed:scale-95 data-closed:transform
+          data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out
+          data-leave:duration-75 data-leave:ease-in"
+        >
+          <MenuItem>
+            <button
+              type="button"
+              onClick={onRunWithCustomInputClick}
+              className="flex items-center gap-2 w-full text-left px-4 py-2
+              text-sm text-gray-700 data-focus:bg-gray-100
+              data-focus:outline-hidden"
+            >
+              <span className="hero-play h-4 w-4" />
+              Run with custom input
+            </button>
+          </MenuItem>
+        </MenuItems>
+      </Menu>
+    </div>
   );
 }

--- a/assets/test/collaborative-editor/components/Header.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.test.tsx
@@ -355,7 +355,9 @@ describe('Header - Basic Rendering', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^run$/i })
+      ).toBeInTheDocument();
     });
   });
 
@@ -760,7 +762,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeInTheDocument();
     });
 
@@ -799,14 +801,14 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeInTheDocument();
     });
 
     // Tooltip should be hidden when panel is open
     // We're testing tooltip visibility, not button enabled state
     // The button may be disabled for workflow validation reasons
-    const startButton = screen.getByRole('button', { name: /run/i });
+    const startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
   });
 
@@ -840,7 +842,9 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^run$/i })
+      ).toBeInTheDocument();
     });
 
     // Make workflow invalid (empty name)
@@ -850,7 +854,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeDisabled();
     });
 
@@ -867,7 +871,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
 
     // Error tooltip should still be shown even when panel is open
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeDisabled();
     });
   });
@@ -902,10 +906,12 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^run$/i })
+      ).toBeInTheDocument();
     });
 
-    let startButton = screen.getByRole('button', { name: /run/i });
+    let startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
     // Tooltip should be present when closed
 
@@ -920,7 +926,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
       </Header>
     );
 
-    startButton = screen.getByRole('button', { name: /run/i });
+    startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
     // Tooltip should be hidden when open
 
@@ -935,7 +941,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
       </Header>
     );
 
-    startButton = screen.getByRole('button', { name: /run/i });
+    startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
     // Tooltip should reappear when closed
   });
@@ -966,13 +972,13 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeInTheDocument();
     });
 
     // Default should show tooltip (panel closed by default)
     // We're testing that the prop defaults correctly, not button state
-    const startButton = screen.getByRole('button', { name: /run/i });
+    const startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

This PR changes how the run button on workflows work
- Clicking on the run button will instantly run the workflow with an empty dataclip
- Clicking the dropdown next to the "Run" button and then choosing "Run with custom input" will allow you to select the dataclip you want to start the run with.

#### Below is a loom demonstration

https://www.loom.com/share/de78ada1dddd449fbc24f287162d0316

Closes #4615 

## Validation steps

1. _(How can a reviewer validate your work?)_

## Additional notes for the reviewer

1. _(Is there anything else the reviewer should know or look out for?)_

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
