### PR TITLE
Soft-delete sandboxes with grace-period purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ and this project adheres to
   (`PURGE_DELETED_AFTER_DAYS`) instead of being hard-deleted immediately, so
   accidental deletions can be recovered by a workspace administrator.
   Soft-deleted sandboxes are hidden from the sandbox listing and surfaced on the
-  existing superuser admin page for restore/cancel.
+  existing superuser admin page for restore/cancel. The merge modal now exposes
+  a "Delete sandbox after merging" checkbox (default checked); unchecking it
+  keeps the sandbox alive after the merge for ongoing work.
   [#4649](https://github.com/OpenFn/lightning/issues/4649)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,10 @@ and this project adheres to
 - Sandbox deletion (manual or after merge) is now soft. The sandbox and its
   descendants are scheduled for purge after the configured grace period
   (`PURGE_DELETED_AFTER_DAYS`) instead of being hard-deleted immediately, so
-  accidental deletions can be recovered by a workspace administrator.
-  Soft-deleted sandboxes are hidden from the sandbox listing and surfaced on the
-  existing superuser admin page for restore/cancel. The merge modal now exposes
-  a "Delete sandbox after merging" toggle (default on); turning it off keeps the
-  sandbox alive after the merge for ongoing work.
+  accidental deletions can be recovered. Scheduled-for-deletion sandboxes remain
+  visible in the parent's sandbox listing with a "Scheduled for deletion" badge
+  and a Cancel-deletion action, so anyone with permission to delete the sandbox
+  can also restore it during the grace window.
   [#4649](https://github.com/OpenFn/lightning/issues/4649)
 - Updated ws-worker from
   [`1.24.0` to `1.24.1`](https://github.com/OpenFn/kit/blob/%40openfn/ws-worker@1.24.1/packages/ws-worker/CHANGELOG.md?plain=1#L5-L12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to
 - Bumped local worker to 1.24.0
 - Updated the Merge Sandbox UI to be cleaner, clearer, and only include changed
   workflows by default [#4651](https://github.com/OpenFn/lightning/issues/4651)
+- Sandbox deletion (manual or after merge) is now soft. The sandbox and its
+  descendants are scheduled for purge after the configured grace period
+  (`PURGE_DELETED_AFTER_DAYS`) instead of being hard-deleted immediately, so
+  accidental deletions can be recovered by a workspace administrator.
+  Soft-deleted sandboxes are hidden from the sandbox listing and surfaced on the
+  existing superuser admin page for restore/cancel.
+  [#4649](https://github.com/OpenFn/lightning/issues/4649)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ and this project adheres to
   accidental deletions can be recovered by a workspace administrator.
   Soft-deleted sandboxes are hidden from the sandbox listing and surfaced on the
   existing superuser admin page for restore/cancel. The merge modal now exposes
-  a "Delete sandbox after merging" checkbox (default checked); unchecking it
-  keeps the sandbox alive after the merge for ongoing work.
+  a "Delete sandbox after merging" toggle (default on); turning it off keeps the
+  sandbox alive after the merge for ongoing work.
   [#4649](https://github.com/OpenFn/lightning/issues/4649)
 
 ### Fixed

--- a/lib/lightning/extensions/project_hook.ex
+++ b/lib/lightning/extensions/project_hook.ex
@@ -34,7 +34,15 @@ defmodule Lightning.Extensions.ProjectHook do
     Projects.project_credentials_query(project) |> Repo.delete_all()
     Projects.delete_project_dataclips(project)
 
-    Repo.delete(project)
+    project
+    |> Repo.delete()
+    |> tap(fn
+      {:ok, %Project{parent_id: parent_id}} when not is_nil(parent_id) ->
+        Lightning.Projects.SandboxPromExPlugin.fire_sandbox_deleted_event()
+
+      _ ->
+        :ok
+    end)
   end
 
   @spec handle_project_validation(Changeset.t(Project.t())) ::

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -135,7 +135,10 @@ defmodule Lightning.Projects do
   def perform(%Oban.Job{
         args: %{"project_id" => project_id, "type" => "purge_deleted"}
       }) do
-    project_id |> get_project!() |> delete_project()
+    case get_project(project_id) do
+      nil -> :ok
+      project -> delete_project(project)
+    end
 
     :ok
   end
@@ -1544,7 +1547,7 @@ defmodule Lightning.Projects do
 
     descendants_query =
       from(p in Project,
-        where: p.parent_id == ^root.id,
+        where: p.parent_id == ^root.id and is_nil(p.scheduled_deletion),
         select: %{id: p.id, parent_id: p.parent_id, level: 1}
       )
 
@@ -1552,6 +1555,7 @@ defmodule Lightning.Projects do
       from(p in Project,
         join: d in "descendants",
         on: p.parent_id == d.id,
+        where: is_nil(p.scheduled_deletion),
         select: %{id: p.id, parent_id: p.parent_id, level: d.level + 1}
       )
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -1439,6 +1439,13 @@ defmodule Lightning.Projects do
 
   This is a flat view: only rows where `parent.id == child.parent_id` are returned.
   If we later support arbitrarily deep nesting, switch this to a recursive CTE.
+
+  Intentionally **unfiltered** by `scheduled_deletion`. This function is the
+  recursive walker used by `Lightning.Extensions.ProjectHook.handle_delete_project/1`
+  to cascade hard-deletes through the subtree at purge time. Filtering would
+  skip scheduled descendants and (because the parent FK is `:nilify_all`) leave
+  them as orphan root projects in the database. User-facing surfaces should use
+  `list_workspace_projects/2`, which filters scheduled rows out.
   """
   @spec list_sandboxes(Ecto.UUID.t()) :: [Project.t()]
   def list_sandboxes(parent_id) when is_binary(parent_id) do

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -1554,7 +1554,7 @@ defmodule Lightning.Projects do
 
     descendants_query =
       from(p in Project,
-        where: p.parent_id == ^root.id and is_nil(p.scheduled_deletion),
+        where: p.parent_id == ^root.id,
         select: %{id: p.id, parent_id: p.parent_id, level: 1}
       )
 
@@ -1562,7 +1562,6 @@ defmodule Lightning.Projects do
       from(p in Project,
         join: d in "descendants",
         on: p.parent_id == d.id,
-        where: is_nil(p.scheduled_deletion),
         select: %{id: p.id, parent_id: p.parent_id, level: d.level + 1}
       )
 

--- a/lib/lightning/projects/sandbox_prom_ex_plugin.ex
+++ b/lib/lightning/projects/sandbox_prom_ex_plugin.ex
@@ -3,7 +3,8 @@ defmodule Lightning.Projects.SandboxPromExPlugin do
   PromEx plugin for sandbox-related telemetry metrics.
 
   Tracks:
-  - Sandbox project creation, merging, and deletion
+  - Sandbox project creation, merging, and the lifecycle of a soft-delete
+    (scheduling, cancelling, and the eventual purge)
   - Workflow saves tagged by project type (sandbox vs regular)
   - Provisioner imports tagged by project type
   """
@@ -13,6 +14,16 @@ defmodule Lightning.Projects.SandboxPromExPlugin do
 
   @sandbox_created_event [:lightning, :sandbox, :created]
   @sandbox_merged_event [:lightning, :sandbox, :merged]
+  @sandbox_scheduled_for_deletion_event [
+    :lightning,
+    :sandbox,
+    :scheduled_for_deletion
+  ]
+  @sandbox_deletion_cancelled_event [
+    :lightning,
+    :sandbox,
+    :deletion_cancelled
+  ]
   @sandbox_deleted_event [:lightning, :sandbox, :deleted]
   @workflow_saved_event [:lightning, :workflow, :saved]
   @provisioner_import_event [:lightning, :provisioner, :import]
@@ -29,6 +40,8 @@ defmodule Lightning.Projects.SandboxPromExPlugin do
     if Lightning.Config.promex_enabled?() do
       seed_counter(@sandbox_created_event ++ [:count], %{})
       seed_counter(@sandbox_merged_event ++ [:count], %{})
+      seed_counter(@sandbox_scheduled_for_deletion_event ++ [:count], %{})
+      seed_counter(@sandbox_deletion_cancelled_event ++ [:count], %{})
       seed_counter(@sandbox_deleted_event ++ [:count], %{})
       seed_counter(@workflow_saved_event ++ [:count], %{is_sandbox: true})
       seed_counter(@workflow_saved_event ++ [:count], %{is_sandbox: false})
@@ -54,8 +67,17 @@ defmodule Lightning.Projects.SandboxPromExPlugin do
       Metrics.counter(@sandbox_merged_event ++ [:count],
         description: "Count of sandbox projects merged into targets."
       ),
+      Metrics.counter(@sandbox_scheduled_for_deletion_event ++ [:count],
+        description:
+          "Count of sandbox projects scheduled for deletion (user clicked delete or merged with the default behaviour)."
+      ),
+      Metrics.counter(@sandbox_deletion_cancelled_event ++ [:count],
+        description:
+          "Count of times a scheduled sandbox deletion was cancelled during the grace period."
+      ),
       Metrics.counter(@sandbox_deleted_event ++ [:count],
-        description: "Count of sandbox projects manually deleted."
+        description:
+          "Count of sandbox projects permanently deleted from the database (purged after the grace period or hard-deleted by an admin)."
       ),
       Metrics.counter(@workflow_saved_event ++ [:count],
         tags: [:is_sandbox],
@@ -80,7 +102,17 @@ defmodule Lightning.Projects.SandboxPromExPlugin do
     :telemetry.execute(@sandbox_merged_event, %{})
   end
 
-  @doc "Fires a telemetry event when a sandbox project is manually deleted."
+  @doc "Fires a telemetry event when a sandbox is scheduled for deletion (user intent)."
+  def fire_sandbox_scheduled_for_deletion_event do
+    :telemetry.execute(@sandbox_scheduled_for_deletion_event, %{})
+  end
+
+  @doc "Fires a telemetry event when a scheduled sandbox deletion is cancelled."
+  def fire_sandbox_deletion_cancelled_event do
+    :telemetry.execute(@sandbox_deletion_cancelled_event, %{})
+  end
+
+  @doc "Fires a telemetry event when a sandbox is permanently deleted from the database."
   def fire_sandbox_deleted_event do
     :telemetry.execute(@sandbox_deleted_event, %{})
   end

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -268,14 +268,7 @@ defmodule Lightning.Projects.Sandboxes do
           {:ok, Project.t()} | {:error, :unauthorized | :not_found | term()}
   def delete_sandbox(%Project{} = sandbox, %User{} = actor) do
     if Permissions.can?(:sandboxes, :delete_sandbox, actor, sandbox) do
-      case Lightning.Projects.delete_project(sandbox) do
-        {:ok, deleted} ->
-          SandboxPromExPlugin.fire_sandbox_deleted_event()
-          {:ok, deleted}
-
-        error ->
-          error
-      end
+      Lightning.Projects.delete_project(sandbox)
     else
       {:error, :unauthorized}
     end
@@ -404,7 +397,7 @@ defmodule Lightning.Projects.Sandboxes do
           set: [enabled: false]
         )
 
-      SandboxPromExPlugin.fire_sandbox_deleted_event()
+      SandboxPromExPlugin.fire_sandbox_scheduled_for_deletion_event()
 
       {:ok, %{sandbox | scheduled_deletion: date}}
     end)
@@ -420,6 +413,8 @@ defmodule Lightning.Projects.Sandboxes do
         ),
         set: [scheduled_deletion: nil]
       )
+
+    SandboxPromExPlugin.fire_sandbox_deletion_cancelled_event()
 
     {:ok, %{sandbox | scheduled_deletion: nil}}
   end

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -302,6 +302,15 @@ defmodule Lightning.Projects.Sandboxes do
   descendant in a single transaction so the entire subtree shares a grace
   period and gets purged together.
 
+  ## Cascade semantics
+
+  Scheduling cascades through every descendant unconditionally. If a child
+  sandbox was already scheduled separately (with an earlier timestamp), that
+  earlier timestamp is overwritten with the new one. The intent is that
+  scheduling a parent always synchronises the whole subtree's grace window;
+  if you need a child to be purged on its original earlier timestamp, do not
+  schedule the parent.
+
   ## Parameters
   * `sandbox` - Sandbox project to schedule (or sandbox ID as string)
   * `actor` - User performing the action (needs `:delete_sandbox` permission)
@@ -337,6 +346,13 @@ defmodule Lightning.Projects.Sandboxes do
   row that has it set. Triggers are not automatically re-enabled: this is an
   admin recovery path and the operator decides whether the subtree should
   resume firing triggers.
+
+  ## Cascade semantics
+
+  The cancel clears `scheduled_deletion` on every descendant that has it set,
+  regardless of whether the schedule originated from this subtree's parent
+  or from a separate scheduling action on the descendant itself. Any row
+  whose `scheduled_deletion` is already nil is left alone.
 
   ## Parameters
   * `sandbox` - Sandbox project to restore (or sandbox ID as string)

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -20,7 +20,12 @@ defmodule Lightning.Projects.Sandboxes do
   * `provision/3` - Create a new sandbox from a parent project
   * `merge/4` - Merge a sandbox into its target (workflows + collections)
   * `update_sandbox/3` - Update sandbox name, color, or environment
-  * `delete_sandbox/2` - Delete a sandbox and all its descendants
+  * `schedule_sandbox_deletion/2` - Soft-delete a sandbox and its descendants;
+    they remain in the database for a grace period before being purged
+  * `cancel_scheduled_sandbox_deletion/2` - Restore a scheduled sandbox subtree
+    while it is still within its grace period (admin recovery path)
+  * `delete_sandbox/2` - Hard-delete a sandbox and all its descendants
+    immediately (used by the Oban purge worker after the grace period elapses)
 
   ## Authorization
 
@@ -281,6 +286,143 @@ defmodule Lightning.Projects.Sandboxes do
       %Project{} = sandbox -> delete_sandbox(sandbox, actor)
       nil -> {:error, :not_found}
     end
+  end
+
+  @doc """
+  Schedules a sandbox and its entire descendant subtree for deletion.
+
+  The sandbox stays in the database for a grace period (controlled by
+  `PURGE_DELETED_AFTER_DAYS`) before the Oban purge worker permanently
+  deletes it. During the grace period the sandbox is hidden from the
+  parent's sandbox listing but remains recoverable via
+  `cancel_scheduled_sandbox_deletion/2`.
+
+  All triggers in the subtree are disabled so that scheduled work stops
+  immediately. The scheduled timestamp is applied to the target and every
+  descendant in a single transaction so the entire subtree shares a grace
+  period and gets purged together.
+
+  ## Parameters
+  * `sandbox` - Sandbox project to schedule (or sandbox ID as string)
+  * `actor` - User performing the action (needs `:delete_sandbox` permission)
+
+  ## Returns
+  * `{:ok, scheduled_sandbox}` - Sandbox subtree scheduled for deletion
+  * `{:error, :unauthorized}` - Actor lacks permission on the sandbox
+  * `{:error, :not_found}` - Sandbox ID not found (when using a string ID)
+  * `{:error, reason}` - Database or other failure
+  """
+  @spec schedule_sandbox_deletion(Project.t() | Ecto.UUID.t(), User.t()) ::
+          {:ok, Project.t()} | {:error, :unauthorized | :not_found | term()}
+  def schedule_sandbox_deletion(%Project{} = sandbox, %User{} = actor) do
+    if Permissions.can?(:sandboxes, :delete_sandbox, actor, sandbox) do
+      do_schedule_sandbox_deletion(sandbox)
+    else
+      {:error, :unauthorized}
+    end
+  end
+
+  def schedule_sandbox_deletion(sandbox_id, %User{} = actor)
+      when is_binary(sandbox_id) do
+    case Lightning.Projects.get_project(sandbox_id) do
+      %Project{} = sandbox -> schedule_sandbox_deletion(sandbox, actor)
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Clears the scheduled deletion on a sandbox subtree, restoring it to active use.
+
+  Walks every descendant of `sandbox` and clears `scheduled_deletion` on any
+  row that has it set. Triggers are not automatically re-enabled: this is an
+  admin recovery path and the operator decides whether the subtree should
+  resume firing triggers.
+
+  ## Parameters
+  * `sandbox` - Sandbox project to restore (or sandbox ID as string)
+  * `actor` - User performing the action (needs `:delete_sandbox` permission)
+
+  ## Returns
+  * `{:ok, restored_sandbox}` - Sandbox subtree restored
+  * `{:error, :unauthorized}` - Actor lacks permission on the sandbox
+  * `{:error, :not_found}` - Sandbox ID not found (when using a string ID)
+  """
+  @spec cancel_scheduled_sandbox_deletion(
+          Project.t() | Ecto.UUID.t(),
+          User.t()
+        ) ::
+          {:ok, Project.t()} | {:error, :unauthorized | :not_found | term()}
+  def cancel_scheduled_sandbox_deletion(%Project{} = sandbox, %User{} = actor) do
+    if Permissions.can?(:sandboxes, :delete_sandbox, actor, sandbox) do
+      do_cancel_scheduled_sandbox_deletion(sandbox)
+    else
+      {:error, :unauthorized}
+    end
+  end
+
+  def cancel_scheduled_sandbox_deletion(sandbox_id, %User{} = actor)
+      when is_binary(sandbox_id) do
+    case Lightning.Projects.get_project(sandbox_id) do
+      %Project{} = sandbox -> cancel_scheduled_sandbox_deletion(sandbox, actor)
+      nil -> {:error, :not_found}
+    end
+  end
+
+  defp do_schedule_sandbox_deletion(%Project{} = sandbox) do
+    date = scheduled_deletion_date()
+    subtree_ids = subtree_ids(sandbox)
+
+    Repo.transact(fn ->
+      {_count, _} =
+        Repo.update_all(
+          from(p in Project, where: p.id in ^subtree_ids),
+          set: [scheduled_deletion: date]
+        )
+
+      {_count, _} =
+        Repo.update_all(
+          from(t in Trigger,
+            join: w in assoc(t, :workflow),
+            where: w.project_id in ^subtree_ids and t.enabled == true
+          ),
+          set: [enabled: false]
+        )
+
+      SandboxPromExPlugin.fire_sandbox_deleted_event()
+
+      {:ok, %{sandbox | scheduled_deletion: date}}
+    end)
+  end
+
+  defp do_cancel_scheduled_sandbox_deletion(%Project{} = sandbox) do
+    subtree_ids = subtree_ids(sandbox)
+
+    {_count, _} =
+      Repo.update_all(
+        from(p in Project,
+          where: p.id in ^subtree_ids and not is_nil(p.scheduled_deletion)
+        ),
+        set: [scheduled_deletion: nil]
+      )
+
+    {:ok, %{sandbox | scheduled_deletion: nil}}
+  end
+
+  defp subtree_ids(%Project{id: id}) do
+    descendant_ids =
+      [id]
+      |> Lightning.Projects.descendants_query()
+      |> Repo.all()
+
+    [id | descendant_ids]
+  end
+
+  defp scheduled_deletion_date do
+    case Lightning.Config.purge_deleted_after_days() do
+      nil -> DateTime.utc_now()
+      integer -> DateTime.utc_now() |> Timex.shift(days: integer)
+    end
+    |> DateTime.truncate(:second)
   end
 
   defp create_sandbox_from_parent(parent, actor, attrs) do

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -290,7 +290,7 @@ defmodule LightningWeb.SandboxLive.Components do
           <div class="space-y-2">
             <div class="flex items-baseline justify-between">
               <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
-                Workflows
+                Workflows to merge
               </span>
               <span class="text-xs text-gray-500">
                 {MapSet.size(@selected_workflow_ids)} of {length(@source_workflows)} selected

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -144,7 +144,9 @@ defmodule LightningWeb.SandboxLive.Components do
 
       <section class="space-y-4">
         <p class="text-gray-700">
-          Deleting a sandbox permanently removes its workflows, triggers, versions, keychain clones, and dataclips.
+          Deleting a sandbox removes it (along with its descendants) from
+          OpenFn. Workflows, triggers, versions, keychain clones, and
+          dataclips will be permanently removed once the grace period ends.
           <%= if @sandbox.is_current do %>
             You are currently viewing this project.
             After deletion, you'll be redirected to <strong>{@root_project.name}</strong>.
@@ -152,8 +154,10 @@ defmodule LightningWeb.SandboxLive.Components do
           To confirm, type the sandbox name below.
         </p>
 
-        <div class="bg-red-50 border border-red-200 rounded-md p-3">
-          <p class="text-sm text-red-800">This action cannot be undone.</p>
+        <div class="bg-amber-50 border border-amber-200 rounded-md p-3">
+          <p class="text-sm text-amber-800">
+            The sandbox will be scheduled for deletion and retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
+          </p>
         </div>
 
         <.form
@@ -178,7 +182,7 @@ defmodule LightningWeb.SandboxLive.Components do
               disabled={!@changeset.valid?}
               {if !@changeset.valid?, do: [tooltip: "Type the sandbox name to enable"], else: []}
             >
-              Delete Sandbox
+              Delete sandbox
             </.button>
             <.button
               theme="secondary"
@@ -192,6 +196,14 @@ defmodule LightningWeb.SandboxLive.Components do
       </section>
     </.modal>
     """
+  end
+
+  defp grace_period_label do
+    case Lightning.Config.purge_deleted_after_days() do
+      nil -> "the configured grace period"
+      1 -> "1 day"
+      days when is_integer(days) -> "#{days} days"
+    end
   end
 
   attr :open?, :boolean, required: true
@@ -269,7 +281,7 @@ defmodule LightningWeb.SandboxLive.Components do
             This will overwrite the selected workflows in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             with the versions from sandbox <strong>{@sandbox.name}</strong>,
-            then delete <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} />
+            then schedule <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} /> for deletion.
             Any conflicting changes in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             will be lost.
@@ -347,16 +359,16 @@ defmodule LightningWeb.SandboxLive.Components do
           <Common.alert
             id="merge-beta-warning"
             type="warning"
-            header="This sandbox will be deleted after merging"
+            header="This sandbox will be scheduled for deletion after merging"
           >
             <:message>
-              This action cannot be undone.
+              The sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
               <div :if={@descendant_count == 1} class="mt-2">
                 Child sandbox <strong>{List.first(@descendants).name}</strong>
-                will also be permanently closed.
+                will also be scheduled for deletion.
               </div>
               <div :if={@descendant_count > 1} class="mt-2">
-                Its {@descendant_count} child sandboxes will also be permanently closed.
+                Its {@descendant_count} child sandboxes will also be scheduled for deletion.
               </div>
             </:message>
           </Common.alert>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -244,7 +244,7 @@ defmodule LightningWeb.SandboxLive.Components do
     >
       <:title>
         <div class="flex items-start justify-between">
-          <span class="font-bold">Merge Sandbox</span>
+          <span class="font-bold">Merge sandbox</span>
           <button
             type="button"
             class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
@@ -285,11 +285,6 @@ defmodule LightningWeb.SandboxLive.Components do
             This will overwrite the selected workflows in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             with the versions from sandbox <strong>{@sandbox.name}</strong>.
-            <%= if @delete_after_merge? do %>
-              <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} /> will then be scheduled for deletion.
-            <% else %>
-              <strong>{@sandbox.name}</strong> will stay available after merging.
-            <% end %>
             Any conflicting changes in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             will be lost.
@@ -377,33 +372,27 @@ defmodule LightningWeb.SandboxLive.Components do
           </div>
 
           <Common.alert
-            id="merge-beta-warning"
+            id="merge-disposition-notice"
             type={if @delete_after_merge?, do: "warning", else: "info"}
             header={
               if @delete_after_merge?,
-                do: "This sandbox will be scheduled for deletion after merging",
-                else: "The sandbox will be kept after merging"
+                do: "Scheduled for deletion after merging",
+                else: "Sandbox will be kept"
             }
           >
             <:message>
-              <div class={[
-                @descendant_count == 0 && "min-h-[3rem]",
-                @descendant_count == 1 && "min-h-[5rem]",
-                @descendant_count > 1 && "min-h-[5rem]"
-              ]}>
-                <%= if @delete_after_merge? do %>
-                  The sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
-                  <div :if={@descendant_count == 1} class="mt-2">
-                    Child sandbox <strong>{List.first(@descendants).name}</strong>
-                    will also be scheduled for deletion.
-                  </div>
-                  <div :if={@descendant_count > 1} class="mt-2">
-                    Its {@descendant_count} child sandboxes will also be scheduled for deletion.
-                  </div>
-                <% else %>
-                  <strong>{@sandbox.name}</strong>
-                  stays available after the merge so you can keep iterating, sync it to GitHub, or use it for live QA. You can still delete it later from the sandboxes list when you are done.
-                <% end %>
+              <%= if @delete_after_merge? do %>
+                Retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator to restore it during that window.
+              <% else %>
+                <strong>{@sandbox.name}</strong>
+                stays available after the merge. You can still delete it later from the sandboxes list.
+              <% end %>
+              <div :if={@delete_after_merge? and @descendant_count == 1} class="mt-2">
+                Child sandbox <strong>{List.first(@descendants).name}</strong>
+                will also be scheduled for deletion.
+              </div>
+              <div :if={@delete_after_merge? and @descendant_count > 1} class="mt-2">
+                Its {@descendant_count} child sandboxes will also be scheduled for deletion.
               </div>
             </:message>
           </Common.alert>
@@ -431,23 +420,6 @@ defmodule LightningWeb.SandboxLive.Components do
       </.form>
     </.modal>
     """
-  end
-
-  # Caller sits in a phx-no-format <p> so no whitespace leaks between
-  # </strong> and this tag; ~H[...] + {" "} preserve the conditional leading
-  # space that heredoc ~H""" would strip.
-  attr :count, :integer, required: true
-  attr :descendants, :list, required: true
-
-  defp descendant_suffix(%{count: 0} = assigns), do: ~H[.]
-
-  defp descendant_suffix(%{count: 1} = assigns) do
-    assigns = assign(assigns, :name, List.first(assigns.descendants).name)
-    ~H[{" "}and its child sandbox <strong>{@name}</strong>.]
-  end
-
-  defp descendant_suffix(assigns) do
-    ~H[{" "}and its {@count} child sandboxes.]
   end
 
   defp merge_select_all_state(_selected, []), do: :empty

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -375,13 +375,13 @@ defmodule LightningWeb.SandboxLive.Components do
               header="This sandbox will be deleted after merging"
             >
               <:message>
-                This action cannot be undone after {grace_period_label()}.
+                It can be restored by a workspace administrator for {grace_period_label()}, then permanently removed.
                 <div :if={@descendant_count == 1} class="mt-2">
                   Child sandbox <strong>{List.first(@descendants).name}</strong>
-                  will also be permanently closed.
+                  will also be deleted.
                 </div>
                 <div :if={@descendant_count > 1} class="mt-2">
-                  Its {@descendant_count} child sandboxes will also be permanently closed.
+                  Its {@descendant_count} child sandboxes will also be deleted.
                 </div>
               </:message>
             </Common.alert>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -370,27 +370,17 @@ defmodule LightningWeb.SandboxLive.Components do
             </ul>
           </div>
 
-          <label class="flex items-start gap-3 text-sm text-gray-700 cursor-pointer">
-            <input
-              type="hidden"
-              name={@merge_form[:delete_after_merge].name}
-              value="false"
-            />
-            <input
+          <div class="space-y-1">
+            <.input
               id="merge-delete-after-merge-toggle"
-              type="checkbox"
-              name={@merge_form[:delete_after_merge].name}
-              value="true"
-              checked={@delete_after_merge?}
-              class="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              field={@merge_form[:delete_after_merge]}
+              type="toggle"
+              label="Delete sandbox after merging"
             />
-            <span>
-              <span class="font-medium">Delete sandbox after merging</span>
-              <span class="block text-xs text-gray-500">
-                Uncheck to keep the sandbox alive after the merge (for ongoing work, GitHub sync, or QA against live triggers).
-              </span>
-            </span>
-          </label>
+            <p class="text-xs text-gray-500 ml-14">
+              Turn this off to keep the sandbox alive after the merge (for ongoing work, GitHub sync, or QA against live triggers).
+            </p>
+          </div>
 
           <Common.alert
             :if={@delete_after_merge?}

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -287,85 +287,78 @@ defmodule LightningWeb.SandboxLive.Components do
             </p>
           </div>
 
-          <div class="space-y-2">
-            <div class="flex items-baseline justify-between">
-              <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
+          <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
+            <label class={[
+              "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
+              @select_all_state == :empty && "cursor-default",
+              @select_all_state != :empty && "cursor-pointer"
+            ]}>
+              <input
+                type="checkbox"
+                id="merge-select-all-workflows"
+                phx-hook="CheckboxIndeterminate"
+                phx-click="toggle-all-workflows"
+                disabled={@select_all_state == :empty}
+                checked={@select_all_state == :all}
+                class={[
+                  "h-4 w-4 rounded border-gray-300 text-indigo-600",
+                  @select_all_state == :partial && "indeterminate"
+                ]}
+              />
+              <span class="flex-1 text-sm font-medium text-gray-900">
                 Workflows to merge
               </span>
               <span class="text-xs text-gray-500">
                 {MapSet.size(@selected_workflow_ids)} of {length(@source_workflows)} selected
               </span>
-            </div>
-            <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
-              <label class={[
-                "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
-                @select_all_state == :empty && "cursor-default",
-                @select_all_state != :empty && "cursor-pointer"
-              ]}>
+            </label>
+            <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
+              <li
+                :for={wf <- @source_workflows}
+                class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+                phx-click="toggle-workflow"
+                phx-value-id={wf.id}
+              >
                 <input
                   type="checkbox"
-                  id="merge-select-all-workflows"
-                  phx-hook="CheckboxIndeterminate"
-                  phx-click="toggle-all-workflows"
-                  disabled={@select_all_state == :empty}
-                  checked={@select_all_state == :all}
-                  class={[
-                    "h-4 w-4 rounded border-gray-300 text-indigo-600",
-                    @select_all_state == :partial && "indeterminate"
-                  ]}
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600"
+                  checked={MapSet.member?(@selected_workflow_ids, wf.id)}
+                  readonly
                 />
-                <span class="text-sm font-medium text-gray-900">
-                  Select all
+                <span class="flex-1 text-sm text-gray-700 truncate">
+                  {wf.name}
                 </span>
-              </label>
-              <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
-                <li
-                  :for={wf <- @source_workflows}
-                  class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
-                  phx-click="toggle-workflow"
-                  phx-value-id={wf.id}
+                <span
+                  :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
+                  class="flex items-center gap-1 text-xs font-medium text-green-700"
+                  title="This workflow has been modified in the sandbox"
                 >
-                  <input
-                    type="checkbox"
-                    class="h-4 w-4 rounded border-gray-300 text-indigo-600"
-                    checked={MapSet.member?(@selected_workflow_ids, wf.id)}
-                    readonly
-                  />
-                  <span class="flex-1 text-sm text-gray-700 truncate">
-                    {wf.name}
-                  </span>
-                  <span
-                    :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
-                    class="flex items-center gap-1 text-xs font-medium text-green-700"
-                    title="This workflow has been modified in the sandbox"
-                  >
-                    Changed
-                  </span>
-                  <span
-                    :if={wf.is_diverged}
-                    class="flex items-center gap-1 text-xs font-medium text-amber-700"
-                    title="This workflow was modified in the target project - this change will be lost"
-                  >
-                    <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
-                    Diverged
-                  </span>
-                  <span
-                    :if={wf.is_new}
-                    class="flex items-center gap-1 text-xs font-medium text-blue-700"
-                    title="This workflow doesn't exist in the target — it will be created"
-                  >
-                    New
-                  </span>
-                  <span
-                    :if={wf.is_deleted}
-                    class="flex items-center gap-1 text-xs font-medium text-red-700"
-                    title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
-                  >
-                    Deleted in sandbox
-                  </span>
-                </li>
-              </ul>
-            </div>
+                  Changed
+                </span>
+                <span
+                  :if={wf.is_diverged}
+                  class="flex items-center gap-1 text-xs font-medium text-amber-700"
+                  title="This workflow was modified in the target project - this change will be lost"
+                >
+                  <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
+                  Diverged
+                </span>
+                <span
+                  :if={wf.is_new}
+                  class="flex items-center gap-1 text-xs font-medium text-blue-700"
+                  title="This workflow doesn't exist in the target — it will be created"
+                >
+                  New
+                </span>
+                <span
+                  :if={wf.is_deleted}
+                  class="flex items-center gap-1 text-xs font-medium text-red-700"
+                  title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
+                >
+                  Deleted in sandbox
+                </span>
+              </li>
+            </ul>
           </div>
 
           <div class="space-y-2">

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -370,7 +370,7 @@ defmodule LightningWeb.SandboxLive.Components do
             />
             <Common.alert
               :if={@delete_after_merge?}
-              id="merge-beta-warning"
+              id="merge-deletion-warning"
               type="warning"
               header="This sandbox will be deleted after merging"
             >

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -386,19 +386,25 @@ defmodule LightningWeb.SandboxLive.Components do
             }
           >
             <:message>
-              <%= if @delete_after_merge? do %>
-                The sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
-                <div :if={@descendant_count == 1} class="mt-2">
-                  Child sandbox <strong>{List.first(@descendants).name}</strong>
-                  will also be scheduled for deletion.
-                </div>
-                <div :if={@descendant_count > 1} class="mt-2">
-                  Its {@descendant_count} child sandboxes will also be scheduled for deletion.
-                </div>
-              <% else %>
-                <strong>{@sandbox.name}</strong>
-                stays available after the merge so you can keep iterating in it. You can still delete it later from the sandboxes list.
-              <% end %>
+              <div class={[
+                @descendant_count == 0 && "min-h-[3rem]",
+                @descendant_count == 1 && "min-h-[5rem]",
+                @descendant_count > 1 && "min-h-[5rem]"
+              ]}>
+                <%= if @delete_after_merge? do %>
+                  The sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
+                  <div :if={@descendant_count == 1} class="mt-2">
+                    Child sandbox <strong>{List.first(@descendants).name}</strong>
+                    will also be scheduled for deletion.
+                  </div>
+                  <div :if={@descendant_count > 1} class="mt-2">
+                    Its {@descendant_count} child sandboxes will also be scheduled for deletion.
+                  </div>
+                <% else %>
+                  <strong>{@sandbox.name}</strong>
+                  stays available after the merge so you can keep iterating, sync it to GitHub, or use it for live QA. You can still delete it later from the sandboxes list when you are done.
+                <% end %>
+              </div>
             </:message>
           </Common.alert>
 

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -221,6 +221,10 @@ defmodule LightningWeb.SandboxLive.Components do
       |> assign(:merge_form, to_form(assigns.changeset, as: :merge))
       |> assign(:descendant_count, length(assigns.descendants))
       |> assign(
+        :delete_after_merge?,
+        Ecto.Changeset.get_field(assigns.changeset, :delete_after_merge, true)
+      )
+      |> assign(
         :select_all_state,
         merge_select_all_state(
           assigns.selected_workflow_ids,
@@ -277,11 +281,21 @@ defmodule LightningWeb.SandboxLive.Components do
             </div>
           </div>
 
-          <p class="text-xs text-gray-700" phx-no-format>
+          <p :if={@delete_after_merge?} class="text-xs text-gray-700" phx-no-format>
             This will overwrite the selected workflows in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             with the versions from sandbox <strong>{@sandbox.name}</strong>,
             then schedule <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} /> for deletion.
+            Any conflicting changes in
+            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
+            will be lost.
+          </p>
+
+          <p :if={!@delete_after_merge?} class="text-xs text-gray-700" phx-no-format>
+            This will overwrite the selected workflows in
+            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
+            with the versions from sandbox <strong>{@sandbox.name}</strong>.
+            <strong>{@sandbox.name}</strong> will stay available after merging.
             Any conflicting changes in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             will be lost.
@@ -356,7 +370,30 @@ defmodule LightningWeb.SandboxLive.Components do
             </ul>
           </div>
 
+          <label class="flex items-start gap-3 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="hidden"
+              name={@merge_form[:delete_after_merge].name}
+              value="false"
+            />
+            <input
+              id="merge-delete-after-merge-toggle"
+              type="checkbox"
+              name={@merge_form[:delete_after_merge].name}
+              value="true"
+              checked={@delete_after_merge?}
+              class="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            <span>
+              <span class="font-medium">Delete sandbox after merging</span>
+              <span class="block text-xs text-gray-500">
+                Uncheck to keep the sandbox alive after the merge (for ongoing work, GitHub sync, or QA against live triggers).
+              </span>
+            </span>
+          </label>
+
           <Common.alert
+            :if={@delete_after_merge?}
             id="merge-beta-warning"
             type="warning"
             header="This sandbox will be scheduled for deletion after merging"
@@ -370,6 +407,18 @@ defmodule LightningWeb.SandboxLive.Components do
               <div :if={@descendant_count > 1} class="mt-2">
                 Its {@descendant_count} child sandboxes will also be scheduled for deletion.
               </div>
+            </:message>
+          </Common.alert>
+
+          <Common.alert
+            :if={!@delete_after_merge?}
+            id="merge-keep-notice"
+            type="info"
+            header="The sandbox will be kept after merging"
+          >
+            <:message>
+              <strong>{@sandbox.name}</strong>
+              stays available after the merge so you can keep iterating in it. You can still delete it later from the sandboxes list.
             </:message>
           </Common.alert>
 

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -281,21 +281,15 @@ defmodule LightningWeb.SandboxLive.Components do
             </div>
           </div>
 
-          <p :if={@delete_after_merge?} class="text-xs text-gray-700" phx-no-format>
-            This will overwrite the selected workflows in
-            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
-            with the versions from sandbox <strong>{@sandbox.name}</strong>,
-            then schedule <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} /> for deletion.
-            Any conflicting changes in
-            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
-            will be lost.
-          </p>
-
-          <p :if={!@delete_after_merge?} class="text-xs text-gray-700" phx-no-format>
+          <p class="text-xs text-gray-700" phx-no-format>
             This will overwrite the selected workflows in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             with the versions from sandbox <strong>{@sandbox.name}</strong>.
