### PR TITLE
Disable browser autocomplete on non-auth input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to
 
 ### Fixed
 
+- Only allow auto-completion in relevant input fields
+  [#1553](https://github.com/OpenFn/lightning/issues/1553)
+
 ## [2.16.2] - 2026-04-20
 
 ## [2.16.2-pre1] - 2026-04-20

--- a/assets/js/collaborative-editor/components/SearchableList/SearchableList.tsx
+++ b/assets/js/collaborative-editor/components/SearchableList/SearchableList.tsx
@@ -58,6 +58,7 @@ export function SearchableList({
           aria-controls={listboxId}
           aria-activedescendant={activeDescendantId}
           aria-autocomplete="list"
+          autoComplete="off"
           className="block w-full rounded-md border-secondary-300
             pl-10 pr-10 shadow-xs sm:text-sm
             focus:border-primary-300 focus:ring

--- a/assets/js/collaborative-editor/components/SessionList.tsx
+++ b/assets/js/collaborative-editor/components/SessionList.tsx
@@ -125,6 +125,7 @@ export function SessionList({
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               placeholder="Search conversations..."
+              autoComplete="off"
               className={cn(
                 'w-full h-[34px] pl-9 pr-3 text-sm',
                 'bg-gray-50 border border-gray-200 rounded-lg',

--- a/assets/js/collaborative-editor/components/VersionPicker.tsx
+++ b/assets/js/collaborative-editor/components/VersionPicker.tsx
@@ -140,6 +140,7 @@ export function VersionPicker({
           role="combobox"
           aria-expanded={isOpen}
           aria-controls="version-listbox"
+          autoComplete="off"
         />
         <button
           type="button"

--- a/assets/js/collaborative-editor/components/form/number-field.tsx
+++ b/assets/js/collaborative-editor/components/form/number-field.tsx
@@ -67,6 +67,7 @@ export function NumberField({
         disabled={disabled}
         min={min}
         max={max}
+        autoComplete="off"
         className={INPUT_CLASSES}
       />
     </FormField>

--- a/assets/js/collaborative-editor/components/form/text-field.tsx
+++ b/assets/js/collaborative-editor/components/form/text-field.tsx
@@ -21,6 +21,7 @@ export function TextField({
         onChange={e => field.handleChange(e.target.value)}
         disabled={disabled}
         placeholder={placeholder}
+        autoComplete="off"
         className={INPUT_CLASSES}
       />
     </FormField>

--- a/assets/js/collaborative-editor/components/inspector/CronFieldBuilder.tsx
+++ b/assets/js/collaborative-editor/components/inspector/CronFieldBuilder.tsx
@@ -756,6 +756,7 @@ export function CronFieldBuilder({
             <input
               id="cron-expression"
               type="text"
+              autoComplete="off"
               value={value}
               onChange={e => {
                 onChange(e.target.value);

--- a/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
+++ b/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
@@ -239,6 +239,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                           value={webhookUrl}
                           readOnly
                           disabled
+                          autoComplete="off"
                           className="block w-full flex-1 rounded-l-lg
                             text-slate-900 disabled:bg-gray-50
                             disabled:text-gray-500 border border-r-0
@@ -582,6 +583,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                               onChange={e => field.handleChange(e.target.value)}
                               onBlur={field.handleBlur}
                               disabled={isReadOnly}
+                              autoComplete="off"
                               placeholder="localhost:9092, broker2:9092"
                               className={`
                                   block w-full px-3 py-2 border rounded-md text-sm
@@ -626,6 +628,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                               onChange={e => field.handleChange(e.target.value)}
                               onBlur={field.handleBlur}
                               disabled={isReadOnly}
+                              autoComplete="off"
                               placeholder="topic1, topic2, topic3"
                               className={`
                                   block w-full px-3 py-2 border rounded-md text-sm
@@ -769,6 +772,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                                       }
                                       onBlur={field.handleBlur}
                                       disabled={isReadOnly}
+                                      autoComplete="off"
                                       className={`
                                           block w-full px-3 py-2 border rounded-md text-sm
                                           ${
@@ -811,6 +815,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                                       }
                                       onBlur={field.handleBlur}
                                       disabled={isReadOnly}
+                                      autoComplete="off"
                                       className={`
                                           block w-full px-3 py-2 border rounded-md text-sm
                                           ${
@@ -928,6 +933,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                                   }
                                   onBlur={field.handleBlur}
                                   disabled={isReadOnly}
+                                  autoComplete="off"
                                   className={`
                                         block w-full px-3 py-2 border rounded-md text-sm
                                         ${

--- a/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
+++ b/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
@@ -239,7 +239,6 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                           value={webhookUrl}
                           readOnly
                           disabled
-                          autoComplete="off"
                           className="block w-full flex-1 rounded-l-lg
                             text-slate-900 disabled:bg-gray-50
                             disabled:text-gray-500 border border-r-0

--- a/assets/js/collaborative-editor/components/left-panel/TemplateSearchInput.tsx
+++ b/assets/js/collaborative-editor/components/left-panel/TemplateSearchInput.tsx
@@ -88,6 +88,7 @@ export function TemplateSearchInput({
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
+        autoComplete="off"
         className={cn(
           'block w-full pl-10 pr-10 py-2 border border-gray-300 rounded-lg',
           'text-sm placeholder-gray-400',

--- a/assets/js/collaborative-editor/components/manual-run/SelectedDataclipView.tsx
+++ b/assets/js/collaborative-editor/components/manual-run/SelectedDataclipView.tsx
@@ -72,6 +72,7 @@ export function SelectedDataclipView({
               <input
                 type="text"
                 value={editedName}
+                autoComplete="off"
                 onChange={e => setEditedName(e.target.value)}
                 onKeyDown={e => {
                   if (e.key === 'Enter' && !isSaving) {

--- a/assets/js/manual-run-panel/views/ExistingView.tsx
+++ b/assets/js/manual-run-panel/views/ExistingView.tsx
@@ -109,6 +109,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
                   setQuery(e.target.value);
                 }}
                 type="text"
+                autoComplete="off"
                 className="focus:outline focus:outline-2 focus:-outline-offset-2 focus:ring-0  disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 border-slate-300 focus:border-slate-400 focus:outline-indigo-600 block w-full rounded-l-md border-0 border-r-0 py-1.5 pl-10 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400  focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                 placeholder="Search names or UUID prefixes"
               />
@@ -164,6 +165,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
                     <input
                       value={selectedDates.after}
                       id="created-after"
+                      autoComplete="off"
                       onChange={e => {
                         setSelectedDates(p => ({
                           after: e.target.value,
@@ -179,6 +181,7 @@ const ExistingView: React.FC<ExistingViewProps> = ({
                     <input
                       value={selectedDates.before}
                       id="created-before"
+                      autoComplete="off"
                       onChange={e => {
                         setSelectedDates(p => ({
                           after: p.after,

--- a/assets/js/picker/Picker.tsx
+++ b/assets/js/picker/Picker.tsx
@@ -252,6 +252,7 @@ export function Picker(props: PickerProps) {
               ref={inputRef}
               type="text"
               spellCheck="false"
+              autoComplete="off"
               placeholder={placeholder}
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}

--- a/assets/js/picker/Picker.tsx
+++ b/assets/js/picker/Picker.tsx
@@ -260,7 +260,6 @@ export function Picker(props: PickerProps) {
               role="combobox"
               aria-controls="picker-options"
               aria-expanded="true"
-              autoComplete="off"
             />
             <kbd className="hidden sm:inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-400 ring-1 ring-gray-300">
               <span>{isMac ? '⌘' : 'Ctrl'}</span>

--- a/assets/js/picker/Picker.tsx
+++ b/assets/js/picker/Picker.tsx
@@ -252,7 +252,6 @@ export function Picker(props: PickerProps) {
               ref={inputRef}
               type="text"
               spellCheck="false"
-              autoComplete="off"
               placeholder={placeholder}
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
@@ -261,6 +260,7 @@ export function Picker(props: PickerProps) {
               role="combobox"
               aria-controls="picker-options"
               aria-expanded="true"
+              autoComplete="off"
             />
             <kbd className="hidden sm:inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-400 ring-1 ring-gray-300">
               <span>{isMac ? '⌘' : 'Ctrl'}</span>

--- a/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
+++ b/assets/js/workflow-diagram/nodes/PlaceholderJob.tsx
@@ -178,6 +178,7 @@ const PlaceholderJobNode = ({ id, data, selected }: NodeProps<NodeData>) => {
               inputRef?.focus();
             }}
             autoFocus
+            autoComplete="off"
             value={jobName}
             onChange={e => {
               setJobName(e.target.value);

--- a/assets/test/collaborative-editor/components/form/number-field.test.tsx
+++ b/assets/test/collaborative-editor/components/form/number-field.test.tsx
@@ -48,11 +48,13 @@ describe('NumberField', () => {
     );
   }
 
-  it('renders with label and help text', () => {
+  it('renders with label, help text, and autoComplete="off"', () => {
     render(<TestForm />);
 
-    expect(screen.getByLabelText('Count')).toBeInTheDocument();
+    const input = screen.getByLabelText('Count') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
     expect(screen.getByText('Enter a number')).toBeInTheDocument();
+    expect(input).toHaveAttribute('autocomplete', 'off');
   });
 
   it('shows placeholder when value is null', () => {

--- a/assets/test/collaborative-editor/components/form/text-field.test.tsx
+++ b/assets/test/collaborative-editor/components/form/text-field.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppForm } from '../../../../js/collaborative-editor/components/form';
+import * as useWorkflowModule from '../../../../js/collaborative-editor/hooks/useWorkflow';
+
+// Mock useWorkflowState and useWorkflowActions (required by useAppForm's
+// useValidation hook, which reads from the collaborative workflow store)
+vi.mock('../../../../js/collaborative-editor/hooks/useWorkflow', () => ({
+  useWorkflowState: vi.fn(),
+  useWorkflowActions: vi.fn(() => ({
+    setClientErrors: vi.fn(),
+  })),
+}));
+
+describe('TextField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useWorkflowModule.useWorkflowState).mockImplementation(
+      (selector?: (state: any) => any) => {
+        const state = {
+          workflow: { id: 'w-1', errors: {} },
+          jobs: [],
+          triggers: [],
+          edges: [],
+        };
+        return selector ? selector(state) : state;
+      }
+    );
+  });
+
+  function TestForm({ defaultValue = '' }: { defaultValue?: string }) {
+    const form = useAppForm({
+      defaultValues: { name: defaultValue },
+    });
+
+    return (
+      <form.AppField name="name">
+        {field => <field.TextField label="Name" placeholder="Enter a name" />}
+      </form.AppField>
+    );
+  }
+
+  it('renders with label, placeholder, and autoComplete="off"', () => {
+    render(<TestForm />);
+
+    const input = screen.getByLabelText('Name') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.placeholder).toBe('Enter a name');
+    expect(input).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('displays initial value', () => {
+    render(<TestForm defaultValue="hello" />);
+
+    const input = screen.getByLabelText('Name') as HTMLInputElement;
+    expect(input.value).toBe('hello');
+  });
+});

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -618,7 +618,6 @@ defmodule LightningWeb.Components.NewInputs do
         id={@id}
         name={@name}
         class={@class}
-        autocomplete={@autocomplete}
         value={@value}
         placeholder={@placeholder}
         {@rest}

--- a/lib/lightning_web/components/new_inputs.ex
+++ b/lib/lightning_web/components/new_inputs.ex
@@ -400,9 +400,11 @@ defmodule LightningWeb.Components.NewInputs do
 
   attr :placeholder, :string, default: ""
 
+  attr :autocomplete, :string, default: "off"
+
   attr :rest, :global,
     include:
-      ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+      ~w(accept capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)
 
   attr :class, :string, default: ""
@@ -616,6 +618,7 @@ defmodule LightningWeb.Components.NewInputs do
         id={@id}
         name={@name}
         class={@class}
+        autocomplete={@autocomplete}
         value={@value}
         placeholder={@placeholder}
         {@rest}
@@ -635,6 +638,7 @@ defmodule LightningWeb.Components.NewInputs do
         id={@id}
         name={@name}
         class={["rounded-md w-full font-mono bg-slate-800 text-slate-100", @class]}
+        autocomplete={@autocomplete}
         value={@value}
         placeholder={@placeholder}
         errors={@errors}
@@ -660,6 +664,7 @@ defmodule LightningWeb.Components.NewInputs do
       </.label>
       <div class="relative mt-2 rounded-lg shadow-xs">
         <input
+          autocomplete={@autocomplete}
           type={@type}
           name={@name}
           id={@id}
@@ -985,6 +990,7 @@ defmodule LightningWeb.Components.NewInputs do
           name={@name}
           id={@id}
           class={@class}
+          autocomplete={@autocomplete}
           value={Form.normalize_value(@type, @value)}
           placeholder={@placeholder}
           {@rest}
@@ -1019,15 +1025,17 @@ defmodule LightningWeb.Components.NewInputs do
   attr :value, :any
   attr :errors, :list, default: []
   attr :class, :string, default: ""
+  attr :autocomplete, :string, default: "off"
 
   attr :rest, :global,
     include:
-      ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+      ~w(accept capture cols disabled form list max maxlength min minlength
               multiple pattern placeholder readonly required rows size step)
 
   def input_element(assigns) do
     ~H"""
     <input
+      autocomplete={@autocomplete}
       type={@type}
       name={@name}
       id={@id}
@@ -1060,15 +1068,17 @@ defmodule LightningWeb.Components.NewInputs do
   attr :value, :any
   attr :errors, :list, default: []
   attr :class, :any, default: ""
+  attr :autocomplete, :string, default: "off"
 
   attr :rest, :global,
     include:
-      ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+      ~w(accept capture cols disabled form list max maxlength min minlength
               multiple pattern placeholder readonly required rows size step)
 
   def textarea_element(assigns) do
     ~H"""
     <textarea
+      autocomplete={@autocomplete}
       id={@id}
       name={@name}
       class={[

--- a/lib/lightning_web/controllers/user_registration_html/new.html.heex
+++ b/lib/lightning_web/controllers/user_registration_html/new.html.heex
@@ -32,10 +32,16 @@
                   field={f[:first_name]}
                   label="First Name"
                   required={true}
+                  autocomplete="given-name"
                 />
               </div>
               <div>
-                <.input field={f[:last_name]} required={true} label="Last Name" />
+                <.input
+                  field={f[:last_name]}
+                  required={true}
+                  label="Last Name"
+                  autocomplete="family-name"
+                />
               </div>
               <div>
                 <.input
@@ -43,6 +49,7 @@
                   type="email"
                   label="Email"
                   required={true}
+                  autocomplete="email"
                 />
               </div>
               <div>
@@ -51,6 +58,7 @@
                   type="password"
                   label="Password"
                   required={true}
+                  autocomplete="new-password"
                 />
               </div>
 

--- a/lib/lightning_web/controllers/user_reset_password_html/edit.html.heex
+++ b/lib/lightning_web/controllers/user_reset_password_html/edit.html.heex
@@ -27,7 +27,12 @@
             <div class="grid grid-flow-row gap-4 auto-rows-max">
               <div>
                 <.label for={:password}>New password</.label>
-                <.input type="password" field={f[:password]} required />
+                <.input
+                  type="password"
+                  field={f[:password]}
+                  required
+                  autocomplete="new-password"
+                />
               </div>
 
               <div>
@@ -38,6 +43,7 @@
                   type="password"
                   field={f[:password_confirmation]}
                   required
+                  autocomplete="new-password"
                 />
               </div>
 

--- a/lib/lightning_web/controllers/user_session_html/new.html.heex
+++ b/lib/lightning_web/controllers/user_session_html/new.html.heex
@@ -33,10 +33,16 @@
                   field={f[:email]}
                   required={true}
                   label="Email"
+                  autocomplete="email"
                 />
               </div>
               <div>
-                <.input type="password" field={f[:password]} label="Password" />
+                <.input
+                  type="password"
+                  field={f[:password]}
+                  label="Password"
+                  autocomplete="current-password"
+                />
               </div>
               <.check_box form={f} field={:remember_me}>
                 <br />

--- a/lib/lightning_web/controllers/user_totp_html/new.html.heex
+++ b/lib/lightning_web/controllers/user_totp_html/new.html.heex
@@ -30,7 +30,7 @@
               type="text"
               field={f[:code]}
               required="true"
-              autocomplete="off"
+              autocomplete="one-time-code"
               inputmode="numeric"
               placeholder="XXXXXX"
               class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"

--- a/lib/lightning_web/live/book_demo_banner.ex
+++ b/lib/lightning_web/live/book_demo_banner.ex
@@ -157,8 +157,20 @@ defmodule LightningWeb.BookDemoBanner do
           phx-submit="schedule-call"
         >
           <div class="flex flex-col gap-2">
-            <.input type="text" field={f[:name]} label="Name" required={true} />
-            <.input type="text" field={f[:email]} label="Email" required={true} />
+            <.input
+              type="text"
+              field={f[:name]}
+              label="Name"
+              required={true}
+              autocomplete="name"
+            />
+            <.input
+              type="text"
+              field={f[:email]}
+              label="Email"
+              required={true}
+              autocomplete="email"
+            />
             <.input
               type="textarea"
               field={f[:message]}

--- a/lib/lightning_web/live/components/form.ex
+++ b/lib/lightning_web/live/components/form.ex
@@ -128,7 +128,10 @@ defmodule LightningWeb.Components.Form do
         label_classes: label_classes,
         error_classes: error_classes,
         input_classes: input_classes,
-        opts: assigns.rest |> assigns_to_attributes()
+        opts:
+          assigns.rest
+          |> assigns_to_attributes()
+          |> Keyword.put_new(:autocomplete, "off")
       )
       |> assign_new(:label, fn -> nil end)
       |> assign_new(:hint, fn -> nil end)
@@ -269,7 +272,10 @@ defmodule LightningWeb.Components.Form do
         label_classes: label_classes,
         error_classes: error_classes,
         input_classes: input_classes,
-        opts: assigns.rest |> assigns_to_attributes()
+        opts:
+          assigns.rest
+          |> assigns_to_attributes()
+          |> Keyword.put_new(:autocomplete, "off")
       )
 
     ~H"""

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -78,7 +78,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         field={@form_field}
         label={@title}
         required={@required}
-        autocomplete={if @type == "password", do: "new-password", else: "off"}
+        autocomplete={if @type == "password", do: "new-password"}
         checked={@type == "checkbox" and @form_field.value == true}
       />
     </div>

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -78,7 +78,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         field={@form_field}
         label={@title}
         required={@required}
-        autocomplete={if @type == "password", do: "new-password"}
+        autocomplete={if @type == "password", do: "new-password", else: "off"}
         checked={@type == "checkbox" and @form_field.value == true}
       />
     </div>

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -78,6 +78,7 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         field={@form_field}
         label={@title}
         required={@required}
+        autocomplete={if @type == "password", do: "new-password", else: "off"}
         checked={@type == "checkbox" and @form_field.value == true}
       />
     </div>

--- a/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
+++ b/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
@@ -422,7 +422,6 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
                   field={f[:client_id]}
                   label="Client ID"
                   required="true"
-                  autocomplete="new-password"
                 />
               </div>
             </div>

--- a/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
+++ b/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
@@ -422,6 +422,7 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
                   field={f[:client_id]}
                   label="Client ID"
                   required="true"
+                  autocomplete="new-password"
                 />
               </div>
             </div>
@@ -433,6 +434,7 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
                   field={f[:client_secret]}
                   label="Client Secret"
                   required="true"
+                  autocomplete="new-password"
                 />
               </div>
             </div>

--- a/lib/lightning_web/live/first_setup_live/superuser.html.heex
+++ b/lib/lightning_web/live/first_setup_live/superuser.html.heex
@@ -35,7 +35,12 @@
 
       <div class="grid grid-cols-6 gap-6">
         <div class="col-span-3">
-          <.input type="password" field={f[:password]} label="Password" />
+          <.input
+            type="password"
+            field={f[:password]}
+            label="Password"
+            autocomplete="new-password"
+          />
         </div>
       </div>
 
@@ -45,6 +50,7 @@
             type="password"
             field={f[:password_confirmation]}
             label="Password confirmation"
+            autocomplete="new-password"
           />
         </div>
       </div>

--- a/lib/lightning_web/live/job_live/kafka_setup_component.ex
+++ b/lib/lightning_web/live/job_live/kafka_setup_component.ex
@@ -69,7 +69,6 @@ defmodule LightningWeb.JobLive.KafkaSetupComponent do
             type="text"
             field={kafka_config[:username]}
             label="Username"
-            autocomplete="off"
             disabled={@disabled}
           />
         </div>
@@ -81,6 +80,7 @@ defmodule LightningWeb.JobLive.KafkaSetupComponent do
             label="Password"
             disabled={@disabled}
             value={password}
+            autocomplete="new-password"
           />
         </div>
 

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -17,6 +17,7 @@
           field={f[:first_name]}
           label="First name"
           required="true"
+          autocomplete="given-name"
         />
       </div>
       <div class="space-y-4">
@@ -25,6 +26,7 @@
           field={f[:last_name]}
           label="Last name"
           required="true"
+          autocomplete="family-name"
         />
       </div>
       <div class="space-y-4">
@@ -80,6 +82,7 @@
           label="Enter password to confirm"
           required="true"
           phx-debounce="blur"
+          autocomplete="current-password"
         />
       </div>
     </div>
@@ -113,6 +116,7 @@
           field={f[:password]}
           label="New password"
           required="true"
+          autocomplete="new-password"
         />
       </div>
       <div class="space-y-4">
@@ -121,6 +125,7 @@
           field={f[:password_confirmation]}
           label="Confirm new password"
           required="true"
+          autocomplete="new-password"
         />
       </div>
       <div class="space-y-4">
@@ -129,6 +134,7 @@
           field={f[:current_password]}
           label="Current password"
           required="true"
+          autocomplete="current-password"
         />
       </div>
     </div>

--- a/lib/lightning_web/live/profile_live/mfa_component.html.heex
+++ b/lib/lightning_web/live/profile_live/mfa_component.html.heex
@@ -160,7 +160,7 @@
               <.input
                 type="text"
                 field={f[:code]}
-                autocomplete="off"
+                autocomplete="one-time-code"
                 placeholder="XXXXXX"
                 label="Verify the code from the app"
               />

--- a/lib/lightning_web/live/re_authenticate_live/new.html.heex
+++ b/lib/lightning_web/live/re_authenticate_live/new.html.heex
@@ -61,6 +61,7 @@
                 type="password"
                 field={f[:password]}
                 required="true"
+                autocomplete="current-password"
                 class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
               />
             <% else %>
@@ -68,7 +69,7 @@
                 type="text"
                 field={f[:code]}
                 required="true"
-                autocomplete="off"
+                autocomplete="one-time-code"
                 inputmode="numeric"
                 placeholder="XXXXXX"
                 class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -167,7 +167,6 @@ defmodule LightningWeb.SandboxLive.Components do
             field={@confirm_form[:name]}
             label="Sandbox name"
             placeholder={@sandbox.name}
-            autocomplete="off"
             required
           />
 

--- a/lib/lightning_web/live/sandbox_live/form_component.ex
+++ b/lib/lightning_web/live/sandbox_live/form_component.ex
@@ -224,7 +224,6 @@ defmodule LightningWeb.SandboxLive.FormComponent do
                 field={f[:raw_name]}
                 label="Name"
                 required
-                autocomplete="off"
                 placeholder="My Sandbox"
                 phx-debounce="300"
               />

--- a/lib/lightning_web/live/tokens_live/index.html.heex
+++ b/lib/lightning_web/live/tokens_live/index.html.heex
@@ -43,6 +43,7 @@
             value={@new_token}
             class="my-auto w-full border-0 bg-inherit disabled:opacity-70 mr-1"
             disabled
+            autocomplete="off"
           />
 
           <button

--- a/lib/lightning_web/live/tokens_live/index.html.heex
+++ b/lib/lightning_web/live/tokens_live/index.html.heex
@@ -43,7 +43,6 @@
             value={@new_token}
             class="my-auto w-full border-0 bg-inherit disabled:opacity-70 mr-1"
             disabled
-            autocomplete="off"
           />
 
           <button

--- a/lib/lightning_web/live/user_live/form_component.html.heex
+++ b/lib/lightning_web/live/user_live/form_component.html.heex
@@ -32,7 +32,7 @@
     <div class="grid grid-cols-6 gap-6">
       <div class="col-span-3">
         <.label for={:password}>Password</.label>
-        <.input type="password" field={f[:password]} />
+        <.input type="password" field={f[:password]} autocomplete="new-password" />
       </div>
     </div>
 

--- a/lib/lightning_web/live/workflow_live/components.ex
+++ b/lib/lightning_web/live/workflow_live/components.ex
@@ -389,6 +389,7 @@ defmodule LightningWeb.WorkflowLive.Components do
                 class="block w-full flex-1 rounded-l-lg text-slate-900 disabled:bg-gray-50 disabled:text-gray-500 border border-r-0 border-secondary-300 sm:text-sm sm:leading-6"
                 value={url(~p"/i/#{@form[:id].value}")}
                 disabled="disabled"
+                autocomplete="off"
               />
 
               <button

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -288,7 +288,12 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
           </div>
         <% end %>
 
-        <.input type="password" field={f[:password]} label="Password" />
+        <.input
+          type="password"
+          field={f[:password]}
+          label="Password"
+          autocomplete="new-password"
+        />
         <div class="relative">
           <div class="absolute inset-0 flex items-center" aria-hidden="true">
             <div class="w-full border-t border-gray-300"></div>
@@ -474,7 +479,12 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
       </div>
     <% else %>
       <.label for={:password}>Password</.label>
-      <.input type="password" field={@form[:password]} required="true" />
+      <.input
+        type="password"
+        field={@form[:password]}
+        required="true"
+        autocomplete="new-password"
+      />
 
       <div class="hidden sm:block" aria-hidden="true">
         <div class="py-1"></div>
@@ -525,6 +535,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
           }
           class="block w-full flex-1 rounded-l-lg text-slate-900 disabled:bg-gray-50 disabled:text-gray-500 border border-r-0 border-secondary-300 sm:text-sm sm:leading-6"
           disabled="disabled"
+          autocomplete="new-password"
         />
 
         <button
@@ -570,6 +581,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
             )
           }
           disabled="disabled"
+          autocomplete="off"
         />
 
         <button

--- a/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
+++ b/lib/lightning_web/live/workflow_live/webhook_auth_method_form_component.ex
@@ -535,7 +535,7 @@ defmodule LightningWeb.WorkflowLive.WebhookAuthMethodFormComponent do
           }
           class="block w-full flex-1 rounded-l-lg text-slate-900 disabled:bg-gray-50 disabled:text-gray-500 border border-r-0 border-secondary-300 sm:text-sm sm:leading-6"
           disabled="disabled"
-          autocomplete="new-password"
+          autocomplete="off"
         />
 
         <button

--- a/test/lightning_web/components/form_test.exs
+++ b/test/lightning_web/components/form_test.exs
@@ -1,0 +1,87 @@
+defmodule LightningWeb.Components.FormTest do
+  @moduledoc false
+  use LightningWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias LightningWeb.Components.Form
+
+  # A minimal embedded schema to produce real Ecto changesets for testing.
+  defmodule Item do
+    use Ecto.Schema
+
+    embedded_schema do
+      field :name, :string
+      field :secret, :string
+    end
+
+    def changeset(item \\ %__MODULE__{}, params) do
+      Ecto.Changeset.cast(item, params, [:name, :secret])
+    end
+  end
+
+  defp form_for_item do
+    Item.changeset(%{"name" => "test", "secret" => ""})
+    |> Phoenix.Component.to_form()
+  end
+
+  # ---- password_field/1 autocomplete ----------------------------------------
+
+  describe "password_field/1 autocomplete" do
+    test "renders autocomplete='off' by default" do
+      form = form_for_item()
+
+      html =
+        render_component(&Form.password_field/1, %{
+          form: form,
+          id: :secret
+        })
+
+      assert html =~ ~s(autocomplete="off")
+    end
+
+    test "allows explicit autocomplete override" do
+      form = form_for_item()
+
+      html =
+        render_component(&Form.password_field/1, %{
+          form: form,
+          id: :secret,
+          autocomplete: "current-password"
+        })
+
+      assert html =~ ~s(autocomplete="current-password")
+      refute html =~ ~s(autocomplete="off")
+    end
+  end
+
+  # ---- text_field/1 autocomplete --------------------------------------------
+
+  describe "text_field/1 autocomplete" do
+    test "renders autocomplete='off' by default" do
+      form = form_for_item()
+
+      html =
+        render_component(&Form.text_field/1, %{
+          form: form,
+          field: :name
+        })
+
+      assert html =~ ~s(autocomplete="off")
+    end
+
+    test "allows explicit autocomplete override" do
+      form = form_for_item()
+
+      html =
+        render_component(&Form.text_field/1, %{
+          form: form,
+          field: :name,
+          autocomplete: "email"
+        })
+
+      assert html =~ ~s(autocomplete="email")
+      refute html =~ ~s(autocomplete="off")
+    end
+  end
+end

--- a/test/lightning_web/components/form_test.exs
+++ b/test/lightning_web/components/form_test.exs
@@ -25,39 +25,7 @@ defmodule LightningWeb.Components.FormTest do
     |> Phoenix.Component.to_form()
   end
 
-  # ---- password_field/1 autocomplete ----------------------------------------
-
-  describe "password_field/1 autocomplete" do
-    test "renders autocomplete='off' by default" do
-      form = form_for_item()
-
-      html =
-        render_component(&Form.password_field/1, %{
-          form: form,
-          id: :secret
-        })
-
-      assert html =~ ~s(autocomplete="off")
-    end
-
-    test "allows explicit autocomplete override" do
-      form = form_for_item()
-
-      html =
-        render_component(&Form.password_field/1, %{
-          form: form,
-          id: :secret,
-          autocomplete: "current-password"
-        })
-
-      assert html =~ ~s(autocomplete="current-password")
-      refute html =~ ~s(autocomplete="off")
-    end
-  end
-
-  # ---- text_field/1 autocomplete --------------------------------------------
-
-  describe "text_field/1 autocomplete" do
+  describe "autocomplete" do
     test "renders autocomplete='off' by default" do
       form = form_for_item()
 

--- a/test/lightning_web/components/new_inputs_test.exs
+++ b/test/lightning_web/components/new_inputs_test.exs
@@ -138,31 +138,6 @@ defmodule LightningWeb.Components.NewInputsTest do
 
       assert html =~ ~s(autocomplete="email")
     end
-
-    test "input/1 password type renders autocomplete='off' by default" do
-      form = used_field_form()
-
-      html =
-        render_component(&NewInputs.input/1, %{
-          field: form[:name],
-          type: "password"
-        })
-
-      assert html =~ ~s(autocomplete="off")
-    end
-
-    test "input/1 password type allows explicit autocomplete override" do
-      form = used_field_form()
-
-      html =
-        render_component(&NewInputs.input/1, %{
-          field: form[:name],
-          type: "password",
-          autocomplete: "current-password"
-        })
-
-      assert html =~ ~s(autocomplete="current-password")
-    end
   end
 
   # ---- old_error/1 (CoreComponents) -----------------------------------------

--- a/test/lightning_web/components/new_inputs_test.exs
+++ b/test/lightning_web/components/new_inputs_test.exs
@@ -136,8 +136,6 @@ defmodule LightningWeb.Components.NewInputsTest do
           autocomplete: "email"
         })
 
-      # The override value is rendered via {@rest} after the static default.
-      # Browsers use the last attribute value, so autocomplete="email" wins.
       assert html =~ ~s(autocomplete="email")
     end
 
@@ -163,8 +161,6 @@ defmodule LightningWeb.Components.NewInputsTest do
           autocomplete: "current-password"
         })
 
-      # The override value is rendered via {@rest} after the static default.
-      # Browsers use the last attribute value, so autocomplete="current-password" wins.
       assert html =~ ~s(autocomplete="current-password")
     end
   end

--- a/test/lightning_web/components/new_inputs_test.exs
+++ b/test/lightning_web/components/new_inputs_test.exs
@@ -111,6 +111,64 @@ defmodule LightningWeb.Components.NewInputsTest do
     end
   end
 
+  # ---- autocomplete defaults --------------------------------------------------
+
+  describe "autocomplete defaults" do
+    test "input/1 renders autocomplete='off' by default" do
+      form = used_field_form()
+
+      html =
+        render_component(&NewInputs.input/1, %{
+          field: form[:name],
+          type: "text"
+        })
+
+      assert html =~ ~s(autocomplete="off")
+    end
+
+    test "input/1 allows explicit autocomplete override" do
+      form = used_field_form()
+
+      html =
+        render_component(&NewInputs.input/1, %{
+          field: form[:name],
+          type: "text",
+          autocomplete: "email"
+        })
+
+      # The override value is rendered via {@rest} after the static default.
+      # Browsers use the last attribute value, so autocomplete="email" wins.
+      assert html =~ ~s(autocomplete="email")
+    end
+
+    test "input/1 password type renders autocomplete='off' by default" do
+      form = used_field_form()
+
+      html =
+        render_component(&NewInputs.input/1, %{
+          field: form[:name],
+          type: "password"
+        })
+
+      assert html =~ ~s(autocomplete="off")
+    end
+
+    test "input/1 password type allows explicit autocomplete override" do
+      form = used_field_form()
+
+      html =
+        render_component(&NewInputs.input/1, %{
+          field: form[:name],
+          type: "password",
+          autocomplete: "current-password"
+        })
+
+      # The override value is rendered via {@rest} after the static default.
+      # Browsers use the last attribute value, so autocomplete="current-password" wins.
+      assert html =~ ~s(autocomplete="current-password")
+    end
+  end
+
   # ---- old_error/1 (CoreComponents) -----------------------------------------
 
   describe "old_error/1 used_input? gating" do


### PR DESCRIPTION
## Description

This PR removes unwanted browser autocomplete and autofill from input fields across Lightning, while keeping browser autofill enabled on the auth forms (register/login etc) where it's genuinely useful.

**Strategy: default off, opt in where needed.**

- Default `autocomplete="off"` in shared Phoenix input components (`new_inputs.ex`, `form.ex`) and shared React form components (`TextField`, `NumberField`) so every field is covered automatically.
- Explicitly opt back in with semantic autocomplete values (`email`, `current-password`, `new-password`, `given-name`, `family-name`,  `name`, `one-time-code`) on login, registration, password reset, profile, TOTP/MFA, re-authenticate, first setup, admin user, and book demo forms.
- Add `autocomplete="off"` directly to raw `<input>` tags that bypass shared components (webhook URL display, token display, raw inputs in `TriggerForm`, `CronFieldBuilder`, etc.).
- Use `autocomplete="new-password"` on credential-pair forms (OAuth Client Secret, webhook auth password, JSON schema password fields) — Chrome ignores `off` on credential-pair-shaped forms (text + password adjacent) and `new-password` is what actually breaks the heuristic and suppresses autofill across the form.
- Add ExUnit and Vitest tests for shared component defaults and overrides.

Closes #1553

## Validation steps

**Autofill should be suppressed:**

1. Open any **OAuth credential** form → focus Client ID / Client Secret →  no saved-credential.
2. Open any **schema-driven credential with a password field** (e.g. Postgres) → focus the password field → no autofill.
3. Open a **webhook trigger** → configure auth → Basic Auth → focus the password field → no autofill.
5. Open the **collaborative editor**: focus job name on a placeholder node,  adaptor version search, cron expression field, manual run search → no autofill on any.
6. Open **project settings**, **sandbox creation**, **token name** → no autofill.

**Autofill should still work on auth forms:**

7. Open the **login** page → email + password fields offer to fill from the browser password manager.
8. Open the **registration** page → password field offers to generate a new password; first/last name fields offer browser-saved values.
9. Open the **profile password change** form → current password field offers existing saved password; new password field offers to generate.
10. **TOTP entry** (mobile, if testable) → authenticator app code autofill works.

## Additional notes for the reviewer

1. **The Chrome "Save Password?" prompt is NOT solved by this PR.** Manual testing confirmed that field-level `autocomplete="off"` and `new-password` do not suppress Chrome's "Save Password?" prompt on credential-pair forms (OAuth, webhook auth, Postgres). This is a separate Chrome heuristic that field-level hints can't override. Perhaps should be tracked in a separate issue.
2. **Follow-up: raw React `<input>` consolidation.** This PR adds `autoComplete="off"` one-by-one to ~12 raw `<input>` tags across `TriggerForm`, `CronFieldBuilder`, etc. Won't scale — every new inline input has to remember the attribute. Worth migrating those to the shared `TextField`/`NumberField` (or a new `RawInput` wrapper) in a separate issue.
3. **Branch was originally named `1533-autocomplete-removal`** by mistake; the actual issue is `#1553`. Renamed.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
