### PR TITLE
Fix Linux bootstrap on aarch64 and surface Rambo errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,23 @@ and this project adheres to
 
 ### Changed
 
+- `./bin/bootstrap` on aarch64 Linux now requires Rust upfront and builds the
+  Rambo native binary via `mix compile.rambo` post-compile, matching the darwin
+  path. x86_64 Linux is unchanged.
+  [#4735](https://github.com/OpenFn/lightning/pull/4735)
+
 ### Fixed
 
+- `mix lightning.install_runtime` no longer reports success when Rambo's binary
+  fails to start; both `Rambo.run/2` calls now raise with the underlying reason.
+  [#4735](https://github.com/OpenFn/lightning/pull/4735)
+- `FakeRambo.run/3` guards against the `:fake_rambo_cache` ETS table not yet
+  existing, restoring the intended missing-cache fallback that Cachex 4.x broke
+  by raising `ArgumentError` from `:ets.lookup` instead of returning
+  `{:error, _}`. [#4735](https://github.com/OpenFn/lightning/pull/4735)
+
 ## [2.16.3] - 2026-05-07
+
 ## [2.16.3-pre3] - 2026-05-07
 
 ### Fixed

--- a/bin/bootstrap.d/linux-debian.sh
+++ b/bin/bootstrap.d/linux-debian.sh
@@ -5,6 +5,16 @@
 # Required system packages for native dependency compilation
 REQUIRED_PACKAGES=(build-essential libsodium-dev cmake)
 MISSING_PACKAGES=()
+MISSING_RUST=false
+
+# Rambo ships precompiled binaries only for x86_64 mac/linux/windows.
+# Other architectures (e.g. aarch64/arm64) must build from source via cargo.
+rust_required_for_arch() {
+  case "$(uname -m)" in
+  aarch64 | arm64) return 0 ;;
+  *) return 1 ;;
+  esac
+}
 
 platform_check_dependencies() {
   for package in "${REQUIRED_PACKAGES[@]}"; do
@@ -15,15 +25,19 @@ platform_check_dependencies() {
     fi
   done
 
-  # Check for Rust (optional but recommended for Rambo)
   if command -v rustc &>/dev/null; then
     echo "  Rust: $(rustc --version)"
+  elif rust_required_for_arch; then
+    echo "  Rust: not installed (required on $(uname -m) — rambo has no precompiled binary)"
+    MISSING_RUST=true
   else
     echo "  Rust: not installed (optional)"
   fi
 }
 
 platform_check_status() {
+  local has_failures=false
+
   if [[ ${#MISSING_PACKAGES[@]} -gt 0 ]]; then
     echo "Missing system packages:"
     for package in "${MISSING_PACKAGES[@]}"; do
@@ -32,6 +46,22 @@ platform_check_status() {
     echo ""
     echo "To install, run:"
     echo "  sudo apt-get update && sudo apt-get install -y ${MISSING_PACKAGES[*]}"
+    has_failures=true
+  fi
+
+  if [[ "$MISSING_RUST" == true ]]; then
+    [[ "$has_failures" == true ]] && echo ""
+    echo "Missing Rust toolchain (rambo has no precompiled binary for $(uname -m))"
+    echo ""
+    echo "Install via rustup (recommended):"
+    echo "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    echo ""
+    echo "Or via apt:"
+    echo "  sudo apt-get install -y rustc cargo"
+    has_failures=true
+  fi
+
+  if [[ "$has_failures" == true ]]; then
     echo ""
     echo "Then re-run ./bin/bootstrap"
     exit 1
@@ -62,7 +92,20 @@ platform_setup_environment() {
 }
 
 platform_post_compile_hooks() {
-  # No platform-specific post-compile hooks needed on Linux
-  # Rambo compiles automatically during mix deps.compile
-  :
+  # On architectures without a precompiled rambo binary (e.g. aarch64),
+  # the `:rambo` compiler builds priv/rambo via cargo. If the binary is
+  # missing — typically because an earlier bootstrap ran before Rust was
+  # installed and mix has since cached rambo as "compiled" — force a
+  # rebuild so the rest of bootstrap can actually invoke it.
+  if ! rust_required_for_arch; then
+    return
+  fi
+
+  local rambo_bin="_build/${MIX_ENV:-dev}/lib/rambo/priv/rambo"
+  if [[ -x "$rambo_bin" ]]; then
+    return
+  fi
+
+  echo "Rambo binary missing at $rambo_bin — building via cargo..."
+  (cd deps/rambo && mix compile.rambo)
 }

--- a/lib/mix/tasks/install_runtime.ex
+++ b/lib/mix/tasks/install_runtime.ex
@@ -14,13 +14,21 @@ defmodule Mix.Tasks.Lightning.InstallRuntime do
   @cli_version "1.35.2"
 
   def run(args) do
-    Rambo.run("/usr/bin/env", ~w(which node))
-    |> case do
-      {:error, %{status: 1}} ->
+    case Rambo.run("/usr/bin/env", ~w(which node)) do
+      {:ok, _} ->
+        :ok
+
+      {:error, %Rambo{status: 1}} ->
         raise "Couldn't find node in the local environment."
 
-      _ ->
-        nil
+      {:error, reason} ->
+        raise """
+        Failed to invoke Rambo while checking for node: #{inspect(reason)}
+
+        The rambo binary may be missing or not executable. On architectures
+        without a precompiled binary (e.g. aarch64/arm64), Rust is required
+        so rambo can be built from source. See ./bin/bootstrap output.
+        """
     end
 
     File.mkdir_p(@default_path)
@@ -34,12 +42,25 @@ defmodule Mix.Tasks.Lightning.InstallRuntime do
 
     package_list = packages(args) |> Enum.join(" ")
 
-    Rambo.run(
-      "/usr/bin/env",
-      ["sh", "-c", "npm install --prefix $NODE_PATH --global #{package_list}"],
-      log: true,
-      env: %{"NODE_PATH" => @default_path}
-    )
+    case Rambo.run(
+           "/usr/bin/env",
+           [
+             "sh",
+             "-c",
+             "npm install --prefix $NODE_PATH --global #{package_list}"
+           ],
+           log: true,
+           env: %{"NODE_PATH" => @default_path}
+         ) do
+      {:ok, result} ->
+        result
+
+      {:error, %Rambo{status: status, err: err}} ->
+        raise "npm install failed (status #{status}): #{err}"
+
+      {:error, reason} ->
+        raise "Failed to invoke Rambo for npm install: #{inspect(reason)}"
+    end
   end
 
   def packages(args \\ []) do

--- a/test/support/fake_rambo.ex
+++ b/test/support/fake_rambo.ex
@@ -19,10 +19,14 @@ defmodule FakeRambo do
   def run(command, args, opts) do
     send(self(), {command, args, opts})
 
-    case Cachex.get(:fake_rambo_cache, :res) do
-      {:ok, nil} -> {:ok, %{out: "", status: 0}}
-      {:ok, res} -> res
-      {:error, _} -> {:ok, %{out: "", status: 0}}
+    if :ets.whereis(:fake_rambo_cache) == :undefined do
+      {:ok, %{out: "", status: 0}}
+    else
+      case Cachex.get(:fake_rambo_cache, :res) do
+        {:ok, nil} -> {:ok, %{out: "", status: 0}}
+        {:ok, res} -> res
+        {:error, _} -> {:ok, %{out: "", status: 0}}
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Brings the aarch64 Linux bootstrap path in line with darwin: Rambo has no
precompiled binary for `aarch64`, so we now require Rust upfront and run
`mix compile.rambo` directly from `deps/rambo/` if the binary is missing —
same as darwin.sh already does.

Two adjacent issues fell out along the way:

- `Mix.Tasks.Lightning.InstallRuntime` swallowed `{:error, _}` results from
  `Rambo.run/2` (binary-failed-to-start) and reported success. Both calls
  now raise with the underlying reason.
- `FakeRambo.run/3` assumed `Cachex.get/2` returns `{:error, _}` for a
  missing cache. Cachex 4.x (bumped in #3078) raises `ArgumentError` from
  `:ets.lookup` instead — a guard restores the intended fallback.
  Seed-dependent, so CI hasn't caught it.

## Validation steps

1. On aarch64 Linux without Rust: `./bin/bootstrap` exits early with a
   rustup / apt install hint, before `mix deps.compile`.
2. Install Rust, re-run `./bin/bootstrap`. Post-compile hook builds the
   rambo binary and the script completes.
3. `mix test test/lightning/cli_test.exs:6` passes on any seed.

## Additional notes for the reviewer

- x86_64 Linux is unchanged — `rambo-linux` still works there.
- `rust_required_for_arch` matches both `aarch64` and `arm64`.

## AI Usage

- [x] I have used Claude Code

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [ ] I have implemented and tested all related **authorization policies** *(no auth changes)*
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR