### PR TITLE
Autoscale collection storage column and make it sortable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,18 @@ and this project adheres to
 
 ### Changed
 
+- Project Settings, Collections panel: rename the "Used Storage (MB)" column to
+  "Used storage" and render values with autoscaled units (B, KB, MB, GB, TB)
+  instead of integer megabytes. The column is now sortable, alongside the
+  existing Name column. Same change applied on the admin collections index.
+  [#4684](https://github.com/OpenFn/lightning/issues/4684)
+
 ### Fixed
+
+- Collection storage on Project Settings, Collections no longer shows `0` for
+  collections holding less than one megabyte of data. The underlying counter was
+  always correct, the rendering now reflects values at any scale.
+  [#4684](https://github.com/OpenFn/lightning/issues/4684)
 
 ## [2.16.3-pre] - 2026-04-30
 

--- a/lib/lightning/collections.ex
+++ b/lib/lightning/collections.ex
@@ -42,12 +42,15 @@ defmodule Lightning.Collections do
     Repo.all(from(c in Collection, order_by: ^order_by, preload: ^preload))
   end
 
-  @spec list_project_collections(Project.t()) :: [Collection.t(), ...] | []
-  def list_project_collections(%Project{id: project_id}) do
+  @spec list_project_collections(Project.t(), keyword()) ::
+          [Collection.t(), ...] | []
+  def list_project_collections(%Project{id: project_id}, opts \\ []) do
+    order_by = Keyword.get(opts, :order_by, asc: :name)
+
     query =
       from c in Collection,
         where: c.project_id == ^project_id,
-        order_by: [desc: :inserted_at]
+        order_by: ^order_by
 
     Repo.all(query)
   end

--- a/lib/lightning/helpers.ex
+++ b/lib/lightning/helpers.ex
@@ -47,6 +47,52 @@ defmodule Lightning.Helpers do
     |> Timex.Format.Duration.Formatters.Humanized.format()
   end
 
+  @doc """
+  Converts a non-negative byte count into a compact human-readable string,
+  autoscaled to the most natural SI unit (B, KB, MB, GB, TB).
+
+  Values smaller than 1 KB are rendered with no decimal. Larger values are
+  rendered with one decimal place when that decimal is non-zero.
+
+      iex> bytes_to_human(0)
+      "0 B"
+
+      iex> bytes_to_human(900)
+      "900 B"
+
+      iex> bytes_to_human(1_500)
+      "1.5 KB"
+
+      iex> bytes_to_human(2_000_000)
+      "2 MB"
+
+      iex> bytes_to_human(2_500_000)
+      "2.5 MB"
+
+      iex> bytes_to_human(3_200_000_000)
+      "3.2 GB"
+  """
+  @spec bytes_to_human(non_neg_integer()) :: String.t()
+  def bytes_to_human(bytes) when is_integer(bytes) and bytes >= 0 do
+    cond do
+      bytes >= 1_000_000_000_000 -> scale(bytes, 1_000_000_000_000, "TB")
+      bytes >= 1_000_000_000 -> scale(bytes, 1_000_000_000, "GB")
+      bytes >= 1_000_000 -> scale(bytes, 1_000_000, "MB")
+      bytes >= 1_000 -> scale(bytes, 1_000, "KB")
+      true -> "#{bytes} B"
+    end
+  end
+
+  defp scale(bytes, divisor, unit) do
+    rounded = Float.round(bytes / divisor, 1)
+
+    if rounded == trunc(rounded) do
+      "#{trunc(rounded)} #{unit}"
+    else
+      "#{rounded} #{unit}"
+    end
+  end
+
   def actual_deletion_date(
         grace_period,
         cron_expression \\ "4 2 * * *",

--- a/lib/lightning_web/live/collection_live/components.ex
+++ b/lib/lightning_web/live/collection_live/components.ex
@@ -85,13 +85,20 @@ defmodule LightningWeb.CollectionLive.Components do
               <.th
                 sortable={true}
                 sort_by="name"
-                active={true}
-                sort_direction={to_string(@name_direction)}
+                active={@sort_by == "name"}
+                sort_direction={to_string(@sort_direction)}
               >
                 Name
               </.th>
               <.th>Project</.th>
-              <.th>Used Storage (MB)</.th>
+              <.th
+                sortable={true}
+                sort_by="byte_size_sum"
+                active={@sort_by == "byte_size_sum"}
+                sort_direction={to_string(@sort_direction)}
+              >
+                Used storage
+              </.th>
               <.th></.th>
             </.tr>
           </:header>
@@ -105,7 +112,7 @@ defmodule LightningWeb.CollectionLive.Components do
                   {collection.project.name}
                 </.td>
                 <.td class="wrap-break-word max-w-[25rem]">
-                  {div(collection.byte_size_sum, 1_000_000)}
+                  {Lightning.Helpers.bytes_to_human(collection.byte_size_sum)}
                 </.td>
                 <.td>
                   <div class="text-right">

--- a/lib/lightning_web/live/collection_live/index.ex
+++ b/lib/lightning_web/live/collection_live/index.ex
@@ -23,7 +23,8 @@ defmodule LightningWeb.CollectionLive.Index do
          page_title: "Collections",
          active_menu_item: :collections,
          collections: Collections.list_collections(),
-         name_sort_direction: :asc
+         sort_by: "name",
+         sort_direction: :asc
        ), layout: {LightningWeb.Layouts, :settings}}
     else
       {:ok,
@@ -34,22 +35,25 @@ defmodule LightningWeb.CollectionLive.Index do
   end
 
   @impl true
-  def handle_event("sort", %{"by" => field}, socket) do
-    sort_key = String.to_atom("#{field}_sort_direction")
-    sort_direction = Map.get(socket.assigns, sort_key, :asc)
-    new_sort_direction = switch_sort_direction(sort_direction)
-
-    order_column = map_sort_field_to_column(field)
+  def handle_event("sort", %{"by" => field}, socket)
+      when field in ~w(name byte_size_sum) do
+    new_direction =
+      if socket.assigns.sort_by == field do
+        switch_sort_direction(socket.assigns.sort_direction)
+      else
+        :asc
+      end
 
     collections =
       Collections.list_collections(
-        order_by: [{new_sort_direction, order_column}]
+        order_by: [{new_direction, String.to_existing_atom(field)}]
       )
 
     {:noreply,
      socket
      |> assign(:collections, collections)
-     |> assign(sort_key, new_sort_direction)}
+     |> assign(:sort_by, field)
+     |> assign(:sort_direction, new_direction)}
   end
 
   def handle_event("delete_collection", %{"collection" => collection_id}, socket) do
@@ -73,8 +77,6 @@ defmodule LightningWeb.CollectionLive.Index do
   defp switch_sort_direction(:asc), do: :desc
   defp switch_sort_direction(:desc), do: :asc
 
-  defp map_sort_field_to_column("name"), do: :name
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -89,7 +91,8 @@ defmodule LightningWeb.CollectionLive.Index do
           <.collections_table
             collections={@collections}
             user={@current_user}
-            name_direction={@name_sort_direction}
+            sort_by={@sort_by}
+            sort_direction={@sort_direction}
           >
             <:empty_state>
               <.empty_state

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -340,6 +340,9 @@ defmodule LightningWeb.Components.DataTables do
   attr :id, :string, required: true
   attr :collections, :list, required: true
   attr :can_create_collection, :boolean, required: true
+  attr :sort_by, :string, default: "name"
+  attr :sort_direction, :atom, default: :asc
+  attr :sort_target, :any, default: nil
 
   slot :actions,
     doc: "the slot for showing user actions in the last table column"
@@ -355,8 +358,24 @@ defmodule LightningWeb.Components.DataTables do
         <.table id={"#{@id}-table"}>
           <:header>
             <.tr>
-              <.th>Name</.th>
-              <.th>Used Storage (MB)</.th>
+              <.th
+                sortable={true}
+                sort_by="name"
+                active={@sort_by == "name"}
+                sort_direction={to_string(@sort_direction)}
+                phx_target={@sort_target}
+              >
+                Name
+              </.th>
+              <.th
+                sortable={true}
+                sort_by="byte_size_sum"
+                active={@sort_by == "byte_size_sum"}
+                sort_direction={to_string(@sort_direction)}
+                phx_target={@sort_target}
+              >
+                Used storage
+              </.th>
               <.th><span class="sr-only">Actions</span></.th>
             </.tr>
           </:header>
@@ -364,7 +383,9 @@ defmodule LightningWeb.Components.DataTables do
             <%= for collection <- @collections do %>
               <.tr id={"collection-row-#{collection.id}"}>
                 <.td>{collection.name}</.td>
-                <.td>{div(collection.byte_size_sum, 1_000_000)}</.td>
+                <.td>
+                  {Lightning.Helpers.bytes_to_human(collection.byte_size_sum)}
+                </.td>
                 <.td class="flex justify-end py-0.5">
                   {render_slot(@actions, collection)}
                 </.td>

--- a/lib/lightning_web/live/project_live/collections_component.ex
+++ b/lib/lightning_web/live/project_live/collections_component.ex
@@ -20,7 +20,9 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
        collection: nil,
        collections: [],
        preview_json: nil,
-       current_user: nil
+       current_user: nil,
+       sort_by: "name",
+       sort_direction: :asc
      )}
   end
 
@@ -28,20 +30,49 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
   def update(
         %{
           can_create_collection: _,
-          collections: _,
           return_to: _,
-          project: _,
+          project: project,
           sandbox?: _,
           current_user: _
         } = assigns,
         socket
       ) do
+    sort_by = Map.get(socket.assigns, :sort_by, "name")
+    sort_direction = Map.get(socket.assigns, :sort_direction, :asc)
+
+    collections =
+      Collections.list_project_collections(project,
+        order_by: [{sort_direction, String.to_existing_atom(sort_by)}]
+      )
+
     {:ok,
      socket
-     |> assign(assigns)}
+     |> assign(assigns)
+     |> assign(:collections, collections)}
   end
 
   @impl true
+  def handle_event("sort", %{"by" => field}, socket)
+      when field in ~w(name byte_size_sum) do
+    new_direction =
+      if socket.assigns.sort_by == field do
+        switch_sort_direction(socket.assigns.sort_direction)
+      else
+        :asc
+      end
+
+    collections =
+      Collections.list_project_collections(socket.assigns.project,
+        order_by: [{new_direction, String.to_existing_atom(field)}]
+      )
+
+    {:noreply,
+     socket
+     |> assign(:collections, collections)
+     |> assign(:sort_by, field)
+     |> assign(:sort_direction, new_direction)}
+  end
+
   def handle_event("toggle_action", %{"action" => "new"}, socket) do
     with :ok <- can_create_collection(socket) do
       changeset = Collection.form_changeset(%Collection{}, %{})
