### PR TITLE
Add workflow :state lifecycle field with backfill

### DIFF
--- a/lib/lightning/workflows/workflow.ex
+++ b/lib/lightning/workflows/workflow.ex
@@ -44,6 +44,7 @@ defmodule Lightning.Workflows.Workflow do
     field :concurrency, :integer, default: nil
     field :enable_job_logs, :boolean, default: true
     field :positions, :map
+    field :state, Ecto.Enum, values: [:draft, :live], default: :draft
 
     # the ordering of edges, triggers and jobs are intentional
     # ecto reverses the relations when inserting. so jobs->triggers->edges

--- a/priv/repo/migrations/20260616135236_add_state_to_workflows.exs
+++ b/priv/repo/migrations/20260616135236_add_state_to_workflows.exs
@@ -1,0 +1,23 @@
+defmodule Lightning.Repo.Migrations.AddStateToWorkflows do
+  use Ecto.Migration
+
+  def up do
+    alter table(:workflows) do
+      add :state, :string, null: false, default: "draft"
+    end
+
+    # Backfill so current behaviour is preserved: a workflow that already has an
+    # enabled trigger is treated as "live"; everything else stays "draft".
+    execute("""
+    UPDATE workflows
+       SET state = 'live'
+     WHERE id IN (SELECT DISTINCT workflow_id FROM triggers WHERE enabled = true)
+    """)
+  end
+
+  def down do
+    alter table(:workflows) do
+      remove :state
+    end
+  end
+end

--- a/test/lightning/workflows/workflow_test.exs
+++ b/test/lightning/workflows/workflow_test.exs
@@ -22,6 +22,16 @@ defmodule Lightning.Workflows.WorkflowTest do
     end
   end
 
+  describe "lifecycle state" do
+    test "defaults to :draft and round-trips :live" do
+      draft = insert(:workflow)
+      assert draft.state == :draft
+
+      live = insert(:workflow, state: :live)
+      assert Repo.reload!(live).state == :live
+    end
+  end
+
   describe "changeset/2 basic validations" do
     test "requires name and valid concurrency" do
       p = insert(:project)


### PR DESCRIPTION
## Description

Adds a `:state` lifecycle field (`:draft | :live`, default `:draft`) to `Lightning.Workflows.Workflow`, with a migration that backfills existing workflows that have an enabled trigger to `:live` so current behaviour is preserved. This is groundwork for the Sandbox DevX lifecycle (draft/live/promote). No behaviour change in this PR: the field is not read anywhere yet.

Part of #4857. Targets the `sandbox-devx` integration branch, not `main`.

## Validation steps

1. Run the migration, then confirm existing workflows with at least one enabled trigger have `state = "live"`, and all others have `state = "draft"`.
2. Create a new workflow and confirm it is created with `state = "draft"`.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (N/A: no authorization changes in this slice)
- [ ] I have updated the **changelog**. (deferred to the final epic PR)
- [x] I have ticked a box in "AI usage" in this PR
