### PR TITLE
Fix workflows_pkey duplicate INSERT on collab reconnect, and remove its root cause (#4830)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to
 
 ### Fixed
 
+- Fix a `workflows_pkey` duplicate-key crash when reconnecting to the
+  collaborative editor after a save. Workflow resolution is now centralised in a
+  single `Lightning.Collaboration.WorkflowResolver`, so the channel join and the
+  session save path can no longer disagree on whether an id should INSERT or
+  UPDATE. [#4830](https://github.com/OpenFn/lightning/issues/4830)
+
 ## [2.16.7] - 2026-06-04
 
 ### Changed

--- a/assets/js/collaborative-editor/contexts/SessionProvider.tsx
+++ b/assets/js/collaborative-editor/contexts/SessionProvider.tsx
@@ -13,6 +13,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -34,6 +35,17 @@ const logger = _logger.ns('SessionProvider').seal();
 interface SessionContextValue {
   sessionStore: SessionStoreInstance;
   isNewWorkflow: boolean;
+  /**
+   * Reports the live "new workflow" status up to the SessionProvider so the
+   * channel-join `action` stays honest across in-place reconnects.
+   *
+   * The SessionContextStore (the source of truth, cleared by
+   * `clearIsNewWorkflow()` after the first successful save) is created in
+   * StoreProvider, which is a *child* of SessionProvider — so SessionProvider
+   * cannot read it directly. A small bridge inside StoreProvider subscribes to
+   * `useIsNewWorkflow()` and calls this to keep the join-param action current.
+   */
+  setIsNewWorkflow?: (isNewWorkflow: boolean) => void;
   initialRunData?: string; // JSON-encoded RunStepsData from server
 }
 
@@ -79,12 +91,27 @@ export const SessionProvider = ({
     [version, workflowId]
   );
 
-  const joinParams = useMemo(
+  // Track the live "new workflow" status in a ref so the channel-join `action`
+  // is read at connect/reconnect time rather than frozen at mount.
+  //
+  // Seeded from the `isNewWorkflow` prop (LiveView `data-is-new-workflow`) so
+  // the very first join is correct before any save. After the first successful
+  // save, the SessionContextStore flag is cleared and `setIsNewWorkflow(false)`
+  // is reported up via the SessionContext bridge, so a subsequent in-place
+  // reconnect rejoins with `action: "edit"` instead of the stale "new".
+  const isNewWorkflowRef = useRef(isNewWorkflow);
+
+  const setIsNewWorkflow = useCallback((next: boolean) => {
+    isNewWorkflowRef.current = next;
+  }, []);
+
+  // Stable getter: read lazily so reconnects pick up the current action.
+  const getJoinParams = useCallback(
     () => ({
       project_id: projectId,
-      action: isNewWorkflow ? 'new' : 'edit',
+      action: isNewWorkflowRef.current ? 'new' : 'edit',
     }),
-    [projectId, isNewWorkflow]
+    [projectId]
   );
 
   // Handle roomname changes (version switching)
@@ -138,7 +165,7 @@ export const SessionProvider = ({
     isConnected,
     sessionStore,
     roomname,
-    joinParams,
+    getJoinParams,
     onError: handleProviderError,
     onProviderReady: handleProviderReady,
     onProviderReconnected: handleProviderReconnected,
@@ -199,9 +226,10 @@ export const SessionProvider = ({
     () => ({
       sessionStore,
       isNewWorkflow,
+      setIsNewWorkflow,
       ...(initialRunData !== undefined && { initialRunData }),
     }),
-    [sessionStore, isNewWorkflow, initialRunData]
+    [sessionStore, isNewWorkflow, setIsNewWorkflow, initialRunData]
   );
 
   return (

--- a/assets/js/collaborative-editor/contexts/StoreProvider.tsx
+++ b/assets/js/collaborative-editor/contexts/StoreProvider.tsx
@@ -144,6 +144,26 @@ export const StoreProvider = ({ children }: StoreProviderProps) => {
     };
   });
 
+  // Bridge the SessionContextStore's `isNewWorkflow` flag up to SessionProvider
+  // so the channel-join `action` stays honest across in-place reconnects.
+  //
+  // SessionProvider owns the join params but sits ABOVE this provider, so it
+  // cannot read the SessionContextStore directly. The store is the source of
+  // truth: it is seeded from the same `isNewWorkflow` prop and is cleared by
+  // `clearIsNewWorkflow()` after the first successful save. We forward every
+  // change up via the SessionContext setter (a ref write, no re-render).
+  const setIsNewWorkflow = sessionContext?.setIsNewWorkflow;
+  useEffect(() => {
+    if (!setIsNewWorkflow) return undefined;
+
+    const store = stores.sessionContextStore;
+    // Sync the current value immediately, then on every change.
+    setIsNewWorkflow(store.getSnapshot().isNewWorkflow);
+    return store.subscribe(() => {
+      setIsNewWorkflow(store.getSnapshot().isNewWorkflow);
+    });
+  }, [setIsNewWorkflow, stores.sessionContextStore]);
+
   // Subscribe to sessionContextStore user changes
   // Note: We use useSyncExternalStore directly here (not useUser hook) because
   // this is StoreProvider itself - the hooks require StoreContext to be available,

--- a/assets/js/collaborative-editor/hooks/useProviderLifecycle.ts
+++ b/assets/js/collaborative-editor/hooks/useProviderLifecycle.ts
@@ -31,8 +31,17 @@ export interface ProviderLifecycleOptions {
   /** Room name for the channel */
   roomname: string;
 
-  /** Parameters for joining the channel */
-  joinParams: Record<string, any>;
+  /**
+   * Returns the parameters for joining the channel.
+   *
+   * Read lazily (not captured once) so that both the initial connection and
+   * any in-place reconnect pick up the *current* values. In particular the
+   * channel-join `action` must reflect whether the workflow has been saved yet
+   * ("new" before the first save, "edit" afterwards) rather than a value frozen
+   * at mount. See SessionProvider for how this stays in sync with the
+   * SessionContextStore's `isNewWorkflow` flag.
+   */
+  getJoinParams: () => Record<string, any>;
 
   /** Callback when provider initialization fails */
   onError?: (error: Error) => void;
@@ -69,7 +78,7 @@ export interface ProviderLifecycleResult {
  *   isConnected,
  *   sessionStore,
  *   roomname: 'workflow:collaborate:xyz',
- *   joinParams: { project_id: '123', action: 'edit' },
+ *   getJoinParams: () => ({ project_id: '123', action: 'edit' }),
  *   onError: (error) => setConnectionError(error),
  *   onProviderReconnected: () => console.log('Syncing...'),
  * });
@@ -79,7 +88,7 @@ export function useProviderLifecycle({
   isConnected,
   sessionStore,
   roomname,
-  joinParams,
+  getJoinParams,
   onError,
   onProviderReady,
   onProviderReconnected,
@@ -102,7 +111,7 @@ export function useProviderLifecycle({
       try {
         sessionStore.initializeSession(socket, roomname, null, {
           connect: true,
-          joinParams,
+          joinParams: getJoinParams(),
         });
 
         hasProviderInitialized.current = true;
@@ -121,7 +130,7 @@ export function useProviderLifecycle({
     isConnected,
     sessionStore,
     roomname,
-    joinParams,
+    getJoinParams,
     onError,
     onProviderReady,
   ]);
@@ -145,10 +154,13 @@ export function useProviderLifecycle({
       });
 
       try {
-        // Reinitialize to create new provider but reuse existing Y.Doc
+        // Reinitialize to create new provider but reuse existing Y.Doc.
+        // Read join params lazily so an in-place reconnect rejoins with the
+        // current `action` ("edit" once the workflow has been saved) instead
+        // of a value frozen at mount.
         sessionStore.initializeSession(socket, roomname, null, {
           connect: true,
-          joinParams,
+          joinParams: getJoinParams(),
         });
 
         setInitError(null);
@@ -170,7 +182,7 @@ export function useProviderLifecycle({
     isConnected,
     sessionStore,
     roomname,
-    joinParams,
+    getJoinParams,
     onError,
     onProviderReconnected,
   ]);

--- a/assets/js/react/contexts/SocketProvider.tsx
+++ b/assets/js/react/contexts/SocketProvider.tsx
@@ -15,7 +15,10 @@ interface SocketContextValue {
   disconnect: () => void;
 }
 
-const SocketContext = createContext<SocketContextValue | null>(null);
+// Exported for tests that need to supply a connected socket context directly
+// (e.g. integration tests that render the real SessionProvider without
+// standing up a real PhoenixSocket).
+export const SocketContext = createContext<SocketContextValue | null>(null);
 
 export const useSocket = () => {
   const context = useContext(SocketContext);

--- a/assets/test/collaborative-editor/contexts/SessionProvider.joinAction.integration.test.tsx
+++ b/assets/test/collaborative-editor/contexts/SessionProvider.joinAction.integration.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * SessionProvider <-> StoreProvider join-action bridge integration test (#4830)
+ *
+ * Regression coverage for the *full* client-side bridge that keeps the
+ * channel-join `action` honest across an in-place reconnect:
+ *
+ *   clearIsNewWorkflow() on the SessionContextStore
+ *     -> StoreProvider effect subscribes & forwards via setIsNewWorkflow
+ *       -> SessionProvider ref write (isNewWorkflowRef.current = false)
+ *         -> getJoinParams() re-read lazily on the NEXT (re)connect
+ *           -> PhoenixChannelProvider constructed with params.action === "edit"
+ *
+ * Unlike `useProviderLifecycle.test.tsx` (which hand-rolls `getJoinParams`),
+ * this test renders the REAL provider wiring — `SessionProvider` wrapping
+ * `StoreProvider`, exactly how `CollaborativeEditor.tsx` composes them — so the
+ * bridge effect, the ref, and the lazy getter are all exercised together.
+ *
+ * The transport boundary is captured by faking the `y-phoenix-channel`
+ * `PhoenixChannelProvider` constructor: every (re)connect records the `params`
+ * (i.e. the join params) it was constructed with. We assert on `params.action`.
+ *
+ * Pre-fix proof: against the frozen-prop implementation (where the join params
+ * were captured once at mount instead of read lazily), the reconnect would
+ * reconstruct the provider with the stale `action: "new"` and the second
+ * assertion below would fail. See the inline NOTE on the reconnect assertion.
+ */
+
+import { act, render } from '@testing-library/react';
+import type React from 'react';
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Transport-boundary fake: y-phoenix-channel PhoenixChannelProvider
+// ---------------------------------------------------------------------------
+//
+// The real SessionStore constructs `new PhoenixChannelProvider(socket, room,
+// ydoc, { params, ... })`. We replace that class with a minimal event-emitter
+// fake exposing only the surface SessionStore touches (on/off/emit, synced,
+// doc, awareness, channel, destroy) and record the params of every
+// construction so the test can assert what was sent on connect vs reconnect.
+
+const providerConstructions: { params: Record<string, unknown> }[] = [];
+
+vi.mock('y-phoenix-channel', () => {
+  class FakePhoenixChannelProvider {
+    public synced = false;
+    public doc: unknown;
+    public awareness: unknown;
+    public channel: { on: () => void; off: () => void; push: () => void };
+    private handlers = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    constructor(
+      _socket: unknown,
+      _roomname: string,
+      ydoc: unknown,
+      options: { awareness?: unknown; params?: Record<string, unknown> } = {}
+    ) {
+      this.doc = ydoc;
+      this.awareness = options.awareness ?? { destroy: () => {} };
+      this.channel = { on: () => {}, off: () => {}, push: () => {} };
+      providerConstructions.push({ params: options.params ?? {} });
+    }
+
+    on(event: string, handler: (...args: unknown[]) => void) {
+      if (!this.handlers.has(event)) this.handlers.set(event, new Set());
+      this.handlers.get(event)!.add(handler);
+    }
+
+    off(event: string, handler: (...args: unknown[]) => void) {
+      this.handlers.get(event)?.delete(handler);
+    }
+
+    emit(event: string, args: unknown[]) {
+      this.handlers.get(event)?.forEach(h => h(...args));
+    }
+
+    destroy() {
+      this.handlers.clear();
+    }
+  }
+
+  return {
+    PhoenixChannelProvider: FakePhoenixChannelProvider,
+    messageAwareness: 1,
+    messageQueryAwareness: 3,
+    messageSync: 0,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Capture the REAL store instances created inside the provider tree so the
+// test can (a) flip isNewWorkflow via the real clearIsNewWorkflow() and
+// (b) null the session provider to drive an in-place reconnect.
+// ---------------------------------------------------------------------------
+
+const capturedSessionStores: SessionStoreInstance[] = [];
+const capturedSessionContextStores: SessionContextStoreInstance[] = [];
+
+vi.mock(
+  '../../../js/collaborative-editor/stores/createSessionStore',
+  async importOriginal => {
+    const mod =
+      await importOriginal<
+        typeof import('../../../js/collaborative-editor/stores/createSessionStore')
+      >();
+    return {
+      ...mod,
+      createSessionStore: () => {
+        const store = mod.createSessionStore();
+        capturedSessionStores.push(store);
+        return store;
+      },
+    };
+  }
+);
+
+vi.mock(
+  '../../../js/collaborative-editor/stores/createSessionContextStore',
+  async importOriginal => {
+    const mod =
+      await importOriginal<
+        typeof import('../../../js/collaborative-editor/stores/createSessionContextStore')
+      >();
+    return {
+      ...mod,
+      createSessionContextStore: (isNewWorkflow?: boolean) => {
+        const store = mod.createSessionContextStore(isNewWorkflow);
+        capturedSessionContextStores.push(store);
+        return store;
+      },
+    };
+  }
+);
+
+// Imports AFTER vi.mock so the mocked modules are used.
+import { SessionProvider } from '../../../js/collaborative-editor/contexts/SessionProvider';
+import { StoreProvider } from '../../../js/collaborative-editor/contexts/StoreProvider';
+import type { SessionContextStoreInstance } from '../../../js/collaborative-editor/stores/createSessionContextStore';
+import type { SessionStoreInstance } from '../../../js/collaborative-editor/stores/createSessionStore';
+import { SocketContext } from '../../../js/react/contexts/SocketProvider';
+import { createMockSocket } from '../mocks/phoenixSocket';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps children in a connected SocketContext using the existing mock socket.
+ * We feed the SocketContext directly (rather than the real SocketProvider,
+ * which would build a real PhoenixSocket) so `socket` is non-null and
+ * `isConnected` is true — the precondition useProviderLifecycle needs to
+ * (re)create the provider.
+ */
+/**
+ * Connected socket provider that keeps `isConnected: true` throughout but
+ * exposes a `forceRerender` so the test can trigger a fresh render of the
+ * provider tree (e.g. after dropping the live channel) without mutating any
+ * useProviderLifecycle dependency. This lets the reconnect effect observe the
+ * provider transition to null and rebuild it.
+ */
+let forceRerender: () => void = () => {};
+
+function ConnectedSocket({
+  socket,
+  children,
+}: {
+  socket: unknown;
+  children: React.ReactNode;
+}) {
+  const [, setTick] = useState(0);
+  // eslint-disable-next-line react-compiler/react-compiler -- test harness: expose a render trigger to the enclosing test
+  forceRerender = () => setTick(t => t + 1);
+  return (
+    <SocketContext.Provider
+      value={{
+        socket: socket as never,
+        isConnected: true,
+        connectionError: null,
+        connect: () => {},
+        disconnect: () => {},
+      }}
+    >
+      {children}
+    </SocketContext.Provider>
+  );
+}
+
+/** action carried by the params of the Nth provider construction (0-based). */
+function actionOfConstruction(index: number): unknown {
+  return providerConstructions[index]?.params['action'];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SessionProvider/StoreProvider join-action bridge (#4830)', () => {
+  beforeEach(() => {
+    providerConstructions.length = 0;
+    capturedSessionStores.length = 0;
+    capturedSessionContextStores.length = 0;
+  });
+
+  afterEach(() => {
+    capturedSessionStores.forEach(store => {
+      try {
+        store.destroy();
+      } catch {
+        /* already destroyed */
+      }
+    });
+    vi.clearAllMocks();
+  });
+
+  test('initial connect joins with action "new", then a reconnect after clearIsNewWorkflow() rejoins with action "edit"', () => {
+    const socket = createMockSocket();
+
+    const tree = (
+      <ConnectedSocket socket={socket}>
+        <SessionProvider
+          workflowId="wf-1"
+          projectId="proj-1"
+          isNewWorkflow={true}
+        >
+          <StoreProvider>
+            <div data-testid="child" />
+          </StoreProvider>
+        </SessionProvider>
+      </ConnectedSocket>
+    );
+
+    act(() => {
+      render(tree);
+    });
+
+    // --- Assertion 1: initial connect carries action "new" -----------------
+    expect(providerConstructions.length).toBeGreaterThanOrEqual(1);
+    expect(actionOfConstruction(0)).toBe('new');
+    const constructionsAfterInitial = providerConstructions.length;
+
+    // The real bridge must have wired the SessionContextStore -> ref.
+    expect(capturedSessionStores.length).toBe(1);
+    expect(capturedSessionContextStores.length).toBe(1);
+
+    const sessionStore = capturedSessionStores[0];
+    const sessionContextStore = capturedSessionContextStores[0];
+
+    // Sanity: the seeded store flag reflects the prop.
+    expect(sessionContextStore.getSnapshot().isNewWorkflow).toBe(true);
+
+    // Settle the live provider so SessionProvider commits a render that
+    // observes a non-null provider. useProviderLifecycle's reconnect effect
+    // then records that provider as its "previous" reference — the baseline a
+    // subsequent provider-loss is compared against.
+    act(() => {
+      sessionStore.provider?.emit('sync', [true]);
+    });
+
+    // --- Drive the REAL path: first save completes -> flag cleared ---------
+    // This is exactly what useWorkflow.tsx (~436) calls after a successful
+    // save of a new workflow. The StoreProvider bridge effect is subscribed,
+    // so this propagates synchronously into SessionProvider's `isNewWorkflow`
+    // ref (no re-render needed for a ref write).
+    act(() => {
+      sessionContextStore.clearIsNewWorkflow();
+    });
+    expect(sessionContextStore.getSnapshot().isNewWorkflow).toBe(false);
+
+    // --- Simulate provider loss + in-place reconnect -----------------------
+    // Drop the live provider (mirrors a lost channel) and force a re-render
+    // while still connected. useProviderLifecycle's reconnect effect detects
+    // the had-provider -> null transition and rebuilds the provider, re-reading
+    // getJoinParams() lazily.
+    act(() => {
+      sessionStore.destroy();
+      forceRerender();
+    });
+
+    // --- Assertion 2: reconnect carries action "edit" ----------------------
+    // NOTE (pre-fix proof): with the old frozen-prop code, getJoinParams was
+    // captured once at mount holding action: "new", so this reconnect would
+    // reconstruct the provider with "new" and this assertion would FAIL.
+    expect(providerConstructions.length).toBeGreaterThan(
+      constructionsAfterInitial
+    );
+    const lastIndex = providerConstructions.length - 1;
+    expect(actionOfConstruction(lastIndex)).toBe('edit');
+  });
+});

--- a/assets/test/collaborative-editor/hooks/useProviderLifecycle.test.tsx
+++ b/assets/test/collaborative-editor/hooks/useProviderLifecycle.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * useProviderLifecycle Hook Tests
+ *
+ * Regression coverage for GitHub #4830: an in-place socket reconnect of an
+ * already-saved "new" workflow must rejoin the channel with `action: "edit"`,
+ * not the stale `action: "new"` frozen at mount.
+ *
+ * The hook reads join params lazily via `getJoinParams()` so the channel-join
+ * `action` reflects the *current* saved state at both initial connect and
+ * reconnect time.
+ */
+
+import { renderHook } from '@testing-library/react';
+import type { Socket } from 'phoenix';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useProviderLifecycle } from '../../../js/collaborative-editor/hooks/useProviderLifecycle';
+import type { SessionStoreInstance } from '../../../js/collaborative-editor/stores/createSessionStore';
+import { createMockSocket } from '../mocks/phoenixSocket';
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+/**
+ * Minimal SessionStore stub exposing only the surface useProviderLifecycle
+ * touches: a mutable `provider` reference and an `initializeSession` spy.
+ */
+function createSessionStoreStub() {
+  const initializeSession = vi.fn(() => {
+    // Mimic the real store: a provider exists after (re)initialisation.
+    stub.provider = {
+      id: Symbol('provider'),
+    } as unknown as SessionStoreInstance['provider'];
+  });
+
+  const stub = {
+    provider: null as SessionStoreInstance['provider'],
+    initializeSession,
+  } as unknown as SessionStoreInstance;
+
+  return stub;
+}
+
+/** Extract the `joinParams` passed to the most recent initializeSession call. */
+function lastJoinParams(store: SessionStoreInstance) {
+  const calls = (store.initializeSession as ReturnType<typeof vi.fn>).mock
+    .calls;
+  const lastCall = calls[calls.length - 1];
+  return lastCall?.[3]?.joinParams as { project_id: string; action: string };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('useProviderLifecycle join action freshness (#4830)', () => {
+  let socket: Socket;
+
+  beforeEach(() => {
+    socket = createMockSocket() as unknown as Socket;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('initial join carries action "new" when the workflow is unsaved', () => {
+    const sessionStore = createSessionStoreStub();
+    let isNew = true;
+
+    renderHook(() =>
+      useProviderLifecycle({
+        socket,
+        isConnected: true,
+        sessionStore,
+        roomname: 'workflow:collaborate:wf-1',
+        getJoinParams: () => ({
+          project_id: 'proj-1',
+          action: isNew ? 'new' : 'edit',
+        }),
+      })
+    );
+
+    expect(sessionStore.initializeSession).toHaveBeenCalledTimes(1);
+    expect(lastJoinParams(sessionStore)).toEqual({
+      project_id: 'proj-1',
+      action: 'new',
+    });
+  });
+
+  test('in-place reconnect rejoins with action "edit" after the workflow is saved', () => {
+    const sessionStore = createSessionStoreStub();
+    // `isNew` models the live SessionContextStore flag, flipped by
+    // clearIsNewWorkflow() after the first successful save.
+    let isNew = true;
+
+    const { rerender } = renderHook(() =>
+      useProviderLifecycle({
+        socket,
+        isConnected: true,
+        sessionStore,
+        roomname: 'workflow:collaborate:wf-1',
+        getJoinParams: () => ({
+          project_id: 'proj-1',
+          action: isNew ? 'new' : 'edit',
+        }),
+      })
+    );
+
+    // First join used the seeded "new" action.
+    expect(lastJoinParams(sessionStore)).toEqual({
+      project_id: 'proj-1',
+      action: 'new',
+    });
+
+    // Simulate: first save completes -> flag flips, then the provider is lost.
+    isNew = false;
+    sessionStore.provider = null;
+    rerender();
+
+    // Reconnect must have re-read the join params lazily and rejoined as "edit".
+    expect(sessionStore.initializeSession).toHaveBeenCalledTimes(2);
+    expect(lastJoinParams(sessionStore)).toEqual({
+      project_id: 'proj-1',
+      action: 'edit',
+    });
+  });
+});

--- a/lib/lightning/collaboration/session.ex
+++ b/lib/lightning/collaboration/session.ex
@@ -21,7 +21,9 @@ defmodule Lightning.Collaboration.Session do
   import LightningWeb.CoreComponents, only: [translate_error: 1]
 
   alias Lightning.Accounts.User
+  alias Lightning.Collaboration.WorkflowResolver
   alias Lightning.Collaboration.WorkflowSerializer
+  alias Lightning.Projects.Project
   alias Lightning.Workflows.Presence
   alias Lightning.Workflows.WorkflowUsageLimiter
   alias Yex.Sync.SharedDoc
@@ -311,7 +313,10 @@ defmodule Lightning.Collaboration.Session do
 
     with {:ok, doc} <- get_document(state),
          {:ok, workflow_data} <- deserialize_workflow(doc, state.workflow.id),
-         {:ok, workflow} <- fetch_workflow(state.workflow),
+         {:ok, workflow, _kind} <-
+           WorkflowResolver.resolve(state.workflow.id, :new,
+             project: %Project{id: state.workflow.project_id}
+           ),
          changeset <-
            Lightning.Workflows.change_workflow(workflow, workflow_data),
          {:ok, changeset} <- maybe_disable_triggers_on_limit(changeset),
@@ -331,6 +336,16 @@ defmodule Lightning.Collaboration.Session do
     else
       {:error, :no_shared_doc} ->
         Logger.error("Cannot save workflow #{state.workflow.id}: no shared doc")
+        {:reply, {:error, :internal_error}, state}
+
+      # Unreachable in practice (the persisted row always shares the seed's
+      # project_id), but the resolver can return :wrong_project given a :project
+      # opt, so guard against a WithClauseError.
+      {:error, :wrong_project} ->
+        Logger.error(
+          "Cannot save workflow #{state.workflow.id}: resolved to wrong project"
+        )
+
         {:reply, {:error, :internal_error}, state}
 
       {:error, :deserialization_failed, reason} ->
@@ -379,11 +394,24 @@ defmodule Lightning.Collaboration.Session do
   def handle_call({:reset_workflow, user}, _from, state) do
     Logger.info("Resetting workflow #{state.workflow.id} for user #{user.id}")
 
-    with {:ok, workflow} <- fetch_workflow(state.workflow),
+    with {:ok, workflow, _kind} <-
+           WorkflowResolver.resolve(state.workflow.id, :new,
+             project: %Project{id: state.workflow.project_id}
+           ),
+         :ok <- ensure_not_deleted(workflow),
          :ok <- clear_and_reset_doc(state, workflow) do
       Logger.info("Successfully reset workflow #{state.workflow.id}")
       {:reply, {:ok, workflow}, state}
     else
+      # Unreachable in practice (see save_workflow), guarded against a
+      # WithClauseError since the resolver is supplied a :project opt.
+      {:error, :wrong_project} ->
+        Logger.error(
+          "Cannot reset workflow #{state.workflow.id}: resolved to wrong project"
+        )
+
+        {:reply, {:error, :internal_error}, state}
+
       {:error, :workflow_deleted} ->
         Logger.warning(
           "Cannot reset workflow #{state.workflow.id}: workflow deleted"
@@ -464,64 +492,6 @@ defmodule Lightning.Collaboration.Session do
       {:error, :deserialization_failed, Exception.message(e)}
   end
 
-  # :built state with positive lock_version means it was saved before - reload from DB
-  defp fetch_workflow(
-         %{__meta__: %{state: :built}, lock_version: lock_version} = workflow
-       )
-       when is_integer(lock_version) and lock_version > 0 do
-    case Lightning.Workflows.get_workflow(workflow.id,
-           include: [:jobs, :edges, :triggers]
-         ) do
-      nil -> {:error, :workflow_deleted}
-      workflow -> {:ok, workflow}
-    end
-  end
-
-  # :built state with default lock_version (0) is the genuine first-save case
-  # (route to INSERT) UNLESS a row already exists for this id. A stale "new"
-  # rejoin after an in-place socket reconnect can hand us a freshly-built struct
-  # for an id that was already persisted by the first save; reloading it here
-  # routes the save to UPDATE and avoids a workflows_pkey duplicate INSERT
-  # (#4830). Reload-by-id mirrors the sibling clauses above and below.
-  defp fetch_workflow(%{__meta__: %{state: :built}} = workflow) do
-    case Lightning.Workflows.get_workflow(workflow.id,
-           include: [:jobs, :edges, :triggers]
-         ) do
-      nil ->
-        workflow =
-          workflow
-          |> Map.put(:edges, %Ecto.Association.NotLoaded{
-            __cardinality__: :many,
-            __field__: :edges,
-            __owner__: Lightning.Workflows.Workflow
-          })
-          |> Map.put(:jobs, %Ecto.Association.NotLoaded{
-            __cardinality__: :many,
-            __field__: :jobs,
-            __owner__: Lightning.Workflows.Workflow
-          })
-          |> Map.put(:triggers, %Ecto.Association.NotLoaded{
-            __cardinality__: :many,
-            __field__: :triggers,
-            __owner__: Lightning.Workflows.Workflow
-          })
-
-        {:ok, workflow}
-
-      persisted_workflow ->
-        {:ok, persisted_workflow}
-    end
-  end
-
-  defp fetch_workflow(workflow) do
-    case Lightning.Workflows.get_workflow(workflow.id,
-           include: [:jobs, :edges, :triggers]
-         ) do
-      nil -> {:error, :workflow_deleted}
-      workflow -> {:ok, workflow}
-    end
-  end
-
   defp merge_saved_workflow_into_ydoc(
          %{shared_doc_pid: shared_doc_pid},
          workflow
@@ -566,6 +536,9 @@ defmodule Lightning.Collaboration.Session do
       end
     end)
   end
+
+  defp ensure_not_deleted(%{deleted_at: nil}), do: :ok
+  defp ensure_not_deleted(_workflow), do: {:error, :workflow_deleted}
 
   defp clear_and_reset_doc(%{shared_doc_pid: nil}, _workflow),
     do: {:error, :no_shared_doc}

--- a/lib/lightning/collaboration/session.ex
+++ b/lib/lightning/collaboration/session.ex
@@ -477,26 +477,40 @@ defmodule Lightning.Collaboration.Session do
     end
   end
 
+  # :built state with default lock_version (0) is the genuine first-save case
+  # (route to INSERT) UNLESS a row already exists for this id. A stale "new"
+  # rejoin after an in-place socket reconnect can hand us a freshly-built struct
+  # for an id that was already persisted by the first save; reloading it here
+  # routes the save to UPDATE and avoids a workflows_pkey duplicate INSERT
+  # (#4830). Reload-by-id mirrors the sibling clauses above and below.
   defp fetch_workflow(%{__meta__: %{state: :built}} = workflow) do
-    workflow =
-      workflow
-      |> Map.put(:edges, %Ecto.Association.NotLoaded{
-        __cardinality__: :many,
-        __field__: :edges,
-        __owner__: Lightning.Workflows.Workflow
-      })
-      |> Map.put(:jobs, %Ecto.Association.NotLoaded{
-        __cardinality__: :many,
-        __field__: :jobs,
-        __owner__: Lightning.Workflows.Workflow
-      })
-      |> Map.put(:triggers, %Ecto.Association.NotLoaded{
-        __cardinality__: :many,
-        __field__: :triggers,
-        __owner__: Lightning.Workflows.Workflow
-      })
+    case Lightning.Workflows.get_workflow(workflow.id,
+           include: [:jobs, :edges, :triggers]
+         ) do
+      nil ->
+        workflow =
+          workflow
+          |> Map.put(:edges, %Ecto.Association.NotLoaded{
+            __cardinality__: :many,
+            __field__: :edges,
+            __owner__: Lightning.Workflows.Workflow
+          })
+          |> Map.put(:jobs, %Ecto.Association.NotLoaded{
+            __cardinality__: :many,
+            __field__: :jobs,
+            __owner__: Lightning.Workflows.Workflow
+          })
+          |> Map.put(:triggers, %Ecto.Association.NotLoaded{
+            __cardinality__: :many,
+            __field__: :triggers,
+            __owner__: Lightning.Workflows.Workflow
+          })
 
-    {:ok, workflow}
+        {:ok, workflow}
+
+      persisted_workflow ->
+        {:ok, persisted_workflow}
+    end
   end
 
   defp fetch_workflow(workflow) do

--- a/lib/lightning/collaboration/workflow_resolver.ex
+++ b/lib/lightning/collaboration/workflow_resolver.ex
@@ -1,0 +1,261 @@
+defmodule Lightning.Collaboration.WorkflowResolver do
+  @moduledoc """
+  Single authority for resolving "given a `workflow_id` and an `action`, what
+  `%Workflow{}` should a collaboration session edit, and in which Ecto state?".
+
+  Both the channel join and the session save delegate here so they cannot
+  disagree on whether an id maps to a `:built` or `:loaded` struct — the
+  structural root cause behind the `workflows_pkey` duplicate INSERT on collab
+  reconnect (#4830).
+
+  The resolver performs **no** authorization (`Permissions.can` stays at the
+  channel). It does enforce project-ownership, but only when a `:project` opt is
+  supplied, because ownership is a property of the resolved row, not of the
+  user.
+  """
+
+  import Ecto.Query
+
+  alias Lightning.Projects.Project
+  alias Lightning.Repo
+  alias Lightning.Workflows
+  alias Lightning.Workflows.Snapshot
+  alias Lightning.Workflows.Trigger
+  alias Lightning.Workflows.WebhookAuthMethod
+  alias Lightning.Workflows.Workflow
+
+  @type action :: :new | :edit
+  @type resolve_opts :: [
+          version: non_neg_integer() | nil,
+          project: Project.t() | nil
+        ]
+
+  @doc """
+  Resolves the `%Workflow{}` a collaboration session should edit.
+
+  Returns `{:ok, workflow, kind}` where `workflow` is already in the correct
+  Ecto state (with `jobs`, `edges`, and `triggers` populated and the
+  `has_auth_method` flag set on each trigger) and `kind` is the newness
+  discriminant (see `t:kind/0`).
+
+  Cases:
+
+    * `action: :new`, no existing row — a freshly built `%Workflow{}` keyed on
+      `workflow_id`, with `project_id` from the supplied project, empty
+      jobs/edges/triggers, and `lock_version: 0`. Ecto state `:built`, kind
+      `:new`. The first-INSERT case.
+    * `action: :new`, row already exists — the persisted workflow loaded with
+      jobs/edges/triggers. Ecto state `:loaded`, kind `:existing`. Resolving an
+      existing id to its loaded row routes the save to UPDATE rather than a
+      duplicate INSERT (#4830).
+    * `action: :edit`, no version, row exists — the persisted workflow loaded
+      with jobs/edges/triggers and `has_auth_method` set. Ecto state `:loaded`,
+      kind `:existing`.
+    * `action: :edit`, no version, no row — `{:error, :workflow_not_found}`.
+    * unknown action — `{:error, :invalid_action}`.
+  """
+  @typedoc """
+  The discriminant the resolver returns alongside the workflow, so callers
+  read newness from the tag rather than re-deriving it from struct shape:
+
+    * `:new`      — `:new` action with no existing DB row (a freshly built
+      `:built` struct).
+    * `:existing` — a `:new` action for an id that already has a row, or an
+      `:edit` action (loaded row).
+    * `:version`  — a snapshot version-view (`resolve_version/3`).
+  """
+  @type kind :: :new | :existing | :version
+
+  @spec resolve(
+          workflow_id :: Ecto.UUID.t(),
+          action :: action(),
+          opts :: resolve_opts()
+        ) ::
+          {:ok, Workflow.t(), kind()}
+          | {:error,
+             :workflow_not_found
+             | :wrong_project
+             | :snapshot_not_found
+             | :invalid_action}
+  def resolve(workflow_id, action, opts \\ [])
+
+  def resolve(workflow_id, :new, opts) do
+    project = Keyword.get(opts, :project)
+
+    case load_workflow(workflow_id) do
+      nil ->
+        # First-INSERT: a freshly built struct keyed on the supplied id, in Ecto
+        # state :built so the save routes to an INSERT. lock_version stays at the
+        # schema default of 0.
+        workflow = %Workflow{
+          id: workflow_id,
+          project_id: project && project.id,
+          name: "Untitled workflow",
+          jobs: [],
+          edges: [],
+          triggers: []
+        }
+
+        tag_kind(check_ownership(workflow, project), :new)
+
+      workflow ->
+        # A :new action for an id that already has a row resolves to the loaded
+        # row, so the save routes to UPDATE rather than a duplicate INSERT
+        # (#4830).
+        tag_kind(check_ownership(workflow, project), :existing)
+    end
+  end
+
+  def resolve(workflow_id, :edit, opts) do
+    # A non-nil `version:` opt dispatches to resolve_version/3 for a read-only
+    # point-in-time view. The version is already a non_neg_integer; the resolver
+    # never parses version strings.
+    case Keyword.get(opts, :version) do
+      nil ->
+        project = Keyword.get(opts, :project)
+
+        case load_workflow(workflow_id) do
+          nil -> {:error, :workflow_not_found}
+          workflow -> tag_kind(check_ownership(workflow, project), :existing)
+        end
+
+      version when is_integer(version) ->
+        resolve_version(workflow_id, version, opts)
+    end
+  end
+
+  def resolve(_workflow_id, _action, _opts) do
+    {:error, :invalid_action}
+  end
+
+  @doc """
+  Hydrates a read-only `%Workflow{}` from a specific snapshot version.
+
+  Dispatched from `resolve/3` when a non-nil `:version` opt is present, and may
+  also be called directly. The `version` is a `non_neg_integer()` already parsed
+  by the caller — the resolver never parses version strings.
+
+  Returns a `%Workflow{}` in Ecto state `:built` carrying the snapshot's
+  `lock_version` and tagged with kind `:version`. A version-view is a read-only
+  point-in-time view that is never saved through this path; the `:version` kind
+  lets callers distinguish it from a genuinely-new workflow.
+
+  Sets `project_id` from the supplied project and performs **no** ownership
+  check, unlike the `:edit` latest path. Performs **no** authorization (auth
+  stays at the channel).
+
+  Returns `{:error, :snapshot_not_found}` when no snapshot exists for the
+  version.
+  """
+  @spec resolve_version(
+          workflow_id :: Ecto.UUID.t(),
+          version :: non_neg_integer(),
+          opts :: resolve_opts()
+        ) :: {:ok, Workflow.t(), kind()} | {:error, :snapshot_not_found}
+  def resolve_version(workflow_id, version, opts \\ []) do
+    project = Keyword.get(opts, :project)
+
+    case Snapshot.get_by_version(workflow_id, version) do
+      nil ->
+        {:error, :snapshot_not_found}
+
+      snapshot ->
+        trigger_ids = Enum.map(snapshot.triggers, &Ecto.UUID.dump!(&1.id))
+
+        # Snapshot triggers reference auth methods through the join table
+        # directly, so derive has_auth_method from a raw query grouped by
+        # trigger_id rather than from the schema preload.
+        trigger_auth_methods =
+          from(twam in "trigger_webhook_auth_methods",
+            where: twam.trigger_id in ^trigger_ids,
+            join: wam in WebhookAuthMethod,
+            on: twam.webhook_auth_method_id == wam.id,
+            where: is_nil(wam.scheduled_deletion),
+            select: %{trigger_id: twam.trigger_id, auth_method: wam}
+          )
+          |> Repo.all()
+          |> Enum.group_by(
+            &Ecto.UUID.cast!(&1.trigger_id),
+            & &1.auth_method
+          )
+
+        workflow = %Workflow{
+          id: workflow_id,
+          project_id: project && project.id,
+          name: snapshot.name,
+          lock_version: snapshot.lock_version,
+          deleted_at: nil,
+          jobs: Enum.map(snapshot.jobs, &Map.from_struct/1),
+          edges: Enum.map(snapshot.edges, &Map.from_struct/1),
+          triggers:
+            Enum.map(snapshot.triggers, fn trigger ->
+              auth_methods = Map.get(trigger_auth_methods, trigger.id, [])
+
+              trigger
+              |> Map.from_struct()
+              |> Map.put(:has_auth_method, length(auth_methods) > 0)
+            end)
+        }
+
+        {:ok, workflow, :version}
+    end
+  end
+
+  # Loads the latest workflow with jobs/edges/triggers, setting has_auth_method
+  # per trigger (triggers preload non-deleted webhook_auth_methods ordered by
+  # name). Returns nil if no row exists.
+  defp load_workflow(workflow_id) do
+    case Workflows.get_workflow(workflow_id,
+           include: [
+             :jobs,
+             :edges,
+             triggers:
+               from(t in Trigger,
+                 preload: [
+                   webhook_auth_methods:
+                     ^from(wam in WebhookAuthMethod,
+                       where: is_nil(wam.scheduled_deletion),
+                       order_by: wam.name
+                     )
+                 ]
+               )
+           ]
+         ) do
+      nil ->
+        nil
+
+      workflow ->
+        %{
+          workflow
+          | triggers:
+              Enum.map(workflow.triggers, fn trigger ->
+                %{
+                  trigger
+                  | has_auth_method:
+                      length(trigger.webhook_auth_methods || []) > 0
+                }
+              end)
+        }
+    end
+  end
+
+  # Attaches the newness discriminant to a successful resolution, passing errors
+  # through untouched.
+  defp tag_kind({:ok, workflow}, kind), do: {:ok, workflow, kind}
+  defp tag_kind({:error, _reason} = error, _kind), do: error
+
+  # Ownership is a property of the resolved row, enforced only when a :project
+  # opt is supplied.
+  defp check_ownership(workflow, nil), do: {:ok, workflow}
+
+  defp check_ownership(%Workflow{project_id: project_id} = workflow, %Project{
+         id: id
+       })
+       when project_id == id do
+    {:ok, workflow}
+  end
+
+  defp check_ownership(_workflow, %Project{}) do
+    {:error, :wrong_project}
+  end
+end

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -12,13 +12,12 @@ defmodule LightningWeb.WorkflowChannel do
   alias Lightning.Collaborate
   alias Lightning.Collaboration.Session
   alias Lightning.Collaboration.Utils
+  alias Lightning.Collaboration.WorkflowResolver
   alias Lightning.Policies.Permissions
   alias Lightning.Repo
   alias Lightning.VersionControl
   alias Lightning.VersionControl.VersionControlUsageLimiter
   alias Lightning.Workflows.Job
-  alias Lightning.Workflows.Snapshot
-  alias Lightning.Workflows.Workflow
   alias Lightning.Workflows.WorkflowUsageLimiter
   alias Lightning.WorkOrders
   alias LightningWeb.Channels.WorkflowJSON
@@ -44,7 +43,7 @@ defmodule LightningWeb.WorkflowChannel do
            {:user, socket.assigns[:current_user]},
          {:project, %_{} = project} <-
            {:project, Lightning.Projects.get_project(project_id)},
-         {:workflow, {:ok, workflow}} <-
+         {:workflow, {:ok, workflow, workflow_kind}} <-
            {:workflow,
             load_workflow(action, workflow_id, project, user, version)} do
       Logger.info("""
@@ -80,7 +79,7 @@ defmodule LightningWeb.WorkflowChannel do
          project: project,
          session_pid: session_pid,
          project_user: project_user,
-         snapshot_version: version
+         workflow_kind: workflow_kind
        )}
     else
       {:user, nil} -> {:error, %{reason: "unauthorized"}}
@@ -205,19 +204,22 @@ defmodule LightningWeb.WorkflowChannel do
     workflow = socket.assigns.workflow
     project = socket.assigns.project
     project_user = socket.assigns.project_user
+    workflow_kind = socket.assigns.workflow_kind
 
     async_task(socket, "get_context", fn ->
-      # For unsaved workflows (action="new"), lock_version is nil and the workflow
-      # doesn't exist in the database yet. Use the in-memory workflow in that case.
-      # For saved workflows, always fetch fresh from DB to get the actual latest
-      # lock_version (socket.assigns.workflow could be stale).
-      fresh_workflow =
-        if is_nil(workflow.lock_version) do
-          workflow
+      # A genuinely-new workflow has no DB row, so use the in-memory struct and
+      # report a nil latest version. Otherwise reload to get the current
+      # lock_version, since socket.assigns.workflow may be stale.
+      {fresh_workflow, latest_lock_version} =
+        if workflow_kind == :new do
+          {workflow, nil}
         else
-          Lightning.Workflows.get_workflow(workflow.id,
-            include: [:edges, :jobs, :triggers]
-          )
+          fresh =
+            Lightning.Workflows.get_workflow(workflow.id,
+              include: [:edges, :jobs, :triggers]
+            )
+
+          {fresh, (fresh && fresh.lock_version) || workflow.lock_version}
         end
 
       project_repo_connection =
@@ -234,9 +236,7 @@ defmodule LightningWeb.WorkflowChannel do
         project: render_project_context(project),
         config: render_config_context(),
         permissions: render_permissions(user, project_user),
-        latest_snapshot_lock_version:
-          (fresh_workflow && fresh_workflow.lock_version) ||
-            workflow.lock_version,
+        latest_snapshot_lock_version: latest_lock_version,
         project_repo_connection: render_repo_connection(project_repo_connection),
         webhook_auth_methods: render_webhook_auth_methods(webhook_auth_methods),
         workflow_template: render_workflow_template(workflow_template),
@@ -460,14 +460,15 @@ defmodule LightningWeb.WorkflowChannel do
   def handle_in("request_versions", _payload, socket) do
     Logger.info("====== RECEIVED request_versions ======")
     workflow = socket.assigns.workflow
+    workflow_kind = socket.assigns.workflow_kind
     Logger.info("Workflow ID: #{workflow.id}")
 
     async_task(socket, "request_versions", fn ->
       Logger.info("Inside async_task for request_versions")
 
-      # For unsaved workflows (action="new"), there are no versions to show.
-      # Return empty list instead of crashing.
-      if is_nil(workflow.lock_version) do
+      # A genuinely-new workflow has no DB row and thus no versions, so
+      # short-circuit to an empty list rather than reloading a nil row.
+      if workflow_kind == :new do
         Logger.info("Workflow is unsaved, returning empty versions list")
         %{versions: []}
       else
@@ -1187,66 +1188,27 @@ defmodule LightningWeb.WorkflowChannel do
 
   defp fetch_auth_methods(_ids, _project), do: []
 
+  # Snapshot-version view. The channel owns version parsing (and the
+  # "invalid version format" error); the resolver hydrates from the snapshot.
+  # Resolve before auth, so a snapshot-not-found beats the auth error.
   defp load_workflow("edit", workflow_id, project, user, version)
        when is_binary(version) do
     Logger.info("Loading workflow snapshot version: #{version}")
 
     case Integer.parse(version) do
       {lock_version, ""} ->
-        case Snapshot.get_by_version(workflow_id, lock_version) do
-          nil ->
-            {:error, "snapshot version #{version} not found"}
-
-          snapshot ->
-            trigger_ids =
-              snapshot.triggers
-              |> Enum.map(& &1.id)
-              |> Enum.map(&Ecto.UUID.dump!/1)
-
-            trigger_auth_methods =
-              from(twam in "trigger_webhook_auth_methods",
-                where: twam.trigger_id in ^trigger_ids,
-                join: wam in Lightning.Workflows.WebhookAuthMethod,
-                on: twam.webhook_auth_method_id == wam.id,
-                where: is_nil(wam.scheduled_deletion),
-                select: %{trigger_id: twam.trigger_id, auth_method: wam}
-              )
-              |> Lightning.Repo.all()
-              |> Enum.group_by(
-                &Ecto.UUID.cast!(&1.trigger_id),
-                & &1.auth_method
-              )
-
-            workflow = %Workflow{
-              id: workflow_id,
-              project_id: project.id,
-              name: snapshot.name,
-              lock_version: snapshot.lock_version,
-              deleted_at: nil,
-              jobs: Enum.map(snapshot.jobs, &Map.from_struct/1),
-              edges: Enum.map(snapshot.edges, &Map.from_struct/1),
-              triggers:
-                Enum.map(snapshot.triggers, fn trigger ->
-                  auth_methods = Map.get(trigger_auth_methods, trigger.id, [])
-
-                  trigger
-                  |> Map.from_struct()
-                  |> Map.put(:has_auth_method, length(auth_methods) > 0)
-                end)
-            }
-
-            case Permissions.can(
-                   :workflows,
-                   :access_read,
-                   user,
-                   project
-                 ) do
-              :ok ->
-                {:ok, workflow}
-
-              {:error, :unauthorized} ->
-                {:error, "unauthorized"}
+        case WorkflowResolver.resolve(workflow_id, :edit,
+               version: lock_version,
+               project: project
+             ) do
+          {:ok, workflow, kind} ->
+            case Permissions.can(:workflows, :access_read, user, project) do
+              :ok -> {:ok, workflow, kind}
+              {:error, :unauthorized} -> {:error, "unauthorized"}
             end
+
+          {:error, :snapshot_not_found} ->
+            {:error, "snapshot version #{version} not found"}
         end
 
       _ ->
@@ -1254,80 +1216,39 @@ defmodule LightningWeb.WorkflowChannel do
     end
   end
 
+  # Edit latest. Resolve before auth, so workflow-not-found and wrong-project
+  # both beat the auth error.
   defp load_workflow("edit", workflow_id, project, user, _version) do
-    # IMPORTANT: Preload associations needed for Y.Doc initialization
-    # When no persisted Y.Doc state exists, the workflow is serialized to Y.Doc
-    # and needs jobs, edges, and triggers loaded to avoid empty workflow state
-    case Lightning.Workflows.get_workflow(workflow_id,
-           include: [
-             :jobs,
-             :edges,
-             triggers:
-               from(t in Lightning.Workflows.Trigger,
-                 preload: [
-                   webhook_auth_methods:
-                     ^from(wam in Lightning.Workflows.WebhookAuthMethod,
-                       where: is_nil(wam.scheduled_deletion),
-                       order_by: wam.name
-                     )
-                 ]
-               )
-           ]
-         ) do
-      nil ->
+    case WorkflowResolver.resolve(workflow_id, :edit, project: project) do
+      {:ok, workflow, kind} ->
+        case Permissions.can(:workflows, :access_read, user, project) do
+          :ok -> {:ok, workflow, kind}
+          {:error, :unauthorized} -> {:error, "unauthorized"}
+        end
+
+      {:error, :workflow_not_found} ->
         {:error, "workflow not found"}
 
-      workflow ->
-        if workflow.project_id != project.id do
-          {:error, "workflow does not belong to specified project"}
-        else
-          case Permissions.can(
-                 :workflows,
-                 :access_read,
-                 user,
-                 project
-               ) do
-            :ok ->
-              workflow_with_auth_flags = %{
-                workflow
-                | triggers:
-                    Enum.map(workflow.triggers, fn trigger ->
-                      %{
-                        trigger
-                        | has_auth_method:
-                            length(trigger.webhook_auth_methods || []) > 0
-                      }
-                    end)
-              }
-
-              {:ok, workflow_with_auth_flags}
-
-            {:error, :unauthorized} ->
-              {:error, "unauthorized"}
-          end
-        end
+      {:error, :wrong_project} ->
+        {:error, "workflow does not belong to specified project"}
     end
   end
 
+  # New workflow. Auth before resolve, so an unauthorised create never resolves.
+  #
+  # The resolver reconciles by id, so a "new" join for an id owned by another
+  # project returns {:error, :wrong_project}, mapped to the same client-facing
+  # string as the "edit" path.
   defp load_workflow("new", workflow_id, project, user, _version) do
-    case Permissions.can(
-           :project_users,
-           :create_workflow,
-           user,
-           project
-         ) do
+    case Permissions.can(:project_users, :create_workflow, user, project) do
       :ok ->
-        workflow = %Lightning.Workflows.Workflow{
-          id: workflow_id,
-          project_id: project.id,
-          name: "Untitled workflow",
-          lock_version: nil,
-          jobs: [],
-          edges: [],
-          triggers: []
-        }
+        case WorkflowResolver.resolve(workflow_id, :new, project: project) do
+          {:ok, workflow, kind} ->
+            {:ok, workflow, kind}
 
-        {:ok, workflow}
+          {:error, :wrong_project} ->
+            {:error, "workflow does not belong to specified project"}
+        end
 
       {:error, :unauthorized} ->
         {:error, "unauthorized"}

--- a/test/lightning/collaboration/session_test.exs
+++ b/test/lightning/collaboration/session_test.exs
@@ -1028,7 +1028,9 @@ defmodule Lightning.SessionTest do
         )
       )
 
-      # Try to save again - should get workflow_deleted error (covering line 475)
+      # Try to save again - should get workflow_deleted error: the resolver
+      # reconciles to the soft-deleted :loaded row and save_workflow's
+      # validate_not_deleted step then rejects it.
       assert {:error, :workflow_deleted} =
                Session.save_workflow(session_pid, user)
     end
@@ -1091,6 +1093,58 @@ defmodule Lightning.SessionTest do
       assert {:error, %Ecto.Changeset{}} = Session.save_workflow(session, user)
 
       assert Process.alive?(session)
+    end
+  end
+
+  describe "reset_workflow/2" do
+    setup do
+      # Set global mode for the mock to allow cross-process calls
+      Mox.set_mox_global(LightningMock)
+      # Stub the broadcast calls that reset_workflow makes
+      Mox.stub(LightningMock, :broadcast, fn _topic, _message -> :ok end)
+
+      user = insert(:user)
+      project = insert(:project)
+      workflow = insert(:workflow, name: "Original Name", project: project)
+
+      start_supervised!(
+        {DocumentSupervisor,
+         workflow: workflow, document_name: "workflow:#{workflow.id}"}
+      )
+
+      session_pid =
+        start_supervised!(
+          {Session,
+           workflow: workflow,
+           user: user,
+           document_name: "workflow:#{workflow.id}"}
+        )
+
+      %{session: session_pid, user: user, workflow: workflow, project: project}
+    end
+
+    test "returns workflow_deleted error for a soft-deleted workflow", %{
+      session: session,
+      user: user,
+      workflow: workflow
+    } do
+      # Soft-delete the workflow
+      Lightning.Repo.update!(
+        Ecto.Changeset.change(workflow,
+          deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+      )
+
+      # Reset should fail
+      assert {:error, :workflow_deleted} = Session.reset_workflow(session, user)
+    end
+
+    test "resets successfully for a live workflow", %{
+      session: session,
+      user: user
+    } do
+      assert {:ok, %Lightning.Workflows.Workflow{}} =
+               Session.reset_workflow(session, user)
     end
   end
 
@@ -1230,10 +1284,10 @@ defmodule Lightning.SessionTest do
       assert saved_trigger.enabled == true
     end
 
-    # #4830: a stale "new" rejoin after an in-place socket reconnect hands the
-    # session a freshly-built struct (default lock_version 0) for an id that the
-    # first save already persisted. Without reconcile-by-id in fetch_workflow/1
-    # the second save routes to INSERT and collides on workflows_pkey.
+    # A stale "new" rejoin after an in-place socket reconnect hands the session a
+    # freshly-built struct (default lock_version 0) for an id the first save
+    # already persisted. The resolver reconciles by id so the second save routes
+    # to UPDATE, not a duplicate INSERT on workflows_pkey (#4830).
     test "reconnect with stale built struct UPDATEs instead of duplicate INSERT",
          %{session: session, user: user, workflow: workflow, project: project} do
       stub(
@@ -1243,8 +1297,8 @@ defmodule Lightning.SessionTest do
       )
 
       # A freshly built workflow is in :built state with the default
-      # lock_version (0, not > 0), so fetch_workflow/1 routes it through the
-      # built clause rather than the lock_version > 0 reload clause.
+      # lock_version of 0. The resolver routes the save by whether a row already
+      # exists, not by lock_version.
       assert workflow.__meta__.state == :built
       refute workflow.lock_version > 0
 

--- a/test/lightning/collaboration/session_test.exs
+++ b/test/lightning/collaboration/session_test.exs
@@ -1229,6 +1229,110 @@ defmodule Lightning.SessionTest do
       saved_trigger = Enum.find(saved_workflow.triggers, &(&1.id == trigger_id))
       assert saved_trigger.enabled == true
     end
+
+    # #4830: a stale "new" rejoin after an in-place socket reconnect hands the
+    # session a freshly-built struct (default lock_version 0) for an id that the
+    # first save already persisted. Without reconcile-by-id in fetch_workflow/1
+    # the second save routes to INSERT and collides on workflows_pkey.
+    test "reconnect with stale built struct UPDATEs instead of duplicate INSERT",
+         %{session: session, user: user, workflow: workflow, project: project} do
+      stub(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, _context -> :ok end
+      )
+
+      # A freshly built workflow is in :built state with the default
+      # lock_version (0, not > 0), so fetch_workflow/1 routes it through the
+      # built clause rather than the lock_version > 0 reload clause.
+      assert workflow.__meta__.state == :built
+      refute workflow.lock_version > 0
+
+      # First Create: the genuine first save inserts the row.
+      assert {:ok, created} = Session.save_workflow(session, user)
+      assert created.id == workflow.id
+
+      assert [%{lock_version: first_lock_version}] =
+               Repo.all(from w in Workflow, where: w.id == ^workflow.id)
+
+      # Simulate the reconnect: a fresh "new" rejoin reconstructs a built
+      # struct (default lock_version 0) for the SAME id with empty associations,
+      # while the persisted row is already present.
+      stale_workflow =
+        build(:workflow,
+          id: workflow.id,
+          name: "New Workflow",
+          project: project,
+          project_id: project.id
+        )
+
+      assert stale_workflow.__meta__.state == :built
+      refute stale_workflow.lock_version > 0
+
+      reconnect_document_name = "workflow:new:reconnect:#{workflow.id}"
+
+      start_supervised!(
+        {DocumentSupervisor,
+         workflow: stale_workflow, document_name: reconnect_document_name},
+        id: :reconnect_doc_sup
+      )
+
+      reconnect_session =
+        start_supervised!(
+          {Session,
+           workflow: stale_workflow,
+           user: user,
+           document_name: reconnect_document_name},
+          id: :reconnect_session
+        )
+
+      # Make a real edit in the reconnect doc so the UPDATE has a change to
+      # commit (and thus advances the optimistic lock).
+      doc = Session.get_doc(reconnect_session)
+      workflow_map = Yex.Doc.get_map(doc, "workflow")
+
+      Yex.Doc.transaction(doc, "rename", fn ->
+        Yex.Map.set(workflow_map, "name", "Renamed After Reconnect")
+      end)
+
+      # The reconcile branch must fire (UPDATE), not raise workflows_pkey and
+      # not be caught by the #4829 ConstraintError rescue (which returns an
+      # error changeset rather than {:ok, _}).
+      assert {:ok, updated} = Session.save_workflow(reconnect_session, user)
+      assert updated.id == workflow.id
+      assert updated.name == "Renamed After Reconnect"
+
+      # lock_version advanced and the row was not duplicated.
+      rows = Repo.all(from w in Workflow, where: w.id == ^workflow.id)
+      assert length(rows) == 1
+      assert [%{lock_version: second_lock_version}] = rows
+      assert second_lock_version > first_lock_version
+    end
+
+    # Lower-level assertion of the routing decision: when a built struct's id
+    # already has a row, the session resolves it to the :loaded DB workflow
+    # (→ UPDATE) rather than keeping it :built (→ INSERT). Observed via the
+    # session state, which save_workflow/2 replaces with the resolved workflow.
+    test "built struct for a persisted id resolves to the :loaded workflow",
+         %{session: session, user: user} do
+      stub(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, _context -> :ok end
+      )
+
+      assert %Session{workflow: %{__meta__: %{state: :built}} = seeded} =
+               :sys.get_state(session)
+
+      refute seeded.lock_version > 0
+
+      assert {:ok, _created} = Session.save_workflow(session, user)
+
+      # After the save the session holds the resolved, persisted workflow.
+      assert %Session{workflow: resolved} = :sys.get_state(session)
+      assert resolved.__meta__.state == :loaded
+      assert is_integer(resolved.lock_version)
+    end
   end
 
   describe "save_workflow/2 validation errors" do

--- a/test/lightning/collaboration/workflow_resolver_test.exs
+++ b/test/lightning/collaboration/workflow_resolver_test.exs
@@ -1,0 +1,270 @@
+defmodule Lightning.Collaboration.WorkflowResolverTest do
+  use Lightning.DataCase, async: true
+
+  alias Lightning.Collaboration.WorkflowResolver
+  alias Lightning.Workflows.Workflow
+
+  import Lightning.Factories
+
+  describe "resolve/3 with action: :new" do
+    test "returns a freshly built struct when no row exists" do
+      workflow_id = Ecto.UUID.generate()
+      project = insert(:project)
+
+      assert {:ok, %Workflow{} = workflow, :new} =
+               WorkflowResolver.resolve(workflow_id, :new, project: project)
+
+      # First-INSERT case: :built state routes to INSERT, lock_version is the
+      # schema default 0.
+      assert workflow.__meta__.state == :built
+      assert workflow.id == workflow_id
+      assert workflow.project_id == project.id
+      assert workflow.lock_version == 0
+      assert workflow.jobs == []
+      assert workflow.edges == []
+      assert workflow.triggers == []
+    end
+
+    test "works without a :project opt" do
+      workflow_id = Ecto.UUID.generate()
+
+      assert {:ok, %Workflow{} = workflow, :new} =
+               WorkflowResolver.resolve(workflow_id, :new)
+
+      assert workflow.__meta__.state == :built
+      assert workflow.id == workflow_id
+      assert workflow.project_id == nil
+      assert workflow.lock_version == 0
+    end
+
+    test "resolves an existing row to :loaded (the #4830 reconcile-by-id guarantee)" do
+      project = insert(:project)
+
+      # Build a genuinely-new workflow, then persist it (build-then-save).
+      workflow_id = Ecto.UUID.generate()
+
+      {:ok, built, :new} =
+        WorkflowResolver.resolve(workflow_id, :new, project: project)
+
+      assert built.__meta__.state == :built
+
+      user = insert(:user)
+
+      {:ok, _persisted} =
+        built
+        |> Workflow.changeset(%{name: "Persisted Workflow"})
+        |> Lightning.Workflows.save_workflow(user)
+
+      # A "new" rejoin for an id that now has a row must resolve to the loaded
+      # row so the next save routes to UPDATE, not a duplicate INSERT.
+      assert {:ok, %Workflow{} = workflow, :existing} =
+               WorkflowResolver.resolve(workflow_id, :new, project: project)
+
+      assert workflow.__meta__.state == :loaded
+      assert workflow.id == workflow_id
+      assert workflow.lock_version == 1
+    end
+  end
+
+  describe "resolve/3 with action: :edit" do
+    test "returns {:error, :workflow_not_found} when no row exists" do
+      assert {:error, :workflow_not_found} =
+               WorkflowResolver.resolve(Ecto.UUID.generate(), :edit)
+    end
+
+    test "loads jobs/edges/triggers and sets has_auth_method per trigger" do
+      project = insert(:project)
+      user = insert(:user)
+      workflow = insert(:workflow, project: project)
+
+      insert(:job, workflow: workflow, name: "A Job")
+
+      trigger_with_auth =
+        insert(:trigger, type: :webhook, workflow: workflow)
+
+      trigger_without_auth =
+        insert(:trigger, type: :cron, workflow: workflow)
+
+      auth_method =
+        insert(:webhook_auth_method,
+          project: project,
+          name: "Basic Auth",
+          auth_type: :basic
+        )
+
+      {:ok, _} =
+        Lightning.WebhookAuthMethods.update_trigger_auth_methods(
+          trigger_with_auth,
+          [auth_method],
+          actor: user
+        )
+
+      assert {:ok, %Workflow{} = resolved, :existing} =
+               WorkflowResolver.resolve(workflow.id, :edit, project: project)
+
+      assert resolved.__meta__.state == :loaded
+      assert [%{name: "A Job"}] = resolved.jobs
+
+      flags =
+        Map.new(resolved.triggers, fn trigger ->
+          {trigger.id, trigger.has_auth_method}
+        end)
+
+      assert flags[trigger_with_auth.id] == true
+      assert flags[trigger_without_auth.id] == false
+    end
+  end
+
+  describe "resolve/3 project ownership" do
+    test "returns {:error, :wrong_project} when the row belongs elsewhere" do
+      other_project = insert(:project)
+      requesting_project = insert(:project)
+      workflow = insert(:workflow, project: other_project)
+
+      assert {:error, :wrong_project} =
+               WorkflowResolver.resolve(workflow.id, :edit,
+                 project: requesting_project
+               )
+    end
+
+    test "does not enforce ownership when no :project opt is supplied" do
+      workflow = insert(:workflow)
+
+      assert {:ok, %Workflow{}, :existing} =
+               WorkflowResolver.resolve(workflow.id, :edit)
+    end
+  end
+
+  describe "resolve_version/3" do
+    setup do
+      project = insert(:project)
+      user = insert(:user)
+
+      workflow =
+        insert(:workflow, project: project, name: "Versioned Workflow")
+
+      job = insert(:job, workflow: workflow, name: "A Job")
+      _edge = insert(:edge, workflow: workflow, target_job: job)
+
+      trigger_with_auth =
+        insert(:trigger, type: :webhook, workflow: workflow)
+
+      trigger_without_auth =
+        insert(:trigger, type: :cron, workflow: workflow)
+
+      auth_method =
+        insert(:webhook_auth_method,
+          project: project,
+          name: "Basic Auth",
+          auth_type: :basic
+        )
+
+      {:ok, _} =
+        Lightning.WebhookAuthMethods.update_trigger_auth_methods(
+          trigger_with_auth,
+          [auth_method],
+          actor: user
+        )
+
+      # Snapshot the workflow at its current lock_version.
+      reloaded =
+        workflow.id
+        |> Lightning.Workflows.get_workflow(include: [:jobs, :edges, :triggers])
+
+      {:ok, snapshot} = Lightning.Workflows.Snapshot.create(reloaded)
+
+      %{
+        project: project,
+        workflow: reloaded,
+        snapshot: snapshot,
+        trigger_with_auth: trigger_with_auth,
+        trigger_without_auth: trigger_without_auth
+      }
+    end
+
+    test "returns {:error, :snapshot_not_found} when no snapshot exists" do
+      assert {:error, :snapshot_not_found} =
+               WorkflowResolver.resolve_version(Ecto.UUID.generate(), 0)
+    end
+
+    test "hydrates a built struct matching the pre-refactor channel assembly",
+         %{
+           project: project,
+           workflow: workflow,
+           snapshot: snapshot,
+           trigger_with_auth: trigger_with_auth,
+           trigger_without_auth: trigger_without_auth
+         } do
+      assert {:ok, %Workflow{} = resolved, :version} =
+               WorkflowResolver.resolve_version(
+                 workflow.id,
+                 snapshot.lock_version,
+                 project: project
+               )
+
+      # Read-only point-in-time view: :built state carrying the snapshot's real
+      # lock_version, tagged with kind :version so callers never confuse it with
+      # a genuinely-new workflow.
+      assert resolved.__meta__.state == :built
+      assert resolved.lock_version == snapshot.lock_version
+      assert resolved.id == workflow.id
+      assert resolved.project_id == project.id
+      assert resolved.name == snapshot.name
+      assert resolved.deleted_at == nil
+
+      # jobs/edges hydrated from the snapshot, one each.
+      assert [%{name: "A Job"}] = resolved.jobs
+      assert [%{}] = resolved.edges
+
+      # per-trigger has_auth_method derived from the raw join query.
+      flags =
+        Map.new(resolved.triggers, fn trigger ->
+          {trigger.id, trigger.has_auth_method}
+        end)
+
+      assert flags[trigger_with_auth.id] == true
+      assert flags[trigger_without_auth.id] == false
+    end
+
+    test "dispatches from resolve/3 when a non-nil :version opt is present", %{
+      project: project,
+      workflow: workflow,
+      snapshot: snapshot
+    } do
+      assert {:ok, %Workflow{lock_version: lock_version} = resolved, :version} =
+               WorkflowResolver.resolve(workflow.id, :edit,
+                 version: snapshot.lock_version,
+                 project: project
+               )
+
+      assert lock_version == snapshot.lock_version
+      assert resolved.__meta__.state == :built
+    end
+
+    test "sets project_id from the project without an ownership check", %{
+      workflow: workflow,
+      snapshot: snapshot
+    } do
+      # The version path sets project_id from the supplied project and performs
+      # no ownership check, unlike the :edit latest path: a foreign project
+      # still resolves.
+      other_project = insert(:project)
+
+      assert {:ok, %Workflow{project_id: project_id}, :version} =
+               WorkflowResolver.resolve_version(
+                 workflow.id,
+                 snapshot.lock_version,
+                 project: other_project
+               )
+
+      assert project_id == other_project.id
+    end
+  end
+
+  describe "resolve/3 with an unknown action" do
+    test "returns {:error, :invalid_action}" do
+      assert {:error, :invalid_action} =
+               WorkflowResolver.resolve(Ecto.UUID.generate(), :delete)
+    end
+  end
+end

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -71,6 +71,28 @@ defmodule LightningWeb.WorkflowChannelTest do
                )
     end
 
+    test "rejects \"new\" join for an id owned by another project", %{
+      project: project,
+      user: user
+    } do
+      # A workflow id that already exists, but belongs to a DIFFERENT project.
+      # The user passes the :create_workflow check on their own project, but the
+      # resolver reconciles by id and finds the foreign-owned row, returning
+      # :wrong_project. The "new" path must map that to the same client-facing
+      # string as the "edit" path.
+      other_project = insert(:project)
+      foreign_workflow = insert(:workflow, project: other_project)
+
+      assert {:error, %{reason: "workflow does not belong to specified project"}} =
+               LightningWeb.UserSocket
+               |> socket("user_#{user.id}", %{current_user: user})
+               |> subscribe_and_join(
+                 LightningWeb.WorkflowChannel,
+                 "workflow:collaborate:#{foreign_workflow.id}",
+                 %{"project_id" => project.id, "action" => "new"}
+               )
+    end
+
     test "accepts authorized users with proper assigns", %{
       socket: socket,
       workflow: workflow,
@@ -3051,14 +3073,52 @@ defmodule LightningWeb.WorkflowChannelTest do
         ensure_doc_supervisor_stopped(workflow_id)
       end)
 
-      # Verify the workflow in socket has nil lock_version
-      assert is_nil(socket.assigns.workflow.lock_version)
+      # A genuinely-new struct is seeded with lock_version 0. The empty-versions
+      # short-circuit keys on workflow_kind, not on lock_version.
+      assert socket.assigns.workflow.lock_version == 0
 
       ref = push(socket, "request_versions", %{})
 
       assert_reply ref, :ok, %{versions: versions}
 
       assert versions == []
+    end
+
+    test "does not short-circuit for a version-view socket", %{
+      workflow: workflow,
+      user: user,
+      project: project
+    } do
+      # Snapshot v0, then bump to v1 so there is genuine version history.
+      {:ok, _snapshot_v0} = Lightning.Workflows.Snapshot.create(workflow)
+
+      workflow_changeset =
+        workflow
+        |> Lightning.Repo.preload([:jobs, :edges, :triggers])
+        |> Lightning.Workflows.Workflow.changeset(%{name: "Version 1"})
+
+      {:ok, _updated} =
+        Lightning.Workflows.save_workflow(workflow_changeset, user)
+
+      # Join viewing the old snapshot (v0). The resolver hydrates a :built struct
+      # with lock_version == 0, BUT this is a version-view, not a genuinely-new
+      # workflow, so request_versions must NOT short-circuit to [].
+      topic_with_version = "workflow:collaborate:#{workflow.id}:v0"
+
+      {:ok, _, snapshot_socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{user.id}", %{current_user: user})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          topic_with_version,
+          %{project_id: project.id, action: "edit"}
+        )
+
+      ref = push(snapshot_socket, "request_versions", %{})
+
+      assert_reply ref, :ok, %{versions: versions}
+
+      assert length(versions) >= 1
     end
 
     test "marks latest version correctly", %{


### PR DESCRIPTION
## Description

This fixes the `workflows_pkey` duplicate-key crash you'd sometimes hit when reconnecting to the collaborative editor after a save — and then goes after the thing that was actually causing it.

The root cause was that we were resolving "which workflow am I editing, and is it new or existing?" in two completely separate places: once when the channel joins (`load_workflow/5`) and again on the session save/reset path (`fetch_workflow/1`). Those two could quietly disagree about whether an id should map to a `:built` struct (→ INSERT) or a `:loaded` one (→ UPDATE). So a reconnect that still thought it was "new" would try to INSERT a row that already existed → boom.

So there are two parts here:

1. The immediate fix — the reconnect path heals the join action and reconciles to the saved row, so the next save UPDATEs instead of colliding.
2. The real fix — I pulled all of that resolution logic into one place, `Lightning.Collaboration.WorkflowResolver`. Both callers now go through it, so they physically can't disagree any more. It also hands back an explicit `kind` (`:new | :existing | :version`) so the channel stops trying to guess "is this new?" from the shape of the struct. `fetch_workflow/1` and the old `NotLoaded` poking are gone.

The nice property that closes the bug: a `"new"` join for an id that already has a row resolves to the existing `:loaded` row (`kind: :existing`), so the save routes to UPDATE. No more duplicate INSERT.

Closes #4830

## Validation steps

1. Open a workflow in the collab editor, make a change, save it.
2. Force a reconnect (drop the socket / refresh the tab) and save again. Before this, that could blow up with a `workflows_pkey` duplicate-key error — now it should just save cleanly.
3. Sanity-check the three normal flows still work: creating a brand-new workflow, editing an existing one, and viewing an older version.
4. `mix test test/lightning/collaboration/ test/lightning_web/channels/workflow_channel_test.exs` — should be green (273 tests here).

## Additional notes for the reviewer

A few things worth your eyes:

- The bit that actually closes the bug is the reconcile-by-id behaviour — a `"new"` action on an id that already has a row comes back as `:existing`. There's a resolver test pinning this specifically, since getting it wrong would bring the duplicate-INSERT straight back.
- Auth ordering is unchanged: `"new"` still authorises first, `"edit"`/version still resolve first. Authorisation stays in the channel; the resolver only does the project-ownership check, and only when it's handed a `:project`.
- One small tightening: a `"new"` rejoin for an id that belongs to *another* project now returns a wrong-project error instead of silently building a fresh struct. Felt like the safer behaviour.
- I kept the `#4829` `Ecto.ConstraintError` rescue in `workflows.ex` as a backstop — didn't want to remove the belt while adding the braces.
- While moving things around, the reset path briefly lost its "this workflow was deleted" error — I put that back (resetting a soft-deleted workflow returns `workflow_deleted` again, same as before), with a test.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR