### PR TITLE
v2 portability: restore legacy provisioner

### DIFF
--- a/assets/js/yaml/v2.ts
+++ b/assets/js/yaml/v2.ts
@@ -255,7 +255,8 @@ interface CanonicalWorkflow {
   steps: CanonicalStep[];
 }
 
-const hyphenate = (value: string): string => value.replace(/\s+/g, '-');
+const hyphenate = (value: string): string =>
+  value.toLowerCase().replace(/\s+/g, '-');
 
 // Kafka config travels flat on the trigger root in YAML
 // (`hosts: [...]`, `topics: [...]`, `connect_timeout: …`, etc.) — matches

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -1,0 +1,457 @@
+defmodule Lightning.ExportUtils do
+  @moduledoc """
+  Module that expose a function generating a complete and valid yaml string
+  from a project and its workflows.
+  """
+
+  alias Lightning.Projects
+  alias Lightning.Workflows
+  alias Lightning.Workflows.Snapshot
+
+  @kafka_trigger_fields [
+    :hosts,
+    :topics,
+    :initial_offset_reset_policy,
+    :connect_timeout
+  ]
+
+  @ordering_map %{
+    project: [
+      :name,
+      :description,
+      :collections,
+      :credentials,
+      :globals,
+      :workflows
+    ],
+    collection: [:name],
+    credential: [:name, :owner],
+    workflow: [:name, :jobs, :triggers, :edges],
+    job: [:name, :adaptor, :credential, :globals, :body],
+    trigger: [
+      :type,
+      :webhook_reply,
+      :cron_expression,
+      :cron_cursor_job,
+      :enabled,
+      :kafka_configuration
+    ],
+    edge: [
+      :source_trigger,
+      :source_job,
+      :target_job,
+      :condition_type,
+      :condition_label,
+      :condition_expression,
+      :enabled
+    ]
+  }
+
+  @special_keys Enum.flat_map(@ordering_map, fn {node_key, child_keys} ->
+                  [node_key | child_keys]
+                end)
+
+  defp hyphenate(string) when is_binary(string) do
+    string |> String.replace(" ", "-")
+  end
+
+  defp hyphenate(other), do: other
+
+  defp job_to_treenode(job, project_credentials) do
+    project_credential =
+      Enum.find(project_credentials, fn pc ->
+        pc.id == job.project_credential_id
+      end)
+
+    %{
+      # The identifier here for our YAML reducer will be the hyphenated name
+      id: job_key(job),
+      name: job.name,
+      node_type: :job,
+      adaptor: job.adaptor,
+      body: job.body,
+      credential:
+        project_credential && project_credential_key(project_credential)
+    }
+  end
+
+  defp trigger_to_treenode(trigger, jobs) do
+    base = %{
+      id: trigger.id,
+      enabled: trigger.enabled,
+      name: Atom.to_string(trigger.type),
+      node_type: :trigger,
+      type: Atom.to_string(trigger.type)
+    }
+
+    case trigger.type do
+      :cron ->
+        base
+        |> Map.put(:cron_expression, trigger.cron_expression)
+        |> then(fn cron ->
+          if trigger.cron_cursor_job_id do
+            cursor_job =
+              Enum.find(jobs, fn j -> j.id == trigger.cron_cursor_job_id end)
+
+            Map.put(cron, :cron_cursor_job, cursor_job && job_key(cursor_job))
+          else
+            cron
+          end
+        end)
+
+      :kafka ->
+        kafka_config =
+          trigger.kafka_configuration
+          |> Map.take(@kafka_trigger_fields)
+          |> Enum.map(fn
+            {:hosts, hosts} when is_list(hosts) ->
+              {:hosts,
+               Enum.map(hosts, fn host_port -> Enum.join(host_port, ":") end)}
+
+            other ->
+              other
+          end)
+          |> Enum.sort_by(
+            fn {key, _val} ->
+              Enum.find_index(@kafka_trigger_fields, &(&1 == key))
+            end,
+            :asc
+          )
+
+        Map.put(base, :kafka_configuration, kafka_config)
+
+      :webhook ->
+        if trigger.webhook_reply do
+          Map.put(base, :webhook_reply, Atom.to_string(trigger.webhook_reply))
+        else
+          base
+        end
+    end
+  end
+
+  defp edge_to_treenode(%{source_job_id: nil} = edge, triggers, jobs) do
+    source_trigger =
+      Enum.find(triggers, fn t -> t.id == edge.source_trigger_id end)
+
+    target_job = Enum.find(jobs, fn j -> j.id == edge.target_job_id end)
+    trigger_name = to_string(source_trigger.type)
+    target_job_name = job_key(target_job)
+
+    %{
+      name: "#{trigger_name}->#{target_job_name}",
+      source_trigger: trigger_name
+    }
+    |> merge_edge_common_fields(edge, target_job)
+  end
+
+  defp edge_to_treenode(%{source_trigger_id: nil} = edge, _triggers, jobs) do
+    target_job = Enum.find(jobs, fn j -> j.id == edge.target_job_id end)
+    source_job = Enum.find(jobs, fn j -> j.id == edge.source_job_id end)
+    source_job_name = job_key(source_job)
+    target_job_name = job_key(target_job)
+
+    %{
+      name: "#{source_job_name}->#{target_job_name}",
+      source_job: source_job_name
+    }
+    |> merge_edge_common_fields(edge, target_job)
+  end
+
+  defp merge_edge_common_fields(json, edge, target_job) do
+    json
+    |> Map.merge(%{
+      target_job: job_key(target_job),
+      condition_type: edge.condition_type |> Atom.to_string(),
+      enabled: edge.enabled,
+      node_type: :edge
+    })
+    |> then(fn map ->
+      if edge.condition_type == :js_expression do
+        Map.merge(map, %{
+          condition_expression: edge.condition_expression,
+          condition_label: edge.condition_label
+        })
+      else
+        map
+      end
+    end)
+  end
+
+  defp pick_and_sort(map) do
+    map
+    |> Enum.filter(fn {key, _value} ->
+      if Map.has_key?(map, :node_type) do
+        @ordering_map[map.node_type]
+        |> Enum.member?(key)
+      else
+        true
+      end
+    end)
+    |> Enum.sort_by(
+      fn {key, _value} ->
+        if Map.has_key?(map, :node_type) do
+          olist = @ordering_map[map.node_type]
+
+          olist
+          |> Enum.find_index(&(&1 == key))
+        end
+      end,
+      :asc
+    )
+  end
+
+  defp handle_binary(k, v, i) do
+    case k do
+      :body ->
+        "body: |\n#{indent_multiline_value(v, i)}"
+
+      :description ->
+        "description: |\n#{indent_multiline_value(v, i)}"
+
+      :adaptor ->
+        "#{k}: '#{v}'"
+
+      :cron_expression ->
+        "#{k}: '#{v}'"
+
+      :condition_expression ->
+        "condition_expression: |\n#{indent_multiline_value(v, i)}"
+
+      _ ->
+        "#{yaml_safe_key(k)}: #{yaml_safe_string(v)}"
+    end
+  end
+
+  defp indent_multiline_value(value, current_indent) do
+    value
+    |> String.split("\n")
+    |> Enum.map_join("\n", fn line -> "#{current_indent}  #{line}" end)
+  end
+
+  defp yaml_safe_string(value) do
+    # starts with alphanumeric
+    # followed by alphanumeric or hyphen or underscore or @ or . or > or space
+    # ends with alphanumeric
+    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.> ]*[a-zA-Z0-9]$/, value) do
+      value
+    else
+      ~s('#{value}')
+    end
+  end
+
+  defp yaml_safe_key(key) do
+    if key in @special_keys do
+      key
+    else
+      key |> to_string() |> hyphenate() |> maybe_escape_key()
+    end
+  end
+
+  defp maybe_escape_key(key) do
+    # starts with alphanumeric
+    # followed by alphanumeric or hyphen or underscore or @ or . or >
+    # ends with alphanumeric
+    if Regex.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9_\-@\.>]*[a-zA-Z0-9]$/, key) do
+      key
+    else
+      ~s("#{key}")
+    end
+  end
+
+  defp handle_input(key, value, indentation) when is_binary(value) do
+    "#{indentation}#{handle_binary(key, value, indentation)}"
+  end
+
+  defp handle_input(key, value, indentation) when is_number(value) do
+    "#{indentation}#{yaml_safe_key(key)}: #{value}"
+  end
+
+  defp handle_input(key, value, indentation) when is_boolean(value) do
+    "#{indentation}#{yaml_safe_key(key)}: #{value}"
+  end
+
+  defp handle_input(key, value, indentation) when value in [%{}, [], nil] do
+    "#{indentation}#{yaml_safe_key(key)}: null"
+  end
+
+  defp handle_input(key, value, indentation) when is_map(value) do
+    "#{indentation}#{yaml_safe_key(key)}:\n#{to_new_yaml(value, "#{indentation}  ")}"
+  end
+
+  defp handle_input(key, value, indentation) when is_list(value) do
+    yaml_value =
+      if Keyword.keyword?(value) do
+        to_new_yaml(value, "#{indentation}  ")
+      else
+        handle_list_value(value, indentation)
+      end
+
+    "#{indentation}#{yaml_safe_key(key)}:\n#{yaml_value}"
+  end
+
+  defp handle_list_value(value, indentation) do
+    Enum.map_join(value, "\n", fn
+      map when is_map(map) ->
+        "#{indentation}  #{yaml_safe_key(map.name)}:\n#{to_new_yaml(map, "#{indentation}    ")}"
+
+      val when is_binary(val) ->
+        "#{indentation}  - #{yaml_safe_string(val)}"
+
+      val ->
+        "#{indentation}  - #{val}"
+    end)
+  end
+
+  defp to_new_yaml(map, indentation \\ "")
+
+  defp to_new_yaml(map, indentation) when is_map(map) do
+    map
+    |> pick_and_sort()
+    |> to_new_yaml(indentation)
+  end
+
+  defp to_new_yaml(keyword, indentation) do
+    keyword
+    |> Enum.map(fn {key, value} ->
+      handle_input(key, value, indentation)
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp to_workflow_yaml_tree(flow_map, workflow) do
+    %{
+      name: workflow.name,
+      jobs: flow_map.jobs,
+      triggers: flow_map.triggers,
+      edges: flow_map.edges,
+      node_type: :workflow
+    }
+  end
+
+  def build_yaml_tree(workflows, project) do
+    workflows_map =
+      workflows
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.reduce(%{}, fn workflow, acc ->
+        ytree = build_workflow_yaml_tree(workflow, project.project_credentials)
+        Map.put(acc, hyphenate(workflow.name), ytree)
+      end)
+
+    credentials_map =
+      project.project_credentials
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.reduce(%{}, fn project_credential, acc ->
+        ytree = build_project_credential_yaml_tree(project_credential)
+
+        Map.put(
+          acc,
+          project_credential_key(project_credential),
+          ytree
+        )
+      end)
+
+    collections_map =
+      project.collections
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.reduce(%{}, fn collection, acc ->
+        ytree = build_collection_yaml_tree(collection)
+
+        Map.put(acc, hyphenate(collection.name), ytree)
+      end)
+
+    %{
+      name: project.name,
+      description: project.description,
+      node_type: :project,
+      workflows: workflows_map,
+      credentials: credentials_map,
+      collections: collections_map
+    }
+  end
+
+  defp job_key(job) do
+    hyphenate(job.name)
+  end
+
+  defp project_credential_key(project_credential) do
+    hyphenate(
+      "#{project_credential.credential.user.email} #{project_credential.credential.name}"
+    )
+  end
+
+  defp build_project_credential_yaml_tree(project_credential) do
+    %{
+      name: project_credential.credential.name,
+      node_type: :credential,
+      owner: project_credential.credential.user.email
+    }
+  end
+
+  defp build_collection_yaml_tree(collection) do
+    %{
+      name: collection.name,
+      node_type: :collection
+    }
+  end
+
+  defp build_workflow_yaml_tree(workflow, project_credentials) do
+    jobs =
+      workflow.jobs
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(fn j -> job_to_treenode(j, project_credentials) end)
+
+    triggers =
+      workflow.triggers
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(fn t -> trigger_to_treenode(t, workflow.jobs) end)
+
+    edges =
+      workflow.edges
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+      |> Enum.map(fn e ->
+        edge_to_treenode(e, workflow.triggers, workflow.jobs)
+      end)
+
+    flow_map = %{jobs: jobs, edges: edges, triggers: triggers}
+
+    flow_map
+    |> to_workflow_yaml_tree(workflow)
+  end
+
+  @spec generate_new_yaml(Projects.Project.t(), [Snapshot.t()] | nil) ::
+          {:ok, binary()}
+  def generate_new_yaml(project, snapshots \\ nil)
+
+  def generate_new_yaml(project, nil) do
+    project =
+      Lightning.Repo.preload(project,
+        project_credentials: [credential: :user],
+        collections: []
+      )
+
+    yaml =
+      project
+      |> Workflows.get_workflows_for()
+      |> build_yaml_tree(project)
+      |> to_new_yaml()
+
+    {:ok, yaml}
+  end
+
+  def generate_new_yaml(project, snapshots) when is_list(snapshots) do
+    project =
+      Lightning.Repo.preload(project,
+        project_credentials: [credential: :user],
+        collections: []
+      )
+
+    yaml =
+      snapshots
+      |> Enum.sort_by(& &1.name)
+      |> build_yaml_tree(project)
+      |> to_new_yaml()
+
+    {:ok, yaml}
+  end
+end

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -14,6 +14,7 @@ defmodule Lightning.Projects do
   alias Lightning.Accounts.UserNotifier
   alias Lightning.Accounts.UserToken
   alias Lightning.Config
+  alias Lightning.ExportUtils
   alias Lightning.Invocation.Dataclip
   alias Lightning.Invocation.Step
   alias Lightning.Projects
@@ -1022,21 +1023,35 @@ defmodule Lightning.Projects do
   @doc """
   Exports a project as yaml.
 
+  The `format` is required and selects the serializer:
+    * `:v1` — legacy Lightning format (`Lightning.ExportUtils`). Hard-wired
+      for the provisioner API so external CLIs that consume
+      `GET /api/provision/yaml` keep working.
+    * `:v2` — portability spec format (`Lightning.Workflows.YamlFormat.V2`).
+      Used by the in-app "Export project as YAML" download.
+
+  `snapshot_ids` may be `nil` (export current workflows) or a list of
+  snapshot ids (export those specific snapshots).
+
   ## Examples
 
-      iex> export_project(:yaml, project_id)
+      iex> export_project(:yaml, project_id, nil, :v2)
       {:ok, string}
 
   """
-  @spec export_project(atom(), Ecto.UUID.t(), [Ecto.UUID.t()] | nil) ::
+  @spec export_project(:yaml, Ecto.UUID.t(), [Ecto.UUID.t()] | nil, :v1 | :v2) ::
           {:ok, binary}
-  def export_project(:yaml, project_id, snapshot_ids \\ nil) do
+  def export_project(:yaml, project_id, snapshot_ids, format)
+      when format in [:v1, :v2] do
     project = get_project!(project_id)
 
     snapshots =
       if snapshot_ids, do: Snapshot.get_all_by_ids(snapshot_ids), else: nil
 
-    {:ok, _yaml} = V2.serialize_project(project, snapshots)
+    case format do
+      :v1 -> ExportUtils.generate_new_yaml(project, snapshots)
+      :v2 -> V2.serialize_project(project, snapshots)
+    end
   end
 
   @doc """

--- a/lib/lightning/workflows/yaml_format/v2.ex
+++ b/lib/lightning/workflows/yaml_format/v2.ex
@@ -443,7 +443,7 @@ defmodule Lightning.Workflows.YamlFormat.V2 do
   defp put_unless_nil(map, key, value), do: Map.put(map, key, value)
 
   defp hyphenate(string) when is_binary(string),
-    do: String.replace(string, " ", "-")
+    do: string |> String.downcase() |> String.replace(" ", "-")
 
   defp hyphenate(other), do: other
 

--- a/lib/lightning_web/controllers/api/provisioning_controller.ex
+++ b/lib/lightning_web/controllers/api/provisioning_controller.ex
@@ -195,7 +195,7 @@ defmodule LightningWeb.API.ProvisioningController do
              conn.assigns.current_resource,
              project
            ) do
-      {:ok, yaml} = Projects.export_project(:yaml, id, params["snapshots"])
+      {:ok, yaml} = Projects.export_project(:yaml, id, params["snapshots"], :v1)
 
       conn
       |> put_resp_content_type("text/yaml")

--- a/lib/lightning_web/controllers/downloads_controller.ex
+++ b/lib/lightning_web/controllers/downloads_controller.ex
@@ -17,7 +17,7 @@ defmodule LightningWeb.DownloadsController do
              conn.assigns.current_user,
              project
            ) do
-      {:ok, yaml} = Projects.export_project(:yaml, id)
+      {:ok, yaml} = Projects.export_project(:yaml, id, nil, :v2)
 
       conn
       |> put_resp_content_type("text/yaml")

--- a/test/fixtures/canonical_project.yaml
+++ b/test/fixtures/canonical_project.yaml
@@ -1,0 +1,87 @@
+name: a-test-project
+description: |
+  This is only a test
+collections:
+  cannonical-collection:
+    name: cannonical-collection
+credentials:
+  cannonical-user@lightning.com-new-credential:
+    name: new credential
+    owner: cannonical-user@lightning.com
+workflows:
+  workflow-1:
+    name: workflow 1
+    jobs:
+      webhook-job:
+        name: webhook job
+        adaptor: '@openfn/language-common@latest'
+        credential: cannonical-user@lightning.com-new-credential
+        body: |
+          console.log('webhook job')
+          fn(state => state)
+      on-fail:
+        name: on fail
+        adaptor: '@openfn/language-common@latest'
+        credential: null
+        body: |
+          console.log('on fail')
+          fn(state => state)
+      on-success:
+        name: on success
+        adaptor: '@openfn/language-common@latest'
+        credential: null
+        body: |
+          console.log('hello!');
+    triggers:
+      webhook:
+        type: webhook
+        webhook_reply: after_completion
+        enabled: true
+    edges:
+      webhook->webhook-job:
+        source_trigger: webhook
+        target_job: webhook-job
+        condition_type: always
+        enabled: true
+      webhook-job->on-fail:
+        source_job: webhook-job
+        target_job: on-fail
+        condition_type: on_job_failure
+        enabled: true
+      webhook-job->on-success:
+        source_job: webhook-job
+        target_job: on-success
+        condition_type: on_job_success
+        enabled: true
+  workflow-2:
+    name: workflow 2
+    jobs:
+      some-cronjob:
+        name: some cronjob
+        adaptor: '@openfn/language-common@latest'
+        credential: null
+        body: |
+          console.log('hello!');
+      on-cron-failure:
+        name: on cron failure
+        adaptor: '@openfn/language-common@latest'
+        credential: null
+        body: |
+          console.log('hello!');
+    triggers:
+      cron:
+        type: cron
+        cron_expression: '0 23 * * *'
+        cron_cursor_job: some-cronjob
+        enabled: true
+    edges:
+      cron->some-cronjob:
+        source_trigger: cron
+        target_job: some-cronjob
+        condition_type: always
+        enabled: true
+      some-cronjob->on-cron-failure:
+        source_job: some-cronjob
+        target_job: on-cron-failure
+        condition_type: on_job_success
+        enabled: true

--- a/test/integration/cli_deploy_test.exs
+++ b/test/integration/cli_deploy_test.exs
@@ -102,8 +102,11 @@ defmodule Lightning.CliDeployTest do
 
       assert actual_state == expected_state_for_comparison
 
-      expected_yaml =
-        File.read!("test/fixtures/portability/v2/canonical_project.yaml")
+      # The provisioner endpoint (`GET /api/provision/yaml`) is hard-wired to
+      # the v1 format for back-compat with deployed CLIs and GitHub sync. So
+      # `openfn pull` always writes v1 YAML to disk, regardless of what the
+      # in-app "Export project as YAML" download emits.
+      expected_yaml = File.read!("test/fixtures/canonical_project.yaml")
 
       actual_yaml = File.read!(config.specPath)
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -615,16 +615,18 @@ defmodule Lightning.ProjectsTest do
     end
   end
 
-  describe "export_project/2 as yaml (v2 portability format):" do
+  describe "export_project/4 as yaml (v2 portability format):" do
     test "works on project with no workflows" do
       project = project_fixture(name: "newly-created-project")
 
-      {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+      {:ok, generated_yaml} =
+        Projects.export_project(:yaml, project.id, nil, :v2)
 
-      # v2 emits the spec-required `id` (hyphenated) plus `name`, and omits
-      # empty top-level sections rather than emitting `null`.
+      # v2 emits the spec-required `id` (hyphenated), `name`, and the
+      # portability `schema_version`. Empty top-level sections are omitted
+      # rather than emitted as `null`.
       assert generated_yaml ==
-               "id: newly-created-project\nname: newly-created-project\n"
+               "id: newly-created-project\nname: newly-created-project\nschema_version: '4.0'\n"
     end
 
     test "adds quotes to values with special characters" do
@@ -636,7 +638,8 @@ defmodule Lightning.ProjectsTest do
       workflow_with_good_name =
         insert(:simple_workflow, project: project, name: "workflow 2")
 
-      assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v2)
 
       # YAML-unsafe values are wrapped in single quotes.
       assert generated_yaml =~ ~s(name: '#{project.name}')
@@ -680,7 +683,8 @@ defmodule Lightning.ProjectsTest do
       )
       |> insert()
 
-      assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v2)
 
       # Per the portability spec, `condition` IS the JS body. Single-line
       # bodies emit as a quoted scalar; the old `condition: js_expression`
@@ -701,10 +705,10 @@ defmodule Lightning.ProjectsTest do
           """
         )
 
-      assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v2)
 
       expected_yaml = """
-      name: project_multiline_special
       description: |
         This is a multiline description.
         It includes special characters: :, #, &, *, ?, |, -, <, >, =, !, %, @, *, &, ?.
@@ -720,7 +724,7 @@ defmodule Lightning.ProjectsTest do
         insert(:project, name: "project_empty_description", description: "")
 
       assert {:ok, generated_yaml} =
-               Projects.export_project(:yaml, project_empty.id)
+               Projects.export_project(:yaml, project_empty.id, nil, :v2)
 
       # v2 elides empty/nil description rather than emitting `description: |`
       # (project name still contains the substring "description").
@@ -732,7 +736,7 @@ defmodule Lightning.ProjectsTest do
         insert(:project, name: "project_nil_description", description: nil)
 
       assert {:ok, generated_yaml} =
-               Projects.export_project(:yaml, project_nil.id)
+               Projects.export_project(:yaml, project_nil.id, nil, :v2)
 
       refute generated_yaml =~ "description: "
       refute generated_yaml =~ "description:\n"
@@ -763,7 +767,8 @@ defmodule Lightning.ProjectsTest do
       |> with_edge({trigger, job}, condition_type: :always)
       |> insert()
 
-      assert {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v2)
 
       # In v2, kafka config fields land flat at the trigger root — no
       # `openfn:` wrapper, no nested `kafka:` block. The spec's `Trigger`
@@ -786,7 +791,8 @@ defmodule Lightning.ProjectsTest do
           description: "This is only a test"
         )
 
-      {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
+      {:ok, generated_yaml} =
+        Projects.export_project(:yaml, project.id, nil, :v2)
 
       # Top-level project metadata (id is the hyphenated name; name is the
       # human label).
@@ -817,6 +823,193 @@ defmodule Lightning.ProjectsTest do
 
       # Collections and credentials are exported.
       assert generated_yaml =~ "cannonical-collection"
+    end
+  end
+
+  describe "export_project/4 as yaml (v1 legacy format):" do
+    test "works on project with no workflows" do
+      project = project_fixture(name: "newly-created-project")
+
+      expected_yaml =
+        "name: newly-created-project\ndescription: null\ncollections: null\ncredentials: null\nworkflows: null"
+
+      {:ok, generated_yaml} =
+        Projects.export_project(:yaml, project.id, nil, :v1)
+
+      assert generated_yaml == expected_yaml
+    end
+
+    test "adds quotes to values with special charaters" do
+      project = insert(:project, name: "project: 1")
+
+      workflow_with_bad_name =
+        insert(:simple_workflow, project: project, name: "workflow: 1")
+
+      workflow_with_good_name =
+        insert(:simple_workflow, project: project, name: "workflow 2")
+
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v1)
+
+      assert generated_yaml =~ ~s(name: '#{project.name}')
+      assert generated_yaml =~ ~s(name: '#{workflow_with_bad_name.name}')
+      # key is quoted
+      assert generated_yaml =~
+               ~s("#{String.replace(workflow_with_bad_name.name, " ", "-")}")
+
+      refute generated_yaml =~ ~s(name: '#{workflow_with_good_name.name}')
+      assert generated_yaml =~ "name: #{workflow_with_good_name.name}"
+
+      # key is not quoted
+      refute generated_yaml =~
+               ~s("#{String.replace(workflow_with_good_name.name, " ", "-")}")
+    end
+
+    test "js_expressions edge conditions are made multiline" do
+      project = insert(:project, name: "project 1")
+
+      trigger =
+        build(:trigger,
+          type: :webhook,
+          enabled: true
+        )
+
+      job =
+        build(:job,
+          body: ~s[fn(state => { return {...state, extra: "data"} })]
+        )
+
+      js_expression = "!state.data && !state.data"
+
+      build(:workflow, name: "workflow 1", project: project)
+      |> with_trigger(trigger)
+      |> with_job(job)
+      |> with_edge({trigger, job},
+        condition_type: :js_expression,
+        condition_expression: js_expression
+      )
+      |> insert()
+
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v1)
+
+      assert generated_yaml =~
+               "condition_expression: |\n          #{js_expression}"
+    end
+
+    test "project descriptions with multiline and special characters are correctly represented" do
+      project =
+        insert(:project,
+          name: "project_multiline_special",
+          description: """
+          This is a multiline description.
+          It includes special characters: :, #, &, *, ?, |, -, <, >, =, !, %, @, *, &, ?.
+          Also, YAML indicators: *alias, &anchor, ?key, !tag.
+          Line breaks and special characters should be preserved.
+          """
+        )
+
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v1)
+
+      expected_yaml = """
+      name: project_multiline_special
+      description: |
+        This is a multiline description.
+        It includes special characters: :, #, &, *, ?, |, -, <, >, =, !, %, @, *, &, ?.
+        Also, YAML indicators: *alias, &anchor, ?key, !tag.
+        Line breaks and special characters should be preserved.
+      """
+
+      assert generated_yaml =~ expected_yaml
+    end
+
+    test "projects with empty and nil descriptions are correctly represented" do
+      project_empty =
+        insert(:project, name: "project_empty_description", description: "")
+
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project_empty.id, nil, :v1)
+
+      expected_yaml = """
+      name: project_empty_description
+      description: |
+      """
+
+      assert generated_yaml =~ expected_yaml
+
+      project_nil =
+        insert(:project, name: "project_nil_description", description: nil)
+
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project_nil.id, nil, :v1)
+
+      expected_yaml = """
+      name: project_nil_description
+      description: null
+      """
+
+      assert generated_yaml =~ expected_yaml
+    end
+
+    test "kafka triggers are included in the export" do
+      project = insert(:project, name: "project 1")
+
+      trigger =
+        build(:trigger,
+          type: :kafka,
+          kafka_configuration: %{
+            hosts: [["localhost", "9092"]],
+            topics: ["dummy"],
+            initial_offset_reset_policy: "earliest"
+          }
+        )
+
+      job =
+        build(:job,
+          body: ~s[fn(state => { return {...state, extra: "data"} })]
+        )
+
+      build(:workflow, name: "workflow 1", project: project)
+      |> with_trigger(trigger)
+      |> with_job(job)
+      |> with_edge({trigger, job}, condition_type: :always)
+      |> insert()
+
+      expected_yaml_trigger = """
+          triggers:
+            kafka:
+              type: kafka
+              enabled: true
+              kafka_configuration:
+                hosts:
+                  - 'localhost:9092'
+                topics:
+                  - dummy
+                initial_offset_reset_policy: earliest
+                connect_timeout: 30
+      """
+
+      assert {:ok, generated_yaml} =
+               Projects.export_project(:yaml, project.id, nil, :v1)
+
+      assert generated_yaml =~ expected_yaml_trigger
+    end
+
+    test "exports canonical project" do
+      project =
+        canonical_project_fixture(
+          name: "a-test-project",
+          description: "This is only a test"
+        )
+
+      expected_yaml =
+        File.read!("test/fixtures/canonical_project.yaml") |> String.trim()
+
+      {:ok, generated_yaml} =
+        Projects.export_project(:yaml, project.id, nil, :v1)
+
+      assert generated_yaml == expected_yaml
     end
   end
 

--- a/test/lightning/workflows/yaml_format_v2_test.exs
+++ b/test/lightning/workflows/yaml_format_v2_test.exs
@@ -75,6 +75,50 @@ defmodule Lightning.Workflows.YamlFormatV2Test do
       refute yaml =~ ~r/^\s*edges:/m
     end
 
+    test "downcases workflow and step ids derived from mixed-case names" do
+      job =
+        build(:job,
+          id: Ecto.UUID.generate(),
+          name: "Fetch Records",
+          body: "fn(state => state)\n"
+        )
+
+      trigger =
+        build(:trigger, id: Ecto.UUID.generate(), type: :webhook, enabled: true)
+
+      edge =
+        build(:edge,
+          id: Ecto.UUID.generate(),
+          source_trigger_id: trigger.id,
+          source_job_id: nil,
+          target_job_id: job.id,
+          condition_type: :always,
+          enabled: true
+        )
+
+      workflow = %Lightning.Workflows.Workflow{
+        id: Ecto.UUID.generate(),
+        name: "MixedCase Workflow",
+        jobs: [job],
+        triggers: [trigger],
+        edges: [edge]
+      }
+
+      {:ok, yaml} = V2.serialize_workflow(workflow)
+
+      # Ids derive from names via a single chokepoint (`hyphenate/1`) that
+      # lowercases as well as space→hyphen. References (`start:`, `next:`
+      # keys) inherit from the same function, so they stay in sync.
+      assert yaml =~ "id: mixedcase-workflow"
+      assert yaml =~ "- id: fetch-records"
+      assert yaml =~ ~r/^\s*start: webhook$/m
+      assert yaml =~ ~r/fetch-records:\s*\n\s*condition: always/
+
+      # Original `name:` strings keep their case — only the id is normalized.
+      assert yaml =~ "name: MixedCase Workflow"
+      assert yaml =~ "name: Fetch Records"
+    end
+
     test ":always edges emit verbose form with `condition: always`", %{
       workflow: workflow
     } do


### PR DESCRIPTION
@midigofrank's eagle eyes showed me something I had missed: the portability updates should not have removed support for v1 formats from the provisioner API.

This PR restores the v1 emmiter and provisioner, but leaves the UI stuff on v2.

## Description

- Restored the v1 emitter in lib/lightning/export_utils.ex (verbatim from main).
- Routed by surface, not by a global default. Projects.export_project/4 now takes a required positional format argument (:v1 | :v2, no default) and dispatches accordingly:
  -DownloadsController ("Export project as YAML" download) → :v2
  - ProvisioningController.show_yaml (GET /api/provision/yaml, used by openfn pull and GitHub sync) → :v1, hard-coded - no version parameter is exposed on the API.
- The frontend "View workflow as code" panel stays on v2 (separate JS code path, untouched).
- The provisioner's POST /api/provision is unaffected — it has always accepted JSON, not YAML.
- Forced v2 yamls to use lower-case id names

## QA Notes:

* ✅ Can pull with legacy cli `openfn pull <uuid>`
* ✅  Can edit and push with legacy cli `openfn deploy <uuid>`
* ✅ Exported workflows can be executed through CLI
* ✅ Exported projects can be checked out with CLI (just pass the file name)
* ✅ v1 app workflows can be imported into this branch
* ✅ v2 app workflows can be imported into this  branch

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
