### PR TITLE
Add sandbox usage cap columns to Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ and this project adheres to
 
 ### Added
 
+- Optional per-project usage cap columns (`run_cap`, `ai_tokens_cap`,
+  `storage_cap_mb`) on `projects`, castable through `Project.changeset/2` and
+  `Project.form_changeset/2` with non-negative-integer validation.
+
 ### Changed
 
 ### Fixed
 
 ## [2.16.3] - 2026-05-07
+
 ## [2.16.3-pre3] - 2026-05-07
 
 ### Fixed

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -32,6 +32,10 @@ defmodule Lightning.Projects.Project do
     field :history_retention_period, :integer
     field :dataclip_retention_period, :integer
 
+    field :run_cap, :integer
+    field :ai_tokens_cap, :integer
+    field :storage_cap_mb, :integer
+
     field :color, :string
     field :env, :string
 
@@ -76,6 +80,9 @@ defmodule Lightning.Projects.Project do
       :retention_policy,
       :history_retention_period,
       :dataclip_retention_period,
+      :run_cap,
+      :ai_tokens_cap,
+      :storage_cap_mb,
       :allow_support_access,
       :parent_id,
       :color,
@@ -104,6 +111,9 @@ defmodule Lightning.Projects.Project do
     |> maybe_validate_dataclip_retention_period()
     |> validate_inclusion(:history_retention_period, data_retention_options())
     |> validate_inclusion(:dataclip_retention_period, data_retention_options())
+    |> validate_number(:run_cap, greater_than_or_equal_to: 0)
+    |> validate_number(:ai_tokens_cap, greater_than_or_equal_to: 0)
+    |> validate_number(:storage_cap_mb, greater_than_or_equal_to: 0)
     |> validate_format(
       :color,
       ~r/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|[A-Fa-f0-9]{8})$/,
@@ -142,6 +152,9 @@ defmodule Lightning.Projects.Project do
       :retention_policy,
       :history_retention_period,
       :dataclip_retention_period,
+      :run_cap,
+      :ai_tokens_cap,
+      :storage_cap_mb,
       :allow_support_access,
       :parent_id,
       :color,

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -165,14 +165,16 @@ defmodule LightningWeb.ProjectLive.Settings do
     project_users = Projects.get_project_users!(socket.assigns.project.id)
     auth_methods = WebhookAuthMethods.list_for_project(socket.assigns.project)
 
-    concurrency_input_component =
+    route_metadata =
       socket.router
       |> Phoenix.Router.route_info(
         "GET",
         ~p"/projects/:project_id/settings",
         nil
       )
-      |> Map.get(:concurrency_input)
+
+    concurrency_input_component = Map.get(route_metadata, :concurrency_input)
+    usage_caps_input_component = Map.get(route_metadata, :usage_caps_input)
 
     socket
     |> assign(
@@ -180,6 +182,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       project_users: project_users,
       webhook_auth_methods: auth_methods,
       concurrency_input_component: concurrency_input_component,
+      usage_caps_input_component: usage_caps_input_component,
       show_collaborators_modal: false,
       show_invite_collaborators_modal: false,
       active_modal: nil,

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -240,6 +240,14 @@
             </.form>
           </div>
 
+          <.live_component
+            :if={assigns[:usage_caps_input_component]}
+            module={assigns[:usage_caps_input_component]}
+            id="usage-caps-input-component"
+            project={@project}
+            current_user={@current_user}
+          />
+
           <div class="bg-white p-4 rounded-md space-y-4">
             <div>
               <h6 class="font-medium text-black">Export your Project</h6>

--- a/priv/repo/migrations/20260508203038_add_sandbox_usage_caps_to_projects.exs
+++ b/priv/repo/migrations/20260508203038_add_sandbox_usage_caps_to_projects.exs
@@ -1,0 +1,11 @@
+defmodule Lightning.Repo.Migrations.AddSandboxUsageCapsToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :run_cap, :integer
+      add :ai_tokens_cap, :integer
+      add :storage_cap_mb, :integer
+    end
+  end
+end

--- a/test/lightning/projects/project_test.exs
+++ b/test/lightning/projects/project_test.exs
@@ -100,6 +100,52 @@ defmodule Lightning.Projects.ProjectTest do
       refute cs.valid?
       assert "cannot be self" in errors_on(cs).parent_id
     end
+
+    test "casts and validates run_cap, ai_tokens_cap, storage_cap_mb" do
+      proj = insert(:project)
+
+      cs =
+        Project.changeset(proj, %{
+          run_cap: 1000,
+          ai_tokens_cap: 50_000,
+          storage_cap_mb: 100
+        })
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :run_cap) == 1000
+      assert Ecto.Changeset.get_field(cs, :ai_tokens_cap) == 50_000
+      assert Ecto.Changeset.get_field(cs, :storage_cap_mb) == 100
+    end
+
+    test "allows nil caps (no cap)" do
+      proj = insert(:project)
+
+      cs =
+        Project.changeset(proj, %{
+          run_cap: nil,
+          ai_tokens_cap: nil,
+          storage_cap_mb: nil
+        })
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :run_cap) == nil
+    end
+
+    test "rejects negative caps" do
+      proj = insert(:project)
+
+      cs = Project.changeset(proj, %{run_cap: -1})
+      refute cs.valid?
+      assert "must be greater than or equal to 0" in errors_on(cs).run_cap
+
+      cs = Project.changeset(proj, %{ai_tokens_cap: -1})
+      refute cs.valid?
+      assert "must be greater than or equal to 0" in errors_on(cs).ai_tokens_cap
+
+      cs = Project.changeset(proj, %{storage_cap_mb: -1})
+      refute cs.valid?
+      assert "must be greater than or equal to 0" in errors_on(cs).storage_cap_mb
+    end
   end
 
   describe "unique name scoped to parent (sandboxes)" do


### PR DESCRIPTION
## Description

This PR adds three nullable integer columns (`run_cap`, `ai_tokens_cap`, `storage_cap_mb`) to the `projects` table for storing optional per-project usage caps on runs, AI tokens, and collection storage. The columns are castable through `Project.changeset/2` and `Project.form_changeset/2` with non-negative-integer validation.

Closes #4724

## Validation steps

1. Run `mix ecto.migrate` and confirm the three new columns appear on `projects` (all nullable, default `nil`).
2. Run `MIX_ENV=test mix test test/lightning/projects/project_test.exs` and confirm all 22 tests pass, including the three new ones for cast / nil values / negative-value rejection.
3. Manually open a project's settings page and confirm no new UI sections appear; this PR is data-layer only.

## Additional notes for the reviewer

1. The migration is purely additive (nullable integer columns), so it runs online in Postgres without locking.
2. A `usage_caps_input` slot is added to the project settings template following the existing `concurrency_input` route-metadata pattern. It stays empty unless a downstream app registers a component into it, so OSS users see no UI from this PR.
3. The cap columns are typed (not JSON) to keep audit/reporting and validation semantics explicit, matching the pattern already used for `concurrency`, `history_retention_period`, and `dataclip_retention_period` on `Project`.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using \`/review\` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (No new authorization concerns; data-layer columns only, no UI in this PR.)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR