### PR TITLE
Portability: explicitly serialize to version 4.0

### DIFF
--- a/assets/js/yaml/schema/workflow-spec-v2.json
+++ b/assets/js/yaml/schema/workflow-spec-v2.json
@@ -79,6 +79,7 @@
     }
   },
   "properties": {
+    "schema_version": { "type": "string" },
     "id": { "type": "string" },
     "name": { "type": ["string", "null"] },
     "start": { "type": "string" },

--- a/assets/js/yaml/schema/workflow-spec.json
+++ b/assets/js/yaml/schema/workflow-spec.json
@@ -3,6 +3,9 @@
   "title": "WorkflowSpec",
   "type": "object",
   "properties": {
+    "schema_version": {
+      "type": "string"
+    },
     "id": {
       "type": ["string", "null"]
     },

--- a/assets/js/yaml/v2.ts
+++ b/assets/js/yaml/v2.ts
@@ -488,6 +488,9 @@ const RESERVED_YAML = new Set([
 const needsQuoting = (s: string): boolean => {
   if (s === '') return true;
   if (RESERVED_YAML.has(s.toLowerCase())) return true;
+  // Quote strings that would otherwise parse as a YAML number on read
+  // (e.g. "4.0" must stay a string for schema_version).
+  if (/^-?(\d+\.?\d*|\.\d+)$/.test(s)) return true;
   // Mirrors `Lightning.Workflows.YamlFormat.V2.quote_if_needed/1`:
   // ^[A-Za-z0-9][A-Za-z0-9_\-@./> ]*[A-Za-z0-9]$  (and not reserved)
   return !/^[A-Za-z0-9][A-Za-z0-9_\-@./> ]*[A-Za-z0-9]$/.test(s);

--- a/assets/js/yaml/v2.ts
+++ b/assets/js/yaml/v2.ts
@@ -250,6 +250,7 @@ type CanonicalStep = CanonicalTriggerStep | CanonicalJobStep;
 interface CanonicalWorkflow {
   id: string;
   name: string;
+  schema_version: string;
   start?: string;
   steps: CanonicalStep[];
 }
@@ -344,6 +345,7 @@ const workflowStateToCanonical = (state: WorkflowState): CanonicalWorkflow => {
   return {
     id: hyphenate(state.name),
     name: state.name,
+    schema_version: '4.0',
     ...(start ? { start } : {}),
     // Trigger steps first, then job steps — matches Elixir's emit order.
     steps: [...triggerSteps, ...jobSteps],

--- a/lib/lightning/workflows/yaml_format/v2.ex
+++ b/lib/lightning/workflows/yaml_format/v2.ex
@@ -457,6 +457,7 @@ defmodule Lightning.Workflows.YamlFormat.V2 do
     [
       emit_scalar_field("id", Map.get(workflow_canonical, :id)),
       emit_scalar_field("name", Map.get(workflow_canonical, :name)),
+      emit_scalar_field("schema_version", "4.0"),
       emit_scalar_field("start", Map.get(workflow_canonical, :start)),
       emit_steps(triggers ++ jobs)
     ]
@@ -772,6 +773,7 @@ defmodule Lightning.Workflows.YamlFormat.V2 do
     [
       emit_top_scalar("id", Map.get(project_canonical, :id)),
       emit_top_scalar("name", Map.get(project_canonical, :name)),
+      emit_top_scalar("schema_version", "4.0"),
       emit_top_description(Map.get(project_canonical, :description)),
       emit_collections_array(Map.get(project_canonical, :collections, [])),
       emit_credentials_array(Map.get(project_canonical, :credentials, [])),

--- a/lib/lightning/workflows/yaml_format/v2.ex
+++ b/lib/lightning/workflows/yaml_format/v2.ex
@@ -658,6 +658,11 @@ defmodule Lightning.Workflows.YamlFormat.V2 do
       value == "" ->
         "''"
 
+      # Quote strings that would otherwise parse as a YAML number on read
+      # (e.g. "4.0" must stay a string for schema_version).
+      Regex.match?(~r/^-?(\d+\.?\d*|\.\d+)$/, value) ->
+        "'" <> value <> "'"
+
       Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.\/> |]*[a-zA-Z0-9]$/, value) and
           not yaml_reserved?(value) ->
         value

--- a/test/fixtures/portability/v2/canonical_project.yaml
+++ b/test/fixtures/portability/v2/canonical_project.yaml
@@ -1,5 +1,6 @@
 id: a-test-project
 name: a-test-project
+schema_version: '4.0'
 description: |
   This is only a test
 collections:

--- a/test/fixtures/portability/v2/canonical_workflow.yaml
+++ b/test/fixtures/portability/v2/canonical_workflow.yaml
@@ -1,5 +1,6 @@
 id: canonical-workflow
 name: canonical workflow
+schema_version: '4.0'
 start: cron
 steps:
   - id: cron


### PR DESCRIPTION
This PR builds on  https://github.com/OpenFn/lightning/pull/4722 by adding the `schema_version` key to the top of the yaml file.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
