### PR TITLE
free legacy soft-deleted workflow names

### DIFF
--- a/lib/lightning/release.ex
+++ b/lib/lightning/release.ex
@@ -13,10 +13,10 @@ defmodule Lightning.Release do
 
   import Ecto.Query
 
-  require Logger
-
   alias Lightning.Workflows
   alias Lightning.Workflows.Workflow
+
+  require Logger
 
   @app :lightning
   @repo Lightning.Repo

--- a/lib/lightning/release.ex
+++ b/lib/lightning/release.ex
@@ -2,9 +2,21 @@ defmodule Lightning.Release do
   @moduledoc """
   Used for executing DB release tasks when run in production without Mix
   installed.
+
+  ## One-off cutover task
+
+  `backfill_deleted_workflow_names/1` frees the names of workflows that were
+  soft-deleted before merges renamed on delete. Run it once, on the release
+  that ships that fix, via `bin/backfill_deleted_workflow_names`. It is
+  idempotent and is removed in the follow-up cleanup PR.
   """
 
+  import Ecto.Query
+
   require Logger
+
+  alias Lightning.Workflows
+  alias Lightning.Workflows.Workflow
 
   @app :lightning
   @repo Lightning.Repo
@@ -50,5 +62,71 @@ defmodule Lightning.Release do
   def load_app do
     Application.ensure_all_started(:ssl)
     Application.ensure_all_started(@repo)
+  end
+
+  @doc """
+  One-off cutover task: frees the names of soft-deleted workflows that still
+  hold their original `(name, project_id)`.
+
+  Workflows soft-deleted before merges renamed on delete keep their original
+  name, which the uniqueness rule then uses to block a later merge from
+  recreating that name. This renames each to `name_del`/`name_delN`, the same
+  scheme UI and merge deletes now use, reusing
+  `Workflows.resolve_name_for_pending_deletion/1` so the freed names match.
+
+  Idempotent: only touches names that aren't already `_del`-suffixed, and each
+  rename is committed before the next so collision-avoidance sees it. Safe to
+  re-run if interrupted. Pass `dry_run: true` to log the count without writing.
+
+  Removed in the follow-up cleanup PR once the cutover has run.
+  """
+  @spec backfill_deleted_workflow_names(keyword()) :: {:ok, non_neg_integer()}
+  def backfill_deleted_workflow_names(opts \\ []) do
+    start_repo()
+
+    targets =
+      from(w in Workflow,
+        where:
+          not is_nil(w.deleted_at) and fragment("? !~ '_del[0-9]*$'", w.name)
+      )
+      |> @repo.all()
+
+    if Keyword.get(opts, :dry_run, false) do
+      Logger.info(
+        "[dry run] #{length(targets)} soft-deleted workflow name(s) would be freed"
+      )
+
+      {:ok, length(targets)}
+    else
+      Enum.each(targets, &free_workflow_name/1)
+
+      Logger.info(
+        "Freed #{length(targets)} soft-deleted workflow name(s). Safe to re-run."
+      )
+
+      {:ok, length(targets)}
+    end
+  end
+
+  defp free_workflow_name(%Workflow{} = workflow) do
+    new_name = Workflows.resolve_name_for_pending_deletion(workflow)
+
+    from(w in Workflow, where: w.id == ^workflow.id)
+    |> @repo.update_all(
+      set: [
+        name: new_name,
+        updated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      ]
+    )
+  end
+
+  defp start_repo do
+    load_app()
+    {:ok, _} = Application.ensure_all_started(:ecto_sql)
+
+    case @repo.start_link(pool_size: 2) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
   end
 end

--- a/rel/overlays/bin/backfill_deleted_workflow_names
+++ b/rel/overlays/bin/backfill_deleted_workflow_names
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./lightning eval Lightning.Release.backfill_deleted_workflow_names

--- a/rel/overlays/bin/backfill_deleted_workflow_names.bat
+++ b/rel/overlays/bin/backfill_deleted_workflow_names.bat
@@ -1,0 +1,1 @@
+call "%~dp0\lightning" eval Lightning.Release.backfill_deleted_workflow_names

--- a/test/lightning/release_test.exs
+++ b/test/lightning/release_test.exs
@@ -1,0 +1,61 @@
+defmodule Lightning.ReleaseTest do
+  use Lightning.DataCase, async: false
+
+  alias Lightning.Release
+  alias Lightning.Workflows.Workflow
+
+  describe "backfill_deleted_workflow_names/1" do
+    test "frees the names of soft-deleted workflows that were never renamed" do
+      project = insert(:project)
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      # Soft-deleted and never renamed: should be freed to "<name>_del".
+      stale =
+        insert(:workflow,
+          project: project,
+          name: "Patient Sync",
+          deleted_at: now
+        )
+
+      # Collision: "Report_del" is already taken, so "Report" must land on
+      # "Report_del1".
+      insert(:workflow, project: project, name: "Report_del", deleted_at: now)
+
+      collide =
+        insert(:workflow, project: project, name: "Report", deleted_at: now)
+
+      # Untouched: a live workflow, and one whose name is already freed.
+      live = insert(:workflow, project: project, name: "Live One")
+
+      freed =
+        insert(:workflow, project: project, name: "Old_del", deleted_at: now)
+
+      assert {:ok, 2} = Release.backfill_deleted_workflow_names()
+
+      assert reload_name(stale) == "Patient Sync_del"
+      assert reload_name(collide) == "Report_del1"
+      assert reload_name(live) == "Live One"
+      assert reload_name(freed) == "Old_del"
+    end
+
+    test "is idempotent across runs" do
+      project = insert(:project)
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      insert(:workflow, project: project, name: "X", deleted_at: now)
+
+      assert {:ok, 1} = Release.backfill_deleted_workflow_names()
+      assert {:ok, 0} = Release.backfill_deleted_workflow_names()
+    end
+
+    test "dry_run reports the count without renaming" do
+      project = insert(:project)
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+      workflow = insert(:workflow, project: project, name: "Y", deleted_at: now)
+
+      assert {:ok, 1} = Release.backfill_deleted_workflow_names(dry_run: true)
+      assert reload_name(workflow) == "Y"
+    end
+  end
+
+  defp reload_name(%Workflow{id: id}), do: Repo.get!(Workflow, id).name
+end


### PR DESCRIPTION
## Description

A one-off release task to free the names of workflows soft-deleted before merges renamed on delete. They still hold their original name, which the uniqueness rule uses to block a later merge from recreating it (~900 such workflows in prod). #4842 stops new ones forming; this clears the existing ones.

`Lightning.Release.backfill_deleted_workflow_names/1` (via `bin/backfill_deleted_workflow_names`) renames each to `name_del`, reusing the app's existing logic. Idempotent, with a `dry_run: true` option.

## Validation steps

In `iex -S mix`, seed a few soft-deleted workflows including a collision:

```elixir
alias Lightning.Repo
alias Lightning.Projects.Project
alias Lightning.Workflows.Workflow

now = DateTime.utc_now() |> DateTime.truncate(:second)
project = Repo.insert!(%Project{name: "backfill-demo"})

# never-renamed soft-deletes
Repo.insert!(%Workflow{project_id: project.id, name: "Patient Sync", deleted_at: now})
Repo.insert!(%Workflow{project_id: project.id, name: "Report", deleted_at: now})
# collision: "Report_del" is already taken
Repo.insert!(%Workflow{project_id: project.id, name: "Report_del", deleted_at: now})
# control: a live workflow, should stay untouched
Repo.insert!(%Workflow{project_id: project.id, name: "Live One"})
```

Then:

1. `Lightning.Release.backfill_deleted_workflow_names(dry_run: true)` reports the count and writes nothing.
2. `Lightning.Release.backfill_deleted_workflow_names()` frees the names: `Patient Sync` becomes `Patient Sync_del`, `Report` becomes `Report_del1` (since `Report_del` is taken), `Live One` is untouched.
3. Re-running returns `{:ok, 0}`.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
