### PR TITLE
Sort adaptor version dropdown per semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
 
 ### Fixed
 
+- Sort the adaptor version dropdown per semver. Pre-release versions previously
+  appeared above the corresponding stable release because the sort relied on
+  structural comparison of parsed version structs rather than
+  `Version.compare/2`.
+
 ## [2.16.3-pre] - 2026-04-30
 
 ### Added

--- a/lib/lightning_web/live/job_live/adaptor_picker.ex
+++ b/lib/lightning_web/live/job_live/adaptor_picker.ex
@@ -148,7 +148,7 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
           Lightning.AdaptorRegistry.versions_for(module_name)
           |> List.wrap()
           |> Enum.map(&Map.get(&1, :version))
-          |> Enum.sort_by(&Version.parse(&1), :desc)
+          |> sort_versions_desc()
           |> Enum.map(fn version ->
             build_select_option(module_name, version)
           end)
@@ -175,6 +175,14 @@ defmodule LightningWeb.JobLive.AdaptorPicker do
 
   defp build_select_option(module_name, version) do
     [key: version, value: "#{module_name}@#{version}"]
+  end
+
+  @doc "Sort version strings in descending semver order."
+  @spec sort_versions_desc([String.t()]) :: [String.t()]
+  def sort_versions_desc(versions) when is_list(versions) do
+    # Use `Version.compare/2`. Structural compare on parsed `Version` structs
+    # disagrees with semver for pre-releases.
+    Enum.sort(versions, {:desc, Version})
   end
 
   @impl true

--- a/test/lightning_web/live/job_live/adaptor_picker_test.exs
+++ b/test/lightning_web/live/job_live/adaptor_picker_test.exs
@@ -31,7 +31,18 @@ defmodule LightningWeb.JobLive.AdaptorPickerTest do
           Version.parse!(version)
         end)
 
-      assert version_numbers == Enum.sort(version_numbers, :desc)
+      assert version_numbers == Enum.sort(version_numbers, {:desc, Version})
+    end
+
+    test "sort_versions_desc/1 orders pre-releases per semver" do
+      # Per semver, a pre-release sorts BEFORE its corresponding release (so
+      # descending puts the release first). Structural compare on parsed
+      # `Version` structs walks struct keys alphabetically (build, major,
+      # minor, patch, pre) and would put `1.0.0-beta` ahead of `1.0.0`.
+      versions = ["1.0.0", "1.0.0-beta", "1.0.0-alpha", "0.9.0"]
+
+      assert AdaptorPicker.sort_versions_desc(versions) ==
+               ["1.0.0", "1.0.0-beta", "1.0.0-alpha", "0.9.0"]
     end
 
     test "handles adaptor with specific version" do


### PR DESCRIPTION
## Description

The adaptor version dropdown could list pre-release versions above their corresponding stable release because the sort relied on structural comparison of parsed version structs rather than semver. Switch to `Version.compare/2` so the order matches semver in every case.

This is a real-but-currently-zero-impact bug. OpenFn adaptors essentially always ship plain `X.Y.Z` semver, so no user is hitting this today. Opening as a draft so the fix is documented and reviewable if pre-release adaptors ever land in the registry.

## Validation steps

1. Run `mix test test/lightning_web/live/job_live/adaptor_picker_test.exs`. All 3 tests pass on this branch, including a new regression test that pins the pre-release ordering.

2. To eyeball the bug directly, run `iex -S mix` and paste:

   ```elixir
   versions = ["1.0.0", "1.0.0-beta", "1.0.0-alpha"]
   LightningWeb.JobLive.AdaptorPicker.sort_versions_desc(versions)
   ```

   On this branch you get `["1.0.0", "1.0.0-beta", "1.0.0-alpha"]` (release first, semver-correct). On `main`, the equivalent line `Enum.sort_by(versions, &Version.parse/1, :desc)` returns `["1.0.0-beta", "1.0.0-alpha", "1.0.0"]` (pre-releases ahead of release, the bug).

## Additional notes for the reviewer

Found while investigating a related bug in the dashboard sort (#4687). Same family: `Enum.sort_by(.., :asc | :desc)` does structural compare on the key, which disagrees with domain-specific compare for types like `DateTime` and `Version`. Different surface, separate PR.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR