### PR TITLE
Avoid exception when fetching auth methods for an unpersisted trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   [#4781](https://github.com/OpenFn/lightning/issues/4781)
 - Slow GitHub responses cause repo list to fail to load on project settings
   [#4810](https://github.com/OpenFn/lightning/issues/4810)
+- Workflow channel raises an exception when fetching trigger auth methods for an
+  unpersisted trigger [#4819](https://github.com/OpenFn/lightning/issues/4819)
 
 ## [2.16.6] - 2026-05-27
 

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -512,24 +512,23 @@ defmodule LightningWeb.WorkflowChannel do
       trigger_id: #{trigger_id}
     """)
 
-    async_task(socket, "request_trigger_auth_methods", fn ->
-      trigger = Lightning.Repo.get!(Lightning.Workflows.Trigger, trigger_id)
+    project_id = socket.assigns.project.id
 
+    async_task(socket, "request_trigger_auth_methods", fn ->
       webhook_auth_methods_query =
         from(wam in Lightning.Workflows.WebhookAuthMethod,
+          join: t in assoc(wam, :triggers),
+          where: t.id == ^trigger_id,
+          where: wam.project_id == ^project_id,
           where: is_nil(wam.scheduled_deletion),
           order_by: wam.name
         )
 
-      trigger_with_auth =
-        Lightning.Repo.preload(trigger,
-          webhook_auth_methods: webhook_auth_methods_query
-        )
+      webhook_auth_methods = Repo.all(webhook_auth_methods_query)
 
       %{
         trigger_id: trigger_id,
-        webhook_auth_methods:
-          render_webhook_auth_methods(trigger_with_auth.webhook_auth_methods)
+        webhook_auth_methods: render_webhook_auth_methods(webhook_auth_methods)
       }
     end)
   end

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -2110,6 +2110,26 @@ defmodule LightningWeb.WorkflowChannelTest do
       assert log =~ trigger.id
     end
 
+    test "request_trigger_auth_methods returns empty list unpersisted trigger_id",
+         %{
+           socket: socket
+         } do
+      unsaved_trigger_id = Ecto.UUID.generate()
+
+      ref =
+        push(socket, "request_trigger_auth_methods", %{
+          "trigger_id" => unsaved_trigger_id
+        })
+
+      assert_reply ref, :ok, %{
+        trigger_id: returned_trigger_id,
+        webhook_auth_methods: methods
+      }
+
+      assert returned_trigger_id == unsaved_trigger_id
+      assert methods == []
+    end
+
     test "update_trigger_auth_methods associates auth methods with trigger", %{
       socket: socket,
       workflow: workflow,


### PR DESCRIPTION
## Description

`request_trigger_auth_methods` used `Repo.get!` to load the trigger, which raised `Ecto.NoResultsError` when the trigger only existed in the collaborative editor document and was not yet persisted. 
This PR queries the webhook auth methods directly via the trigger association so an unpersisted trigger returns an empty list instead.

Fixes #4819

## Validation steps

This is hard to reproduce given it happens in an async task and therefore doesn't bubble up to the UI.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
