### PR TITLE
feat: pick a custom input panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to
   [#4615](https://github.com/OpenFn/lightning/issues/4615)
 - Clearer step panel button design with icon-only secondary buttons for Code and
   Delete. [#4618](https://github.com/OpenFn/lightning/issues/4618)
+- "Pick a custom input" panel and renamed "New" tab when opening the manual run
+  panel from the canvas Run dropdown.
+  [#4616](https://github.com/OpenFn/lightning/issues/4616)
 
 ### Fixed
 

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -300,7 +300,10 @@ export function Header({
     if (firstTriggerId) {
       selectNode(firstTriggerId);
       updateSearchParams({ panel: 'run' });
-      openRunPanel({ triggerId: firstTriggerId });
+      openRunPanel({
+        triggerId: firstTriggerId,
+        entryPoint: 'custom-input',
+      });
     }
   }, [firstTriggerId, openRunPanel, selectNode, updateSearchParams]);
 

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -18,6 +18,7 @@ import ExistingView from '../../manual-run-panel/views/ExistingView';
 import type { Dataclip } from '../api/dataclips';
 import * as dataclipApi from '../api/dataclips';
 import { RENDER_MODES, type RenderMode } from '../constants/panel';
+import type { RunPanelEntryPoint } from '../types/ui';
 import { useActiveRun, useFollowRun } from '../hooks/useHistory';
 import { useRunRetry } from '../hooks/useRunRetry';
 import { useRunRetryShortcuts } from '../hooks/useRunRetryShortcuts';
@@ -42,6 +43,7 @@ interface ManualRunPanelProps {
   jobId?: string | null;
   triggerId?: string | null;
   edgeId?: string | null;
+  entryPoint?: RunPanelEntryPoint | null;
   onClose: () => void;
   /** Called when close button is clicked in embedded mode */
   onClosePanel?: () => void;
@@ -70,6 +72,7 @@ export function ManualRunPanel({
   jobId,
   triggerId,
   edgeId,
+  entryPoint = null,
   onClose,
   onClosePanel,
   renderMode = RENDER_MODES.STANDALONE,
@@ -179,11 +182,14 @@ export function ManualRunPanel({
       ? workflow.triggers.find(t => t.id === runContext.id)
       : null;
 
-  const panelTitle = contextJob
-    ? `Run from ${contextJob.name}`
-    : contextTrigger
-      ? `Run from Trigger (${contextTrigger.type})`
-      : 'Run Workflow';
+  const panelTitle =
+    entryPoint === 'custom-input'
+      ? 'Pick a custom input'
+      : contextJob
+        ? `Run from ${contextJob.name}`
+        : contextTrigger
+          ? `Run from Trigger (${contextTrigger.type})`
+          : 'Run Workflow';
 
   // For triggers: find first connected job for dataclip fetching
   // (dataclips are associated with jobs, not triggers)
@@ -564,7 +570,7 @@ export function ManualRunPanel({
           { value: 'empty', label: 'Empty', icon: DocumentIcon },
           {
             value: 'custom',
-            label: 'Custom',
+            label: 'New',
             icon: PencilSquareIcon,
           },
           {

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -182,14 +182,16 @@ export function ManualRunPanel({
       ? workflow.triggers.find(t => t.id === runContext.id)
       : null;
 
-  const panelTitle =
-    entryPoint === 'custom-input'
-      ? 'Pick a custom input'
-      : contextJob
-        ? `Run from ${contextJob.name}`
-        : contextTrigger
-          ? `Run from Trigger (${contextTrigger.type})`
-          : 'Run Workflow';
+  let panelTitle: string;
+  if (entryPoint === 'custom-input') {
+    panelTitle = 'Pick a custom input';
+  } else if (contextJob) {
+    panelTitle = `Run from ${contextJob.name}`;
+  } else if (contextTrigger) {
+    panelTitle = `Run from Trigger (${contextTrigger.type})`;
+  } else {
+    panelTitle = 'Run Workflow';
+  }
 
   // For triggers: find first connected job for dataclip fetching
   // (dataclips are associated with jobs, not triggers)

--- a/assets/js/collaborative-editor/components/WorkflowEditor.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowEditor.tsx
@@ -84,6 +84,9 @@ export function WorkflowEditor({
     if (isRunPanelOpen) {
       const contextJobId = runPanelContext?.jobId;
       const contextTriggerId = runPanelContext?.triggerId;
+      const contextEntryPoint = runPanelContext?.entryPoint ?? null;
+      const runModeParam =
+        contextEntryPoint === 'custom-input' ? 'custom-input' : null;
 
       // run panel can override all panels
       const nodePanels = ['editor', 'run', 'code', 'settings'].includes(
@@ -96,15 +99,17 @@ export function WorkflowEditor({
             panel: 'run',
             job: contextJobId,
             trigger: null,
+            runMode: runModeParam,
           });
         } else if (contextTriggerId) {
           updateSearchParams({
             panel: 'run',
             trigger: contextTriggerId,
             job: null,
+            runMode: runModeParam,
           });
         } else {
-          updateSearchParams({ panel: 'run' });
+          updateSearchParams({ panel: 'run', runMode: runModeParam });
         }
         setTimeout(() => {
           isSyncingRef.current = false;
@@ -117,7 +122,7 @@ export function WorkflowEditor({
       !isInitialMountRef.current
     ) {
       isSyncingRef.current = true;
-      updateSearchParams({ panel: null });
+      updateSearchParams({ panel: null, runMode: null });
       setTimeout(() => {
         isSyncingRef.current = false;
       }, 0);
@@ -132,19 +137,32 @@ export function WorkflowEditor({
 
       const jobParam = params['job'] ?? null;
       const triggerParam = params['trigger'] ?? null;
+      const entryPointFromUrl =
+        params['runMode'] === 'custom-input'
+          ? { entryPoint: 'custom-input' as const }
+          : {};
 
       if (jobParam) {
-        openRunPanel({ jobId: jobParam });
+        openRunPanel({ jobId: jobParam, ...entryPointFromUrl });
       } else if (triggerParam) {
-        openRunPanel({ triggerId: triggerParam });
+        openRunPanel({ triggerId: triggerParam, ...entryPointFromUrl });
       } else if (currentNode.type === 'job' && currentNode.node) {
-        openRunPanel({ jobId: currentNode.node.id });
+        openRunPanel({
+          jobId: currentNode.node.id,
+          ...entryPointFromUrl,
+        });
       } else if (currentNode.type === 'trigger' && currentNode.node) {
-        openRunPanel({ triggerId: currentNode.node.id });
+        openRunPanel({
+          triggerId: currentNode.node.id,
+          ...entryPointFromUrl,
+        });
       } else {
         const firstTrigger = workflow.triggers[0];
         if (firstTrigger?.id) {
-          openRunPanel({ triggerId: firstTrigger.id });
+          openRunPanel({
+            triggerId: firstTrigger.id,
+            entryPoint: 'custom-input',
+          });
         }
       }
 
@@ -424,7 +442,10 @@ export function WorkflowEditor({
       } else {
         const firstTrigger = workflow.triggers[0];
         if (firstTrigger?.id) {
-          openRunPanel({ triggerId: firstTrigger.id });
+          openRunPanel({
+            triggerId: firstTrigger.id,
+            entryPoint: 'custom-input',
+          });
         }
       }
     },
@@ -768,6 +789,7 @@ export function WorkflowEditor({
                 jobId={runPanelContext.jobId ?? null}
                 triggerId={runPanelContext.triggerId ?? null}
                 edgeId={runPanelContext.edgeId ?? null}
+                entryPoint={runPanelContext.entryPoint ?? null}
                 onClose={closeRunPanel}
                 saveWorkflow={saveWorkflow}
               />

--- a/assets/js/collaborative-editor/components/WorkflowEditor.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowEditor.tsx
@@ -84,6 +84,9 @@ export function WorkflowEditor({
     if (isRunPanelOpen) {
       const contextJobId = runPanelContext?.jobId;
       const contextTriggerId = runPanelContext?.triggerId;
+      // runMode persists the panel entry point in the URL so the title
+      // ("Pick a custom input") survives reload, deep-link, and back/forward.
+      // Read back by the URL→store sync below.
       const contextEntryPoint = runPanelContext?.entryPoint ?? null;
       const runModeParam =
         contextEntryPoint === 'custom-input' ? 'custom-input' : null;

--- a/assets/js/collaborative-editor/stores/createUIStore.ts
+++ b/assets/js/collaborative-editor/stores/createUIStore.ts
@@ -63,7 +63,7 @@ import { produce } from 'immer';
 
 import _logger from '#/utils/logger';
 
-import type { UIState, UIStore } from '../types/ui';
+import type { UICommands, UIState, UIStore } from '../types/ui';
 
 import { createWithSelector } from './common';
 import { wrapStoreWithDevTools } from './devtools';
@@ -157,7 +157,7 @@ export const createUIStore = (): UIStore => {
 
   const withSelector = createWithSelector(getSnapshot);
 
-  const openRunPanel = (context: { jobId?: string; triggerId?: string }) => {
+  const openRunPanel: UICommands['openRunPanel'] = context => {
     state = produce(state, draft => {
       draft.runPanelContext = context;
       draft.runPanelOpen = true;

--- a/assets/js/collaborative-editor/types/ui.ts
+++ b/assets/js/collaborative-editor/types/ui.ts
@@ -12,6 +12,13 @@ import type { Template, WorkflowTemplate } from './template';
 // =============================================================================
 
 /**
+ * Entry point that opened the run panel. Drives the panel title.
+ * - 'custom-input': opened from the canvas Run dropdown or a default
+ *   (no specific node) entry path.
+ */
+export type RunPanelEntryPoint = 'custom-input';
+
+/**
  * UI store state for transient UI concerns like panel visibility
  */
 export interface UIState {
@@ -22,6 +29,7 @@ export interface UIState {
     jobId?: string | null;
     triggerId?: string | null;
     edgeId?: string | null;
+    entryPoint?: RunPanelEntryPoint | null;
   } | null;
 
   /** GitHub sync modal open state */
@@ -62,6 +70,7 @@ export interface UICommands {
     jobId?: string;
     triggerId?: string;
     edgeId?: string;
+    entryPoint?: RunPanelEntryPoint;
   }) => void;
 
   /** Close run panel */

--- a/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.keyboard.test.tsx
@@ -550,8 +550,8 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
       // Wait for component to be fully ready
       await new Promise(resolve => setTimeout(resolve, 200));
 
-      // Switch to Custom tab
-      const customTab = screen.getByText('Custom');
+      // Switch to New tab (custom input)
+      const customTab = screen.getByText('New');
       await user.click(customTab);
 
       // The Monaco editor is mocked, so we need to find the mock element
@@ -1360,8 +1360,8 @@ describe('ManualRunPanel Keyboard Shortcuts', () => {
         // Wait for component to be fully ready
         await new Promise(resolve => setTimeout(resolve, 200));
 
-        // Switch to Custom tab
-        const customTab = screen.getByText('Custom');
+        // Switch to New tab (custom input)
+        const customTab = screen.getByText('New');
         await user.click(customTab);
 
         // The Monaco editor is mocked

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -252,6 +252,24 @@ describe('ManualRunPanel', () => {
     });
   });
 
+  test('renders "Pick a custom input" title when entryPoint is custom-input', async () => {
+    renderManualRunPanel({
+      workflow: mockWorkflow,
+      projectId: 'project-1',
+      workflowId: 'workflow-1',
+      triggerId: 'trigger-1',
+      entryPoint: 'custom-input',
+      onClose: () => {},
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Pick a custom input')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText('Run from Trigger (webhook)')
+    ).not.toBeInTheDocument();
+  });
+
   test('shows three tabs with correct labels', async () => {
     renderManualRunPanel({
       workflow: mockWorkflow,

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -264,7 +264,7 @@ describe('ManualRunPanel', () => {
     await waitFor(() => {
       expect(screen.getByText('Empty')).toBeInTheDocument();
     });
-    expect(screen.getByText('Custom')).toBeInTheDocument();
+    expect(screen.getByText('New')).toBeInTheDocument();
     expect(screen.getByText('Existing')).toBeInTheDocument();
   });
 
@@ -294,8 +294,8 @@ describe('ManualRunPanel', () => {
       onClose: () => {},
     });
 
-    // Click Custom tab
-    await user.click(screen.getByText('Custom'));
+    // Click New tab (custom input)
+    await user.click(screen.getByText('New'));
 
     // Monaco editor should appear
     await waitFor(() => {
@@ -518,8 +518,8 @@ describe('ManualRunPanel', () => {
       onClose: () => {},
     });
 
-    // Switch to Custom tab
-    await user.click(screen.getByText('Custom'));
+    // Switch to New tab (custom input)
+    await user.click(screen.getByText('New'));
 
     // The Monaco editor is mocked, so we can't actually test JSON validation
     // through user interaction. This is acceptable as JSON validation is
@@ -1116,8 +1116,8 @@ describe('ManualRunPanel', () => {
       );
       await user.click(xButton!);
 
-      // Switch to Custom tab
-      await user.click(screen.getByText('Custom'));
+      // Switch to New tab (custom input)
+      await user.click(screen.getByText('New'));
 
       // Switch back to Existing tab
       await user.click(screen.getByText('Existing'));

--- a/assets/test/collaborative-editor/components/WorkflowEditor.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/WorkflowEditor.keyboard.test.tsx
@@ -316,6 +316,7 @@ describe('WorkflowEditor keyboard shortcuts', () => {
       await waitFor(() => {
         expect(mockOpenRunPanel).toHaveBeenCalledWith({
           triggerId: 'trigger-1',
+          entryPoint: 'custom-input',
         });
       });
     });

--- a/assets/test/collaborative-editor/components/WorkflowEditor.test.tsx
+++ b/assets/test/collaborative-editor/components/WorkflowEditor.test.tsx
@@ -372,6 +372,67 @@ describe('WorkflowEditor', () => {
     });
   });
 
+  describe('URL persistence of run-panel entry point', () => {
+    test('URL with runMode=custom-input opens panel with entryPoint', async () => {
+      urlState.setParams({
+        panel: 'run',
+        trigger: 'trigger-1',
+        runMode: 'custom-input',
+      });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          triggerId: 'trigger-1',
+          entryPoint: 'custom-input',
+        });
+      });
+    });
+
+    test('URL without runMode opens panel without entryPoint', async () => {
+      urlState.setParams({ panel: 'run', trigger: 'trigger-1' });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          triggerId: 'trigger-1',
+        });
+      });
+    });
+
+    test('URL with runMode=custom-input + jobParam preserves entryPoint', async () => {
+      urlState.setParams({
+        panel: 'run',
+        job: 'job-1',
+        runMode: 'custom-input',
+      });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          jobId: 'job-1',
+          entryPoint: 'custom-input',
+        });
+      });
+    });
+
+    test('URL with only panel=run defaults to first trigger + custom-input', async () => {
+      urlState.setParams({ panel: 'run' });
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(mockOpenRunPanel).toHaveBeenCalledWith({
+          triggerId: 'trigger-1',
+          entryPoint: 'custom-input',
+        });
+      });
+    });
+  });
+
   describe('inspector integration', () => {
     test('shows inspector when node is selected', async () => {
       // Select a job


### PR DESCRIPTION
## Description

This PR adds the "Pick a custom input" panel for issue #4616. When the run panel opens via the canvas Run dropdown, the title reads "Pick a custom input" and the second tab is labelled "New". The entry point is round-tripped through a `runMode` query parameter via bidirectional store and URL sync, so the title survives reload, deep links, and back/forward. When the panel is entered from a step (Run From Here on a job/trigger inspector) or via direct node selection, the existing per-step title is preserved.

Closes #4616

## Validation steps

1. Open a workflow on the canvas. Click the run button dropdown chevron and pick "Run with custom input". The panel title should read "Pick a custom input" and the second tab should be labelled "New".
2. Refresh the page. The title should still read "Pick a custom input"; the URL should keep `runMode=custom-input`.
3. Click a job in the canvas while the panel is open. The title should switch to "Run from <job name>" and the URL should no longer have `runMode=custom-input`.
4. Click "Run From Here" on a step inspector. The title should be the existing per-step title, not "Pick a custom input".
5. `cd assets && npx vitest run test/collaborative-editor` is green.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
