### PR TITLE
Auto-bump @openfn/cli and @openfn/ws-worker via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,19 @@
 
 version: 2
 updates:
-  - package-ecosystem: "mix" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "mix"
+    directory: "/"
     schedule:
       interval: "weekly"
-      
-  - package-ecosystem: "mix"
-    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+
+  - package-ecosystem: "npm"
     directory: "/assets"
     schedule:
-      interval: "weekly"  
-      
+      interval: "daily"
+    allow:
+      - dependency-name: "@openfn/*"
+
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
       interval: "weekly"

--- a/assets/package.json
+++ b/assets/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
     "@eslint/js": "^9.21.0",
+    "@openfn/cli": "1.35.3",
     "@openfn/ws-worker": "^1.25.0",
     "@playwright/test": "^1.55.0",
     "@redux-devtools/extension": "^3.3.0",

--- a/lib/mix/tasks/install_runtime.ex
+++ b/lib/mix/tasks/install_runtime.ex
@@ -11,7 +11,18 @@ defmodule Mix.Tasks.Lightning.InstallRuntime do
   use Mix.Task
 
   @default_path "priv/openfn"
-  @cli_version "1.35.3"
+
+  # Single source of truth for the `@openfn/cli` version: `assets/package.json`.
+  # Putting it there lets Dependabot track it like any other npm dependency
+  # and open bump PRs when a new release ships.
+  @package_json Path.expand("../../../assets/package.json", __DIR__)
+  @external_resource @package_json
+  @cli_version @package_json
+               |> File.read!()
+               |> Jason.decode!()
+               |> get_in(["devDependencies", "@openfn/cli"])
+               |> String.trim_leading("^")
+               |> String.trim_leading("~")
 
   def run(args) do
     case Rambo.run("/usr/bin/env", ~w(which node)) do

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -267,10 +267,11 @@ defmodule Lightning.WebAndWorkerTest do
       end
 
       version_logs = pick_out_version_logs(run)
-      assert version_logs["@openfn/language-http"] =~ "3.1.12"
-      assert version_logs["worker"] =~ "1.25"
-      assert version_logs["node.js"] =~ "22.12"
-      assert version_logs["@openfn/language-common"] == "3.0.2"
+
+      for key <- ~w(@openfn/language-http worker node.js @openfn/language-common) do
+        assert version_logs[key] =~ ~r/\d+\.\d+/,
+               "expected #{key} log line to contain a version, got #{inspect(version_logs[key])}"
+      end
 
       [step_1, step_2, step_3, step_4] = run.steps
 


### PR DESCRIPTION
## Description

Three orthogonal hygiene fixes around the `@openfn/cli` and `@openfn/ws-worker` runtime pins:

1. **Fix `.github/dependabot.yml`.** The existing `/assets` entry was set to `ecosystem: "mix"`, which silently matched nothing. Change it to `"npm"` and scope it to `@openfn/*` so Dependabot opens a daily auto-PR when either package ships a release.
2. **Move the `@openfn/cli` pin into `assets/package.json`.** The version was previously a hardcoded Elixir constant (`@cli_version` in `lib/mix/tasks/install_runtime.ex`), which Dependabot can't track. The Mix task now reads the pin at compile time from `package.json` via `File.read!` + `Jason.decode!`, with `@external_resource` so recompiles trip when the JSON changes. Single source of truth for both pins.
3. **Loosen brittle version assertions in `web_and_worker_test`.** The test pinned exact builds for `language-http`, `worker`, `node.js`, and `language-common`. Each upstream release turned the test red for reasons unrelated to Lightning. Asserts each version key is present and looks like a version (`\d+\.\d+`) instead.

Pairs with #4760 (which removes the per-PR runtime checks entirely). These three changes stand on their own — they pay off whether or not those checks ever return.

## Validation steps

- Run `mix lightning.install_runtime` after changing `@openfn/cli` in `assets/package.json` and confirm the new version is installed under `priv/openfn`.
- After merge, Dependabot will open its first bump PR within 24 hours of the next `@openfn/*` release.

## Additional notes for the reviewer

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
