### PR TITLE
Job code AI assistant: Show statuses streamed after the text answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to
 
 ### Added
 
+- The job code AI assistant now shows the progress statuses (e.g. "Writing
+  code...") that Apollo streams _after_ the text answer while it generates code,
+  displayed below the answer in the same style as the initial "Thinking..."
+  indicator. Statuses are surfaced in whatever order Apollo sends them.
+  [#PR](https://github.com/OpenFn/lightning/pull/PR)
+
 ### Changed
 
 - Stop reporting expected credential-resolution failures (OAuth re-auth needed,
@@ -38,7 +44,8 @@ and this project adheres to
   the whole run. The search vector is now built off the insert path by a
   background `Lightning.Invocation.DataclipSearchVectorWorker` (sharing the
   `search_indexing` queue with the log-lines worker), making dataclip search
-  eventually consistent. [#4800](https://github.com/OpenFn/lightning/issues/4800)
+  eventually consistent.
+  [#4800](https://github.com/OpenFn/lightning/issues/4800)
 - Channel join crashes when multiple users open the same workflow concurrently
   [#4802](https://github.com/OpenFn/lightning/issues/4802)
 - Fix `purge_deleted` Oban job crashing when a soft-deleted project has

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -676,9 +676,7 @@ export function MessageList({
                   {!isStreaming(message) && message.status === 'processing' && (
                     <div className="flex items-center gap-2 text-gray-600">
                       <div className="flex items-center gap-1">
-                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" />
-                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.15s]" />
-                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
+                        <BouncingDots />
                       </div>
                     </div>
                   )}

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -15,6 +15,18 @@ const PROSE_CLASSES =
   'text-sm text-gray-700 leading-relaxed prose prose-sm max-w-none prose-headings:font-medium prose-h1:text-lg prose-h1:text-gray-900 prose-h1:mb-3 prose-h2:text-base prose-h2:text-gray-900 prose-h2:mb-2 prose-h2:mt-5 prose-h3:text-sm prose-h3:text-gray-900 prose-h3:mb-2 prose-h3:font-semibold prose-p:mb-3 prose-p:last:mb-0 prose-p:text-gray-700 prose-ul:list-disc prose-ul:pl-5 prose-ul:mb-3 prose-ul:space-y-1 prose-ol:list-decimal prose-ol:pl-5 prose-ol:mb-3 prose-ol:space-y-1 prose-li:text-gray-700 prose-strong:font-medium prose-strong:text-gray-900 prose-em:italic prose-a:text-primary-600 prose-a:hover:text-primary-700 prose-a:underline prose-a:font-normal prose-code:px-1.5 prose-code:py-0.5 prose-code:bg-gray-100 prose-code:text-gray-800 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal prose-code:before:content-none prose-code:after:content-none prose-pre:rounded-md prose-pre:bg-slate-100 prose-pre:border-2 prose-pre:border-slate-200 prose-pre:text-slate-800 prose-pre:p-4 prose-pre:overflow-x-auto prose-pre:text-xs prose-pre:font-mono prose-pre:mb-4';
 
 /**
+ * Three-dot bouncing "typing" indicator, shared by the pre-text loading
+ * indicator and the post-text streaming status.
+ */
+const BouncingDots = () => (
+  <>
+    <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" />
+    <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.15s]" />
+    <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
+  </>
+);
+
+/**
  * Custom code block component for react-markdown
  * Renders code with COPY/ADD action buttons
  */
@@ -555,9 +567,7 @@ export function MessageList({
                       data-testid="streaming-status"
                     >
                       <div className="flex items-center gap-1">
-                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" />
-                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.15s]" />
-                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
+                        <BouncingDots />
                       </div>
                       <span className="text-xs text-gray-400 italic">
                         {streamingStatus}
@@ -787,9 +797,7 @@ export function MessageList({
           <div className="max-w-3xl mx-auto">
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-1">
-                <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" />
-                <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.15s]" />
-                <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
+                <BouncingDots />
               </div>
               <span className="text-xs text-gray-400 italic">
                 {streamingStatus}

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -546,6 +546,25 @@ export function MessageList({
                     className={PROSE_CLASSES}
                   />
 
+                  {/* Status (e.g. "Generating code...") Apollo may stream
+                      after the text answer, while we wait for code. Same
+                      visual as the pre-text loading indicator. */}
+                  {isStreaming(message) && streamingStatus && (
+                    <div
+                      className="flex items-center gap-2"
+                      data-testid="streaming-status"
+                    >
+                      <div className="flex items-center gap-1">
+                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" />
+                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.15s]" />
+                        <span className="inline-block w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0.3s]" />
+                      </div>
+                      <span className="text-xs text-gray-400 italic">
+                        {streamingStatus}
+                      </span>
+                    </div>
+                  )}
+
                   {!isStreaming(message) && message.code && (
                     <div className="rounded-lg overflow-hidden border border-gray-200 bg-white">
                       <div

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -152,6 +152,14 @@ export class AIChannelRegistry {
    * Buffer a streaming text chunk and start draining word-by-word.
    */
   private bufferStreamingChunk(content: string): void {
+    // A text chunk arriving over the wire supersedes any active status
+    // (e.g. "Thinking...", "Writing code..."). Clearing here — at network
+    // arrival, not in the slow char-by-char drain — means a status Apollo
+    // streams *after* the text answer survives, while one followed by more
+    // text is correctly dismissed.
+    if (this.store.getSnapshot().streamingStatus) {
+      this.store.setStreamingStatus(null);
+    }
     this.streamingBuffer += content;
     this.startDraining();
   }

--- a/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
+++ b/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
@@ -576,20 +576,12 @@ export const createAIAssistantStore = (): AIAssistantStore => {
 
   const _appendStreamingChunk = (content: string) => {
     state = produce(state, draft => {
-      const hadContent = !!draft.streamingContent;
       draft.streamingContent = (draft.streamingContent || '') + content;
-      // Clear the pre-text status (e.g. "Thinking...") only on the first
-      // chunk. Text drains one char at a time, so nulling on every chunk
-      // would wipe any status Apollo streams *after* the text answer
-      // (e.g. "Writing code...") before it's ever visible.
-      if (!hadContent) {
-        draft.streamingStatus = null;
-      }
     });
     notify('_appendStreamingChunk');
   };
 
-  const setStreamingStatus = (text: string) => {
+  const setStreamingStatus = (text: string | null) => {
     state = produce(state, draft => {
       draft.streamingStatus = text;
     });

--- a/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
+++ b/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
@@ -576,9 +576,15 @@ export const createAIAssistantStore = (): AIAssistantStore => {
 
   const _appendStreamingChunk = (content: string) => {
     state = produce(state, draft => {
+      const hadContent = !!draft.streamingContent;
       draft.streamingContent = (draft.streamingContent || '') + content;
-      // Clear status (e.g. "Thinking...") once actual content starts arriving
-      draft.streamingStatus = null;
+      // Clear the pre-text status (e.g. "Thinking...") only on the first
+      // chunk. Text drains one char at a time, so nulling on every chunk
+      // would wipe any status Apollo streams *after* the text answer
+      // (e.g. "Writing code...") before it's ever visible.
+      if (!hadContent) {
+        draft.streamingStatus = null;
+      }
     });
     notify('_appendStreamingChunk');
   };

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -199,7 +199,7 @@ export interface AIAssistantStore {
   ) => void;
   _setProcessingState: (isProcessing: boolean) => void;
   _appendStreamingChunk: (content: string) => void;
-  setStreamingStatus: (text: string) => void;
+  setStreamingStatus: (text: string | null) => void;
   _setStreamingChanges: (changes: Record<string, unknown>) => void;
   _clearStreaming: () => void;
   _connectChannel: (channelProvider: unknown) => () => void;

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -155,6 +155,44 @@ describe('MessageList', () => {
       expect(screen.getByText('Question')).toBeInTheDocument();
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
+
+    it('should show streaming status below the text answer once content has streamed', () => {
+      const messages = [
+        createMockAIMessage({ role: 'user', content: 'Question' }),
+      ];
+
+      render(
+        <MessageList
+          messages={messages}
+          isLoading
+          streamingContent="Here is the answer"
+          streamingStatus="Generating code..."
+        />
+      );
+
+      // Pre-text loading indicator is gone once content streams in
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+
+      // Status renders below the streamed text, reusing the bouncing dots
+      const status = screen.getByTestId('streaming-status');
+      expect(status).toHaveTextContent('Generating code...');
+      expect(status.querySelectorAll('.animate-bounce')).toHaveLength(3);
+    });
+
+    it('should not show streaming status when none is set', () => {
+      const messages = [
+        createMockAIMessage({ role: 'user', content: 'Question' }),
+      ];
+
+      render(
+        <MessageList
+          messages={messages}
+          streamingContent="Here is the answer"
+        />
+      );
+
+      expect(screen.queryByTestId('streaming-status')).not.toBeInTheDocument();
+    });
   });
 
   describe('Message Status', () => {

--- a/assets/test/collaborative-editor/lib/AIChannelRegistry.test.ts
+++ b/assets/test/collaborative-editor/lib/AIChannelRegistry.test.ts
@@ -1,0 +1,74 @@
+/**
+ * AIChannelRegistry - Tests for streaming chunk buffering
+ *
+ * Focuses on the streaming-status handoff that lives in the channel buffer:
+ * a text chunk arriving over the wire supersedes any active status, while a
+ * status Apollo streams *after* the text answer must survive the slow
+ * char-by-char drain.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { AIChannelRegistry } from '../../../js/collaborative-editor/lib/AIChannelRegistry';
+import { createAIAssistantStore } from '../../../js/collaborative-editor/stores/createAIAssistantStore';
+import type { AIAssistantStore } from '../../../js/collaborative-editor/types/ai-assistant';
+import { createMockJobCodeContext } from '../__helpers__/aiAssistantHelpers';
+import { createMockPhoenixChannel } from '../mocks/phoenixChannel';
+import type { MockPhoenixChannel } from '../mocks/phoenixChannel';
+
+describe('AIChannelRegistry streaming', () => {
+  const topic = 'ai_assistant:job_code:session-1';
+  let store: AIAssistantStore;
+  let channel: MockPhoenixChannel;
+  let registry: AIChannelRegistry;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    store = createAIAssistantStore();
+    channel = createMockPhoenixChannel(topic);
+
+    const socket = {
+      channel: () => channel,
+      isConnected: () => true,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registry = new AIChannelRegistry(socket as any, store as any);
+
+    // Subscribe wires up the channel event handlers (streaming_chunk, etc.)
+    registry.subscribe(topic, 'subscriber-1', createMockJobCodeContext());
+  });
+
+  afterEach(() => {
+    registry.destroy();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('clears an active status when a text chunk arrives over the wire', () => {
+    // A status is showing (e.g. "Writing code...") when text starts streaming.
+    channel._test.emit('streaming_status', { text: 'Writing code...' });
+    expect(store.getSnapshot().streamingStatus).toBe('Writing code...');
+
+    channel._test.emit('streaming_chunk', { content: 'Here is the answer' });
+
+    // Cleared at network arrival, before any draining happens.
+    expect(store.getSnapshot().streamingStatus).toBeNull();
+  });
+
+  it('keeps a status streamed after the text answer through the char drain', () => {
+    // Text answer starts streaming first.
+    channel._test.emit('streaming_chunk', { content: 'Answer' });
+
+    // Apollo then streams a status *after* the text.
+    channel._test.emit('streaming_status', { text: 'Writing code...' });
+
+    // Drain the entire buffer char-by-char (15ms per char).
+    vi.advanceTimersByTime(500);
+
+    // The per-char drain must not wipe a status set after the text.
+    expect(store.getSnapshot().streamingStatus).toBe('Writing code...');
+    expect(store.getSnapshot().streamingContent).toBe('Answer');
+  });
+});

--- a/assets/test/collaborative-editor/stores/createAIAssistantStore.test.ts
+++ b/assets/test/collaborative-editor/stores/createAIAssistantStore.test.ts
@@ -337,20 +337,21 @@ describe('createAIAssistantStore', () => {
   });
 
   describe('Streaming Status', () => {
-    it('should clear a pre-text status on the first chunk only', () => {
-      store.setStreamingStatus('Thinking...');
-      store._appendStreamingChunk('Here');
-
-      // First chunk clears the pre-text status
-      expect(store.getSnapshot().streamingStatus).toBeNull();
-
-      // A status streamed after the text answer survives later chunks
-      // (text drains one char at a time, so this must not be wiped).
+    it('should not clear the status when content is appended', () => {
+      // Clearing on new text is the channel buffer's job (at network
+      // arrival), not the drain — so the store must leave status alone.
       store.setStreamingStatus('Writing code...');
-      store._appendStreamingChunk(' is the answer');
+      store._appendStreamingChunk('Here is the answer');
 
       expect(store.getSnapshot().streamingStatus).toBe('Writing code...');
       expect(store.getSnapshot().streamingContent).toBe('Here is the answer');
+    });
+
+    it('should clear the status when set to null', () => {
+      store.setStreamingStatus('Thinking...');
+      store.setStreamingStatus(null);
+
+      expect(store.getSnapshot().streamingStatus).toBeNull();
     });
 
     it('should clear the status once changes arrive', () => {

--- a/assets/test/collaborative-editor/stores/createAIAssistantStore.test.ts
+++ b/assets/test/collaborative-editor/stores/createAIAssistantStore.test.ts
@@ -336,6 +336,33 @@ describe('createAIAssistantStore', () => {
     });
   });
 
+  describe('Streaming Status', () => {
+    it('should clear a pre-text status on the first chunk only', () => {
+      store.setStreamingStatus('Thinking...');
+      store._appendStreamingChunk('Here');
+
+      // First chunk clears the pre-text status
+      expect(store.getSnapshot().streamingStatus).toBeNull();
+
+      // A status streamed after the text answer survives later chunks
+      // (text drains one char at a time, so this must not be wiped).
+      store.setStreamingStatus('Writing code...');
+      store._appendStreamingChunk(' is the answer');
+
+      expect(store.getSnapshot().streamingStatus).toBe('Writing code...');
+      expect(store.getSnapshot().streamingContent).toBe('Here is the answer');
+    });
+
+    it('should clear the status once changes arrive', () => {
+      store._appendStreamingChunk('Answer');
+      store.setStreamingStatus('Writing code...');
+
+      store._setStreamingChanges({ code: 'fn(s => s)' });
+
+      expect(store.getSnapshot().streamingStatus).toBeNull();
+    });
+  });
+
   describe('State Subscriptions', () => {
     it('should notify subscribers on state changes', () => {
       const subscriber = vi.fn();


### PR DESCRIPTION
## Description

If Apollo streams a thinking status (e.g. "Writing code…") after the text answer while job code is still being generated, it will now be displayed below the answer using the same indicator style as the pre-text "Thinking…" status. 

Closes #4832

Currently the order of events from Apollo when there are code changes is strictly stream status -> text -> stream status -> code. However, I tried to implement this in a way that will also work if we add more interleaved text/stream statuses. 

## Validation steps

1. Open a workflow step.
2. Ask the assistant (not the experimental global assistant) for code changes, or new code if generating from scratch. Ask for extensive changes requiring more than a couple of lines of changes.
3. Verify that you see: 
-> streaming statuses 
-> text explanation of what the assistant is going to do 
-> **new: another streaming status** 
-> code diffs are noted in the chat and displayed the code.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
