### PR TITLE
fix: tolerate transient jsdelivr timeouts in install_schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ and this project adheres to
   when the `limit` query param is missing, empty, non-numeric, or non-integer.
   It now returns 400 with a clear error and defaults to 10 when the param is
   absent. [#4746](https://github.com/OpenFn/lightning/pull/4746)
+- `mix lightning.install_schemas` now tolerates transient jsdelivr CDN timeouts
+  by retrying each fetch with escalating recv_timeouts, logs and skips packages
+  that genuinely can't be fetched (with the underlying reason), and reports a
+  tally of installed vs. skipped packages instead of aborting the whole task on
+  a single failure. [#4750](https://github.com/OpenFn/lightning/issues/4750)
 
 ### Security
 

--- a/lib/mix/tasks/install_schemas.ex
+++ b/lib/mix/tasks/install_schemas.ex
@@ -16,6 +16,8 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
     "language-divoc"
   ]
 
+  @recv_timeouts [30_000, 15_000, 5_000]
+
   @spec run(any) :: any
   def run(args) do
     HTTPoison.start()
@@ -24,14 +26,17 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
 
     init_schema_dir(dir)
 
-    result =
+    {installed, skipped} =
       args
       |> parse_excluded()
       |> fetch_schemas(&persist_schema(dir, &1))
-      |> Enum.to_list()
+      |> Enum.reduce({0, 0}, fn
+        {:installed, _name}, {ok, skip} -> {ok + 1, skip}
+        {:skipped, _name, _reason}, {ok, skip} -> {ok, skip + 1}
+      end)
 
     Mix.shell().info(
-      "Schemas installation has finished. #{length(result)} installed"
+      "Schemas installation has finished. #{installed} installed, #{skipped} skipped."
     )
   end
 
@@ -78,23 +83,39 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
   end
 
   def persist_schema(dir, package_name) do
-    get(
-      "https://cdn.jsdelivr.net/npm/#{package_name}/configuration-schema.json",
-      [],
-      hackney: [pool: :default],
-      recv_timeout: 15_000
-    )
-    |> case do
-      {:error, _} ->
-        raise "Unable to access #{package_name}"
+    attempt_persist_schema(dir, package_name, @recv_timeouts)
+  end
 
+  defp attempt_persist_schema(dir, package_name, [timeout | rest]) do
+    url =
+      "https://cdn.jsdelivr.net/npm/#{package_name}/configuration-schema.json"
+
+    case get(url, [], hackney: [pool: :default], recv_timeout: timeout) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         write_schema(dir, package_name, body)
+        {:installed, package_name}
 
       {:ok, %HTTPoison.Response{status_code: status_code}} ->
         Logger.warning(
           "Unable to fetch #{package_name} configuration schema. status=#{status_code}"
         )
+
+        {:skipped, package_name, {:http_status, status_code}}
+
+      {:error, %HTTPoison.Error{reason: reason}} when rest != [] ->
+        Logger.warning(
+          "Transient error fetching #{package_name} (#{inspect(reason)}); " <>
+            "retrying with recv_timeout=#{hd(rest)}ms"
+        )
+
+        attempt_persist_schema(dir, package_name, rest)
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.warning(
+          "Skipping #{package_name}: #{inspect(reason)} after #{length(@recv_timeouts)} attempts"
+        )
+
+        {:skipped, package_name, reason}
     end
   end
 
@@ -104,8 +125,8 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
       recv_timeout: 15_000
     )
     |> case do
-      {:error, %HTTPoison.Error{}} ->
-        raise "Unable to connect to NPM; no adaptors fetched."
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        raise "Unable to connect to NPM; no adaptors fetched: #{inspect(reason)}"
 
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         excluded = excluded |> Enum.map(&"@openfn/#{&1}")
@@ -122,9 +143,19 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
         |> Task.async_stream(fun,
           ordered: false,
           max_concurrency: 5,
-          timeout: 30_000
+          timeout: 60_000
         )
-        |> Stream.map(fn {:ok, detail} -> detail end)
+        |> Stream.map(fn
+          {:ok, result} ->
+            result
+
+          {:exit, reason} ->
+            Logger.warning(
+              "Schema fetch task exited unexpectedly: #{inspect(reason)}"
+            )
+
+            {:skipped, "unknown", reason}
+        end)
 
       {:ok, %HTTPoison.Response{status_code: status_code}} ->
         raise "Unable to access openfn user packages. status=#{status_code}"

--- a/lib/mix/tasks/install_schemas.ex
+++ b/lib/mix/tasks/install_schemas.ex
@@ -16,7 +16,19 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
     "language-divoc"
   ]
 
+  # Descending on purpose: the first attempt is generous to let jsdelivr warm
+  # a cold cache for packages it hasn't served recently. Follow-up attempts
+  # are shorter because we expect a now-warm hit and want to fail fast if not.
   @recv_timeouts [30_000, 15_000, 5_000]
+
+  # hackney error reasons that we treat as transient and worth retrying.
+  # Anything else (e.g. :nxdomain, :econnrefused) is logged with its reason
+  # and skipped immediately rather than retried.
+  @retriable_reasons [:timeout, :closed, :connect_timeout, :checkout_timeout]
+
+  # Outer Task.async_stream timeout. Must comfortably exceed the sum of
+  # @recv_timeouts (50s) plus connect/DNS/body overhead.
+  @async_stream_timeout 75_000
 
   @spec run(any) :: any
   def run(args) do
@@ -102,17 +114,23 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
 
         {:skipped, package_name, {:http_status, status_code}}
 
-      {:error, %HTTPoison.Error{reason: reason}} when rest != [] ->
+      {:error, %HTTPoison.Error{reason: reason}}
+      when reason in @retriable_reasons and rest != [] ->
+        [next_timeout | _] = rest
+
         Logger.warning(
           "Transient error fetching #{package_name} (#{inspect(reason)}); " <>
-            "retrying with recv_timeout=#{hd(rest)}ms"
+            "retrying with recv_timeout=#{next_timeout}ms"
         )
 
         attempt_persist_schema(dir, package_name, rest)
 
       {:error, %HTTPoison.Error{reason: reason}} ->
+        attempts_used = length(@recv_timeouts) - length(rest)
+
         Logger.warning(
-          "Skipping #{package_name}: #{inspect(reason)} after #{length(@recv_timeouts)} attempts"
+          "Skipping #{package_name}: #{inspect(reason)} after " <>
+            "#{attempts_used} attempt(s)"
         )
 
         {:skipped, package_name, reason}
@@ -131,30 +149,50 @@ defmodule Mix.Tasks.Lightning.InstallSchemas do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         excluded = excluded |> Enum.map(&"@openfn/#{&1}")
 
-        body
-        |> Jason.decode!()
-        |> Enum.map(fn {name, _} -> name end)
-        |> Enum.filter(fn name ->
-          Regex.match?(~r/@openfn\/language-\w+/, name)
-        end)
-        |> Enum.reject(fn name ->
-          name in excluded
-        end)
-        |> Task.async_stream(fun,
-          ordered: false,
+        names =
+          body
+          |> Jason.decode!()
+          |> Enum.map(fn {name, _} -> name end)
+          |> Enum.filter(fn name ->
+            Regex.match?(~r/@openfn\/language-\w+/, name)
+          end)
+          |> Enum.reject(fn name -> name in excluded end)
+
+        # Wrap fun so a worker crash (raise/exit) becomes a normal {:skipped,
+        # _, _} result instead of taking the caller down via the task link.
+        # ordered: true (the default) lets us zip results against `names` so
+        # the on_timeout: :kill_task path can also recover the package name.
+        safe_fun = fn name ->
+          try do
+            fun.(name)
+          catch
+            kind, reason ->
+              Logger.warning(
+                "Schema fetch worker for #{name} crashed: " <>
+                  "#{inspect({kind, reason})}"
+              )
+
+              {:skipped, name, {kind, reason}}
+          end
+        end
+
+        names
+        |> Task.async_stream(safe_fun,
           max_concurrency: 5,
-          timeout: 60_000
+          timeout: @async_stream_timeout,
+          on_timeout: :kill_task
         )
+        |> Stream.zip(names)
         |> Stream.map(fn
-          {:ok, result} ->
+          {{:ok, result}, _name} ->
             result
 
-          {:exit, reason} ->
+          {{:exit, reason}, name} ->
             Logger.warning(
-              "Schema fetch task exited unexpectedly: #{inspect(reason)}"
+              "Schema fetch task for #{name} killed: #{inspect(reason)}"
             )
 
-            {:skipped, "unknown", reason}
+            {:skipped, name, reason}
         end)
 
       {:ok, %HTTPoison.Response{status_code: status_code}} ->

--- a/test/lightning/install_schemas_test.exs
+++ b/test/lightning/install_schemas_test.exs
@@ -8,14 +8,54 @@ defmodule Lightning.InstallSchemasTest do
 
   alias Mix.Tasks.Lightning.InstallSchemas
 
+  @registry_url "https://registry.npmjs.org/-/user/openfn/package"
   @registry_request_options [recv_timeout: 15_000, pool: :default]
+
+  # Per-package recv_timeouts as the implementation escalates them.
   @first_attempt_opts [recv_timeout: 30_000, pool: :default]
   @second_attempt_opts [recv_timeout: 15_000, pool: :default]
   @third_attempt_opts [recv_timeout: 5_000, pool: :default]
+
   @ok_200 {:ok, 200, "headers", :client}
   @ok_400 {:ok, 400, "headers", :client}
 
   @schemas_path Application.compile_env(:lightning, :schemas_path)
+
+  # --- helpers ----------------------------------------------------------
+
+  defp schema_url(package_name) do
+    "https://cdn.jsdelivr.net/npm/#{package_name}/configuration-schema.json"
+  end
+
+  defp expect_registry(response) do
+    expect(:hackney, :request, fn
+      :get, @registry_url, [], "", @registry_request_options -> response
+    end)
+  end
+
+  defp expect_body(body) do
+    expect(:hackney, :body, fn :client, _timeout -> body end)
+  end
+
+  # Stub a single jsdelivr fetch attempt for `package_name` at the given
+  # timeout-options profile, returning `response`.
+  defp expect_schema_request(package_name, opts, response) do
+    url = schema_url(package_name)
+
+    expect(:hackney, :request, fn
+      :get, ^url, [], "", ^opts -> response
+    end)
+  end
+
+  # Stub all three escalating attempts for `package_name` with the same
+  # error response (used when verifying retry-exhaustion behaviour).
+  defp expect_all_attempts_error(package_name, reason) do
+    error = {:error, reason}
+
+    expect_schema_request(package_name, @first_attempt_opts, error)
+    expect_schema_request(package_name, @second_attempt_opts, error)
+    expect_schema_request(package_name, @third_attempt_opts, error)
+  end
 
   describe "install_schemas mix task" do
     setup do
@@ -23,285 +63,27 @@ defmodule Lightning.InstallSchemasTest do
       :ok
     end
 
-    test "run success" do
-      expect(:hackney, :request, fn
-        :get,
-        "https://registry.npmjs.org/-/user/openfn/package",
-        [],
-        "",
-        @registry_request_options ->
-          @ok_200
-      end)
+    test "run reports a tally of installed and skipped packages" do
+      # Registry returns 3 packages:
+      #   language-common  -> excluded by default
+      #   language-asana   -> installed on first attempt
+      #   language-primero -> skipped after exhausting all retries
+      expect_registry(@ok_200)
 
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok,
-         ~s({"@openfn/language-primero": "write","@openfn/language-asana": "write", "@openfn/language-common": "write"})}
-      end)
-
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          @ok_200
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, ~s({"name": "language-asana"})}
-      end)
-
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          @ok_200
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, ~s({"name": "language-primero"})}
-      end)
-
-      File
-      |> expect(:rm_rf, fn _ -> nil end)
-      |> expect(:mkdir_p, fn _ -> nil end)
-      |> expect(:open!, fn
-        "test/fixtures/schemas/primero.json", [:write] -> nil
-        "test/fixtures/schemas/asana.json", [:write] -> nil
-      end)
-      |> expect(:close, 2, fn _ -> nil end)
-
-      IO
-      |> expect(:binwrite, fn _, ~s({"name": "language-asana"}) -> nil end)
-      |> expect(:binwrite, fn _, ~s({"name": "language-primero"}) -> nil end)
-
-      output =
-        capture_io(fn ->
-          InstallSchemas.run([])
-        end)
-
-      assert output =~ "2 installed, 0 skipped"
-    end
-
-    test "run fail" do
-      expect(File, :rm_rf, fn _ -> {:error, "error occured"} end)
-      expect(File, :mkdir_p, fn _ -> {:error, "error occured"} end)
-
-      assert_raise RuntimeError,
-                   "Couldn't create the schemas directory: test/fixtures/schemas, got :error occured.",
-                   fn ->
-                     InstallSchemas.run([])
-                   end
-    end
-
-    test "persist_schema retries then succeeds" do
-      # First attempt times out
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          {:error, :timeout}
-      end)
-
-      # Second attempt succeeds
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @second_attempt_opts ->
-          @ok_200
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, ~s({"name": "language-asana"})}
-      end)
-
-      File
-      |> expect(:open!, fn "test/fixtures/schemas/asana.json", [:write] ->
-        nil
-      end)
-      |> expect(:close, fn _ -> nil end)
-
-      expect(IO, :binwrite, fn _, ~s({"name": "language-asana"}) -> nil end)
-
-      {result, log} =
-        with_log(fn ->
-          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
-        end)
-
-      assert result == {:installed, "@openfn/language-asana"}
-
-      assert log =~
-               "Transient error fetching @openfn/language-asana (:timeout); retrying with recv_timeout=15000ms"
-    end
-
-    test "persist_schema logs and skips after all retries fail" do
-      # All three attempts time out
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          {:error, :timeout}
-      end)
-
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @second_attempt_opts ->
-          {:error, :timeout}
-      end)
-
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @third_attempt_opts ->
-          {:error, :timeout}
-      end)
-
-      {result, log} =
-        with_log(fn ->
-          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
-        end)
-
-      assert result == {:skipped, "@openfn/language-asana", :timeout}
-      assert log =~ "Skipping @openfn/language-asana: :timeout after 3 attempts"
-    end
-
-    test "persist_schema HTTP 400" do
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          @ok_400
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, ""}
-      end)
-
-      {result, log} =
-        with_log(fn ->
-          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
-        end)
-
-      assert {:skipped, "@openfn/language-asana", {:http_status, 400}} = result
-
-      assert log =~
-               "Unable to fetch @openfn/language-asana configuration schema. status=400"
-    end
-
-    test "fetch_schemas fail 1" do
-      expect(:hackney, :request, fn
-        :get,
-        "https://registry.npmjs.org/-/user/openfn/package",
-        [],
-        "",
-        @registry_request_options ->
-          @ok_200
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:error, %HTTPoison.Error{}}
-      end)
-
-      assert_raise RuntimeError,
-                   ~r/Unable to connect to NPM; no adaptors fetched: /,
-                   fn ->
-                     InstallSchemas.fetch_schemas([])
-                   end
-    end
-
-    test "fetch_schemas fail 2" do
-      expect(:hackney, :request, fn
-        :get,
-        "https://registry.npmjs.org/-/user/openfn/package",
-        [],
-        "",
-        @registry_request_options ->
-          @ok_400
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, ""}
-      end)
-
-      assert_raise RuntimeError,
-                   "Unable to access openfn user packages. status=400",
-                   fn ->
-                     InstallSchemas.fetch_schemas([])
-                   end
-    end
-
-    test "run reports skipped packages in the tally" do
-      # Registry returns 3 packages: language-common (excluded), language-asana (succeeds), language-primero (fails all retries)
-      expect(:hackney, :request, fn
-        :get,
-        "https://registry.npmjs.org/-/user/openfn/package",
-        [],
-        "",
-        @registry_request_options ->
-          @ok_200
-      end)
-
-      expect(:hackney, :body, fn :client, _timeout ->
+      expect_body(
         {:ok,
          ~s({"@openfn/language-common": "write", "@openfn/language-asana": "write", "@openfn/language-primero": "write"})}
-      end)
+      )
 
-      # language-asana: first attempt succeeds
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          @ok_200
-      end)
+      expect_schema_request(
+        "@openfn/language-asana",
+        @first_attempt_opts,
+        @ok_200
+      )
 
-      expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, ~s({"name": "language-asana"})}
-      end)
+      expect_body({:ok, ~s({"name": "language-asana"})})
 
-      # language-primero: all three attempts fail
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
-        [],
-        "",
-        @first_attempt_opts ->
-          {:error, :timeout}
-      end)
-
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
-        [],
-        "",
-        @second_attempt_opts ->
-          {:error, :timeout}
-      end)
-
-      expect(:hackney, :request, fn
-        :get,
-        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
-        [],
-        "",
-        @third_attempt_opts ->
-          {:error, :timeout}
-      end)
+      expect_all_attempts_error("@openfn/language-primero", :timeout)
 
       File
       |> expect(:rm_rf, fn _ -> nil end)
@@ -323,10 +105,148 @@ defmodule Lightning.InstallSchemasTest do
       assert output =~ "1 installed, 1 skipped"
 
       assert log =~
-               "Skipping @openfn/language-primero: :timeout after 3 attempts"
+               "Skipping @openfn/language-primero: :timeout after 3 attempt(s)"
     end
 
-    test "parse_excluded" do
+    test "run raises when the schemas directory cannot be created" do
+      expect(File, :rm_rf, fn _ -> {:error, "error occured"} end)
+      expect(File, :mkdir_p, fn _ -> {:error, "error occured"} end)
+
+      assert_raise RuntimeError,
+                   "Couldn't create the schemas directory: test/fixtures/schemas, got :error occured.",
+                   fn ->
+                     InstallSchemas.run([])
+                   end
+    end
+
+    test "persist_schema retries transient errors then succeeds" do
+      # First attempt times out; second succeeds. We also verify that the
+      # retry escalates to the 15s recv_timeout profile.
+      expect_schema_request(
+        "@openfn/language-asana",
+        @first_attempt_opts,
+        {:error, :timeout}
+      )
+
+      expect_schema_request(
+        "@openfn/language-asana",
+        @second_attempt_opts,
+        @ok_200
+      )
+
+      expect_body({:ok, ~s({"name": "language-asana"})})
+
+      File
+      |> expect(:open!, fn "test/fixtures/schemas/asana.json", [:write] ->
+        nil
+      end)
+      |> expect(:close, fn _ -> nil end)
+
+      expect(IO, :binwrite, fn _, ~s({"name": "language-asana"}) -> nil end)
+
+      {result, log} =
+        with_log(fn ->
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
+        end)
+
+      assert result == {:installed, "@openfn/language-asana"}
+
+      assert log =~
+               "Transient error fetching @openfn/language-asana (:timeout); retrying with recv_timeout=15000ms"
+    end
+
+    test "persist_schema skips after exhausting all retries" do
+      expect_all_attempts_error("@openfn/language-asana", :timeout)
+
+      {result, log} =
+        with_log(fn ->
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
+        end)
+
+      assert result == {:skipped, "@openfn/language-asana", :timeout}
+
+      assert log =~
+               "Skipping @openfn/language-asana: :timeout after 3 attempt(s)"
+    end
+
+    test "persist_schema skips immediately on non-retriable errors" do
+      # :nxdomain is not in @retriable_reasons, so we expect exactly one
+      # attempt (no retry) and an "after 1 attempt(s)" log line.
+      expect_schema_request(
+        "@openfn/language-asana",
+        @first_attempt_opts,
+        {:error, :nxdomain}
+      )
+
+      {result, log} =
+        with_log(fn ->
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
+        end)
+
+      assert result == {:skipped, "@openfn/language-asana", :nxdomain}
+
+      assert log =~
+               "Skipping @openfn/language-asana: :nxdomain after 1 attempt(s)"
+    end
+
+    test "persist_schema skips on non-200 status without retrying" do
+      expect_schema_request(
+        "@openfn/language-asana",
+        @first_attempt_opts,
+        @ok_400
+      )
+
+      expect_body({:ok, ""})
+
+      {result, log} =
+        with_log(fn ->
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
+        end)
+
+      assert {:skipped, "@openfn/language-asana", {:http_status, 400}} = result
+
+      assert log =~
+               "Unable to fetch @openfn/language-asana configuration schema. status=400"
+    end
+
+    test "fetch_schemas raises when the registry request errors" do
+      expect_registry(@ok_200)
+      expect_body({:error, %HTTPoison.Error{}})
+
+      assert_raise RuntimeError,
+                   ~r/Unable to connect to NPM; no adaptors fetched: /,
+                   fn -> InstallSchemas.fetch_schemas([]) end
+    end
+
+    test "fetch_schemas raises when the registry returns a non-200 status" do
+      expect_registry(@ok_400)
+      expect_body({:ok, ""})
+
+      assert_raise RuntimeError,
+                   "Unable to access openfn user packages. status=400",
+                   fn -> InstallSchemas.fetch_schemas([]) end
+    end
+
+    test "fetch_schemas preserves the package name when a worker crashes" do
+      # Regression guard: an earlier bug surfaced the {:exit, _} branch with
+      # the name "unknown" because results weren't zipped against the input
+      # names. We feed fetch_schemas a worker that always raises and assert
+      # the skip tuple still carries the package name.
+      expect_registry(@ok_200)
+      expect_body({:ok, ~s({"@openfn/language-boom": "write"})})
+
+      crashing_fun = fn _name -> raise "boom" end
+
+      {results, log} =
+        with_log(fn ->
+          InstallSchemas.fetch_schemas([], crashing_fun) |> Enum.to_list()
+        end)
+
+      assert [{:skipped, "@openfn/language-boom", _reason}] = results
+      assert log =~ "Schema fetch worker for @openfn/language-boom crashed"
+    end
+
+    test "parse_excluded merges CLI args with defaults" do
       assert [
                "pack1",
                "pack2",

--- a/test/lightning/install_schemas_test.exs
+++ b/test/lightning/install_schemas_test.exs
@@ -8,7 +8,10 @@ defmodule Lightning.InstallSchemasTest do
 
   alias Mix.Tasks.Lightning.InstallSchemas
 
-  @request_options [recv_timeout: 15_000, pool: :default]
+  @registry_request_options [recv_timeout: 15_000, pool: :default]
+  @first_attempt_opts [recv_timeout: 30_000, pool: :default]
+  @second_attempt_opts [recv_timeout: 15_000, pool: :default]
+  @third_attempt_opts [recv_timeout: 5_000, pool: :default]
   @ok_200 {:ok, 200, "headers", :client}
   @ok_400 {:ok, 400, "headers", :client}
 
@@ -17,7 +20,6 @@ defmodule Lightning.InstallSchemasTest do
   describe "install_schemas mix task" do
     setup do
       stub(:hackney)
-
       :ok
     end
 
@@ -27,7 +29,7 @@ defmodule Lightning.InstallSchemasTest do
         "https://registry.npmjs.org/-/user/openfn/package",
         [],
         "",
-        @request_options ->
+        @registry_request_options ->
           @ok_200
       end)
 
