### PR TITLE
Close ancestor-branch race + broaden rule to whole project tree

### DIFF
--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -819,9 +819,6 @@ defmodule Lightning.Projects do
   Returns a list of ancestor project IDs for the given project, walking the
   `parent_id` chain upward via a recursive CTE. The project's own id is **not**
   included; for a non-sandbox project (`parent_id == nil`) returns `[]`.
-
-  Used by the GitHub-sync sandbox guard to ensure a sandbox cannot claim the
-  same `(repo, branch)` as any of its ancestors.
   """
   @spec ancestor_ids(Project.t() | Ecto.UUID.t()) :: [Ecto.UUID.t()]
   def ancestor_ids(%Project{parent_id: nil}), do: []
@@ -855,6 +852,44 @@ defmodule Lightning.Projects do
     )
     |> select([a], type(a.id, Ecto.UUID))
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the topmost ancestor (root) project id for the given project. For a
+  root project (`parent_id == nil`) returns its own id. Returns `nil` if the
+  project does not exist.
+
+  Used by the GitHub-sync guard to ensure no two projects sharing the same
+  ultimate root claim the same `(repo, branch)` pair.
+  """
+  @spec root_id(Project.t() | Ecto.UUID.t()) :: Ecto.UUID.t() | nil
+  def root_id(%Project{id: id, parent_id: nil}) when is_binary(id), do: id
+
+  def root_id(%Project{id: id, parent_id: parent_id})
+      when is_binary(parent_id) and is_binary(id) do
+    root_id(id)
+  end
+
+  def root_id(project_id) when is_binary(project_id) do
+    initial =
+      from(p in Project,
+        where: p.id == ^project_id,
+        select: %{id: p.id, parent_id: p.parent_id}
+      )
+
+    recursion =
+      from(p in Project,
+        join: a in "project_chain",
+        on: a.parent_id == p.id,
+        select: %{id: p.id, parent_id: p.parent_id}
+      )
+
+    "project_chain"
+    |> recursive_ctes(true)
+    |> with_cte("project_chain", as: ^union_all(initial, ^recursion))
+    |> where([c], is_nil(c.parent_id))
+    |> select([c], type(c.id, Ecto.UUID))
+    |> Repo.one()
   end
 
   @doc """

--- a/lib/lightning/version_control/project_repo_connection.ex
+++ b/lib/lightning/version_control/project_repo_connection.ex
@@ -10,12 +10,16 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
   alias Lightning.Projects.Project
   alias Lightning.Repo
 
+  @tree_branch_error "this branch is already linked to another project in the same project family; use a different branch"
+  @tree_unique_index "project_repo_connections_root_repo_branch_index"
+
   @type t() :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: Ecto.UUID.t() | nil,
           github_installation_id: String.t() | nil,
           repo: String.t() | nil,
           branch: String.t() | nil,
+          root_project_id: Ecto.UUID.t() | nil,
           project: nil | Project.t() | Ecto.Association.NotLoaded
         }
 
@@ -26,6 +30,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     field :access_token, :binary
     field :config_path, :string
     field :sync_version, :boolean, default: false
+    field :root_project_id, Ecto.UUID
     field :accept, :boolean, virtual: true
 
     field :sync_direction, Ecto.Enum,
@@ -66,10 +71,15 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     project_repo_connection
     |> cast(attrs, @required_fields ++ @other_fields)
     |> validate_required(@required_fields)
+    |> put_root_project_id()
     |> unique_constraint(:project_id,
       message: "project already has a repo connection"
     )
-    |> validate_no_ancestor_branch_conflict()
+    |> unique_constraint(:branch,
+      name: @tree_unique_index,
+      message: @tree_branch_error
+    )
+    |> validate_no_tree_branch_conflict()
   end
 
   def configure_changeset(project_repo_connection, attrs) do
@@ -106,21 +116,32 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     end
   end
 
-  defp validate_no_ancestor_branch_conflict(changeset) do
-    project_id = get_field(changeset, :project_id)
+  defp put_root_project_id(changeset) do
+    case get_field(changeset, :root_project_id) do
+      nil ->
+        with project_id when is_binary(project_id) <-
+               get_field(changeset, :project_id),
+             root_id when is_binary(root_id) <-
+               Lightning.Projects.root_id(project_id) do
+          put_change(changeset, :root_project_id, root_id)
+        else
+          _ -> changeset
+        end
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp validate_no_tree_branch_conflict(changeset) do
+    root_project_id = get_field(changeset, :root_project_id)
     repo = get_field(changeset, :repo)
     branch = get_field(changeset, :branch)
+    self_id = get_field(changeset, :id)
 
-    if is_binary(project_id) and is_binary(repo) and is_binary(branch) do
-      ancestor_ids = Lightning.Projects.ancestor_ids(project_id)
-
-      if ancestor_ids != [] and
-           ancestor_branch_conflict?(ancestor_ids, repo, branch) do
-        add_error(
-          changeset,
-          :branch,
-          "this branch is already linked to a parent project; sandboxes must use a different branch"
-        )
+    if is_binary(root_project_id) and is_binary(repo) and is_binary(branch) do
+      if tree_branch_conflict?(root_project_id, repo, branch, self_id) do
+        add_error(changeset, :branch, @tree_branch_error)
       else
         changeset
       end
@@ -129,20 +150,52 @@ defmodule Lightning.VersionControl.ProjectRepoConnection do
     end
   end
 
-  @doc false
-  @spec ancestor_branch_conflict?([Ecto.UUID.t()], String.t(), String.t()) ::
-          boolean()
-  def ancestor_branch_conflict?([], _repo, _branch), do: false
-
-  def ancestor_branch_conflict?(ancestor_ids, repo, branch)
-      when is_list(ancestor_ids) and is_binary(repo) and is_binary(branch) do
-    Repo.exists?(
+  @doc """
+  Returns `true` when any other connection already binds the given
+  `(repo, branch)` to the same project tree (identified by `root_project_id`).
+  Excludes the row identified by `self_id` so that updates to an existing
+  connection don't conflict with themselves.
+  """
+  @spec tree_branch_conflict?(
+          Ecto.UUID.t(),
+          String.t(),
+          String.t(),
+          Ecto.UUID.t() | nil
+        ) :: boolean()
+  def tree_branch_conflict?(root_project_id, repo, branch, self_id \\ nil)
+      when is_binary(root_project_id) and is_binary(repo) and is_binary(branch) do
+    base =
       from(c in __MODULE__,
-        where: c.project_id in ^ancestor_ids,
+        where: c.root_project_id == ^root_project_id,
         where: c.repo == ^repo,
         where: c.branch == ^branch
       )
-    )
+
+    query =
+      if is_binary(self_id) do
+        from c in base, where: c.id != ^self_id
+      else
+        base
+      end
+
+    Repo.exists?(query)
+  end
+
+  @doc """
+  True if the given changeset's insert/update failed on the tree-uniqueness
+  index. Used to translate a constraint violation back into the
+  `:branch_used_in_project_tree` atom error at the boundary.
+  """
+  @spec tree_unique_violation?(Ecto.Changeset.t()) :: boolean()
+  def tree_unique_violation?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn
+      {:branch, {_msg, opts}} ->
+        Keyword.get(opts, :constraint) == :unique and
+          Keyword.get(opts, :constraint_name) == @tree_unique_index
+
+      _ ->
+        false
+    end)
   end
 
   defp validate_sync_direction(changeset) do

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -25,21 +25,26 @@ defmodule Lightning.VersionControl do
   defdelegate subscribe(user), to: Events
 
   @doc """
-  Creates a connection between a project and a github repo
+  Creates a connection between a project and a github repo.
+
+  The `(root_project_id, repo, branch)` uniqueness constraint on
+  `project_repo_connections` is the source of truth: two concurrent inserts
+  for the same project family + (repo, branch) cannot both succeed even at
+  READ COMMITTED isolation. The constraint violation is translated back into
+  `:branch_used_in_project_tree` for callers.
   """
   @spec create_github_connection(map(), User.t()) ::
           {:ok, ProjectRepoConnection.t()}
           | {:error,
              Ecto.Changeset.t()
              | UsageLimiting.message()
-             | :branch_used_by_ancestor}
+             | :branch_used_in_project_tree}
   def create_github_connection(attrs, user) do
     changeset =
       ProjectRepoConnection.create_changeset(%ProjectRepoConnection{}, attrs)
 
     Repo.transact(fn ->
-      with :ok <- check_ancestor_branch_conflict(changeset),
-           {:ok, repo_connection} <- Repo.insert(changeset),
+      with {:ok, repo_connection} <- insert_repo_connection(changeset),
            {:ok, _audit} <-
              repo_connection
              |> Audit.repo_connection(:created, user)
@@ -54,25 +59,17 @@ defmodule Lightning.VersionControl do
     end)
   end
 
-  defp check_ancestor_branch_conflict(changeset) do
-    project_id = Ecto.Changeset.get_field(changeset, :project_id)
-    repo = Ecto.Changeset.get_field(changeset, :repo)
-    branch = Ecto.Changeset.get_field(changeset, :branch)
+  defp insert_repo_connection(changeset) do
+    case Repo.insert(changeset) do
+      {:ok, repo_connection} ->
+        {:ok, repo_connection}
 
-    if is_binary(project_id) and is_binary(repo) and is_binary(branch) do
-      ancestor_ids = Lightning.Projects.ancestor_ids(project_id)
-
-      if ProjectRepoConnection.ancestor_branch_conflict?(
-           ancestor_ids,
-           repo,
-           branch
-         ) do
-        {:error, :branch_used_by_ancestor}
-      else
-        :ok
-      end
-    else
-      :ok
+      {:error, %Ecto.Changeset{} = failed} ->
+        if ProjectRepoConnection.tree_unique_violation?(failed) do
+          {:error, :branch_used_in_project_tree}
+        else
+          {:error, failed}
+        end
     end
   end
 

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -174,15 +174,15 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
     |> maybe_force_branch_error_action()
   end
 
-  # When the ancestor-branch guard fails on a branch the user just selected,
-  # set the changeset action so Phoenix renders the error inline. We only
-  # promote the action when the conflict error is present so other "blank"
-  # errors stay hidden until the user submits.
+  # When the project-tree branch guard fails on a branch the user just
+  # selected, set the changeset action so Phoenix renders the error inline.
+  # We only promote the action when the conflict error is present so other
+  # "blank" errors stay hidden until the user submits.
   defp maybe_force_branch_error_action(changeset) do
     branch_errors = Keyword.get_values(changeset.errors, :branch)
 
     if Enum.any?(branch_errors, fn {msg, _} ->
-         msg =~ "already linked to a parent project"
+         msg =~ "already linked to another project in the same project family"
        end) do
       Map.put(changeset, :action, :validate)
     else

--- a/priv/repo/migrations/20260509132430_scope_repo_connection_uniqueness_to_project_root.exs
+++ b/priv/repo/migrations/20260509132430_scope_repo_connection_uniqueness_to_project_root.exs
@@ -1,0 +1,64 @@
+defmodule Lightning.Repo.Migrations.ScopeRepoConnectionUniquenessToProjectRoot do
+  use Ecto.Migration
+
+  @moduledoc """
+  Adds `root_project_id` to `project_repo_connections` and a unique index on
+  `(root_project_id, repo, branch)`. This makes the database the source of
+  truth for "no two projects sharing the same ultimate root may claim the same
+  (repo, branch) pair" — closing the check-then-insert race that otherwise
+  exists at READ COMMITTED isolation.
+
+  Backfill walks the `parent_id` chain of each connection's project to find
+  the topmost ancestor and writes that into `root_project_id`. If two existing
+  connections in the same project tree already share `(repo, branch)`, the
+  unique index creation will fail; resolve by removing one of the connections
+  and re-running the migration.
+  """
+
+  def up do
+    alter table(:project_repo_connections) do
+      add :root_project_id,
+          references(:projects, type: :binary_id, on_delete: :restrict)
+    end
+
+    flush()
+
+    execute("""
+    WITH RECURSIVE project_roots AS (
+      SELECT id, parent_id, id AS root_id
+      FROM projects
+      WHERE parent_id IS NULL
+      UNION ALL
+      SELECT p.id, p.parent_id, pr.root_id
+      FROM projects p
+      JOIN project_roots pr ON p.parent_id = pr.id
+    )
+    UPDATE project_repo_connections prc
+    SET root_project_id = pr.root_id
+    FROM project_roots pr
+    WHERE prc.project_id = pr.id;
+    """)
+
+    alter table(:project_repo_connections) do
+      modify :root_project_id, :binary_id, null: false
+    end
+
+    create unique_index(
+             "project_repo_connections",
+             [:root_project_id, :repo, :branch],
+             name: "project_repo_connections_root_repo_branch_index"
+           )
+  end
+
+  def down do
+    drop index(
+           "project_repo_connections",
+           [:root_project_id, :repo, :branch],
+           name: "project_repo_connections_root_repo_branch_index"
+         )
+
+    alter table(:project_repo_connections) do
+      remove :root_project_id
+    end
+  end
+end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -2967,6 +2967,43 @@ defmodule Lightning.ProjectsTest do
     end
   end
 
+  describe "root_id/1" do
+    test "returns the project's own id for a root project" do
+      project = insert(:project)
+      assert Projects.root_id(project) == project.id
+      assert Projects.root_id(project.id) == project.id
+    end
+
+    test "returns the parent's id for a direct sandbox" do
+      parent = insert(:project)
+      sandbox = insert(:project, parent: parent)
+
+      assert Projects.root_id(sandbox) == parent.id
+      assert Projects.root_id(sandbox.id) == parent.id
+    end
+
+    test "walks all the way to the top of a deep chain" do
+      grandparent = insert(:project)
+      parent = insert(:project, parent: grandparent)
+      grandchild = insert(:project, parent: parent)
+
+      assert Projects.root_id(grandchild) == grandparent.id
+    end
+
+    test "siblings share the same root" do
+      parent = insert(:project)
+      a = insert(:project, parent: parent)
+      b = insert(:project, parent: parent)
+
+      assert Projects.root_id(a) == parent.id
+      assert Projects.root_id(b) == parent.id
+    end
+
+    test "returns nil for an unknown project id" do
+      assert Projects.root_id(Ecto.UUID.generate()) == nil
+    end
+  end
+
   describe "sandbox facade delegates" do
     test "provision_sandbox/3 creates a child project and sets parent_id" do
       owner = insert(:user)

--- a/test/lightning/version_control/project_repo_connection_test.exs
+++ b/test/lightning/version_control/project_repo_connection_test.exs
@@ -5,9 +5,9 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
 
   import Lightning.Factories
 
-  @ancestor_branch_error "this branch is already linked to a parent project; sandboxes must use a different branch"
+  @tree_branch_error "this branch is already linked to another project in the same project family; use a different branch"
 
-  describe "validate_no_ancestor_branch_conflict in changeset/2" do
+  describe "validate_no_tree_branch_conflict in changeset/2" do
     test "rejects sandbox claiming the same (repo, branch) as its direct parent" do
       parent = insert(:project)
 
@@ -28,7 +28,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
         })
 
       refute changeset.valid?
-      assert {@ancestor_branch_error, _} = changeset.errors[:branch]
+      assert {@tree_branch_error, _} = changeset.errors[:branch]
     end
 
     test "rejects grandchild sandbox claiming a grandparent's (repo, branch)" do
@@ -52,7 +52,52 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
         })
 
       refute changeset.valid?
-      assert {@ancestor_branch_error, _} = changeset.errors[:branch]
+      assert {@tree_branch_error, _} = changeset.errors[:branch]
+    end
+
+    test "rejects sibling sandboxes from sharing the same (repo, branch)" do
+      parent = insert(:project)
+      sibling_a = insert(:project, parent: parent)
+      sibling_b = insert(:project, parent: parent)
+
+      insert(:project_repo_connection,
+        project: sibling_a,
+        repo: "openfn/example",
+        branch: "dev"
+      )
+
+      changeset =
+        ProjectRepoConnection.changeset(%ProjectRepoConnection{}, %{
+          project_id: sibling_b.id,
+          repo: "openfn/example",
+          branch: "dev",
+          github_installation_id: "1234"
+        })
+
+      refute changeset.valid?
+      assert {@tree_branch_error, _} = changeset.errors[:branch]
+    end
+
+    test "rejects a parent claiming a (repo, branch) already taken by its sandbox" do
+      parent = insert(:project)
+      sandbox = insert(:project, parent: parent)
+
+      insert(:project_repo_connection,
+        project: sandbox,
+        repo: "openfn/example",
+        branch: "feature"
+      )
+
+      changeset =
+        ProjectRepoConnection.changeset(%ProjectRepoConnection{}, %{
+          project_id: parent.id,
+          repo: "openfn/example",
+          branch: "feature",
+          github_installation_id: "1234"
+        })
+
+      refute changeset.valid?
+      assert {@tree_branch_error, _} = changeset.errors[:branch]
     end
 
     test "allows a sandbox to share parent's repo on a different branch" do
@@ -101,7 +146,7 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
       refute changeset.errors[:branch]
     end
 
-    test "non-sandbox project (no parent) is unaffected by the guard" do
+    test "non-sandbox project (no parent) is unaffected when no other project in its tree uses the (repo, branch)" do
       project = insert(:project)
 
       changeset =
@@ -116,22 +161,21 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
       refute changeset.errors[:branch]
     end
 
-    test "sibling sandboxes can share the same (repo, branch) — they are not ancestors" do
-      parent = insert(:project)
-      sibling_a = insert(:project, parent: parent)
-      sibling_b = insert(:project, parent: parent)
+    test "unrelated projects (separate trees) may share the same (repo, branch)" do
+      tree_a = insert(:project)
+      tree_b = insert(:project)
 
       insert(:project_repo_connection,
-        project: sibling_a,
+        project: tree_a,
         repo: "openfn/example",
-        branch: "dev"
+        branch: "main"
       )
 
       changeset =
         ProjectRepoConnection.changeset(%ProjectRepoConnection{}, %{
-          project_id: sibling_b.id,
+          project_id: tree_b.id,
           repo: "openfn/example",
-          branch: "dev",
+          branch: "main",
           github_installation_id: "1234"
         })
 
@@ -158,11 +202,11 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
           github_installation_id: "1234"
         })
 
-      refute changeset.errors[:branch] == {@ancestor_branch_error, []}
+      refute changeset.errors[:branch] == {@tree_branch_error, []}
     end
   end
 
-  describe "validate_no_ancestor_branch_conflict in configure_changeset/2" do
+  describe "validate_no_tree_branch_conflict in configure_changeset/2" do
     test "rejects on configure_changeset path too" do
       parent = insert(:project)
 
@@ -185,48 +229,68 @@ defmodule Lightning.VersionControl.ProjectRepoConnectionTest do
         })
 
       refute changeset.valid?
-      assert {@ancestor_branch_error, _} = changeset.errors[:branch]
+      assert {@tree_branch_error, _} = changeset.errors[:branch]
     end
   end
 
-  describe "ancestor_branch_conflict?/3" do
-    test "returns false for an empty ancestor list" do
-      refute ProjectRepoConnection.ancestor_branch_conflict?(
-               [],
-               "any/repo",
-               "any"
-             )
-    end
+  describe "tree_branch_conflict?/4" do
+    test "returns false when no other connection in the tree uses the (repo, branch)" do
+      root = insert(:project)
 
-    test "returns true when an ancestor is linked to (repo, branch)" do
-      parent = insert(:project)
-
-      insert(:project_repo_connection,
-        project: parent,
-        repo: "openfn/example",
-        branch: "main"
-      )
-
-      assert ProjectRepoConnection.ancestor_branch_conflict?(
-               [parent.id],
+      refute ProjectRepoConnection.tree_branch_conflict?(
+               root.id,
                "openfn/example",
                "main"
              )
     end
 
-    test "returns false when no ancestor matches" do
-      parent = insert(:project)
+    test "returns true when another connection in the same tree uses the (repo, branch)" do
+      root = insert(:project)
 
       insert(:project_repo_connection,
-        project: parent,
+        project: root,
         repo: "openfn/example",
         branch: "main"
       )
 
-      refute ProjectRepoConnection.ancestor_branch_conflict?(
-               [parent.id],
+      assert ProjectRepoConnection.tree_branch_conflict?(
+               root.id,
+               "openfn/example",
+               "main"
+             )
+    end
+
+    test "returns false when a different branch is used in the tree" do
+      root = insert(:project)
+
+      insert(:project_repo_connection,
+        project: root,
+        repo: "openfn/example",
+        branch: "main"
+      )
+
+      refute ProjectRepoConnection.tree_branch_conflict?(
+               root.id,
                "openfn/example",
                "dev"
+             )
+    end
+
+    test "excludes self_id so a row doesn't conflict with itself" do
+      root = insert(:project)
+
+      conn =
+        insert(:project_repo_connection,
+          project: root,
+          repo: "openfn/example",
+          branch: "main"
+        )
+
+      refute ProjectRepoConnection.tree_branch_conflict?(
+               root.id,
+               "openfn/example",
+               "main",
+               conn.id
              )
     end
   end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -246,7 +246,7 @@ defmodule Lightning.VersionControlTest do
       assert Repo.aggregate(ProjectRepoConnection, :count) == 0
     end
 
-    test "returns {:error, :branch_used_by_ancestor} when sandbox claims an ancestor's (repo, branch)" do
+    test "returns a changeset error when sandbox claims an ancestor's (repo, branch)" do
       parent = insert(:project)
 
       insert(:project_repo_connection,
@@ -267,10 +267,76 @@ defmodule Lightning.VersionControlTest do
         "accept" => "true"
       }
 
-      assert {:error, :branch_used_by_ancestor} =
+      assert {:error, %Ecto.Changeset{valid?: false} = changeset} =
                VersionControl.create_github_connection(params, user)
 
+      assert {msg, _} = changeset.errors[:branch]
+      assert msg =~ "already linked to another project in the same project family"
+
       # parent's existing connection is the only one in the DB
+      assert Repo.aggregate(ProjectRepoConnection, :count) == 1
+    end
+
+    test "returns a changeset error when a sibling sandbox already uses the (repo, branch)" do
+      parent = insert(:project)
+      sibling_a = insert(:project, parent: parent)
+      sibling_b = insert(:project, parent: parent)
+
+      insert(:project_repo_connection,
+        project: sibling_a,
+        repo: "someaccount/somerepo",
+        branch: "feature"
+      )
+
+      user = user_with_valid_github_oauth()
+
+      params = %{
+        "project_id" => sibling_b.id,
+        "repo" => "someaccount/somerepo",
+        "branch" => "feature",
+        "github_installation_id" => "1234",
+        "sync_direction" => "pull",
+        "accept" => "true"
+      }
+
+      assert {:error, %Ecto.Changeset{valid?: false} = changeset} =
+               VersionControl.create_github_connection(params, user)
+
+      assert {msg, _} = changeset.errors[:branch]
+      assert msg =~ "already linked to another project in the same project family"
+
+      assert Repo.aggregate(ProjectRepoConnection, :count) == 1
+    end
+
+    test "DB unique index closes the check-then-insert race even when the application-level guard is bypassed" do
+      # Build two raw structs that have already passed the in-memory guard —
+      # this models the race window in which two concurrent transactions both
+      # SELECT no-row before either INSERTs. With the unique index in place,
+      # exactly one INSERT survives; the other raises Ecto.ConstraintError on
+      # `project_repo_connections_root_repo_branch_index`.
+      parent = insert(:project)
+      sibling_a = insert(:project, parent: parent)
+      sibling_b = insert(:project, parent: parent)
+
+      build_struct = fn project ->
+        %Lightning.VersionControl.ProjectRepoConnection{
+          project_id: project.id,
+          root_project_id: parent.id,
+          repo: "someaccount/somerepo",
+          branch: "main",
+          github_installation_id: "1234",
+          access_token: "token-#{project.id}"
+        }
+      end
+
+      assert {:ok, _} = Repo.insert(build_struct.(sibling_a))
+
+      assert_raise Postgrex.Error,
+                   ~r/project_repo_connections_root_repo_branch/,
+                   fn ->
+                     Repo.insert(build_struct.(sibling_b))
+                   end
+
       assert Repo.aggregate(ProjectRepoConnection, :count) == 1
     end
   end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -12,14 +12,42 @@ defmodule Lightning.Factories do
     }
   end
 
-  def project_repo_connection_factory do
-    %Lightning.VersionControl.ProjectRepoConnection{
-      project: build(:project),
+  def project_repo_connection_factory(attrs) do
+    project =
+      case Map.get(attrs, :project) do
+        %Lightning.Projects.Project{id: id} = p when is_binary(id) -> p
+        %Lightning.Projects.Project{} = p -> insert(p)
+        nil -> nil
+      end
+
+    project =
+      project ||
+        case Map.get(attrs, :project_id) do
+          id when is_binary(id) ->
+            Lightning.Repo.get!(Lightning.Projects.Project, id)
+
+          _ ->
+            insert(:project)
+        end
+
+    root_project_id =
+      Map.get_lazy(attrs, :root_project_id, fn ->
+        Lightning.Projects.root_id(project.id)
+      end)
+
+    base = %Lightning.VersionControl.ProjectRepoConnection{
+      project: project,
+      root_project_id: root_project_id,
       repo: "some/repo",
       branch: "branch",
       github_installation_id: "some-id",
       access_token: sequence(:token, &"prc_sometoken#{&1}")
     }
+
+    merge_attributes(
+      base,
+      Map.drop(attrs, [:project, :project_id, :root_project_id])
+    )
   end
 
   def project_factory do


### PR DESCRIPTION
## Summary

Addresses the PR-review blocker on the GitHub-sync `(repo, branch)` guard. The original guard checked ancestors only and ran as a check-then-insert pattern inside an Elixir transaction — two concurrent inserts at READ COMMITTED could both pass the in-memory check and both commit.

This PR broadens the rule and moves enforcement to the database:

- **Rule**: No two projects sharing the same ultimate root (root, sandboxes, siblings, cousins, etc.) may claim the same `(repo, branch)` pair. Unrelated project trees may still share freely.
- **Enforcement**: Postgres unique index on `(root_project_id, repo, branch)`. Two concurrent inserts cannot both succeed regardless of isolation level.

## Changes

- `Lightning.Projects.root_id/1` — walks `parent_id` to the topmost ancestor (or self).
- Migration `20260509132430_scope_repo_connection_uniqueness_to_project_root` — adds `root_project_id` (NOT NULL after backfill via recursive CTE) and the unique index. Migration fails loudly if existing data already violates the new rule.
- `ProjectRepoConnection`:
  - schema gains `:root_project_id`
  - changeset sets it via `put_root_project_id/1`, declares `unique_constraint(:branch, name: ...)`, and runs a friendly pre-flight check for nice form errors
  - exposes `tree_unique_violation?/1` so the boundary can translate the index violation back to an atom
- `VersionControl.create_github_connection`:
  - drops the race-prone in-memory pre-flight check
  - converts a unique-violation changeset error from `Repo.insert` into `{:error, :branch_used_in_project_tree}`
- `GithubSyncComponent` — branch-error matcher updated for the new message.
- Factory updated to set `root_project_id` so existing `insert(:project_repo_connection, ...)` calls keep working.

## Test plan

- [x] Existing `validate_no_*_branch_conflict` tests rewritten and extended:
  - sibling sandboxes can no longer share `(repo, branch)`
  - parent rejected if a sandbox already claims the pair
  - unrelated trees may still share
- [x] `Lightning.Projects.root_id/1` covered for root, deep chain, siblings, missing.
- [x] Concurrency test inserts two raw structs that both pass the in-memory guard, asserts exactly one survives and the other raises on the unique index.
- [ ] CI: `mix verify` (format/credo/dialyzer/sobelow) — could not run locally; relying on CI in this environment.
- [ ] CI: full test suite — same caveat.

## Notes / caveats

- `Lightning.Projects.ancestor_ids/1` is no longer used outside its own tests. Left in place as a general-purpose helper.
- `root_project_id` is set at connection insertion time. If a project is reparented after its connection is created, the connection's `root_project_id` is not auto-updated. Out of scope for this PR; flag as follow-up if reparenting is supported with active connections.
- Existing dev/staging data with sibling-sharing connections will block the migration; operators must remove duplicates before re-running. Migration docstring documents this.

https://claude.ai/code/session_01Y6UVYpN4Wv2yXPRN96YQeE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6UVYpN4Wv2yXPRN96YQeE)_