### PR TITLE
Fix legacy workflow editor crash on AI assistant streaming events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to
 
 ### Fixed
 
+- Legacy workflow editor no longer crashes when the AI assistant streams
+  progress updates. The editor LiveView shares a PubSub topic with the
+  collaborative editor's React channel and was missing a clause for the four
+  streaming events, causing a `CaseClauseError` and a reconnect on the first
+  "Thinking..." update. [#4719](https://github.com/OpenFn/lightning/issues/4719)
+
 ## [2.16.3-pre3] - 2026-05-07
 
 ### Fixed

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -2401,6 +2401,11 @@ defmodule LightningWeb.WorkflowLive.Edit do
 
       :unregister_component ->
         handle_component_unregistration(socket, payload)
+
+      # Streaming events share the ai_session:* topic but are consumed by
+      # AiAssistantChannel, not this LiveView.
+      _ ->
+        {:noreply, socket}
     end
   end
 

--- a/test/lightning_web/live/workflow_live/edit_test.exs
+++ b/test/lightning_web/live/workflow_live/edit_test.exs
@@ -622,6 +622,39 @@ defmodule LightningWeb.WorkflowLive.EditTest do
 
       assert html =~ "You are not authorized to perform this action."
     end
+
+    test "ignores AI assistant streaming events on the shared ai_session topic",
+         %{conn: conn, project: project} do
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project.id}/w/new/legacy", on_error: :raise)
+
+      session_id = Ecto.UUID.generate()
+
+      send(
+        view.pid,
+        {:ai_assistant, :register_component,
+         %{component_id: "new-workflow-panel-assistant", session_id: session_id}}
+      )
+
+      # Force a sync round-trip so the LV finishes handling :register_component
+      # (and therefore subscribes to the topic) before we publish on it.
+      assert render(view)
+
+      for action <- [
+            :streaming_status,
+            :streaming_chunk,
+            :streaming_changes,
+            :streaming_error
+          ] do
+        Lightning.broadcast(
+          "ai_session:#{session_id}",
+          {:ai_assistant, action, %{session_id: session_id}}
+        )
+      end
+
+      assert render(view)
+      assert Process.alive?(view.pid)
+    end
   end
 
   describe "edit" do


### PR DESCRIPTION
## Description

This PR fixes a crash in the legacy workflow editor (`/w/new/legacy`, `/w/:id/legacy`) that fired the moment the AI assistant emitted its first streaming progress update. In production this was the "Thinking..." status message Apollo broadcasts when it starts processing. The legacy editor was listening on the same PubSub topic as the collaborative editor's AI panel but had no handler for any of the streaming events, so the first one raised a `CaseClauseError` and the LiveView reconnected. The fix drops those events in the legacy editor since it does not display any of them. The completed-message event it does need is unchanged. The collaborative editor is unaffected.

Closes #4719

## Validation steps

1. With this branch checked out, open the legacy editor for any project at `/projects/<id>/w/new/legacy?method=ai`. Ask the AI assistant any question. The editor stays connected through the "Thinking..." phase and renders the finished response. There should be no `CaseClauseError` in the server logs and no reconnect.

2. To see the bug on `main`, repeat the same flow without this branch. As soon as Apollo emits its first "Thinking..." update, the editor LiveView raises `CaseClauseError: no case clause matching: :streaming_status` and reconnects.

3. If you don't have a working Apollo connection locally, the regression test reproduces the same crash on `main` and passes on this branch:

   ```
   mix test test/lightning_web/live/workflow_live/edit_test.exs
   ```

4. Spot-check that the collaborative editor still streams normally. Open `/projects/<id>/w/new`, use the AI assistant there, and confirm the typewriter effect still renders character-by-character. The fix only touches the legacy editor's handler for the shared PubSub topic; the collaborative editor's channel is the actual consumer of those streaming events and is unchanged.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