@@ -41,7 +43,7 @@ defmodule Lightning.InstallSchemasTest do
         "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
         [],
         "",
-        @request_options ->
+        @first_attempt_opts ->
           @ok_200
       end)
 
@@ -54,7 +56,7 @@ defmodule Lightning.InstallSchemasTest do
         "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
         [],
         "",
-        @request_options ->
+        @first_attempt_opts ->
           @ok_200
       end)
 
@@ -75,11 +77,12 @@ defmodule Lightning.InstallSchemasTest do
       |> expect(:binwrite, fn _, ~s({"name": "language-asana"}) -> nil end)
       |> expect(:binwrite, fn _, ~s({"name": "language-primero"}) -> nil end)
 
-      # |> expect(:binwrite, fn _, ~s({"name": "language-common"}) -> nil end)
+      output =
+        capture_io(fn ->
+          InstallSchemas.run([])
+        end)
 
-      capture_io(fn ->
-        InstallSchemas.run([])
-      end)
+      assert output =~ "2 installed, 0 skipped"
     end
 
     test "run fail" do
@@ -93,43 +96,108 @@ defmodule Lightning.InstallSchemasTest do
                    end
     end
 
-    test "persist_schema fail 1" do
+    test "persist_schema retries then succeeds" do
+      # First attempt times out
       expect(:hackney, :request, fn
         :get,
         "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
         [],
         "",
-        @request_options ->
+        @first_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      # Second attempt succeeds
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
+        [],
+        "",
+        @second_attempt_opts ->
           @ok_200
       end)
 
       expect(:hackney, :body, fn :client, _timeout ->
-        {:error, %HTTPoison.Error{}}
+        {:ok, ~s({"name": "language-asana"})}
       end)
 
-      assert_raise RuntimeError, "Unable to access @openfn/language-asana", fn ->
-        InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
-      end
+      File
+      |> expect(:open!, fn "test/fixtures/schemas/asana.json", [:write] ->
+        nil
+      end)
+      |> expect(:close, fn _ -> nil end)
+
+      expect(IO, :binwrite, fn _, ~s({"name": "language-asana"}) -> nil end)
+
+      {result, log} =
+        with_log(fn ->
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
+        end)
+
+      assert result == {:installed, "@openfn/language-asana"}
+
+      assert log =~
+               "Transient error fetching @openfn/language-asana (:timeout); retrying with recv_timeout=15000ms"
     end
 
-    test "persist_schema fail 2" do
+    test "persist_schema logs and skips after all retries fail" do
+      # All three attempts time out
       expect(:hackney, :request, fn
         :get,
         "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
         [],
         "",
-        @request_options ->
+        @first_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
+        [],
+        "",
+        @second_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
+        [],
+        "",
+        @third_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      {result, log} =
+        with_log(fn ->
+          InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
+        end)
+
+      assert result == {:skipped, "@openfn/language-asana", :timeout}
+      assert log =~ "Skipping @openfn/language-asana: :timeout after 3 attempts"
+    end
+
+    test "persist_schema HTTP 400" do
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
+        [],
+        "",
+        @first_attempt_opts ->
           @ok_400
       end)
 
       expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, %HTTPoison.Response{status_code: 400}}
+        {:ok, ""}
       end)
 
-      {_result, log} =
+      {result, log} =
         with_log(fn ->
           InstallSchemas.persist_schema(@schemas_path, "@openfn/language-asana")
         end)
+
+      assert {:skipped, "@openfn/language-asana", {:http_status, 400}} = result
 
       assert log =~
                "Unable to fetch @openfn/language-asana configuration schema. status=400"
@@ -141,7 +209,7 @@ defmodule Lightning.InstallSchemasTest do
         "https://registry.npmjs.org/-/user/openfn/package",
         [],
         "",
-        @request_options ->
+        @registry_request_options ->
           @ok_200
       end)
 
@@ -150,7 +218,7 @@ defmodule Lightning.InstallSchemasTest do
       end)
 
       assert_raise RuntimeError,
-                   "Unable to connect to NPM; no adaptors fetched.",
+                   ~r/Unable to connect to NPM; no adaptors fetched: /,
                    fn ->
                      InstallSchemas.fetch_schemas([])
                    end
@@ -162,12 +230,12 @@ defmodule Lightning.InstallSchemasTest do
         "https://registry.npmjs.org/-/user/openfn/package",
         [],
         "",
-        @request_options ->
+        @registry_request_options ->
           @ok_400
       end)
 
       expect(:hackney, :body, fn :client, _timeout ->
-        {:ok, %HTTPoison.Response{status_code: 400}}
+        {:ok, ""}
       end)
 
       assert_raise RuntimeError,
@@ -175,6 +243,87 @@ defmodule Lightning.InstallSchemasTest do
                    fn ->
                      InstallSchemas.fetch_schemas([])
                    end
+    end
+
+    test "run reports skipped packages in the tally" do
+      # Registry returns 3 packages: language-common (excluded), language-asana (succeeds), language-primero (fails all retries)
+      expect(:hackney, :request, fn
+        :get,
+        "https://registry.npmjs.org/-/user/openfn/package",
+        [],
+        "",
+        @registry_request_options ->
+          @ok_200
+      end)
+
+      expect(:hackney, :body, fn :client, _timeout ->
+        {:ok,
+         ~s({"@openfn/language-common": "write", "@openfn/language-asana": "write", "@openfn/language-primero": "write"})}
+      end)
+
+      # language-asana: first attempt succeeds
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-asana/configuration-schema.json",
+        [],
+        "",
+        @first_attempt_opts ->
+          @ok_200
+      end)
+
+      expect(:hackney, :body, fn :client, _timeout ->
+        {:ok, ~s({"name": "language-asana"})}
+      end)
+
+      # language-primero: all three attempts fail
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
+        [],
+        "",
+        @first_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
+        [],
+        "",
+        @second_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      expect(:hackney, :request, fn
+        :get,
+        "https://cdn.jsdelivr.net/npm/@openfn/language-primero/configuration-schema.json",
+        [],
+        "",
+        @third_attempt_opts ->
+          {:error, :timeout}
+      end)
+
+      File
+      |> expect(:rm_rf, fn _ -> nil end)
+      |> expect(:mkdir_p, fn _ -> nil end)
+      |> expect(:open!, fn "test/fixtures/schemas/asana.json", [:write] ->
+        nil
+      end)
+      |> expect(:close, fn _ -> nil end)
+
+      expect(IO, :binwrite, fn _, ~s({"name": "language-asana"}) -> nil end)
+
+      {output, log} =
+        with_log(fn ->
+          capture_io(fn ->
+            InstallSchemas.run([])
+          end)
+        end)
+
+      assert output =~ "1 installed, 1 skipped"
+
+      assert log =~
+               "Skipping @openfn/language-primero: :timeout after 3 attempts"
     end
 
     test "parse_excluded" do


### PR DESCRIPTION
## Description

This PR fixes `mix lightning.install_schemas` (and by extension `bin/bootstrap`) so it no longer aborts the whole task when a single jsdelivr fetch times out. Each per-package fetch now retries with escalating `recv_timeout`s (30s → 15s → 5s) on transient hackney errors. Packages that genuinely can't be fetched are logged with the underlying reason and skipped. The task reports a final tally of installed vs. skipped packages.

Implementation notes:

- Retry only on transient reasons (`:timeout`, `:closed`, `:connect_timeout`, `:checkout_timeout`); other errors skip immediately.
- The outer `Task.async_stream` was hardened: worker raises are caught locally, the package name is preserved through `{:exit, _}` results (via `ordered: true` + `Stream.zip`), and `on_timeout: :kill_task` is set so the outer-timeout branch is actually reachable.
- The `@recv_timeouts` are deliberately descending — the first generous attempt warms a cold jsdelivr cache, follow-ups fail fast.

Closes #4750

## Validation steps

1. `mix lightning.install_schemas` completes against a live jsdelivr (the original failure mode is non-deterministic; usually visible after wiping `priv/schemas` and re-running cold).
2. `mix test test/lightning/install_schemas_test.exs` — 10 tests cover the retry escalation, exhaustion path, non-retriable errors, HTTP non-200, registry failures, the end-to-end tally, and the worker-crash name-preservation regression guard.
3. `./bin/bootstrap` completes without manual workarounds.

## Additional notes for the reviewer

- Two commits: the substantive change (`refactor: tighten install_schemas retry semantics and tests`) builds on the earlier `fix: retry jsdelivr fetches in install_schemas instead of raising` from this branch. Happy to squash on merge.
- Test file shrunk from 372 → 263 lines via stub helpers; coverage went up.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [ ] I have implemented and tested all related **authorization policies** — _N/A, mix task with no auth surface_
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR