### PR TITLE
Add go_live/2 and switch_to_draft/2 workflow transitions

### DIFF
--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -1024,6 +1024,34 @@ defmodule Lightning.Workflows do
     |> Ecto.Changeset.put_assoc(:triggers, updated_triggers)
   end
 
+  @doc """
+  Publishes a draft workflow: sets its state to `:live`, enables its triggers,
+  and saves in one transaction (capturing a snapshot and recording a version).
+  """
+  @spec go_live(Workflow.t(), struct()) ::
+          {:ok, Workflow.t()} | {:error, Ecto.Changeset.t(Workflow.t())}
+  def go_live(%Workflow{} = workflow, actor) do
+    workflow
+    |> Repo.preload(:triggers)
+    |> update_triggers_enabled_state(true)
+    |> Ecto.Changeset.put_change(:state, :live)
+    |> save_workflow(actor)
+  end
+
+  @doc """
+  Takes a live workflow offline for editing: sets its state to `:draft` and
+  disables its triggers, saved in one transaction.
+  """
+  @spec switch_to_draft(Workflow.t(), struct()) ::
+          {:ok, Workflow.t()} | {:error, Ecto.Changeset.t(Workflow.t())}
+  def switch_to_draft(%Workflow{} = workflow, actor) do
+    workflow
+    |> Repo.preload(:triggers)
+    |> update_triggers_enabled_state(false)
+    |> Ecto.Changeset.put_change(:state, :draft)
+    |> save_workflow(actor)
+  end
+
   defp update_triggers(triggers, enabled?) do
     Enum.map(triggers, &Ecto.Changeset.change(&1, %{enabled: enabled?}))
   end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -12,6 +12,43 @@ defmodule Lightning.WorkflowsTest do
   alias Lightning.Workflows.Triggers.Events
   alias Lightning.Workflows.Triggers.Events.KafkaTriggerUpdated
 
+  describe "go_live/2 and switch_to_draft/2" do
+    setup do
+      %{user: insert(:user)}
+    end
+
+    test "go_live sets state to :live and enables triggers", %{user: user} do
+      {:ok, workflow} =
+        insert(:simple_workflow)
+        |> Workflows.update_triggers_enabled_state(false)
+        |> Ecto.Changeset.put_change(:state, :draft)
+        |> Workflows.save_workflow(user)
+
+      assert workflow.state == :draft
+
+      {:ok, live} = Workflows.go_live(workflow, user)
+
+      assert live.state == :live
+
+      assert Repo.preload(live, :triggers, force: true).triggers
+             |> Enum.all?(& &1.enabled)
+    end
+
+    test "switch_to_draft sets state to :draft and disables triggers", %{
+      user: user
+    } do
+      {:ok, live} = Workflows.go_live(insert(:simple_workflow), user)
+      assert live.state == :live
+
+      {:ok, draft} = Workflows.switch_to_draft(live, user)
+
+      assert draft.state == :draft
+
+      refute Repo.preload(draft, :triggers, force: true).triggers
+             |> Enum.any?(& &1.enabled)
+    end
+  end
+
   describe "workflows" do
     test "list_workflows/0 returns all workflows" do
       workflow = insert(:workflow)


### PR DESCRIPTION
## Description

Adds two lifecycle transitions to `Lightning.Workflows`:

- `go_live/2`: sets a workflow's state to `:live` and enables its triggers.
- `switch_to_draft/2`: sets it back to `:draft` and disables its triggers.

Both go through the existing `save_workflow/3` path, so each transition captures a snapshot and records a version in one transaction. No UI wiring and no read-only lock yet (those are the next slices), so nothing user-facing changes from this PR alone.

Part of #4857. Targets the `sandbox-devx` integration branch, not `main`.

## Validation steps

1. For a draft workflow with disabled triggers, call `Workflows.go_live/2` and confirm the workflow is `:live` and all its triggers are enabled.
2. For a live workflow, call `Workflows.switch_to_draft/2` and confirm it is `:draft` and all its triggers are disabled.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (N/A: no authorization changes in this slice)
- [ ] I have updated the **changelog**. (deferred to the final epic PR)
- [x] I have ticked a box in "AI usage" in this PR
