### PR TITLE
ci: run mix deps.audit and hex.audit in lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,18 @@ jobs:
           command: |
             sudo -u lightning mix sobelow --threshold medium || echo "sobelow" >> /tmp/lint_failed
       - run:
+          name: "Check for known-vulnerable Hex dependencies"
+          when: always
+          command: |
+            sudo -u lightning mix deps.audit \
+              --ignore-advisory-ids GHSA-g2wm-735q-3f56 \
+              || echo "deps.audit" >> /tmp/lint_failed
+      - run:
+          name: "Check for retired Hex packages"
+          when: always
+          command: |
+            sudo -u lightning mix hex.audit || echo "hex.audit" >> /tmp/lint_failed
+      - run:
           name: "Verify all checks passed"
           when: always
           command: |


### PR DESCRIPTION
## Description

This PR adds two new steps to the CircleCI `lint` job:

- `mix deps.audit` — scans `mix.lock` against the GitHub Security Advisory
  DB (provided by the `mix_audit` package added in #4789).
- `mix hex.audit` — built-in Hex check for retired packages.

Both run via the existing `/tmp/lint_failed` aggregator (`when: always`)
so a failure in one doesn't short-circuit the rest of the lint suite.

The `deps.audit` step ignores `GHSA-g2wm-735q-3f56` — a low-severity
cowlib cookie issue with no upstream fix. We don't construct cookies
server-side from untrusted input, so it isn't reachable; #4789 has the
full rationale.

Re: #4789

## Validation steps

1. CI lint job should now run two additional steps after `sobelow`:
   "Check for known-vulnerable Hex dependencies" and "Check for retired
   Hex packages".
2. With #4789 merged into this branch's base, both new steps should pass.
3. To verify the failure path, temporarily remove `--ignore-advisory-ids`
   and confirm the job fails with `deps.audit` in the aggregator output.

## Additional notes for the reviewer

- **Depends on #4789** — the `mix_audit` dep ships there. This branch is
  cut from `security/bump-vulnerable-deps` for that reason; once #4789
  merges this rebases cleanly onto main.
- No CHANGELOG entry — CI-only changes (e.g. #4760, #4378) haven't
  historically touched the changelog.
- If/when upstream patches `GHSA-g2wm-735q-3f56`, the `--ignore-advisory-ids`
  flag should be removed.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [x] I have implemented and tested all related **authorization policies**.
      (n/a — CI config only)
- [x] I have updated the **changelog**. (n/a — CI-only, per repo convention)
- [x] I have ticked a box in "AI usage" in this PR