### PR TITLE
Sandboxes: handle credentials on merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ and this project adheres to
 - Ensure that credentials are properly transferred when merging a sandbox. This
   fixes a validation error which can occur on merge
   [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Free up a workflow's name when it is deleted by a merge, so a later merge can
+  reuse that name [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Replace the generic "validation error" on a failed sandbox merge with a clear
+  message, naming the conflicting workflow when there is one
+  [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Add a credential created in a sandbox to its full ancestor chain, so it
+  survives a merge into any ancestor
 
 ## [2.16.7] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ and this project adheres to
 - Consolidated run and work order state definitions into single source of truth
   by adding `Run.active_states/0`, `WorkOrder.states/0`, and
   `WorkOrder.active_states/0` and replacing all hardcoded state lists across the
-  codebase
-  [#4589](https://github.com/OpenFn/lightning/issues/4589)
+  codebase [#4589](https://github.com/OpenFn/lightning/issues/4589)
 
 ### Fixed
 
@@ -38,6 +37,9 @@ and this project adheres to
   single `Lightning.Collaboration.WorkflowResolver`, so the channel join and the
   session save path can no longer disagree on whether an id should INSERT or
   UPDATE. [#4830](https://github.com/OpenFn/lightning/issues/4830)
+- Ensure that credentials are properly transferred when merging a sandbox. This
+  fixes a validation error which can occur on merge
+  [#4831](https://github.com/OpenFn/lightning/issues/4831)
 
 ## [2.16.7] - 2026-06-04
 

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -592,12 +592,7 @@ defmodule Lightning.Projects.MergeProjects do
   end
 
   # Builds a map of `source_project_credential_id => target_project_credential_id`
-  # by matching on the shared underlying `credential_id`. A sandbox and its
-  # parent reference the same credentials, but via project-scoped
-  # `project_credentials` rows with different ids; this map translates a
-  # sandbox-scoped reference into the parent's equivalent. Source credentials
-  # the target project does not have map to `nil` (the reference is dropped, as
-  # it cannot be imported into the target project).
+  # by matching on the shared underlying `credential_id`
   defp build_credential_remap(
          source_project_credentials,
          target_project_credentials
@@ -610,9 +605,6 @@ defmodule Lightning.Projects.MergeProjects do
     end)
   end
 
-  # Rewrites every job's `project_credential_id` in the merged document using
-  # the source -> target credential map. Ids that are not source-scoped (target
-  # ids on passthrough jobs, or `nil`) are left untouched.
   defp remap_document_credentials(document, credential_map)
        when map_size(credential_map) == 0,
        do: document

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -51,16 +51,26 @@ defmodule Lightning.Projects.MergeProjects do
         opts
       ) do
     source_project =
-      Repo.preload(source_project, workflows: [:jobs, :triggers, :edges])
+      Repo.preload(source_project,
+        workflows: [:jobs, :triggers, :edges],
+        project_credentials: []
+      )
 
     target_project =
-      Repo.preload(target_project, workflows: [:jobs, :triggers, :edges])
+      Repo.preload(target_project,
+        workflows: [:jobs, :triggers, :edges],
+        project_credentials: []
+      )
 
-    merge_project(
-      Map.from_struct(source_project),
-      Map.from_struct(target_project),
-      opts
-    )
+    credential_map =
+      build_credential_remap(
+        source_project.project_credentials,
+        target_project.project_credentials
+      )
+
+    Map.from_struct(source_project)
+    |> merge_project(Map.from_struct(target_project), opts)
+    |> remap_document_credentials(credential_map)
   end
 
   def merge_project(source_project, target_project, opts) do
@@ -551,12 +561,13 @@ defmodule Lightning.Projects.MergeProjects do
             ])
             |> then(fn job_attrs ->
               if target_job do
-                job_attrs
-                |> Map.put(
-                  :project_credential_id,
-                  target_job.project_credential_id
-                )
-                |> Map.put(
+                # Keep the source's project_credential_id (remapped to the
+                # target project's credential later via
+                # remap_document_credentials/2) so credential changes made in
+                # the sandbox propagate. Keychains are project-scoped and are
+                # not remapped here, so the target's value is preserved.
+                Map.put(
+                  job_attrs,
                   :keychain_credential_id,
                   target_job.keychain_credential_id
                 )
@@ -584,6 +595,58 @@ defmodule Lightning.Projects.MergeProjects do
 
     {new_mapping, merged_from_source ++ deleted_targets}
   end
+
+  # Builds a map of `source_project_credential_id => target_project_credential_id`
+  # by matching on the shared underlying `credential_id`. A sandbox and its
+  # parent reference the same credentials, but via project-scoped
+  # `project_credentials` rows with different ids; this map translates a
+  # sandbox-scoped reference into the parent's equivalent. Source credentials
+  # the target project does not have map to `nil` (the reference is dropped, as
+  # it cannot be imported into the target project).
+  defp build_credential_remap(
+         source_project_credentials,
+         target_project_credentials
+       ) do
+    target_by_credential =
+      Map.new(target_project_credentials, &{&1.credential_id, &1.id})
+
+    Map.new(source_project_credentials, fn pc ->
+      {pc.id, Map.get(target_by_credential, pc.credential_id)}
+    end)
+  end
+
+  # Rewrites every job's `project_credential_id` in the merged document using
+  # the source -> target credential map. Ids that are not source-scoped (target
+  # ids on passthrough jobs, or `nil`) are left untouched.
+  defp remap_document_credentials(document, credential_map)
+       when map_size(credential_map) == 0,
+       do: document
+
+  defp remap_document_credentials(document, credential_map) do
+    Map.update(document, "workflows", [], fn workflows ->
+      Enum.map(workflows, &remap_workflow_credentials(&1, credential_map))
+    end)
+  end
+
+  defp remap_workflow_credentials(%{"jobs" => jobs} = workflow, credential_map) do
+    Map.put(
+      workflow,
+      "jobs",
+      Enum.map(jobs, &remap_job_credential(&1, credential_map))
+    )
+  end
+
+  defp remap_workflow_credentials(workflow, _credential_map), do: workflow
+
+  defp remap_job_credential(
+         %{"project_credential_id" => pc_id} = job,
+         credential_map
+       )
+       when not is_nil(pc_id) do
+    Map.put(job, "project_credential_id", Map.get(credential_map, pc_id, pc_id))
+  end
+
+  defp remap_job_credential(job, _credential_map), do: job
 
   defp build_merged_triggers(source_triggers, target_triggers, trigger_mappings) do
     # Process source triggers (matched and new)

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -561,13 +561,8 @@ defmodule Lightning.Projects.MergeProjects do
             ])
             |> then(fn job_attrs ->
               if target_job do
-                # Keep the source's project_credential_id (remapped to the
-                # target project's credential later via
-                # remap_document_credentials/2) so credential changes made in
-                # the sandbox propagate. Keychains are project-scoped and are
-                # not remapped here, so the target's value is preserved.
-                Map.put(
-                  job_attrs,
+                job_attrs
+                |> Map.put(
                   :keychain_credential_id,
                   target_job.keychain_credential_id
                 )

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -687,10 +687,7 @@ defmodule Lightning.Projects.Provisioner do
       {true, others} when map_size(others) == 0 ->
         changeset
         |> Map.put(:changes, others)
-        |> put_change(
-          :deleted_at,
-          DateTime.utc_now() |> DateTime.truncate(:second)
-        )
+        |> Workflows.soft_delete_changeset()
 
       {true, others} when map_size(others) > 0 ->
         changeset

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -62,6 +62,8 @@ defmodule Lightning.Projects.Sandboxes do
   alias Lightning.Workflows.WorkflowVersion
   alias Lightning.WorkflowVersions
 
+  require Logger
+
   @typedoc """
   Attributes for creating a new sandbox via `provision/3`.
 
@@ -163,24 +165,50 @@ defmodule Lightning.Projects.Sandboxes do
   * `source` - The sandbox project being merged
   * `target` - The project receiving the merge
   * `actor` - The user performing the merge
-  * `opts` - Merge options (`:selected_workflow_ids`, `:deleted_target_workflow_ids`)
+  * `opts` - Merge options (`:selected_workflow_ids`,
+    `:deleted_target_workflow_ids`, `:selected_credential_ids`)
+
+  ## Credential attachment
+
+  A credential that lives only in the sandbox (the target has no
+  `project_credential` for its underlying `credential_id`) would otherwise be
+  dropped on merge, since the remap only matches on shared credentials. Pass
+  `:selected_credential_ids` (a list of the sandbox `project_credential` ids the
+  caller chose to carry over) and each one is attached to the target before the
+  document is imported, so the remap finds a match instead of dropping it.
+  Sandbox `project_credentials` left out of the list stay dropped. Only regular
+  `project_credentials` are handled here; keychain credentials are out of scope.
 
   ## Returns
   * `{:ok, updated_target}` - Merge succeeded
-  * `{:error, reason}` - Workflow merge or collection sync failed
+  * `{:error, merge_error}` - Merge failed, classified into a domain reason
+
+  Failures are returned as typed reasons (see `t:merge_error/0`) so callers can
+  render user-facing copy without inspecting changeset internals. The full
+  validation detail is logged for diagnosis.
   """
+  @type merge_error ::
+          :merge_failed | Lightning.Extensions.UsageLimiting.message()
+
   @spec merge(Project.t(), Project.t(), User.t(), map()) ::
-          {:ok, Project.t()} | {:error, term()}
+          {:ok, Project.t()} | {:error, merge_error()}
   def merge(
         %Project{} = source,
         %Project{} = target,
         %User{} = actor,
         opts \\ %{}
       ) do
-    merge_doc = MergeProjects.merge_project(source, target, opts)
+    selected_credential_ids = Map.get(opts, :selected_credential_ids, [])
 
     Repo.transact(fn ->
-      with {:ok, updated_target} <-
+      with :ok <-
+             attach_selected_credentials(source, target, selected_credential_ids),
+           # Re-preload so the credential remap sees the just-attached
+           # associations; merge_project skips the preload if they're already loaded.
+           target =
+             Repo.preload(target, [project_credentials: []], force: true),
+           merge_doc = MergeProjects.merge_project(source, target, opts),
+           {:ok, updated_target} <-
              Provisioner.import_document(target, actor, merge_doc,
                allow_stale: true
              ),
@@ -188,6 +216,85 @@ defmodule Lightning.Projects.Sandboxes do
         {:ok, updated_target}
       end
     end)
+    |> case do
+      {:ok, _} = ok -> ok
+      {:error, reason} -> {:error, classify_merge_error(reason)}
+    end
+  end
+
+  # Attaches the chosen sandbox-only credentials to the target so the merge
+  # remap can match them. The credential diff is recomputed from the database
+  # rather than trusting the caller's list verbatim: only sandbox
+  # project_credentials whose underlying credential the target still lacks are
+  # attached, and ON CONFLICT DO NOTHING guards against a concurrent attach.
+  defp attach_selected_credentials(_source, _target, []), do: :ok
+
+  defp attach_selected_credentials(source, target, selected_credential_ids) do
+    selected_set = MapSet.new(selected_credential_ids)
+
+    target_credential_ids =
+      from(pc in ProjectCredential,
+        where: pc.project_id == ^target.id,
+        select: pc.credential_id
+      )
+      |> Repo.all()
+      |> MapSet.new()
+
+    rows =
+      from(pc in ProjectCredential,
+        where: pc.project_id == ^source.id,
+        select: %{id: pc.id, credential_id: pc.credential_id}
+      )
+      |> Repo.all()
+      |> Enum.filter(fn pc ->
+        MapSet.member?(selected_set, pc.id) and
+          not MapSet.member?(target_credential_ids, pc.credential_id)
+      end)
+      |> build_target_credential_rows(target.id)
+
+    Repo.insert_all(ProjectCredential, rows,
+      on_conflict: :nothing,
+      conflict_target: [:project_id, :credential_id]
+    )
+
+    :ok
+  end
+
+  defp build_target_credential_rows(source_credentials, target_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Enum.map(source_credentials, fn pc ->
+      %{
+        id: Ecto.UUID.generate(),
+        project_id: target_id,
+        credential_id: pc.credential_id,
+        inserted_at: now,
+        updated_at: now
+      }
+    end)
+  end
+
+  # A failed merge is sensitive (it can block or lose a user's work), so every
+  # failure is logged at :error to surface in Sentry. A usage-limit message is
+  # an expected, user-actionable block, so it passes through unlogged.
+  defp classify_merge_error(%Ecto.Changeset{} = changeset) do
+    Logger.error(
+      "Sandbox merge failed. #{inspect(merge_error_details(changeset))}"
+    )
+
+    :merge_failed
+  end
+
+  defp classify_merge_error(%{text: _} = usage_limit_message),
+    do: usage_limit_message
+
+  defp classify_merge_error(reason) do
+    Logger.error("Sandbox merge failed. #{inspect(reason)}")
+    :merge_failed
+  end
+
+  defp merge_error_details(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, _opts} -> message end)
   end
 
   @doc """

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -717,16 +717,10 @@ defmodule Lightning.Workflows do
         where: t.workflow_id == ^workflow.id
       )
 
-    new_name = resolve_name_for_pending_deletion(workflow)
-
     Multi.new()
     |> Multi.update(
       :workflow,
-      workflow
-      |> Workflow.request_deletion_changeset(%{
-        "deleted_at" => DateTime.utc_now()
-      })
-      |> Ecto.Changeset.put_change(:name, new_name)
+      soft_delete_changeset(Ecto.Changeset.change(workflow))
     )
     |> Multi.insert(:audit, Audit.marked_for_deletion(workflow.id, actor))
     |> Multi.update_all(
@@ -744,10 +738,39 @@ defmodule Lightning.Workflows do
     end)
   end
 
-  defp resolve_name_for_pending_deletion(%Workflow{
-         name: name,
-         project_id: project_id
-       }) do
+  @doc """
+  Marks a workflow deleted and frees its name for reuse, in one step.
+
+  The single soft-delete transition both `mark_for_deletion/3` and the
+  provisioner route through, so a deleted workflow can never keep its name
+  reserved on a hidden row.
+  """
+  @spec soft_delete_changeset(Ecto.Changeset.t(Workflow.t())) ::
+          Ecto.Changeset.t(Workflow.t())
+  def soft_delete_changeset(
+        %Ecto.Changeset{data: %Workflow{} = workflow} = changeset
+      ) do
+    changeset
+    |> Workflow.request_deletion_changeset(%{
+      deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Ecto.Changeset.put_change(
+      :name,
+      resolve_name_for_pending_deletion(workflow)
+    )
+  end
+
+  @doc """
+  Computes the `name_del`-style name a workflow should take when it is soft
+  deleted, so it frees up its original name for reuse within the project.
+
+  Used by `soft_delete_changeset/1`, which every delete path routes through.
+  """
+  @spec resolve_name_for_pending_deletion(Workflow.t()) :: String.t()
+  def resolve_name_for_pending_deletion(%Workflow{
+        name: name,
+        project_id: project_id
+      }) do
     base_name = "#{name}_del"
 
     existing_names =

--- a/lib/lightning_web/live/credential_live/credential_index_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_index_component.ex
@@ -91,15 +91,9 @@ defmodule LightningWeb.CredentialLive.CredentialIndexComponent do
   def handle_event("show_modal", %{"target" => "new_credential"}, socket) do
     if socket.assigns.can_create_project_credential do
       project_credentials =
-        if socket.assigns.project do
-          [
-            %Lightning.Projects.ProjectCredential{
-              project_id: socket.assigns.project.id
-            }
-          ]
-        else
-          []
-        end
+        LightningWeb.CredentialLive.Helpers.default_project_credentials(
+          socket.assigns.project
+        )
 
       {:noreply,
        assign(socket,

--- a/lib/lightning_web/live/credential_live/helpers.ex
+++ b/lib/lightning_web/live/credential_live/helpers.ex
@@ -146,21 +146,15 @@ defmodule LightningWeb.CredentialLive.Helpers do
   end
 
   @doc """
-  Builds the `project_credentials` to pre-select when creating a credential in
-  a project context: the active project plus its root parent project (when the
-  active project is a sandbox), deduplicated and order-preserving.
-
-  Returns an empty list when there is no project context.
+  The `project_credentials` to pre-select when creating a credential: only the
+  active project. Empty when there is no project context.
   """
   @spec default_project_credentials(Lightning.Projects.Project.t() | nil) ::
           [Lightning.Projects.ProjectCredential.t()]
   def default_project_credentials(nil), do: []
 
-  def default_project_credentials(%Lightning.Projects.Project{} = project) do
-    [project, Lightning.Projects.root_of(project)]
-    |> Enum.map(& &1.id)
-    |> Enum.uniq()
-    |> Enum.map(&%Lightning.Projects.ProjectCredential{project_id: &1})
+  def default_project_credentials(%Lightning.Projects.Project{id: id}) do
+    [%Lightning.Projects.ProjectCredential{project_id: id}]
   end
 
   def handle_save_response(socket, credential) do

--- a/lib/lightning_web/live/credential_live/helpers.ex
+++ b/lib/lightning_web/live/credential_live/helpers.ex
@@ -145,6 +145,24 @@ defmodule LightningWeb.CredentialLive.Helpers do
     }
   end
 
+  @doc """
+  Builds the `project_credentials` to pre-select when creating a credential in
+  a project context: the active project plus its root parent project (when the
+  active project is a sandbox), deduplicated and order-preserving.
+
+  Returns an empty list when there is no project context.
+  """
+  @spec default_project_credentials(Lightning.Projects.Project.t() | nil) ::
+          [Lightning.Projects.ProjectCredential.t()]
+  def default_project_credentials(nil), do: []
+
+  def default_project_credentials(%Lightning.Projects.Project{} = project) do
+    [project, Lightning.Projects.root_of(project)]
+    |> Enum.map(& &1.id)
+    |> Enum.uniq()
+    |> Enum.map(&%Lightning.Projects.ProjectCredential{project_id: &1})
+  end
+
   def handle_save_response(socket, credential) do
     if socket.assigns[:on_save] do
       socket.assigns[:on_save].(credential)

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -249,6 +249,8 @@ defmodule LightningWeb.SandboxLive.Components do
   attr :diverged_workflows, :list, default: []
   attr :source_workflows, :list, required: true
   attr :selected_workflow_ids, :any, required: true
+  attr :credentials, :list, default: []
+  attr :selected_credential_ids, :any, default: %MapSet{}
 
   def merge_modal(assigns) do
     assigns =
@@ -260,6 +262,13 @@ defmodule LightningWeb.SandboxLive.Components do
         merge_select_all_state(
           assigns.selected_workflow_ids,
           assigns.source_workflows
+        )
+      )
+      |> assign(
+        :credentials_select_all_state,
+        merge_select_all_state(
+          assigns.selected_credential_ids,
+          assigns.credentials
         )
       )
 
@@ -387,6 +396,54 @@ defmodule LightningWeb.SandboxLive.Components do
                   title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
                 >
                   Deleted in sandbox
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <div
+            :if={@credentials != []}
+            class="border border-gray-200 rounded-lg overflow-hidden bg-white"
+          >
+            <label class={[
+              "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
+              @credentials_select_all_state == :empty && "cursor-default",
+              @credentials_select_all_state != :empty && "cursor-pointer"
+            ]}>
+              <input
+                type="checkbox"
+                id="merge-select-all-credentials"
+                phx-hook="CheckboxIndeterminate"
+                phx-click="toggle-all-credentials"
+                disabled={@credentials_select_all_state == :empty}
+                checked={@credentials_select_all_state == :all}
+                class={[
+                  "h-4 w-4 rounded border-gray-300 text-indigo-600",
+                  @credentials_select_all_state == :partial && "indeterminate"
+                ]}
+              />
+              <span class="flex-1 text-sm font-medium text-gray-900">
+                Credentials to add
+              </span>
+              <span class="text-xs text-gray-500">
+                {MapSet.size(@selected_credential_ids)} of {length(@credentials)} selected
+              </span>
+            </label>
+            <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
+              <li
+                :for={credential <- @credentials}
+                class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+                phx-click="toggle-credential"
+                phx-value-id={credential.id}
+              >
+                <input
+                  type="checkbox"
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600"
+                  checked={MapSet.member?(@selected_credential_ids, credential.id)}
+                  readonly
+                />
+                <span class="flex-1 text-sm text-gray-700 truncate">
+                  {credential.name}
                 </span>
               </li>
             </ul>

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -249,6 +249,8 @@ defmodule LightningWeb.SandboxLive.Index do
             |> Enum.filter(fn wf -> wf.is_changed end)
             |> MapSet.new(fn wf -> wf.id end)
 
+          merge_credentials = sandbox_only_credentials(sandbox, target_project)
+
           {:noreply,
            socket
            |> assign(:merge_modal_open?, true)
@@ -258,7 +260,12 @@ defmodule LightningWeb.SandboxLive.Index do
            |> assign(:merge_descendants, descendants)
            |> assign(:merge_diverged_workflows, diverged_workflows)
            |> assign(:merge_source_workflows, source_workflows)
-           |> assign(:merge_selected_workflow_ids, selected_ids)}
+           |> assign(:merge_selected_workflow_ids, selected_ids)
+           |> assign(:merge_credentials, merge_credentials)
+           |> assign(
+             :merge_selected_credential_ids,
+             all_credential_ids(merge_credentials)
+           )}
         else
           {:noreply,
            socket
@@ -299,6 +306,34 @@ defmodule LightningWeb.SandboxLive.Index do
       end
 
     {:noreply, assign(socket, :merge_selected_workflow_ids, new_selected)}
+  end
+
+  @impl true
+  def handle_event("toggle-credential", %{"id" => credential_id}, socket) do
+    selected = socket.assigns.merge_selected_credential_ids
+
+    new_selected =
+      if MapSet.member?(selected, credential_id) do
+        MapSet.delete(selected, credential_id)
+      else
+        MapSet.put(selected, credential_id)
+      end
+
+    {:noreply, assign(socket, :merge_selected_credential_ids, new_selected)}
+  end
+
+  @impl true
+  def handle_event("toggle-all-credentials", _params, socket) do
+    all_ids = MapSet.new(socket.assigns.merge_credentials, fn c -> c.id end)
+
+    new_selected =
+      if MapSet.equal?(socket.assigns.merge_selected_credential_ids, all_ids) do
+        MapSet.new()
+      else
+        all_ids
+      end
+
+    {:noreply, assign(socket, :merge_selected_credential_ids, new_selected)}
   end
 
   @impl true
@@ -350,12 +385,29 @@ defmodule LightningWeb.SandboxLive.Index do
       |> MapSet.intersection(all_ids)
       |> MapSet.union(added_changed_ids)
 
+    merge_credentials = sandbox_only_credentials(sandbox, target_project)
+
+    # Preserve the user's credential choices across form changes (the checkboxes
+    # live in the same form, so toggling one fires this event). Keep selections
+    # still in the diff, and default any newly-appeared credential to selected.
+    new_credential_ids = all_credential_ids(merge_credentials)
+    previously_shown_ids = MapSet.new(socket.assigns.merge_credentials, & &1.id)
+
+    selected_credential_ids =
+      socket.assigns.merge_selected_credential_ids
+      |> MapSet.intersection(new_credential_ids)
+      |> MapSet.union(
+        MapSet.difference(new_credential_ids, previously_shown_ids)
+      )
+
     {:noreply,
      socket
      |> assign(:merge_changeset, merge_changeset)
      |> assign(:merge_diverged_workflows, diverged_workflows)
      |> assign(:merge_source_workflows, source_workflows)
-     |> assign(:merge_selected_workflow_ids, selected_ids)}
+     |> assign(:merge_selected_workflow_ids, selected_ids)
+     |> assign(:merge_credentials, merge_credentials)
+     |> assign(:merge_selected_credential_ids, selected_credential_ids)}
   end
 
   @impl true
@@ -403,8 +455,16 @@ defmodule LightningWeb.SandboxLive.Index do
               selected_ids =
                 resolve_selected_workflow_ids(socket.assigns)
 
+              selected_credential_ids =
+                MapSet.to_list(socket.assigns.merge_selected_credential_ids)
+
               source
-              |> perform_merge(target, actor, selected_ids)
+              |> perform_merge(
+                target,
+                actor,
+                selected_ids,
+                selected_credential_ids
+              )
               |> handle_merge_result(socket, source, target, root_project, actor)
             else
               socket
@@ -498,6 +558,8 @@ defmodule LightningWeb.SandboxLive.Index do
           diverged_workflows={@merge_diverged_workflows}
           source_workflows={@merge_source_workflows}
           selected_workflow_ids={@merge_selected_workflow_ids}
+          credentials={@merge_credentials}
+          selected_credential_ids={@merge_selected_credential_ids}
         />
 
         <.live_component
@@ -627,6 +689,8 @@ defmodule LightningWeb.SandboxLive.Index do
     |> assign(:merge_diverged_workflows, [])
     |> assign(:merge_source_workflows, [])
     |> assign(:merge_selected_workflow_ids, MapSet.new())
+    |> assign(:merge_credentials, [])
+    |> assign(:merge_selected_credential_ids, MapSet.new())
   end
 
   defp merge_changeset(params \\ %{}) do
@@ -877,6 +941,35 @@ defmodule LightningWeb.SandboxLive.Index do
   defp preload_merge_projects(source, target),
     do: {Repo.preload(source, :workflows), Repo.preload(target, :workflows)}
 
+  # The sandbox's project_credentials whose underlying credential the target
+  # does not already have. These would be dropped on merge unless the user
+  # chooses to carry them over.
+  defp sandbox_only_credentials(_source, nil), do: []
+
+  defp sandbox_only_credentials(source, target) do
+    source =
+      Repo.preload(source, project_credentials: [:credential])
+
+    target = Repo.preload(target, :project_credentials)
+
+    target_credential_ids =
+      MapSet.new(target.project_credentials, & &1.credential_id)
+
+    source.project_credentials
+    |> Enum.reject(&MapSet.member?(target_credential_ids, &1.credential_id))
+    |> Enum.map(fn pc ->
+      %{id: pc.id, name: credential_display_name(pc.credential)}
+    end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp credential_display_name(%{name: name}) when is_binary(name), do: name
+  defp credential_display_name(_), do: "Untitled credential"
+
+  defp all_credential_ids(merge_credentials) do
+    MapSet.new(merge_credentials, & &1.id)
+  end
+
   defp get_diverged_workflows(_source, nil), do: []
 
   defp get_diverged_workflows(source, target_project) do
@@ -893,7 +986,8 @@ defmodule LightningWeb.SandboxLive.Index do
          source,
          target,
          actor,
-         {selected_workflow_ids, deleted_target_workflow_ids}
+         {selected_workflow_ids, deleted_target_workflow_ids},
+         selected_credential_ids
        ) do
     maybe_commit_to_github(target, "pre-merge commit")
 
@@ -906,6 +1000,8 @@ defmodule LightningWeb.SandboxLive.Index do
       else
         %{}
       end
+
+    opts = Map.put(opts, :selected_credential_ids, selected_credential_ids)
 
     case Sandboxes.merge(source, target, actor, opts) do
       {:ok, _updated_target} = success ->
@@ -989,16 +1085,9 @@ defmodule LightningWeb.SandboxLive.Index do
     end
   end
 
-  defp format_merge_error(%Ecto.Changeset{} = changeset) do
-    changeset.errors
-    |> List.first()
-    |> case do
-      {field, {message, _}} -> "#{field}: #{message}"
-      _ -> "Failed to merge: validation error"
-    end
-  end
-
   defp format_merge_error(%{text: text}), do: text
-  defp format_merge_error(reason) when is_binary(reason), do: reason
-  defp format_merge_error(reason), do: "Failed to merge: #{inspect(reason)}"
+
+  defp format_merge_error(_reason) do
+    "Couldn't merge this sandbox. Please try again."
+  end
 end

--- a/lib/lightning_web/live/workflow_live/collaborate.ex
+++ b/lib/lightning_web/live/workflow_live/collaborate.ex
@@ -18,6 +18,7 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
   alias Lightning.Workflows.WebhookAuthMethod
   alias Lightning.Workflows.Workflow
   alias LightningWeb.Channels.WorkflowJSON
+  alias LightningWeb.CredentialLive
 
   on_mount({LightningWeb.Hooks, :project_scope})
   on_mount({LightningWeb.Hooks, :check_limits})
@@ -45,6 +46,8 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
        show_credential_modal: false,
        credential_schema: nil,
        credential_to_edit: nil,
+       new_credential_project_credentials:
+         CredentialLive.Helpers.default_project_credentials(project),
        show_webhook_auth_modal: false,
        webhook_auth_method: nil,
        ai_assistant_enabled: AiAssistant.enabled?()
@@ -223,11 +226,7 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
           %Lightning.Credentials.Credential{
             schema: @credential_schema,
             user_id: @current_user.id,
-            project_credentials: [
-              %Lightning.Projects.ProjectCredential{
-                project_id: @project.id
-              }
-            ]
+            project_credentials: @new_credential_project_credentials
           }
       }
       on_save={

--- a/lib/lightning_web/live/workflow_live/edit.ex
+++ b/lib/lightning_web/live/workflow_live/edit.ex
@@ -454,11 +454,7 @@ defmodule LightningWeb.WorkflowLive.Edit do
             credential={
               %Lightning.Credentials.Credential{
                 user_id: @current_user.id,
-                project_credentials: [
-                  %Lightning.Projects.ProjectCredential{
-                    project_id: @project.id
-                  }
-                ]
+                project_credentials: @new_credential_project_credentials
               }
             }
             current_user={@current_user}
@@ -1462,6 +1458,10 @@ defmodule LightningWeb.WorkflowLive.Edit do
        show_canvas_placeholder: assigns.live_action == :new,
        show_workflow_ai_chat: false,
        show_job_credential_modal: false,
+       new_credential_project_credentials:
+         LightningWeb.CredentialLive.Helpers.default_project_credentials(
+           assigns.project
+         ),
        active_modal: nil,
        active_modal_assigns: nil,
        admin_contacts: Projects.list_project_admin_emails(assigns.project.id),

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -924,6 +924,46 @@ defmodule Lightning.Projects.ProvisionerTest do
              "The soft-deleted workflow should be excluded from the project"
     end
 
+    test "soft-deleting a workflow frees its name for reuse", %{
+      project: project,
+      user: user
+    } do
+      %{
+        body: body,
+        workflows: [%{id: workflow_id}]
+      } = valid_document(project.id)
+
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      original_name =
+        Repo.get!(Lightning.Workflows.Workflow, workflow_id).name
+
+      {:ok, _} =
+        body
+        |> remove_workflow_from_document(workflow_id)
+        |> then(&Provisioner.import_document(project, user, &1))
+
+      deleted = Repo.get!(Lightning.Workflows.Workflow, workflow_id)
+
+      assert deleted.deleted_at
+
+      assert deleted.name == "#{original_name}_del",
+             "The soft-deleted workflow should release its original name"
+
+      # A fresh workflow can now reuse the freed name on a later import.
+      %{body: reuse_body} = valid_document(project.id)
+
+      reuse_body =
+        Map.update!(reuse_body, "workflows", fn [workflow] ->
+          [Map.put(workflow, "name", original_name)]
+        end)
+
+      assert {:ok, reimported} =
+               Provisioner.import_document(project, user, reuse_body)
+
+      assert Enum.any?(reimported.workflows, &(&1.name == original_name))
+    end
+
     test "disables all triggers on a workflow that is soft-deleted via provisioner",
          %{
            project: project,

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -945,6 +945,69 @@ defmodule Lightning.Projects.SandboxesTest do
     end
   end
 
+  describe "merge/4 workflows and credentials" do
+    test "merges a brand-new sandbox workflow into the parent" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:owner)
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      # Add a brand-new workflow to the sandbox only.
+      insert(:simple_workflow, project: sandbox, name: "NewFlow")
+
+      refute Repo.exists?(
+               from(w in Workflow,
+                 where: w.project_id == ^parent.id and w.name == "NewFlow"
+               )
+             )
+
+      assert {:ok, _updated} = Sandboxes.merge(sandbox, parent, actor)
+
+      new_workflow =
+        Workflow
+        |> Repo.get_by!(project_id: parent.id, name: "NewFlow")
+        |> Repo.preload([:jobs, :triggers, :edges])
+
+      assert length(new_workflow.jobs) == 1
+      assert length(new_workflow.triggers) == 1
+      assert length(new_workflow.edges) == 1
+    end
+
+    test "merges a credential newly added to an existing step" do
+      %{actor: actor, parent: parent, pc: pc, nodes: %{j2: parent_a2}} =
+        build_parent_fixture!(:owner)
+
+      # Start with A2 (an existing parent step) having no credential.
+      Repo.update!(Ecto.Changeset.change(parent_a2, project_credential_id: nil))
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      # The sandbox clones the parent's credential as its own project_credential
+      # referencing the same underlying credential.
+      sandbox_pc =
+        Repo.get_by!(ProjectCredential,
+          project_id: sandbox.id,
+          credential_id: pc.credential_id
+        )
+
+      # In the sandbox, add that credential to the previously-uncredentialed
+      # step.
+      sandbox
+      |> find_sandbox_job!("Alpha", "A2")
+      |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
+      |> Repo.update!()
+
+      assert {:ok, _updated} = Sandboxes.merge(sandbox, parent, actor)
+
+      # The credential added in the sandbox should propagate to the parent,
+      # mapped to the parent's project_credential for the same credential.
+      #
+      # NOTE: this currently fails. The merge drops credential changes made to
+      # existing steps (matched jobs reuse the target's credential ids), so A2
+      # ends up with no credential in the parent.
+      assert Repo.reload!(parent_a2).project_credential_id == pc.id
+    end
+  end
+
   describe "keychains" do
     test "clones only used keychains and rewires jobs to cloned keychains" do
       %{

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1062,6 +1062,98 @@ defmodule Lightning.Projects.SandboxesTest do
     end
   end
 
+  describe "merge/4 sandbox-only credentials" do
+    # Adds a credential that exists only in the sandbox (the target has no
+    # project_credential for its underlying credential) and wires the sandbox's
+    # A1 step to reference it. Returns the sandbox project_credential so the
+    # test can choose whether to select it for attachment.
+    defp add_sandbox_only_credential!(sandbox, actor) do
+      cred =
+        insert(:credential,
+          name: "sandbox-only",
+          body: %{"token" => "only-here"},
+          user: actor
+        )
+
+      sandbox_pc =
+        insert(:project_credential, project: sandbox, credential: cred)
+
+      sandbox
+      |> find_sandbox_job!("Alpha", "A1")
+      |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
+      |> Repo.update!()
+
+      {cred, sandbox_pc}
+    end
+
+    test "attaches a selected sandbox-only credential to the target and the merged job references it" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:owner)
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      {cred, sandbox_pc} = add_sandbox_only_credential!(sandbox, actor)
+
+      refute Repo.exists?(
+               from(pc in ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^cred.id
+               )
+             )
+
+      assert {:ok, _updated} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_credential_ids: [sandbox_pc.id]
+               })
+
+      parent_pc =
+        Repo.get_by!(ProjectCredential,
+          project_id: parent.id,
+          credential_id: cred.id
+        )
+
+      merged_a1 =
+        Repo.get_by!(Job,
+          workflow_id:
+            Repo.get_by!(Workflow, project_id: parent.id, name: "Alpha").id,
+          name: "A1"
+        )
+
+      assert merged_a1.project_credential_id == parent_pc.id
+    end
+
+    test "does not attach a deselected sandbox-only credential" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:owner)
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      {cred, _sandbox_pc} = add_sandbox_only_credential!(sandbox, actor)
+
+      assert {:ok, _updated} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_credential_ids: []
+               })
+
+      refute Repo.exists?(
+               from(pc in ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^cred.id
+               )
+             )
+
+      # The merged step drops the credential it could not map.
+      merged_a1 =
+        Repo.get_by!(Job,
+          workflow_id:
+            Repo.get_by!(Workflow, project_id: parent.id, name: "Alpha").id,
+          name: "A1"
+        )
+
+      assert merged_a1.project_credential_id == nil
+    end
+  end
+
   describe "keychains" do
     test "clones only used keychains and rewires jobs to cloned keychains" do
       %{

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -946,7 +946,7 @@ defmodule Lightning.Projects.SandboxesTest do
   end
 
   describe "merge/4 workflows and credentials" do
-    test "merges a brand-new sandbox workflow into the parent" do
+    test "merges a new workflow from a sandbox into the parent" do
       %{actor: actor, parent: parent} = build_parent_fixture!(:owner)
 
       {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
@@ -972,7 +972,7 @@ defmodule Lightning.Projects.SandboxesTest do
       assert length(new_workflow.edges) == 1
     end
 
-    test "merges a credential newly added to an existing step" do
+    test "merges a credential added to an existing step in the sandbox" do
       %{actor: actor, parent: parent, pc: pc, nodes: %{j2: parent_a2}} =
         build_parent_fixture!(:owner)
 
@@ -1007,7 +1007,7 @@ defmodule Lightning.Projects.SandboxesTest do
       assert Repo.reload!(parent_a2).project_credential_id == pc.id
     end
 
-    test "merges a new workflow whose step references a credential" do
+    test "merges a new workflow in the sandbox with a step that references a credential" do
       %{actor: actor, parent: parent, pc: pc} = build_parent_fixture!(:owner)
 
       {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1038,6 +1038,28 @@ defmodule Lightning.Projects.SandboxesTest do
 
       assert merged_job.project_credential_id == pc.id
     end
+
+    test "merges a credential removed from an existing step in the sandbox" do
+      # A1 references the credential in the parent (per build_parent_fixture!).
+      %{actor: actor, parent: parent, pc: pc, nodes: %{j1: parent_a1}} =
+        build_parent_fixture!(:owner)
+
+      assert parent_a1.project_credential_id == pc.id
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      # In the sandbox, remove the credential from the step.
+      sandbox
+      |> find_sandbox_job!("Alpha", "A1")
+      |> Ecto.Changeset.change(project_credential_id: nil)
+      |> Repo.update!()
+
+      assert {:ok, _updated} = Sandboxes.merge(sandbox, parent, actor)
+
+      # The removal propagates to the parent: the step no longer references a
+      # credential.
+      assert Repo.reload!(parent_a1).project_credential_id == nil
+    end
   end
 
   describe "keychains" do

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1006,6 +1006,44 @@ defmodule Lightning.Projects.SandboxesTest do
       # ends up with no credential in the parent.
       assert Repo.reload!(parent_a2).project_credential_id == pc.id
     end
+
+    test "merges a new workflow whose step references a credential" do
+      %{actor: actor, parent: parent, pc: pc} = build_parent_fixture!(:owner)
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      sandbox_pc =
+        Repo.get_by!(ProjectCredential,
+          project_id: sandbox.id,
+          credential_id: pc.credential_id
+        )
+
+      # Add a brand-new workflow to the sandbox whose step references the
+      # (sandbox-scoped) credential.
+      new_wf = insert(:simple_workflow, project: sandbox, name: "NewFlow")
+      [new_job] = Repo.preload(new_wf, :jobs).jobs
+
+      new_job
+      |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
+      |> Repo.update!()
+
+      # The new workflow should merge into the parent, mapping the credential to
+      # the parent's project_credential for the same credential.
+      #
+      # NOTE: this currently fails with a validation error. The new (unmatched)
+      # job keeps the sandbox-scoped project_credential_id, which the parent
+      # does not own, so import rejects it ("credential doesnt exist or isn't
+      # available in this project").
+      assert {:ok, _updated} = Sandboxes.merge(sandbox, parent, actor)
+
+      parent_new_wf =
+        Repo.get_by!(Workflow, project_id: parent.id, name: "NewFlow")
+
+      merged_job =
+        Repo.get_by!(Job, workflow_id: parent_new_wf.id, name: new_job.name)
+
+      assert merged_job.project_credential_id == pc.id
+    end
   end
 
   describe "keychains" do

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -998,12 +998,8 @@ defmodule Lightning.Projects.SandboxesTest do
 
       assert {:ok, _updated} = Sandboxes.merge(sandbox, parent, actor)
 
-      # The credential added in the sandbox should propagate to the parent,
-      # mapped to the parent's project_credential for the same credential.
-      #
-      # NOTE: this currently fails. The merge drops credential changes made to
-      # existing steps (matched jobs reuse the target's credential ids), so A2
-      # ends up with no credential in the parent.
+      # The credential added in the sandbox propagates to the parent, mapped to
+      # the parent's project_credential for the same underlying credential.
       assert Repo.reload!(parent_a2).project_credential_id == pc.id
     end
 
@@ -1027,12 +1023,10 @@ defmodule Lightning.Projects.SandboxesTest do
       |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
       |> Repo.update!()
 
-      # The new workflow should merge into the parent, mapping the credential to
-      # the parent's project_credential for the same credential.
-      #
-      # NOTE: this currently fails with a validation error. The new (unmatched)
-      # job keeps the sandbox-scoped project_credential_id, which the parent
-      # does not own, so import rejects it ("credential doesnt exist or isn't
+      # The new workflow merges into the parent, mapping the (sandbox-scoped)
+      # credential to the parent's project_credential for the same underlying
+      # credential. Without remapping, import would reject the new job's
+      # sandbox-scoped project_credential_id ("credential doesnt exist or isn't
       # available in this project").
       assert {:ok, _updated} = Sandboxes.merge(sandbox, parent, actor)
 

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -1576,6 +1576,21 @@ defmodule Lightning.WorkflowsTest do
       assert_received %KafkaTriggerUpdated{trigger_id: ^kafka_trigger_1_id}
     end
 
+    test "soft_delete_changeset/1 marks deleted and frees the name in one step" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project, name: "Shared Transition")
+
+      changeset =
+        workflow
+        |> Ecto.Changeset.change()
+        |> Workflows.soft_delete_changeset()
+
+      assert %DateTime{} = Ecto.Changeset.get_change(changeset, :deleted_at)
+
+      assert Ecto.Changeset.get_change(changeset, :name) ==
+               "Shared Transition_del"
+    end
+
     test "mark_for_deletion/3 renames workflow with _del suffix" do
       # Use a separate project to avoid pollution from setup
       project = insert(:project)

--- a/test/lightning_web/live/credential_live_helpers_test.exs
+++ b/test/lightning_web/live/credential_live_helpers_test.exs
@@ -247,4 +247,33 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
       assert updated.available_projects == projects
     end
   end
+
+  describe "default_project_credentials/1" do
+    test "returns an empty list without a project context" do
+      assert Helpers.default_project_credentials(nil) == []
+    end
+
+    test "returns only the project itself for a root project" do
+      project = insert(:project)
+
+      assert [%{project_id: project_id}] =
+               Helpers.default_project_credentials(project)
+
+      assert project_id == project.id
+    end
+
+    test "returns the sandbox and its root parent for a sandbox" do
+      root = insert(:project)
+      child = insert(:project, parent_id: root.id)
+      grandchild = insert(:project, parent_id: child.id)
+
+      project_ids =
+        grandchild
+        |> Helpers.default_project_credentials()
+        |> Enum.map(& &1.project_id)
+
+      # The active (sandbox) project and the root parent, not the intermediate.
+      assert project_ids == [grandchild.id, root.id]
+    end
+  end
 end

--- a/test/lightning_web/live/credential_live_helpers_test.exs
+++ b/test/lightning_web/live/credential_live_helpers_test.exs
@@ -262,7 +262,7 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
       assert project_id == project.id
     end
 
-    test "returns the sandbox and its root parent for a sandbox" do
+    test "returns only the sandbox itself, not its ancestors" do
       root = insert(:project)
       child = insert(:project, parent_id: root.id)
       grandchild = insert(:project, parent_id: child.id)
@@ -272,8 +272,7 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
         |> Helpers.default_project_credentials()
         |> Enum.map(& &1.project_id)
 
-      # The active (sandbox) project and the root parent, not the intermediate.
-      assert project_ids == [grandchild.id, root.id]
+      assert project_ids == [grandchild.id]
     end
   end
 end

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1021,7 +1021,7 @@ defmodule LightningWeb.ProjectLiveTest do
       end)
     end
 
-    test "new credential in a sandbox pre-selects the sandbox and its root parent",
+    test "new credential in a sandbox pre-selects only the active sandbox",
          %{conn: conn, user: user} do
       root =
         insert(:project,
@@ -1047,21 +1047,21 @@ defmodule LightningWeb.ProjectLiveTest do
       view |> select_credential_type("http")
       view |> click_continue()
 
-      # Both the active sandbox and the root parent are pre-selected; the
-      # intermediate project in the chain is not.
+      # Only the active sandbox is pre-selected. Ancestors are attached at
+      # merge time, not speculatively at credential creation.
       assert has_element?(
                view,
                "#remove-project-credential-button-new-#{sandbox.id}"
              )
 
-      assert has_element?(
+      refute has_element?(
                view,
-               "#remove-project-credential-button-new-#{root.id}"
+               "#remove-project-credential-button-new-#{intermediate.id}"
              )
 
       refute has_element?(
                view,
-               "#remove-project-credential-button-new-#{intermediate.id}"
+               "#remove-project-credential-button-new-#{root.id}"
              )
     end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1021,6 +1021,50 @@ defmodule LightningWeb.ProjectLiveTest do
       end)
     end
 
+    test "new credential in a sandbox pre-selects the sandbox and its root parent",
+         %{conn: conn, user: user} do
+      root =
+        insert(:project,
+          name: "root-project",
+          project_users: [%{user_id: user.id, role: :admin}]
+        )
+
+      intermediate = insert(:project, name: "intermediate", parent_id: root.id)
+
+      sandbox =
+        insert(:project,
+          name: "sandbox-project",
+          parent_id: intermediate.id,
+          project_users: [%{user_id: user.id, role: :admin}]
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{sandbox}/settings#credentials",
+          on_error: :raise
+        )
+
+      view |> element("#new-credential-option-menu-item") |> render_click()
+      view |> select_credential_type("http")
+      view |> click_continue()
+
+      # Both the active sandbox and the root parent are pre-selected; the
+      # intermediate project in the chain is not.
+      assert has_element?(
+               view,
+               "#remove-project-credential-button-new-#{sandbox.id}"
+             )
+
+      assert has_element?(
+               view,
+               "#remove-project-credential-button-new-#{root.id}"
+             )
+
+      refute has_element?(
+               view,
+               "#remove-project-credential-button-new-#{intermediate.id}"
+             )
+    end
+
     test "support users can create new credentials in the project credentials page",
          %{
            conn: conn,

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1825,7 +1825,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "Failed to merge"
+      assert html =~ "merge this sandbox"
 
       refute has_element?(view, "#merge-sandbox-modal")
     end
@@ -2001,7 +2001,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
                "Successfully merged child1 into root, but could not schedule the sandbox for deletion."
     end
 
-    test "formats changeset error correctly", %{
+    test "shows a generic message when a merge fails validation", %{
       conn: conn,
       root: root,
       child1: child1
@@ -2014,7 +2014,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         "merged_yaml"
       end)
 
-      # Return changeset error
+      # A validation failure with no recognised cause.
       changeset = %Ecto.Changeset{
         errors: [name: {"is invalid", []}],
         valid?: false
@@ -2039,7 +2039,63 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-      assert html =~ "name: is invalid"
+      assert html =~ "merge this sandbox"
+      # No schema field paths or raw changeset internals leak to the user.
+      refute html =~ "name: is invalid"
+      refute has_element?(view, "#merge-sandbox-modal")
+    end
+
+    test "shows a generic message for a nested workflow error, without leaking it",
+         %{
+           conn: conn,
+           root: root,
+           child1: child1
+         } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      Mimic.expect(Lightning.Projects.MergeProjects, :merge_project, fn _source,
+                                                                        _target,
+                                                                        _opts ->
+        "merged_yaml"
+      end)
+
+      # A name collision surfaces as an error on a nested workflow's :name.
+      nested_changeset =
+        %Lightning.Workflows.Workflow{name: "Patient Sync"}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(
+          :name,
+          "A workflow with this name already exists (possibly pending deletion) in this project."
+        )
+
+      changeset =
+        %Lightning.Projects.Project{workflows: []}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.put_assoc(:workflows, [nested_changeset])
+
+      Mimic.expect(Lightning.Projects.Provisioner, :import_document, fn _target,
+                                                                        _actor,
+                                                                        _yaml,
+                                                                        _opts ->
+        {:error, changeset}
+      end)
+
+      Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
+
+      view
+      |> element("#branch-rewire-sandbox-#{child1.id} button")
+      |> render_click()
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      html = render(view)
+      assert html =~ "merge this sandbox"
+      # The workflow name and the raw error must not leak to the user.
+      refute html =~ "Patient Sync"
+      refute html =~ "already exists"
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
@@ -2079,11 +2135,12 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
-    test "formats generic error with inspect", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
+    test "shows a generic message for an unexpected failure, without leaking internals",
+         %{
+           conn: conn,
+           root: root,
+           child1: child1
+         } do
       {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
 
       Mimic.expect(Lightning.Projects.MergeProjects, :merge_project, fn _source,
@@ -2111,8 +2168,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-      assert html =~ "Failed to merge:"
-      assert html =~ "unexpected"
+      assert html =~ "merge this sandbox"
+      # The raw reason must not leak to the user.
+      refute html =~ "unexpected"
+      refute html =~ "something went wrong"
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
@@ -2290,7 +2349,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert hd(parent_collections).name == "shared"
     end
 
-    test "merge fails with flash error when collection sync fails", %{
+    test "merge failure shows a flash error and closes the modal", %{
       conn: conn,
       root: root,
       sandbox: sandbox
@@ -2301,7 +2360,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
                                                             _tgt,
                                                             _actor,
                                                             _opts ->
-        {:error, "Failed to sync collections: :boom"}
+        {:error, :merge_failed}
       end)
 
       Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
@@ -2313,7 +2372,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       view |> form("#merge-sandbox-modal form") |> render_submit()
 
       html = render(view)
-      assert html =~ "Failed to sync collections"
+      assert html =~ "merge this sandbox"
       refute has_element?(view, "#merge-sandbox-modal")
     end
   end
@@ -3795,6 +3854,210 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       assert shared_wf2.is_new
       assert sibling_wf2.is_diverged
+    end
+  end
+
+  describe "credential selection in merge modal" do
+    setup :register_and_log_in_user
+
+    # Provisions a real sandbox from the parent, then adds a credential that
+    # lives only in the sandbox and wires the sandbox's job to it. The merge of
+    # this sandbox into the parent would drop that credential unless the user
+    # keeps it selected in the modal.
+    setup %{user: user} do
+      parent =
+        insert(:project,
+          name: "parent",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      wf = insert(:workflow, project: parent, name: "Alpha")
+      trigger = insert(:trigger, workflow: wf, type: :webhook)
+
+      job =
+        insert(:job,
+          workflow: wf,
+          name: "A1",
+          adaptor: "@openfn/language-common@latest",
+          body: "console.log('A1');"
+        )
+
+      insert(:edge,
+        workflow: wf,
+        source_trigger_id: trigger.id,
+        target_job_id: job.id,
+        condition_type: :always,
+        enabled: true
+      )
+
+      {:ok, sandbox} =
+        Lightning.Projects.Sandboxes.provision(parent, user, %{name: "sb"})
+
+      credential =
+        insert(:credential,
+          name: "sandbox-only-cred",
+          body: %{"token" => "x"},
+          user: user
+        )
+
+      sandbox_pc =
+        insert(:project_credential, project: sandbox, credential: credential)
+
+      sandbox_job =
+        from(j in Lightning.Workflows.Job,
+          join: w in assoc(j, :workflow),
+          where: w.project_id == ^sandbox.id and j.name == "A1"
+        )
+        |> Repo.one!()
+
+      sandbox_job
+      |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
+      |> Repo.update!()
+
+      {:ok,
+       parent: parent,
+       sandbox: sandbox,
+       credential: credential,
+       sandbox_pc: sandbox_pc}
+    end
+
+    test "modal lists sandbox-only credentials checked by default", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert [%{id: listed_id, name: "sandbox-only-cred"}] =
+               assigns.merge_credentials
+
+      assert listed_id == sandbox_pc.id
+
+      assert MapSet.equal?(
+               assigns.merge_selected_credential_ids,
+               MapSet.new([sandbox_pc.id])
+             )
+
+      html = render(view)
+      assert html =~ "Credentials to add"
+      assert html =~ "sandbox-only-cred"
+    end
+
+    test "select-all toggles every credential", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      # Default is all selected; the select-all clears them, then re-selects.
+      view |> element("#merge-select-all-credentials") |> render_click()
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.size(assigns.merge_selected_credential_ids) == 0
+
+      view |> element("#merge-select-all-credentials") |> render_click()
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.member?(assigns.merge_selected_credential_ids, sandbox_pc.id)
+    end
+
+    test "a deselected credential survives a form change", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> element("li[phx-value-id='#{sandbox_pc.id}']")
+      |> render_click()
+
+      # The checkboxes share the merge form, so any form change re-runs
+      # select-merge-target; it must not wipe the user's deselection.
+      view
+      |> form("#merge-sandbox-modal form", merge: %{target_id: parent.id})
+      |> render_change()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+      refute MapSet.member?(assigns.merge_selected_credential_ids, sandbox_pc.id)
+    end
+
+    test "deselecting a credential and merging does not attach it", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc,
+      credential: credential
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> element("li[phx-value-id='#{sandbox_pc.id}']")
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.size(assigns.merge_selected_credential_ids) == 0
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      assert_redirect(view, ~p"/projects/#{parent.id}/w")
+
+      refute Repo.exists?(
+               from(pc in Lightning.Projects.ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^credential.id
+               )
+             )
+    end
+
+    test "keeping a credential selected and merging attaches it", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      credential: credential
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      assert_redirect(view, ~p"/projects/#{parent.id}/w")
+
+      assert Repo.exists?(
+               from(pc in Lightning.Projects.ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^credential.id
+               )
+             )
     end
   end
 


### PR DESCRIPTION
## EDIT

This PR has been updated to include https://github.com/OpenFn/lightning/pull/4842

Instead of attaching credentials in the UI at create time, @elias-ba's work now attached credentials at _merge_ time, and tells the user about it. Big improvement which removes The Ick.

## Description

This PR ensures that when merging a sandbox, any credentials added to the sandbox get properly mapped to a matching credential on the parent.

When adding a new credential, the UI will auto-fill to also add the credential to the parent.

Closes #4831 #4834 

## Discussion

I'm _sure_ I've tested this back in the early days of sandboxes. I can visualise doing it. Did we break it? Am I misremembering? Most likely I didn't test properly after the environments work.

~The original fix is to map credentials from sandbox -> parent on merge, which fixes most of the problems. But that still leaves an issue when you create a whole new credential on the sandbox: after merging, the credential is not linked to the parent project. What happens then? Do we auto-create the credential? Probably but it feels a little bit icky.~

~My solution is to handle this in the UI: when creating a new credential within a sandbox, automatically add it to the parent project. Now we ensure it'll survive on merge.~

## Validation steps

Run the following tests on a new sandbox and merge
* Add an existing credential to an existing step
* Add an existing credential to a new step
* Create a new workflow and add an existing credential to the step
* Add a new credential to an existing step (expected behaviour)?

Also need to ensure existing production behaviour isn't broken

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
