### PR TITLE
Fix cron scheduler tick discards on single trigger failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to
   renderer doesn't recognise (such as `StateTooLargeError`); unknown kill
   reasons fall back to the resource-budget icon instead.
   [#4709](https://github.com/OpenFn/lightning/issues/4709)
+- Cron scheduler now attempts all triggers each tick, even if one fails. A
+  single slow or erroring trigger previously aborted the entire batch.
+  [#4716](https://github.com/OpenFn/lightning/issues/4716)
 
 ## [2.16.3-pre2] - 2026-05-07
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -235,6 +235,12 @@ defmodule Lightning.Invocation do
   Scopes by workflow (not trigger) so that manual runs are also considered.
   """
   def last_run_final_dataclip(%Trigger{workflow_id: workflow_id}) do
+    # `prepare: :unnamed` forces a custom plan per workflow_id. With named
+    # prepared statements, Postgres flips to a generic plan after 5
+    # executions which scans `runs_finished_at_index` backward and
+    # post-filters on state — catastrophic for workflows with sparse
+    # successes (full backward scan looking for nothing). The custom plan
+    # bounds via the workflow's work_orders.
     from(r in Run,
       join: wo in assoc(r, :work_order),
       join: d in assoc(r, :final_dataclip),
@@ -245,7 +251,7 @@ defmodule Lightning.Invocation do
       limit: 1,
       select: d
     )
-    |> Repo.one()
+    |> Repo.one(prepare: :unnamed)
   end
 
   @doc """
@@ -253,6 +259,9 @@ defmodule Lightning.Invocation do
   Used when cron_cursor_job_id is set to a specific job.
   """
   def last_successful_step_dataclip(job_id) do
+    # `prepare: :unnamed` for the same reason as `last_run_final_dataclip/1`:
+    # LIMIT 1 + ORDER BY DESC queries are vulnerable to generic-plan flips
+    # that degrade into full-table scans. Custom plans guarantee selectivity.
     from(d in Dataclip,
       join: s in Step,
       on: s.output_dataclip_id == d.id,
@@ -262,7 +271,7 @@ defmodule Lightning.Invocation do
       order_by: [desc: s.finished_at],
       limit: 1
     )
-    |> Repo.one()
+    |> Repo.one(prepare: :unnamed)
   end
 
   @doc """

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -81,6 +81,9 @@ defmodule Lightning.Projects.Provisioner do
            {:ok, %{workflows: workflows} = project} <-
              Repo.insert_or_update(project_changeset, allow_stale: allow_stale),
            :ok <- cleanup_orphaned_edges(edges_to_cleanup),
+           :ok <-
+             disable_triggers_for_soft_deleted_workflows(project_changeset),
+           :ok <- notify_kafka_for_soft_deleted_workflows(project_changeset),
            :ok <- handle_collection_deletion(project_changeset),
            updated_project <- preload_dependencies(project),
            {:ok, _changes} <-
@@ -607,6 +610,37 @@ defmodule Lightning.Projects.Provisioner do
       )
     else
       changeset
+    end
+  end
+
+  defp notify_kafka_for_soft_deleted_workflows(project_changeset) do
+    project_changeset
+    |> get_assoc(:workflows)
+    |> Enum.filter(
+      &(&1.action == :update and not is_nil(get_change(&1, :deleted_at)))
+    )
+    |> Enum.map(&get_field(&1, :id))
+    |> Workflows.notify_kafka_triggers_for_workflows()
+  end
+
+  defp disable_triggers_for_soft_deleted_workflows(project_changeset) do
+    deleted_workflow_ids =
+      project_changeset
+      |> get_assoc(:workflows)
+      |> Enum.filter(fn cs ->
+        cs.action == :update and not is_nil(get_change(cs, :deleted_at))
+      end)
+      |> Enum.map(&get_field(&1, :id))
+
+    if deleted_workflow_ids == [] do
+      :ok
+    else
+      from(t in Trigger,
+        where: t.workflow_id in ^deleted_workflow_ids and t.enabled
+      )
+      |> Repo.update_all(set: [enabled: false])
+
+      :ok
     end
   end
 

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -309,6 +309,26 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
+  Fires `kafka_trigger_updated` for every kafka trigger belonging to the
+  given workflow IDs. Call after triggers have been disabled so kafka pipeline
+  supervisors shut down those pipelines.
+  """
+  @spec notify_kafka_triggers_for_workflows([Ecto.UUID.t()]) :: :ok
+  def notify_kafka_triggers_for_workflows([]), do: :ok
+
+  def notify_kafka_triggers_for_workflows(workflow_ids)
+      when is_list(workflow_ids) do
+    from(t in Trigger,
+      where: t.workflow_id in ^workflow_ids and t.type == :kafka,
+      select: t.id
+    )
+    |> Repo.all()
+    |> Enum.each(&Triggers.Events.kafka_trigger_updated/1)
+
+    :ok
+  end
+
+  @doc """
   Creates a snapshot from a multi.
 
   When the multi already has a `:workflow` change, it is assumed to be changed
@@ -571,10 +591,9 @@ defmodule Lightning.Workflows do
     |> Repo.transaction()
     |> tap(fn result ->
       with {:ok, _} <- result do
-        workflow
-        |> Repo.preload([:triggers], force: true)
-        |> tap(&notify_of_affected_kafka_triggers/1)
-        |> Events.workflow_updated()
+        preloaded = Repo.preload(workflow, [:triggers], force: true)
+        notify_kafka_triggers_for_workflows([workflow.id])
+        Events.workflow_updated(preloaded)
       end
     end)
   end
@@ -604,12 +623,6 @@ defmodule Lightning.Workflows do
     if MapSet.member?(existing_names, candidate),
       do: find_available_name(base_name, existing_names, n + 1),
       else: candidate
-  end
-
-  defp notify_of_affected_kafka_triggers(%{triggers: triggers}) do
-    triggers
-    |> Enum.filter(&(&1.type == :kafka))
-    |> Enum.each(&Triggers.Events.kafka_trigger_updated(&1.id))
   end
 
   @doc """

--- a/lib/lightning/workflows/query.ex
+++ b/lib/lightning/workflows/query.ex
@@ -65,8 +65,9 @@ defmodule Lightning.Workflows.Query do
   def enabled_cron_jobs_by_edge do
     from(e in Edge,
       join: j in assoc(e, :target_job),
+      join: w in assoc(j, :workflow),
       join: t in assoc(e, :source_trigger),
-      where: t.type == :cron and t.enabled,
+      where: t.type == :cron and t.enabled and is_nil(w.deleted_at),
       preload: [:source_trigger, [target_job: :workflow]]
     )
   end

--- a/lib/lightning/workflows/scheduler.ex
+++ b/lib/lightning/workflows/scheduler.ex
@@ -30,7 +30,47 @@ defmodule Lightning.Workflows.Scheduler do
   def enqueue_cronjobs(date_time) do
     date_time
     |> Workflows.get_edges_for_cron_execution()
-    |> Enum.each(&invoke_cronjob/1)
+    |> Enum.each(&safe_invoke_cronjob/1)
+  end
+
+  # Wraps invoke_cronjob/1 so a failure on a single edge does not abort the
+  # rest of the tick. Errors are logged and forwarded to Sentry; the loop
+  # continues with the next edge.
+  #
+  # Why `rescue` only:
+  #   - `rescue` covers all database and changeset exceptions.
+  #   - `Repo.rollback/1` uses `throw`, but it's consumed by the surrounding
+  #     `Repo.transaction(multi)` in `Runs.enqueue/1` — it never reaches here.
+  #   - `:exit` signals (DB pool death, supervisor restart) should propagate
+  #     to Oban's failure surface, not get swallowed here with N Sentry copies.
+  #   - `:throw` from outside Ecto's rollback flow is a control-flow bug
+  #     we want visible, not swallowed.
+  @spec safe_invoke_cronjob(Edge.t()) :: {:ok, map()} | {:error, term()}
+  defp safe_invoke_cronjob(%Edge{} = edge) do
+    invoke_cronjob(edge)
+  rescue
+    e ->
+      stacktrace = __STACKTRACE__
+
+      Logger.error(
+        "Scheduler failed to invoke cronjob for edge #{edge.id}:\n" <>
+          Exception.format(:error, e, stacktrace)
+      )
+
+      Lightning.Sentry.capture_exception(e,
+        stacktrace: stacktrace,
+        extra: %{
+          edge_id: edge.id,
+          trigger_id: edge.source_trigger && edge.source_trigger.id,
+          job_id: edge.target_job && edge.target_job.id,
+          workflow_id:
+            edge.target_job && edge.target_job.workflow &&
+              edge.target_job.workflow.id
+        },
+        tags: %{type: "scheduler"}
+      )
+
+      {:error, e}
   end
 
   @spec invoke_cronjob(Edge.t()) :: {:ok, map()} | {:error, map()}

--- a/priv/repo/migrations/20260507000000_add_steps_job_id_exit_reason_finished_at_index.exs
+++ b/priv/repo/migrations/20260507000000_add_steps_job_id_exit_reason_finished_at_index.exs
@@ -1,0 +1,18 @@
+defmodule Lightning.Repo.Migrations.AddStepsJobIdExitReasonFinishedAtIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS steps_job_id_exit_reason_finished_at_index
+      ON steps (job_id, exit_reason, finished_at DESC)
+      """,
+      """
+      DROP INDEX CONCURRENTLY IF EXISTS steps_job_id_exit_reason_finished_at_index
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20260507000001_add_runs_work_order_id_state_finished_at_index.exs
+++ b/priv/repo/migrations/20260507000001_add_runs_work_order_id_state_finished_at_index.exs
@@ -1,0 +1,18 @@
+defmodule Lightning.Repo.Migrations.AddRunsWorkOrderIdStateFinishedAtIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute(
+      """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS runs_work_order_id_state_finished_at_index
+      ON runs (work_order_id, state, finished_at DESC)
+      """,
+      """
+      DROP INDEX CONCURRENTLY IF EXISTS runs_work_order_id_state_finished_at_index
+      """
+    )
+  end
+end

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -785,6 +785,98 @@ defmodule Lightning.Projects.ProvisionerTest do
              "The soft-deleted workflow should be excluded from the project"
     end
 
+    test "disables all triggers on a workflow that is soft-deleted via provisioner",
+         %{
+           project: project,
+           user: user
+         } do
+      extra_trigger_id = Ecto.UUID.generate()
+
+      %{
+        body: body,
+        workflows: [%{id: workflow_id, trigger_id: trigger_id}]
+      } = valid_document(project.id)
+
+      body =
+        add_entity_to_workflow(body, workflow_id, "triggers", %{
+          "id" => extra_trigger_id,
+          "type" => "cron",
+          "cron_expression" => "* * * * *",
+          "enabled" => true
+        })
+
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      body = remove_workflow_from_document(body, workflow_id)
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      assert %{deleted_at: %DateTime{}} =
+               Repo.get!(Lightning.Workflows.Workflow, workflow_id)
+
+      assert Repo.get!(Lightning.Workflows.Trigger, trigger_id).enabled == false
+
+      assert Repo.get!(Lightning.Workflows.Trigger, extra_trigger_id).enabled ==
+               false
+    end
+
+    test "does not disable triggers on workflows that are not soft-deleted",
+         %{
+           project: project,
+           user: user
+         } do
+      %{
+        body: body,
+        workflows: [%{trigger_id: wf1_trigger_id}, %{id: wf2_id}]
+      } = valid_document(project.id, 2)
+
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      body = remove_workflow_from_document(body, wf2_id)
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      assert Repo.get!(Lightning.Workflows.Trigger, wf1_trigger_id).enabled ==
+               true
+    end
+
+    test "fires kafka_trigger_updated for kafka triggers on a workflow soft-deleted via provisioner",
+         %{
+           project: project,
+           user: user
+         } do
+      alias Lightning.Workflows.Triggers.Events
+      alias Lightning.Workflows.Triggers.Events.KafkaTriggerUpdated
+
+      kafka_trigger_id = Ecto.UUID.generate()
+
+      %{
+        body: body,
+        workflows: [%{id: workflow_id, trigger_id: webhook_trigger_id}]
+      } = valid_document(project.id)
+
+      body =
+        add_entity_to_workflow(body, workflow_id, "triggers", %{
+          "id" => kafka_trigger_id,
+          "type" => "kafka",
+          "enabled" => true,
+          "kafka_configuration" => %{
+            "hosts" => [["localhost", "9092"]],
+            "topics" => ["topic"],
+            "initial_offset_reset_policy" => "earliest",
+            "connect_timeout" => 30
+          }
+        })
+
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      Events.subscribe_to_kafka_trigger_updated()
+
+      body = remove_workflow_from_document(body, workflow_id)
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      assert_receive %KafkaTriggerUpdated{trigger_id: ^kafka_trigger_id}
+      refute_received %KafkaTriggerUpdated{trigger_id: ^webhook_trigger_id}
+    end
+
     test "marking a new/changed record for deletion", %{
       project: project,
       user: user

--- a/test/lightning/workflows/query_test.exs
+++ b/test/lightning/workflows/query_test.exs
@@ -2,6 +2,8 @@ defmodule Lightning.Workflows.QueryTest do
   use Lightning.DataCase, async: true
 
   alias Lightning.Workflows.Query
+  alias Lightning.Workflows.Workflow
+  import Ecto.Query
   import Lightning.JobsFixtures
   import Lightning.AccountsFixtures
   import Lightning.ProjectsFixtures
@@ -51,6 +53,31 @@ defmodule Lightning.Workflows.QueryTest do
         |> Enum.map(fn e -> e.target_job.id end)
 
       assert jobs == [job.id]
+    end
+
+    test "excludes edges whose workflow is soft-deleted" do
+      trigger =
+        insert(:trigger, %{
+          type: :cron,
+          cron_expression: "* * * * *",
+          enabled: true
+        })
+
+      job = insert(:job, workflow: trigger.workflow)
+
+      insert(:edge, %{
+        source_trigger: trigger,
+        target_job: job,
+        workflow: job.workflow,
+        enabled: true
+      })
+
+      Repo.update_all(
+        from(w in Workflow, where: w.id == ^trigger.workflow_id),
+        set: [deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)]
+      )
+
+      assert Query.enabled_cron_jobs_by_edge() |> Repo.all() == []
     end
 
     test "returns no jobs when trigger is disabled" do

--- a/test/lightning/workflows/scheduler_test.exs
+++ b/test/lightning/workflows/scheduler_test.exs
@@ -2,6 +2,8 @@ defmodule Lightning.Workflows.SchedulerTest do
   @moduledoc false
   use Lightning.DataCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias Lightning.Invocation
   alias Lightning.Repo
   alias Lightning.Run
@@ -213,6 +215,98 @@ defmodule Lightning.Workflows.SchedulerTest do
 
       assert Jason.decode!(new_run.dataclip.body) ==
                old_step.output_dataclip.body
+    end
+  end
+
+  describe "enqueue_cronjobs/1 error isolation" do
+    setup do
+      Mox.verify_on_exit!()
+      :ok
+    end
+
+    test "a raised exception in one edge does not prevent subsequent edges from being processed" do
+      # Failing edge — its UsageLimiter check will raise.
+      failing_job = insert(:job)
+
+      failing_trigger =
+        insert(:trigger, %{
+          type: :cron,
+          cron_expression: "* * * * *",
+          workflow: failing_job.workflow
+        })
+
+      failing_edge =
+        insert(:edge, %{
+          workflow: failing_job.workflow,
+          source_trigger: failing_trigger,
+          target_job: failing_job
+        })
+
+      with_snapshot(failing_job.workflow)
+
+      failing_project_id = failing_job.workflow.project_id
+      failing_workflow_id = failing_job.workflow.id
+
+      # Surviving edge — should still create a Run despite the other edge
+      # raising.
+      surviving_job = insert(:job)
+
+      surviving_trigger =
+        insert(:trigger, %{
+          type: :cron,
+          cron_expression: "* * * * *",
+          workflow: surviving_job.workflow
+        })
+
+      insert(:edge, %{
+        workflow: surviving_job.workflow,
+        source_trigger: surviving_trigger,
+        target_job: surviving_job
+      })
+
+      with_snapshot(surviving_job.workflow)
+
+      # Raise only when invoked for the failing project; pass for the other.
+      Mox.stub(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, %{project_id: project_id} ->
+          if project_id == failing_project_id do
+            raise RuntimeError, "boom"
+          else
+            :ok
+          end
+        end
+      )
+
+      # Route Lightning.Sentry through the Mox-backed mock for this test.
+      Mox.stub(Lightning.MockConfig, :sentry, fn -> Lightning.MockSentry end)
+
+      # The scheduler must report the failing edge to Sentry exactly once,
+      # with rich context for triage.
+      Mox.expect(Lightning.MockSentry, :capture_exception, fn error, opts ->
+        assert %RuntimeError{message: "boom"} = error
+        assert opts[:tags][:type] == "scheduler"
+        assert opts[:extra][:edge_id] == failing_edge.id
+        assert opts[:extra][:trigger_id] == failing_trigger.id
+        assert opts[:extra][:job_id] == failing_job.id
+        assert opts[:extra][:workflow_id] == failing_workflow_id
+        assert is_list(opts[:stacktrace])
+        assert opts[:stacktrace] != []
+        :ok
+      end)
+
+      logs = capture_log(fn -> Scheduler.enqueue_cronjobs() end)
+
+      # The surviving edge created a Run; the failing edge did not.
+      runs = Repo.all(Run)
+      assert length(runs) == 1
+      [run] = runs
+      assert run.starting_trigger_id == surviving_trigger.id
+
+      # The failure was logged with the formatted exception.
+      assert logs =~ "Scheduler failed to invoke cronjob"
+      assert logs =~ "boom"
     end
   end
 end


### PR DESCRIPTION
## Description

Fixes a bug where a single slow trigger query caused the scheduler to silently skip every subsequent trigger in that minute's tick.

`Lightning.Workflows.Scheduler` runs once a minute and loops over all enabled cron triggers. When a query exceeded Postgrex's 15s database timeout, the exception propagated out of the bare `Enum.each` and all remaining triggers in the batch were dropped without any error recorded.

Three things were wrong:

**No error isolation.** One bad trigger killed the whole tick. The fix wraps each trigger in a `rescue` that logs the failure, reports to Sentry with full context (edge, trigger, job, workflow IDs), and lets the loop continue.

**Slow queries on the cron dataclip path.** The two queries that look up the seed dataclip for a trigger had no supporting composite indexes, causing scans of millions of rows per trigger. Two migrations add the right composites — both are idempotent for indexes of the same name.

**Prepared statement plan-cache flip.** Even with the indexes in place, Postgres switches from a custom plan (bounded, fast) to a generic plan after 5 executions of the same prepared statement on a connection. For workflows with no successful runs, the generic plan scans the entire `runs` table backward looking for nothing — 8–25 seconds per trigger. `prepare: :unnamed` on the two affected `Repo.one` calls pins each query to a custom plan.

As a side fix: soft-deleted workflows processed via the provisioner were leaving their triggers enabled, so the scheduler kept enumerating them. The query now filters on `deleted_at`, and the provisioner disables triggers and notifies the kafka pipeline supervisor on soft-delete, matching what the UI path already did.

Closes #4716

## Validation steps

1. To see the plan-cache flip that caused the slow queries, run the following against your database. Pick any workflow ID that has few or no successful runs:

```sql
PREPARE bench(uuid, varchar) AS
  SELECT d.*
  FROM runs r
  INNER JOIN work_orders wo ON wo.id = r.work_order_id
  INNER JOIN dataclips d ON d.id = r.final_dataclip_id
  WHERE wo.workflow_id = $1 AND r.state = $2 AND d.wiped_at IS NULL
  ORDER BY r.finished_at DESC LIMIT 1;

-- Generic plan — what named prepared statements eventually flip to:
SET plan_cache_mode = force_generic_plan;
EXPLAIN (ANALYZE, BUFFERS)
  EXECUTE bench('<workflow_id>', 'success');
-- Expect: Index Scan Backward on runs_finished_at_index, many rows, slow

-- Custom plan — what prepare: :unnamed always uses:
SET plan_cache_mode = force_custom_plan;
EXPLAIN (ANALYZE, BUFFERS)
  EXECUTE bench('<workflow_id>', 'success');
-- Expect: Nested Loop via runs_work_order_id_state_finished_at_index, <1ms

DEALLOCATE bench;
RESET plan_cache_mode;
```

2. Confirm scheduler failures appear in Sentry with `tags: {type: "scheduler"}` and the four context IDs (edge, trigger, job, workflow) rather than as unattributed Oban job discards.

3. Soft-delete a workflow via the provisioner and confirm its cron trigger no longer appears in the scheduler's next tick.

## Additional notes for the reviewer

- The `rescue` in `safe_invoke_cronjob/1` is intentionally `rescue` and not `catch`. `Repo.rollback` uses `throw` internally but that throw is consumed by the transaction wrapper in `Runs.enqueue/1` — it never reaches this frame. `:exit` signals from genuine infrastructure death should propagate to Oban's failure surface rather than get swallowed here.
- `prepare: :unnamed` has a small per-query planning cost. For ~30–50 cron trigger queries per minute this is negligible.

## AI Usage

- [x] I have used Claude Code

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [ ] I have implemented and tested all related **authorization policies** *(no auth changes)*
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR