### PR TITLE
Lock live workflows read-only on main

### DIFF
--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -129,6 +129,19 @@ defmodule Lightning.Workflows do
     |> preload(^include)
   end
 
+  @doc """
+  Returns true when a workflow's lifecycle state permits editing in the given
+  project. A `:live` workflow is read-only on its own project; inside a sandbox
+  the clone stays editable, and drafts are always editable. Anything that is not
+  a live workflow (a draft, or a snapshot view) is editable as far as this rule
+  is concerned.
+  """
+  @spec editable_state?(struct() | nil, Project.t()) :: boolean()
+  def editable_state?(%Workflow{state: :live}, %Project{} = project),
+    do: Project.sandbox?(project)
+
+  def editable_state?(_workflow, _project), do: true
+
   @spec save_workflow(
           Ecto.Changeset.t(Workflow.t()) | map(),
           struct(),

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -235,7 +235,8 @@ defmodule LightningWeb.WorkflowChannel do
         user: render_user_context(user),
         project: render_project_context(project),
         config: render_config_context(),
-        permissions: render_permissions(user, project_user),
+        permissions:
+          render_permissions(user, project_user, fresh_workflow, project),
         latest_snapshot_lock_version: latest_lock_version,
         project_repo_connection: render_repo_connection(project_repo_connection),
         webhook_auth_methods: render_webhook_auth_methods(webhook_auth_methods),
@@ -902,14 +903,14 @@ defmodule LightningWeb.WorkflowChannel do
     }
   end
 
-  defp render_permissions(user, project_user) do
+  defp render_permissions(user, project_user, workflow, project) do
     can_edit =
       Permissions.can?(
         :project_users,
         :edit_workflow,
         user,
         project_user
-      )
+      ) and Lightning.Workflows.editable_state?(workflow, project)
 
     can_run =
       Permissions.can?(

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -1832,6 +1832,17 @@ defmodule Lightning.WorkflowsTest do
            } = audit
   end
 
+  describe "editable_state?/2" do
+    test "live workflows are read-only on main but editable in a sandbox" do
+      main = build(:project)
+      sandbox = build(:project, parent_id: Ecto.UUID.generate())
+
+      refute Workflows.editable_state?(build(:workflow, state: :live), main)
+      assert Workflows.editable_state?(build(:workflow, state: :live), sandbox)
+      assert Workflows.editable_state?(build(:workflow, state: :draft), main)
+    end
+  end
+
   defp create_workflow(opts \\ []) do
     enabled = Keyword.get(opts, :enabled, false)
     trigger = build(:trigger, type: :cron, enabled: enabled)


### PR DESCRIPTION
## Description

Makes a `:live` workflow read-only on its own (non-sandbox) project. Adds `Lightning.Workflows.editable_state?/2` and ANDs it into the workflow channel's `can_edit_workflow` permission, so the collaborative editor's existing read-only path (disabled Save, trigger toggle, and Monaco) applies automatically. Drafts are always editable, and the cloned workflow inside a sandbox stays editable.

Part of #4857. Targets the `sandbox-devx` integration branch, not `main`. Independent of the transitions PR (#4869); only needs the `state` field.

## Validation steps

1. Open a `:live` workflow on a normal (non-sandbox) project in the collaborative editor and confirm it is read-only.
2. Open a `:draft` workflow and confirm it is editable.
3. Open that workflow's clone inside a sandbox and confirm it is editable.

## Additional notes for the reviewer

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (extends the existing `:edit_workflow` permission with a lifecycle check)
- [ ] I have updated the **changelog**. (deferred to the final epic PR)
- [x] I have ticked a box in "AI usage" in this PR
