### PR TITLE
Fix wrong sort order at UTC month boundaries and pre-release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to
   in-memory sort over project rows previously relied on structural comparison of
   timestamps and could invert when projects' last activity straddled a month
   boundary in UTC.
+- Sort admin tables chronologically when the active column is a date column
+  (admin projects "Created at" and "Scheduled deletion", admin users "Scheduled
+  deletion"). The shared in-memory sort helper previously used structural
+  comparison on date values and could invert across a month boundary in UTC.
 
 ## [2.16.3-pre] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,20 @@ and this project adheres to
 - Sort the project workflow list chronologically by Latest Work Order. The
   column previously sorted incorrectly when the most recent work orders for two
   workflows fell on either side of a month boundary in UTC.
+  [#4687](https://github.com/OpenFn/lightning/pull/4687)
 - Sort the adaptor version dropdown per semver. Pre-release versions previously
   appeared above the corresponding stable release because the sort relied on
   structural comparison of parsed version structs rather than
-  `Version.compare/2`.
+  `Version.compare/2`. [#4687](https://github.com/OpenFn/lightning/pull/4687)
 - Sort the support-user projects overview chronologically by Last Updated. The
   in-memory sort over project rows previously relied on structural comparison of
   timestamps and could invert when projects' last activity straddled a month
-  boundary in UTC.
+  boundary in UTC. [#4687](https://github.com/OpenFn/lightning/pull/4687)
 - Sort admin tables chronologically when the active column is a date column
   (admin projects "Created at" and "Scheduled deletion", admin users "Scheduled
   deletion"). The shared in-memory sort helper previously used structural
   comparison on date values and could invert across a month boundary in UTC.
+  [#4687](https://github.com/OpenFn/lightning/pull/4687)
 - Prevent crash when an unsupported data type from `credential-schema.json` is
   loaded for building a credential schema from an adaptor. Fall-back to
   `:string` type, log warning and alert Sentry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to
 - Sort the project workflow list chronologically by Latest Work Order. The
   column previously sorted incorrectly when the most recent work orders for two
   workflows fell on either side of a month boundary in UTC.
+- Sort the adaptor version dropdown per semver. Pre-release versions previously
+  appeared above the corresponding stable release because the sort relied on
+  structural comparison of parsed version structs rather than
+  `Version.compare/2`.
 
 ## [2.16.3-pre] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
 
 ### Fixed
 
+- Sort the project workflow list chronologically by Latest Work Order. The sort
+  previously used structural comparison on timestamps, so the order could flip
+  when the most recent work orders straddled a UTC date boundary.
+
 ## [2.16.3-pre] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,22 +21,14 @@ and this project adheres to
 
 ### Fixed
 
-- Sort the project workflow list chronologically by Latest Work Order. The
-  column previously sorted incorrectly when the most recent work orders for two
-  workflows fell on either side of a month boundary in UTC.
+- Sort the workflow list, projects overview, and admin tables chronologically by
+  their date columns. Each previously inverted when timestamps fell on either
+  side of a month boundary in UTC. Affected columns: "Latest Work Order" on the
+  workflow list, "Last Updated" on the support-user projects overview, "Created
+  at" and "Scheduled deletion" on the admin Projects and Users tables.
   [#4687](https://github.com/OpenFn/lightning/pull/4687)
 - Sort the adaptor version dropdown per semver. Pre-release versions previously
-  appeared above the corresponding stable release because the sort relied on
-  structural comparison of parsed version structs rather than
-  `Version.compare/2`. [#4687](https://github.com/OpenFn/lightning/pull/4687)
-- Sort the support-user projects overview chronologically by Last Updated. The
-  in-memory sort over project rows previously relied on structural comparison of
-  timestamps and could invert when projects' last activity straddled a month
-  boundary in UTC. [#4687](https://github.com/OpenFn/lightning/pull/4687)
-- Sort admin tables chronologically when the active column is a date column
-  (admin projects "Created at" and "Scheduled deletion", admin users "Scheduled
-  deletion"). The shared in-memory sort helper previously used structural
-  comparison on date values and could invert across a month boundary in UTC.
+  appeared above their corresponding stable release.
   [#4687](https://github.com/OpenFn/lightning/pull/4687)
 - Prevent crash when an unsupported data type from `credential-schema.json` is
   loaded for building a credential schema from an adaptor. Fall-back to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ and this project adheres to
 
 ### Fixed
 
-- Sort the project workflow list chronologically by Latest Work Order. The sort
-  previously used structural comparison on timestamps, so the order could flip
-  when the most recent work orders straddled a UTC date boundary.
+- Sort the project workflow list chronologically by Latest Work Order. The
+  column previously sorted incorrectly when the most recent work orders for two
+  workflows fell on either side of a month boundary in UTC.
 
 ## [2.16.3-pre] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to
   appeared above the corresponding stable release because the sort relied on
   structural comparison of parsed version structs rather than
   `Version.compare/2`.
+- Sort the support-user projects overview chronologically by Last Updated. The
+  in-memory sort over project rows previously relied on structural comparison of
+  timestamps and could invert when projects' last activity straddled a month
+  boundary in UTC.
 
 ## [2.16.3-pre] - 2026-04-30
 

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -158,9 +158,16 @@ defmodule Lightning.DashboardStats do
     Enum.sort_by(workflow_stats, sorter, sort_direction)
   end
 
+  # `Enum.sort_by/3` with `:asc`/`:desc` does structural term comparison, which
+  # on `DateTime` structs orders by struct keys (day before month before year),
+  # not chronologically. Returning unix microseconds avoids that pitfall for
+  # any datetime-valued sort key added later.
   defp get_sorter(:last_workorder_updated_at) do
     fn stats ->
-      stats.last_workorder.updated_at || ~U[1970-01-01 00:00:00Z]
+      case stats.last_workorder.updated_at do
+        nil -> 0
+        dt -> DateTime.to_unix(dt, :microsecond)
+      end
     end
   end
 

--- a/lib/lightning/dashboard_stats.ex
+++ b/lib/lightning/dashboard_stats.ex
@@ -160,13 +160,15 @@ defmodule Lightning.DashboardStats do
 
   # `Enum.sort_by/3` with `:asc`/`:desc` does structural term comparison, which
   # on `DateTime` structs orders by struct keys (day before month before year),
-  # not chronologically. Returning unix microseconds avoids that pitfall for
-  # any datetime-valued sort key added later.
+  # not chronologically. Returning unix microseconds avoids that pitfall.
+  # The leading sentinel (`0` for nil, `1` for present) keeps nil rows
+  # cleanly separate from a hypothetical `~U[1970-01-01]` row, so the two
+  # can never tie at the comparator.
   defp get_sorter(:last_workorder_updated_at) do
     fn stats ->
       case stats.last_workorder.updated_at do
-        nil -> 0
-        dt -> DateTime.to_unix(dt, :microsecond)
+        nil -> {0, 0}
+        dt -> {1, DateTime.to_unix(dt, :microsecond)}
       end
     end
   end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -84,7 +84,7 @@ defmodule Lightning.Projects do
     [user_projects, support_projects]
     |> Enum.concat()
     |> Enum.uniq_by(& &1.id)
-    |> Enum.sort_by(&Map.get(&1, sort_key), sort_direction)
+    |> Enum.sort_by(&overview_sort_key(&1, sort_key), sort_direction)
   end
 
   def get_projects_overview(%User{id: user_id}, opts) do
@@ -94,6 +94,18 @@ defmodule Lightning.Projects do
     |> projects_overview_query()
     |> order_by(^dynamic_order_by(order_by))
     |> Repo.all()
+  end
+
+  # `Enum.sort_by/3` with `:asc`/`:desc` does structural term comparison, which
+  # on `DateTime` structs orders by struct keys (day before month before year),
+  # not chronologically. Map datetime keys to unix microseconds so the sort is
+  # chronological at month boundaries.
+  defp overview_sort_key(row, sort_key) do
+    case Map.get(row, sort_key) do
+      %DateTime{} = dt -> DateTime.to_unix(dt, :microsecond)
+      nil -> 0
+      other -> other
+    end
   end
 
   defp projects_overview_query(user_id) do

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -98,13 +98,15 @@ defmodule Lightning.Projects do
 
   # `Enum.sort_by/3` with `:asc`/`:desc` does structural term comparison, which
   # on `DateTime` structs orders by struct keys (day before month before year),
-  # not chronologically. Map datetime keys to unix microseconds so the sort is
-  # chronological at month boundaries.
+  # not chronologically. Map datetime keys to unix microseconds so the sort
+  # is chronological at month boundaries. The leading sentinel (`0` for nil,
+  # `1` for present) keeps nil rows cleanly separate from a hypothetical
+  # `~U[1970-01-01]` row, so the two can never tie at the comparator.
   defp overview_sort_key(row, sort_key) do
     case Map.get(row, sort_key) do
-      %DateTime{} = dt -> DateTime.to_unix(dt, :microsecond)
-      nil -> 0
-      other -> other
+      nil -> {0, 0}
+      %DateTime{} = dt -> {1, DateTime.to_unix(dt, :microsecond)}
+      other -> {1, other}
     end
   end
 

--- a/lib/lightning_web/live/helpers/table_helpers.ex
+++ b/lib/lightning_web/live/helpers/table_helpers.ex
@@ -192,14 +192,16 @@ defmodule LightningWeb.Live.Helpers.TableHelpers do
   # comparison, which on `DateTime`/`NaiveDateTime`/`Date`/`Time` walks struct
   # keys alphabetically (day before month before year) and disagrees with
   # chronology at month boundaries. Convert to ISO 8601 strings, which sort
-  # lexicographically the same as chronologically.
-  defp normalize_sort_value(nil), do: ""
-  defp normalize_sort_value(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  # lexicographically the same as chronologically. The leading sentinel
+  # (`0` for nil, `1` for present) keeps nil rows cleanly separate from any
+  # real value, so the two can never tie at the comparator.
+  defp normalize_sort_value(nil), do: {0, ""}
+  defp normalize_sort_value(%DateTime{} = dt), do: {1, DateTime.to_iso8601(dt)}
 
   defp normalize_sort_value(%NaiveDateTime{} = dt),
-    do: NaiveDateTime.to_iso8601(dt)
+    do: {1, NaiveDateTime.to_iso8601(dt)}
 
-  defp normalize_sort_value(%Date{} = d), do: Date.to_iso8601(d)
-  defp normalize_sort_value(%Time{} = t), do: Time.to_iso8601(t)
-  defp normalize_sort_value(value), do: value
+  defp normalize_sort_value(%Date{} = d), do: {1, Date.to_iso8601(d)}
+  defp normalize_sort_value(%Time{} = t), do: {1, Time.to_iso8601(t)}
+  defp normalize_sort_value(value), do: {1, value}
 end

--- a/lib/lightning_web/live/helpers/table_helpers.ex
+++ b/lib/lightning_web/live/helpers/table_helpers.ex
@@ -177,18 +177,29 @@ defmodule LightningWeb.Live.Helpers.TableHelpers do
   end
 
   defp get_sort_value(item, field) when is_atom(field) do
-    case Map.get(item, field) do
-      nil -> ""
-      value when is_binary(value) -> value
-      value -> value
-    end
+    item |> Map.get(field) |> normalize_sort_value()
   end
 
   defp get_sort_value(item, field) when is_function(field, 1) do
-    field.(item)
+    item |> field.() |> normalize_sort_value()
   end
 
   defp get_sort_value(_item, field) do
     field
   end
+
+  # `<=/>=` (used by sort_items's compare_fn) does Erlang structural term
+  # comparison, which on `DateTime`/`NaiveDateTime`/`Date`/`Time` walks struct
+  # keys alphabetically (day before month before year) and disagrees with
+  # chronology at month boundaries. Convert to ISO 8601 strings, which sort
+  # lexicographically the same as chronologically.
+  defp normalize_sort_value(nil), do: ""
+  defp normalize_sort_value(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+
+  defp normalize_sort_value(%NaiveDateTime{} = dt),
+    do: NaiveDateTime.to_iso8601(dt)
+
+  defp normalize_sort_value(%Date{} = d), do: Date.to_iso8601(d)
+  defp normalize_sort_value(%Time{} = t), do: Time.to_iso8601(t)
+  defp normalize_sort_value(value), do: value
 end

--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -148,7 +148,7 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
           Lightning.AdaptorRegistry.versions_for(module_name)
           |> List.wrap()
           |> Enum.map(&Map.get(&1, :version))
-          |> Enum.sort_by(&Version.parse(&1), :desc)
+          |> sort_versions_desc()
           |> Enum.map(fn version ->
             build_select_option(module_name, version)
           end)
@@ -175,6 +175,14 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
 
   defp build_select_option(module_name, version) do
     [key: version, value: "#{module_name}@#{version}"]
+  end
+
+  @doc "Sort version strings in descending semver order."
+  @spec sort_versions_desc([String.t()]) :: [String.t()]
+  def sort_versions_desc(versions) when is_list(versions) do
+    # Use `Version.compare/2`. Structural compare on parsed `Version` structs
+    # disagrees with semver for pre-releases.
+    Enum.sort(versions, {:desc, Version})
   end
 
   @impl true

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -274,5 +274,37 @@ defmodule Lightning.DashboardStatsTest do
 
       assert first_stat.last_workorder.updated_at == nil
     end
+
+    test "keeps nil and a real 1970-01-01 timestamp cleanly separated", %{
+      stats: [stats1, stats2 | _]
+    } do
+      # The sort-key extractor returns a sentinel tuple ({0, _} for nil,
+      # {1, _} for present) so nil rows can never tie with a real
+      # `~U[1970-01-01 00:00:00Z]` row even though both map to unix 0.
+      stats_nil = put_in(stats1.last_workorder.updated_at, nil)
+
+      stats_epoch =
+        put_in(stats2.last_workorder.updated_at, ~U[1970-01-01 00:00:00Z])
+
+      asc =
+        DashboardStats.sort_workflow_stats(
+          [stats_epoch, stats_nil],
+          :last_workorder_updated_at,
+          :asc
+        )
+
+      assert Enum.map(asc, & &1.last_workorder.updated_at) ==
+               [nil, ~U[1970-01-01 00:00:00Z]]
+
+      desc =
+        DashboardStats.sort_workflow_stats(
+          [stats_nil, stats_epoch],
+          :last_workorder_updated_at,
+          :desc
+        )
+
+      assert Enum.map(desc, & &1.last_workorder.updated_at) ==
+               [~U[1970-01-01 00:00:00Z], nil]
+    end
   end
 end

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -220,7 +220,7 @@ defmodule Lightning.DashboardStatsTest do
       assert timestamps == Enum.sort(timestamps, {:desc, DateTime})
     end
 
-    test "sorts by last_workorder_updated_at chronologically across UTC midnight",
+    test "sorts by last_workorder_updated_at chronologically across a UTC month boundary",
          %{stats: [stats1, stats2, stats3]} do
       later = ~U[2026-05-01 01:10:00.000000Z]
       earlier = ~U[2026-04-30 23:10:00.000000Z]

--- a/test/lightning/dashboard_stats_test.exs
+++ b/test/lightning/dashboard_stats_test.exs
@@ -205,7 +205,7 @@ defmodule Lightning.DashboardStatsTest do
         )
 
       timestamps = Enum.map(sorted, & &1.last_workorder.updated_at)
-      assert timestamps == Enum.sort(timestamps)
+      assert timestamps == Enum.sort(timestamps, {:asc, DateTime})
     end
 
     test "sorts by last_workorder_updated_at descending", %{stats: stats} do
@@ -217,7 +217,38 @@ defmodule Lightning.DashboardStatsTest do
         )
 
       timestamps = Enum.map(sorted, & &1.last_workorder.updated_at)
-      assert timestamps == Enum.sort(timestamps, :desc)
+      assert timestamps == Enum.sort(timestamps, {:desc, DateTime})
+    end
+
+    test "sorts by last_workorder_updated_at chronologically across UTC midnight",
+         %{stats: [stats1, stats2, stats3]} do
+      later = ~U[2026-05-01 01:10:00.000000Z]
+      earlier = ~U[2026-04-30 23:10:00.000000Z]
+      earliest = ~U[2026-04-30 21:10:00.000000Z]
+
+      stats1 = put_in(stats1.last_workorder.updated_at, later)
+      stats2 = put_in(stats2.last_workorder.updated_at, earlier)
+      stats3 = put_in(stats3.last_workorder.updated_at, earliest)
+
+      sorted_desc =
+        DashboardStats.sort_workflow_stats(
+          [stats2, stats3, stats1],
+          :last_workorder_updated_at,
+          :desc
+        )
+
+      assert Enum.map(sorted_desc, & &1.last_workorder.updated_at) ==
+               [later, earlier, earliest]
+
+      sorted_asc =
+        DashboardStats.sort_workflow_stats(
+          [stats1, stats2, stats3],
+          :last_workorder_updated_at,
+          :asc
+        )
+
+      assert Enum.map(sorted_asc, & &1.last_workorder.updated_at) ==
+               [earliest, earlier, later]
     end
 
     test "sorts by workflow name when given invalid sort field", %{stats: stats} do

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1947,6 +1947,55 @@ defmodule Lightning.ProjectsTest do
                }
              ] = result
     end
+
+    test "orders support-user view by last_updated_at chronologically across a UTC month boundary" do
+      # Support users go through the in-memory `Enum.sort_by/3` path. With
+      # `:asc`/`:desc` the comparison walks `DateTime` struct keys
+      # alphabetically (day before month before year), which inverts at month
+      # boundaries. Pin chronological ordering with timestamps that straddle
+      # a month boundary in UTC.
+      user = insert(:user, support_user: true)
+
+      project_april =
+        %{id: april_id} =
+        insert(:project,
+          name: "Project April",
+          allow_support_access: true
+        )
+
+      project_may =
+        %{id: may_id} =
+        insert(:project,
+          name: "Project May",
+          allow_support_access: true
+        )
+
+      insert(:simple_workflow,
+        project: project_april,
+        updated_at: ~U[2026-04-30 23:10:00Z]
+      )
+
+      insert(:simple_workflow,
+        project: project_may,
+        updated_at: ~U[2026-05-01 01:10:00Z]
+      )
+
+      desc =
+        Projects.get_projects_overview(user, order_by: {:last_updated_at, :desc})
+
+      assert [
+               %ProjectOverviewRow{id: ^may_id},
+               %ProjectOverviewRow{id: ^april_id}
+             ] = desc
+
+      asc =
+        Projects.get_projects_overview(user, order_by: {:last_updated_at, :asc})
+
+      assert [
+               %ProjectOverviewRow{id: ^april_id},
+               %ProjectOverviewRow{id: ^may_id}
+             ] = asc
+    end
   end
 
   describe ".update_project/3" do

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1996,6 +1996,60 @@ defmodule Lightning.ProjectsTest do
                %ProjectOverviewRow{id: ^may_id}
              ] = asc
     end
+
+    test "support-user view sorts projects with no workflows below those with activity" do
+      # Covers the `nil -> 0` branch in the in-memory sort key helper: a
+      # project with no workflows has `last_updated_at: nil`, which should
+      # sort below any project with real activity in descending order.
+      user = insert(:user, support_user: true)
+
+      project_with_activity =
+        %{id: with_id} =
+        insert(:project,
+          name: "With Activity",
+          allow_support_access: true
+        )
+
+      %{id: without_id} =
+        insert(:project,
+          name: "No Activity",
+          allow_support_access: true
+        )
+
+      insert(:simple_workflow,
+        project: project_with_activity,
+        updated_at: ~U[2026-05-01 01:10:00Z]
+      )
+
+      desc =
+        Projects.get_projects_overview(user, order_by: {:last_updated_at, :desc})
+
+      assert [
+               %ProjectOverviewRow{id: ^with_id},
+               %ProjectOverviewRow{id: ^without_id}
+             ] = desc
+    end
+
+    test "support-user view sorts by name when requested" do
+      # Covers the `other -> other` branch in the in-memory sort key helper:
+      # non-DateTime sort keys (here, :name) pass through unchanged so the
+      # default lexicographic compare still applies.
+      user = insert(:user, support_user: true)
+
+      %{id: zebra_id} =
+        insert(:project, name: "Zebra Project", allow_support_access: true)
+
+      %{id: alpha_id} =
+        insert(:project, name: "Alpha Project", allow_support_access: true)
+
+      asc =
+        Projects.get_projects_overview(user, order_by: {:name, :asc})
+
+      assert [
+               %ProjectOverviewRow{id: ^alpha_id},
+               %ProjectOverviewRow{id: ^zebra_id}
+             ] = asc
+    end
   end
 
   describe ".update_project/3" do

--- a/test/lightning_web/live/helpers/table_helpers_test.exs
+++ b/test/lightning_web/live/helpers/table_helpers_test.exs
@@ -1,0 +1,44 @@
+defmodule LightningWeb.Live.Helpers.TableHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias LightningWeb.Live.Helpers.TableHelpers
+
+  describe "sort_items/4" do
+    test "sorts DateTime fields chronologically across a UTC month boundary" do
+      # `<=`/`>=` (sort_items's compare_fn) does structural compare on
+      # `DateTime`, which walks struct keys alphabetically (day before month
+      # before year) and inverts at month boundaries. Pin chronological
+      # ordering with timestamps that straddle April 30 / May 1.
+      items = [
+        %{name: "April", inserted_at: ~U[2026-04-30 23:10:00Z]},
+        %{name: "May", inserted_at: ~U[2026-05-01 01:10:00Z]},
+        %{name: "Earlier", inserted_at: ~U[2026-04-30 21:10:00Z]}
+      ]
+
+      sort_map = %{"inserted_at" => :inserted_at}
+
+      asc = TableHelpers.sort_items(items, "inserted_at", "asc", sort_map)
+      assert Enum.map(asc, & &1.name) == ["Earlier", "April", "May"]
+
+      desc = TableHelpers.sort_items(items, "inserted_at", "desc", sort_map)
+      assert Enum.map(desc, & &1.name) == ["May", "April", "Earlier"]
+    end
+
+    test "sorts function-keyed DateTime fields chronologically across a UTC month boundary" do
+      # Same gotcha when the sort_map maps a key to a function returning a
+      # DateTime, as with the admin projects "scheduled_deletion" sort.
+      items = [
+        %{name: "April", deletion: ~U[2026-04-30 23:10:00Z]},
+        %{name: "May", deletion: ~U[2026-05-01 01:10:00Z]}
+      ]
+
+      sort_map = %{"deletion" => fn item -> item.deletion end}
+
+      asc = TableHelpers.sort_items(items, "deletion", "asc", sort_map)
+      assert Enum.map(asc, & &1.name) == ["April", "May"]
+
+      desc = TableHelpers.sort_items(items, "deletion", "desc", sort_map)
+      assert Enum.map(desc, & &1.name) == ["May", "April"]
+    end
+  end
+end

--- a/test/lightning_web/live/helpers/table_helpers_test.exs
+++ b/test/lightning_web/live/helpers/table_helpers_test.exs
@@ -40,5 +40,95 @@ defmodule LightningWeb.Live.Helpers.TableHelpersTest do
       desc = TableHelpers.sort_items(items, "deletion", "desc", sort_map)
       assert Enum.map(desc, & &1.name) == ["May", "April"]
     end
+
+    test "sorts NaiveDateTime fields chronologically across a UTC month boundary" do
+      items = [
+        %{name: "April", at: ~N[2026-04-30 23:10:00]},
+        %{name: "May", at: ~N[2026-05-01 01:10:00]}
+      ]
+
+      sort_map = %{"at" => :at}
+
+      assert TableHelpers.sort_items(items, "at", "desc", sort_map)
+             |> Enum.map(& &1.name) == ["May", "April"]
+    end
+
+    test "sorts Date fields chronologically across a month boundary" do
+      items = [
+        %{name: "April", on: ~D[2026-04-30]},
+        %{name: "May", on: ~D[2026-05-01]}
+      ]
+
+      sort_map = %{"on" => :on}
+
+      assert TableHelpers.sort_items(items, "on", "desc", sort_map)
+             |> Enum.map(& &1.name) == ["May", "April"]
+    end
+
+    test "sorts Time fields chronologically" do
+      items = [
+        %{name: "Late", at: ~T[23:10:00]},
+        %{name: "Early", at: ~T[01:10:00]}
+      ]
+
+      sort_map = %{"at" => :at}
+
+      assert TableHelpers.sort_items(items, "at", "asc", sort_map)
+             |> Enum.map(& &1.name) == ["Early", "Late"]
+    end
+
+    test "treats nil sort values as the lowest, both for missing fields and explicit nil" do
+      items = [
+        %{name: "Has", scheduled: ~U[2026-05-01 00:00:00Z]},
+        %{name: "Nil", scheduled: nil},
+        %{name: "Missing"}
+      ]
+
+      sort_map = %{"scheduled" => :scheduled}
+
+      asc = TableHelpers.sort_items(items, "scheduled", "asc", sort_map)
+      # Nil and missing both normalize to "", which is the empty-string lowest
+      # value; "Has" comes last because its ISO 8601 timestamp sorts greater.
+      assert List.last(asc).name == "Has"
+
+      assert Enum.take(asc, 2) |> Enum.map(& &1.name) |> Enum.sort() == [
+               "Missing",
+               "Nil"
+             ]
+    end
+
+    test "leaves order unchanged when the sort key is not in the sort_map" do
+      # When sort_map has no entry for the key, sort_field falls back to the
+      # raw string key. `get_sort_value/2`'s catch-all returns the field
+      # unchanged, so every item gets the same value, and stable sort
+      # preserves input order.
+      items = [
+        %{name: "First"},
+        %{name: "Second"},
+        %{name: "Third"}
+      ]
+
+      assert TableHelpers.sort_items(items, "unknown", "asc", %{})
+             |> Enum.map(& &1.name) == ["First", "Second", "Third"]
+
+      assert TableHelpers.sort_items(items, "unknown", "desc", %{})
+             |> Enum.map(& &1.name) == ["First", "Second", "Third"]
+    end
+
+    test "sorts plain string fields lexicographically" do
+      items = [
+        %{name: "Bob"},
+        %{name: "Alice"},
+        %{name: "Charlie"}
+      ]
+
+      sort_map = %{"name" => :name}
+
+      assert TableHelpers.sort_items(items, "name", "asc", sort_map)
+             |> Enum.map(& &1.name) == ["Alice", "Bob", "Charlie"]
+
+      assert TableHelpers.sort_items(items, "name", "desc", sort_map)
+             |> Enum.map(& &1.name) == ["Charlie", "Bob", "Alice"]
+    end
   end
 end

--- a/test/lightning_web/live/helpers/table_helpers_test.exs
+++ b/test/lightning_web/live/helpers/table_helpers_test.exs
@@ -130,5 +130,24 @@ defmodule LightningWeb.Live.Helpers.TableHelpersTest do
       assert TableHelpers.sort_items(items, "name", "desc", sort_map)
              |> Enum.map(& &1.name) == ["Charlie", "Bob", "Alice"]
     end
+
+    test "keeps nil and a real 1970-01-01 timestamp cleanly separated" do
+      # The sort-key normalizer returns a sentinel tuple ({0, _} for nil,
+      # {1, _} for present) so nil rows can never tie with a real
+      # `~U[1970-01-01]` row even though both would otherwise normalize
+      # toward the empty string / unix epoch.
+      items = [
+        %{name: "Epoch", at: ~U[1970-01-01 00:00:00Z]},
+        %{name: "Nil", at: nil}
+      ]
+
+      sort_map = %{"at" => :at}
+
+      asc = TableHelpers.sort_items(items, "at", "asc", sort_map)
+      assert Enum.map(asc, & &1.name) == ["Nil", "Epoch"]
+
+      desc = TableHelpers.sort_items(items, "at", "desc", sort_map)
+      assert Enum.map(desc, & &1.name) == ["Epoch", "Nil"]
+    end
   end
 end

--- a/test/lightning_web/live/job_live/adaptor_picker_test.exs
+++ b/test/lightning_web/live/job_live/adaptor_picker_test.exs
@@ -31,7 +31,18 @@ defmodule LightningWeb.JobLive.AdaptorPickerTest do
           Version.parse!(version)
         end)
 
-      assert version_numbers == Enum.sort(version_numbers, :desc)
+      assert version_numbers == Enum.sort(version_numbers, {:desc, Version})
+    end
+
+    test "sort_versions_desc/1 orders pre-releases per semver" do
+      # Per semver, a pre-release sorts BEFORE its corresponding release (so
+      # descending puts the release first). Structural compare on parsed
+      # `Version` structs walks struct keys alphabetically (build, major,
+      # minor, patch, pre) and would put `1.0.0-beta` ahead of `1.0.0`.
+      versions = ["1.0.0", "1.0.0-beta", "1.0.0-alpha", "0.9.0"]
+
+      assert AdaptorPicker.sort_versions_desc(versions) ==
+               ["1.0.0", "1.0.0-beta", "1.0.0-alpha", "0.9.0"]
     end
 
     test "handles adaptor with specific version" do


### PR DESCRIPTION
## Description

Several places in the codebase used `Enum.sort_by(.., :asc | :desc)` (or the equivalent `Enum.sort/2` form, or `<=`/`>=` as a comparator) on a key whose value was a `DateTime` or a `Version` struct. That form does Erlang structural term comparison, which on these structs walks fields alphabetically and disagrees with chronological / semver order. Same root cause across four surfaces.

- **Workflow list, "Latest Work Order" column** (project dashboard). Sorted incorrectly when the most recent work orders for two workflows fell on either side of a UTC month boundary.
- **Projects list, "Last Updated" column, support-user view**. Same shape, same trigger. Non-support users were unaffected; they go through a SQL `order_by`.
- **Admin tables that sort on date columns** ("Created at" and "Scheduled deletion" on the admin projects table, "Scheduled deletion" on the admin users table). All go through a shared `TableHelpers.sort_items/4` helper, which used `<=`/`>=` (structural compare) and produced the same inversion at month boundaries.
- **Adaptor version dropdown**. Listed pre-release versions above their corresponding stable release because the sort relied on structural compare of parsed version structs.

Each fix maps the sort key through a domain-aware comparator: `DateTime` becomes integer microseconds (or ISO 8601 strings inside the shared table helper), version strings go through `Version.compare/2`. The dashboard, projects-overview, and admin-table fixes have real user impact at month boundaries. The adaptor version fix is a real-but-currently-zero-impact correction (OpenFn adaptors essentially always ship plain `X.Y.Z` semver, so today no user is hitting it; included here because it is the same root cause).

## Validation steps

1. Run the affected test files together:

   ```
   mix test \
     test/lightning/dashboard_stats_test.exs \
     test/lightning/projects_test.exs \
     test/lightning_web/live/helpers/table_helpers_test.exs \
     test/lightning_web/live/job_live/adaptor_picker_test.exs
   ```

   All tests pass on this branch, including four new regression tests that pin chronological / semver ordering across boundaries.

2. Quick spot-check in `iex -S mix`:

   ```elixir
   # DateTime sort, dashboard / projects family
   stats = [
     %Lightning.DashboardStats.WorkflowStats{workflow: %{name: "older"}, last_workorder: %{updated_at: ~U[2026-04-30 23:10:00Z]}},
     %Lightning.DashboardStats.WorkflowStats{workflow: %{name: "newer"}, last_workorder: %{updated_at: ~U[2026-05-01 01:10:00Z]}}
   ]
   Lightning.DashboardStats.sort_workflow_stats(stats, :last_workorder_updated_at, :desc) |> Enum.map(& &1.workflow.name)
   # On this branch: ["newer", "older"]. On main: ["older", "newer"].

   # Admin tables sort helper
   items = [
     %{name: "April", inserted_at: ~U[2026-04-30 23:10:00Z]},
     %{name: "May", inserted_at: ~U[2026-05-01 01:10:00Z]}
   ]
   LightningWeb.Live.Helpers.TableHelpers.sort_items(items, "inserted_at", "desc", %{"inserted_at" => :inserted_at}) |> Enum.map(& &1.name)
   # On this branch: ["May", "April"]. On main: ["April", "May"].

   # Version sort, adaptor family
   LightningWeb.JobLive.AdaptorPicker.sort_versions_desc(["1.0.0", "1.0.0-beta", "1.0.0-alpha"])
   # On this branch: ["1.0.0", "1.0.0-beta", "1.0.0-alpha"]. On main: ["1.0.0-beta", "1.0.0-alpha", "1.0.0"].
   ```

## Additional notes for the reviewer

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR