### PR TITLE
Can't purge projects that have project oauth clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to
 
 ### Fixed
 
+- Fix `purge_deleted` Oban job crashing when a soft-deleted project has
+  associated OAuth clients. The `project_oauth_clients` join rows are now
+  cleaned up alongside the other project-scoped deletes in
+  `ProjectHook.handle_delete_project/1`.
+  [#4807](https://github.com/OpenFn/lightning/pull/4807)
 - Bump Tesla from 1.15.3 to 1.18.2 to pick up the streaming-error fix
   ([elixir-tesla/tesla#819](https://github.com/elixir-tesla/tesla/pull/819)).
   The older adapter raised `CaseClauseError` when Finch reported a transport

--- a/lib/lightning/extensions/project_hook.ex
+++ b/lib/lightning/extensions/project_hook.ex
@@ -32,6 +32,7 @@ defmodule Lightning.Extensions.ProjectHook do
     Projects.project_workflows_query(project) |> Repo.delete_all()
     Projects.project_users_query(project) |> Repo.delete_all()
     Projects.project_credentials_query(project) |> Repo.delete_all()
+    Projects.project_oauth_clients_query(project) |> Repo.delete_all()
     Projects.delete_project_dataclips(project)
 
     project

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -22,6 +22,7 @@ defmodule Lightning.Projects do
   alias Lightning.Projects.Events
   alias Lightning.Projects.Project
   alias Lightning.Projects.ProjectCredential
+  alias Lightning.Projects.ProjectOauthClient
   alias Lightning.Projects.ProjectUser
   alias Lightning.Projects.Sandboxes
   alias Lightning.Repo
@@ -828,6 +829,10 @@ defmodule Lightning.Projects do
 
   def project_credentials_query(project) do
     from(pc in ProjectCredential, where: pc.project_id == ^project.id)
+  end
+
+  def project_oauth_clients_query(project) do
+    from(poc in ProjectOauthClient, where: poc.project_id == ^project.id)
   end
 
   def project_dataclips_query(project) do

--- a/test/lightning/install_adaptor_icons_test.exs
+++ b/test/lightning/install_adaptor_icons_test.exs
@@ -18,8 +18,13 @@ defmodule Lightning.InstallAdaptorIconsTest do
                        )
   setup do
     File.mkdir_p(@icons_path)
+    previous_shell = Mix.shell()
     Mix.shell(Mix.Shell.Process)
-    on_exit(fn -> File.rm_rf!(@icons_path) end)
+
+    on_exit(fn ->
+      Mix.shell(previous_shell)
+      File.rm_rf!(@icons_path)
+    end)
   end
 
   @tag :capture_log

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -448,6 +448,32 @@ defmodule Lightning.ProjectsTest do
       refute Repo.get(Lightning.Channels.ChannelRequest, request.id)
     end
 
+    test "delete_project/1 deletes project with associated oauth clients" do
+      project =
+        insert(:project,
+          scheduled_deletion:
+            Lightning.current_time() |> DateTime.truncate(:second)
+        )
+
+      oauth_client = insert(:oauth_client)
+
+      project_oauth_client =
+        insert(:project_oauth_client,
+          project: project,
+          oauth_client: oauth_client
+        )
+
+      assert {:ok, %Project{}} = Projects.delete_project(project)
+
+      refute Repo.get(
+               Lightning.Projects.ProjectOauthClient,
+               project_oauth_client.id
+             )
+
+      assert Repo.get(Lightning.Credentials.OauthClient, oauth_client.id),
+             "The OAuth client itself should survive — only the join row is project-scoped"
+    end
+
     test "change_project/1 returns a project changeset" do
       project = project_fixture()
       assert %Ecto.Changeset{} = Projects.change_project(project)


### PR DESCRIPTION
## Description

The `project_oauth_clients` FK on `projects` was created with the default
`on_delete: :nothing`, and `ProjectHook.handle_delete_project/1` never deleted
the join rows before calling `Repo.delete(project)`. So any project that has
an OAuth client attached fails to purge — the scheduled `purge_deleted` Oban
job crashes with a `project_oauth_clients_project_id_fkey` constraint error
and the project is stuck in the soft-deleted state forever.

Fix is straightforward: clean up the join rows alongside the other
project-scoped deletes in `ProjectHook.handle_delete_project/1`. The OAuth
client itself is not project-scoped so it's left alone.

Drive-by: also includes a small fix for a flaky `InstallAdaptorIconsTest`
where `Mix.shell` wasn't being restored between tests.

## Validation steps

1. New regression test in `test/lightning/projects_test.exs` covers it —
   insert a project with a `project_oauth_client`, delete the project,
   assert the join row is gone and the OAuth client survives.
2. `mix test test/lightning/projects_test.exs` — all green.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR