### PR TITLE
Fix GitHub repo list failing to load on slow installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   error mid-stream, taking down the AI assistant worker; 1.16+ handles the
   3-tuple error shape gracefully.
   [#4781](https://github.com/OpenFn/lightning/issues/4781)
+- Slow GitHub responses cause repo list to fail to load on project settings
+  [#4810](https://github.com/OpenFn/lightning/issues/4810)
 
 ## [2.16.6] - 2026-05-27
 

--- a/lib/lightning_web/live/project_live/github_sync_component.ex
+++ b/lib/lightning_web/live/project_live/github_sync_component.ex
@@ -326,9 +326,13 @@ defmodule LightningWeb.ProjectLive.GithubSyncComponent do
 
       repos =
         installations
-        |> Task.async_stream(fn installation ->
-          {installation["id"], fetch_repos(installation["id"])}
-        end)
+        |> Task.async_stream(
+          fn installation ->
+            {installation["id"], fetch_repos(installation["id"])}
+          end,
+          timeout: 30_000,
+          on_timeout: :kill_task
+        )
         |> Stream.filter(&match?({:ok, _}, &1))
         |> Map.new(fn {:ok, val} -> val end)
 


### PR DESCRIPTION
## Description

Fixes a captured error on `/projects/:id/settings` where the GitHub sync section fails to load repos list when one of a user's GitHub installations takes >5s to return its repos.

By default, `Task.async_stream` has a timeout of `5 secs`, this PR bumps it up to `30 secs`


Closes #4810

## Validation steps

1. Existing version-control test suite still passes:
   `mix test test/lightning_web/live/project_live_test.exs:4132`
2. To reproduce the original bug locally, add a `Process.sleep(5005)` inside
   the `Task.async_stream` callback in
   `lib/lightning_web/live/project_live/github_sync_component.ex` on `main`
   and open the project settings page — the GitHub section shows the
   failure state. With this fix the section loads (slow installations are
   dropped).
3. The existing `Stream.filter(&match?({:ok, _}, &1))` was meant to drop failed tasks but only works under `on_timeout: :kill_task`. This PR sets that, plus a 30s per-task timeout, so slow installations are dropped and the rest of the user's installations and repos still render.

## Additional notes for the reviewer

1. No test was added for the timeout itself — exercising the new 30s threshold
   in a test would make it slow and flaky. The existing 30-test version-control
   suite covers the happy path.
2. The inner pagination call (`maybe_fetch_remaining_repos`) already uses
   `timeout: :infinity`, so a single installation's full repo fetch can easily
   exceed 5s. 30s on the outer task is a generous but bounded upper limit.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