-            <strong>{@sandbox.name}</strong> will stay available after merging.
+            <%= if @delete_after_merge? do %>
+              <strong>{@sandbox.name}</strong><.descendant_suffix count={@descendant_count} descendants={@descendants} /> will then be scheduled for deletion.
+            <% else %>
+              <strong>{@sandbox.name}</strong> will stay available after merging.
+            <% end %>
             Any conflicting changes in
             <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
             will be lost.
@@ -383,32 +377,28 @@ defmodule LightningWeb.SandboxLive.Components do
           </div>
 
           <Common.alert
-            :if={@delete_after_merge?}
             id="merge-beta-warning"
-            type="warning"
-            header="This sandbox will be scheduled for deletion after merging"
+            type={if @delete_after_merge?, do: "warning", else: "info"}
+            header={
+              if @delete_after_merge?,
+                do: "This sandbox will be scheduled for deletion after merging",
+                else: "The sandbox will be kept after merging"
+            }
           >
             <:message>
-              The sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
-              <div :if={@descendant_count == 1} class="mt-2">
-                Child sandbox <strong>{List.first(@descendants).name}</strong>
-                will also be scheduled for deletion.
-              </div>
-              <div :if={@descendant_count > 1} class="mt-2">
-                Its {@descendant_count} child sandboxes will also be scheduled for deletion.
-              </div>
-            </:message>
-          </Common.alert>
-
-          <Common.alert
-            :if={!@delete_after_merge?}
-            id="merge-keep-notice"
-            type="info"
-            header="The sandbox will be kept after merging"
-          >
-            <:message>
-              <strong>{@sandbox.name}</strong>
-              stays available after the merge so you can keep iterating in it. You can still delete it later from the sandboxes list.
+              <%= if @delete_after_merge? do %>
+                The sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
+                <div :if={@descendant_count == 1} class="mt-2">
+                  Child sandbox <strong>{List.first(@descendants).name}</strong>
+                  will also be scheduled for deletion.
+                </div>
+                <div :if={@descendant_count > 1} class="mt-2">
+                  Its {@descendant_count} child sandboxes will also be scheduled for deletion.
+                </div>
+              <% else %>
+                <strong>{@sandbox.name}</strong>
+                stays available after the merge so you can keep iterating in it. You can still delete it later from the sandboxes list.
+              <% end %>
             </:message>
           </Common.alert>
 

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -369,9 +369,6 @@ defmodule LightningWeb.SandboxLive.Components do
           </div>
 
           <div class="space-y-2">
-            <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
-              After merging
-            </span>
             <.input
               id="merge-delete-after-merge-toggle"
               field={@merge_form[:delete_after_merge]}

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -261,141 +261,181 @@ defmodule LightningWeb.SandboxLive.Components do
         phx-change="select-merge-target"
         phx-submit="confirm-merge"
       >
-        <section class="space-y-4">
-          <div class="flex items-center gap-2 text-gray-700">
-            <span>Merge</span>
-            <span class="p-1 bg-gray-50 text-gray-800 rounded-md border border-slate-200 font-medium">
-              {@sandbox.name}
-            </span>
-            <span>into</span>
-            <div class="inline-block min-w-[200px]">
-              <.input
-                type="custom-select"
-                id="merge-target-select"
-                field={@merge_form[:target_id]}
-                options={
-                  Enum.map(@target_options, fn opt -> {opt.label, opt.value} end)
-                }
-                class="text-base"
-              />
-            </div>
-          </div>
-
-          <p class="text-xs text-gray-700" phx-no-format>
-            This will overwrite the selected workflows in
-            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
-            with the versions from sandbox <strong>{@sandbox.name}</strong>.
-            Any conflicting changes in
-            <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>
-            will be lost.
-          </p>
-
-          <div class="border border-gray-200 rounded-md overflow-hidden">
-            <label class={[
-              "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
-              @select_all_state == :empty && "cursor-default",
-              @select_all_state != :empty && "cursor-pointer"
-            ]}>
-              <input
-                type="checkbox"
-                id="merge-select-all-workflows"
-                phx-hook="CheckboxIndeterminate"
-                phx-click="toggle-all-workflows"
-                disabled={@select_all_state == :empty}
-                checked={@select_all_state == :all}
-                class={[
-                  "h-4 w-4 rounded border-gray-300 text-indigo-600",
-                  @select_all_state == :partial && "indeterminate"
-                ]}
-              />
-              <span class="text-sm font-medium text-gray-700">
-                Workflows to merge
+        <section class="space-y-5">
+          <div class="space-y-1.5">
+            <div class="flex items-center gap-2 text-sm text-gray-700">
+              <span>Merge</span>
+              <span class="px-2 py-0.5 bg-gray-100 text-gray-900 rounded-md font-medium">
+                {@sandbox.name}
               </span>
-            </label>
-            <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
-              <li
-                :for={wf <- @source_workflows}
-                class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
-                phx-click="toggle-workflow"
-                phx-value-id={wf.id}
-              >
-                <input
-                  type="checkbox"
-                  class="h-4 w-4 rounded border-gray-300 text-indigo-600"
-                  checked={MapSet.member?(@selected_workflow_ids, wf.id)}
-                  readonly
+              <span>into</span>
+              <div class="flex-1 max-w-[260px]">
+                <.input
+                  type="custom-select"
+                  id="merge-target-select"
+                  field={@merge_form[:target_id]}
+                  options={
+                    Enum.map(@target_options, fn opt -> {opt.label, opt.value} end)
+                  }
+                  class="text-sm"
                 />
-                <span class="flex-1 text-sm text-gray-800">{wf.name}</span>
-                <span
-                  :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
-                  class="flex items-center gap-1 text-xs text-green-600"
-                  title="This workflow has been modified in the sandbox"
-                >
-                  Changed
-                </span>
-                <span
-                  :if={wf.is_diverged}
-                  class="flex items-center gap-1 text-xs text-amber-600"
-                  title="This workflow was modified in the target project - this change will be lost"
-                >
-                  <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
-                  <strong>Diverged</strong>
-                </span>
-                <span
-                  :if={wf.is_new}
-                  class="flex items-center gap-1 text-xs text-blue-600"
-                  title="This workflow doesn't exist in the target — it will be created"
-                >
-                  New
-                </span>
-                <span
-                  :if={wf.is_deleted}
-                  class="flex items-center gap-1 text-xs text-red-600"
-                  title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
-                >
-                  Deleted in sandbox
-                </span>
-              </li>
-            </ul>
-          </div>
-
-          <div class="space-y-1">
-            <.input
-              id="merge-delete-after-merge-toggle"
-              field={@merge_form[:delete_after_merge]}
-              type="toggle"
-              label="Delete sandbox after merging"
-            />
-            <p class="text-xs text-gray-500 ml-14">
-              Turn this off to keep the sandbox alive after the merge (for ongoing work, GitHub sync, or QA against live triggers).
+              </div>
+            </div>
+            <p class="text-xs text-gray-500" phx-no-format>
+              The workflows you select below will overwrite their counterparts in
+              <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>. Any conflicting changes in the target are lost.
             </p>
           </div>
 
-          <Common.alert
-            id="merge-disposition-notice"
-            type={if @delete_after_merge?, do: "warning", else: "info"}
-            header={
-              if @delete_after_merge?,
-                do: "Scheduled for deletion after merging",
-                else: "Sandbox will be kept"
-            }
-          >
-            <:message>
-              <%= if @delete_after_merge? do %>
-                Retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator to restore it during that window.
-              <% else %>
-                <strong>{@sandbox.name}</strong>
-                stays available after the merge. You can still delete it later from the sandboxes list.
-              <% end %>
-              <div :if={@delete_after_merge? and @descendant_count == 1} class="mt-2">
-                Child sandbox <strong>{List.first(@descendants).name}</strong>
-                will also be scheduled for deletion.
+          <div class="space-y-1.5">
+            <div class="flex items-baseline justify-between">
+              <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                Workflows
+              </span>
+              <span class="text-xs text-gray-500">
+                {MapSet.size(@selected_workflow_ids)} of {length(@source_workflows)} selected
+              </span>
+            </div>
+            <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
+              <label class={[
+                "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
+                @select_all_state == :empty && "cursor-default",
+                @select_all_state != :empty && "cursor-pointer"
+              ]}>
+                <input
+                  type="checkbox"
+                  id="merge-select-all-workflows"
+                  phx-hook="CheckboxIndeterminate"
+                  phx-click="toggle-all-workflows"
+                  disabled={@select_all_state == :empty}
+                  checked={@select_all_state == :all}
+                  class={[
+                    "h-4 w-4 rounded border-gray-300 text-indigo-600",
+                    @select_all_state == :partial && "indeterminate"
+                  ]}
+                />
+                <span class="text-sm font-medium text-gray-700">
+                  Select all
+                </span>
+              </label>
+              <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
+                <li
+                  :for={wf <- @source_workflows}
+                  class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+                  phx-click="toggle-workflow"
+                  phx-value-id={wf.id}
+                >
+                  <input
+                    type="checkbox"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600"
+                    checked={MapSet.member?(@selected_workflow_ids, wf.id)}
+                    readonly
+                  />
+                  <span class="flex-1 text-sm text-gray-800 truncate">
+                    {wf.name}
+                  </span>
+                  <span
+                    :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
+                    class="flex items-center gap-1 text-xs text-green-600"
+                    title="This workflow has been modified in the sandbox"
+                  >
+                    Changed
+                  </span>
+                  <span
+                    :if={wf.is_diverged}
+                    class="flex items-center gap-1 text-xs text-amber-600"
+                    title="This workflow was modified in the target project - this change will be lost"
+                  >
+                    <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
+                    <strong>Diverged</strong>
+                  </span>
+                  <span
+                    :if={wf.is_new}
+                    class="flex items-center gap-1 text-xs text-blue-600"
+                    title="This workflow doesn't exist in the target — it will be created"
+                  >
+                    New
+                  </span>
+                  <span
+                    :if={wf.is_deleted}
+                    class="flex items-center gap-1 text-xs text-red-600"
+                    title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
+                  >
+                    Deleted in sandbox
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="space-y-1.5">
+            <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
+              After merging
+            </span>
+            <div class={[
+              "rounded-lg border transition-colors",
+              @delete_after_merge? && "border-amber-200 bg-amber-50/60",
+              !@delete_after_merge? && "border-sky-200 bg-sky-50/60"
+            ]}>
+              <div class="flex items-start gap-4 p-4">
+                <div class="flex-shrink-0 pt-0.5">
+                  <.input
+                    id="merge-delete-after-merge-toggle"
+                    field={@merge_form[:delete_after_merge]}
+                    type="toggle"
+                  />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <p class={[
+                    "text-sm font-medium",
+                    @delete_after_merge? && "text-amber-900",
+                    !@delete_after_merge? && "text-sky-900"
+                  ]}>
+                    <%= if @delete_after_merge? do %>
+                      Delete sandbox after merging
+                    <% else %>
+                      Keep sandbox after merging
+                    <% end %>
+                  </p>
+                  <p class={[
+                    "text-xs mt-1",
+                    @delete_after_merge? && "text-amber-800",
+                    !@delete_after_merge? && "text-sky-800"
+                  ]}>
+                    <%= if @delete_after_merge? do %>
+                      Scheduled for deletion. Retained for {grace_period_label()} before being permanently removed.
+                    <% else %>
+                      <strong>{@sandbox.name}</strong>
+                      stays available after the merge. You can still delete it later from the sandboxes list.
+                    <% end %>
+                  </p>
+                  <p
+                    :if={@delete_after_merge? and @descendant_count == 1}
+                    class="text-xs mt-1.5 text-amber-800"
+                  >
+                    Child sandbox <strong>{List.first(@descendants).name}</strong>
+                    will also be scheduled for deletion.
+                  </p>
+                  <p
+                    :if={@delete_after_merge? and @descendant_count > 1}
+                    class="text-xs mt-1.5 text-amber-800"
+                  >
+                    Its {@descendant_count} child sandboxes will also be scheduled for deletion.
+                  </p>
+                </div>
+                <.icon
+                  :if={@delete_after_merge?}
+                  name="hero-exclamation-triangle"
+                  class="h-5 w-5 text-amber-500 flex-shrink-0"
+                />
+                <.icon
+                  :if={!@delete_after_merge?}
+                  name="hero-information-circle"
+                  class="h-5 w-5 text-sky-500 flex-shrink-0"
+                />
               </div>
-              <div :if={@delete_after_merge? and @descendant_count > 1} class="mt-2">
-                Its {@descendant_count} child sandboxes will also be scheduled for deletion.
-              </div>
-            </:message>
-          </Common.alert>
+            </div>
+          </div>
 
           <.modal_footer>
             <.button

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -262,10 +262,10 @@ defmodule LightningWeb.SandboxLive.Components do
         phx-submit="confirm-merge"
       >
         <section class="space-y-5">
-          <div class="space-y-1.5">
+          <div class="space-y-2">
             <div class="flex items-center gap-2 text-sm text-gray-700">
               <span>Merge</span>
-              <span class="px-2 py-0.5 bg-gray-100 text-gray-900 rounded-md font-medium">
+              <span class="px-2 py-0.5 bg-gray-100 text-sm font-medium text-gray-900 rounded-md">
                 {@sandbox.name}
               </span>
               <span>into</span>
@@ -281,13 +281,13 @@ defmodule LightningWeb.SandboxLive.Components do
                 />
               </div>
             </div>
-            <p class="text-xs text-gray-500" phx-no-format>
+            <p class="text-sm text-gray-700" phx-no-format>
               The workflows you select below will overwrite their counterparts in
-              <strong>{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>. Any conflicting changes in the target are lost.
+              <strong class="font-medium text-gray-900">{get_selected_target_label(@target_options, @merge_form[:target_id].value)}</strong>. Any conflicting changes in the target are lost.
             </p>
           </div>
 
-          <div class="space-y-1.5">
+          <div class="space-y-2">
             <div class="flex items-baseline justify-between">
               <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
                 Workflows
@@ -314,7 +314,7 @@ defmodule LightningWeb.SandboxLive.Components do
                     @select_all_state == :partial && "indeterminate"
                   ]}
                 />
-                <span class="text-sm font-medium text-gray-700">
+                <span class="text-sm font-medium text-gray-900">
                   Select all
                 </span>
               </label>
@@ -331,34 +331,34 @@ defmodule LightningWeb.SandboxLive.Components do
                     checked={MapSet.member?(@selected_workflow_ids, wf.id)}
                     readonly
                   />
-                  <span class="flex-1 text-sm text-gray-800 truncate">
+                  <span class="flex-1 text-sm text-gray-700 truncate">
                     {wf.name}
                   </span>
                   <span
                     :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
-                    class="flex items-center gap-1 text-xs text-green-600"
+                    class="flex items-center gap-1 text-xs font-medium text-green-700"
                     title="This workflow has been modified in the sandbox"
                   >
                     Changed
                   </span>
                   <span
                     :if={wf.is_diverged}
-                    class="flex items-center gap-1 text-xs text-amber-600"
+                    class="flex items-center gap-1 text-xs font-medium text-amber-700"
                     title="This workflow was modified in the target project - this change will be lost"
                   >
                     <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
-                    <strong>Diverged</strong>
+                    Diverged
                   </span>
                   <span
                     :if={wf.is_new}
-                    class="flex items-center gap-1 text-xs text-blue-600"
+                    class="flex items-center gap-1 text-xs font-medium text-blue-700"
                     title="This workflow doesn't exist in the target — it will be created"
                   >
                     New
                   </span>
                   <span
                     :if={wf.is_deleted}
-                    class="flex items-center gap-1 text-xs text-red-600"
+                    class="flex items-center gap-1 text-xs font-medium text-red-700"
                     title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
                   >
                     Deleted in sandbox
@@ -368,7 +368,7 @@ defmodule LightningWeb.SandboxLive.Components do
             </div>
           </div>
 
-          <div class="space-y-1.5">
+          <div class="space-y-2">
             <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
               After merging
             </span>
@@ -385,7 +385,7 @@ defmodule LightningWeb.SandboxLive.Components do
                     type="toggle"
                   />
                 </div>
-                <div class="flex-1 min-w-0">
+                <div class="flex-1 min-w-0 space-y-1.5">
                   <p class={[
                     "text-sm font-medium",
                     @delete_after_merge? && "text-amber-900",
@@ -398,27 +398,30 @@ defmodule LightningWeb.SandboxLive.Components do
                     <% end %>
                   </p>
                   <p class={[
-                    "text-xs mt-1",
+                    "text-sm",
                     @delete_after_merge? && "text-amber-800",
                     !@delete_after_merge? && "text-sky-800"
                   ]}>
                     <%= if @delete_after_merge? do %>
                       Scheduled for deletion. Retained for {grace_period_label()} before being permanently removed.
                     <% else %>
-                      <strong>{@sandbox.name}</strong>
+                      <strong class="font-medium">{@sandbox.name}</strong>
                       stays available after the merge. You can still delete it later from the sandboxes list.
                     <% end %>
                   </p>
                   <p
                     :if={@delete_after_merge? and @descendant_count == 1}
-                    class="text-xs mt-1.5 text-amber-800"
+                    class="text-sm text-amber-800"
                   >
-                    Child sandbox <strong>{List.first(@descendants).name}</strong>
+                    Child sandbox
+                    <strong class="font-medium">
+                      {List.first(@descendants).name}
+                    </strong>
                     will also be scheduled for deletion.
                   </p>
                   <p
                     :if={@delete_after_merge? and @descendant_count > 1}
-                    class="text-xs mt-1.5 text-amber-800"
+                    class="text-sm text-amber-800"
                   >
                     Its {@descendant_count} child sandboxes will also be scheduled for deletion.
                   </p>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -144,19 +144,25 @@ defmodule LightningWeb.SandboxLive.Components do
 
       <section class="space-y-4">
         <p class="text-gray-700">
-          Deleting a sandbox removes it (along with its descendants) from
-          OpenFn. Workflows, triggers, versions, keychain clones, and
-          dataclips will be permanently removed once the grace period ends.
-          <%= if @sandbox.is_current do %>
-            You are currently viewing this project.
-            After deletion, you'll be redirected to <strong>{@root_project.name}</strong>.
-          <% end %>
+          Deleting a sandbox removes it (along with its descendants) from OpenFn.
+        </p>
+
+        <p class="text-gray-700">
+          Workflows, triggers, versions, keychain clones, and dataclips will be permanently removed.
+        </p>
+
+        <p :if={@sandbox.is_current} class="text-gray-700">
+          You are currently viewing this project.
+          After deletion, you'll be redirected to <strong>{@root_project.name}</strong>.
+        </p>
+
+        <p class="text-gray-700">
           To confirm, type the sandbox name below.
         </p>
 
         <div class="bg-amber-50 border border-amber-200 rounded-md p-3">
           <p class="text-sm text-amber-800">
-            The sandbox will be scheduled for deletion and retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
+            This sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
           </p>
         </div>
 
@@ -220,10 +226,6 @@ defmodule LightningWeb.SandboxLive.Components do
       assigns
       |> assign(:merge_form, to_form(assigns.changeset, as: :merge))
       |> assign(:descendant_count, length(assigns.descendants))
-      |> assign(
-        :delete_after_merge?,
-        Ecto.Changeset.get_field(assigns.changeset, :delete_after_merge, true)
-      )
       |> assign(
         :select_all_state,
         merge_select_all_state(
@@ -361,31 +363,22 @@ defmodule LightningWeb.SandboxLive.Components do
             </ul>
           </div>
 
-          <div class="space-y-2">
-            <.input
-              id="merge-delete-after-merge-toggle"
-              field={@merge_form[:delete_after_merge]}
-              type="toggle"
-              label="Delete sandbox after merging"
-            />
-            <Common.alert
-              :if={@delete_after_merge?}
-              id="merge-deletion-warning"
-              type="warning"
-              header="This sandbox will be deleted after merging"
-            >
-              <:message>
-                It can be restored by a workspace administrator for {grace_period_label()}, then permanently removed.
-                <div :if={@descendant_count == 1} class="mt-2">
-                  Child sandbox <strong>{List.first(@descendants).name}</strong>
-                  will also be deleted.
-                </div>
-                <div :if={@descendant_count > 1} class="mt-2">
-                  Its {@descendant_count} child sandboxes will also be deleted.
-                </div>
-              </:message>
-            </Common.alert>
-          </div>
+          <Common.alert
+            id="merge-deletion-warning"
+            type="warning"
+            header="This sandbox will be deleted after merging"
+          >
+            <:message>
+              It can be restored by a workspace administrator for {grace_period_label()}, then permanently removed.
+              <div :if={@descendant_count == 1} class="mt-2">
+                Child sandbox <strong>{List.first(@descendants).name}</strong>
+                will also be deleted.
+              </div>
+              <div :if={@descendant_count > 1} class="mt-2">
+                Its {@descendant_count} child sandboxes will also be deleted.
+              </div>
+            </:message>
+          </Common.alert>
 
           <.modal_footer>
             <.button
@@ -511,7 +504,13 @@ defmodule LightningWeb.SandboxLive.Components do
   defp sandbox_card(assigns) do
     ~H"""
     <div
-      class="group block cursor-pointer rounded-xl bg-white border border-gray-200 bg-white hover:bg-gray-50 transition-all duration-200 overflow-hidden"
+      class={[
+        "group block rounded-xl border transition-all duration-200 overflow-hidden",
+        if(@sandbox.scheduled_for_deletion?,
+          do: "bg-amber-50/40 border-amber-200 cursor-pointer hover:bg-amber-50/70",
+          else: "bg-white border-gray-200 hover:bg-gray-50 cursor-pointer"
+        )
+      ]}
       phx-click={JS.navigate(~p"/projects/#{@sandbox.id}/w")}
       role="button"
       tabindex="0"
@@ -525,7 +524,13 @@ defmodule LightningWeb.SandboxLive.Components do
         <div class="flex-1 px-4 py-4 flex items-center justify-between min-w-0">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-3 mb-1">
-              <h3 class="font-semibold text-slate-900 text-lg group-hover:text-slate-800 truncate">
+              <h3 class={[
+                "font-semibold text-lg group-hover:text-slate-800 truncate",
+                if(@sandbox.scheduled_for_deletion?,
+                  do: "text-slate-500",
+                  else: "text-slate-900"
+                )
+              ]}>
                 {@sandbox.name}
               </h3>
               <.badge
@@ -538,6 +543,14 @@ defmodule LightningWeb.SandboxLive.Components do
                 id={"active-badge-#{@sandbox.id}"}
                 env="active"
               />
+              <span
+                :if={@sandbox.scheduled_for_deletion?}
+                id={"scheduled-deletion-badge-#{@sandbox.id}"}
+                class="inline-flex items-center gap-1 px-2 py-1 bg-amber-100 text-amber-800 text-xs rounded-full"
+              >
+                <.icon name="hero-clock-mini" class="h-3.5 w-3.5" />
+                Scheduled for deletion
+              </span>
             </div>
           </div>
           <.sandbox_actions sandbox={@sandbox} />
@@ -562,6 +575,41 @@ defmodule LightningWeb.SandboxLive.Components do
   end
 
   attr :sandbox, :map, required: true
+
+  defp sandbox_actions(%{sandbox: %{scheduled_for_deletion?: true}} = assigns) do
+    ~H"""
+    <div class="flex gap-1 flex-shrink-0 ml-4">
+      <.action_button
+        id={"cancel-deletion-sandbox-#{@sandbox.id}"}
+        icon_type="heroicon"
+        icon_name="hero-arrow-uturn-left"
+        label={
+          if @sandbox.can_cancel_deletion do
+            "Cancel deletion"
+          else
+            "You are not authorized to cancel deletion of this sandbox"
+          end
+        }
+        action={
+          if @sandbox.can_cancel_deletion,
+            do: JS.push("cancel-sandbox-deletion", value: %{id: @sandbox.id}),
+            else: %JS{}
+        }
+        disabled={not @sandbox.can_cancel_deletion}
+        icon_class={
+          if @sandbox.can_cancel_deletion,
+            do: "text-amber-700",
+            else: "text-slate-300"
+        }
+        button_class={
+          if @sandbox.can_cancel_deletion,
+            do: "hover:bg-amber-100",
+            else: "cursor-not-allowed"
+        }
+      />
+    </div>
+    """
+  end
 
   defp sandbox_actions(assigns) do
     ~H"""

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -372,72 +372,41 @@ defmodule LightningWeb.SandboxLive.Components do
             <span class="text-xs font-medium uppercase tracking-wide text-gray-500">
               After merging
             </span>
-            <div class={[
-              "rounded-lg border transition-colors",
-              @delete_after_merge? && "border-amber-200 bg-amber-50/60",
-              !@delete_after_merge? && "border-sky-200 bg-sky-50/60"
-            ]}>
-              <div class="flex items-start gap-4 p-4">
-                <div class="flex-shrink-0 pt-0.5">
-                  <.input
-                    id="merge-delete-after-merge-toggle"
-                    field={@merge_form[:delete_after_merge]}
-                    type="toggle"
-                  />
-                </div>
-                <div class="flex-1 min-w-0 space-y-1.5">
-                  <p class={[
-                    "text-sm font-medium",
-                    @delete_after_merge? && "text-amber-900",
-                    !@delete_after_merge? && "text-sky-900"
-                  ]}>
-                    <%= if @delete_after_merge? do %>
-                      Delete sandbox after merging
-                    <% else %>
-                      Keep sandbox after merging
-                    <% end %>
-                  </p>
-                  <p class={[
-                    "text-sm",
-                    @delete_after_merge? && "text-amber-800",
-                    !@delete_after_merge? && "text-sky-800"
-                  ]}>
-                    <%= if @delete_after_merge? do %>
-                      Scheduled for deletion. Retained for {grace_period_label()} before being permanently removed.
-                    <% else %>
-                      <strong class="font-medium">{@sandbox.name}</strong>
-                      stays available after the merge. You can still delete it later from the sandboxes list.
-                    <% end %>
-                  </p>
-                  <p
-                    :if={@delete_after_merge? and @descendant_count == 1}
-                    class="text-sm text-amber-800"
-                  >
-                    Child sandbox
-                    <strong class="font-medium">
-                      {List.first(@descendants).name}
-                    </strong>
-                    will also be scheduled for deletion.
-                  </p>
-                  <p
-                    :if={@delete_after_merge? and @descendant_count > 1}
-                    class="text-sm text-amber-800"
-                  >
-                    Its {@descendant_count} child sandboxes will also be scheduled for deletion.
-                  </p>
-                </div>
-                <.icon
-                  :if={@delete_after_merge?}
-                  name="hero-exclamation-triangle"
-                  class="h-5 w-5 text-amber-500 flex-shrink-0"
-                />
-                <.icon
-                  :if={!@delete_after_merge?}
-                  name="hero-information-circle"
-                  class="h-5 w-5 text-sky-500 flex-shrink-0"
-                />
-              </div>
-            </div>
+            <.input
+              id="merge-delete-after-merge-toggle"
+              field={@merge_form[:delete_after_merge]}
+              type="toggle"
+              label="Delete sandbox after merging"
+            />
+            <Common.alert
+              id="merge-disposition-notice"
+              type={if @delete_after_merge?, do: "warning", else: "info"}
+            >
+              <:message>
+                <%= if @delete_after_merge? do %>
+                  Scheduled for deletion. Retained for {grace_period_label()} before being permanently removed.
+                <% else %>
+                  <strong class="font-medium">{@sandbox.name}</strong>
+                  stays available after the merge. You can still delete it later from the sandboxes list.
+                <% end %>
+                <p
+                  :if={@delete_after_merge? and @descendant_count == 1}
+                  class="mt-1.5"
+                >
+                  Child sandbox
+                  <strong class="font-medium">
+                    {List.first(@descendants).name}
+                  </strong>
+                  will also be scheduled for deletion.
+                </p>
+                <p
+                  :if={@delete_after_merge? and @descendant_count > 1}
+                  class="mt-1.5"
+                >
+                  Its {@descendant_count} child sandboxes will also be scheduled for deletion.
+                </p>
+              </:message>
+            </Common.alert>
           </div>
 
           <.modal_footer>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -369,32 +369,20 @@ defmodule LightningWeb.SandboxLive.Components do
               label="Delete sandbox after merging"
             />
             <Common.alert
-              id="merge-disposition-notice"
-              type={if @delete_after_merge?, do: "warning", else: "info"}
+              :if={@delete_after_merge?}
+              id="merge-beta-warning"
+              type="warning"
+              header="This sandbox will be deleted after merging"
             >
               <:message>
-                <%= if @delete_after_merge? do %>
-                  Scheduled for deletion. Retained for {grace_period_label()} before being permanently removed.
-                <% else %>
-                  <strong class="font-medium">{@sandbox.name}</strong>
-                  stays available after the merge. You can still delete it later from the sandboxes list.
-                <% end %>
-                <p
-                  :if={@delete_after_merge? and @descendant_count == 1}
-                  class="mt-1.5"
-                >
-                  Child sandbox
-                  <strong class="font-medium">
-                    {List.first(@descendants).name}
-                  </strong>
-                  will also be scheduled for deletion.
-                </p>
-                <p
-                  :if={@delete_after_merge? and @descendant_count > 1}
-                  class="mt-1.5"
-                >
-                  Its {@descendant_count} child sandboxes will also be scheduled for deletion.
-                </p>
+                This action cannot be undone after {grace_period_label()}.
+                <div :if={@descendant_count == 1} class="mt-2">
+                  Child sandbox <strong>{List.first(@descendants).name}</strong>
+                  will also be permanently closed.
+                </div>
+                <div :if={@descendant_count > 1} class="mt-2">
+                  Its {@descendant_count} child sandboxes will also be permanently closed.
+                </div>
               </:message>
             </Common.alert>
           </div>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -507,7 +507,8 @@ defmodule LightningWeb.SandboxLive.Components do
       id={"sandbox-card-#{@sandbox.id}"}
       class="group block rounded-xl border border-gray-200 bg-gray-50 opacity-75 cursor-not-allowed overflow-hidden"
       aria-disabled="true"
-      title="This sandbox is scheduled for deletion. Cancel the deletion to use it again."
+      phx-hook="Tooltip"
+      aria-label="This sandbox is scheduled for deletion. Cancel the deletion to use it again."
     >
       <div class="flex items-stretch">
         <div

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -593,7 +593,7 @@ defmodule LightningWeb.SandboxLive.Components do
     ~H"""
     <span
       id={@id}
-      class="inline-block px-2 py-1 bg-slate-100 text-slate-600 text-xs rounded-full truncate max-w-32"
+      class="inline-block px-2 py-1 bg-slate-200 text-slate-700 text-xs rounded-full truncate max-w-32"
     >
       {@env}
     </span>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -501,16 +501,46 @@ defmodule LightningWeb.SandboxLive.Components do
 
   attr :sandbox, :map, required: true
 
+  defp sandbox_card(%{sandbox: %{scheduled_for_deletion?: true}} = assigns) do
+    ~H"""
+    <div
+      id={"sandbox-card-#{@sandbox.id}"}
+      class="group block rounded-xl border border-gray-200 bg-gray-50 opacity-75 cursor-not-allowed overflow-hidden"
+      aria-disabled="true"
+      title="This sandbox is scheduled for deletion. Cancel the deletion to use it again."
+    >
+      <div class="flex items-stretch">
+        <div
+          class="w-3 flex-shrink-0 opacity-60"
+          style={"background-color: #{@sandbox.color || "#4f39f6"};"}
+        >
+        </div>
+        <div class="flex-1 px-4 py-4 flex items-center justify-between min-w-0">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-3 mb-1">
+              <h3 class="font-semibold text-lg text-slate-500 line-through truncate">
+                {@sandbox.name}
+              </h3>
+              <span
+                id={"scheduled-deletion-badge-#{@sandbox.id}"}
+                class="inline-flex items-center gap-1 px-2 py-1 bg-amber-100 text-amber-800 text-xs rounded-full"
+              >
+                <.icon name="hero-clock-mini" class="h-3.5 w-3.5" />
+                Scheduled for deletion
+              </span>
+            </div>
+          </div>
+          <.sandbox_actions sandbox={@sandbox} />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   defp sandbox_card(assigns) do
     ~H"""
     <div
-      class={[
-        "group block rounded-xl border transition-all duration-200 overflow-hidden",
-        if(@sandbox.scheduled_for_deletion?,
-          do: "bg-amber-50/40 border-amber-200 cursor-pointer hover:bg-amber-50/70",
-          else: "bg-white border-gray-200 hover:bg-gray-50 cursor-pointer"
-        )
-      ]}
+      class="group block cursor-pointer rounded-xl bg-white border border-gray-200 hover:bg-gray-50 transition-all duration-200 overflow-hidden"
       phx-click={JS.navigate(~p"/projects/#{@sandbox.id}/w")}
       role="button"
       tabindex="0"
@@ -524,13 +554,7 @@ defmodule LightningWeb.SandboxLive.Components do
         <div class="flex-1 px-4 py-4 flex items-center justify-between min-w-0">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-3 mb-1">
-              <h3 class={[
-                "font-semibold text-lg group-hover:text-slate-800 truncate",
-                if(@sandbox.scheduled_for_deletion?,
-                  do: "text-slate-500",
-                  else: "text-slate-900"
-                )
-              ]}>
+              <h3 class="font-semibold text-slate-900 text-lg group-hover:text-slate-800 truncate">
                 {@sandbox.name}
               </h3>
               <.badge
@@ -543,14 +567,6 @@ defmodule LightningWeb.SandboxLive.Components do
                 id={"active-badge-#{@sandbox.id}"}
                 env="active"
               />
-              <span
-                :if={@sandbox.scheduled_for_deletion?}
-                id={"scheduled-deletion-badge-#{@sandbox.id}"}
-                class="inline-flex items-center gap-1 px-2 py-1 bg-amber-100 text-amber-800 text-xs rounded-full"
-              >
-                <.icon name="hero-clock-mini" class="h-3.5 w-3.5" />
-                Scheduled for deletion
-              </span>
             </div>
           </div>
           <.sandbox_actions sandbox={@sandbox} />

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -828,12 +828,10 @@ defmodule LightningWeb.SandboxLive.Components do
 
   defp deletion_tooltip(%{scheduled_deletion: %DateTime{} = at}) do
     formatted = Calendar.strftime(at, "%d %b %Y")
+    suffix = relative_deletion_suffix(at)
 
-    "Scheduled for deletion on #{formatted}#{relative_deletion_suffix(at)}. Cancel the deletion to restore it."
+    "Scheduled for deletion on #{formatted}#{suffix}. Cancel the deletion to restore it."
   end
-
-  defp deletion_tooltip(_),
-    do: "Scheduled for deletion. Cancel the deletion to restore it."
 
   defp relative_deletion_suffix(at) do
     case DateTime.diff(at, DateTime.utc_now(), :day) do

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -162,7 +162,7 @@ defmodule LightningWeb.SandboxLive.Components do
 
         <div class="bg-amber-50 border border-amber-200 rounded-md p-3">
           <p class="text-sm text-amber-800">
-            This sandbox will be retained for {grace_period_label()} before being permanently removed. Contact a workspace administrator if you need it restored within that window.
+            This sandbox will be retained for {grace_period_label()} before being permanently removed. You can restore it from the sandbox list during that window.
           </p>
         </div>
 
@@ -369,7 +369,7 @@ defmodule LightningWeb.SandboxLive.Components do
             header="This sandbox will be deleted after merging"
           >
             <:message>
-              It can be restored by a workspace administrator for {grace_period_label()}, then permanently removed.
+              It can be restored from the sandbox list for {grace_period_label()}, then permanently removed.
               <div :if={@descendant_count == 1} class="mt-2">
                 Child sandbox <strong>{List.first(@descendants).name}</strong>
                 will also be deleted.

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -508,10 +508,8 @@ defmodule LightningWeb.SandboxLive.Components do
     ~H"""
     <div
       id={"sandbox-card-#{@sandbox.id}"}
-      class="group block rounded-xl border border-gray-200 bg-gray-50 opacity-75 cursor-not-allowed overflow-hidden"
+      class="group block rounded-xl border border-gray-200 bg-gray-50 opacity-75 overflow-hidden"
       aria-disabled="true"
-      phx-hook="Tooltip"
-      aria-label={@deletion_tooltip}
     >
       <div class="flex items-stretch">
         <div
@@ -520,7 +518,12 @@ defmodule LightningWeb.SandboxLive.Components do
         >
         </div>
         <div class="flex-1 px-4 py-4 flex items-center justify-between min-w-0">
-          <div class="flex-1 min-w-0">
+          <div
+            id={"sandbox-card-info-#{@sandbox.id}"}
+            class="flex-1 min-w-0 cursor-not-allowed"
+            phx-hook="Tooltip"
+            aria-label={@deletion_tooltip}
+          >
             <div class="flex items-center gap-3 mb-1">
               <h3 class="font-semibold text-lg text-slate-500 line-through truncate">
                 {@sandbox.name}

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -521,6 +521,16 @@ defmodule LightningWeb.SandboxLive.Components do
               <h3 class="font-semibold text-lg text-slate-500 line-through truncate">
                 {@sandbox.name}
               </h3>
+              <.badge
+                :if={has_environment?(@sandbox)}
+                id={"env-badge-#{@sandbox.id}"}
+                env={@sandbox.env}
+              />
+              <.badge
+                :if={@sandbox.is_current}
+                id={"active-badge-#{@sandbox.id}"}
+                env="active"
+              />
               <span
                 id={"scheduled-deletion-badge-#{@sandbox.id}"}
                 class="inline-flex items-center gap-1 px-2 py-1 bg-amber-100 text-amber-800 text-xs rounded-full"

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -71,39 +71,58 @@ defmodule LightningWeb.SandboxLive.Components do
   attr :disabled_button_tooltip, :string, default: nil
 
   def workspace_list(assigns) do
+    {scheduled, active} =
+      Enum.split_with(assigns.sandboxes, & &1.scheduled_for_deletion?)
+
+    assigns =
+      assigns
+      |> assign(:active_sandboxes, active)
+      |> assign(:scheduled_sandboxes, scheduled)
+
     ~H"""
-    <div class="space-y-3">
-      <div>
-        <.root_project_card
-          root_project={@root_project}
-          is_current={@current_project.id == @root_project.id}
-        />
-      </div>
-      <div>
-        <%= if Enum.empty?(@sandboxes) do %>
-          <div class="text-gray-500 text-center py-8 rounded-lg border-2 border-dashed border-gray-200">
-            <div class="space-y-3">
-              <div class="text-base font-medium">No sandboxes found</div>
-              <div class="text-sm">
-                <%= if @enable_create_button do %>
-                  <.link
-                    navigate={~p"/projects/#{@current_project.id}/sandboxes/new"}
-                    class="text-blue-600 hover:text-blue-800 font-medium"
-                  >
-                    Create your first sandbox
-                  </.link>
-                  to start experimenting.
-                <% else %>
-                  {@disabled_button_tooltip}
-                <% end %>
+    <div class="space-y-8">
+      <div class="space-y-3">
+        <div>
+          <.root_project_card
+            root_project={@root_project}
+            is_current={@current_project.id == @root_project.id}
+          />
+        </div>
+        <div>
+          <%= if Enum.empty?(@active_sandboxes) and Enum.empty?(@scheduled_sandboxes) do %>
+            <div class="text-gray-500 text-center py-8 rounded-lg border-2 border-dashed border-gray-200">
+              <div class="space-y-3">
+                <div class="text-base font-medium">No sandboxes found</div>
+                <div class="text-sm">
+                  <%= if @enable_create_button do %>
+                    <.link
+                      navigate={~p"/projects/#{@current_project.id}/sandboxes/new"}
+                      class="text-blue-600 hover:text-blue-800 font-medium"
+                    >
+                      Create your first sandbox
+                    </.link>
+                    to start experimenting.
+                  <% else %>
+                    {@disabled_button_tooltip}
+                  <% end %>
+                </div>
               </div>
             </div>
-          </div>
-        <% else %>
-          <div class="space-y-3">
-            <.sandbox_card :for={sandbox <- @sandboxes} sandbox={sandbox} />
-          </div>
-        <% end %>
+          <% else %>
+            <div class="space-y-3">
+              <.sandbox_card :for={sandbox <- @active_sandboxes} sandbox={sandbox} />
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div :if={@scheduled_sandboxes != []} id="scheduled-for-deletion-section">
+        <h2 class="text-2xl font-bold text-slate-900 mb-3">
+          Scheduled for deletion
+        </h2>
+        <div class="space-y-3">
+          <.sandbox_card :for={sandbox <- @scheduled_sandboxes} sandbox={sandbox} />
+        </div>
       </div>
     </div>
     """
@@ -538,13 +557,6 @@ defmodule LightningWeb.SandboxLive.Components do
                 id={"active-badge-#{@sandbox.id}"}
                 env="active"
               />
-              <span
-                id={"scheduled-deletion-badge-#{@sandbox.id}"}
-                class="inline-flex items-center gap-1 px-2 py-1 bg-amber-100 text-amber-800 text-xs rounded-full"
-              >
-                <.icon name="hero-clock-mini" class="h-3.5 w-3.5" />
-                Scheduled for deletion
-              </span>
             </div>
           </div>
           <.sandbox_actions sandbox={@sandbox} />

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -623,35 +623,23 @@ defmodule LightningWeb.SandboxLive.Components do
 
   defp sandbox_actions(%{sandbox: %{scheduled_for_deletion?: true}} = assigns) do
     ~H"""
-    <div class="flex gap-1 flex-shrink-0 ml-4">
-      <.action_button
-        id={"cancel-deletion-sandbox-#{@sandbox.id}"}
-        icon_type="heroicon"
-        icon_name="hero-arrow-uturn-left"
-        label={
-          if @sandbox.can_cancel_deletion do
-            "Cancel deletion"
-          else
+    <div id={"cancel-deletion-sandbox-#{@sandbox.id}"} class="flex-shrink-0 ml-4">
+      <.button
+        theme="secondary"
+        type="button"
+        disabled={not @sandbox.can_cancel_deletion}
+        tooltip={
+          not @sandbox.can_cancel_deletion &&
             "You are not authorized to cancel deletion of this sandbox"
-          end
         }
-        action={
+        phx-click={
           if @sandbox.can_cancel_deletion,
             do: JS.push("cancel-sandbox-deletion", value: %{id: @sandbox.id}),
             else: %JS{}
         }
-        disabled={not @sandbox.can_cancel_deletion}
-        icon_class={
-          if @sandbox.can_cancel_deletion,
-            do: "text-amber-700",
-            else: "text-slate-300"
-        }
-        button_class={
-          if @sandbox.can_cancel_deletion,
-            do: "hover:bg-amber-100",
-            else: "cursor-not-allowed"
-        }
-      />
+      >
+        Restore
+      </.button>
     </div>
     """
   end

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -826,11 +826,11 @@ defmodule LightningWeb.SandboxLive.Components do
   defp deletion_tooltip(%{scheduled_deletion: %DateTime{} = at}) do
     formatted = Calendar.strftime(at, "%d %b %Y")
 
-    "Scheduled for deletion on #{formatted}#{relative_deletion_suffix(at)}. Cancel the deletion to keep it."
+    "Scheduled for deletion on #{formatted}#{relative_deletion_suffix(at)}. Cancel the deletion to restore it."
   end
 
   defp deletion_tooltip(_),
-    do: "Scheduled for deletion. Cancel the deletion to keep it."
+    do: "Scheduled for deletion. Cancel the deletion to restore it."
 
   defp relative_deletion_suffix(at) do
     case DateTime.diff(at, DateTime.utc_now(), :day) do

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -502,13 +502,16 @@ defmodule LightningWeb.SandboxLive.Components do
   attr :sandbox, :map, required: true
 
   defp sandbox_card(%{sandbox: %{scheduled_for_deletion?: true}} = assigns) do
+    assigns =
+      assign(assigns, :deletion_tooltip, deletion_tooltip(assigns.sandbox))
+
     ~H"""
     <div
       id={"sandbox-card-#{@sandbox.id}"}
       class="group block rounded-xl border border-gray-200 bg-gray-50 opacity-75 cursor-not-allowed overflow-hidden"
       aria-disabled="true"
       phx-hook="Tooltip"
-      aria-label="This sandbox is scheduled for deletion. Cancel the deletion to use it again."
+      aria-label={@deletion_tooltip}
     >
       <div class="flex items-stretch">
         <div
@@ -819,6 +822,24 @@ defmodule LightningWeb.SandboxLive.Components do
   end
 
   defp has_environment?(_), do: false
+
+  defp deletion_tooltip(%{scheduled_deletion: %DateTime{} = at}) do
+    formatted = Calendar.strftime(at, "%d %b %Y")
+
+    "Scheduled for deletion on #{formatted}#{relative_deletion_suffix(at)}. Cancel the deletion to keep it."
+  end
+
+  defp deletion_tooltip(_),
+    do: "Scheduled for deletion. Cancel the deletion to keep it."
+
+  defp relative_deletion_suffix(at) do
+    case DateTime.diff(at, DateTime.utc_now(), :day) do
+      n when n > 1 -> " (in #{n} days)"
+      1 -> " (in 1 day)"
+      0 -> " (today)"
+      _ -> ""
+    end
+  end
 
   defp get_selected_target_label(target_options, selected_target_id) do
     case Enum.find(target_options, &(&1.value == selected_target_id)) do

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -284,10 +284,11 @@ defmodule LightningWeb.SandboxLive.Index do
   @impl true
   def handle_event(
         "select-merge-target",
-        %{"merge" => %{"target_id" => target_id}},
+        %{"merge" => merge_params},
         socket
       ) do
-    merge_changeset = merge_changeset(%{target_id: target_id})
+    merge_changeset = merge_changeset(merge_params)
+    target_id = merge_params["target_id"]
 
     target_project =
       Enum.find(socket.assigns.workspace_projects, fn project ->
@@ -341,7 +342,7 @@ defmodule LightningWeb.SandboxLive.Index do
   @impl true
   def handle_event(
         "confirm-merge",
-        %{"merge" => %{"target_id" => target_id}},
+        %{"merge" => merge_params},
         %{
           assigns: %{
             merge_source_sandbox: source,
@@ -350,6 +351,9 @@ defmodule LightningWeb.SandboxLive.Index do
           }
         } = socket
       ) do
+    target_id = merge_params["target_id"]
+    delete_after_merge? = parse_delete_after_merge(merge_params)
+
     cond do
       is_nil(source) ->
         socket
@@ -385,7 +389,14 @@ defmodule LightningWeb.SandboxLive.Index do
 
               source
               |> perform_merge(target, actor, selected_ids)
-              |> handle_merge_result(socket, source, target, root_project, actor)
+              |> handle_merge_result(
+                socket,
+                source,
+                target,
+                root_project,
+                actor,
+                delete_after_merge?
+              )
             else
               socket
               |> put_flash(
@@ -555,10 +566,10 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp merge_changeset(params \\ %{}) do
-    types = %{target_id: :string}
+    types = %{target_id: :string, delete_after_merge: :boolean}
 
-    {%{}, types}
-    |> Changeset.cast(params, [:target_id])
+    {%{delete_after_merge: true}, types}
+    |> Changeset.cast(params, [:target_id, :delete_after_merge])
     |> Changeset.validate_required([:target_id])
   end
 
@@ -852,11 +863,13 @@ defmodule LightningWeb.SandboxLive.Index do
          source,
          target,
          _root_project,
-         actor
+         actor,
+         delete_after_merge?
        ) do
     Lightning.Projects.SandboxPromExPlugin.fire_sandbox_merged_event()
 
-    flash_message = build_merge_success_message(source, target, actor)
+    flash_message =
+      build_merge_success_message(source, target, actor, delete_after_merge?)
 
     socket
     |> put_flash(:info, flash_message)
@@ -871,7 +884,8 @@ defmodule LightningWeb.SandboxLive.Index do
          _source,
          _target,
          _root,
-         _actor
+         _actor,
+         _delete_after_merge?
        ) do
     socket
     |> put_flash(:error, format_merge_error(reason))
@@ -879,7 +893,7 @@ defmodule LightningWeb.SandboxLive.Index do
     |> noreply()
   end
 
-  defp build_merge_success_message(source, target, actor) do
+  defp build_merge_success_message(source, target, actor, true) do
     case Sandboxes.schedule_sandbox_deletion(source, actor) do
       {:ok, _} ->
         "Successfully merged #{source.name} into #{target.name}. " <>
@@ -891,6 +905,18 @@ defmodule LightningWeb.SandboxLive.Index do
           "but could not schedule the sandbox for deletion."
     end
   end
+
+  defp build_merge_success_message(source, target, _actor, false) do
+    "Successfully merged #{source.name} into #{target.name}. " <>
+      "The sandbox has been kept and remains available for further work."
+  end
+
+  defp parse_delete_after_merge(%{"delete_after_merge" => "true"}), do: true
+  defp parse_delete_after_merge(%{"delete_after_merge" => "false"}), do: false
+  defp parse_delete_after_merge(%{"delete_after_merge" => true}), do: true
+  defp parse_delete_after_merge(%{"delete_after_merge" => false}), do: false
+  defp parse_delete_after_merge(%{"delete_after_merge" => "on"}), do: true
+  defp parse_delete_after_merge(_), do: true
 
   defp human_readable_grace_period do
     case Lightning.Config.purge_deleted_after_days() do

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -284,6 +284,14 @@ defmodule LightningWeb.SandboxLive.Index do
   @impl true
   def handle_event(
         "select-merge-target",
+        %{"_target" => ["merge", "delete_after_merge"], "merge" => merge_params},
+        socket
+      ) do
+    {:noreply, assign(socket, :merge_changeset, merge_changeset(merge_params))}
+  end
+
+  def handle_event(
+        "select-merge-target",
         %{"merge" => merge_params},
         socket
       ) do

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -163,7 +163,7 @@ defmodule LightningWeb.SandboxLive.Index do
 
         if changeset.valid? do
           {:noreply,
-           Lightning.Projects.delete_sandbox(
+           Sandboxes.schedule_sandbox_deletion(
              sandbox,
              current_user
            )
@@ -597,7 +597,9 @@ defmodule LightningWeb.SandboxLive.Index do
       socket
       |> put_flash(
         :info,
-        "Sandbox #{deleted_sandbox.name} and all its associated descendants deleted"
+        "Sandbox #{deleted_sandbox.name} and its descendants have been " <>
+          "scheduled for deletion. They will be retained for " <>
+          "#{human_readable_grace_period()} before being permanently removed."
       )
       |> reset_delete_modal_state()
 
@@ -622,7 +624,10 @@ defmodule LightningWeb.SandboxLive.Index do
 
   defp handle_sandbox_delete_result({:error, reason}, _sandbox, socket) do
     socket
-    |> put_flash(:error, "Failed to delete sandbox: #{inspect(reason)}")
+    |> put_flash(
+      :error,
+      "Failed to schedule sandbox deletion: #{inspect(reason)}"
+    )
     |> assign(:confirm_delete_open?, false)
   end
 
@@ -875,12 +880,23 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp build_merge_success_message(source, target, actor) do
-    case Lightning.Projects.delete_sandbox(source, actor) do
+    case Sandboxes.schedule_sandbox_deletion(source, actor) do
       {:ok, _} ->
-        "Successfully merged #{source.name} into #{target.name} and deleted the sandbox"
+        "Successfully merged #{source.name} into #{target.name}. " <>
+          "The sandbox has been scheduled for deletion and will be retained " <>
+          "for #{human_readable_grace_period()} before being permanently removed."
 
       {:error, _} ->
-        "Successfully merged #{source.name} into #{target.name}, but could not delete the sandbox"
+        "Successfully merged #{source.name} into #{target.name}, " <>
+          "but could not schedule the sandbox for deletion."
+    end
+  end
+
+  defp human_readable_grace_period do
+    case Lightning.Config.purge_deleted_after_days() do
+      nil -> "the configured grace period"
+      1 -> "1 day"
+      days when is_integer(days) -> "#{days} days"
     end
   end
 

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -180,6 +180,32 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   @impl true
+  def handle_event(
+        "cancel-sandbox-deletion",
+        %{"id" => sandbox_id},
+        %{assigns: %{current_user: current_user}} = socket
+      ) do
+    case Enum.find(socket.assigns.sandboxes, &(&1.id == sandbox_id)) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Sandbox not found")}
+
+      sandbox ->
+        if sandbox.can_cancel_deletion do
+          Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, current_user)
+          |> handle_cancel_deletion_result(sandbox, socket)
+          |> noreply()
+        else
+          {:noreply,
+           put_flash(
+             socket,
+             :error,
+             "You are not authorized to cancel this sandbox's deletion"
+           )}
+        end
+    end
+  end
+
+  @impl true
   def handle_event("open-merge-modal", %{"id" => sandbox_id}, socket) do
     case Enum.find(socket.assigns.sandboxes, &(&1.id == sandbox_id)) do
       nil ->
@@ -284,19 +310,10 @@ defmodule LightningWeb.SandboxLive.Index do
   @impl true
   def handle_event(
         "select-merge-target",
-        %{"_target" => ["merge", "delete_after_merge"], "merge" => merge_params},
+        %{"merge" => %{"target_id" => target_id}},
         socket
       ) do
-    {:noreply, assign(socket, :merge_changeset, merge_changeset(merge_params))}
-  end
-
-  def handle_event(
-        "select-merge-target",
-        %{"merge" => merge_params},
-        socket
-      ) do
-    merge_changeset = merge_changeset(merge_params)
-    target_id = merge_params["target_id"]
+    merge_changeset = merge_changeset(%{target_id: target_id})
 
     target_project =
       Enum.find(socket.assigns.workspace_projects, fn project ->
@@ -350,7 +367,7 @@ defmodule LightningWeb.SandboxLive.Index do
   @impl true
   def handle_event(
         "confirm-merge",
-        %{"merge" => merge_params},
+        %{"merge" => %{"target_id" => target_id}},
         %{
           assigns: %{
             merge_source_sandbox: source,
@@ -359,9 +376,6 @@ defmodule LightningWeb.SandboxLive.Index do
           }
         } = socket
       ) do
-    target_id = merge_params["target_id"]
-    delete_after_merge? = parse_delete_after_merge(merge_params)
-
     cond do
       is_nil(source) ->
         socket
@@ -397,14 +411,7 @@ defmodule LightningWeb.SandboxLive.Index do
 
               source
               |> perform_merge(target, actor, selected_ids)
-              |> handle_merge_result(
-                socket,
-                source,
-                target,
-                root_project,
-                actor,
-                delete_after_merge?
-              )
+              |> handle_merge_result(socket, source, target, root_project, actor)
             else
               socket
               |> put_flash(
@@ -539,10 +546,14 @@ defmodule LightningWeb.SandboxLive.Index do
             merge: false
           })
 
+        scheduled? = not is_nil(sandbox.scheduled_deletion)
+
         sandbox
-        |> Map.put(:can_edit, perms.update)
-        |> Map.put(:can_delete, perms.delete)
-        |> Map.put(:can_merge, perms.merge)
+        |> Map.put(:can_edit, perms.update and not scheduled?)
+        |> Map.put(:can_delete, perms.delete and not scheduled?)
+        |> Map.put(:can_merge, perms.merge and not scheduled?)
+        |> Map.put(:can_cancel_deletion, perms.delete and scheduled?)
+        |> Map.put(:scheduled_for_deletion?, scheduled?)
         |> Map.put(:is_current, project.id == sandbox.id)
       end)
 
@@ -574,10 +585,10 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp merge_changeset(params \\ %{}) do
-    types = %{target_id: :string, delete_after_merge: :boolean}
+    types = %{target_id: :string}
 
-    {%{delete_after_merge: true}, types}
-    |> Changeset.cast(params, [:target_id, :delete_after_merge])
+    {%{}, types}
+    |> Changeset.cast(params, [:target_id])
     |> Changeset.validate_required([:target_id])
   end
 
@@ -646,6 +657,35 @@ defmodule LightningWeb.SandboxLive.Index do
       "Failed to schedule sandbox deletion: #{inspect(reason)}"
     )
     |> assign(:confirm_delete_open?, false)
+  end
+
+  defp handle_cancel_deletion_result({:ok, _sandbox}, sandbox, socket) do
+    socket
+    |> put_flash(
+      :info,
+      "Cancelled deletion of sandbox #{sandbox.name}."
+    )
+    |> load_workspace_projects()
+  end
+
+  defp handle_cancel_deletion_result({:error, :unauthorized}, _sandbox, socket) do
+    put_flash(
+      socket,
+      :error,
+      "You are not authorized to cancel this sandbox's deletion"
+    )
+  end
+
+  defp handle_cancel_deletion_result({:error, :not_found}, _sandbox, socket) do
+    put_flash(socket, :error, "Sandbox not found")
+  end
+
+  defp handle_cancel_deletion_result({:error, reason}, _sandbox, socket) do
+    put_flash(
+      socket,
+      :error,
+      "Failed to cancel sandbox deletion: #{inspect(reason)}"
+    )
   end
 
   defp get_merge_target_options(socket, source_sandbox) do
@@ -869,13 +909,11 @@ defmodule LightningWeb.SandboxLive.Index do
          source,
          target,
          _root_project,
-         actor,
-         delete_after_merge?
+         actor
        ) do
     Lightning.Projects.SandboxPromExPlugin.fire_sandbox_merged_event()
 
-    flash_message =
-      build_merge_success_message(source, target, actor, delete_after_merge?)
+    flash_message = build_merge_success_message(source, target, actor)
 
     socket
     |> put_flash(:info, flash_message)
@@ -890,8 +928,7 @@ defmodule LightningWeb.SandboxLive.Index do
          _source,
          _target,
          _root,
-         _actor,
-         _delete_after_merge?
+         _actor
        ) do
     socket
     |> put_flash(:error, format_merge_error(reason))
@@ -899,7 +936,7 @@ defmodule LightningWeb.SandboxLive.Index do
     |> noreply()
   end
 
-  defp build_merge_success_message(source, target, actor, true) do
+  defp build_merge_success_message(source, target, actor) do
     case Sandboxes.schedule_sandbox_deletion(source, actor) do
       {:ok, _} ->
         "Successfully merged #{source.name} into #{target.name}. " <>
@@ -910,17 +947,6 @@ defmodule LightningWeb.SandboxLive.Index do
           "but could not schedule the sandbox for deletion."
     end
   end
-
-  defp build_merge_success_message(source, target, _actor, false) do
-    "Successfully merged #{source.name} into #{target.name}."
-  end
-
-  defp parse_delete_after_merge(%{"delete_after_merge" => "true"}), do: true
-  defp parse_delete_after_merge(%{"delete_after_merge" => "false"}), do: false
-  defp parse_delete_after_merge(%{"delete_after_merge" => true}), do: true
-  defp parse_delete_after_merge(%{"delete_after_merge" => false}), do: false
-  defp parse_delete_after_merge(%{"delete_after_merge" => "on"}), do: true
-  defp parse_delete_after_merge(_), do: true
 
   defp create_sandbox_tooltip_message(can_create_sandbox, limiter_result) do
     case {can_create_sandbox, limiter_result} do

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -616,9 +616,7 @@ defmodule LightningWeb.SandboxLive.Index do
       socket
       |> put_flash(
         :info,
-        "Sandbox #{deleted_sandbox.name} and its descendants have been " <>
-          "scheduled for deletion. They will be retained for " <>
-          "#{human_readable_grace_period()} before being permanently removed."
+        "Sandbox #{deleted_sandbox.name} scheduled for deletion."
       )
       |> reset_delete_modal_state()
 
@@ -905,8 +903,7 @@ defmodule LightningWeb.SandboxLive.Index do
     case Sandboxes.schedule_sandbox_deletion(source, actor) do
       {:ok, _} ->
         "Successfully merged #{source.name} into #{target.name}. " <>
-          "The sandbox has been scheduled for deletion and will be retained " <>
-          "for #{human_readable_grace_period()} before being permanently removed."
+          "Sandbox scheduled for deletion."
 
       {:error, _} ->
         "Successfully merged #{source.name} into #{target.name}, " <>
@@ -915,8 +912,7 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp build_merge_success_message(source, target, _actor, false) do
-    "Successfully merged #{source.name} into #{target.name}. " <>
-      "The sandbox has been kept and remains available for further work."
+    "Successfully merged #{source.name} into #{target.name}."
   end
 
   defp parse_delete_after_merge(%{"delete_after_merge" => "true"}), do: true
@@ -925,14 +921,6 @@ defmodule LightningWeb.SandboxLive.Index do
   defp parse_delete_after_merge(%{"delete_after_merge" => false}), do: false
   defp parse_delete_after_merge(%{"delete_after_merge" => "on"}), do: true
   defp parse_delete_after_merge(_), do: true
-
-  defp human_readable_grace_period do
-    case Lightning.Config.purge_deleted_after_days() do
-      nil -> "the configured grace period"
-      1 -> "1 day"
-      days when is_integer(days) -> "#{days} days"
-    end
-  end
 
   defp create_sandbox_tooltip_message(can_create_sandbox, limiter_result) do
     case {can_create_sandbox, limiter_result} do

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -682,14 +682,6 @@ defmodule LightningWeb.SandboxLive.Index do
     put_flash(socket, :error, "Sandbox not found")
   end
 
-  defp handle_cancel_deletion_result({:error, reason}, _sandbox, socket) do
-    put_flash(
-      socket,
-      :error,
-      "Failed to cancel sandbox deletion: #{inspect(reason)}"
-    )
-  end
-
   defp get_merge_target_options(socket, source_sandbox) do
     current_user = socket.assigns.current_user
     root_project = socket.assigns.root_project

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -632,7 +632,9 @@ defmodule LightningWeb.SandboxLive.Index do
       |> reset_delete_modal_state()
 
     if should_redirect do
-      push_navigate(socket_to_return, to: ~p"/projects/#{root_project.id}/w")
+      push_navigate(socket_to_return,
+        to: ~p"/projects/#{deleted_sandbox.parent_id}/sandboxes"
+      )
     else
       load_workspace_projects(socket_to_return)
     end

--- a/test/lightning/projects/sandbox_prom_ex_plugin_test.exs
+++ b/test/lightning/projects/sandbox_prom_ex_plugin_test.exs
@@ -12,10 +12,10 @@ defmodule Lightning.Projects.SandboxPromExPluginTest do
              ] = SandboxPromExPlugin.event_metrics([])
     end
 
-    test "returns five counter metrics" do
+    test "returns seven counter metrics" do
       [%{metrics: metrics}] = SandboxPromExPlugin.event_metrics([])
 
-      assert Enum.count(metrics) == 5
+      assert Enum.count(metrics) == 7
 
       assert Enum.all?(metrics, fn metric ->
                match?(%Telemetry.Metrics.Counter{}, metric)
@@ -56,7 +56,38 @@ defmodule Lightning.Projects.SandboxPromExPluginTest do
 
       assert %Telemetry.Metrics.Counter{
                name: [:lightning, :sandbox, :deleted, :count],
-               description: "Count of sandbox projects manually deleted.",
+               description:
+                 "Count of sandbox projects permanently deleted from the database (purged after the grace period or hard-deleted by an admin).",
+               tags: []
+             } = metric
+    end
+
+    test "contains sandbox scheduled-for-deletion counter metric" do
+      [%{metrics: metrics}] = SandboxPromExPlugin.event_metrics([])
+
+      metric =
+        find_metric(
+          metrics,
+          [:lightning, :sandbox, :scheduled_for_deletion, :count]
+        )
+
+      assert %Telemetry.Metrics.Counter{
+               name: [:lightning, :sandbox, :scheduled_for_deletion, :count],
+               tags: []
+             } = metric
+    end
+
+    test "contains sandbox deletion-cancelled counter metric" do
+      [%{metrics: metrics}] = SandboxPromExPlugin.event_metrics([])
+
+      metric =
+        find_metric(
+          metrics,
+          [:lightning, :sandbox, :deletion_cancelled, :count]
+        )
+
+      assert %Telemetry.Metrics.Counter{
+               name: [:lightning, :sandbox, :deletion_cancelled, :count],
                tags: []
              } = metric
     end
@@ -120,6 +151,28 @@ defmodule Lightning.Projects.SandboxPromExPluginTest do
       ref = :telemetry_test.attach_event_handlers(self(), [event])
 
       SandboxPromExPlugin.fire_sandbox_deleted_event()
+
+      assert_received {^event, ^ref, %{}, %{}}
+    end
+  end
+
+  describe "fire_sandbox_scheduled_for_deletion_event/0" do
+    test "emits telemetry event" do
+      event = [:lightning, :sandbox, :scheduled_for_deletion]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      SandboxPromExPlugin.fire_sandbox_scheduled_for_deletion_event()
+
+      assert_received {^event, ^ref, %{}, %{}}
+    end
+  end
+
+  describe "fire_sandbox_deletion_cancelled_event/0" do
+    test "emits telemetry event" do
+      event = [:lightning, :sandbox, :deletion_cancelled]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      SandboxPromExPlugin.fire_sandbox_deletion_cancelled_event()
 
       assert_received {^event, ^ref, %{}, %{}}
     end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -862,6 +862,15 @@ defmodule Lightning.ProjectsTest do
       refute Repo.get(Project, project_to_delete.id)
       assert Repo.get(Project, not_to_delete.id)
     end
+
+    test "no-ops when the per-project purge target was already cascaded" do
+      missing_id = Ecto.UUID.generate()
+
+      assert :ok =
+               Projects.perform(%Oban.Job{
+                 args: %{"project_id" => missing_id, "type" => "purge_deleted"}
+               })
+    end
   end
 
   describe "Projects.perform/1 for data retention periods" do
@@ -2651,6 +2660,41 @@ defmodule Lightning.ProjectsTest do
       # Should get both "duplicate" projects in alphabetical order
       names = Enum.map(descendants, & &1.name)
       assert names == ["duplicate", "duplicate", "other"]
+    end
+
+    test "excludes descendants with scheduled_deletion set" do
+      root = insert(:project, name: "root")
+      active = insert(:project, name: "active", parent: root)
+
+      _scheduled =
+        insert(:project,
+          name: "scheduled",
+          parent: root,
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      %{descendants: descendants} =
+        Projects.list_workspace_projects(root.id)
+
+      assert Enum.map(descendants, & &1.id) == [active.id]
+    end
+
+    test "excludes the entire subtree under a scheduled descendant" do
+      root = insert(:project, name: "root")
+
+      scheduled =
+        insert(:project,
+          name: "scheduled",
+          parent: root,
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      _grandchild = insert(:project, name: "grandchild", parent: scheduled)
+
+      %{descendants: descendants} =
+        Projects.list_workspace_projects(root.id)
+
+      assert descendants == []
     end
 
     test "raises when project doesn't exist" do

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -2662,11 +2662,11 @@ defmodule Lightning.ProjectsTest do
       assert names == ["duplicate", "duplicate", "other"]
     end
 
-    test "excludes descendants with scheduled_deletion set" do
+    test "includes descendants with scheduled_deletion set so the listing can offer cancel" do
       root = insert(:project, name: "root")
       active = insert(:project, name: "active", parent: root)
 
-      _scheduled =
+      scheduled =
         insert(:project,
           name: "scheduled",
           parent: root,
@@ -2676,10 +2676,11 @@ defmodule Lightning.ProjectsTest do
       %{descendants: descendants} =
         Projects.list_workspace_projects(root.id)
 
-      assert Enum.map(descendants, & &1.id) == [active.id]
+      ids = Enum.map(descendants, & &1.id) |> MapSet.new()
+      assert MapSet.equal?(ids, MapSet.new([active.id, scheduled.id]))
     end
 
-    test "excludes the entire subtree under a scheduled descendant" do
+    test "includes the subtree under a scheduled descendant" do
       root = insert(:project, name: "root")
 
       scheduled =
@@ -2689,12 +2690,13 @@ defmodule Lightning.ProjectsTest do
           scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
         )
 
-      _grandchild = insert(:project, name: "grandchild", parent: scheduled)
+      grandchild = insert(:project, name: "grandchild", parent: scheduled)
 
       %{descendants: descendants} =
         Projects.list_workspace_projects(root.id)
 
-      assert descendants == []
+      ids = Enum.map(descendants, & &1.id) |> MapSet.new()
+      assert MapSet.equal?(ids, MapSet.new([scheduled.id, grandchild.id]))
     end
 
     test "raises when project doesn't exist" do

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1913,4 +1913,223 @@ defmodule Lightning.Projects.SandboxesTest do
                Sandboxes.delete_sandbox(sandbox.id, actor)
     end
   end
+
+  describe "schedule_sandbox_deletion/2" do
+    test "sets scheduled_deletion on the target sandbox" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      assert {:ok, scheduled} =
+               Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      assert %DateTime{} = scheduled.scheduled_deletion
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion != nil
+    end
+
+    test "uses PURGE_DELETED_AFTER_DAYS to compute the grace period" do
+      previous = Application.get_env(:lightning, :purge_deleted_after_days)
+      Application.put_env(:lightning, :purge_deleted_after_days, 7)
+
+      on_exit(fn ->
+        Application.put_env(:lightning, :purge_deleted_after_days, previous)
+      end)
+
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      before = DateTime.utc_now()
+      {:ok, scheduled} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      diff_seconds = DateTime.diff(scheduled.scheduled_deletion, before)
+      assert diff_seconds in (7 * 86_400 - 5)..(7 * 86_400 + 5)
+    end
+
+    test "cascades scheduled_deletion to descendants" do
+      actor = insert(:user)
+      grandparent = insert(:project, name: "gp")
+      parent = insert(:project, name: "p", parent: grandparent)
+      child = insert(:project, name: "c", parent: parent)
+
+      for project <- [grandparent, parent, child] do
+        ensure_member!(project, actor, :owner)
+      end
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(grandparent, actor)
+
+      for project <- [grandparent, parent, child] do
+        assert Repo.get!(Project, project.id).scheduled_deletion != nil
+      end
+    end
+
+    test "disables enabled triggers across the subtree" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      child = insert(:project, name: "child", parent: parent)
+
+      for project <- [parent, child] do
+        ensure_member!(project, actor, :owner)
+      end
+
+      parent_workflow = insert(:workflow, project: parent)
+      child_workflow = insert(:workflow, project: child)
+
+      parent_trigger =
+        insert(:trigger,
+          workflow: parent_workflow,
+          type: :webhook,
+          enabled: true
+        )
+
+      child_trigger =
+        insert(:trigger, workflow: child_workflow, type: :webhook, enabled: true)
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(parent, actor)
+
+      refute Repo.get!(Trigger, parent_trigger.id).enabled
+      refute Repo.get!(Trigger, child_trigger.id).enabled
+    end
+
+    test "leaves projects outside the subtree untouched" do
+      actor = insert(:user)
+      sibling_root = insert(:project, name: "sibling_root")
+      target = insert(:project, name: "target")
+
+      ensure_member!(target, actor, :owner)
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(target, actor)
+
+      assert Repo.get!(Project, sibling_root.id).scheduled_deletion == nil
+    end
+
+    test "emits the sandbox deleted telemetry event" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      event = [:lightning, :sandbox, :deleted]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      assert_received {^event, ^ref, %{}, %{}}
+    end
+
+    test "returns :unauthorized when actor lacks delete_sandbox permission" do
+      actor = insert(:user)
+      sandbox = insert(:project, name: "no-perm")
+
+      event = [:lightning, :sandbox, :deleted]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      assert {:error, :unauthorized} =
+               Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion == nil
+      refute_received {^event, ^ref, %{}, %{}}
+    end
+
+    test "accepts a string ID" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      assert {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox.id, actor)
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion != nil
+    end
+
+    test "returns :not_found for an unknown string ID" do
+      actor = insert(:user)
+      non_existent_id = Ecto.UUID.generate()
+
+      assert {:error, :not_found} =
+               Sandboxes.schedule_sandbox_deletion(non_existent_id, actor)
+    end
+  end
+
+  describe "cancel_scheduled_sandbox_deletion/2" do
+    test "clears scheduled_deletion on the target sandbox" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion != nil
+
+      assert {:ok, restored} =
+               Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, actor)
+
+      assert restored.scheduled_deletion == nil
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion == nil
+    end
+
+    test "cascades the cancel through descendants" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      child = insert(:project, name: "child", parent: parent)
+      grandchild = insert(:project, name: "grandchild", parent: child)
+
+      for project <- [parent, child, grandchild] do
+        ensure_member!(project, actor, :owner)
+      end
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(parent, actor)
+      {:ok, _} = Sandboxes.cancel_scheduled_sandbox_deletion(parent, actor)
+
+      for project <- [parent, child, grandchild] do
+        assert Repo.get!(Project, project.id).scheduled_deletion == nil
+      end
+    end
+
+    test "is a no-op for sandboxes that aren't scheduled" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      assert {:ok, _} =
+               Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, actor)
+
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion == nil
+    end
+
+    test "returns :unauthorized when actor lacks delete_sandbox permission" do
+      actor = insert(:user)
+      sandbox = insert(:project, name: "no-perm")
+
+      assert {:error, :unauthorized} =
+               Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, actor)
+    end
+
+    test "accepts a string ID" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      assert {:ok, _} =
+               Sandboxes.cancel_scheduled_sandbox_deletion(sandbox.id, actor)
+
+      assert Repo.get!(Project, sandbox.id).scheduled_deletion == nil
+    end
+
+    test "returns :not_found for an unknown string ID" do
+      actor = insert(:user)
+      non_existent_id = Ecto.UUID.generate()
+
+      assert {:error, :not_found} =
+               Sandboxes.cancel_scheduled_sandbox_deletion(
+                 non_existent_id,
+                 actor
+               )
+    end
+  end
 end

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -2005,6 +2005,28 @@ defmodule Lightning.Projects.SandboxesTest do
       assert Repo.get!(Project, sibling_root.id).scheduled_deletion == nil
     end
 
+    test "scheduling a parent overwrites a child's earlier scheduled_deletion" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      child = insert(:project, name: "child", parent: parent)
+
+      for project <- [parent, child] do
+        ensure_member!(project, actor, :owner)
+      end
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(child, actor)
+      child_first_scheduled = Repo.get!(Project, child.id).scheduled_deletion
+      assert %DateTime{} = child_first_scheduled
+
+      :timer.sleep(1100)
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(parent, actor)
+      child_second_scheduled = Repo.get!(Project, child.id).scheduled_deletion
+
+      assert DateTime.compare(child_second_scheduled, child_first_scheduled) ==
+               :gt
+    end
+
     test "emits the sandbox deleted telemetry event" do
       actor = insert(:user)
       parent = insert(:project, name: "parent")
@@ -2097,6 +2119,27 @@ defmodule Lightning.Projects.SandboxesTest do
                Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, actor)
 
       assert Repo.get!(Project, sandbox.id).scheduled_deletion == nil
+    end
+
+    test "leaves un-scheduled siblings untouched when cancelling" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      scheduled_child = insert(:project, name: "scheduled", parent: parent)
+      active_sibling = insert(:project, name: "active", parent: parent)
+
+      for project <- [parent, scheduled_child, active_sibling] do
+        ensure_member!(project, actor, :owner)
+      end
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(scheduled_child, actor)
+
+      assert Repo.get!(Project, scheduled_child.id).scheduled_deletion != nil
+      assert Repo.get!(Project, active_sibling.id).scheduled_deletion == nil
+
+      {:ok, _} = Sandboxes.cancel_scheduled_sandbox_deletion(parent, actor)
+
+      assert Repo.get!(Project, scheduled_child.id).scheduled_deletion == nil
+      assert Repo.get!(Project, active_sibling.id).scheduled_deletion == nil
     end
 
     test "returns :unauthorized when actor lacks delete_sandbox permission" do

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -2027,7 +2027,21 @@ defmodule Lightning.Projects.SandboxesTest do
                :gt
     end
 
-    test "emits the sandbox deleted telemetry event" do
+    test "emits the sandbox scheduled-for-deletion telemetry event" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      event = [:lightning, :sandbox, :scheduled_for_deletion]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      assert_received {^event, ^ref, %{}, %{}}
+    end
+
+    test "does not emit the deleted event at schedule time" do
       actor = insert(:user)
       parent = insert(:project, name: "parent")
       sandbox = insert(:project, name: "sandbox", parent: parent)
@@ -2038,14 +2052,14 @@ defmodule Lightning.Projects.SandboxesTest do
 
       {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
 
-      assert_received {^event, ^ref, %{}, %{}}
+      refute_received {^event, ^ref, %{}, %{}}
     end
 
     test "returns :unauthorized when actor lacks delete_sandbox permission" do
       actor = insert(:user)
       sandbox = insert(:project, name: "no-perm")
 
-      event = [:lightning, :sandbox, :deleted]
+      event = [:lightning, :sandbox, :scheduled_for_deletion]
       ref = :telemetry_test.attach_event_handlers(self(), [event])
 
       assert {:error, :unauthorized} =
@@ -2119,6 +2133,22 @@ defmodule Lightning.Projects.SandboxesTest do
                Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, actor)
 
       assert Repo.get!(Project, sandbox.id).scheduled_deletion == nil
+    end
+
+    test "emits the deletion-cancelled telemetry event" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      {:ok, _} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      event = [:lightning, :sandbox, :deletion_cancelled]
+      ref = :telemetry_test.attach_event_handlers(self(), [event])
+
+      {:ok, _} = Sandboxes.cancel_scheduled_sandbox_deletion(sandbox, actor)
+
+      assert_received {^event, ^ref, %{}, %{}}
     end
 
     test "leaves un-scheduled siblings untouched when cancelling" do

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1948,6 +1948,26 @@ defmodule Lightning.Projects.SandboxesTest do
       assert diff_seconds in (7 * 86_400 - 5)..(7 * 86_400 + 5)
     end
 
+    test "schedules at now when PURGE_DELETED_AFTER_DAYS is nil" do
+      previous = Application.get_env(:lightning, :purge_deleted_after_days)
+      Application.put_env(:lightning, :purge_deleted_after_days, nil)
+
+      on_exit(fn ->
+        Application.put_env(:lightning, :purge_deleted_after_days, previous)
+      end)
+
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      sandbox = insert(:project, name: "sandbox", parent: parent)
+      ensure_member!(sandbox, actor, :owner)
+
+      before = DateTime.utc_now()
+      {:ok, scheduled} = Sandboxes.schedule_sandbox_deletion(sandbox, actor)
+
+      diff_seconds = DateTime.diff(scheduled.scheduled_deletion, before)
+      assert abs(diff_seconds) <= 5
+    end
+
     test "cascades scheduled_deletion to descendants" do
       actor = insert(:user)
       grandparent = insert(:project, name: "gp")

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -812,6 +812,77 @@ defmodule LightningWeb.SandboxLive.IndexTest do
     end
   end
 
+  describe "Scheduled-for-deletion sandboxes" do
+    setup :register_and_log_in_user
+
+    setup %{user: user} do
+      parent =
+        insert(:project,
+          name: "parent",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      scheduled =
+        insert(:project,
+          name: "scheduled",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      {:ok, parent: parent, scheduled: scheduled}
+    end
+
+    test "shows scheduled sandboxes with a deletion badge and cancel action",
+         %{conn: conn, parent: parent, scheduled: scheduled} do
+      {:ok, view, html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert html =~ "Scheduled for deletion"
+      assert has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      assert has_element?(view, "#cancel-deletion-sandbox-#{scheduled.id}")
+      refute has_element?(view, "#delete-sandbox-#{scheduled.id}")
+      refute has_element?(view, "#edit-sandbox-#{scheduled.id}")
+      refute has_element?(view, "#branch-rewire-sandbox-#{scheduled.id}")
+    end
+
+    test "cancelling deletion clears scheduled_deletion and refreshes the list",
+         %{conn: conn, parent: parent, scheduled: scheduled} do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#cancel-deletion-sandbox-#{scheduled.id} button")
+      |> render_click()
+
+      assert render(view) =~ "Cancelled deletion of sandbox #{scheduled.name}"
+      assert Repo.get!(Project, scheduled.id).scheduled_deletion == nil
+      refute has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      assert has_element?(view, "#delete-sandbox-#{scheduled.id}")
+    end
+
+    test "cancelling fails gracefully when actor lacks permission", %{
+      conn: conn,
+      parent: parent,
+      scheduled: scheduled
+    } do
+      other_user = insert(:user)
+      conn = log_in_user(conn, other_user)
+
+      _ =
+        Lightning.Projects.add_project_users(parent, [
+          %{user_id: other_user.id, role: :viewer}
+        ])
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+
+      refute has_element?(
+               view,
+               "#cancel-deletion-sandbox-#{scheduled.id} button:not([disabled])"
+             )
+    end
+  end
+
   describe "Merge modal functionality" do
     setup :register_and_log_in_user
 
@@ -1137,51 +1208,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert_redirect(view, ~p"/projects/#{root.id}/w")
     end
 
-    test "merge with delete_after_merge unchecked keeps the sandbox", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      Mimic.expect(
-        Lightning.Projects.MergeProjects,
-        :merge_project,
-        fn _source, _target, _opts -> "merged_yaml" end
-      )
-
-      Mimic.expect(
-        Lightning.Projects.Provisioner,
-        :import_document,
-        fn _target, _actor, _yaml, _opts -> {:ok, root} end
-      )
-
-      Mimic.reject(
-        Lightning.Projects.Sandboxes,
-        :schedule_sandbox_deletion,
-        2
-      )
-
-      Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
-      Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
-      Mimic.allow(Lightning.Projects, self(), view.pid)
-      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
-
-      view
-      |> element("#branch-rewire-sandbox-#{child1.id} button")
-      |> render_click()
-
-      {:ok, _view, html} =
-        view
-        |> form("#merge-sandbox-modal form")
-        |> render_submit(%{"merge" => %{"delete_after_merge" => "false"}})
-        |> follow_redirect(conn)
-
-      assert html =~ "Successfully merged"
-      refute html =~ "scheduled for deletion"
-      assert Repo.get!(Project, child1.id).scheduled_deletion == nil
-    end
-
     test "merge shows error on merge failure", %{
       conn: conn,
       root: root,
@@ -1246,59 +1272,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       assert html =~ "child sandboxes will also be deleted"
-    end
-
-    test "toggling delete-after-merge off hides the deletion warning", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      view
-      |> element("#branch-rewire-sandbox-#{child1.id} button")
-      |> render_click()
-
-      assert has_element?(view, "#merge-deletion-warning")
-
-      view
-      |> form("#merge-sandbox-modal form")
-      |> render_change(%{
-        "_target" => ["merge", "delete_after_merge"],
-        "merge" => %{
-          "target_id" => root.id,
-          "delete_after_merge" => "false"
-        }
-      })
-
-      refute has_element?(view, "#merge-deletion-warning")
-    end
-
-    test "toggling delete-after-merge does not rebuild the workflow list", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      view
-      |> element("#branch-rewire-sandbox-#{child1.id} button")
-      |> render_click()
-
-      Mimic.reject(Lightning.Projects.MergeProjects, :diverged_workflows, 2)
-      Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
-
-      view
-      |> form("#merge-sandbox-modal form")
-      |> render_change(%{
-        "_target" => ["merge", "delete_after_merge"],
-        "merge" => %{
-          "target_id" => root.id,
-          "delete_after_merge" => "false"
-        }
-      })
-
-      refute has_element?(view, "#merge-deletion-warning")
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -990,65 +990,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert html =~ child1.name
     end
 
-    test "merge sentence: leaf sandbox has no gap before period", %{
-      conn: conn,
-      root: root,
-      child2: child2
-    } do
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      view
-      |> element("#branch-rewire-sandbox-#{child2.id} button")
-      |> render_click()
-
-      html = render(view)
-
-      refute html =~ ~r{<strong>child2</strong>\s+\.},
-             "visible space between sandbox name and period for leaf sandbox"
-
-      assert html =~ "<strong>child2</strong>."
-
-      refute html =~ "phx-no-format",
-             "formatter directive leaked into rendered HTML"
-    end
-
-    test "merge sentence: single descendant has space and bolded child name",
-         %{conn: conn, root: root, grandchild1: grandchild1, user: user} do
-      _great =
-        insert(:project,
-          name: "great-grandchild",
-          parent: grandchild1,
-          project_users: [%{user: user, role: :owner}]
-        )
-
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      view
-      |> element("#branch-rewire-sandbox-#{grandchild1.id} button")
-      |> render_click()
-
-      html = render(view)
-
-      assert html =~
-               "<strong>grandchild1</strong> and its child sandbox <strong>great-grandchild</strong>."
-    end
-
-    test "merge sentence: multiple descendants mentions count", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
-      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
-
-      view
-      |> element("#branch-rewire-sandbox-#{child1.id} button")
-      |> render_click()
-
-      html = render(view)
-
-      assert html =~ "<strong>child1</strong> and its 2 child sandboxes."
-    end
-
     test "merge modal shows correct dropdown options", %{
       conn: conn,
       root: root,
@@ -1306,6 +1247,63 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       assert html =~ "child sandboxes will also be scheduled for deletion"
+    end
+
+    test "toggling delete-after-merge off hides the descendants notice", %{
+      conn: conn,
+      root: root,
+      child1: child1
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{child1.id} button")
+      |> render_click()
+
+      assert render(view) =~
+               "child sandboxes will also be scheduled for deletion"
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_change(%{
+        "_target" => ["merge", "delete_after_merge"],
+        "merge" => %{
+          "target_id" => root.id,
+          "delete_after_merge" => "false"
+        }
+      })
+
+      html = render(view)
+
+      refute html =~ "child sandboxes will also be scheduled for deletion"
+      assert html =~ "stays available after the merge"
+    end
+
+    test "toggling delete-after-merge does not rebuild the workflow list", %{
+      conn: conn,
+      root: root,
+      child1: child1
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{child1.id} button")
+      |> render_click()
+
+      Mimic.reject(Lightning.Projects.MergeProjects, :diverged_workflows, 2)
+      Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_change(%{
+        "_target" => ["merge", "delete_after_merge"],
+        "merge" => %{
+          "target_id" => root.id,
+          "delete_after_merge" => "false"
+        }
+      })
+
+      assert render(view) =~ "Sandbox will be kept"
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -970,7 +970,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       assert html =~ great_grandchild.name
-      assert html =~ "will also be scheduled for deletion"
+      assert html =~ "will also be permanently closed"
     end
 
     test "merge modal shows multiple descendants warning with full list", %{
@@ -986,7 +986,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "child sandboxes will also be scheduled for deletion"
+      assert html =~ "child sandboxes will also be permanently closed"
       assert html =~ child1.name
     end
 
@@ -1246,10 +1246,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "child sandboxes will also be scheduled for deletion"
+      assert html =~ "child sandboxes will also be permanently closed"
     end
 
-    test "toggling delete-after-merge off hides the descendants notice", %{
+    test "toggling delete-after-merge off hides the deletion warning", %{
       conn: conn,
       root: root,
       child1: child1
@@ -1260,8 +1260,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> element("#branch-rewire-sandbox-#{child1.id} button")
       |> render_click()
 
-      assert render(view) =~
-               "child sandboxes will also be scheduled for deletion"
+      assert has_element?(view, "#merge-beta-warning")
 
       view
       |> form("#merge-sandbox-modal form")
@@ -1273,10 +1272,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         }
       })
 
-      html = render(view)
-
-      refute html =~ "child sandboxes will also be scheduled for deletion"
-      assert html =~ "stays available after the merge"
+      refute has_element?(view, "#merge-beta-warning")
     end
 
     test "toggling delete-after-merge does not rebuild the workflow list", %{
@@ -1303,7 +1299,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         }
       })
 
-      assert render(view) =~ "stays available after the merge"
+      refute has_element?(view, "#merge-beta-warning")
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1197,6 +1197,51 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert_redirect(view, ~p"/projects/#{root.id}/w")
     end
 
+    test "merge with delete_after_merge unchecked keeps the sandbox", %{
+      conn: conn,
+      root: root,
+      child1: child1
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      Mimic.expect(
+        Lightning.Projects.MergeProjects,
+        :merge_project,
+        fn _source, _target, _opts -> "merged_yaml" end
+      )
+
+      Mimic.expect(
+        Lightning.Projects.Provisioner,
+        :import_document,
+        fn _target, _actor, _yaml, _opts -> {:ok, root} end
+      )
+
+      Mimic.reject(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        2
+      )
+
+      Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
+      Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
+
+      view
+      |> element("#branch-rewire-sandbox-#{child1.id} button")
+      |> render_click()
+
+      {:ok, _view, html} =
+        view
+        |> form("#merge-sandbox-modal form")
+        |> render_submit(%{"merge" => %{"delete_after_merge" => "false"}})
+        |> follow_redirect(conn)
+
+      assert html =~ "The sandbox has been kept"
+      refute html =~ "scheduled for deletion"
+      assert Repo.get!(Project, child1.id).scheduled_deletion == nil
+    end
+
     test "merge shows error on merge failure", %{
       conn: conn,
       root: root,

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1303,7 +1303,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         }
       })
 
-      assert render(view) =~ "Keep sandbox after merging"
+      assert render(view) =~ "stays available after the merge"
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1259,7 +1259,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> element("#branch-rewire-sandbox-#{child1.id} button")
       |> render_click()
 
-      assert has_element?(view, "#merge-beta-warning")
+      assert has_element?(view, "#merge-deletion-warning")
 
       view
       |> form("#merge-sandbox-modal form")
@@ -1271,7 +1271,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         }
       })
 
-      refute has_element?(view, "#merge-beta-warning")
+      refute has_element?(view, "#merge-deletion-warning")
     end
 
     test "toggling delete-after-merge does not rebuild the workflow list", %{
@@ -1298,7 +1298,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         }
       })
 
-      refute has_element?(view, "#merge-beta-warning")
+      refute has_element?(view, "#merge-deletion-warning")
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -970,7 +970,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       assert html =~ great_grandchild.name
-      assert html =~ "will also be permanently closed"
+      assert html =~ "will also be deleted"
     end
 
     test "merge modal shows multiple descendants warning with full list", %{
@@ -986,7 +986,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "child sandboxes will also be permanently closed"
+      assert html =~ "child sandboxes will also be deleted"
       assert html =~ child1.name
     end
 
@@ -1246,7 +1246,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "child sandboxes will also be permanently closed"
+      assert html =~ "child sandboxes will also be deleted"
     end
 
     test "toggling delete-after-merge off hides the deletion warning", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1303,7 +1303,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         }
       })
 
-      assert render(view) =~ "Sandbox will be kept"
+      assert render(view) =~ "Keep sandbox after merging"
     end
 
     test "sibling can be selected as merge target", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -312,12 +312,15 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       {:ok, view, _} =
         live(conn, ~p"/projects/#{parent.id}/sandboxes", on_error: :raise)
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn %Project{id: id},
-                                                           user_arg ->
-        assert id == sb1.id
-        assert user_arg.id == user.id
-        {:ok, %Project{}}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn %Project{id: id}, user_arg ->
+          assert id == sb1.id
+          assert user_arg.id == user.id
+          {:ok, %Project{}}
+        end
+      )
 
       Mimic.expect(Lightning.Projects, :list_workspace_projects, fn id ->
         assert id == parent.id
@@ -329,6 +332,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       end)
 
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view |> element("#delete-sandbox-#{sb1.id} button") |> render_click()
 
@@ -338,21 +342,22 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> render_submit()
 
       assert html =~
-               "Sandbox #{sb1.name} and all its associated descendants deleted"
+               "Sandbox #{sb1.name} and its descendants have been scheduled for deletion."
 
       assert has_element?(view, "#edit-sandbox-#{sb2.id}")
 
       target_id = sb2.id
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn %Project{
-                                                             id: ^target_id
-                                                           },
-                                                           user_arg ->
-        assert user_arg.id == user.id
-        {:error, :unauthorized}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn %Project{id: ^target_id}, user_arg ->
+          assert user_arg.id == user.id
+          {:error, :unauthorized}
+        end
+      )
 
-      Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view |> element("#delete-sandbox-#{target_id} button") |> render_click()
 
@@ -363,15 +368,16 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       assert html =~ "You don&#39;t have permission to delete this sandbox"
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn %Project{
-                                                             id: ^target_id
-                                                           },
-                                                           user_arg ->
-        assert user_arg.id == user.id
-        {:error, :not_found}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn %Project{id: ^target_id}, user_arg ->
+          assert user_arg.id == user.id
+          {:error, :not_found}
+        end
+      )
 
-      Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view |> element("#delete-sandbox-#{target_id} button") |> render_click()
 
@@ -382,15 +388,16 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       assert html =~ "Sandbox not found"
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn %Project{
-                                                             id: ^target_id
-                                                           },
-                                                           user_arg ->
-        assert user_arg.id == user.id
-        {:error, :boom}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn %Project{id: ^target_id}, user_arg ->
+          assert user_arg.id == user.id
+          {:error, :boom}
+        end
+      )
 
-      Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view |> element("#delete-sandbox-#{target_id} button") |> render_click()
 
@@ -399,7 +406,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> form("#confirm-delete-sandbox form", confirm: %{"name" => sb2.name})
         |> render_submit()
 
-      assert html =~ "Failed to delete sandbox: "
+      assert html =~ "Failed to schedule sandbox deletion: "
     end
 
     test "open-delete-modal with unknown id shows flash", %{
@@ -728,11 +735,15 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       {:ok, view, _} =
         live(conn, ~p"/projects/#{grandchild_sandbox.id}/sandboxes")
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn sandbox, user_arg ->
-        assert sandbox.id == child_sandbox.id
-        assert user_arg.id == user.id
-        {:ok, %Project{}}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn sandbox, user_arg ->
+          assert sandbox.id == child_sandbox.id
+          assert user_arg.id == user.id
+          {:ok, %Project{}}
+        end
+      )
 
       Mimic.expect(Lightning.Projects, :descendant_of?, fn current,
                                                            deleted,
@@ -744,6 +755,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       end)
 
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#delete-sandbox-#{child_sandbox.id} button")
@@ -767,10 +779,14 @@ defmodule LightningWeb.SandboxLive.IndexTest do
          } do
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn sandbox, _user_arg ->
-        assert sandbox.id == child_sandbox.id
-        {:ok, %Project{}}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn sandbox, _user_arg ->
+          assert sandbox.id == child_sandbox.id
+          {:ok, %Project{}}
+        end
+      )
 
       Mimic.expect(Lightning.Projects, :list_workspace_projects, fn id ->
         assert id == parent.id
@@ -778,6 +794,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       end)
 
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#delete-sandbox-#{child_sandbox.id} button")
@@ -953,7 +970,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       html = render(view)
 
       assert html =~ great_grandchild.name
-      assert html =~ "will also be permanently closed"
+      assert html =~ "will also be scheduled for deletion"
     end
 
     test "merge modal shows multiple descendants warning with full list", %{
@@ -969,7 +986,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "child sandboxes will also be permanently closed"
+      assert html =~ "child sandboxes will also be scheduled for deletion"
       assert html =~ child1.name
     end
 
@@ -1154,15 +1171,20 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         end
       )
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn source, actor ->
-        assert source.id == child1.id
-        assert actor.id == user.id
-        {:ok, source}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn source, actor ->
+          assert source.id == child1.id
+          assert actor.id == user.id
+          {:ok, source}
+        end
+      )
 
       Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
       Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#branch-rewire-sandbox-#{child1.id} button")
@@ -1238,7 +1260,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "child sandboxes will also be permanently closed"
+      assert html =~ "child sandboxes will also be scheduled for deletion"
     end
 
     test "sibling can be selected as merge target", %{
@@ -1339,7 +1361,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
-    test "shows partial success when merge succeeds but delete fails", %{
+    test "shows partial success when merge succeeds but schedule fails", %{
       conn: conn,
       root: root,
       child1: child1,
@@ -1360,13 +1382,18 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         {:ok, root}
       end)
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn _source, _actor ->
-        {:error, :unauthorized}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn _source, _actor ->
+          {:error, :unauthorized}
+        end
+      )
 
       Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
       Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#branch-rewire-sandbox-#{child1.id} button")
@@ -1379,7 +1406,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> follow_redirect(conn)
 
       assert html =~
-               "Successfully merged child1 into root, but could not delete the sandbox"
+               "Successfully merged child1 into root, but could not schedule the sandbox for deletion."
     end
 
     test "formats changeset error correctly", %{
@@ -1548,9 +1575,13 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         {:ok, target}
       end)
 
-      Mimic.expect(Lightning.Projects, :delete_sandbox, fn source, _actor ->
-        {:ok, source}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn source, _actor ->
+          {:ok, source}
+        end
+      )
     end
 
     test "new collections in sandbox are created in parent on merge", %{
@@ -1566,6 +1597,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
       Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#branch-rewire-sandbox-#{sandbox.id} button")
@@ -1594,6 +1626,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
       Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#branch-rewire-sandbox-#{sandbox.id} button")
@@ -1622,6 +1655,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
       Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#branch-rewire-sandbox-#{sandbox.id} button")
@@ -1825,14 +1859,15 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       )
 
       Mimic.expect(
-        Lightning.Projects,
-        :delete_sandbox,
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
         fn _source, _actor -> {:ok, sandbox} end
       )
 
       Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
       Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
       Mimic.allow(Lightning.Projects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
       |> element("#branch-rewire-sandbox-#{sandbox.id} button")

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -341,8 +341,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> form("#confirm-delete-sandbox form", confirm: %{"name" => sb1.name})
         |> render_submit()
 
-      assert html =~
-               "Sandbox #{sb1.name} and its descendants have been scheduled for deletion."
+      assert html =~ "Sandbox #{sb1.name} scheduled for deletion."
 
       assert has_element?(view, "#edit-sandbox-#{sb2.id}")
 
@@ -1178,7 +1177,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> render_submit(%{"merge" => %{"delete_after_merge" => "false"}})
         |> follow_redirect(conn)
 
-      assert html =~ "The sandbox has been kept"
+      assert html =~ "Successfully merged"
       refute html =~ "scheduled for deletion"
       assert Repo.get!(Project, child1.id).scheduled_deletion == nil
     end

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -887,7 +887,12 @@ defmodule LightningWeb.SandboxLive.IndexTest do
                ~s(#scheduled-for-deletion-section #sandbox-card-#{scheduled.id}[aria-disabled="true"])
              )
 
-      assert has_element?(view, "#cancel-deletion-sandbox-#{scheduled.id}")
+      assert has_element?(
+               view,
+               "#cancel-deletion-sandbox-#{scheduled.id} button",
+               "Restore"
+             )
+
       refute has_element?(view, "#delete-sandbox-#{scheduled.id}")
       refute has_element?(view, "#edit-sandbox-#{scheduled.id}")
       refute has_element?(view, "#branch-rewire-sandbox-#{scheduled.id}")

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -766,7 +766,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       )
       |> render_submit()
 
-      assert_redirect(view, ~p"/projects/#{parent.id}/w")
+      assert_redirect(view, ~p"/projects/#{parent.id}/sandboxes")
     end
 
     test "deleting sandbox does not redirect when current project is not descendant",

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -485,6 +485,45 @@ defmodule LightningWeb.SandboxLive.IndexTest do
              |> has_element?()
     end
 
+    test "delete modal mentions the configured grace period when no purge window is set",
+         %{conn: conn, parent: parent, sb1: sb1} do
+      previous = Application.get_env(:lightning, :purge_deleted_after_days)
+      Application.put_env(:lightning, :purge_deleted_after_days, nil)
+
+      on_exit(fn ->
+        Application.put_env(:lightning, :purge_deleted_after_days, previous)
+      end)
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      html =
+        view
+        |> element("#delete-sandbox-#{sb1.id} button")
+        |> render_click()
+
+      assert html =~ "the configured grace period"
+    end
+
+    test "delete modal uses singular '1 day' when grace period is one day",
+         %{conn: conn, parent: parent, sb1: sb1} do
+      previous = Application.get_env(:lightning, :purge_deleted_after_days)
+      Application.put_env(:lightning, :purge_deleted_after_days, 1)
+
+      on_exit(fn ->
+        Application.put_env(:lightning, :purge_deleted_after_days, previous)
+      end)
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      html =
+        view
+        |> element("#delete-sandbox-#{sb1.id} button")
+        |> render_click()
+
+      assert html =~ "retained for 1 day "
+      refute html =~ "retained for 1 days"
+    end
+
     test "confirm-delete-validate ignores event when no sandbox selected" do
       socket = %Phoenix.LiveView.Socket{
         assigns: %{
@@ -845,6 +884,68 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute has_element?(view, "#branch-rewire-sandbox-#{scheduled.id}")
     end
 
+    test "shows the env badge on a scheduled sandbox card", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "p-env",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      scheduled =
+        insert(:project,
+          name: "scheduled-with-env",
+          env: "production",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert has_element?(view, "#env-badge-#{scheduled.id}", "production")
+    end
+
+    test "shows the active badge when the current project gets scheduled mid-session",
+         %{conn: conn, user: user} do
+      grandparent =
+        insert(:project,
+          name: "gp-active",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      current =
+        insert(:project,
+          name: "current-mid-session",
+          parent: grandparent,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      sibling =
+        insert(:project,
+          name: "sibling",
+          parent: grandparent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{current.id}/sandboxes")
+
+      Repo.update!(
+        Ecto.Changeset.change(current,
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+      )
+
+      view
+      |> element("#cancel-deletion-sandbox-#{sibling.id} button")
+      |> render_click()
+
+      assert has_element?(view, "#active-badge-#{current.id}", "active")
+    end
+
     test "cancelling deletion clears scheduled_deletion and refreshes the list",
          %{conn: conn, parent: parent, scheduled: scheduled} do
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
@@ -880,6 +981,164 @@ defmodule LightningWeb.SandboxLive.IndexTest do
                view,
                "#cancel-deletion-sandbox-#{scheduled.id} button:not([disabled])"
              )
+    end
+
+    test "cancel-sandbox-deletion with an unknown id flashes a not-found error",
+         %{conn: conn, parent: parent} do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      html =
+        render_click(view, "cancel-sandbox-deletion", %{
+          "id" => Ecto.UUID.generate()
+        })
+
+      assert html =~ "Sandbox not found"
+    end
+
+    test "flashes an unauthorized error when the context refuses the cancel",
+         %{conn: conn, parent: parent, scheduled: scheduled} do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :cancel_scheduled_sandbox_deletion,
+        fn _sandbox, _actor -> {:error, :unauthorized} end
+      )
+
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
+
+      html =
+        view
+        |> element("#cancel-deletion-sandbox-#{scheduled.id} button")
+        |> render_click()
+
+      assert html =~
+               "You are not authorized to cancel this sandbox&#39;s deletion"
+    end
+
+    test "flashes a not-found error when the sandbox vanished before the cancel",
+         %{conn: conn, parent: parent, scheduled: scheduled} do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :cancel_scheduled_sandbox_deletion,
+        fn _sandbox, _actor -> {:error, :not_found} end
+      )
+
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
+
+      html =
+        view
+        |> element("#cancel-deletion-sandbox-#{scheduled.id} button")
+        |> render_click()
+
+      assert html =~ "Sandbox not found"
+    end
+
+    test "tooltip shows the day count when scheduled more than a day out", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "p-multi-day",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      _scheduled =
+        insert(:project,
+          name: "later",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion:
+            DateTime.utc_now()
+            |> DateTime.add(5, :day)
+            |> DateTime.truncate(:second)
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert html =~ ~r/\(in \d+ days\)/
+    end
+
+    test "tooltip shows '1 day' when scheduled exactly one day out", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "p-1day",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      _scheduled =
+        insert(:project,
+          name: "soon",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion:
+            DateTime.utc_now()
+            |> DateTime.add(1, :day)
+            |> DateTime.truncate(:second)
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert html =~ "(in 1 day)"
+    end
+
+    test "tooltip shows '(today)' when scheduled within the same day", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "p-today",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      _scheduled =
+        insert(:project,
+          name: "now",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion:
+            DateTime.utc_now()
+            |> DateTime.add(2, :hour)
+            |> DateTime.truncate(:second)
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert html =~ "(today)"
+    end
+
+    test "tooltip omits the relative suffix when scheduled in the past", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "p-past",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      scheduled =
+        insert(:project,
+          name: "overdue",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}],
+          scheduled_deletion:
+            DateTime.utc_now()
+            |> DateTime.add(-2, :day)
+            |> DateTime.truncate(:second)
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      assert has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      refute render(view) =~ "(in"
     end
   end
 

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -872,12 +872,21 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       {:ok, parent: parent, scheduled: scheduled}
     end
 
-    test "shows scheduled sandboxes with a deletion badge and cancel action",
+    test "lists scheduled sandboxes under a separate section with the cancel action",
          %{conn: conn, parent: parent, scheduled: scheduled} do
-      {:ok, view, html} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
 
-      assert html =~ "Scheduled for deletion"
-      assert has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      assert has_element?(
+               view,
+               "#scheduled-for-deletion-section",
+               "Scheduled for deletion"
+             )
+
+      assert has_element?(
+               view,
+               ~s(#scheduled-for-deletion-section #sandbox-card-#{scheduled.id}[aria-disabled="true"])
+             )
+
       assert has_element?(view, "#cancel-deletion-sandbox-#{scheduled.id}")
       refute has_element?(view, "#delete-sandbox-#{scheduled.id}")
       refute has_element?(view, "#edit-sandbox-#{scheduled.id}")
@@ -956,7 +965,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       assert render(view) =~ "Cancelled deletion of sandbox #{scheduled.name}"
       assert Repo.get!(Project, scheduled.id).scheduled_deletion == nil
-      refute has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      refute has_element?(view, "#scheduled-for-deletion-section")
       assert has_element?(view, "#delete-sandbox-#{scheduled.id}")
     end
 
@@ -975,7 +984,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
 
-      assert has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      assert has_element?(
+               view,
+               ~s(#sandbox-card-#{scheduled.id}[aria-disabled="true"])
+             )
 
       refute has_element?(
                view,
@@ -1137,7 +1149,11 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
 
-      assert has_element?(view, "#scheduled-deletion-badge-#{scheduled.id}")
+      assert has_element?(
+               view,
+               ~s(#sandbox-card-#{scheduled.id}[aria-disabled="true"])
+             )
+
       refute render(view) =~ "(in"
     end
   end


### PR DESCRIPTION
## Description

Sandbox deletion, both manual and automatic-after-merge, now happens softly. The sandbox and its descendant subtree are scheduled for deletion and stay around for a grace period (configurable via `PURGE_DELETED_AFTER_DAYS`, default 7 days) before the existing project purge worker permanently removes them. This mirrors how credentials and root projects already work, so accidental deletions can be recovered by a workspace administrator from `/settings/projects`.

The merge modal also has a new "Delete sandbox after merging" toggle, default on. Turning it off keeps the sandbox alive after the merge for ongoing work, picking up the opt-out behaviour proposed in the issue's comments.

End-user cancel UI is intentionally not in this PR. We did not want a sandbox-only recovery affordance while project owners still can't self-cancel either; #4673 tracks adding self-serve cancel for both projects and sandboxes together so they stay consistent.

Closes #4649

## Validation steps

1. Create a sandbox, delete it from the sandboxes tab. Confirm the sandbox disappears from the list, the database row has its scheduled-deletion timestamp set, and triggers in the subtree are disabled.
2. From the superuser `/settings/projects` page, click "Cancel deletion" on the sandbox row. Confirm the sandbox reappears under the parent's sandboxes tab and the timestamp is cleared on the whole subtree.
3. Merge a sandbox into its parent with the toggle on (default). Confirm the flash mentions the merge succeeded plus the deletion was scheduled, and the sandbox is hidden from the list afterwards.
4. Merge a sandbox with the toggle off. Confirm the merge happens, the sandbox stays in the list, and nothing was scheduled for deletion.
5. Create a parent sandbox with descendants, schedule it for deletion, advance time past the grace window, and trigger the purge worker. Confirm the entire subtree is purged.

## Additional notes for the reviewer

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR

