### PR TITLE
Project picker: precompute the label and drop the silent fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to
 
 ### Fixed
 
+- The breadcrumb project picker now shows the full ancestor path on the project
+  settings page (previously it collapsed to the sandbox's own name).
+  [#4769](https://github.com/OpenFn/lightning/issues/4769)
+
 ## [2.16.4-pre] - 2026-05-18
 
 ### Added

--- a/lib/lightning_web/components/layout_components.ex
+++ b/lib/lightning_web/components/layout_components.ex
@@ -305,7 +305,7 @@ defmodule LightningWeb.LayoutComponents do
   ## Example
 
       <.breadcrumbs>
-        <.breadcrumb_project_picker project={@project} current_user={@current_user} access_root={@access_root} />
+        <.breadcrumb_project_picker project={@project} label={@project_label} />
         <.breadcrumb_items items={[{"History", "/projects/\#{@project}/history"}]} />
         <.breadcrumb>
           <:label>{@page_title}</:label>
@@ -356,32 +356,15 @@ defmodule LightningWeb.LayoutComponents do
   LiveView pages and the collaborative editor.
   """
   attr :project, Lightning.Projects.Project, required: true
-  attr :current_user, Lightning.Accounts.User, default: nil
-  attr :access_root, Lightning.Projects.Project, default: nil
+  attr :label, :string, required: true
 
   def breadcrumb_project_picker(assigns) do
-    alias Lightning.Projects
-    alias Lightning.Projects.Project
-
-    access_root =
-      case {assigns[:access_root], assigns[:current_user]} do
-        {%Project{} = ar, _} ->
-          ar
-
-        {nil, %Lightning.Accounts.User{} = user} ->
-          Projects.access_root_for_user(assigns.project, user)
-
-        _ ->
-          assigns.project
-      end
-
     assigns =
       assigns
       |> assign(
-        :label,
-        Projects.display_name_within_access_root(assigns.project, access_root)
+        :is_sandbox,
+        to_string(Lightning.Projects.Project.sandbox?(assigns.project))
       )
-      |> assign(:is_sandbox, to_string(Project.sandbox?(assigns.project)))
       |> assign(:color, assigns.project.color)
 
     ~H"""

--- a/lib/lightning_web/hooks.ex
+++ b/lib/lightning_web/hooks.ex
@@ -58,12 +58,19 @@ defmodule LightningWeb.Hooks do
         access_root =
           Lightning.Projects.access_root_for_user(project, current_user)
 
+        project_label =
+          Lightning.Projects.display_name_within_access_root(
+            project,
+            access_root
+          )
+
         {:cont,
          socket
          |> assign(:side_menu_theme, "primary-theme")
          |> assign(:project_user, project_user)
          |> assign(:project, project)
          |> assign(:access_root, access_root)
+         |> assign(:project_label, project_label)
          |> assign(:projects, projects)}
 
       true ->

--- a/lib/lightning_web/live/channel_live/index.ex
+++ b/lib/lightning_web/live/channel_live/index.ex
@@ -30,8 +30,7 @@ defmodule LightningWeb.ChannelLive.Index do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb>
                 <:label>{@page_title}</:label>

--- a/lib/lightning_web/live/channel_request_live/show.ex
+++ b/lib/lightning_web/live/channel_request_live/show.ex
@@ -57,8 +57,7 @@ defmodule LightningWeb.ChannelRequestLive.Show do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb_items items={[
                 {"History", ~p"/projects/#{@project}/history"},

--- a/lib/lightning_web/live/dataclip_live/show.ex
+++ b/lib/lightning_web/live/dataclip_live/show.ex
@@ -42,8 +42,7 @@ defmodule LightningWeb.DataclipLive.Show do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb>
                 <:label>

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -10,7 +10,10 @@
     <LayoutComponents.header current_user={@current_user}>
       <:breadcrumbs>
         <LayoutComponents.breadcrumbs>
-          <LayoutComponents.breadcrumb_project_picker project={@project} />
+          <LayoutComponents.breadcrumb_project_picker
+            project={@project}
+            label={@project_label}
+          />
           <LayoutComponents.breadcrumb>
             <:label>{@page_title}</:label>
           </LayoutComponents.breadcrumb>

--- a/lib/lightning_web/live/run_live/index.html.heex
+++ b/lib/lightning_web/live/run_live/index.html.heex
@@ -12,8 +12,7 @@
         <LayoutComponents.breadcrumbs>
           <LayoutComponents.breadcrumb_project_picker
             project={@project}
-            current_user={@current_user}
-            access_root={@access_root}
+            label={@project_label}
           />
           <LayoutComponents.breadcrumb>
             <:label>{@page_title}</:label>

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -66,8 +66,7 @@ defmodule LightningWeb.RunLive.Show do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb_items items={[
                 {"History", ~p"/projects/#{@project}/history"}

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -436,8 +436,7 @@ defmodule LightningWeb.SandboxLive.Index do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb>
                 <:label>Sandboxes</:label>

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -97,8 +97,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb_items items={[
                 {"Workflows", "/projects/#{@project.id}/w"}

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -41,8 +41,7 @@ defmodule LightningWeb.WorkflowLive.Index do
             <LayoutComponents.breadcrumbs>
               <LayoutComponents.breadcrumb_project_picker
                 project={@project}
-                current_user={@current_user}
-                access_root={@access_root}
+                label={@project_label}
               />
               <LayoutComponents.breadcrumb>
                 <:label>{@page_title}</:label>

--- a/test/lightning_web/components/layout_components_test.exs
+++ b/test/lightning_web/components/layout_components_test.exs
@@ -62,21 +62,16 @@ defmodule LightningWeb.LayoutComponentsTest do
   end
 
   describe "breadcrumb_project_picker/1" do
-    test "renders ReactComponent mount point for a root project" do
+    test "renders the ReactComponent mount point for a root project" do
       project = %Lightning.Projects.Project{
         id: Ecto.UUID.generate(),
         name: "my-project",
-        parent_id: nil,
-        parent: %Ecto.Association.NotLoaded{
-          __field__: :parent,
-          __owner__: Lightning.Projects.Project,
-          __cardinality__: :one
-        }
+        parent_id: nil
       }
 
       html =
         (&LayoutComponents.breadcrumb_project_picker/1)
-        |> render_component(%{project: project})
+        |> render_component(%{project: project, label: "my-project"})
 
       assert html =~ "breadcrumb-project-picker-trigger"
       assert html =~ ~s(data-react-name="PickerButton")
@@ -84,7 +79,7 @@ defmodule LightningWeb.LayoutComponentsTest do
       assert html =~ ~s(data-is-sandbox="false")
     end
 
-    test "renders ReactComponent mount point with sandbox data" do
+    test "renders the ReactComponent mount point for a sandbox" do
       parent = %Lightning.Projects.Project{
         id: Ecto.UUID.generate(),
         name: "parent-project"
@@ -100,44 +95,16 @@ defmodule LightningWeb.LayoutComponentsTest do
 
       html =
         (&LayoutComponents.breadcrumb_project_picker/1)
-        |> render_component(%{project: project})
+        |> render_component(%{
+          project: project,
+          label: "parent-project/my-sandbox"
+        })
 
       assert html =~ "breadcrumb-project-picker-trigger"
       assert html =~ ~s(data-react-name="PickerButton")
-      assert html =~ ~s(data-label="my-sandbox")
+      assert html =~ ~s(data-label="parent-project/my-sandbox")
       assert html =~ ~s(data-is-sandbox="true")
       assert html =~ ~s(data-color="#E33D63")
-    end
-
-    test "uses the access_root attr to truncate the displayed ancestor chain" do
-      root = insert(:project, name: "acme-workspace")
-      sandbox = insert(:project, name: "acme-staging", parent: root)
-
-      html =
-        (&LayoutComponents.breadcrumb_project_picker/1)
-        |> render_component(%{project: sandbox, access_root: sandbox})
-
-      assert html =~ ~s(data-label="acme-staging")
-      refute html =~ "acme-workspace/acme-staging"
-    end
-
-    test "derives access_root from current_user when access_root is not passed" do
-      user = insert(:user)
-      root = insert(:project, name: "acme-workspace")
-
-      sandbox =
-        insert(:project,
-          name: "acme-staging",
-          parent: root,
-          project_users: [%{user: user, role: :admin}]
-        )
-
-      html =
-        (&LayoutComponents.breadcrumb_project_picker/1)
-        |> render_component(%{project: sandbox, current_user: user})
-
-      assert html =~ ~s(data-label="acme-staging")
-      refute html =~ "acme-workspace/acme-staging"
     end
   end
 


### PR DESCRIPTION
## Description

The breadcrumb project picker on the settings page collapsed to the sandbox's own name instead of the full ancestor path, because the page didn't pass the user's access root and the component fell back silently. This PR moves the label computation into the `:project_scope` hook (precomputed as `project_label`) and makes the picker a pure render with a required `label` attr, removing the silent fallback and the `access_root_for_user/2` query that the component used to run inside its render path. Every call site now passes `label={@project_label}`.

Two tests in `layout_components_test.exs` that exercised the old in-component dispatch (the `access_root` and `current_user` resolution paths) are removed — those semantics now live in the hook and in `display_name_within_access_root/2`, which is already covered in `projects_test.exs`. The two remaining picker tests pass a precomputed `label`.

Closes #4769.

## Validation steps

1. Sign in as a user with access to both a parent project and one of its sandboxes (the demo user `demo@openfn.org` works after `Lightning.SetupUtils.setup_demo(create_super: true)`).
2. Open the sandbox (DHIS2 > Sandboxes > pick one).
3. Visit any page inside the sandbox other than Settings (Workflows, Runs, Channels, Dataclips). The picker shows the full path, e.g. `dhis2-project/feature-x`.
4. Click **Settings**. The picker should still show `dhis2-project/feature-x` (before this PR it showed `feature-x`).
5. Switch back to the parent project. The picker shows just the parent project's name on every page, including Settings.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [x] I have implemented and tested all related **authorization policies**
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR
