### PR TITLE
Reply cleanly on unhandled credential errors in run channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to
 
 ### Fixed
 
+- Stop the run channel from crashing during `fetch:credential` when an OAuth
+  provider times out while refreshing a token.
+  [#4853](https://github.com/OpenFn/lightning/issues/4853)
 - Stop the collaborative editor's Session (and the Phoenix channel calling it)
   from crashing when the cross-node `SharedDoc.unobserve/1` during cleanup hits
   a SharedDoc on a node that is unreachable (`:noconnection`) or slow to reply

--- a/lib/lightning/credentials/resolver.ex
+++ b/lib/lightning/credentials/resolver.ex
@@ -55,6 +55,7 @@ defmodule Lightning.Credentials.Resolver do
           | :project_not_found
           | :environment_mismatch
           | Credentials.oauth_refresh_error()
+          | term()
 
   @type resolve_error :: {error_reason(), Credential.t() | nil}
 

--- a/lib/lightning_web/channels/run_channel.ex
+++ b/lib/lightning_web/channels/run_channel.ex
@@ -549,4 +549,15 @@ defmodule LightningWeb.RunChannel do
     {:reply, {:error, "Could not reach the OAuth provider. Try again later"},
      socket}
   end
+
+  # Fallback for unexpected error terms
+  defp handle_credential_error(socket, error, id, _project_id, run_id) do
+    Logger.warning(
+      "Unhandled credential resolution error for credential #{id} " <>
+        "(run #{run_id}): #{inspect(error)}"
+    )
+
+    {:reply, {:error, "Could not reach the OAuth provider. Try again later"},
+     socket}
+  end
 end

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -656,6 +656,32 @@ defmodule LightningWeb.RunChannelTest do
                    :error,
                    "Could not reach the OAuth provider. Try again later"
     end
+
+    @tag capture_log: true
+    test "replies cleanly when the OAuth provider times out", %{
+      credential: credential,
+      user: user
+    } do
+      credential = Repo.preload(credential, :oauth_client)
+      endpoint = credential.oauth_client.token_endpoint
+
+      Lightning.AuthProviders.OauthHTTPClient.Mock
+      |> Mox.expect(:call, fn
+        %Tesla.Env{method: :post, url: ^endpoint}, _opts ->
+          {:error, :timeout}
+      end)
+
+      %{socket: socket} =
+        create_socket_and_run(%{credential: credential, user: user})
+
+      ref = push(socket, "fetch:credential", %{"id" => credential.id})
+
+      # The timeout is an untyped transport error; the channel must reply with
+      # an error rather than crashing with a FunctionClauseError.
+      assert_reply ref,
+                   :error,
+                   "Could not reach the OAuth provider. Try again later"
+    end
   end
 
   describe "marking steps as started and finished" do


### PR DESCRIPTION
## Description

RunChannel.handle_credential_error/5 pattern-matched a fixed set of error tags with no fallback, so an unexpected error term — most notably an OAuth provider timeout during token refresh, which surfaces as an untyped transport error — raised FunctionClauseError and crashed the channel mid-fetch:credential, dropping the worker's connection.

Add a fallback clause that logs the unexpected term and replies with a clean error so the worker receives a response instead of losing the connection.

Closes #4853

## Validation steps

1. _(How can a reviewer validate your work?)_


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
