### PR TITLE
feat: Better Run Experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ and this project adheres to
   [#4615](https://github.com/OpenFn/lightning/issues/4615)
 - Clearer step panel button design with icon-only secondary buttons for Code and
   Delete. [#4618](https://github.com/OpenFn/lightning/issues/4618)
+- "Pick a custom input" panel and renamed "New" tab when opening the manual run
+  panel from the canvas Run dropdown.
+  [#4616](https://github.com/OpenFn/lightning/issues/4616)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,6 @@ and this project adheres to
   [#4510](https://github.com/OpenFn/lightning/issues/4510)
 - Worker plan payload now includes `project_id` so workers can scope callbacks
   (e.g. the collections API) to the project that owns the run.
-- Bumped local worker to 1.24.0
 - Updated the Merge Sandbox UI to be cleaner, clearer, and only include changed
   workflows by default [#4651](https://github.com/OpenFn/lightning/issues/4651)
 - Sandbox deletion (manual or after merge) is now soft. The sandbox and its
@@ -101,6 +100,9 @@ and this project adheres to
   [#4649](https://github.com/OpenFn/lightning/issues/4649)
 - Updated ws-worker from
   [`1.24.0` to `1.24.1`](https://github.com/OpenFn/kit/blob/%40openfn/ws-worker@1.24.1/packages/ws-worker/CHANGELOG.md?plain=1#L5-L12)
+- bumped local worker to 1.24.0
+- Update 'Run' button label to 'Run From Here' in the job inspector panel
+  [#4617](https://github.com/OpenFn/lightning/issues/4617)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ and this project adheres to
 - bumped local worker to 1.24.0
 - Update 'Run' button label to 'Run From Here' in the job inspector panel
   [#4617](https://github.com/OpenFn/lightning/issues/4617)
+- Split run button in the canvas header. one-click runs instantly, dropdown
+  opens run with custom input.
+  [#4615](https://github.com/OpenFn/lightning/issues/4615)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to
 
 ### Added
 
+- Update 'Run' button label to 'Run From Here' in the job inspector panel
+  [#4617](https://github.com/OpenFn/lightning/issues/4617)
+- Split run button in the canvas header. one-click runs instantly, dropdown
+  opens run with custom input.
+  [#4615](https://github.com/OpenFn/lightning/issues/4615)
+- Clearer step panel button design with icon-only secondary buttons for Code and
+  Delete. [#4618](https://github.com/OpenFn/lightning/issues/4618)
+- "Pick a custom input" panel and renamed "New" tab when opening the manual run
+  panel from the canvas Run dropdown.
+  [#4616](https://github.com/OpenFn/lightning/issues/4616)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to
   [#4510](https://github.com/OpenFn/lightning/issues/4510)
 - Worker plan payload now includes `project_id` so workers can scope callbacks
   (e.g. the collections API) to the project that owns the run.
+- Bumped local worker to 1.24.0
 - Updated the Merge Sandbox UI to be cleaner, clearer, and only include changed
   workflows by default [#4651](https://github.com/OpenFn/lightning/issues/4651)
 - Sandbox deletion (manual or after merge) is now soft. The sandbox and its
@@ -100,17 +101,6 @@ and this project adheres to
   [#4649](https://github.com/OpenFn/lightning/issues/4649)
 - Updated ws-worker from
   [`1.24.0` to `1.24.1`](https://github.com/OpenFn/kit/blob/%40openfn/ws-worker@1.24.1/packages/ws-worker/CHANGELOG.md?plain=1#L5-L12)
-- bumped local worker to 1.24.0
-- Update 'Run' button label to 'Run From Here' in the job inspector panel
-  [#4617](https://github.com/OpenFn/lightning/issues/4617)
-- Split run button in the canvas header. one-click runs instantly, dropdown
-  opens run with custom input.
-  [#4615](https://github.com/OpenFn/lightning/issues/4615)
-- Clearer step panel button design with icon-only secondary buttons for Code and
-  Delete. [#4618](https://github.com/OpenFn/lightning/issues/4618)
-- "Pick a custom input" panel and renamed "New" tab when opening the manual run
-  panel from the canvas Run dropdown.
-  [#4616](https://github.com/OpenFn/lightning/issues/4616)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ and this project adheres to
 - Split run button in the canvas header. one-click runs instantly, dropdown
   opens run with custom input.
   [#4615](https://github.com/OpenFn/lightning/issues/4615)
+- Clearer step panel button design with icon-only secondary buttons for Code and
+  Delete. [#4618](https://github.com/OpenFn/lightning/issues/4618)
 
 ### Fixed
 

--- a/assets/js/collaborative-editor/components/AdaptorDisplay.tsx
+++ b/assets/js/collaborative-editor/components/AdaptorDisplay.tsx
@@ -2,8 +2,12 @@ import { useMemo } from 'react';
 
 import { cn } from '#/utils/cn';
 
+import { ADAPTORS_WITHOUT_CREDENTIALS } from '../constants/adaptors';
 import { useCredentialQueries } from '../hooks/useCredentials';
-import { extractAdaptorDisplayName } from '../utils/adaptorUtils';
+import {
+  extractAdaptorDisplayName,
+  extractAdaptorName,
+} from '../utils/adaptorUtils';
 
 import { AdaptorIcon } from './AdaptorIcon';
 import { Tooltip } from '../../components/Tooltip';
@@ -84,6 +88,9 @@ export function AdaptorDisplay({
   // Check if credential is connected and found
   const hasCredential = !!credentialId;
   const credentialNotFound = hasCredential && !credential;
+  const needsCredential = !ADAPTORS_WITHOUT_CREDENTIALS.includes(
+    extractAdaptorName(adaptorPackage as string) ?? ''
+  );
 
   // TODO - come back to pulse concept later
   // // Check if adaptor is language-common (shouldn't pulse for common)
@@ -261,7 +268,7 @@ export function AdaptorDisplay({
             config.editButton,
             'rounded-md font-medium focus:outline-none flex-shrink-0 transition-colors relative',
             config.textSize,
-            hasCredential
+            hasCredential || !needsCredential
               ? 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
               : 'bg-primary-600 hover:bg-primary-500 text-white shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600'
           )}

--- a/assets/js/collaborative-editor/components/AdaptorDisplay.tsx
+++ b/assets/js/collaborative-editor/components/AdaptorDisplay.tsx
@@ -272,9 +272,13 @@ export function AdaptorDisplay({
               ? 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
               : 'bg-primary-600 hover:bg-primary-500 text-white shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600'
           )}
-          aria-label={hasCredential ? 'Edit adaptor' : 'Connect credential'}
+          aria-label={
+            hasCredential || !needsCredential
+              ? 'Edit adaptor'
+              : 'Connect credential'
+          }
         >
-          {hasCredential ? 'Edit' : 'Connect'}
+          {hasCredential || !needsCredential ? 'Edit' : 'Connect'}
           {/* TODO - come back to pulse concept later
           {shouldPulse && (
             <span className="absolute -top-1 -right-1 flex h-3 w-3">

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -1,10 +1,13 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
-import { useCallback } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { useURLState } from '#/react/lib/use-url-state';
 
 import { buildClassicalEditorUrl } from '../../utils/editorUrlConversion';
+import * as dataclipApi from '../api/dataclips';
+import { StoreContext } from '../contexts/StoreProvider';
 import { channelRequest } from '../hooks/useChannel';
+import { useActiveRun } from '../hooks/useHistory';
 import { useSession } from '../hooks/useSession';
 import {
   useIsNewWorkflow,
@@ -29,6 +32,8 @@ import {
   useWorkflowState,
 } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
+import { notifications } from '../lib/notifications';
+import { isFinalState } from '../types/history';
 
 import { ActiveCollaborators } from './ActiveCollaborators';
 import { AIButton } from './AIButton';
@@ -226,6 +231,11 @@ export function Header({
   const limits = useLimits();
   const { isReadOnly } = useWorkflowReadOnly();
   const { hasChanges } = useUnsavedChanges();
+  const storeContext = useContext(StoreContext);
+  const getLimits = storeContext?.sessionContextStore.getLimits;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const activeRun = useActiveRun();
+  const runIsProcessing = activeRun ? !isFinalState(activeRun.state) : false;
 
   // Check GitHub sync limit
   const githubSyncLimit = limits.github_sync ?? {
@@ -251,15 +261,45 @@ export function Header({
 
   const showChangeIndicator = hasChanges && canSave && !isNewWorkflow;
 
-  const handleRunClick = useCallback(() => {
-    if (firstTriggerId) {
-      // select the first trigger
-      selectNode(firstTriggerId);
-      // switch panel to run
-      updateSearchParams({
-        panel: 'run',
+  const handleRunClick = useCallback(async () => {
+    if (!firstTriggerId || !projectId || !workflowId) return;
+
+    setIsSubmitting(true);
+    try {
+      await saveWorkflow({ silent: true });
+      const response = await dataclipApi.submitManualRun({
+        workflowId,
+        projectId,
+        triggerId: firstTriggerId,
       });
-      // Canvas context: open run panel with first trigger
+      notifications.success({
+        title: 'Run started',
+        description: 'Saved latest changes and created new work order',
+      });
+      if (getLimits) void getLimits('new_run');
+      updateSearchParams({ run: response.data.run_id });
+    } catch (error) {
+      notifications.alert({
+        title: 'Failed to submit run',
+        description:
+          error instanceof Error ? error.message : 'An unknown error occurred',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    firstTriggerId,
+    projectId,
+    workflowId,
+    saveWorkflow,
+    getLimits,
+    updateSearchParams,
+  ]);
+
+  const handleRunWithCustomInputClick = useCallback(() => {
+    if (firstTriggerId) {
+      selectNode(firstTriggerId);
+      updateSearchParams({ panel: 'run' });
       openRunPanel({ triggerId: firstTriggerId });
     }
   }, [firstTriggerId, openRunPanel, selectNode, updateSearchParams]);
@@ -398,7 +438,9 @@ export function Header({
               {projectId && workflowId && firstTriggerId && !isNewWorkflow && (
                 <NewRunButton
                   onClick={handleRunClick}
+                  onRunWithCustomInputClick={handleRunWithCustomInputClick}
                   disabled={!canRun || isRunPanelOpen || isIDEOpen}
+                  isRunning={isSubmitting || runIsProcessing}
                 />
               )}
               <SaveButton

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -300,7 +300,10 @@ export function Header({
     if (firstTriggerId) {
       selectNode(firstTriggerId);
       updateSearchParams({ panel: 'run' });
-      openRunPanel({ triggerId: firstTriggerId });
+      openRunPanel({
+        triggerId: firstTriggerId,
+        entryPoint: 'custom-input',
+      });
     }
   }, [firstTriggerId, openRunPanel, selectNode, updateSearchParams]);
 

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -647,7 +647,7 @@ export function ManualRunPanel({
                 void handleRetry().then(ok => ok && closeAfterRun());
               }}
               buttonText={{
-                run: 'Run',
+                run: 'Run From Here',
                 retry: 'Run (Retry)',
                 processing: 'Processing',
               }}

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -18,6 +18,7 @@ import ExistingView from '../../manual-run-panel/views/ExistingView';
 import type { Dataclip } from '../api/dataclips';
 import * as dataclipApi from '../api/dataclips';
 import { RENDER_MODES, type RenderMode } from '../constants/panel';
+import type { RunPanelEntryPoint } from '../types/ui';
 import { useActiveRun, useFollowRun } from '../hooks/useHistory';
 import { useRunRetry } from '../hooks/useRunRetry';
 import { useRunRetryShortcuts } from '../hooks/useRunRetryShortcuts';
@@ -42,6 +43,7 @@ interface ManualRunPanelProps {
   jobId?: string | null;
   triggerId?: string | null;
   edgeId?: string | null;
+  entryPoint?: RunPanelEntryPoint | null;
   onClose: () => void;
   /** Called when close button is clicked in embedded mode */
   onClosePanel?: () => void;
@@ -70,6 +72,7 @@ export function ManualRunPanel({
   jobId,
   triggerId,
   edgeId,
+  entryPoint = null,
   onClose,
   onClosePanel,
   renderMode = RENDER_MODES.STANDALONE,
@@ -179,11 +182,16 @@ export function ManualRunPanel({
       ? workflow.triggers.find(t => t.id === runContext.id)
       : null;
 
-  const panelTitle = contextJob
-    ? `Run from ${contextJob.name}`
-    : contextTrigger
-      ? `Run from Trigger (${contextTrigger.type})`
-      : 'Run Workflow';
+  let panelTitle: string;
+  if (entryPoint === 'custom-input') {
+    panelTitle = 'Pick a custom input';
+  } else if (contextJob) {
+    panelTitle = `Run from ${contextJob.name}`;
+  } else if (contextTrigger) {
+    panelTitle = `Run from Trigger (${contextTrigger.type})`;
+  } else {
+    panelTitle = 'Run Workflow';
+  }
 
   // For triggers: find first connected job for dataclip fetching
   // (dataclips are associated with jobs, not triggers)
@@ -564,7 +572,7 @@ export function ManualRunPanel({
           { value: 'empty', label: 'Empty', icon: DocumentIcon },
           {
             value: 'custom',
-            label: 'Custom',
+            label: 'New',
             icon: PencilSquareIcon,
           },
           {

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -8,6 +8,7 @@ interface NewRunButtonProps {
   onClick: () => void;
   disabled?: boolean;
   tooltipSide?: 'top' | 'bottom';
+  text?: string;
 }
 
 /**
@@ -26,6 +27,7 @@ export function NewRunButton({
   onClick,
   disabled: disabledProp,
   tooltipSide = 'bottom',
+  text = 'Run',
 }: NewRunButtonProps) {
   const { canRun, tooltipMessage } = useCanRun();
 
@@ -44,7 +46,7 @@ export function NewRunButton({
         <Button variant="primary" onClick={onClick} disabled={isDisabled}>
           <span className="flex items-center gap-1">
             <span className="hero-play h-4 w-4" />
-            Run
+            {text}
           </span>
         </Button>
       </span>

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -13,6 +13,7 @@ interface NewRunButtonProps {
   isRunning?: boolean;
   tooltipSide?: 'top' | 'bottom';
   text?: string;
+  variant?: 'primary' | 'secondary';
 }
 
 /**
@@ -35,6 +36,7 @@ export function NewRunButton({
   isRunning = false,
   tooltipSide = 'bottom',
   text = 'Run',
+  variant = 'primary',
 }: NewRunButtonProps) {
   const { canRun, tooltipMessage } = useCanRun();
 
@@ -53,11 +55,16 @@ export function NewRunButton({
     <span className="hero-play h-4 w-4" />
   );
 
+  const splitButtonClasses =
+    variant === 'secondary'
+      ? 'bg-white text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:inset-ring-gray-400 disabled:bg-gray-50 disabled:text-gray-400'
+      : 'bg-primary-600 hover:bg-primary-500 disabled:bg-primary-300 disabled:hover:bg-primary-300 text-white focus-visible:outline-primary-600';
+
   if (!onRunWithCustomInputClick) {
     return (
       <Tooltip content={tooltip} side={tooltipSide}>
         <span className="inline-block">
-          <Button variant="primary" onClick={onClick} disabled={isDisabled}>
+          <Button variant={variant} onClick={onClick} disabled={isDisabled}>
             <span className="flex items-center gap-1">
               {icon}
               {text}
@@ -73,13 +80,11 @@ export function NewRunButton({
       <Tooltip content={tooltip} side={tooltipSide}>
         <button
           type="button"
-          className="rounded-l-md text-sm font-semibold shadow-xs
+          className={`rounded-l-md text-sm font-semibold shadow-xs
           phx-submit-loading:opacity-75 cursor-pointer
-          disabled:cursor-not-allowed disabled:bg-primary-300 px-3 py-2
-          bg-primary-600 hover:bg-primary-500
-          disabled:hover:bg-primary-300 text-white
+          disabled:cursor-not-allowed px-3 py-2
           focus-visible:outline-2 focus-visible:outline-offset-2
-          focus-visible:outline-primary-600 focus:ring-transparent"
+          focus:ring-transparent ${splitButtonClasses}`}
           onClick={onClick}
           disabled={isDisabled}
         >
@@ -92,12 +97,10 @@ export function NewRunButton({
       <Menu as="div" className="relative -ml-px block">
         <MenuButton
           disabled={isDisabled}
-          className="h-full rounded-r-md pr-2 pl-2 text-sm font-semibold
+          className={`h-full rounded-r-md pr-2 pl-2 text-sm font-semibold
           shadow-xs cursor-pointer disabled:cursor-not-allowed
-          bg-primary-600 hover:bg-primary-500
-          disabled:bg-primary-300 disabled:hover:bg-primary-300 text-white
           focus-visible:outline-2 focus-visible:outline-offset-2
-          focus-visible:outline-primary-600 focus:ring-transparent"
+          focus:ring-transparent ${splitButtonClasses}`}
         >
           <span className="sr-only">Open run options</span>
           <span className="hero-chevron-down w-4 h-4" />

--- a/assets/js/collaborative-editor/components/NewRunButton.tsx
+++ b/assets/js/collaborative-editor/components/NewRunButton.tsx
@@ -1,3 +1,5 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+
 import { useCanRun } from '../hooks/useWorkflow';
 
 import { Button } from './Button';
@@ -6,7 +8,9 @@ import { Tooltip } from '../../components/Tooltip';
 
 interface NewRunButtonProps {
   onClick: () => void;
+  onRunWithCustomInputClick?: () => void;
   disabled?: boolean;
+  isRunning?: boolean;
   tooltipSide?: 'top' | 'bottom';
   text?: string;
 }
@@ -14,8 +18,9 @@ interface NewRunButtonProps {
 /**
  * NewRunButton - Standardized button for opening the manual run panel.
  *
- * Displays a play-circle outline icon with "Run" text.
- * Shows keyboard shortcut tooltip when enabled, error message when disabled.
+ * Displays a play icon with "Run" text. Shows a spinner when isRunning=true.
+ * When onRunWithCustomInputClick is provided, renders as a split button with a
+ * dropdown containing a "Run with custom input" option.
  *
  * Used in:
  * - Header (canvas)
@@ -25,14 +30,16 @@ interface NewRunButtonProps {
  */
 export function NewRunButton({
   onClick,
+  onRunWithCustomInputClick,
   disabled: disabledProp,
+  isRunning = false,
   tooltipSide = 'bottom',
   text = 'Run',
 }: NewRunButtonProps) {
   const { canRun, tooltipMessage } = useCanRun();
 
-  // Disable if parent requests OR if canRun is false
-  const isDisabled = disabledProp || !canRun;
+  // Disable if parent requests, canRun is false, or a run is in progress
+  const isDisabled = disabledProp || !canRun || isRunning;
 
   const tooltip = canRun ? (
     <ShortcutKeys keys={['mod', 'enter']} />
@@ -40,16 +47,83 @@ export function NewRunButton({
     tooltipMessage
   );
 
+  const icon = isRunning ? (
+    <span className="hero-arrow-path h-4 w-4 animate-spin" />
+  ) : (
+    <span className="hero-play h-4 w-4" />
+  );
+
+  if (!onRunWithCustomInputClick) {
+    return (
+      <Tooltip content={tooltip} side={tooltipSide}>
+        <span className="inline-block">
+          <Button variant="primary" onClick={onClick} disabled={isDisabled}>
+            <span className="flex items-center gap-1">
+              {icon}
+              {text}
+            </span>
+          </Button>
+        </span>
+      </Tooltip>
+    );
+  }
+
   return (
-    <Tooltip content={tooltip} side={tooltipSide}>
-      <span className="inline-block">
-        <Button variant="primary" onClick={onClick} disabled={isDisabled}>
+    <div className="inline-flex rounded-md shadow-xs">
+      <Tooltip content={tooltip} side={tooltipSide}>
+        <button
+          type="button"
+          className="rounded-l-md text-sm font-semibold shadow-xs
+          phx-submit-loading:opacity-75 cursor-pointer
+          disabled:cursor-not-allowed disabled:bg-primary-300 px-3 py-2
+          bg-primary-600 hover:bg-primary-500
+          disabled:hover:bg-primary-300 text-white
+          focus-visible:outline-2 focus-visible:outline-offset-2
+          focus-visible:outline-primary-600 focus:ring-transparent"
+          onClick={onClick}
+          disabled={isDisabled}
+        >
           <span className="flex items-center gap-1">
-            <span className="hero-play h-4 w-4" />
+            {icon}
             {text}
           </span>
-        </Button>
-      </span>
-    </Tooltip>
+        </button>
+      </Tooltip>
+      <Menu as="div" className="relative -ml-px block">
+        <MenuButton
+          disabled={isDisabled}
+          className="h-full rounded-r-md pr-2 pl-2 text-sm font-semibold
+          shadow-xs cursor-pointer disabled:cursor-not-allowed
+          bg-primary-600 hover:bg-primary-500
+          disabled:bg-primary-300 disabled:hover:bg-primary-300 text-white
+          focus-visible:outline-2 focus-visible:outline-offset-2
+          focus-visible:outline-primary-600 focus:ring-transparent"
+        >
+          <span className="sr-only">Open run options</span>
+          <span className="hero-chevron-down w-4 h-4" />
+        </MenuButton>
+        <MenuItems
+          transition
+          className="absolute right-0 z-[100] mt-2 w-max origin-top-right
+          rounded-md bg-white py-1 shadow-lg outline outline-black/5
+          transition data-closed:scale-95 data-closed:transform
+          data-closed:opacity-0 data-enter:duration-200 data-enter:ease-out
+          data-leave:duration-75 data-leave:ease-in"
+        >
+          <MenuItem>
+            <button
+              type="button"
+              onClick={onRunWithCustomInputClick}
+              className="flex items-center gap-2 w-full text-left px-4 py-2
+              text-sm text-gray-700 data-focus:bg-gray-100
+              data-focus:outline-hidden"
+            >
+              <span className="hero-play h-4 w-4" />
+              Run with custom input
+            </button>
+          </MenuItem>
+        </MenuItems>
+      </Menu>
+    </div>
   );
 }

--- a/assets/js/collaborative-editor/components/WorkflowEditor.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowEditor.tsx
@@ -84,6 +84,12 @@ export function WorkflowEditor({
     if (isRunPanelOpen) {
       const contextJobId = runPanelContext?.jobId;
       const contextTriggerId = runPanelContext?.triggerId;
+      // runMode persists the panel entry point in the URL so the title
+      // ("Pick a custom input") survives reload, deep-link, and back/forward.
+      // Read back by the URL→store sync below.
+      const contextEntryPoint = runPanelContext?.entryPoint ?? null;
+      const runModeParam =
+        contextEntryPoint === 'custom-input' ? 'custom-input' : null;
 
       // run panel can override all panels
       const nodePanels = ['editor', 'run', 'code', 'settings'].includes(
@@ -96,15 +102,17 @@ export function WorkflowEditor({
             panel: 'run',
             job: contextJobId,
             trigger: null,
+            runMode: runModeParam,
           });
         } else if (contextTriggerId) {
           updateSearchParams({
             panel: 'run',
             trigger: contextTriggerId,
             job: null,
+            runMode: runModeParam,
           });
         } else {
-          updateSearchParams({ panel: 'run' });
+          updateSearchParams({ panel: 'run', runMode: runModeParam });
         }
         setTimeout(() => {
           isSyncingRef.current = false;
@@ -117,7 +125,7 @@ export function WorkflowEditor({
       !isInitialMountRef.current
     ) {
       isSyncingRef.current = true;
-      updateSearchParams({ panel: null });
+      updateSearchParams({ panel: null, runMode: null });
       setTimeout(() => {
         isSyncingRef.current = false;
       }, 0);
@@ -132,19 +140,32 @@ export function WorkflowEditor({
 
       const jobParam = params['job'] ?? null;
       const triggerParam = params['trigger'] ?? null;
+      const entryPointFromUrl =
+        params['runMode'] === 'custom-input'
+          ? { entryPoint: 'custom-input' as const }
+          : {};
 
       if (jobParam) {
-        openRunPanel({ jobId: jobParam });
+        openRunPanel({ jobId: jobParam, ...entryPointFromUrl });
       } else if (triggerParam) {
-        openRunPanel({ triggerId: triggerParam });
+        openRunPanel({ triggerId: triggerParam, ...entryPointFromUrl });
       } else if (currentNode.type === 'job' && currentNode.node) {
-        openRunPanel({ jobId: currentNode.node.id });
+        openRunPanel({
+          jobId: currentNode.node.id,
+          ...entryPointFromUrl,
+        });
       } else if (currentNode.type === 'trigger' && currentNode.node) {
-        openRunPanel({ triggerId: currentNode.node.id });
+        openRunPanel({
+          triggerId: currentNode.node.id,
+          ...entryPointFromUrl,
+        });
       } else {
         const firstTrigger = workflow.triggers[0];
         if (firstTrigger?.id) {
-          openRunPanel({ triggerId: firstTrigger.id });
+          openRunPanel({
+            triggerId: firstTrigger.id,
+            entryPoint: 'custom-input',
+          });
         }
       }
 
@@ -424,7 +445,10 @@ export function WorkflowEditor({
       } else {
         const firstTrigger = workflow.triggers[0];
         if (firstTrigger?.id) {
-          openRunPanel({ triggerId: firstTrigger.id });
+          openRunPanel({
+            triggerId: firstTrigger.id,
+            entryPoint: 'custom-input',
+          });
         }
       }
     },
@@ -768,6 +792,7 @@ export function WorkflowEditor({
                 jobId={runPanelContext.jobId ?? null}
                 triggerId={runPanelContext.triggerId ?? null}
                 edgeId={runPanelContext.edgeId ?? null}
+                entryPoint={runPanelContext.entryPoint ?? null}
                 onClose={closeRunPanel}
                 saveWorkflow={saveWorkflow}
               />

--- a/assets/js/collaborative-editor/components/inspector/JobInspector.tsx
+++ b/assets/js/collaborative-editor/components/inspector/JobInspector.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { useURLState } from '#/react/lib/use-url-state';
 
+import { ADAPTORS_WITHOUT_CREDENTIALS } from '../../constants/adaptors';
 import { useJobDeleteValidation } from '../../hooks/useJobDeleteValidation';
 import { usePermissions } from '../../hooks/useSessionContext';
 import {
@@ -10,6 +11,7 @@ import {
   useWorkflowReadOnly,
 } from '../../hooks/useWorkflow';
 import type { Workflow } from '../../types/workflow';
+import { extractAdaptorName } from '../../utils/adaptorUtils';
 import { AlertDialog } from '../AlertDialog';
 import { Button } from '../Button';
 import { NewRunButton } from '../NewRunButton';
@@ -73,6 +75,15 @@ export function JobInspector({
   // Determine if Delete should be disabled
   const canEdit = permissions?.can_edit_workflow && !isReadOnly;
 
+  const hasCredential = !!(
+    job.project_credential_id || job.keychain_credential_id
+  );
+  const needsConnect =
+    !hasCredential &&
+    !ADAPTORS_WITHOUT_CREDENTIALS.includes(
+      extractAdaptorName(job.adaptor) ?? ''
+    );
+
   // Build footer with edit, run, and delete buttons
   const footer = (
     <InspectorFooter
@@ -90,34 +101,43 @@ export function JobInspector({
           >
             <span className="inline-block">
               <Button
-                variant="primary"
+                aria-label="Code"
+                variant="secondary"
                 onClick={() => updateSearchParams({ panel: 'editor' })}
                 disabled={isIDEOpen}
               >
-                Code
+                <span className="hero-arrows-pointing-out"></span>
               </Button>
             </span>
           </Tooltip>
+          <Tooltip content={deleteTooltipMessage}>
+            <span className="inline-block">
+              <Button
+                aria-label="Delete"
+                variant="secondary"
+                onClick={() => setIsDeleteDialogOpen(true)}
+                disabled={!canDelete || !canEdit || isDeleting}
+              >
+                {isDeleting ? (
+                  <span className="hero-arrow-path animate-spin"></span>
+                ) : (
+                  <span className="hero-trash"></span>
+                )}
+              </Button>
+            </span>
+          </Tooltip>
+        </>
+      }
+      rightButtons={
+        <>
           <NewRunButton
             onClick={() => onOpenRunPanel({ jobId: job.id })}
             tooltipSide="top"
             disabled={isReadOnly}
             text="Run From Here"
+            variant={needsConnect ? 'secondary' : 'primary'}
           />
         </>
-      }
-      rightButtons={
-        <Tooltip content={deleteTooltipMessage}>
-          <span className="inline-block">
-            <Button
-              variant="danger"
-              onClick={() => setIsDeleteDialogOpen(true)}
-              disabled={!canDelete || !canEdit}
-            >
-              {isDeleting ? 'Deleting...' : 'Delete'}
-            </Button>
-          </span>
-        </Tooltip>
       }
     />
   );

--- a/assets/js/collaborative-editor/components/inspector/JobInspector.tsx
+++ b/assets/js/collaborative-editor/components/inspector/JobInspector.tsx
@@ -102,6 +102,7 @@ export function JobInspector({
             onClick={() => onOpenRunPanel({ jobId: job.id })}
             tooltipSide="top"
             disabled={isReadOnly}
+            text="Run From Here"
           />
         </>
       }

--- a/assets/js/collaborative-editor/constants/adaptors.ts
+++ b/assets/js/collaborative-editor/constants/adaptors.ts
@@ -1,0 +1,12 @@
+// Adaptors that don't require a credential to run
+export const ADAPTORS_WITHOUT_CREDENTIALS = [
+  'common',
+  'http',
+  'testing',
+  'ping',
+  'fhir',
+  'fhir-4',
+  'fhir-eswatini',
+  'fhir-fr',
+  'fhir-ndr-et',
+];

--- a/assets/js/collaborative-editor/stores/createUIStore.ts
+++ b/assets/js/collaborative-editor/stores/createUIStore.ts
@@ -63,7 +63,7 @@ import { produce } from 'immer';
 
 import _logger from '#/utils/logger';
 
-import type { UIState, UIStore } from '../types/ui';
+import type { UICommands, UIState, UIStore } from '../types/ui';
 
 import { createWithSelector } from './common';
 import { wrapStoreWithDevTools } from './devtools';
@@ -157,7 +157,7 @@ export const createUIStore = (): UIStore => {
 
   const withSelector = createWithSelector(getSnapshot);
 
-  const openRunPanel = (context: { jobId?: string; triggerId?: string }) => {
+  const openRunPanel: UICommands['openRunPanel'] = context => {
     state = produce(state, draft => {
       draft.runPanelContext = context;
       draft.runPanelOpen = true;

--- a/assets/js/collaborative-editor/types/ui.ts
+++ b/assets/js/collaborative-editor/types/ui.ts
@@ -12,6 +12,13 @@ import type { Template, WorkflowTemplate } from './template';
 // =============================================================================
 
 /**
+ * Entry point that opened the run panel. Drives the panel title.
+ * - 'custom-input': opened from the canvas Run dropdown or a default
+ *   (no specific node) entry path.
+ */
+export type RunPanelEntryPoint = 'custom-input';
+
+/**
  * UI store state for transient UI concerns like panel visibility
  */
 export interface UIState {
@@ -22,6 +29,7 @@ export interface UIState {
     jobId?: string | null;
     triggerId?: string | null;
     edgeId?: string | null;
+    entryPoint?: RunPanelEntryPoint | null;
   } | null;
 
   /** GitHub sync modal open state */
@@ -62,6 +70,7 @@ export interface UICommands {
     jobId?: string;
     triggerId?: string;
     edgeId?: string;
+    entryPoint?: RunPanelEntryPoint;
   }) => void;
 
   /** Close run panel */

--- a/assets/test/collaborative-editor/components/Header.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.test.tsx
@@ -355,7 +355,9 @@ describe('Header - Basic Rendering', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^run$/i })
+      ).toBeInTheDocument();
     });
   });
 
@@ -760,7 +762,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeInTheDocument();
     });
 
@@ -799,14 +801,14 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeInTheDocument();
     });
 
     // Tooltip should be hidden when panel is open
     // We're testing tooltip visibility, not button enabled state
     // The button may be disabled for workflow validation reasons
-    const startButton = screen.getByRole('button', { name: /run/i });
+    const startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
   });
 
@@ -840,7 +842,9 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^run$/i })
+      ).toBeInTheDocument();
     });
 
     // Make workflow invalid (empty name)
@@ -850,7 +854,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeDisabled();
     });
 
@@ -867,7 +871,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
 
     // Error tooltip should still be shown even when panel is open
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeDisabled();
     });
   });
@@ -902,10 +906,12 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^run$/i })
+      ).toBeInTheDocument();
     });
 
-    let startButton = screen.getByRole('button', { name: /run/i });
+    let startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
     // Tooltip should be present when closed
 
@@ -920,7 +926,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
       </Header>
     );
 
-    startButton = screen.getByRole('button', { name: /run/i });
+    startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
     // Tooltip should be hidden when open
 
@@ -935,7 +941,7 @@ describe('Header - Run Button Tooltip with Panel State', () => {
       </Header>
     );
 
-    startButton = screen.getByRole('button', { name: /run/i });
+    startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
     // Tooltip should reappear when closed
   });
@@ -966,13 +972,13 @@ describe('Header - Run Button Tooltip with Panel State', () => {
     });
 
     await waitFor(() => {
-      const startButton = screen.getByRole('button', { name: /run/i });
+      const startButton = screen.getByRole('button', { name: /^run$/i });
       expect(startButton).toBeInTheDocument();
     });
 
     // Default should show tooltip (panel closed by default)
     // We're testing that the prop defaults correctly, not button state
-    const startButton = screen.getByRole('button', { name: /run/i });
+    const startButton = screen.getByRole('button', { name: /^run$/i });
     expect(startButton).toBeInTheDocument();
   });
 });

--- a/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
@@ -550,8 +550,8 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       // Wait for component to be fully ready
       await new Promise(resolve => setTimeout(resolve, 200));
 
-      // Switch to Custom tab
-      const customTab = screen.getByText('Custom');
+      // Switch to New tab (custom input)
+      const customTab = screen.getByText('New');
       await user.click(customTab);
 
       // The Monaco editor is mocked, so we need to find the mock element
@@ -1360,8 +1360,8 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
         // Wait for component to be fully ready
         await new Promise(resolve => setTimeout(resolve, 200));
 
-        // Switch to Custom tab
-        const customTab = screen.getByText('Custom');
+        // Switch to New tab (custom input)
+        const customTab = screen.getByText('New');
         await user.click(customTab);
 
         // The Monaco editor is mocked

--- a/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
@@ -592,7 +592,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // Verify Run button is available (shortcuts configured in lines 439-447)
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
     });
 
@@ -618,7 +618,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
 
       // Verify Run button is NOT shown in embedded mode
       // (shortcuts disabled via enabled: renderMode === RENDER_MODES.STANDALONE)
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
     });
 
     test('run button respects canRun guard', async () => {
@@ -644,7 +644,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // Verify Run button is disabled when canRun is false
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).toBeDisabled();
     });
 
@@ -670,7 +670,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // Click Run button
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       act(() => {
         runButton.click();
       });
@@ -709,7 +709,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       // In embedded mode, shortcuts are disabled (enabled: renderMode === STANDALONE)
       // This prevents conflicts with IDE shortcuts
       expect(screen.queryByText('Run from Test Job')).not.toBeInTheDocument();
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
     });
 
     test('standalone mode provides full UI with shortcuts', async () => {
@@ -733,7 +733,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       });
 
       // In standalone mode, full UI is rendered with shortcuts enabled
-      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.getByText('Run From Here')).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /close panel/i })
       ).toBeInTheDocument();
@@ -762,7 +762,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
 
       // useRunRetryShortcuts configured with enabled: renderMode === RENDER_MODES.STANDALONE
       // This ensures shortcuts only work in standalone mode, preventing conflicts with IDE
-      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.getByText('Run From Here')).toBeInTheDocument();
     });
   });
 
@@ -1279,7 +1279,7 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
         await new Promise(resolve => setTimeout(resolve, 200));
 
         // Click run button to start running
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         act(() => {
           runButton.click();
         });

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -252,6 +252,24 @@ describe('ManualRunPanel', () => {
     });
   });
 
+  test('renders "Pick a custom input" title when entryPoint is custom-input', async () => {
+    renderManualRunPanel({
+      workflow: mockWorkflow,
+      projectId: 'project-1',
+      workflowId: 'workflow-1',
+      triggerId: 'trigger-1',
+      entryPoint: 'custom-input',
+      onClose: () => {},
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Pick a custom input')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText('Run from Trigger (webhook)')
+    ).not.toBeInTheDocument();
+  });
+
   test('shows three tabs with correct labels', async () => {
     renderManualRunPanel({
       workflow: mockWorkflow,
@@ -264,7 +282,7 @@ describe('ManualRunPanel', () => {
     await waitFor(() => {
       expect(screen.getByText('Empty')).toBeInTheDocument();
     });
-    expect(screen.getByText('Custom')).toBeInTheDocument();
+    expect(screen.getByText('New')).toBeInTheDocument();
     expect(screen.getByText('Existing')).toBeInTheDocument();
   });
 
@@ -294,8 +312,8 @@ describe('ManualRunPanel', () => {
       onClose: () => {},
     });
 
-    // Click Custom tab
-    await user.click(screen.getByText('Custom'));
+    // Click New tab (custom input)
+    await user.click(screen.getByText('New'));
 
     // Monaco editor should appear
     await waitFor(() => {
@@ -518,8 +536,8 @@ describe('ManualRunPanel', () => {
       onClose: () => {},
     });
 
-    // Switch to Custom tab
-    await user.click(screen.getByText('Custom'));
+    // Switch to New tab (custom input)
+    await user.click(screen.getByText('New'));
 
     // The Monaco editor is mocked, so we can't actually test JSON validation
     // through user interaction. This is acceptable as JSON validation is
@@ -1116,8 +1134,8 @@ describe('ManualRunPanel', () => {
       );
       await user.click(xButton!);
 
-      // Switch to Custom tab
-      await user.click(screen.getByText('Custom'));
+      // Switch to New tab (custom input)
+      await user.click(screen.getByText('New'));
 
       // Switch back to Existing tab
       await user.click(screen.getByText('Existing'));

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -360,7 +360,7 @@ describe('ManualRunPanel', () => {
     });
 
     await waitFor(() => {
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
     });
   });
@@ -560,7 +560,7 @@ describe('ManualRunPanel', () => {
 
     // Run button should be enabled
     await waitFor(() => {
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
     });
   });
@@ -608,7 +608,7 @@ describe('ManualRunPanel', () => {
       ).toBeInTheDocument();
 
       // Should show footer with Run button
-      expect(screen.getByText('Run')).toBeInTheDocument();
+      expect(screen.getByText('Run From Here')).toBeInTheDocument();
     });
 
     test('embedded mode shows only content, no header or footer', async () => {
@@ -635,7 +635,7 @@ describe('ManualRunPanel', () => {
       ).not.toBeInTheDocument();
 
       // Should NOT show footer with Run button
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
     });
 
     test('embedded mode with trigger context', async () => {
@@ -735,7 +735,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });
@@ -751,7 +751,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
     });
@@ -802,7 +802,7 @@ describe('ManualRunPanel', () => {
 
       // Run button should still be disabled due to lack of permission
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });
@@ -840,11 +840,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for initial render
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Click Run button
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Verify save was called first, then run
       await waitFor(() => {
@@ -871,10 +871,10 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Save should be called
       await waitFor(() => {
@@ -910,10 +910,10 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Save should be called
       await waitFor(() => {
@@ -954,11 +954,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for initial render
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Click Run button
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Verify saveWorkflow was called with { silent: true }
       await waitFor(() => {
@@ -994,11 +994,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for initial render
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Click Run button - this will start the save
-      await user.click(screen.getByText('Run'));
+      await user.click(screen.getByText('Run From Here'));
 
       // Button should show "Processing" while submitting
       // Use helper for CSS Grid layout (invisible spacers render same text)
@@ -1050,7 +1050,7 @@ describe('ManualRunPanel', () => {
 
       // Button should be enabled with selected dataclip
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
 
@@ -1073,7 +1073,7 @@ describe('ManualRunPanel', () => {
 
       // Button should now be disabled
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });
@@ -1133,7 +1133,7 @@ describe('ManualRunPanel', () => {
       expect(screen.getByText('Test Dataclip')).toBeInTheDocument();
 
       // Run button should still be disabled
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).toBeDisabled();
     });
 
@@ -1178,7 +1178,7 @@ describe('ManualRunPanel', () => {
 
       // Run button should be enabled on Empty tab
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
     });
@@ -1248,10 +1248,10 @@ describe('ManualRunPanel', () => {
 
       // Footer should be rendered with Run button
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).not.toBeDisabled();
 
       // The footer button passes showKeyboardShortcuts=true
@@ -1271,7 +1271,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
 
@@ -1309,11 +1309,11 @@ describe('ManualRunPanel', () => {
 
       // Wait for component to load with retryable state
       await waitFor(() => {
-        expect(screen.getByText('Run')).toBeInTheDocument();
+        expect(screen.getByText('Run From Here')).toBeInTheDocument();
       });
 
       // Footer button should be rendered
-      const runButton = screen.getByText('Run');
+      const runButton = screen.getByText('Run From Here');
       expect(runButton).toBeInTheDocument();
 
       // showKeyboardShortcuts=true is passed, enabling tooltip for main button
@@ -1336,7 +1336,7 @@ describe('ManualRunPanel', () => {
       });
 
       // Footer should NOT be rendered in embedded mode
-      expect(screen.queryByText('Run')).not.toBeInTheDocument();
+      expect(screen.queryByText('Run From Here')).not.toBeInTheDocument();
 
       // No tooltip concerns because RunRetryButton is not rendered in footer
     });
@@ -1361,7 +1361,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).not.toBeDisabled();
       });
     });
@@ -1384,7 +1384,7 @@ describe('ManualRunPanel', () => {
       });
 
       await waitFor(() => {
-        const runButton = screen.getByText('Run');
+        const runButton = screen.getByText('Run From Here');
         expect(runButton).toBeDisabled();
       });
     });

--- a/assets/test/collaborative-editor/components/NewRunButton.test.tsx
+++ b/assets/test/collaborative-editor/components/NewRunButton.test.tsx
@@ -75,6 +75,21 @@ describe('NewRunButton - Disabled Prop', () => {
 
     expect(screen.getByText('Run')).toBeInTheDocument();
   });
+
+  test('button renders with custom text when text prop is provided', () => {
+    const mockOnClick = vi.fn();
+
+    render(
+      <NewRunButton
+        onClick={mockOnClick}
+        disabled={false}
+        text="Run From Here"
+      />
+    );
+
+    expect(screen.getByText('Run From Here')).toBeInTheDocument();
+    expect(screen.queryByText('Run')).not.toBeInTheDocument();
+  });
 });
 
 describe('NewRunButton - Tooltip Positioning', () => {

--- a/assets/test/collaborative-editor/components/WorkflowEditor.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/WorkflowEditor.keyboard.test.tsx
@@ -316,6 +316,7 @@ describe('WorkflowEditor keyboard shortcuts', () => {
       await waitFor(() => {
         expect(mockOpenRunPanel).toHaveBeenCalledWith({
           triggerId: 'trigger-1',
+          entryPoint: 'custom-input',
         });
       });
     });

--- a/assets/test/collaborative-editor/components/WorkflowEditor.test.tsx
+++ b/assets/test/collaborative-editor/components/WorkflowEditor.test.tsx
@@ -372,6 +372,67 @@ describe('WorkflowEditor', () => {
     });
   });
 
+  describe('URL persistence of run-panel entry point', () => {
+    test('URL with runMode=custom-input opens panel with entryPoint', async () => {
+      urlState.setParams({
+        panel: 'run',
+        trigger: 'trigger-1',
+        runMode: 'custom-input',
+      });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          triggerId: 'trigger-1',
+          entryPoint: 'custom-input',
+        });
+      });
+    });
+
+    test('URL without runMode opens panel without entryPoint', async () => {
+      urlState.setParams({ panel: 'run', trigger: 'trigger-1' });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          triggerId: 'trigger-1',
+        });
+      });
+    });
+
+    test('URL with runMode=custom-input + jobParam preserves entryPoint', async () => {
+      urlState.setParams({
+        panel: 'run',
+        job: 'job-1',
+        runMode: 'custom-input',
+      });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          jobId: 'job-1',
+          entryPoint: 'custom-input',
+        });
+      });
+    });
+
+    test('URL with only panel=run defaults to first trigger + custom-input', async () => {
+      urlState.setParams({ panel: 'run' });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          triggerId: 'trigger-1',
+          entryPoint: 'custom-input',
+        });
+      });
+    });
+  });
+
   describe('inspector integration', () => {
     test('shows inspector when node is selected', async () => {
       // Select a job

--- a/assets/test/collaborative-editor/components/inspector/JobForm.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/JobForm.test.tsx
@@ -211,12 +211,12 @@ describe('JobForm - Adaptor Display Section', () => {
     // Phase 2R: Version is NO LONGER displayed in inspector
     // Version selection moved to ConfigureAdaptorModal (Phase 3R)
 
-    // Check "Connect" button exists (no credential set yet)
+    // Check "Edit" button exists (no credential set yet)
     const connectButton = screen.getByRole('button', {
-      name: /connect credential/i,
+      name: /edit adaptor/i,
     });
     expect(connectButton).toBeInTheDocument();
-    expect(connectButton).toHaveTextContent('Connect');
+    expect(connectButton).toHaveTextContent('Edit');
   });
 
   test("opens ConfigureAdaptorModal when 'Connect' clicked (Phase 3R)", async () => {
@@ -233,9 +233,9 @@ describe('JobForm - Adaptor Display Section', () => {
       ),
     });
 
-    // Click "Connect" button to open ConfigureAdaptorModal
+    // Click "Edit" button to open ConfigureAdaptorModal
     const connectButton = screen.getByRole('button', {
-      name: /connect credential/i,
+      name: /edit adaptor/i,
     });
     await user.click(connectButton);
 
@@ -265,9 +265,9 @@ describe('JobForm - Adaptor Display Section', () => {
     // Verify initial adaptor
     expect(screen.getByText('Http')).toBeInTheDocument();
 
-    // Open modal with "Connect" button
+    // Open modal with "Edit" button
     const connectButton = screen.getByRole('button', {
-      name: /connect credential/i,
+      name: /edit adaptor/i,
     });
     await user.click(connectButton);
 
@@ -324,6 +324,86 @@ describe('JobForm - Adaptor Display Section', () => {
     await waitFor(() => {
       expect(screen.getByText('Salesforce')).toBeInTheDocument();
     });
+  });
+
+  test("shows 'Edit' button for adaptors that don't need credentials (no credential set)", async () => {
+    const ydocWithCommon = createWorkflowYDoc({
+      jobs: {
+        'job-1': {
+          id: 'job-1',
+          name: 'Common Job',
+          adaptor: '@openfn/language-common@2.0.0',
+          body: 'fn(state => state)',
+          project_credential_id: null,
+          keychain_credential_id: null,
+        },
+      },
+    });
+
+    const commonStore = createConnectedWorkflowStore(ydocWithCommon);
+    const job = commonStore.getSnapshot().jobs[0];
+
+    render(<JobForm job={job} />, {
+      wrapper: createWrapper(
+        commonStore,
+        credentialStore,
+        sessionContextStore,
+        adaptorStore,
+        awarenessStore
+      ),
+    });
+
+    // language-common doesn't need credentials — button should say "Edit" even without a credential
+    await waitFor(() => {
+      const editButton = screen.getByRole('button', { name: /edit adaptor/i });
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toHaveTextContent('Edit');
+    });
+
+    expect(
+      screen.queryByRole('button', { name: /connect credential/i })
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows 'Connect' button for adaptors that need credentials (no credential set)", async () => {
+    const ydocWithSalesforce = createWorkflowYDoc({
+      jobs: {
+        'job-1': {
+          id: 'job-1',
+          name: 'Salesforce Job',
+          adaptor: '@openfn/language-salesforce@2.0.0',
+          body: 'fn(state => state)',
+          project_credential_id: null,
+          keychain_credential_id: null,
+        },
+      },
+    });
+
+    const sfStore = createConnectedWorkflowStore(ydocWithSalesforce);
+    const job = sfStore.getSnapshot().jobs[0];
+
+    render(<JobForm job={job} />, {
+      wrapper: createWrapper(
+        sfStore,
+        credentialStore,
+        sessionContextStore,
+        adaptorStore,
+        awarenessStore
+      ),
+    });
+
+    // language-salesforce needs credentials — button should say "Connect" when no credential is set
+    await waitFor(() => {
+      const connectButton = screen.getByRole('button', {
+        name: /connect credential/i,
+      });
+      expect(connectButton).toBeInTheDocument();
+      expect(connectButton).toHaveTextContent('Connect');
+    });
+
+    expect(
+      screen.queryByRole('button', { name: /edit adaptor/i })
+    ).not.toBeInTheDocument();
   });
 
   // REMOVED (Phase 2R): Version dropdown no longer in inspector
@@ -1206,7 +1286,7 @@ describe('JobForm - Credential Configuration', () => {
 
     // Open ConfigureAdaptorModal
     const connectButton = screen.getByRole('button', {
-      name: /connect credential/i,
+      name: /edit adaptor/i,
     });
     await user.click(connectButton);
 


### PR DESCRIPTION
## Description

This is a PR for the EPIC on better run experience. All sub-issues will be merged into this till it's ready to be merged to main

Closes #4614 

## Validation steps

This Epic PR contains multiple issues and validation will be for all the sub-issues involved.

#### One click split button #4615 
The run button is now a split button with a dropdown on the right
- Clicking on the run button itself should instantly run a workflow with a default/empty dataclip
- Clicking the dropdown on the run button and the selecting "Run with custom input" should allow you to select a dataclip before running the workflow

#### Run with custom input #4616 
- Whenever you click the "Run with custom input" button. the run panel should show up with the title "Pick a custom input" instead of eg. "Run from trigger"

#### Run from Here Button text #4617 
- The text on the run panels should now be "Run From Here" instead of just run. to show that a run begins for the active step

#### Clearer Step panel design #4618 
This changes the look of the step panel a bit
- "Run From Here" button moves to the right.
- "Delete" and "Code" buttons become icons to the left
- When an adaptor is selected that requires a credential to be useful, the "Run From Here" button become gray coloured while the connect button for the adaptor becomes primary colored to give it more focus. Once a credential is attached, the connect button becomes gray instead while the "Run From Here" button steals the focus by becoming primary coloured.

## Additional notes for the reviewer

1. _(Is there anything else the reviewer should know or look out for?)_

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
