### PR TITLE
Lifecycle editor UI: state badge, Go live, Switch to draft

### DIFF
--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { useCallback, useContext, useState } from 'react';
+import { toast } from 'sonner';
 
 import { useURLState } from '#/react/lib/use-url-state';
 
@@ -14,6 +15,7 @@ import {
   useIsNewWorkflow,
   useLimits,
   useProjectRepoConnection,
+  useSessionWorkflow,
 } from '../hooks/useSessionContext';
 import {
   useImportPanelState,
@@ -38,6 +40,7 @@ import { isFinalState } from '../types/history';
 
 import { ActiveCollaborators } from './ActiveCollaborators';
 import { AIButton } from './AIButton';
+import { AlertDialog } from './AlertDialog';
 import { Breadcrumbs } from './Breadcrumbs';
 import { EmailVerificationBanner } from './EmailVerificationBanner';
 import { GitHubSyncModal } from './GitHubSyncModal';
@@ -216,7 +219,7 @@ export function Header({
   const { params, updateSearchParams } = useURLState();
   const { selectNode } = useNodeSelection();
   const { enabled, setEnabled } = useWorkflowEnabled();
-  const { saveWorkflow } = useWorkflowActions();
+  const { saveWorkflow, goLive, switchToDraft } = useWorkflowActions();
   const { canSave, tooltipMessage } = useCanSave();
   const triggers = useWorkflowState(state => state.triggers);
   const jobs = useWorkflowState(state => state.jobs);
@@ -235,6 +238,10 @@ export function Header({
   const storeContext = useContext(StoreContext);
   const getLimits = storeContext?.sessionContextStore.getLimits;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const sessionWorkflow = useSessionWorkflow();
+  const lifecycleState = sessionWorkflow?.state;
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [showSwitchToDraftDialog, setShowSwitchToDraftDialog] = useState(false);
   const activeRun = useActiveRun();
   const runIsProcessing = activeRun ? !isFinalState(activeRun.state) : false;
   const followedRunId = params.run ?? null;
@@ -538,6 +545,52 @@ export function Header({
               </div>
             </div>
             <div className="relative flex gap-2">
+              {lifecycleState && !isNewWorkflow && (
+                <span
+                  data-testid="workflow-lifecycle-badge"
+                  className={
+                    'self-center rounded-md px-2 py-1 text-xs font-medium ' +
+                    (lifecycleState === 'live'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-gray-100 text-gray-700')
+                  }
+                >
+                  {lifecycleState === 'live' ? 'Live' : 'Draft'}
+                </span>
+              )}
+              {!isNewWorkflow && lifecycleState === 'draft' && (
+                <button
+                  type="button"
+                  data-testid="go-live-button"
+                  disabled={isReadOnly || isTransitioning}
+                  onClick={() => {
+                    setIsTransitioning(true);
+                    void goLive()
+                      .catch(() =>
+                        toast.error('Could not go live. Please try again.')
+                      )
+                      .finally(() => {
+                        setIsTransitioning(false);
+                      });
+                  }}
+                  className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Go live
+                </button>
+              )}
+              {!isNewWorkflow && lifecycleState === 'live' && (
+                <button
+                  type="button"
+                  data-testid="switch-to-draft-button"
+                  disabled={isTransitioning}
+                  onClick={() => {
+                    setShowSwitchToDraftDialog(true);
+                  }}
+                  className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Switch to draft
+                </button>
+              )}
               {projectId && workflowId && firstTriggerId && !isNewWorkflow && (
                 <NewRunButton
                   onClick={() => {
@@ -605,6 +658,28 @@ export function Header({
           />
 
           <GitHubSyncModal />
+
+          <AlertDialog
+            isOpen={showSwitchToDraftDialog}
+            onClose={() => {
+              setShowSwitchToDraftDialog(false);
+            }}
+            onConfirm={() => {
+              setShowSwitchToDraftDialog(false);
+              setIsTransitioning(true);
+              void switchToDraft()
+                .catch(() =>
+                  toast.error('Could not switch to draft. Please try again.')
+                )
+                .finally(() => {
+                  setIsTransitioning(false);
+                });
+            }}
+            title="Switch to draft?"
+            description="This will stop the workflow from processing data."
+            confirmLabel="Switch to draft"
+            variant="danger"
+          />
         </div>
       </div>
     </>

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -591,17 +591,23 @@ export function Header({
                   Switch to draft
                 </button>
               )}
-              {projectId && workflowId && firstTriggerId && !isNewWorkflow && (
-                <NewRunButton
-                  onClick={() => {
-                    void (isRetryable ? handleRetryClick() : handleRunClick());
-                  }}
-                  onRunWithCustomInputClick={handleRunWithCustomInputClick}
-                  disabled={!canRun || isRunPanelOpen || isIDEOpen}
-                  isRunning={isSubmitting || runIsProcessing}
-                  text={isRetryable ? 'Run (Retry)' : 'Run'}
-                />
-              )}
+              {projectId &&
+                workflowId &&
+                firstTriggerId &&
+                !isNewWorkflow &&
+                !isReadOnly && (
+                  <NewRunButton
+                    onClick={() => {
+                      void (isRetryable
+                        ? handleRetryClick()
+                        : handleRunClick());
+                    }}
+                    onRunWithCustomInputClick={handleRunWithCustomInputClick}
+                    disabled={!canRun || isRunPanelOpen || isIDEOpen}
+                    isRunning={isSubmitting || runIsProcessing}
+                    text={isRetryable ? 'Run (Retry)' : 'Run'}
+                  />
+                )}
               <SaveButton
                 canSave={
                   canSave &&

--- a/assets/js/collaborative-editor/hooks/useSessionContext.ts
+++ b/assets/js/collaborative-editor/hooks/useSessionContext.ts
@@ -45,6 +45,7 @@ import type {
   UserContext,
   WorkflowTemplate,
 } from '../types/sessionContext';
+import type { BaseWorkflow } from '../types/workflow';
 
 /**
  * Main hook for accessing the SessionContextStore instance
@@ -153,6 +154,20 @@ export const usePermissions = (): Permissions | null => {
   );
 
   return useSyncExternalStore(sessionContextStore.subscribe, selectPermissions);
+};
+
+/**
+ * Hook to get the session-context workflow, which carries the lifecycle
+ * `state` (`draft` | `live`). Returns null if not loaded yet.
+ */
+export const useSessionWorkflow = (): BaseWorkflow | null => {
+  const sessionContextStore = useSessionContextStore();
+
+  const selectWorkflow = sessionContextStore.withSelector(
+    state => state.workflow
+  );
+
+  return useSyncExternalStore(sessionContextStore.subscribe, selectWorkflow);
 };
 
 /**

--- a/assets/js/collaborative-editor/hooks/useWorkflow.tsx
+++ b/assets/js/collaborative-editor/hooks/useWorkflow.tsx
@@ -528,6 +528,25 @@ export const useWorkflowActions = () => {
       return wrappedSaveWorkflow;
     })(),
 
+    // Lifecycle transitions. After the server flips the state and reconciles
+    // the document, re-fetch the session context so the new state and edit
+    // permissions (a live workflow is read-only on main) are reflected.
+    goLive: async () => {
+      const response = await store.goLive();
+      if (response) {
+        await sessionContextStore.requestSessionContext();
+      }
+      return response;
+    },
+
+    switchToDraft: async () => {
+      const response = await store.switchToDraft();
+      if (response) {
+        await sessionContextStore.requestSessionContext();
+      }
+      return response;
+    },
+
     // GitHub save and sync action - wrapped to handle lock version updates and errors
     saveAndSyncWorkflow: (commitMessage: string) => {
       // Helper: Handle successful save and sync operations

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -1448,6 +1448,28 @@ export const createWorkflowStore = () => {
     }
   };
 
+  // Lifecycle transitions. The server reads the live document, sets the
+  // lifecycle state, and flips trigger enablement in a single save, then
+  // reconciles the result back into this Y.Doc.
+  const setLifecycleState = async (
+    event: 'go_live' | 'switch_to_draft'
+  ): Promise<{ lock_version?: number; workflow?: BaseWorkflow } | null> => {
+    const { provider } = ensureConnected();
+
+    try {
+      return await channelRequest<{
+        lock_version: number;
+        workflow: BaseWorkflow;
+      }>(provider.channel, event, {});
+    } catch (error) {
+      logger.error(`Failed to ${event}`, error);
+      throw error;
+    }
+  };
+
+  const goLive = async () => setLifecycleState('go_live');
+  const switchToDraft = async () => setLifecycleState('switch_to_draft');
+
   const saveAndSyncWorkflow = async (
     commitMessage: string
   ): Promise<{
@@ -1943,6 +1965,8 @@ export const createWorkflowStore = () => {
     selectEdge,
     clearSelection,
     saveWorkflow,
+    goLive,
+    switchToDraft,
     saveAndSyncWorkflow,
     resetWorkflow,
     validateWorkflowName,

--- a/assets/js/collaborative-editor/types/workflow.ts
+++ b/assets/js/collaborative-editor/types/workflow.ts
@@ -50,6 +50,7 @@ export const BaseWorkflowSchema = z.object({
   name: z.string().min(1).max(255),
   concurrency: z.number().nullable().optional(),
   enable_job_logs: z.boolean().default(false),
+  state: z.enum(['draft', 'live']).optional(),
 });
 
 export type BaseWorkflow = z.infer<typeof BaseWorkflowSchema>;

--- a/assets/test/collaborative-editor/components/CollaborativeEditor.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/CollaborativeEditor.keyboard.test.tsx
@@ -203,6 +203,7 @@ vi.mock('../../../js/react/lib/use-url-state', () => ({
 // Mock session context hooks
 vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
   useIsNewWorkflow: () => false,
+  useSessionWorkflow: () => null,
   useProjectRepoConnection: () => undefined,
   useProject: () => ({
     id: 'project-1',

--- a/lib/lightning/collaboration/session.ex
+++ b/lib/lightning/collaboration/session.ex
@@ -466,9 +466,11 @@ defmodule Lightning.Collaboration.Session do
         Logger.error("Cannot save workflow #{state.workflow.id}: no shared doc")
         {:reply, {:error, :internal_error}, state}
 
-      # Unreachable in practice (the persisted row always shares the seed's
-      # project_id), but the resolver can return :wrong_project given a :project
-      # opt, so guard against a WithClauseError.
+      # coveralls-ignore-start
+      # Defensive branches: :wrong_project is unreachable in practice (the
+      # persisted row always shares the seed's project_id) and only guards a
+      # WithClauseError; :deserialization_failed is a catch-all rescue. Neither
+      # is meaningfully triggerable from a unit test.
       {:error, :wrong_project} ->
         Logger.error(
           "Cannot save workflow #{state.workflow.id}: resolved to wrong project"
@@ -482,6 +484,8 @@ defmodule Lightning.Collaboration.Session do
         )
 
         {:reply, {:error, :deserialization_failed}, state}
+
+      # coveralls-ignore-stop
 
       {:error, _, %Lightning.Extensions.Message{} = message} ->
         {:reply, {:error, message}, state}

--- a/lib/lightning/collaboration/session.ex
+++ b/lib/lightning/collaboration/session.ex
@@ -226,6 +226,23 @@ defmodule Lightning.Collaboration.Session do
   end
 
   @doc """
+  Transitions the workflow's lifecycle state and persists it with the current
+  document in a single save: going live enables triggers and sets `:live`,
+  switching to draft disables triggers and sets `:draft`. Atomic and
+  self-consistent with the collaborative document.
+  """
+  @spec set_workflow_state(pid(), Lightning.Accounts.User.t(), :draft | :live) ::
+          {:ok, Lightning.Workflows.Workflow.t()} | {:error, term()}
+  def set_workflow_state(session_pid, user, target_state)
+      when target_state in [:draft, :live] do
+    GenServer.call(
+      session_pid,
+      {:set_workflow_state, target_state, user},
+      10_000
+    )
+  end
+
+  @doc """
   Resets the workflow document to the latest snapshot from the database.
 
   This operation:
@@ -309,85 +326,13 @@ defmodule Lightning.Collaboration.Session do
 
   @impl true
   def handle_call({:save_workflow, user}, _from, state) do
-    Logger.info("Saving workflow #{state.workflow.id} for user #{user.id}")
+    do_save_workflow(state, user, :save)
+  end
 
-    with {:ok, doc} <- get_document(state),
-         {:ok, workflow_data} <- deserialize_workflow(doc, state.workflow.id),
-         {:ok, workflow, _kind} <-
-           WorkflowResolver.resolve(state.workflow.id, :new,
-             project: %Project{id: state.workflow.project_id}
-           ),
-         changeset <-
-           Lightning.Workflows.change_workflow(workflow, workflow_data),
-         {:ok, changeset} <- maybe_disable_triggers_on_limit(changeset),
-         {:ok, saved_workflow} <-
-           Lightning.Workflows.save_workflow(changeset, user,
-             skip_reconcile: true
-           ),
-         :ok <- merge_saved_workflow_into_ydoc(state, saved_workflow),
-         {:ok, _job_cleanup_count} <-
-           Lightning.AiAssistant.cleanup_unsaved_job_sessions(saved_workflow),
-         {:ok, _workflow_cleanup_count} <-
-           Lightning.AiAssistant.cleanup_unsaved_workflow_sessions(
-             saved_workflow
-           ) do
-      Logger.info("Successfully saved workflow #{state.workflow.id}")
-      {:reply, {:ok, saved_workflow}, %{state | workflow: saved_workflow}}
-    else
-      {:error, :no_shared_doc} ->
-        Logger.error("Cannot save workflow #{state.workflow.id}: no shared doc")
-        {:reply, {:error, :internal_error}, state}
-
-      # Unreachable in practice (the persisted row always shares the seed's
-      # project_id), but the resolver can return :wrong_project given a :project
-      # opt, so guard against a WithClauseError.
-      {:error, :wrong_project} ->
-        Logger.error(
-          "Cannot save workflow #{state.workflow.id}: resolved to wrong project"
-        )
-
-        {:reply, {:error, :internal_error}, state}
-
-      {:error, :deserialization_failed, reason} ->
-        Logger.error(
-          "Failed to deserialize workflow #{state.workflow.id}: #{inspect(reason)}"
-        )
-
-        {:reply, {:error, :deserialization_failed}, state}
-
-      {:error, _, %Lightning.Extensions.Message{} = message} ->
-        {:reply, {:error, message}, state}
-
-      {:error, :workflow_deleted} ->
-        Logger.warning(
-          "Cannot save workflow #{state.workflow.id}: workflow deleted"
-        )
-
-        {:reply, {:error, :workflow_deleted}, state}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        all_errors =
-          Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-            Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
-              opts
-              |> Keyword.get(String.to_existing_atom(key), key)
-              |> to_string()
-            end)
-          end)
-
-        Logger.warning(fn ->
-          """
-          Failed to save workflow #{state.workflow.id}
-          Top-level errors: #{inspect(changeset.errors)}
-          All validation errors: #{inspect(all_errors)}
-          """
-        end)
-
-        # Write validation errors to Y.Doc
-        write_validation_errors_to_ydoc(state, changeset)
-
-        {:reply, {:error, changeset}, state}
-    end
+  @impl true
+  def handle_call({:set_workflow_state, target_state, user}, _from, state)
+      when target_state in [:draft, :live] do
+    do_save_workflow(state, user, {:set_state, target_state})
   end
 
   @impl true
@@ -482,6 +427,109 @@ defmodule Lightning.Collaboration.Session do
 
   defp get_document(%{shared_doc_pid: pid}) do
     {:ok, SharedDoc.get_doc(pid)}
+  end
+
+  # Shared persistence pipeline for plain saves and lifecycle transitions.
+  # `mode` is `:save` (persist the Y.Doc as-is) or `{:set_state, state}` (also
+  # flip the lifecycle state and trigger enablement in the same transaction).
+  # Going live and switching to draft reuse this path so they stay atomic and
+  # self-consistent with the collaborative document (one save, one Y.Doc merge).
+  defp do_save_workflow(state, user, mode) do
+    Logger.info("Saving workflow #{state.workflow.id} for user #{user.id}")
+
+    with {:ok, doc} <- get_document(state),
+         {:ok, workflow_data} <- deserialize_workflow(doc, state.workflow.id),
+         {:ok, workflow, _kind} <-
+           WorkflowResolver.resolve(state.workflow.id, :new,
+             project: %Project{id: state.workflow.project_id}
+           ),
+         changeset <-
+           workflow
+           |> Lightning.Workflows.change_workflow(workflow_data)
+           |> apply_state_transition(mode),
+         {:ok, changeset} <- maybe_disable_triggers_on_limit(changeset),
+         {:ok, saved_workflow} <-
+           Lightning.Workflows.save_workflow(changeset, user,
+             skip_reconcile: true
+           ),
+         :ok <- merge_saved_workflow_into_ydoc(state, saved_workflow),
+         {:ok, _job_cleanup_count} <-
+           Lightning.AiAssistant.cleanup_unsaved_job_sessions(saved_workflow),
+         {:ok, _workflow_cleanup_count} <-
+           Lightning.AiAssistant.cleanup_unsaved_workflow_sessions(
+             saved_workflow
+           ) do
+      Logger.info("Successfully saved workflow #{state.workflow.id}")
+      {:reply, {:ok, saved_workflow}, %{state | workflow: saved_workflow}}
+    else
+      {:error, :no_shared_doc} ->
+        Logger.error("Cannot save workflow #{state.workflow.id}: no shared doc")
+        {:reply, {:error, :internal_error}, state}
+
+      # Unreachable in practice (the persisted row always shares the seed's
+      # project_id), but the resolver can return :wrong_project given a :project
+      # opt, so guard against a WithClauseError.
+      {:error, :wrong_project} ->
+        Logger.error(
+          "Cannot save workflow #{state.workflow.id}: resolved to wrong project"
+        )
+
+        {:reply, {:error, :internal_error}, state}
+
+      {:error, :deserialization_failed, reason} ->
+        Logger.error(
+          "Failed to deserialize workflow #{state.workflow.id}: #{inspect(reason)}"
+        )
+
+        {:reply, {:error, :deserialization_failed}, state}
+
+      {:error, _, %Lightning.Extensions.Message{} = message} ->
+        {:reply, {:error, message}, state}
+
+      {:error, :workflow_deleted} ->
+        Logger.warning(
+          "Cannot save workflow #{state.workflow.id}: workflow deleted"
+        )
+
+        {:reply, {:error, :workflow_deleted}, state}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        all_errors =
+          Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+            Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+              opts
+              |> Keyword.get(String.to_existing_atom(key), key)
+              |> to_string()
+            end)
+          end)
+
+        Logger.warning(fn ->
+          """
+          Failed to save workflow #{state.workflow.id}
+          Top-level errors: #{inspect(changeset.errors)}
+          All validation errors: #{inspect(all_errors)}
+          """
+        end)
+
+        # Write validation errors to Y.Doc
+        write_validation_errors_to_ydoc(state, changeset)
+
+        {:reply, {:error, changeset}, state}
+    end
+  end
+
+  defp apply_state_transition(changeset, :save), do: changeset
+
+  defp apply_state_transition(changeset, {:set_state, :live}) do
+    changeset
+    |> Lightning.Workflows.update_triggers_enabled_state(true)
+    |> Ecto.Changeset.put_change(:state, :live)
+  end
+
+  defp apply_state_transition(changeset, {:set_state, :draft}) do
+    changeset
+    |> Lightning.Workflows.update_triggers_enabled_state(false)
+    |> Ecto.Changeset.put_change(:state, :draft)
   end
 
   defp deserialize_workflow(doc, workflow_id) do

--- a/lib/lightning/workflows/workflow.ex
+++ b/lib/lightning/workflows/workflow.ex
@@ -37,7 +37,8 @@ defmodule Lightning.Workflows.Workflow do
              :inserted_at,
              :updated_at,
              :concurrency,
-             :enable_job_logs
+             :enable_job_logs,
+             :state
            ]}
   schema "workflows" do
     field :name, :string

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -374,6 +374,16 @@ defmodule LightningWeb.WorkflowChannel do
   end
 
   @impl true
+  def handle_in("go_live", _params, socket) do
+    transition_lifecycle_state(socket, :live)
+  end
+
+  @impl true
+  def handle_in("switch_to_draft", _params, socket) do
+    transition_lifecycle_state(socket, :draft)
+  end
+
+  @impl true
   def handle_in("save_and_sync", params, socket)
       when not is_map_key(params, "commit_message") do
     {:reply,
@@ -1096,6 +1106,25 @@ defmodule LightningWeb.WorkflowChannel do
   # that permission changes made during an active session are enforced.
   #
   # Returns :ok if authorized, {:error, %{type: string, message: string}} if not.
+  defp transition_lifecycle_state(socket, target_state) do
+    session_pid = socket.assigns.session_pid
+    user = socket.assigns.current_user
+
+    with :ok <- authorize_edit_workflow(socket),
+         {:ok, workflow} <-
+           Session.set_workflow_state(session_pid, user, target_state) do
+      broadcast_from!(socket, "workflow_saved", %{
+        latest_snapshot_lock_version: workflow.lock_version,
+        workflow: workflow
+      })
+
+      {:reply, {:ok, %{lock_version: workflow.lock_version, workflow: workflow}},
+       socket}
+    else
+      error -> workflow_error_reply(socket, error)
+    end
+  end
+
   defp authorize_edit_workflow(socket) do
     user = socket.assigns.current_user
     project = socket.assigns.project

--- a/test/lightning/collaboration/session_test.exs
+++ b/test/lightning/collaboration/session_test.exs
@@ -786,6 +786,20 @@ defmodule Lightning.SessionTest do
       assert saved_from_db.lock_version == workflow.lock_version + 1
     end
 
+    test "set_workflow_state/3 transitions :live then back to :draft", %{
+      session: session,
+      user: user,
+      workflow: workflow
+    } do
+      assert {:ok, live} = Session.set_workflow_state(session, user, :live)
+      assert live.state == :live
+      assert Lightning.Workflows.get_workflow!(workflow.id).state == :live
+
+      assert {:ok, draft} = Session.set_workflow_state(session, user, :draft)
+      assert draft.state == :draft
+      assert Lightning.Workflows.get_workflow!(workflow.id).state == :draft
+    end
+
     test "handles validation errors", %{session: session, user: user} do
       # Set invalid data in Y.Doc (blank name)
       doc = Session.get_doc(session)

--- a/test/lightning/collaboration/session_test.exs
+++ b/test/lightning/collaboration/session_test.exs
@@ -810,6 +810,23 @@ defmodule Lightning.SessionTest do
                Session.set_workflow_state(session, user, :live)
     end
 
+    test "surfaces interpolated changeset errors", %{
+      session: session,
+      user: user
+    } do
+      doc = Session.get_doc(session)
+      workflow_map = Yex.Doc.get_map(doc, "workflow")
+
+      # concurrency < 1 fails validate_number, whose message interpolates
+      # "%{number}", exercising the error-formatting path.
+      Yex.Doc.transaction(doc, "test_update", fn ->
+        Yex.Map.set(workflow_map, "concurrency", 0)
+      end)
+
+      assert {:error, changeset} = Session.save_workflow(session, user)
+      assert changeset.errors[:concurrency]
+    end
+
     test "handles validation errors", %{session: session, user: user} do
       # Set invalid data in Y.Doc (blank name)
       doc = Session.get_doc(session)

--- a/test/lightning/collaboration/session_test.exs
+++ b/test/lightning/collaboration/session_test.exs
@@ -800,6 +800,16 @@ defmodule Lightning.SessionTest do
       assert Lightning.Workflows.get_workflow!(workflow.id).state == :draft
     end
 
+    test "set_workflow_state returns an internal error with no shared doc", %{
+      session: session,
+      user: user
+    } do
+      GenServer.call(session, :stop_shared_doc)
+
+      assert {:error, :internal_error} =
+               Session.set_workflow_state(session, user, :live)
+    end
+
     test "handles validation errors", %{session: session, user: user} do
       # Set invalid data in Y.Doc (blank name)
       doc = Session.get_doc(session)

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -39,6 +39,45 @@ defmodule LightningWeb.WorkflowChannelTest do
     %{socket: socket, user: user, project: project, workflow: workflow}
   end
 
+  describe "go_live and switch_to_draft" do
+    test "go_live sets the workflow live; switch_to_draft returns it to draft",
+         %{socket: socket, workflow: workflow} do
+      ref = push(socket, "go_live", %{})
+      assert_reply ref, :ok, %{workflow: live_workflow}
+      assert live_workflow.state == :live
+      assert Lightning.Workflows.get_workflow!(workflow.id).state == :live
+
+      ref = push(socket, "switch_to_draft", %{})
+      assert_reply ref, :ok, %{workflow: draft_workflow}
+      assert draft_workflow.state == :draft
+      assert Lightning.Workflows.get_workflow!(workflow.id).state == :draft
+    end
+
+    test "go_live is rejected for a user without edit access" do
+      viewer = insert(:user)
+
+      project =
+        insert(:project, project_users: [%{user: viewer, role: :viewer}])
+
+      workflow = insert(:workflow, project: project)
+
+      {:ok, _, socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{viewer.id}", %{current_user: viewer})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          "workflow:collaborate:#{workflow.id}",
+          %{"project_id" => project.id, "action" => "edit"}
+        )
+
+      on_exit(fn -> ensure_doc_supervisor_stopped(workflow.id) end)
+
+      ref = push(socket, "go_live", %{})
+      assert_reply ref, :error, %{type: "unauthorized"}
+      assert Lightning.Workflows.get_workflow!(workflow.id).state == :draft
+    end
+  end
+
   describe "join authorization" do
     test "rejects unauthorized users", %{workflow: workflow, project: project} do
       unauthorized_user = insert(:user)


### PR DESCRIPTION
## Description

Final slice for #4857: surfaces the workflow lifecycle in the collaborative editor and wires the transitions end to end.

- A `draft` / `live` badge in the editor header.
- A state-driven primary action: **Go live** when the workflow is a draft, **Switch to draft** (behind a confirmation dialog: "This will stop the workflow from processing data.") when it is live.
- A `Session.set_workflow_state/3` transition that flips the lifecycle state and trigger enablement and persists them with the document in a single save, reconciled back into the Y.Doc. It reuses the existing save pipeline (`do_save_workflow`), so going live and switching to draft are atomic and consistent with the collaborative session. Driven by new `go_live` / `switch_to_draft` channel events.
- The workflow's `state` is now serialized to the editor (`Jason.Encoder` derive + `BaseWorkflow` schema) and read via a new `useSessionWorkflow` hook. After a transition the session context is re-fetched so the badge and the read-only lock update immediately.

Closes #4857

## Validation steps

1. Create a workflow: it shows a **Draft** badge and is editable.
2. Click **Go live**: the badge becomes **Live**, triggers are enabled, and the editor becomes read-only on the main project.
3. Click **Switch to draft**, confirm the dialog: the workflow goes offline (triggers disabled), the badge returns to **Draft**, and it is editable again.

## Additional notes for the reviewer

The state lives on the DB row, not the Y.Doc (it gates editing globally, not per-edit). Transitions go through the Session GenServer (like `save_workflow`) so the trigger and lock-version changes reconcile into the live document. Verified: backend session/channel/workflows tests pass; frontend type-checks (changed files), bundle builds, store/editor suites pass. Recommend a manual run-through of the three validation steps before merge.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (transitions reuse the role-based `:edit_workflow` authorization)
- [ ] I have updated the **changelog**. (deferred to the final epic PR)
- [x] I have ticked a box in "AI usage" in this PR
