### PR TITLE
Fix RunChannel crash when wiping non-eligible dataclips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Fixed
 
+- Run channel crashes when wiping `global` dataclip
+  [#4795](https://github.com/OpenFn/lightning/issues/4795)
+
 ### Security
 
 - Bumped `plug` (1.19.2), `cowboy` (2.15.0), `cowlib` (2.16.1), `postgrex`

--- a/lib/lightning/runs.ex
+++ b/lib/lightning/runs.ex
@@ -179,9 +179,13 @@ defmodule Lightning.Runs do
     |> select([d], d)
     |> Lightning.Invocation.Query.wipe_dataclips()
     |> Repo.update_all([])
-    |> then(fn {1, [dataclip]} ->
-      Events.dataclip_updated(run.id, dataclip)
-      :ok
+    |> then(fn
+      {1, [dataclip]} ->
+        Events.dataclip_updated(run.id, dataclip)
+        :ok
+
+      {0, []} ->
+        :ok
     end)
   end
 

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -356,6 +356,22 @@ defmodule LightningWeb.RunChannelTest do
       refute body
     end
 
+    @tag project_retention_policy: :erase_all
+    test "fetch:dataclip does not wipe :global dataclip body for projects with erase_all retention policy",
+         %{socket: socket, dataclip: dataclip} do
+      dataclip
+      |> Ecto.Changeset.change(type: :global, body: %{})
+      |> Repo.update!()
+
+      ref = push(socket, "fetch:dataclip", %{})
+
+      assert_reply ref, :ok, {:binary, "{}"}
+
+      %{wiped_at: wiped_at, body: body} = get_dataclip_with_body(dataclip.id)
+      assert is_nil(wiped_at)
+      assert body == %{}
+    end
+
     @tag project_retention_policy: :retain_all
     test "fetch:dataclip wipes dataclip body for projects with retain_all retention policy",
          context do


### PR DESCRIPTION
## Description

Runs.wipe_dataclips/1 pattern-matched Repo.update_all as {1, [dataclip]}, but the underlying query only touches :http_request, :step_result, and :saved_input dataclips. For other types — notably the :global dataclip that Scheduler.invoke_cronjob/1 seeds for the first cron run — the update affects zero rows and the channel crashes with FunctionClauseError.

Most often triggered by the first cron run on an :erase_all project, where save_dataclips: false makes fetch:dataclip call wipe_dataclips/1.

Closes #4795

## Validation steps

1. Run the new regression test on this branch — it passes here and fails on `main` with `FunctionClauseError` in `Lightning.Runs.wipe_dataclips/1`:
   ```
   mix test test/lightning_web/channels/run_channel_test.exs:360
   ```
2. Run the full channel test file to confirm no regression to the existing `:http_request` wipe path:
   ```
   mix test test/lightning_web/channels/run_channel_test.exs
   ```


## Additional notes for the reviewer

1. `:global` dataclips are intentionally outside the per-run wipe set in `Lightning.Invocation.Query.wipe_dataclips/1`. The scheduler seeds them with `body: %{}` and they carry no user input to clear, so the per-run wipe has nothing to do — the new `{0, _}` clause just makes that a no-op rather than a crash. Do we want to wipe `:global` dataclips? @taylordowns2000 @stuartc I'll need your input here
2. They are not leaked: orphaned, unnamed dataclips older than the project's `history_retention_period` are still deleted by `Lightning.Projects.delete_history_for/1` (`lib/lightning/projects.ex:1571`), and that sweep runs regardless of dataclip type. So `:global` dataclips simply live until the retention sweep collects them instead of being wiped per-run.
3. The pattern-match bug has been latent since #1844 ("Retention Periods"); it only began firing on staging recently, when a project there started exercising the cron + `:erase_all` combination (1,551 events over 5 days, staging only — no production events yet).

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR