### PR TITLE
Sandboxes: address remaining merge failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ and this project adheres to
   [#4831](https://github.com/OpenFn/lightning/issues/4831)
 - Free up a workflow's name when it is deleted by a merge, so a later merge can
   reuse that name [#4831](https://github.com/OpenFn/lightning/issues/4831)
-- Show the underlying reason when a sandbox merge fails, instead of a generic
-  "validation error" [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Replace the generic "validation error" on a failed sandbox merge with a clear
+  message, naming the conflicting workflow when there is one
+  [#4831](https://github.com/OpenFn/lightning/issues/4831)
 - Add a credential created in a sandbox to its full ancestor chain, so it
   survives a merge into any ancestor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,12 @@ and this project adheres to
 - Ensure that credentials are properly transferred when merging a sandbox. This
   fixes a validation error which can occur on merge
   [#4831](https://github.com/OpenFn/lightning/issues/4831)
-- Free up a workflow's name when it is deleted as part of a merge, the same way
-  UI deletes already do. Previously the hidden workflow kept its name and a
-  later merge that recreated that name was rejected, surfacing as a merge
-  validation error [#4831](https://github.com/OpenFn/lightning/issues/4831)
-- Surface the underlying reason when a sandbox merge fails on a nested
-  validation error, instead of a generic "validation error" message
-  [#4831](https://github.com/OpenFn/lightning/issues/4831)
-- Add a credential created within a sandbox to its full ancestor chain rather
-  than only the root project, so the credential survives a merge into any
-  ancestor, including a nested parent
+- Free up a workflow's name when it is deleted by a merge, so a later merge can
+  reuse that name [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Show the underlying reason when a sandbox merge fails, instead of a generic
+  "validation error" [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Add a credential created in a sandbox to its full ancestor chain, so it
+  survives a merge into any ancestor
 
 ## [2.16.7] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to
 - Ensure that credentials are properly transferred when merging a sandbox. This
   fixes a validation error which can occur on merge
   [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Free up a workflow's name when it is deleted as part of a merge, the same way
+  UI deletes already do. Previously the hidden workflow kept its name and a
+  later merge that recreated that name was rejected, surfacing as a merge
+  validation error [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Surface the underlying reason when a sandbox merge fails on a nested
+  validation error, instead of a generic "validation error" message
+  [#4831](https://github.com/OpenFn/lightning/issues/4831)
+- Add a credential created within a sandbox to its full ancestor chain rather
+  than only the root project, so the credential survives a merge into any
+  ancestor, including a nested parent
 
 ## [2.16.7] - 2026-06-04
 

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -691,6 +691,7 @@ defmodule Lightning.Projects.Provisioner do
           :deleted_at,
           DateTime.utc_now() |> DateTime.truncate(:second)
         )
+        |> free_up_workflow_name()
 
       {true, others} when map_size(others) > 0 ->
         changeset
@@ -700,6 +701,23 @@ defmodule Lightning.Projects.Provisioner do
         changeset
     end
   end
+
+  # Renames a workflow on soft delete so it releases its name for reuse, mirroring
+  # the UI delete path. Without this, a workflow deleted as a side effect of a
+  # merge keeps its name while hidden, and the `(name, project_id)` unique index
+  # rejects any later merge that recreates a workflow with that name.
+  defp free_up_workflow_name(
+         %{data: %Workflow{name: name} = workflow} = changeset
+       )
+       when is_binary(name) do
+    put_change(
+      changeset,
+      :name,
+      Lightning.Workflows.resolve_name_for_pending_deletion(workflow)
+    )
+  end
+
+  defp free_up_workflow_name(changeset), do: changeset
 
   defp maybe_mark_for_deletion(changeset) do
     changeset.changes

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -687,11 +687,7 @@ defmodule Lightning.Projects.Provisioner do
       {true, others} when map_size(others) == 0 ->
         changeset
         |> Map.put(:changes, others)
-        |> put_change(
-          :deleted_at,
-          DateTime.utc_now() |> DateTime.truncate(:second)
-        )
-        |> free_up_workflow_name()
+        |> Workflows.soft_delete_changeset()
 
       {true, others} when map_size(others) > 0 ->
         changeset
@@ -701,23 +697,6 @@ defmodule Lightning.Projects.Provisioner do
         changeset
     end
   end
-
-  # Renames a workflow on soft delete so it releases its name for reuse, mirroring
-  # the UI delete path. Without this, a workflow deleted as a side effect of a
-  # merge keeps its name while hidden, and the `(name, project_id)` unique index
-  # rejects any later merge that recreates a workflow with that name.
-  defp free_up_workflow_name(
-         %{data: %Workflow{name: name} = workflow} = changeset
-       )
-       when is_binary(name) do
-    put_change(
-      changeset,
-      :name,
-      Lightning.Workflows.resolve_name_for_pending_deletion(workflow)
-    )
-  end
-
-  defp free_up_workflow_name(changeset), do: changeset
 
   defp maybe_mark_for_deletion(changeset) do
     changeset.changes

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -206,13 +206,24 @@ defmodule Lightning.Projects.Sandboxes do
   end
 
   defp classify_merge_error(%Ecto.Changeset{} = changeset) do
-    Logger.warning(
-      "Sandbox merge failed validation: #{inspect(merge_error_details(changeset))}"
-    )
+    details = inspect(merge_error_details(changeset))
 
     case conflicting_workflow_name(changeset) do
-      {:ok, name} -> {:workflow_name_conflict, name}
-      :error -> :merge_validation_failed
+      {:ok, name} ->
+        Logger.warning(
+          "Sandbox merge failed: workflow name conflict. #{details}"
+        )
+
+        {:workflow_name_conflict, name}
+
+      :error ->
+        # Unrecognised failure mode: log at :error so it reaches Sentry and we
+        # can give it a typed reason.
+        Logger.error(
+          "Sandbox merge failed validation (unclassified). #{details}"
+        )
+
+        :merge_validation_failed
     end
   end
 

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -179,7 +179,6 @@ defmodule Lightning.Projects.Sandboxes do
           {:workflow_name_conflict, String.t()}
           | :merge_validation_failed
           | :merge_failed
-          | String.t()
           | Lightning.Extensions.UsageLimiting.message()
 
   @spec merge(Project.t(), Project.t(), User.t(), map()) ::
@@ -231,8 +230,6 @@ defmodule Lightning.Projects.Sandboxes do
 
   defp classify_merge_error(%{text: _} = usage_limit_message),
     do: usage_limit_message
-
-  defp classify_merge_error(reason) when is_binary(reason), do: reason
 
   defp classify_merge_error(reason) do
     Logger.error("Sandbox merge failed unexpectedly. #{inspect(reason)}")

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -41,6 +41,8 @@ defmodule Lightning.Projects.Sandboxes do
   """
   import Ecto.Query
 
+  require Logger
+
   alias Lightning.Accounts.User
   alias Lightning.Collections
   alias Lightning.Collections.Collection
@@ -167,10 +169,19 @@ defmodule Lightning.Projects.Sandboxes do
 
   ## Returns
   * `{:ok, updated_target}` - Merge succeeded
-  * `{:error, reason}` - Workflow merge or collection sync failed
+  * `{:error, merge_error}` - Merge failed, classified into a domain reason
+
+  Failures are returned as typed reasons (see `t:merge_error/0`) so callers can
+  render user-facing copy without inspecting changeset internals. The full
+  validation detail is logged for diagnosis.
   """
+  @type merge_error ::
+          {:workflow_name_conflict, String.t()}
+          | :merge_validation_failed
+          | Lightning.Extensions.UsageLimiting.message()
+
   @spec merge(Project.t(), Project.t(), User.t(), map()) ::
-          {:ok, Project.t()} | {:error, term()}
+          {:ok, Project.t()} | {:error, merge_error()}
   def merge(
         %Project{} = source,
         %Project{} = target,
@@ -187,6 +198,41 @@ defmodule Lightning.Projects.Sandboxes do
            {:ok, _} <- sync_collections(source, target) do
         {:ok, updated_target}
       end
+    end)
+    |> case do
+      {:ok, _} = ok -> ok
+      {:error, reason} -> {:error, classify_merge_error(reason)}
+    end
+  end
+
+  defp classify_merge_error(%Ecto.Changeset{} = changeset) do
+    Logger.warning(
+      "Sandbox merge failed validation: #{inspect(merge_error_details(changeset))}"
+    )
+
+    case conflicting_workflow_name(changeset) do
+      {:ok, name} -> {:workflow_name_conflict, name}
+      :error -> :merge_validation_failed
+    end
+  end
+
+  defp classify_merge_error(reason), do: reason
+
+  defp conflicting_workflow_name(changeset) do
+    changeset
+    |> Ecto.Changeset.get_change(:workflows, [])
+    |> Enum.find_value(:error, fn workflow_changeset ->
+      if Keyword.has_key?(workflow_changeset.errors, :name) do
+        {:ok, Ecto.Changeset.get_field(workflow_changeset, :name)}
+      end
+    end)
+  end
+
+  defp merge_error_details(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r/%\{(\w+)\}/, message, fn _whole, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
     end)
   end
 

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -165,7 +165,19 @@ defmodule Lightning.Projects.Sandboxes do
   * `source` - The sandbox project being merged
   * `target` - The project receiving the merge
   * `actor` - The user performing the merge
-  * `opts` - Merge options (`:selected_workflow_ids`, `:deleted_target_workflow_ids`)
+  * `opts` - Merge options (`:selected_workflow_ids`,
+    `:deleted_target_workflow_ids`, `:selected_credential_ids`)
+
+  ## Credential attachment
+
+  A credential that lives only in the sandbox (the target has no
+  `project_credential` for its underlying `credential_id`) would otherwise be
+  dropped on merge, since the remap only matches on shared credentials. Pass
+  `:selected_credential_ids` (a list of the sandbox `project_credential` ids the
+  caller chose to carry over) and each one is attached to the target before the
+  document is imported, so the remap finds a match instead of dropping it.
+  Sandbox `project_credentials` left out of the list stay dropped. Only regular
+  `project_credentials` are handled here; keychain credentials are out of scope.
 
   ## Returns
   * `{:ok, updated_target}` - Merge succeeded
@@ -186,10 +198,17 @@ defmodule Lightning.Projects.Sandboxes do
         %User{} = actor,
         opts \\ %{}
       ) do
-    merge_doc = MergeProjects.merge_project(source, target, opts)
+    selected_credential_ids = Map.get(opts, :selected_credential_ids, [])
 
     Repo.transact(fn ->
-      with {:ok, updated_target} <-
+      with :ok <-
+             attach_selected_credentials(source, target, selected_credential_ids),
+           # Re-preload so the credential remap sees the just-attached
+           # associations; merge_project skips the preload if they're already loaded.
+           target =
+             Repo.preload(target, [project_credentials: []], force: true),
+           merge_doc = MergeProjects.merge_project(source, target, opts),
+           {:ok, updated_target} <-
              Provisioner.import_document(target, actor, merge_doc,
                allow_stale: true
              ),
@@ -201,6 +220,58 @@ defmodule Lightning.Projects.Sandboxes do
       {:ok, _} = ok -> ok
       {:error, reason} -> {:error, classify_merge_error(reason)}
     end
+  end
+
+  # Attaches the chosen sandbox-only credentials to the target so the merge
+  # remap can match them. The credential diff is recomputed from the database
+  # rather than trusting the caller's list verbatim: only sandbox
+  # project_credentials whose underlying credential the target still lacks are
+  # attached, and ON CONFLICT DO NOTHING guards against a concurrent attach.
+  defp attach_selected_credentials(_source, _target, []), do: :ok
+
+  defp attach_selected_credentials(source, target, selected_credential_ids) do
+    selected_set = MapSet.new(selected_credential_ids)
+
+    target_credential_ids =
+      from(pc in ProjectCredential,
+        where: pc.project_id == ^target.id,
+        select: pc.credential_id
+      )
+      |> Repo.all()
+      |> MapSet.new()
+
+    rows =
+      from(pc in ProjectCredential,
+        where: pc.project_id == ^source.id,
+        select: %{id: pc.id, credential_id: pc.credential_id}
+      )
+      |> Repo.all()
+      |> Enum.filter(fn pc ->
+        MapSet.member?(selected_set, pc.id) and
+          not MapSet.member?(target_credential_ids, pc.credential_id)
+      end)
+      |> build_target_credential_rows(target.id)
+
+    Repo.insert_all(ProjectCredential, rows,
+      on_conflict: :nothing,
+      conflict_target: [:project_id, :credential_id]
+    )
+
+    :ok
+  end
+
+  defp build_target_credential_rows(source_credentials, target_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Enum.map(source_credentials, fn pc ->
+      %{
+        id: Ecto.UUID.generate(),
+        project_id: target_id,
+        credential_id: pc.credential_id,
+        inserted_at: now,
+        updated_at: now
+      }
+    end)
   end
 
   # A failed merge is sensitive (it can block or lose a user's work), so every

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -176,10 +176,7 @@ defmodule Lightning.Projects.Sandboxes do
   validation detail is logged for diagnosis.
   """
   @type merge_error ::
-          {:workflow_name_conflict, String.t()}
-          | :merge_validation_failed
-          | :merge_failed
-          | Lightning.Extensions.UsageLimiting.message()
+          :merge_failed | Lightning.Extensions.UsageLimiting.message()
 
   @spec merge(Project.t(), Project.t(), User.t(), map()) ::
           {:ok, Project.t()} | {:error, merge_error()}
@@ -206,44 +203,23 @@ defmodule Lightning.Projects.Sandboxes do
     end
   end
 
+  # A failed merge is sensitive (it can block or lose a user's work), so every
+  # failure is logged at :error to surface in Sentry. A usage-limit message is
+  # an expected, user-actionable block, so it passes through unlogged.
   defp classify_merge_error(%Ecto.Changeset{} = changeset) do
-    details = inspect(merge_error_details(changeset))
+    Logger.error(
+      "Sandbox merge failed. #{inspect(merge_error_details(changeset))}"
+    )
 
-    case conflicting_workflow_name(changeset) do
-      {:ok, name} ->
-        Logger.warning(
-          "Sandbox merge failed: workflow name conflict. #{details}"
-        )
-
-        {:workflow_name_conflict, name}
-
-      :error ->
-        # Unrecognised failure mode: log at :error so it reaches Sentry and we
-        # can give it a typed reason.
-        Logger.error(
-          "Sandbox merge failed validation (unclassified). #{details}"
-        )
-
-        :merge_validation_failed
-    end
+    :merge_failed
   end
 
   defp classify_merge_error(%{text: _} = usage_limit_message),
     do: usage_limit_message
 
   defp classify_merge_error(reason) do
-    Logger.error("Sandbox merge failed unexpectedly. #{inspect(reason)}")
+    Logger.error("Sandbox merge failed. #{inspect(reason)}")
     :merge_failed
-  end
-
-  defp conflicting_workflow_name(changeset) do
-    changeset
-    |> Ecto.Changeset.get_change(:workflows, [])
-    |> Enum.find_value(:error, fn workflow_changeset ->
-      if Keyword.has_key?(workflow_changeset.errors, :name) do
-        {:ok, Ecto.Changeset.get_field(workflow_changeset, :name)}
-      end
-    end)
   end
 
   defp merge_error_details(changeset) do

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -178,6 +178,7 @@ defmodule Lightning.Projects.Sandboxes do
   @type merge_error ::
           {:workflow_name_conflict, String.t()}
           | :merge_validation_failed
+          | :merge_failed
           | Lightning.Extensions.UsageLimiting.message()
 
   @spec merge(Project.t(), Project.t(), User.t(), map()) ::
@@ -227,7 +228,15 @@ defmodule Lightning.Projects.Sandboxes do
     end
   end
 
-  defp classify_merge_error(reason), do: reason
+  defp classify_merge_error(%{text: _} = usage_limit_message),
+    do: usage_limit_message
+
+  defp classify_merge_error(reason) when is_binary(reason), do: reason
+
+  defp classify_merge_error(reason) do
+    Logger.error("Sandbox merge failed unexpectedly. #{inspect(reason)}")
+    :merge_failed
+  end
 
   defp conflicting_workflow_name(changeset) do
     changeset

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -41,8 +41,6 @@ defmodule Lightning.Projects.Sandboxes do
   """
   import Ecto.Query
 
-  require Logger
-
   alias Lightning.Accounts.User
   alias Lightning.Collections
   alias Lightning.Collections.Collection
@@ -63,6 +61,8 @@ defmodule Lightning.Projects.Sandboxes do
   alias Lightning.Workflows.Workflow
   alias Lightning.Workflows.WorkflowVersion
   alias Lightning.WorkflowVersions
+
+  require Logger
 
   @typedoc """
   Attributes for creating a new sandbox via `provision/3`.
@@ -179,6 +179,7 @@ defmodule Lightning.Projects.Sandboxes do
           {:workflow_name_conflict, String.t()}
           | :merge_validation_failed
           | :merge_failed
+          | String.t()
           | Lightning.Extensions.UsageLimiting.message()
 
   @spec merge(Project.t(), Project.t(), User.t(), map()) ::

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -247,11 +247,7 @@ defmodule Lightning.Projects.Sandboxes do
   end
 
   defp merge_error_details(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-      Regex.replace(~r/%\{(\w+)\}/, message, fn _whole, key ->
-        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
-      end)
-    end)
+    Ecto.Changeset.traverse_errors(changeset, fn {message, _opts} -> message end)
   end
 
   @doc """

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -717,16 +717,10 @@ defmodule Lightning.Workflows do
         where: t.workflow_id == ^workflow.id
       )
 
-    new_name = resolve_name_for_pending_deletion(workflow)
-
     Multi.new()
     |> Multi.update(
       :workflow,
-      workflow
-      |> Workflow.request_deletion_changeset(%{
-        "deleted_at" => DateTime.utc_now()
-      })
-      |> Ecto.Changeset.put_change(:name, new_name)
+      soft_delete_changeset(Ecto.Changeset.change(workflow))
     )
     |> Multi.insert(:audit, Audit.marked_for_deletion(workflow.id, actor))
     |> Multi.update_all(
@@ -745,11 +739,35 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
+  Applies the soft-delete transition to a workflow changeset: marks it deleted
+  and frees its name for reuse, in a single step.
+
+  This is the one definition of what soft deleting a workflow means at the data
+  level. Every path that removes a workflow routes through it, the workflows
+  list (`mark_for_deletion/3`) and the provisioner-driven imports (YAML, CLI,
+  GitHub sync, sandbox merge), so the name can never stay reserved on a hidden
+  row. Setting `deleted_at` without freeing the name is not expressible here.
+  """
+  @spec soft_delete_changeset(Ecto.Changeset.t(Workflow.t())) ::
+          Ecto.Changeset.t(Workflow.t())
+  def soft_delete_changeset(
+        %Ecto.Changeset{data: %Workflow{} = workflow} = changeset
+      ) do
+    changeset
+    |> Workflow.request_deletion_changeset(%{
+      deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Ecto.Changeset.put_change(
+      :name,
+      resolve_name_for_pending_deletion(workflow)
+    )
+  end
+
+  @doc """
   Computes the `name_del`-style name a workflow should take when it is soft
   deleted, so it frees up its original name for reuse within the project.
 
-  Used both by UI-initiated deletion and by merge/provisioning soft deletes,
-  keeping the name-freeing behaviour consistent across every delete path.
+  Used by `soft_delete_changeset/1`, which every delete path routes through.
   """
   @spec resolve_name_for_pending_deletion(Workflow.t()) :: String.t()
   def resolve_name_for_pending_deletion(%Workflow{

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -744,10 +744,18 @@ defmodule Lightning.Workflows do
     end)
   end
 
-  defp resolve_name_for_pending_deletion(%Workflow{
-         name: name,
-         project_id: project_id
-       }) do
+  @doc """
+  Computes the `name_del`-style name a workflow should take when it is soft
+  deleted, so it frees up its original name for reuse within the project.
+
+  Used both by UI-initiated deletion and by merge/provisioning soft deletes,
+  keeping the name-freeing behaviour consistent across every delete path.
+  """
+  @spec resolve_name_for_pending_deletion(Workflow.t()) :: String.t()
+  def resolve_name_for_pending_deletion(%Workflow{
+        name: name,
+        project_id: project_id
+      }) do
     base_name = "#{name}_del"
 
     existing_names =

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -739,14 +739,11 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
-  Applies the soft-delete transition to a workflow changeset: marks it deleted
-  and frees its name for reuse, in a single step.
+  Marks a workflow deleted and frees its name for reuse, in one step.
 
-  This is the one definition of what soft deleting a workflow means at the data
-  level. Every path that removes a workflow routes through it, the workflows
-  list (`mark_for_deletion/3`) and the provisioner-driven imports (YAML, CLI,
-  GitHub sync, sandbox merge), so the name can never stay reserved on a hidden
-  row. Setting `deleted_at` without freeing the name is not expressible here.
+  The single soft-delete transition both `mark_for_deletion/3` and the
+  provisioner route through, so a deleted workflow can never keep its name
+  reserved on a hidden row.
   """
   @spec soft_delete_changeset(Ecto.Changeset.t(Workflow.t())) ::
           Ecto.Changeset.t(Workflow.t())

--- a/lib/lightning_web/live/credential_live/helpers.ex
+++ b/lib/lightning_web/live/credential_live/helpers.ex
@@ -146,30 +146,16 @@ defmodule LightningWeb.CredentialLive.Helpers do
   end
 
   @doc """
-  The `project_credentials` to pre-select when creating a credential: the active
-  project plus every ancestor, so the credential survives a merge into any of
-  them. Empty when there is no project context.
+  The `project_credentials` to pre-select when creating a credential: only the
+  active project. Empty when there is no project context.
   """
   @spec default_project_credentials(Lightning.Projects.Project.t() | nil) ::
           [Lightning.Projects.ProjectCredential.t()]
   def default_project_credentials(nil), do: []
 
-  def default_project_credentials(%Lightning.Projects.Project{} = project) do
-    project
-    |> Lightning.Projects.preload_ancestors()
-    |> project_and_ancestor_ids()
-    |> Enum.uniq()
-    |> Enum.map(&%Lightning.Projects.ProjectCredential{project_id: &1})
+  def default_project_credentials(%Lightning.Projects.Project{id: id}) do
+    [%Lightning.Projects.ProjectCredential{project_id: id}]
   end
-
-  defp project_and_ancestor_ids(%Lightning.Projects.Project{
-         id: id,
-         parent: %Lightning.Projects.Project{} = parent
-       }) do
-    [id | project_and_ancestor_ids(parent)]
-  end
-
-  defp project_and_ancestor_ids(%Lightning.Projects.Project{id: id}), do: [id]
 
   def handle_save_response(socket, credential) do
     if socket.assigns[:on_save] do

--- a/lib/lightning_web/live/credential_live/helpers.ex
+++ b/lib/lightning_web/live/credential_live/helpers.ex
@@ -147,8 +147,13 @@ defmodule LightningWeb.CredentialLive.Helpers do
 
   @doc """
   Builds the `project_credentials` to pre-select when creating a credential in
-  a project context: the active project plus its root parent project (when the
+  a project context: the active project plus every ancestor project (when the
   active project is a sandbox), deduplicated and order-preserving.
+
+  A sandbox can be merged into any of its ancestors, not just the root, and the
+  merge maps credentials by matching them on the target project. Pre-selecting
+  the whole ancestor chain ensures the credential exists on whichever ancestor
+  the merge targets, so it survives the merge instead of being dropped.
 
   Returns an empty list when there is no project context.
   """
@@ -157,11 +162,21 @@ defmodule LightningWeb.CredentialLive.Helpers do
   def default_project_credentials(nil), do: []
 
   def default_project_credentials(%Lightning.Projects.Project{} = project) do
-    [project, Lightning.Projects.root_of(project)]
-    |> Enum.map(& &1.id)
+    project
+    |> Lightning.Projects.preload_ancestors()
+    |> project_and_ancestor_ids()
     |> Enum.uniq()
     |> Enum.map(&%Lightning.Projects.ProjectCredential{project_id: &1})
   end
+
+  defp project_and_ancestor_ids(%Lightning.Projects.Project{
+         id: id,
+         parent: %Lightning.Projects.Project{} = parent
+       }) do
+    [id | project_and_ancestor_ids(parent)]
+  end
+
+  defp project_and_ancestor_ids(%Lightning.Projects.Project{id: id}), do: [id]
 
   def handle_save_response(socket, credential) do
     if socket.assigns[:on_save] do

--- a/lib/lightning_web/live/credential_live/helpers.ex
+++ b/lib/lightning_web/live/credential_live/helpers.ex
@@ -146,16 +146,9 @@ defmodule LightningWeb.CredentialLive.Helpers do
   end
 
   @doc """
-  Builds the `project_credentials` to pre-select when creating a credential in
-  a project context: the active project plus every ancestor project (when the
-  active project is a sandbox), deduplicated and order-preserving.
-
-  A sandbox can be merged into any of its ancestors, not just the root, and the
-  merge maps credentials by matching them on the target project. Pre-selecting
-  the whole ancestor chain ensures the credential exists on whichever ancestor
-  the merge targets, so it survives the merge instead of being dropped.
-
-  Returns an empty list when there is no project context.
+  The `project_credentials` to pre-select when creating a credential: the active
+  project plus every ancestor, so the credential survives a merge into any of
+  them. Empty when there is no project context.
   """
   @spec default_project_credentials(Lightning.Projects.Project.t() | nil) ::
           [Lightning.Projects.ProjectCredential.t()]

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -249,6 +249,8 @@ defmodule LightningWeb.SandboxLive.Components do
   attr :diverged_workflows, :list, default: []
   attr :source_workflows, :list, required: true
   attr :selected_workflow_ids, :any, required: true
+  attr :credentials, :list, default: []
+  attr :selected_credential_ids, :any, default: %MapSet{}
 
   def merge_modal(assigns) do
     assigns =
@@ -387,6 +389,35 @@ defmodule LightningWeb.SandboxLive.Components do
                   title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
                 >
                   Deleted in sandbox
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <div
+            :if={@credentials != []}
+            class="border border-gray-200 rounded-lg overflow-hidden bg-white"
+          >
+            <div class="flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200">
+              <span class="flex-1 text-sm font-medium text-gray-900">
+                Credentials to add to the target project
+              </span>
+            </div>
+            <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
+              <li
+                :for={credential <- @credentials}
+                class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+                phx-click="toggle-credential"
+                phx-value-id={credential.id}
+              >
+                <input
+                  type="checkbox"
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600"
+                  checked={MapSet.member?(@selected_credential_ids, credential.id)}
+                  readonly
+                />
+                <span class="flex-1 text-sm text-gray-700 truncate">
+                  {credential.name}
                 </span>
               </li>
             </ul>

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -264,6 +264,13 @@ defmodule LightningWeb.SandboxLive.Components do
           assigns.source_workflows
         )
       )
+      |> assign(
+        :credentials_select_all_state,
+        merge_select_all_state(
+          assigns.selected_credential_ids,
+          assigns.credentials
+        )
+      )
 
     ~H"""
     <.modal
@@ -398,11 +405,30 @@ defmodule LightningWeb.SandboxLive.Components do
             :if={@credentials != []}
             class="border border-gray-200 rounded-lg overflow-hidden bg-white"
           >
-            <div class="flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200">
+            <label class={[
+              "flex items-center gap-3 px-3 py-2 bg-gray-50 border-b border-gray-200",
+              @credentials_select_all_state == :empty && "cursor-default",
+              @credentials_select_all_state != :empty && "cursor-pointer"
+            ]}>
+              <input
+                type="checkbox"
+                id="merge-select-all-credentials"
+                phx-hook="CheckboxIndeterminate"
+                phx-click="toggle-all-credentials"
+                disabled={@credentials_select_all_state == :empty}
+                checked={@credentials_select_all_state == :all}
+                class={[
+                  "h-4 w-4 rounded border-gray-300 text-indigo-600",
+                  @credentials_select_all_state == :partial && "indeterminate"
+                ]}
+              />
               <span class="flex-1 text-sm font-medium text-gray-900">
-                Credentials to add to the target project
+                Credentials to add
               </span>
-            </div>
+              <span class="text-xs text-gray-500">
+                {MapSet.size(@selected_credential_ids)} of {length(@credentials)} selected
+              </span>
+            </label>
             <ul class="divide-y divide-gray-100 max-h-48 overflow-y-auto">
               <li
                 :for={credential <- @credentials}

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -990,15 +990,47 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp format_merge_error(%Ecto.Changeset{} = changeset) do
-    changeset.errors
-    |> List.first()
-    |> case do
-      {field, {message, _}} -> "#{field}: #{message}"
-      _ -> "Failed to merge: validation error"
+    case first_changeset_error(changeset) do
+      {path, message} -> "Failed to merge: #{path}: #{message}"
+      nil -> "Failed to merge: validation error"
     end
   end
 
   defp format_merge_error(%{text: text}), do: text
   defp format_merge_error(reason) when is_binary(reason), do: reason
   defp format_merge_error(reason), do: "Failed to merge: #{inspect(reason)}"
+
+  # Finds the first error anywhere in the changeset, including errors nested in
+  # associations (e.g. a workflow's name or a job's credential). Without this,
+  # a nested error has no top-level entry and the merge screen would only show a
+  # generic "validation error" with no indication of the real cause.
+  defp first_changeset_error(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(&interpolate_error_message/1)
+    |> first_nested_error([])
+  end
+
+  defp first_nested_error(errors, path) when is_map(errors) do
+    Enum.find_value(errors, fn {field, value} ->
+      first_nested_error(value, [to_string(field) | path])
+    end)
+  end
+
+  defp first_nested_error(values, path) when is_list(values) do
+    Enum.find_value(values, &first_nested_error(&1, path))
+  end
+
+  defp first_nested_error(message, path) when is_binary(message) do
+    {path |> Enum.reverse() |> Enum.join("."), message}
+  end
+
+  defp first_nested_error(_other, _path), do: nil
+
+  defp interpolate_error_message({message, opts}) do
+    Regex.replace(~r/%\{(\w+)\}/, message, fn _whole, key ->
+      opts
+      |> Keyword.get(String.to_existing_atom(key), key)
+      |> to_string()
+    end)
+  end
 end

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -994,10 +994,13 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp format_merge_error(:merge_validation_failed) do
-    "Couldn't merge this sandbox because the result didn't pass validation. Please try again, or contact support if it persists."
+    "Couldn't merge this sandbox. Some changes didn't pass validation."
   end
 
   defp format_merge_error(%{text: text}), do: text
   defp format_merge_error(reason) when is_binary(reason), do: reason
-  defp format_merge_error(reason), do: "Failed to merge: #{inspect(reason)}"
+
+  defp format_merge_error(_reason) do
+    "Couldn't merge this sandbox. Please try again."
+  end
 end

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -1000,10 +1000,7 @@ defmodule LightningWeb.SandboxLive.Index do
   defp format_merge_error(reason) when is_binary(reason), do: reason
   defp format_merge_error(reason), do: "Failed to merge: #{inspect(reason)}"
 
-  # Finds the first error anywhere in the changeset, including errors nested in
-  # associations (e.g. a workflow's name or a job's credential). Without this,
-  # a nested error has no top-level entry and the merge screen would only show a
-  # generic "validation error" with no indication of the real cause.
+  # Errors nested in an association have no top-level entry, so walk them too.
   defp first_changeset_error(%Ecto.Changeset{} = changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(&interpolate_error_message/1)

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -249,6 +249,8 @@ defmodule LightningWeb.SandboxLive.Index do
             |> Enum.filter(fn wf -> wf.is_changed end)
             |> MapSet.new(fn wf -> wf.id end)
 
+          merge_credentials = sandbox_only_credentials(sandbox, target_project)
+
           {:noreply,
            socket
            |> assign(:merge_modal_open?, true)
@@ -258,7 +260,12 @@ defmodule LightningWeb.SandboxLive.Index do
            |> assign(:merge_descendants, descendants)
            |> assign(:merge_diverged_workflows, diverged_workflows)
            |> assign(:merge_source_workflows, source_workflows)
-           |> assign(:merge_selected_workflow_ids, selected_ids)}
+           |> assign(:merge_selected_workflow_ids, selected_ids)
+           |> assign(:merge_credentials, merge_credentials)
+           |> assign(
+             :merge_selected_credential_ids,
+             all_credential_ids(merge_credentials)
+           )}
         else
           {:noreply,
            socket
@@ -299,6 +306,20 @@ defmodule LightningWeb.SandboxLive.Index do
       end
 
     {:noreply, assign(socket, :merge_selected_workflow_ids, new_selected)}
+  end
+
+  @impl true
+  def handle_event("toggle-credential", %{"id" => credential_id}, socket) do
+    selected = socket.assigns.merge_selected_credential_ids
+
+    new_selected =
+      if MapSet.member?(selected, credential_id) do
+        MapSet.delete(selected, credential_id)
+      else
+        MapSet.put(selected, credential_id)
+      end
+
+    {:noreply, assign(socket, :merge_selected_credential_ids, new_selected)}
   end
 
   @impl true
@@ -350,12 +371,19 @@ defmodule LightningWeb.SandboxLive.Index do
       |> MapSet.intersection(all_ids)
       |> MapSet.union(added_changed_ids)
 
+    merge_credentials = sandbox_only_credentials(sandbox, target_project)
+
     {:noreply,
      socket
      |> assign(:merge_changeset, merge_changeset)
      |> assign(:merge_diverged_workflows, diverged_workflows)
      |> assign(:merge_source_workflows, source_workflows)
-     |> assign(:merge_selected_workflow_ids, selected_ids)}
+     |> assign(:merge_selected_workflow_ids, selected_ids)
+     |> assign(:merge_credentials, merge_credentials)
+     |> assign(
+       :merge_selected_credential_ids,
+       all_credential_ids(merge_credentials)
+     )}
   end
 
   @impl true
@@ -403,8 +431,16 @@ defmodule LightningWeb.SandboxLive.Index do
               selected_ids =
                 resolve_selected_workflow_ids(socket.assigns)
 
+              selected_credential_ids =
+                MapSet.to_list(socket.assigns.merge_selected_credential_ids)
+
               source
-              |> perform_merge(target, actor, selected_ids)
+              |> perform_merge(
+                target,
+                actor,
+                selected_ids,
+                selected_credential_ids
+              )
               |> handle_merge_result(socket, source, target, root_project, actor)
             else
               socket
@@ -498,6 +534,8 @@ defmodule LightningWeb.SandboxLive.Index do
           diverged_workflows={@merge_diverged_workflows}
           source_workflows={@merge_source_workflows}
           selected_workflow_ids={@merge_selected_workflow_ids}
+          credentials={@merge_credentials}
+          selected_credential_ids={@merge_selected_credential_ids}
         />
 
         <.live_component
@@ -627,6 +665,8 @@ defmodule LightningWeb.SandboxLive.Index do
     |> assign(:merge_diverged_workflows, [])
     |> assign(:merge_source_workflows, [])
     |> assign(:merge_selected_workflow_ids, MapSet.new())
+    |> assign(:merge_credentials, [])
+    |> assign(:merge_selected_credential_ids, MapSet.new())
   end
 
   defp merge_changeset(params \\ %{}) do
@@ -877,6 +917,35 @@ defmodule LightningWeb.SandboxLive.Index do
   defp preload_merge_projects(source, target),
     do: {Repo.preload(source, :workflows), Repo.preload(target, :workflows)}
 
+  # The sandbox's project_credentials whose underlying credential the target
+  # does not already have. These would be dropped on merge unless the user
+  # chooses to carry them over.
+  defp sandbox_only_credentials(_source, nil), do: []
+
+  defp sandbox_only_credentials(source, target) do
+    source =
+      Repo.preload(source, project_credentials: [:credential])
+
+    target = Repo.preload(target, :project_credentials)
+
+    target_credential_ids =
+      MapSet.new(target.project_credentials, & &1.credential_id)
+
+    source.project_credentials
+    |> Enum.reject(&MapSet.member?(target_credential_ids, &1.credential_id))
+    |> Enum.map(fn pc ->
+      %{id: pc.id, name: credential_display_name(pc.credential)}
+    end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp credential_display_name(%{name: name}) when is_binary(name), do: name
+  defp credential_display_name(_), do: "Untitled credential"
+
+  defp all_credential_ids(merge_credentials) do
+    MapSet.new(merge_credentials, & &1.id)
+  end
+
   defp get_diverged_workflows(_source, nil), do: []
 
   defp get_diverged_workflows(source, target_project) do
@@ -893,7 +962,8 @@ defmodule LightningWeb.SandboxLive.Index do
          source,
          target,
          actor,
-         {selected_workflow_ids, deleted_target_workflow_ids}
+         {selected_workflow_ids, deleted_target_workflow_ids},
+         selected_credential_ids
        ) do
     maybe_commit_to_github(target, "pre-merge commit")
 
@@ -906,6 +976,8 @@ defmodule LightningWeb.SandboxLive.Index do
       else
         %{}
       end
+
+    opts = Map.put(opts, :selected_credential_ids, selected_credential_ids)
 
     case Sandboxes.merge(source, target, actor, opts) do
       {:ok, _updated_target} = success ->

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -998,7 +998,6 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp format_merge_error(%{text: text}), do: text
-  defp format_merge_error(reason) when is_binary(reason), do: reason
 
   defp format_merge_error(_reason) do
     "Couldn't merge this sandbox. Please try again."

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -387,6 +387,19 @@ defmodule LightningWeb.SandboxLive.Index do
 
     merge_credentials = sandbox_only_credentials(sandbox, target_project)
 
+    # Preserve the user's credential choices across form changes (the checkboxes
+    # live in the same form, so toggling one fires this event). Keep selections
+    # still in the diff, and default any newly-appeared credential to selected.
+    new_credential_ids = all_credential_ids(merge_credentials)
+    previously_shown_ids = MapSet.new(socket.assigns.merge_credentials, & &1.id)
+
+    selected_credential_ids =
+      socket.assigns.merge_selected_credential_ids
+      |> MapSet.intersection(new_credential_ids)
+      |> MapSet.union(
+        MapSet.difference(new_credential_ids, previously_shown_ids)
+      )
+
     {:noreply,
      socket
      |> assign(:merge_changeset, merge_changeset)
@@ -394,10 +407,7 @@ defmodule LightningWeb.SandboxLive.Index do
      |> assign(:merge_source_workflows, source_workflows)
      |> assign(:merge_selected_workflow_ids, selected_ids)
      |> assign(:merge_credentials, merge_credentials)
-     |> assign(
-       :merge_selected_credential_ids,
-       all_credential_ids(merge_credentials)
-     )}
+     |> assign(:merge_selected_credential_ids, selected_credential_ids)}
   end
 
   @impl true

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -989,45 +989,15 @@ defmodule LightningWeb.SandboxLive.Index do
     end
   end
 
-  defp format_merge_error(%Ecto.Changeset{} = changeset) do
-    case first_changeset_error(changeset) do
-      {path, message} -> "Failed to merge: #{path}: #{message}"
-      nil -> "Failed to merge: validation error"
-    end
+  defp format_merge_error({:workflow_name_conflict, name}) do
+    ~s(Couldn't merge: a workflow named "#{name}" already exists in the target project. Rename it and merge again.)
+  end
+
+  defp format_merge_error(:merge_validation_failed) do
+    "Couldn't merge this sandbox because the result didn't pass validation. Please try again, or contact support if it persists."
   end
 
   defp format_merge_error(%{text: text}), do: text
   defp format_merge_error(reason) when is_binary(reason), do: reason
   defp format_merge_error(reason), do: "Failed to merge: #{inspect(reason)}"
-
-  # Errors nested in an association have no top-level entry, so walk them too.
-  defp first_changeset_error(%Ecto.Changeset{} = changeset) do
-    changeset
-    |> Ecto.Changeset.traverse_errors(&interpolate_error_message/1)
-    |> first_nested_error([])
-  end
-
-  defp first_nested_error(errors, path) when is_map(errors) do
-    Enum.find_value(errors, fn {field, value} ->
-      first_nested_error(value, [to_string(field) | path])
-    end)
-  end
-
-  defp first_nested_error(values, path) when is_list(values) do
-    Enum.find_value(values, &first_nested_error(&1, path))
-  end
-
-  defp first_nested_error(message, path) when is_binary(message) do
-    {path |> Enum.reverse() |> Enum.join("."), message}
-  end
-
-  defp first_nested_error(_other, _path), do: nil
-
-  defp interpolate_error_message({message, opts}) do
-    Regex.replace(~r/%\{(\w+)\}/, message, fn _whole, key ->
-      opts
-      |> Keyword.get(String.to_existing_atom(key), key)
-      |> to_string()
-    end)
-  end
 end

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -989,17 +989,6 @@ defmodule LightningWeb.SandboxLive.Index do
     end
   end
 
-  defp format_merge_error({:workflow_name_conflict, name}) do
-    ~s(Couldn't merge: a workflow named "#{name}" already exists in the target project. Rename it and merge again.)
-  end
-
-  defp format_merge_error(:merge_validation_failed) do
-    "Couldn't merge this sandbox. Some changes didn't pass validation."
-  end
-
   defp format_merge_error(%{text: text}), do: text
-
-  defp format_merge_error(_reason) do
-    "Couldn't merge this sandbox. Please try again."
-  end
+  defp format_merge_error(_reason), do: "Couldn't merge this sandbox."
 end

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -323,6 +323,20 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   @impl true
+  def handle_event("toggle-all-credentials", _params, socket) do
+    all_ids = MapSet.new(socket.assigns.merge_credentials, fn c -> c.id end)
+
+    new_selected =
+      if MapSet.equal?(socket.assigns.merge_selected_credential_ids, all_ids) do
+        MapSet.new()
+      else
+        all_ids
+      end
+
+    {:noreply, assign(socket, :merge_selected_credential_ids, new_selected)}
+  end
+
+  @impl true
   def handle_event(
         "select-merge-target",
         %{"merge" => %{"target_id" => target_id}},

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -990,5 +990,8 @@ defmodule LightningWeb.SandboxLive.Index do
   end
 
   defp format_merge_error(%{text: text}), do: text
-  defp format_merge_error(_reason), do: "Couldn't merge this sandbox."
+
+  defp format_merge_error(_reason) do
+    "Couldn't merge this sandbox. Please try again."
+  end
 end

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -950,8 +950,7 @@ defmodule Lightning.Projects.ProvisionerTest do
       assert deleted.name == "#{original_name}_del",
              "The soft-deleted workflow should release its original name"
 
-      # Importing a fresh workflow that reuses the original name now succeeds,
-      # rather than colliding with the hidden, soft-deleted one.
+      # A fresh workflow can now reuse the freed name on a later import.
       %{body: reuse_body} = valid_document(project.id)
 
       reuse_body =

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -924,6 +924,47 @@ defmodule Lightning.Projects.ProvisionerTest do
              "The soft-deleted workflow should be excluded from the project"
     end
 
+    test "soft-deleting a workflow frees its name for reuse", %{
+      project: project,
+      user: user
+    } do
+      %{
+        body: body,
+        workflows: [%{id: workflow_id}]
+      } = valid_document(project.id)
+
+      {:ok, _} = Provisioner.import_document(project, user, body)
+
+      original_name =
+        Repo.get!(Lightning.Workflows.Workflow, workflow_id).name
+
+      {:ok, _} =
+        body
+        |> remove_workflow_from_document(workflow_id)
+        |> then(&Provisioner.import_document(project, user, &1))
+
+      deleted = Repo.get!(Lightning.Workflows.Workflow, workflow_id)
+
+      assert deleted.deleted_at
+
+      assert deleted.name == "#{original_name}_del",
+             "The soft-deleted workflow should release its original name"
+
+      # Importing a fresh workflow that reuses the original name now succeeds,
+      # rather than colliding with the hidden, soft-deleted one.
+      %{body: reuse_body} = valid_document(project.id)
+
+      reuse_body =
+        Map.update!(reuse_body, "workflows", fn [workflow] ->
+          [Map.put(workflow, "name", original_name)]
+        end)
+
+      assert {:ok, reimported} =
+               Provisioner.import_document(project, user, reuse_body)
+
+      assert Enum.any?(reimported.workflows, &(&1.name == original_name))
+    end
+
     test "disables all triggers on a workflow that is soft-deleted via provisioner",
          %{
            project: project,

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1062,6 +1062,98 @@ defmodule Lightning.Projects.SandboxesTest do
     end
   end
 
+  describe "merge/4 sandbox-only credentials" do
+    # Adds a credential that exists only in the sandbox (the target has no
+    # project_credential for its underlying credential) and wires the sandbox's
+    # A1 step to reference it. Returns the sandbox project_credential so the
+    # test can choose whether to select it for attachment.
+    defp add_sandbox_only_credential!(sandbox, actor) do
+      cred =
+        insert(:credential,
+          name: "sandbox-only",
+          body: %{"token" => "only-here"},
+          user: actor
+        )
+
+      sandbox_pc =
+        insert(:project_credential, project: sandbox, credential: cred)
+
+      sandbox
+      |> find_sandbox_job!("Alpha", "A1")
+      |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
+      |> Repo.update!()
+
+      {cred, sandbox_pc}
+    end
+
+    test "attaches a selected sandbox-only credential to the target and the merged job references it" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:owner)
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      {cred, sandbox_pc} = add_sandbox_only_credential!(sandbox, actor)
+
+      refute Repo.exists?(
+               from(pc in ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^cred.id
+               )
+             )
+
+      assert {:ok, _updated} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_credential_ids: [sandbox_pc.id]
+               })
+
+      parent_pc =
+        Repo.get_by!(ProjectCredential,
+          project_id: parent.id,
+          credential_id: cred.id
+        )
+
+      merged_a1 =
+        Repo.get_by!(Job,
+          workflow_id:
+            Repo.get_by!(Workflow, project_id: parent.id, name: "Alpha").id,
+          name: "A1"
+        )
+
+      assert merged_a1.project_credential_id == parent_pc.id
+    end
+
+    test "does not attach a deselected sandbox-only credential" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:owner)
+
+      {:ok, sandbox} = Sandboxes.provision(parent, actor, %{name: "sandbox-x"})
+
+      {cred, _sandbox_pc} = add_sandbox_only_credential!(sandbox, actor)
+
+      assert {:ok, _updated} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_credential_ids: []
+               })
+
+      refute Repo.exists?(
+               from(pc in ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^cred.id
+               )
+             )
+
+      # The merged step drops the credential it could not map.
+      merged_a1 =
+        Repo.get_by!(Job,
+          workflow_id:
+            Repo.get_by!(Workflow, project_id: parent.id, name: "Alpha").id,
+          name: "A1"
+        )
+
+      assert merged_a1.project_credential_id == nil
+    end
+  end
+
   describe "keychains" do
     test "clones only used keychains and rewires jobs to cloned keychains" do
       %{

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -1585,8 +1585,6 @@ defmodule Lightning.WorkflowsTest do
         |> Ecto.Changeset.change()
         |> Workflows.soft_delete_changeset()
 
-      # The single definition both the workflows list and the provisioner route
-      # through: setting deleted_at and freeing the name are inseparable here.
       assert %DateTime{} = Ecto.Changeset.get_change(changeset, :deleted_at)
 
       assert Ecto.Changeset.get_change(changeset, :name) ==

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -1576,6 +1576,23 @@ defmodule Lightning.WorkflowsTest do
       assert_received %KafkaTriggerUpdated{trigger_id: ^kafka_trigger_1_id}
     end
 
+    test "soft_delete_changeset/1 marks deleted and frees the name in one step" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project, name: "Shared Transition")
+
+      changeset =
+        workflow
+        |> Ecto.Changeset.change()
+        |> Workflows.soft_delete_changeset()
+
+      # The single definition both the workflows list and the provisioner route
+      # through: setting deleted_at and freeing the name are inseparable here.
+      assert %DateTime{} = Ecto.Changeset.get_change(changeset, :deleted_at)
+
+      assert Ecto.Changeset.get_change(changeset, :name) ==
+               "Shared Transition_del"
+    end
+
     test "mark_for_deletion/3 renames workflow with _del suffix" do
       # Use a separate project to avoid pollution from setup
       project = insert(:project)

--- a/test/lightning_web/live/credential_live_helpers_test.exs
+++ b/test/lightning_web/live/credential_live_helpers_test.exs
@@ -262,7 +262,7 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
       assert project_id == project.id
     end
 
-    test "returns the sandbox and its root parent for a sandbox" do
+    test "returns the sandbox and its full ancestor chain for a sandbox" do
       root = insert(:project)
       child = insert(:project, parent_id: root.id)
       grandchild = insert(:project, parent_id: child.id)
@@ -272,8 +272,9 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
         |> Helpers.default_project_credentials()
         |> Enum.map(& &1.project_id)
 
-      # The active (sandbox) project and the root parent, not the intermediate.
-      assert project_ids == [grandchild.id, root.id]
+      # The active (sandbox) project and every ancestor, including the
+      # intermediate parent, so the credential survives a merge into any of them.
+      assert project_ids == [grandchild.id, child.id, root.id]
     end
   end
 end

--- a/test/lightning_web/live/credential_live_helpers_test.exs
+++ b/test/lightning_web/live/credential_live_helpers_test.exs
@@ -272,8 +272,7 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
         |> Helpers.default_project_credentials()
         |> Enum.map(& &1.project_id)
 
-      # The active (sandbox) project and every ancestor, including the
-      # intermediate parent, so the credential survives a merge into any of them.
+      # Includes the intermediate parent, not just the root.
       assert project_ids == [grandchild.id, child.id, root.id]
     end
   end

--- a/test/lightning_web/live/credential_live_helpers_test.exs
+++ b/test/lightning_web/live/credential_live_helpers_test.exs
@@ -262,7 +262,7 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
       assert project_id == project.id
     end
 
-    test "returns the sandbox and its full ancestor chain for a sandbox" do
+    test "returns only the sandbox itself, not its ancestors" do
       root = insert(:project)
       child = insert(:project, parent_id: root.id)
       grandchild = insert(:project, parent_id: child.id)
@@ -272,8 +272,7 @@ defmodule LightningWeb.CredentialLive.HelpersTest do
         |> Helpers.default_project_credentials()
         |> Enum.map(& &1.project_id)
 
-      # Includes the intermediate parent, not just the root.
-      assert project_ids == [grandchild.id, child.id, root.id]
+      assert project_ids == [grandchild.id]
     end
   end
 end

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1021,7 +1021,7 @@ defmodule LightningWeb.ProjectLiveTest do
       end)
     end
 
-    test "new credential in a sandbox pre-selects the sandbox and its root parent",
+    test "new credential in a sandbox pre-selects the sandbox and its full ancestor chain",
          %{conn: conn, user: user} do
       root =
         insert(:project,
@@ -1047,8 +1047,8 @@ defmodule LightningWeb.ProjectLiveTest do
       view |> select_credential_type("http")
       view |> click_continue()
 
-      # Both the active sandbox and the root parent are pre-selected; the
-      # intermediate project in the chain is not.
+      # The active sandbox and every ancestor are pre-selected, including the
+      # intermediate, so the credential survives a merge into any of them.
       assert has_element?(
                view,
                "#remove-project-credential-button-new-#{sandbox.id}"
@@ -1056,12 +1056,12 @@ defmodule LightningWeb.ProjectLiveTest do
 
       assert has_element?(
                view,
-               "#remove-project-credential-button-new-#{root.id}"
+               "#remove-project-credential-button-new-#{intermediate.id}"
              )
 
-      refute has_element?(
+      assert has_element?(
                view,
-               "#remove-project-credential-button-new-#{intermediate.id}"
+               "#remove-project-credential-button-new-#{root.id}"
              )
     end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1021,7 +1021,7 @@ defmodule LightningWeb.ProjectLiveTest do
       end)
     end
 
-    test "new credential in a sandbox pre-selects the sandbox and its full ancestor chain",
+    test "new credential in a sandbox pre-selects only the active sandbox",
          %{conn: conn, user: user} do
       root =
         insert(:project,
@@ -1047,19 +1047,19 @@ defmodule LightningWeb.ProjectLiveTest do
       view |> select_credential_type("http")
       view |> click_continue()
 
-      # The active sandbox and every ancestor are pre-selected, including the
-      # intermediate, so the credential survives a merge into any of them.
+      # Only the active sandbox is pre-selected. Ancestors are attached at
+      # merge time, not speculatively at credential creation.
       assert has_element?(
                view,
                "#remove-project-credential-button-new-#{sandbox.id}"
              )
 
-      assert has_element?(
+      refute has_element?(
                view,
                "#remove-project-credential-button-new-#{intermediate.id}"
              )
 
-      assert has_element?(
+      refute has_element?(
                view,
                "#remove-project-credential-button-new-#{root.id}"
              )

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1825,7 +1825,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       html = render(view)
 
-      assert html =~ "Failed to merge"
+      assert html =~ "merge this sandbox"
 
       refute has_element?(view, "#merge-sandbox-modal")
     end
@@ -2133,11 +2133,12 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
-    test "formats generic error with inspect", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
+    test "shows a generic message for an unexpected failure, without leaking internals",
+         %{
+           conn: conn,
+           root: root,
+           child1: child1
+         } do
       {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
 
       Mimic.expect(Lightning.Projects.MergeProjects, :merge_project, fn _source,
@@ -2165,8 +2166,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-      assert html =~ "Failed to merge:"
-      assert html =~ "unexpected"
+      assert html =~ "merge this sandbox"
+      # The raw reason must not leak to the user.
+      refute html =~ "unexpected"
+      refute html =~ "something went wrong"
       refute has_element?(view, "#merge-sandbox-modal")
     end
 

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -3946,8 +3946,30 @@ defmodule LightningWeb.SandboxLive.IndexTest do
              )
 
       html = render(view)
-      assert html =~ "Credentials to add to the target project"
+      assert html =~ "Credentials to add"
       assert html =~ "sandbox-only-cred"
+    end
+
+    test "select-all toggles every credential", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      # Default is all selected; the select-all clears them, then re-selects.
+      view |> element("#merge-select-all-credentials") |> render_click()
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.size(assigns.merge_selected_credential_ids) == 0
+
+      view |> element("#merge-select-all-credentials") |> render_click()
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.member?(assigns.merge_selected_credential_ids, sandbox_pc.id)
     end
 
     test "deselecting a credential and merging does not attach it", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2001,7 +2001,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
                "Successfully merged child1 into root, but could not schedule the sandbox for deletion."
     end
 
-    test "formats changeset error correctly", %{
+    test "shows a generic message when a merge fails validation", %{
       conn: conn,
       root: root,
       child1: child1
@@ -2014,7 +2014,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         "merged_yaml"
       end)
 
-      # Return changeset error
+      # A validation failure with no recognised cause.
       changeset = %Ecto.Changeset{
         errors: [name: {"is invalid", []}],
         valid?: false
@@ -2039,16 +2039,17 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-      assert html =~ "name: is invalid"
+      assert html =~ "pass validation"
+      # No schema field paths or raw changeset internals leak to the user.
+      refute html =~ "name: is invalid"
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
-    test "surfaces errors nested in associations instead of a generic message",
-         %{
-           conn: conn,
-           root: root,
-           child1: child1
-         } do
+    test "names the conflicting workflow on a name collision", %{
+      conn: conn,
+      root: root,
+      child1: child1
+    } do
       {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
 
       Mimic.expect(Lightning.Projects.MergeProjects, :merge_project, fn _source,
@@ -2057,10 +2058,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         "merged_yaml"
       end)
 
-      # An error nested under :workflows, with nothing at the top level.
+      # A name collision surfaces as an error on a nested workflow's :name.
       nested_changeset =
-        %Lightning.Workflows.Workflow{}
-        |> Ecto.Changeset.change(%{})
+        %Lightning.Workflows.Workflow{name: "Patient Sync"}
+        |> Ecto.Changeset.change()
         |> Ecto.Changeset.add_error(
           :name,
           "A workflow with this name already exists (possibly pending deletion) in this project."
@@ -2068,7 +2069,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       changeset =
         %Lightning.Projects.Project{workflows: []}
-        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.change()
         |> Ecto.Changeset.put_assoc(:workflows, [nested_changeset])
 
       Mimic.expect(Lightning.Projects.Provisioner, :import_document, fn _target,
@@ -2090,10 +2091,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-
-      refute html =~ "Failed to merge: validation error"
-      assert html =~ "workflows.name"
-      assert html =~ "A workflow with this name already exists"
+      assert html =~ "Patient Sync"
+      assert html =~ "already exists in the target project"
+      refute html =~ "validation error"
+      refute has_element?(view, "#merge-sandbox-modal")
     end
 
     test "formats text error correctly", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2057,8 +2057,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         "merged_yaml"
       end)
 
-      # A workflow-name collision surfaces as an error nested under the
-      # :workflows association, with no top-level error.
+      # An error nested under :workflows, with nothing at the top level.
       nested_changeset =
         %Lightning.Workflows.Workflow{}
         |> Ecto.Changeset.change(%{})

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2347,7 +2347,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert hd(parent_collections).name == "shared"
     end
 
-    test "merge fails with flash error when collection sync fails", %{
+    test "merge failure shows a flash error and closes the modal", %{
       conn: conn,
       root: root,
       sandbox: sandbox
@@ -2358,7 +2358,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
                                                             _tgt,
                                                             _actor,
                                                             _opts ->
-        {:error, "Failed to sync collections: :boom"}
+        {:error, :merge_failed}
       end)
 
       Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
@@ -2370,7 +2370,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       view |> form("#merge-sandbox-modal form") |> render_submit()
 
       html = render(view)
-      assert html =~ "Failed to sync collections"
+      assert html =~ "merge this sandbox"
       refute has_element?(view, "#merge-sandbox-modal")
     end
   end

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -3857,6 +3857,162 @@ defmodule LightningWeb.SandboxLive.IndexTest do
     end
   end
 
+  describe "credential selection in merge modal" do
+    setup :register_and_log_in_user
+
+    # Provisions a real sandbox from the parent, then adds a credential that
+    # lives only in the sandbox and wires the sandbox's job to it. The merge of
+    # this sandbox into the parent would drop that credential unless the user
+    # keeps it selected in the modal.
+    setup %{user: user} do
+      parent =
+        insert(:project,
+          name: "parent",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      wf = insert(:workflow, project: parent, name: "Alpha")
+      trigger = insert(:trigger, workflow: wf, type: :webhook)
+
+      job =
+        insert(:job,
+          workflow: wf,
+          name: "A1",
+          adaptor: "@openfn/language-common@latest",
+          body: "console.log('A1');"
+        )
+
+      insert(:edge,
+        workflow: wf,
+        source_trigger_id: trigger.id,
+        target_job_id: job.id,
+        condition_type: :always,
+        enabled: true
+      )
+
+      {:ok, sandbox} =
+        Lightning.Projects.Sandboxes.provision(parent, user, %{name: "sb"})
+
+      credential =
+        insert(:credential,
+          name: "sandbox-only-cred",
+          body: %{"token" => "x"},
+          user: user
+        )
+
+      sandbox_pc =
+        insert(:project_credential, project: sandbox, credential: credential)
+
+      sandbox_job =
+        from(j in Lightning.Workflows.Job,
+          join: w in assoc(j, :workflow),
+          where: w.project_id == ^sandbox.id and j.name == "A1"
+        )
+        |> Repo.one!()
+
+      sandbox_job
+      |> Ecto.Changeset.change(project_credential_id: sandbox_pc.id)
+      |> Repo.update!()
+
+      {:ok,
+       parent: parent,
+       sandbox: sandbox,
+       credential: credential,
+       sandbox_pc: sandbox_pc}
+    end
+
+    test "modal lists sandbox-only credentials checked by default", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert [%{id: listed_id, name: "sandbox-only-cred"}] =
+               assigns.merge_credentials
+
+      assert listed_id == sandbox_pc.id
+
+      assert MapSet.equal?(
+               assigns.merge_selected_credential_ids,
+               MapSet.new([sandbox_pc.id])
+             )
+
+      html = render(view)
+      assert html =~ "Credentials to add to the target project"
+      assert html =~ "sandbox-only-cred"
+    end
+
+    test "deselecting a credential and merging does not attach it", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc,
+      credential: credential
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> element("li[phx-value-id='#{sandbox_pc.id}']")
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+      assert MapSet.size(assigns.merge_selected_credential_ids) == 0
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      assert_redirect(view, ~p"/projects/#{parent.id}/w")
+
+      refute Repo.exists?(
+               from(pc in Lightning.Projects.ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^credential.id
+               )
+             )
+    end
+
+    test "keeping a credential selected and merging attaches it", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      credential: credential
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      assert_redirect(view, ~p"/projects/#{parent.id}/w")
+
+      assert Repo.exists?(
+               from(pc in Lightning.Projects.ProjectCredential,
+                 where:
+                   pc.project_id == ^parent.id and
+                     pc.credential_id == ^credential.id
+               )
+             )
+    end
+  end
+
   describe "GitHub sync integration during merge" do
     setup do
       Mox.verify_on_exit!()

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2043,6 +2043,60 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
+    test "surfaces errors nested in associations instead of a generic message",
+         %{
+           conn: conn,
+           root: root,
+           child1: child1
+         } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
+
+      Mimic.expect(Lightning.Projects.MergeProjects, :merge_project, fn _source,
+                                                                        _target,
+                                                                        _opts ->
+        "merged_yaml"
+      end)
+
+      # A workflow-name collision surfaces as an error nested under the
+      # :workflows association, with no top-level error.
+      nested_changeset =
+        %Lightning.Workflows.Workflow{}
+        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.add_error(
+          :name,
+          "A workflow with this name already exists (possibly pending deletion) in this project."
+        )
+
+      changeset =
+        %Lightning.Projects.Project{workflows: []}
+        |> Ecto.Changeset.change(%{})
+        |> Ecto.Changeset.put_assoc(:workflows, [nested_changeset])
+
+      Mimic.expect(Lightning.Projects.Provisioner, :import_document, fn _target,
+                                                                        _actor,
+                                                                        _yaml,
+                                                                        _opts ->
+        {:error, changeset}
+      end)
+
+      Mimic.allow(Lightning.Projects.MergeProjects, self(), view.pid)
+      Mimic.allow(Lightning.Projects.Provisioner, self(), view.pid)
+
+      view
+      |> element("#branch-rewire-sandbox-#{child1.id} button")
+      |> render_click()
+
+      view
+      |> form("#merge-sandbox-modal form")
+      |> render_submit()
+
+      html = render(view)
+
+      refute html =~ "Failed to merge: validation error"
+      assert html =~ "workflows.name"
+      assert html =~ "A workflow with this name already exists"
+    end
+
     test "formats text error correctly", %{
       conn: conn,
       root: root,

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -2039,17 +2039,18 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-      assert html =~ "pass validation"
+      assert html =~ "merge this sandbox"
       # No schema field paths or raw changeset internals leak to the user.
       refute html =~ "name: is invalid"
       refute has_element?(view, "#merge-sandbox-modal")
     end
 
-    test "names the conflicting workflow on a name collision", %{
-      conn: conn,
-      root: root,
-      child1: child1
-    } do
+    test "shows a generic message for a nested workflow error, without leaking it",
+         %{
+           conn: conn,
+           root: root,
+           child1: child1
+         } do
       {:ok, view, _} = live(conn, ~p"/projects/#{root.id}/sandboxes")
 
       Mimic.expect(Lightning.Projects.MergeProjects, :merge_project, fn _source,
@@ -2091,9 +2092,10 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       html = render(view)
-      assert html =~ "Patient Sync"
-      assert html =~ "already exists in the target project"
-      refute html =~ "validation error"
+      assert html =~ "merge this sandbox"
+      # The workflow name and the raw error must not leak to the user.
+      refute html =~ "Patient Sync"
+      refute html =~ "already exists"
       refute has_element?(view, "#merge-sandbox-modal")
     end
 

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -3972,6 +3972,32 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert MapSet.member?(assigns.merge_selected_credential_ids, sandbox_pc.id)
     end
 
+    test "a deselected credential survives a form change", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      sandbox_pc: sandbox_pc
+    } do
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      view
+      |> element("li[phx-value-id='#{sandbox_pc.id}']")
+      |> render_click()
+
+      # The checkboxes share the merge form, so any form change re-runs
+      # select-merge-target; it must not wipe the user's deselection.
+      view
+      |> form("#merge-sandbox-modal form", merge: %{target_id: parent.id})
+      |> render_change()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+      refute MapSet.member?(assigns.merge_selected_credential_ids, sandbox_pc.id)
+    end
+
     test "deselecting a credential and merging does not attach it", %{
       conn: conn,
       parent: parent,


### PR DESCRIPTION
## Description

This builds on #4835 and covers the cases where merging a sandbox could still fail or quietly drop something. Three changes:

- **Free up a deleted workflow's name on merge.** When a merge deletes a workflow, it now renames it (the same way deleting from the workflows list already does) so the name is free to reuse. A leftover name was the remaining cause of the "validation error" people saw on merge.
- **Stop swallowing merge failures.** A failed merge used to show a bare "validation error" and leave no trace, so we only learned about one when someone reported it. Now the user sees "Couldn't merge this sandbox. Please try again.", and the full reason is logged and sent to Sentry, so we find out about failures as they happen and can fix the cause instead of waiting on a report. The one exception is hitting a plan limit, which the user sees directly and which we don't treat as an error.
- **Choose which sandbox credentials to carry over.** The merge dialog now lists the credentials that exist only in the sandbox under "Credentials to add", with per-credential toggles and a select-all. The ones left selected are attached to the target as part of the merge, so they survive instead of being silently dropped; the ones you deselect are left behind. See screenshot
<img width="579" height="596" alt="Screenshot 2026-06-10 at 16 52 00" src="https://github.com/user-attachments/assets/5890d2f1-3bf4-4e4c-8ad3-48d79ed7e4e7" />

## Validation steps

1. In a sandbox, create a credential and attach it to a step. Open the merge dialog and confirm it appears under "Credentials to add". Merge with it selected and confirm it is attached to the target; on a fresh sandbox, deselect it and confirm it is not.
2. Delete a workflow on the parent through a merge, then merge again recreating a workflow with the same name. It should succeed (before, this failed).
3. Make a merge fail and confirm the flash shows the try-again message rather than a raw "validation error".

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR

