### PR TITLE
Seed demo sandboxes in setup_demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 ### Added
 
+- `Lightning.SetupUtils.setup_demo/1` now seeds three sandboxes (one nested)
+  under the existing demo projects.
+  [#4774](https://github.com/OpenFn/lightning/issues/4774)
+
 ### Changed
 
 ### Fixed

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -75,16 +75,38 @@ defmodule Lightning.SetupUtils do
         %{user_id: admin.id, role: :owner}
       ])
 
+    sandboxes = create_demo_sandboxes(openhie_project, dhis2_project, admin)
+
     %{
       jobs: openhie_jobs ++ dhis2_jobs,
       users: [super_user, admin, editor, viewer],
       projects: [openhie_project, dhis2_project],
+      sandboxes: sandboxes,
       workflows: [openhie_workflow, dhis2_workflow],
       workorders: [
         openhie_workorder,
         failure_dhis2_workorder
       ]
     }
+  end
+
+  defp create_demo_sandboxes(openhie_project, dhis2_project, admin) do
+    {:ok, openhie_dev} =
+      Lightning.Projects.Sandboxes.provision(openhie_project, admin, %{
+        name: "openhie-dev"
+      })
+
+    {:ok, dhis2_dev} =
+      Lightning.Projects.Sandboxes.provision(dhis2_project, admin, %{
+        name: "dhis2-dev"
+      })
+
+    {:ok, dhis2_feature_x} =
+      Lightning.Projects.Sandboxes.provision(dhis2_dev, admin, %{
+        name: "dhis2-feature-x"
+      })
+
+    [openhie_dev, dhis2_dev, dhis2_feature_x]
   end
 
   defp to_log_lines(log) do

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -10,6 +10,7 @@ defmodule Lightning.SetupUtils do
   alias Lightning.Credentials
   alias Lightning.Jobs
   alias Lightning.Projects
+  alias Lightning.Projects.Sandboxes
   alias Lightning.Repo
   alias Lightning.Runs
   alias Lightning.Workflows
@@ -41,6 +42,7 @@ defmodule Lightning.SetupUtils do
   @spec setup_demo(nil | maybe_improper_list | map) :: %{
           jobs: [...],
           projects: [atom | %{:id => any, optional(any) => any}, ...],
+          sandboxes: [atom | %{:id => any, optional(any) => any}, ...],
           users: [atom | %{:id => any, optional(any) => any}, ...],
           workflows: [atom | %{:id => any, optional(any) => any}, ...],
           workorders: [atom | %{:id => any, optional(any) => any}, ...]
@@ -92,17 +94,17 @@ defmodule Lightning.SetupUtils do
 
   defp create_demo_sandboxes(openhie_project, dhis2_project, admin) do
     {:ok, openhie_dev} =
-      Lightning.Projects.Sandboxes.provision(openhie_project, admin, %{
+      Sandboxes.provision(openhie_project, admin, %{
         name: "openhie-dev"
       })
 
     {:ok, dhis2_dev} =
-      Lightning.Projects.Sandboxes.provision(dhis2_project, admin, %{
+      Sandboxes.provision(dhis2_project, admin, %{
         name: "dhis2-dev"
       })
 
     {:ok, dhis2_feature_x} =
-      Lightning.Projects.Sandboxes.provision(dhis2_dev, admin, %{
+      Sandboxes.provision(dhis2_dev, admin, %{
         name: "dhis2-feature-x"
       })
 

--- a/test/lightning/setup_utils_test.exs
+++ b/test/lightning/setup_utils_test.exs
@@ -608,9 +608,11 @@ defmodule Lightning.SetupUtilsTest do
 
     test "all initial data gets wiped out of database" do
       assert Lightning.Accounts.list_users() |> Enum.count() > 0
-      assert Lightning.Projects.list_projects() |> Enum.count() == 2
-      assert Lightning.Workflows.list_workflows() |> Enum.count() == 2
-      assert Lightning.Jobs.list_jobs() |> Enum.count() == 6
+      # 2 root projects + 3 demo sandboxes
+      assert Lightning.Projects.list_projects() |> Enum.count() == 5
+      # 2 root workflows + 3 cloned into the demo sandboxes
+      assert Lightning.Workflows.list_workflows() |> Enum.count() == 5
+      assert Lightning.Jobs.list_jobs() |> Enum.count() == 14
       assert Repo.all(Lightning.Invocation.Step) |> Enum.count() == 5
 
       assert Repo.all(Lightning.Invocation.LogLine)
@@ -630,9 +632,11 @@ defmodule Lightning.SetupUtilsTest do
 
     test "all initial data gets wiped out of database except superusers" do
       assert Lightning.Accounts.list_users() |> Enum.count() > 1
-      assert Lightning.Projects.list_projects() |> Enum.count() == 2
-      assert Lightning.Workflows.list_workflows() |> Enum.count() == 2
-      assert Lightning.Jobs.list_jobs() |> Enum.count() == 6
+      # 2 root projects + 3 demo sandboxes
+      assert Lightning.Projects.list_projects() |> Enum.count() == 5
+      # 2 root workflows + 3 cloned into the demo sandboxes
+      assert Lightning.Workflows.list_workflows() |> Enum.count() == 5
+      assert Lightning.Jobs.list_jobs() |> Enum.count() == 14
       assert Repo.all(Lightning.Invocation.Step) |> Enum.count() == 5
 
       assert Repo.all(Lightning.Invocation.LogLine)


### PR DESCRIPTION
## Description

`Lightning.SetupUtils.setup_demo/1` now provisions three sandboxes after seeding the two demo projects: `openhie-dev` under OpenHIE, `dhis2-dev` under DHIS2, and `dhis2-feature-x` nested under `dhis2-dev`. This makes the sandbox UX (list, picker, breadcrumb truncation, nested provisioning) demonstrable on a fresh demo instance without any extra setup.

Closes #4774.

## Validation steps

1. `Lightning.SetupUtils.setup_demo(create_super: true)` from IEx, or `IS_RESETTABLE_DEMO=yes mix run priv/repo/demo.exs`.
2. Sign in as Amy (`demo@openfn.org` / `welcome12345`). Visit DHIS2 → Sandboxes and OpenHIE → Sandboxes. Each shows its dev sandbox; DHIS2's also shows `dhis2-feature-x` nested under `dhis2-dev`.
3. Sign in as Sizwe (`super@openfn.org`). DHIS2 is not in the picker; OpenHIE → Sandboxes shows `openhie-dev`.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [x] I have implemented and tested all related **authorization policies**
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR
