### PR TITLE
Restore data/meta envelope on webhook responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to
 
 ### Fixed
 
+## [2.16.5] - 2026-05-21
+
+### Fixed
+
+- Restore webhook responses to include `data` and `meta` fields, with `data`
+  containing the actual response body and `meta` containing run metadata.
+  [#4785](https://github.com/OpenFn/lightning/issues/4785)
+
 ## [2.16.4] - 2026-05-20
 
 ## [2.16.4-pre2] - 2026-05-20

--- a/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
+++ b/assets/js/collaborative-editor/components/inspector/TriggerForm.tsx
@@ -645,7 +645,7 @@ export function TriggerForm({ trigger }: TriggerFormProps) {
                                                   <input
                                                     id={`${field.name}-error-code`}
                                                     type="number"
-                                                    placeholder="500"
+                                                    placeholder="201"
                                                     value={
                                                       config?.error_code ?? ''
                                                     }

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -363,10 +363,22 @@ defmodule LightningWeb.RunChannel do
     if already_sent?(webhook_response) do
       socket
     else
+      meta = %{
+        work_order_id: run.work_order_id,
+        run_id: run.id,
+        state: run.state,
+        error_type: run.error_type,
+        inserted_at: run.inserted_at,
+        started_at: run.started_at,
+        claimed_at: run.claimed_at,
+        finished_at: run.finished_at
+      }
+
       Phoenix.PubSub.broadcast(
         Lightning.PubSub,
         "work_order:#{run.work_order_id}:webhook_response",
-        {:webhook_response, webhook_response.status, webhook_response.body}
+        {:webhook_response, webhook_response.status,
+         %{data: webhook_response.body, meta: meta}}
       )
 
       assign(socket, :webhook_response, %{
@@ -429,7 +441,7 @@ defmodule LightningWeb.RunChannel do
        when is_integer(code),
        do: code
 
-  defp default_response_status(_run_status, _config), do: 500
+  defp default_response_status(_run_status, _config), do: 201
 
   defp default_response_body(:success, final_state, _config),
     do: final_state

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lightning.MixProject do
   def project do
     [
       app: :lightning,
-      version: "2.16.4",
+      version: "2.16.5",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -471,7 +471,15 @@ defmodule Lightning.WebAndWorkerTest do
       response = Task.await(task, 10_000)
 
       assert response.status == 201
-      assert %{"data" => %{"value" => 10}, "result" => "success"} = response.body
+
+      assert %{
+               "data" => %{"data" => %{"value" => 10}, "result" => "success"},
+               "meta" => meta
+             } = response.body
+
+      assert meta["state"] == "success"
+      assert is_binary(meta["run_id"])
+      assert is_binary(meta["work_order_id"])
 
       # Verify the work order completed successfully
       work_order =
@@ -532,11 +540,12 @@ defmodule Lightning.WebAndWorkerTest do
         )
         |> Tesla.post!("/i/#{trigger.id}", webhook_body)
 
-      # Should return 500 for failed workflow
-      assert response.status == 500
+      # Default status when no error_code is configured
+      assert response.status == 201
 
-      # Response should include the final state
-      assert is_map(response.body)
+      assert %{"data" => %{"message" => msg}, "meta" => meta} = response.body
+      assert msg =~ "security policy"
+      assert meta["state"] == "failed"
 
       # Verify the work order failed
       work_order =
@@ -693,7 +702,7 @@ defmodule Lightning.WebAndWorkerTest do
 
       assert response.status == 201
 
-      final_state = response.body
+      assert %{"data" => final_state, "meta" => _meta} = response.body
 
       # The final_state is keyed by job ID. When the same job is reached
       # twice (step 5), the second entry gets a "-1" suffix.
@@ -795,7 +804,7 @@ defmodule Lightning.WebAndWorkerTest do
         |> Tesla.post!("/i/#{trigger.id}", %{})
 
       assert response.status == 500
-      assert %{"message" => msg} = response.body
+      assert %{"data" => %{"message" => msg}, "meta" => _meta} = response.body
       assert msg =~ "security policy"
     end
 
@@ -837,7 +846,9 @@ defmodule Lightning.WebAndWorkerTest do
         |> Tesla.post!("/i/#{trigger.id}", %{"value" => 42})
 
       assert response.status == 200
-      assert response.body == %{"ack" => true, "received" => 42}
+
+      assert %{"data" => %{"ack" => true, "received" => 42}, "meta" => _} =
+               response.body
     end
 
     @tag :integration
@@ -921,7 +932,9 @@ defmodule Lightning.WebAndWorkerTest do
 
       # input x=1 → step 1: x=2 → step 2: x=6 → step 4: x=7
       assert response.status == 202
-      assert response.body == %{"from" => "step-4", "x" => 7}
+
+      assert %{"data" => %{"from" => "step-4", "x" => 7}, "meta" => _} =
+               response.body
 
       %{entries: steps} = Invocation.list_steps_for_project(project)
       assert Enum.count(steps) == 6
@@ -970,7 +983,9 @@ defmodule Lightning.WebAndWorkerTest do
         |> Tesla.post!("/i/#{trigger.id}", %{"value" => 42})
 
       assert response.status == 200
-      assert response.body == %{"ack" => true, "received" => 42}
+
+      assert %{"data" => %{"ack" => true, "received" => 42}, "meta" => _} =
+               response.body
 
       # Confirm erase_all actually took effect: the step's output dataclip
       # was persisted with the body wiped. The webhook response made it

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -1849,9 +1849,11 @@ defmodule LightningWeb.RunChannelTest do
       refute_receive {:webhook_response, _, _}
     end
 
-    test "broadcasts final state as body on success with no captured response",
+    test "broadcasts envelope with final state on success with no captured response",
          %{
-           socket: socket
+           socket: socket,
+           run: run,
+           work_order: work_order
          } do
       final_state = %{"data" => %{"result" => "ok"}}
 
@@ -1862,7 +1864,12 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 201, ^final_state}
+      assert_receive {:webhook_response, 201, body}
+
+      assert %{data: ^final_state, meta: meta} = body
+      assert meta.run_id == run.id
+      assert meta.work_order_id == work_order.id
+      assert meta.state == :success
     end
 
     test "broadcasts security message on error with no captured response", %{
@@ -1877,7 +1884,9 @@ defmodule LightningWeb.RunChannelTest do
 
       assert_reply ref, :ok, nil
 
-      assert_receive {:webhook_response, 500, %{message: message}}
+      assert_receive {:webhook_response, 201,
+                      %{data: %{message: message}, meta: _meta}}
+
       assert message =~ "failed"
       assert message =~ "security policy"
     end
@@ -1897,7 +1906,7 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 200, ^final_state}
+      assert_receive {:webhook_response, 200, %{data: ^final_state, meta: _meta}}
     end
 
     test "uses configured error_code on error", %{
@@ -1914,7 +1923,9 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 422, %{message: _}}
+
+      assert_receive {:webhook_response, 422,
+                      %{data: %{message: _}, meta: _meta}}
     end
 
     test "uses 201 on success when only error_code is configured", %{
@@ -1932,7 +1943,7 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 201, ^final_state}
+      assert_receive {:webhook_response, 201, %{data: ^final_state, meta: _meta}}
     end
 
     test "does not broadcast for runs with no starting trigger", %{
@@ -1978,7 +1989,9 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 200, ^override_body}
+
+      assert_receive {:webhook_response, 200,
+                      %{data: ^override_body, meta: _meta}}
     end
 
     test "last step:complete with a webhook_response wins (last-write-wins)",
@@ -2004,7 +2017,7 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 202, ^last_body}
+      assert_receive {:webhook_response, 202, %{data: ^last_body, meta: _meta}}
     end
 
     test "step without webhook_response does not clear a previously captured one",
@@ -2028,7 +2041,9 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 200, ^captured_body}
+
+      assert_receive {:webhook_response, 200,
+                      %{data: ^captured_body, meta: _meta}}
     end
 
     test "float status in webhook_response is normalised to integer", %{
@@ -2049,10 +2064,12 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 200, ^override_body}
+
+      assert_receive {:webhook_response, 200,
+                      %{data: ^override_body, meta: _meta}}
     end
 
-    test "webhook_response with only status uses default body", %{
+    test "webhook_response with only status uses default body envelope", %{
       socket: socket,
       run: run,
       job: job
@@ -2068,7 +2085,8 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 200, ^final_state}
+
+      assert_receive {:webhook_response, 200, %{data: ^final_state, meta: _meta}}
     end
 
     test "webhook_response with only body uses config status code", %{
@@ -2090,7 +2108,7 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 202, ^custom_body}
+      assert_receive {:webhook_response, 202, %{data: ^custom_body, meta: _meta}}
     end
 
     test "webhook_response with only body falls back to 201 when no config", %{
@@ -2109,7 +2127,7 @@ defmodule LightningWeb.RunChannelTest do
         })
 
       assert_reply ref, :ok, nil
-      assert_receive {:webhook_response, 201, ^custom_body}
+      assert_receive {:webhook_response, 201, %{data: ^custom_body, meta: _meta}}
     end
 
     test "malformed status in webhook_response yields 201 with explanation", %{
@@ -2129,7 +2147,9 @@ defmodule LightningWeb.RunChannelTest do
 
       assert_reply ref, :ok, nil
 
-      assert_receive {:webhook_response, 201, %{message: message}}
+      assert_receive {:webhook_response, 201,
+                      %{data: %{message: message}, meta: _meta}}
+
       assert message =~ "webhook_response was malformed"
       assert message =~ "status"
     end
@@ -2151,7 +2171,9 @@ defmodule LightningWeb.RunChannelTest do
 
       assert_reply ref, :ok, nil
 
-      assert_receive {:webhook_response, 201, %{message: message}}
+      assert_receive {:webhook_response, 201,
+                      %{data: %{message: message}, meta: _meta}}
+
       assert message =~ "webhook_response was malformed"
       assert message =~ "body"
     end
@@ -2175,7 +2197,9 @@ defmodule LightningWeb.RunChannelTest do
 
       assert_reply ref, :ok, nil
 
-      assert_receive {:webhook_response, 500, %{message: message}}
+      assert_receive {:webhook_response, 201,
+                      %{data: %{message: message}, meta: _meta}}
+
       assert message =~ "webhook_response was malformed"
     end
 
@@ -2201,7 +2225,9 @@ defmodule LightningWeb.RunChannelTest do
 
       assert_reply ref, :ok, nil
 
-      assert_receive {:webhook_response, 422, %{message: message}}
+      assert_receive {:webhook_response, 422,
+                      %{data: %{message: message}, meta: _meta}}
+
       assert message =~ "webhook_response was malformed"
     end
   end


### PR DESCRIPTION
## Description

The configurable webhook responses change in 2.16.4 dropped the `{data, meta}` envelope from synchronous webhook replies, breaking consumers that read `response.data.data.*` (e.g. Palladium's Ethiopia MPI workflow).

Wrap the broadcast body in `%{data: body, meta: meta}` for every case — default success state, default failure security message, and custom webhookResponse overrides — so the original shape is restored while preserving the 2.16.4 features (per-trigger status codes, custom body override, security message on failure).

Default response status is now 201 for all states; per-trigger success_code / error_code overrides still apply.

Closes #4785


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
