### PR TITLE
Sandboxes: remove duplicate button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,15 +77,13 @@ and this project adheres to
   and sandbox merge [#4596](https://github.com/OpenFn/lightning/issues/4596)
 - Bump `@openfn/ws-worker` from
   [`1.24.2` to `1.25.0`](https://github.com/OpenFn/kit/blob/@openfn/ws-worker@1.25.0/packages/ws-worker/CHANGELOG.md#1250)
-<<<<<<< HEAD
 - Use `tls_certificate_check` for SMTP TLS options, adding TLS 1.2 support. OTP
   trusted CA certificates will now be used (usualy the OS CA store), failing
   which the library's bundled CA store will be used; use
   `tls_certificate_check`'s `override_trusted_authorities/1` to customise
   [#4755](https://github.com/OpenFn/lightning/issues/4755)
-=======
-- Removed `Duplicate` button from Sandbox UI.
->>>>>>> 86f6c8c12b (remove duplicate button)
+- Removed `Duplicate` button from Sandbox UI
+  [#4767](https://github.com/OpenFn/lightning/pull/4767)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,11 +77,15 @@ and this project adheres to
   and sandbox merge [#4596](https://github.com/OpenFn/lightning/issues/4596)
 - Bump `@openfn/ws-worker` from
   [`1.24.2` to `1.25.0`](https://github.com/OpenFn/kit/blob/@openfn/ws-worker@1.25.0/packages/ws-worker/CHANGELOG.md#1250)
+<<<<<<< HEAD
 - Use `tls_certificate_check` for SMTP TLS options, adding TLS 1.2 support. OTP
   trusted CA certificates will now be used (usualy the OS CA store), failing
   which the library's bundled CA store will be used; use
   `tls_certificate_check`'s `override_trusted_authorities/1` to customise
   [#4755](https://github.com/OpenFn/lightning/issues/4755)
+=======
+- Removed `Duplicate` button from Sandbox UI.
+>>>>>>> 86f6c8c12b (remove duplicate button)
 
 ### Fixed
 

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -689,16 +689,6 @@ defmodule LightningWeb.SandboxLive.Components do
       />
 
       <.action_button
-        id={"duplicate-sandbox-#{@sandbox.id}"}
-        icon_type="heroicon"
-        icon_name="hero-clipboard-document"
-        label="Duplicate (coming soon)"
-        disabled={true}
-        icon_class="text-slate-300"
-        button_class="cursor-not-allowed"
-      />
-
-      <.action_button
         id={"edit-sandbox-#{@sandbox.id}"}
         icon_type="heroicon"
         icon_name="hero-pencil-square"


### PR DESCRIPTION
Tiny PR to remove the unimplemented "Duplicate Sandbox" button

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