@@ -252,6 +283,9 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
     end
   end
 
+  defp switch_sort_direction(:asc), do: :desc
+  defp switch_sort_direction(:desc), do: :asc
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -306,6 +340,9 @@ defmodule LightningWeb.ProjectLive.CollectionsComponent do
         id="collections-table"
         collections={@collections}
         can_create_collection={@can_create_collection}
+        sort_by={@sort_by}
+        sort_direction={@sort_direction}
+        sort_target={@myself}
       >
         <:actions :let={collection}>
           <div class="text-right flex">

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -8,7 +8,6 @@ defmodule LightningWeb.ProjectLive.Settings do
   import LightningWeb.LayoutComponents
 
   alias Lightning.Accounts.User
-  alias Lightning.Collections
   alias Lightning.Credentials
   alias Lightning.Helpers
   alias Lightning.Policies.Permissions
@@ -45,7 +44,6 @@ defmodule LightningWeb.ProjectLive.Settings do
     project_user = Projects.get_project_user(project, current_user)
 
     project_files = Projects.list_project_files(project)
-    collections = Collections.list_project_collections(project)
 
     projects = Projects.get_projects_for_user(current_user)
 
@@ -130,7 +128,6 @@ defmodule LightningWeb.ProjectLive.Settings do
        active_menu_item: :settings,
        can_receive_failure_alerts: can_receive_failure_alerts,
        collaborators_to_invite: [],
-       collections: collections,
        current_user: socket.assigns.current_user,
        github_enabled: VersionControl.github_enabled?(),
        name: project.name,

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -360,7 +360,6 @@
           module={LightningWeb.ProjectLive.CollectionsComponent}
           id="collections"
           project={@project}
-          collections={@collections}
           can_create_collection={@can_create_collection}
           sandbox?={@sandbox?}
           current_user={@current_user}

--- a/test/lightning/helpers_test.exs
+++ b/test/lightning/helpers_test.exs
@@ -163,4 +163,42 @@ defmodule Lightning.HelpersTest do
       assert Helpers.url_safe_name("Project 2023") == "project-2023"
     end
   end
+
+  describe "bytes_to_human/1" do
+    test "renders zero bytes" do
+      assert Helpers.bytes_to_human(0) == "0 B"
+    end
+
+    test "renders sub-KB values in bytes" do
+      assert Helpers.bytes_to_human(512) == "512 B"
+      assert Helpers.bytes_to_human(999) == "999 B"
+    end
+
+    test "renders sub-MB values in KB" do
+      assert Helpers.bytes_to_human(1_000) == "1 KB"
+      assert Helpers.bytes_to_human(1_483) == "1.5 KB"
+      assert Helpers.bytes_to_human(999_999) == "1000 KB"
+    end
+
+    test "renders sub-GB values in MB" do
+      assert Helpers.bytes_to_human(1_000_000) == "1 MB"
+      assert Helpers.bytes_to_human(2_500_000) == "2.5 MB"
+      assert Helpers.bytes_to_human(600_000_000) == "600 MB"
+    end
+
+    test "renders sub-TB values in GB" do
+      assert Helpers.bytes_to_human(1_000_000_000) == "1 GB"
+      assert Helpers.bytes_to_human(3_200_000_000) == "3.2 GB"
+    end
+
+    test "renders multi-TB values in TB" do
+      assert Helpers.bytes_to_human(1_000_000_000_000) == "1 TB"
+      assert Helpers.bytes_to_human(2_700_000_000_000) == "2.7 TB"
+    end
+
+    test "drops the decimal when scaled value is a whole number" do
+      assert Helpers.bytes_to_human(2_000_000) == "2 MB"
+      assert Helpers.bytes_to_human(2_000) == "2 KB"
+    end
+  end
 end

--- a/test/lightning_web/live/collection_live_test.exs
+++ b/test/lightning_web/live/collection_live_test.exs
@@ -57,9 +57,24 @@ defmodule LightningWeb.CollectionLiveTest do
       sorted_names = get_sorted_collection_names(view)
       assert sorted_names == ["A Collection", "B Collection"]
 
-      view |> element("a[phx-click='sort']") |> render_click()
+      view |> element("a[phx-value-by='name']") |> render_click()
       sorted_names = get_sorted_collection_names(view)
       assert sorted_names == ["B Collection", "A Collection"]
+    end
+
+    test "Collections can be sorted by used storage for superuser", %{conn: conn} do
+      insert(:collection, name: "Tiny", byte_size_sum: 100)
+      insert(:collection, name: "Huge", byte_size_sum: 5_000_000_000)
+      insert(:collection, name: "Medium", byte_size_sum: 2_500_000)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/settings/collections", on_error: :raise)
+
+      view |> element("a[phx-value-by='byte_size_sum']") |> render_click()
+      assert get_sorted_collection_names(view) == ["Tiny", "Medium", "Huge"]
+
+      view |> element("a[phx-value-by='byte_size_sum']") |> render_click()
+      assert get_sorted_collection_names(view) == ["Huge", "Medium", "Tiny"]
     end
 
     test "Superuser can delete a collection", %{conn: conn} do

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -6900,6 +6900,60 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert flash["error"] == "Collection not found"
     end
+
+    test "collections can be sorted by name and used storage", %{conn: conn} do
+      project = insert(:project)
+      [{conn, _user} | _] = setup_project_users(conn, project, [:owner])
+
+      insert(:collection,
+        project: project,
+        name: "Charlie",
+        byte_size_sum: 100
+      )
+
+      insert(:collection,
+        project: project,
+        name: "Alpha",
+        byte_size_sum: 5_000_000_000
+      )
+
+      insert(:collection,
+        project: project,
+        name: "Bravo",
+        byte_size_sum: 2_500_000
+      )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project.id}/settings#collections")
+
+      assert collection_row_names(view) == ["Alpha", "Bravo", "Charlie"]
+
+      view
+      |> element("#collections-table-table a[phx-value-by='name']")
+      |> render_click()
+
+      assert collection_row_names(view) == ["Charlie", "Bravo", "Alpha"]
+
+      view
+      |> element("#collections-table-table a[phx-value-by='byte_size_sum']")
+      |> render_click()
+
+      assert collection_row_names(view) == ["Charlie", "Bravo", "Alpha"]
+
+      view
+      |> element("#collections-table-table a[phx-value-by='byte_size_sum']")
+      |> render_click()
+
+      assert collection_row_names(view) == ["Alpha", "Bravo", "Charlie"]
+    end
+  end
+
+  defp collection_row_names(view) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find("#collections-table-table tbody tr td:first-child")
+    |> Enum.map(&(Floki.text(&1) |> String.trim()))
   end
 
   defp find_selected_option(html, selector) do

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -6923,8 +6923,12 @@ defmodule LightningWeb.ProjectLiveTest do
         byte_size_sum: 2_500_000
       )
 
-      {:ok, view, _html} =
+      {:ok, view, html} =
         live(conn, ~p"/projects/#{project.id}/settings#collections")
+
+      assert html =~ "100 B"
+      assert html =~ "2.5 MB"
+      assert html =~ "5 GB"
 
       assert collection_row_names(view) == ["Alpha", "Bravo", "Charlie"]
 


### PR DESCRIPTION
## Description

The Collections panel under Project Settings (and the admin collections index) used to render the storage column as integer megabytes, so any collection holding less than one megabyte displayed as `0`. The underlying counter was always correct, the rendering just rounded down. This PR replaces the integer-MB rendering with autoscaled units (B, KB, MB, GB, TB) via a shared helper, drops the hardcoded "(MB)" from the column header, and makes the column sortable alongside Name. Default sort is by name, ascending.

Closes #4684

## Validation steps

Loom video here for faster QA: https://www.loom.com/share/2caf6a6cb2434158a14534689aa19e0c

1. Open a project and navigate to **Settings**, then **Collections**.
2. Confirm the column header reads "Used storage" (no unit in the title).
3. Confirm a collection with a small payload (a few kilobytes) now shows its size as e.g. "1.5 KB" rather than "0".
4. Click the **Name** column header. Order toggles between ascending and descending.
5. Click the **Used storage** column header. Order toggles between ascending and descending and the chevron indicator follows the active column.
6. Repeat on the admin collections index at `/settings/collections` (superuser).
7. To exercise the full unit range, vary the storage size of a few collections from a few hundred bytes up to several terabytes and confirm each renders in the natural unit (B, KB, MB, GB, TB).

## Additional notes for the reviewer

The default sort for the per-project collections list changes from "newest first" to "by name (ascending)". The two internal callers of that list function (sandbox provisioning and merge sync) only consume names and byte-size totals, so they are not order-sensitive.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [x] I have implemented and tested all related **authorization policies**.
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR