### PR TITLE
Fix credential form crash for array-form JSON Schema type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,10 @@ and this project adheres to
 
 - Credential form no longer crashes when opening a schema that declares a
   property `type` as a JSON Schema array (e.g. `["string", "null"]`), as the
-  Browserless adaptor does. Also corrected the bundled `browserless.json`
-  schema, where `baseUrl` was simultaneously required and nullable.
+  Browserless adaptor does. The contradictory `null` member in the Browserless
+  schema itself (the field is `required` with `minLength: 1`) is corrected
+  upstream in
+  [`@openfn/language-browserless`](https://github.com/OpenFn/adaptors/pull/1659).
   [#4647](https://github.com/OpenFn/lightning/issues/4647)
 
 ## [2.16.2] - 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to
 
 ### Fixed
 
+- Credential form no longer crashes when opening a schema that declares a
+  property `type` as a JSON Schema array (e.g. `["string", "null"]`), as the
+  Browserless adaptor does. Also corrected the bundled `browserless.json`
+  schema, where `baseUrl` was simultaneously required and nullable.
+  [#4647](https://github.com/OpenFn/lightning/issues/4647)
+
 ## [2.16.2] - 2026-04-20
 
 ## [2.16.2-pre1] - 2026-04-20

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -162,13 +162,26 @@ defmodule Lightning.Credentials.Schema do
       type =
         properties
         |> Map.get("type", "string")
-        |> then(fn type -> if type == "object", do: "map", else: type end)
+        |> normalize_property_type()
         |> String.to_atom()
 
       {String.to_existing_atom(field), type}
     end)
     |> Map.new()
   end
+
+  # JSON Schema draft-07 lets `type` be a list (e.g. `["string", "null"]`
+  # for nullable fields). Pick the first non-null member, defaulting to
+  # "string" if only "null" remains.
+  defp normalize_property_type(types) when is_list(types) do
+    types
+    |> Enum.reject(&(&1 == "null"))
+    |> List.first("string")
+    |> normalize_property_type()
+  end
+
+  defp normalize_property_type("object"), do: "map"
+  defp normalize_property_type(type) when is_binary(type), do: type
 
   defp validate_json_object(value) when is_binary(value) do
     case Jason.decode(value) do

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -41,6 +41,24 @@ defmodule Lightning.Credentials.SchemaTest do
   end
 
   describe "new/1" do
+    test "handles JSON Schema array-form `type` (e.g. nullable fields)" do
+      schema =
+        Schema.new(%{
+          "properties" => %{
+            "baseUrl" => %{"type" => ["string", "null"]},
+            "settings" => %{"type" => ["object", "null"]},
+            "fallback" => %{"type" => ["null"]}
+          },
+          "type" => "object"
+        })
+
+      assert schema.types == %{
+               baseUrl: :string,
+               settings: :map,
+               fallback: :string
+             }
+    end
+
     test "creates a struct containing the schema, types and data", %{
       schema_map: schema_map
     } do

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -59,6 +59,35 @@ defmodule Lightning.Credentials.SchemaTest do
              }
     end
 
+    test "validates round-trip against schema using array-form `type`" do
+      schema =
+        Schema.new(%{
+          "properties" => %{
+            "baseUrl" => %{
+              "type" => ["string", "null"],
+              "format" => "uri",
+              "minLength" => 1
+            }
+          },
+          "type" => "object",
+          "required" => ["baseUrl"]
+        })
+
+      ok =
+        %Ecto.Changeset{data: %{}, types: schema.types}
+        |> Ecto.Changeset.put_change(:baseUrl, "https://example.com")
+        |> Schema.validate(schema)
+
+      assert ok.errors == []
+
+      bad =
+        %Ecto.Changeset{data: %{}, types: schema.types}
+        |> Ecto.Changeset.put_change(:baseUrl, "not a uri")
+        |> Schema.validate(schema)
+
+      assert {:baseUrl, {"expected to be a URI", []}} in bad.errors
+    end
+
     test "creates a struct containing the schema, types and data", %{
       schema_map: schema_map
     } do


### PR DESCRIPTION
## Description

Picking the Browserless type from the credential modal crashes the form on render, change, and save. The credential schema parser couldn't handle JSON Schema's array form for nullable fields (`["string", "null"]`), which Browserless uses for the Base URL field. Now it can.

The Browserless schema is also internally contradictory (Base URL is `required` with `minLength: 1`, so "null" could never validate). That's fixed upstream in OpenFn/adaptors#1659.

Closes #4647

## Validation steps

With this branch, open a project's Credentials, click "Add credential", and pick **Browserless**. The form should render and let you save.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR