### PR TITLE
Safer credential schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to
   upstream in
   [`@openfn/language-browserless`](https://github.com/OpenFn/adaptors/pull/1659).
   [#4647](https://github.com/OpenFn/lightning/issues/4647)
+- Prevent crash when an unsupported data type from `credential-schema.json` is
+  loaded for building a credential schema from an adaptor. Fall-back to
+  `:string` type, log warning and alert Sentry.
 
 ## [2.16.2] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
 
 ### Fixed
 
+- Prevent crash when an unsupported data type from `credential-schema.json` is
+  loaded for building a credential schema from an adaptor. Fall-back to
+  `:string` type, log warning and alert Sentry.
+  [#4681](https://github.com/OpenFn/lightning/issues/4681)
+
 ## [2.16.3-pre] - 2026-04-30
 
 ### Added
@@ -73,10 +78,6 @@ and this project adheres to
   upstream in
   [`@openfn/language-browserless`](https://github.com/OpenFn/adaptors/pull/1659).
   [#4647](https://github.com/OpenFn/lightning/issues/4647)
-- Prevent crash when an unsupported data type from `credential-schema.json` is
-  loaded for building a credential schema from an adaptor. Fall-back to
-  `:string` type, log warning and alert Sentry.
-  [#4681](https://github.com/OpenFn/lightning/issues/4681)
 
 ## [2.16.2] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to
 - Prevent crash when an unsupported data type from `credential-schema.json` is
   loaded for building a credential schema from an adaptor. Fall-back to
   `:string` type, log warning and alert Sentry.
+  [#4681](https://github.com/OpenFn/lightning/issues/4681)
 
 ## [2.16.2] - 2026-04-20
 

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -8,14 +8,30 @@ defmodule Lightning.Credentials.Schema do
   alias Ecto.Changeset
   alias ExJsonSchema.Validator
 
+  require Logger
+
+  # Maps JSON Schema type names (case-insensitive) to Ecto types. Anything not
+  # listed here falls back to :string with a logged warning so a malformed
+  # schema can't take the credential form down.
+  @type_map %{
+    "string" => :string,
+    "integer" => :integer,
+    "number" => :float,
+    "boolean" => :boolean,
+    "object" => :map,
+    "array" => {:array, :string},
+    "null" => :string
+  }
+
   @type t :: %__MODULE__{
           name: String.t() | nil,
           root: ExJsonSchema.Schema.Root.t(),
           types: Ecto.Changeset.types(),
-          fields: [String.t()]
+          fields: [atom()],
+          warnings: %{atom() => String.t()}
         }
 
-  defstruct [:name, :root, :types, :fields]
+  defstruct [:name, :root, :types, :fields, warnings: %{}]
 
   @spec new(
           json_schema :: %{String.t() => any()} | binary(),
@@ -27,15 +43,22 @@ defmodule Lightning.Credentials.Schema do
   # can be ignored since not near to atom limit
   # sobelow_skip ["DOS.StringToAtom"]
   def new(json_schema, name) when is_map(json_schema) do
-    fields =
-      json_schema["properties"]
-      # credo:disable-for-next-line
-      |> Enum.map(fn {k, _v} -> k |> String.to_atom() end)
+    fields = collect_fields(json_schema)
 
-    root = ExJsonSchema.Schema.resolve(json_schema)
+    plain_schema = to_plain_map(json_schema)
+
+    {sanitized, warnings} = sanitize_property_types(plain_schema, name)
+
+    root = ExJsonSchema.Schema.resolve(sanitized)
     types = get_types(root)
 
-    struct!(__MODULE__, name: name, root: root, types: types, fields: fields)
+    struct!(__MODULE__,
+      name: name,
+      root: root,
+      types: types,
+      fields: fields,
+      warnings: warnings
+    )
   end
 
   def new(raw_schema, name) when is_binary(raw_schema) do
@@ -43,6 +66,33 @@ defmodule Lightning.Credentials.Schema do
     |> Jason.decode!(objects: :ordered_objects)
     |> new(name)
   end
+
+  # `Jason.decode!(objects: :ordered_objects)` returns `Jason.OrderedObject`
+  # structs, so we capture field order from the original before flattening.
+  defp collect_fields(json_schema) do
+    case json_schema["properties"] do
+      nil ->
+        []
+
+      properties ->
+        # credo:disable-for-next-line
+        Enum.map(properties, fn {k, _v} -> String.to_atom(k) end)
+    end
+  end
+
+  defp to_plain_map(%Jason.OrderedObject{values: pairs}) do
+    Map.new(pairs, fn {k, v} -> {k, to_plain_map(v)} end)
+  end
+
+  defp to_plain_map(map) when is_map(map) and not is_struct(map) do
+    Map.new(map, fn {k, v} -> {k, to_plain_map(v)} end)
+  end
+
+  defp to_plain_map(list) when is_list(list) do
+    Enum.map(list, &to_plain_map/1)
+  end
+
+  defp to_plain_map(other), do: other
 
   @spec validate(changeset :: Ecto.Changeset.t(), schema :: t()) ::
           Ecto.Changeset.t()
@@ -75,6 +125,21 @@ defmodule Lightning.Credentials.Schema do
     schema.root.schema
     |> Map.get("required", [])
     |> Enum.any?(fn required_field -> field == required_field end)
+  end
+
+  @doc """
+  Returns the original (unrecognized) JSON Schema type for a field if the
+  schema's type was rewritten to "string" during loading, or `nil` otherwise.
+  """
+  @spec warning(t(), atom() | String.t()) :: String.t() | nil
+  def warning(%__MODULE__{warnings: warnings}, field) when is_atom(field) do
+    Map.get(warnings, field)
+  end
+
+  def warning(schema, field) when is_binary(field) do
+    warning(schema, String.to_existing_atom(field))
+  rescue
+    ArgumentError -> nil
   end
 
   defp error_to_changeset(
@@ -152,36 +217,116 @@ defmodule Lightning.Credentials.Schema do
     Changeset.add_error(changeset, field, "must be an object")
   end
 
-  # can be ignored since not near to atom limit
-  # sobelow_skip ["DOS.StringToAtom"]
   defp get_types(root) do
     root.schema
     |> Map.get("properties", [])
     |> Enum.map(fn {field, properties} ->
-      # credo:disable-for-next-line
-      type =
-        properties
-        |> Map.get("type", "string")
-        |> normalize_property_type()
-        |> String.to_atom()
-
-      {String.to_existing_atom(field), type}
+      type_string = resolve_type(properties)
+      ecto_type = Map.get(@type_map, type_string, :string)
+      {String.to_existing_atom(field), ecto_type}
     end)
     |> Map.new()
   end
 
+  defp resolve_type(%{"type" => type}) when is_binary(type), do: type
+
   # JSON Schema draft-07 lets `type` be a list (e.g. `["string", "null"]`
   # for nullable fields). Pick the first non-null member, defaulting to
   # "string" if only "null" remains.
-  defp normalize_property_type(types) when is_list(types) do
+  defp resolve_type(%{"type" => types}) when is_list(types) do
     types
     |> Enum.reject(&(&1 == "null"))
     |> List.first("string")
-    |> normalize_property_type()
   end
 
-  defp normalize_property_type("object"), do: "map"
-  defp normalize_property_type(type) when is_binary(type), do: type
+  defp resolve_type(%{"anyOf" => alternatives}) when is_list(alternatives) do
+    Enum.find_value(alternatives, "string", fn alt -> Map.get(alt, "type") end)
+  end
+
+  defp resolve_type(_), do: "string"
+
+  # Walks `properties` and replaces any "type" value that isn't a known JSON
+  # Schema primitive with "string". ExJsonSchema's meta-schema validation
+  # rejects unknown type names outright, so this has to run before
+  # `ExJsonSchema.Schema.resolve/1`. Returns `{sanitized_schema, warnings}`
+  # where warnings is `%{field_atom => original_unknown_type}`.
+  defp sanitize_property_types(json_schema, schema_name) do
+    case Map.get(json_schema, "properties") do
+      properties when is_map(properties) ->
+        {sanitized_props, warnings} =
+          Enum.map_reduce(properties, %{}, fn {field, prop}, acc ->
+            {sanitized, unknown} = sanitize_property(prop, field, schema_name)
+
+            acc =
+              case unknown do
+                nil -> acc
+                type -> Map.put(acc, String.to_existing_atom(field), type)
+              end
+
+            {{field, sanitized}, acc}
+          end)
+
+        {Map.put(json_schema, "properties", Map.new(sanitized_props)), warnings}
+
+      _ ->
+        {json_schema, %{}}
+    end
+  end
+
+  # Returns {sanitized_property, unknown_type_or_nil}.
+  defp sanitize_property(%{"type" => type} = prop, field, schema_name)
+       when is_binary(type) do
+    case normalize_type_string(type, field, schema_name) do
+      {:ok, normalized} -> {Map.put(prop, "type", normalized), nil}
+      {:rewritten, normalized} -> {Map.put(prop, "type", normalized), type}
+    end
+  end
+
+  defp sanitize_property(%{"anyOf" => alternatives} = prop, _field, schema_name)
+       when is_list(alternatives) do
+    sanitized =
+      Enum.map(alternatives, fn alt ->
+        {alt_sanitized, _unknown} = sanitize_property(alt, "anyOf", schema_name)
+        alt_sanitized
+      end)
+
+    {Map.put(prop, "anyOf", sanitized), nil}
+  end
+
+  defp sanitize_property(prop, _field, _schema_name), do: {prop, nil}
+
+  defp normalize_type_string(type, field, schema_name) do
+    downcased = String.downcase(type)
+
+    if Map.has_key?(@type_map, downcased) do
+      {:ok, downcased}
+    else
+      report_unknown_type(type, field, schema_name)
+      {:rewritten, "string"}
+    end
+  end
+
+  defp report_unknown_type(type, field, schema_name) do
+    message =
+      "Unknown JSON Schema type #{inspect(type)} for field " <>
+        "#{inspect(field)}#{schema_label(schema_name)}; " <>
+        "falling back to \"string\"."
+
+    Logger.warning(message)
+
+    Lightning.Sentry.capture_message(message,
+      level: :warning,
+      tags: %{type: "credential_schema"},
+      extra: %{
+        schema_name: schema_name,
+        field: to_string(field),
+        unknown_type: type
+      }
+    )
+  end
+
+  defp schema_label(nil), do: ""
+  defp schema_label(name), do: " in schema #{inspect(name)}"
 
   defp validate_json_object(value) when is_binary(value) do
     case Jason.decode(value) do

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -45,7 +45,10 @@ defmodule Lightning.Credentials.Schema do
   def new(json_schema, name) when is_map(json_schema) do
     fields = collect_fields(json_schema)
 
-    plain_schema = to_plain_map(json_schema)
+    plain_schema =
+      json_schema
+      |> to_plain_map()
+      |> normalize_schema_uri()
 
     {sanitized, warnings} = sanitize_property_types(plain_schema, name)
 
@@ -91,6 +94,18 @@ defmodule Lightning.Credentials.Schema do
   end
 
   defp to_plain_map(other), do: other
+
+  # ExJsonSchema's version detection only matches the canonical `http://`
+  # form of the JSON Schema URI. The spec calls the URI an identifier, not
+  # a literal URL, and `https://json-schema.org/...` is widely used in the
+  # wild. Rewrite to the canonical form so the resolver accepts either.
+  defp normalize_schema_uri(
+         %{"$schema" => "https://json-schema.org/" <> rest} = schema
+       ) do
+    Map.put(schema, "$schema", "http://json-schema.org/" <> rest)
+  end
+
+  defp normalize_schema_uri(schema), do: schema
 
   @spec validate(changeset :: Ecto.Changeset.t(), schema :: t()) ::
           Ecto.Changeset.t()

--- a/lib/lightning/credentials/schema.ex
+++ b/lib/lightning/credentials/schema.ex
@@ -67,8 +67,6 @@ defmodule Lightning.Credentials.Schema do
     |> new(name)
   end
 
-  # `Jason.decode!(objects: :ordered_objects)` returns `Jason.OrderedObject`
-  # structs, so we capture field order from the original before flattening.
   defp collect_fields(json_schema) do
     case json_schema["properties"] do
       nil ->
@@ -240,16 +238,14 @@ defmodule Lightning.Credentials.Schema do
   end
 
   defp resolve_type(%{"anyOf" => alternatives}) when is_list(alternatives) do
-    Enum.find_value(alternatives, "string", fn alt -> Map.get(alt, "type") end)
+    alternatives
+    |> Enum.map(&Map.get(&1, "type"))
+    |> Enum.reject(&(&1 in [nil, "null"]))
+    |> List.first("string")
   end
 
   defp resolve_type(_), do: "string"
 
-  # Walks `properties` and replaces any "type" value that isn't a known JSON
-  # Schema primitive with "string". ExJsonSchema's meta-schema validation
-  # rejects unknown type names outright, so this has to run before
-  # `ExJsonSchema.Schema.resolve/1`. Returns `{sanitized_schema, warnings}`
-  # where warnings is `%{field_atom => original_unknown_type}`.
   defp sanitize_property_types(json_schema, schema_name) do
     case Map.get(json_schema, "properties") do
       properties when is_map(properties) ->
@@ -273,7 +269,6 @@ defmodule Lightning.Credentials.Schema do
     end
   end
 
-  # Returns {sanitized_property, unknown_type_or_nil}.
   defp sanitize_property(%{"type" => type} = prop, field, schema_name)
        when is_binary(type) do
     case normalize_type_string(type, field, schema_name) do
@@ -282,15 +277,15 @@ defmodule Lightning.Credentials.Schema do
     end
   end
 
-  defp sanitize_property(%{"anyOf" => alternatives} = prop, _field, schema_name)
+  defp sanitize_property(%{"anyOf" => alternatives} = prop, field, schema_name)
        when is_list(alternatives) do
-    sanitized =
-      Enum.map(alternatives, fn alt ->
-        {alt_sanitized, _unknown} = sanitize_property(alt, "anyOf", schema_name)
-        alt_sanitized
+    {sanitized, unknown} =
+      Enum.map_reduce(alternatives, nil, fn alt, acc ->
+        {alt_sanitized, alt_unknown} = sanitize_property(alt, field, schema_name)
+        {alt_sanitized, acc || alt_unknown}
       end)
 
-    {Map.put(prop, "anyOf", sanitized), nil}
+    {Map.put(prop, "anyOf", sanitized), unknown}
   end
 
   defp sanitize_property(prop, _field, _schema_name), do: {prop, nil}

--- a/lib/lightning_web/live/credential_live/json_schema_body_component.ex
+++ b/lib/lightning_web/live/credential_live/json_schema_body_component.ex
@@ -68,7 +68,8 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         form_field: assigns.form[assigns.field],
         title: Map.get(properties, "title"),
         type: input_type(properties),
-        required: Credentials.Schema.required?(assigns.schema, assigns.field)
+        required: Credentials.Schema.required?(assigns.schema, assigns.field),
+        schema_warning: Credentials.Schema.warning(assigns.schema, assigns.field)
       )
 
     ~H"""
@@ -81,6 +82,18 @@ defmodule LightningWeb.CredentialLive.JsonSchemaBodyComponent do
         autocomplete={if @type == "password", do: "new-password", else: "off"}
         checked={@type == "checkbox" and @form_field.value == true}
       />
+      <div
+        :if={@schema_warning}
+        class="mt-1 flex items-start gap-1 text-xs text-yellow-700"
+      >
+        <span class="hero-exclamation-triangle-solid h-4 w-4 text-yellow-500 flex-shrink-0">
+        </span>
+        <span>
+          This adaptor's configuration schema specifies an unrecognized type
+          (<code>{@schema_warning}</code>) for this field;
+          we'll store it as text.
+        </span>
+      </div>
     </div>
     """
   end

--- a/test/fixtures/schemas/unknownish.json
+++ b/test/fixtures/schemas/unknownish.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "host": {
+      "type": "string",
+      "description": "The host"
+    },
+    "port": {
+      "type": "badThing",
+      "description": "The port"
+    }
+  },
+  "required": ["host"]
+}

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -1,9 +1,20 @@
 defmodule Lightning.Credentials.SchemaTest do
   use Lightning.DataCase, async: true
 
+  import ExUnit.CaptureLog
+  import Mox
+
   alias Lightning.Credentials
   alias Lightning.Credentials.Schema
   alias Lightning.Credentials.SchemaDocument
+
+  setup :verify_on_exit!
+
+  setup do
+    Mox.stub(Lightning.MockConfig, :sentry, fn -> Lightning.MockSentry end)
+    Mox.stub(Lightning.MockSentry, :capture_message, fn _msg, _opts -> :ok end)
+    :ok
+  end
 
   setup do
     schema_map =
@@ -112,6 +123,134 @@ defmodule Lightning.Credentials.SchemaTest do
              }
 
       assert schema.fields == [:username, :password, :hostUrl, :number]
+    end
+
+    test "falls back to :string and logs a warning for unknown types" do
+      schema_map = %{
+        "title" => "broken",
+        "properties" => %{
+          "count" => %{"type" => "Number"},
+          "label" => %{"type" => "string"}
+        }
+      }
+
+      {schema, log} =
+        with_log(fn -> Schema.new(schema_map) end)
+
+      assert schema.types == %{count: :float, label: :string}
+      refute log =~ "count"
+
+      schema_map = put_in(schema_map["properties"]["count"]["type"], "Bogus")
+
+      test_pid = self()
+
+      expect(Lightning.MockSentry, :capture_message, fn msg, opts ->
+        send(test_pid, {:sentry_called, msg, opts})
+        :ok
+      end)
+
+      {schema, log} =
+        with_log(fn -> Schema.new(schema_map, "broken-schema") end)
+
+      assert schema.types == %{count: :string, label: :string}
+      assert log =~ ~s(Unknown JSON Schema type "Bogus")
+      assert log =~ ~s("count")
+      assert log =~ ~s(in schema "broken-schema")
+
+      assert_received {:sentry_called, msg, opts}
+      assert msg =~ ~s(Unknown JSON Schema type "Bogus")
+      assert opts[:level] == :warning
+      assert opts[:tags] == %{type: "credential_schema"}
+
+      assert opts[:extra] == %{
+               schema_name: "broken-schema",
+               field: "count",
+               unknown_type: "Bogus"
+             }
+    end
+
+    test "accepts JSON Schema types case-insensitively" do
+      schema_map = %{
+        "properties" => %{
+          "flag" => %{"type" => "Boolean"},
+          "count" => %{"type" => "INTEGER"},
+          "items" => %{"type" => "Array"}
+        }
+      }
+
+      {schema, log} = with_log(fn -> Schema.new(schema_map) end)
+
+      assert schema.types == %{
+               flag: :boolean,
+               count: :integer,
+               items: {:array, :string}
+             }
+
+      assert log == ""
+    end
+
+    test "resolves anyOf types by picking the first concrete type" do
+      schema_map = %{
+        "properties" => %{
+          "maybe_int" => %{
+            "anyOf" => [%{"type" => "integer"}, %{"type" => "null"}]
+          }
+        }
+      }
+
+      schema = Schema.new(schema_map)
+      assert schema.types == %{maybe_int: :integer}
+    end
+
+    test "defaults to :string when type is missing entirely" do
+      schema_map = %{"properties" => %{"name" => %{"description" => "no type"}}}
+
+      schema = Schema.new(schema_map)
+      assert schema.types == %{name: :string}
+    end
+
+    test "sanitizes unknown types in JSON loaded with ordered_objects" do
+      raw = ~s({
+        "properties": {
+          "endPoint": {"type": "string"},
+          "port": {"type": "mistake"},
+          "useSSL": {"type": "boolean"}
+        }
+      })
+
+      {schema, _log} = with_log(fn -> Schema.new(raw, "minio") end)
+
+      assert schema.types == %{
+               endPoint: :string,
+               port: :string,
+               useSSL: :boolean
+             }
+
+      assert schema.fields == [:endPoint, :port, :useSSL]
+      assert schema.warnings == %{port: "mistake"}
+
+      changeset =
+        SchemaDocument.changeset(%{"port" => "2"}, schema: schema)
+
+      assert changeset.valid? or
+               not Enum.any?(changeset.errors, fn {field, _} ->
+                 field == :port
+               end)
+    end
+
+    test "exposes warning/2 for fields with rewritten types" do
+      schema_map = %{
+        "properties" => %{
+          "weird" => %{"type" => "Bogus"},
+          "fine" => %{"type" => "string"}
+        }
+      }
+
+      {schema, _log} = with_log(fn -> Schema.new(schema_map) end)
+
+      assert Schema.warning(schema, :weird) == "Bogus"
+      assert Schema.warning(schema, "weird") == "Bogus"
+      assert Schema.warning(schema, :fine) == nil
     end
   end
 

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -232,10 +232,44 @@ defmodule Lightning.Credentials.SchemaTest do
       changeset =
         SchemaDocument.changeset(%{"port" => "2"}, schema: schema)
 
-      assert changeset.valid? or
-               not Enum.any?(changeset.errors, fn {field, _} ->
-                 field == :port
-               end)
+      refute Enum.any?(changeset.errors, &match?({:port, _}, &1))
+    end
+
+    test "prefers non-null anyOf alternatives regardless of order" do
+      schema_map = %{
+        "properties" => %{
+          "null_first" => %{
+            "anyOf" => [%{"type" => "null"}, %{"type" => "integer"}]
+          }
+        }
+      }
+
+      schema = Schema.new(schema_map)
+      assert schema.types == %{null_first: :integer}
+    end
+
+    test "bubbles unknown anyOf types up to the parent field's warning" do
+      schema_map = %{
+        "properties" => %{
+          "weird" => %{
+            "anyOf" => [%{"type" => "Bogus"}, %{"type" => "string"}]
+          }
+        }
+      }
+
+      {schema, log} = with_log(fn -> Schema.new(schema_map, "weird-schema") end)
+
+      assert schema.warnings == %{weird: "Bogus"}
+      assert log =~ ~s(Unknown JSON Schema type "Bogus")
+      assert log =~ ~s("weird")
+    end
+
+    test "tolerates schemas without a `properties` key" do
+      schema = Schema.new(%{"type" => "object"})
+
+      assert schema.fields == []
+      assert schema.types == %{}
+      assert schema.warnings == %{}
     end
 
     test "exposes warning/2 for fields with rewritten types" do
@@ -251,6 +285,7 @@ defmodule Lightning.Credentials.SchemaTest do
       assert Schema.warning(schema, :weird) == "Bogus"
       assert Schema.warning(schema, "weird") == "Bogus"
       assert Schema.warning(schema, :fine) == nil
+      assert Schema.warning(schema, "never_seen_field_name") == nil
     end
   end
 

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -272,6 +272,18 @@ defmodule Lightning.Credentials.SchemaTest do
       assert schema.warnings == %{}
     end
 
+    test "accepts both `http://` and `https://` JSON Schema URIs" do
+      raw = ~s({
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "properties": {"server": {"type": "string"}},
+        "type": "object"
+      })
+
+      schema = Schema.new(raw, "https-uri")
+      assert schema.types == %{server: :string}
+      assert schema.fields == [:server]
+    end
+
     test "exposes warning/2 for fields with rewritten types" do
       schema_map = %{
         "properties" => %{

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -968,6 +968,42 @@ defmodule LightningWeb.CredentialLiveTest do
       {_path, flash} = assert_redirect(view)
       assert flash == %{"info" => "Credential created successfully"}
     end
+
+    test "renders the unrecognized-type warning under affected fields", %{
+      conn: conn
+    } do
+      Mox.stub(Lightning.MockConfig, :sentry, fn -> Lightning.MockSentry end)
+      Mox.stub(Lightning.MockSentry, :capture_message, fn _msg, _opts -> :ok end)
+
+      {:ok, view, _html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      open_create_credential_modal(view)
+      select_credential_type(view, "unknownish")
+      click_continue(view)
+
+      refute view |> has_element?("#credential-type-picker")
+
+      html = view |> element("#credential-form-new") |> render()
+
+      assert html =~ "unrecognized type"
+      assert html =~ "<code>badThing</code>"
+      assert html =~ "we&#39;ll store it as text"
+    end
+
+    test "does not render an unrecognized-type warning for known types", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      open_create_credential_modal(view)
+      select_credential_type(view, "dhis2")
+      click_continue(view)
+
+      html = view |> element("#credential-form-new") |> render()
+
+      refute html =~ "unrecognized type"
+      refute html =~ "we&#39;ll store it as text"
+    end
   end
 
   describe "Edit" do


### PR DESCRIPTION
## Description

Prevents a crash when an adaptor's credential schema declares an unrecognized `type`. The unknown field is treated as text, the credential form shows a yellow note under it explaining the fallback, the developer log records a warning, and Sentry receives a tagged message with the schema name, field, and offending type.

Type matching is now case-insensitive (`"Boolean"`, `"INTEGER"` resolve correctly), `anyOf` alternatives skip `null` so a non-null type wins regardless of order, and array-form types like `["string", "null"]` continue to resolve correctly.

closes #4681

## Validation steps

1. Edit a local credential schema and set one field's `type` to a nonsense value like `"badThing"`.
2. Open the credential form for that schema. The form should render without crashing, with a yellow note under the affected field reading "This adaptor's configuration schema specifies an unrecognized type (`badThing`) for this field; we'll store it as text".
3. Confirm the developer log has a warning line and that Sentry received a message tagged `credential_schema`.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
