### PR TITLE
Couple trigger enabled state to workflow lifecycle

### DIFF
--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -29,7 +29,6 @@ import {
   useCanSave,
   useNodeSelection,
   useWorkflowActions,
-  useWorkflowEnabled,
   useWorkflowReadOnly,
   useWorkflowSettingsErrors,
   useWorkflowState,
@@ -44,7 +43,6 @@ import { AlertDialog } from './AlertDialog';
 import { Breadcrumbs } from './Breadcrumbs';
 import { EmailVerificationBanner } from './EmailVerificationBanner';
 import { GitHubSyncModal } from './GitHubSyncModal';
-import { Switch } from './inputs/Switch';
 import { NewRunButton } from './NewRunButton';
 import { ReadOnlyWarning } from './ReadOnlyWarning';
 import { ShortcutKeys } from './ShortcutKeys';
@@ -218,7 +216,6 @@ export function Header({
   // IMPORTANT: All hooks must be called unconditionally before any early returns or conditional logic
   const { params, updateSearchParams } = useURLState();
   const { selectNode } = useNodeSelection();
-  const { enabled, setEnabled } = useWorkflowEnabled();
   const { saveWorkflow, goLive, switchToDraft } = useWorkflowActions();
   const { canSave, tooltipMessage } = useCanSave();
   const triggers = useWorkflowState(state => state.triggers);
@@ -484,27 +481,6 @@ export function Header({
 
           <div className="flex flex-row gap-2 items-center">
             <div className="flex flex-row gap-2 items-center">
-              {!isPinnedVersion && (
-                <Tooltip
-                  content={
-                    isNewWorkflow && isWorkflowEmpty
-                      ? 'Add a workflow to enable'
-                      : null
-                  }
-                  side="bottom"
-                >
-                  <span className="inline-flex items-center">
-                    <Switch
-                      checked={enabled ?? false}
-                      onChange={setEnabled}
-                      disabled={
-                        isReadOnly || (isNewWorkflow && isWorkflowEmpty)
-                      }
-                    />
-                  </span>
-                </Tooltip>
-              )}
-
               <div>
                 <Tooltip
                   content={

--- a/assets/js/collaborative-editor/components/inspector/TriggerInspector.tsx
+++ b/assets/js/collaborative-editor/components/inspector/TriggerInspector.tsx
@@ -1,14 +1,6 @@
-import { useCallback } from 'react';
-
-import { usePermissions } from '../../hooks/useSessionContext';
-import {
-  useWorkflowActions,
-  useWorkflowReadOnly,
-} from '../../hooks/useWorkflow';
+import { useWorkflowReadOnly } from '../../hooks/useWorkflow';
 import type { Workflow } from '../../types/workflow';
 import { NewRunButton } from '../NewRunButton';
-import { Toggle } from '../Toggle';
-import { Tooltip } from '../../../components/Tooltip';
 
 import { InspectorFooter } from './InspectorFooter';
 import { InspectorLayout } from './InspectorLayout';
@@ -49,41 +41,11 @@ export function TriggerInspector({
   onClose,
   onOpenRunPanel,
 }: TriggerInspectorProps) {
-  const permissions = usePermissions();
-  const { updateTrigger } = useWorkflowActions();
-  const { isReadOnly, tooltipMessage } = useWorkflowReadOnly();
+  const { isReadOnly } = useWorkflowReadOnly();
 
-  const handleEnabledChange = useCallback(
-    (enabled: boolean) => {
-      updateTrigger(trigger.id, { enabled });
-    },
-    [trigger.id, updateTrigger]
-  );
-
-  // Determine toggle disabled state and tooltip
-  const isToggleDisabled = !permissions?.can_edit_workflow || isReadOnly;
-
-  const toggleTooltip =
-    isReadOnly || !permissions?.can_edit_workflow
-      ? tooltipMessage || 'You do not have permission to edit this workflow'
-      : 'Enable or disable this trigger';
-
-  // Build footer with enabled toggle and run button
+  // Build footer with run button
   const footer = (
     <InspectorFooter
-      leftButtons={
-        <Tooltip content={toggleTooltip} side="top">
-          <span className="inline-block">
-            <Toggle
-              id={`trigger-enabled-${trigger.id}`}
-              checked={trigger.enabled}
-              onChange={handleEnabledChange}
-              label="Enabled"
-              disabled={isToggleDisabled}
-            />
-          </span>
-        </Tooltip>
-      }
       rightButtons={
         <NewRunButton
           onClick={() => onOpenRunPanel({ triggerId: trigger.id })}

--- a/assets/js/collaborative-editor/hooks/useWorkflow.tsx
+++ b/assets/js/collaborative-editor/hooks/useWorkflow.tsx
@@ -155,7 +155,6 @@ export const useWorkflowSelector = <T,>(
  * @example
  * // Simple state selections - ideal use cases
  * const jobs = useWorkflowState(state => state.jobs);
- * const enabled = useWorkflowState(state => state.enabled);
  * const triggers = useWorkflowState(state => state.triggers);
  *
  * @example
@@ -212,16 +211,6 @@ export const usePositions = () => {
 // =============================================================================
 // SPECIALIZED HOOKS
 // =============================================================================
-
-export const useWorkflowEnabled = () => {
-  return useWorkflowSelector(
-    (state, store) => ({
-      enabled: state.enabled,
-      setEnabled: store.setEnabled,
-    }),
-    []
-  );
-};
 
 /**
  * Hook for accessing current selected job with YText body.
@@ -373,7 +362,6 @@ export const useWorkflowActions = () => {
     removeEdge: store.removeEdge,
 
     updateTrigger: store.updateTrigger,
-    setEnabled: store.setEnabled,
 
     updatePositions: store.updatePositions,
     updatePosition: store.updatePosition,

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -157,10 +157,6 @@ const EdgeShape = EdgeSchema.shape;
 
 // Helper to update derived state (defined first to avoid hoisting issues)
 function updateDerivedState(draft: Workflow.State) {
-  // Compute enabled from triggers
-  draft.enabled =
-    draft.triggers.length > 0 ? draft.triggers.some(t => t.enabled) : null;
-
   // Compute selected node
   if (draft.selectedJobId) {
     draft.selectedNode =
@@ -197,7 +193,6 @@ function produceInitialState() {
       selectedEdgeId: null,
 
       // Initialize computed state
-      enabled: null,
       selectedNode: null,
       selectedEdge: null,
 
@@ -1041,19 +1036,6 @@ export const createWorkflowStore = () => {
         });
       });
     }
-  };
-
-  const setEnabled = (enabled: boolean) => {
-    const ydoc = ensureYDoc();
-
-    const triggersArray = ydoc.getArray('triggers');
-    const triggers = triggersArray.toArray() as Y.Map<unknown>[];
-
-    ydoc.transact(() => {
-      triggers.forEach(trigger => {
-        trigger.set('enabled', enabled);
-      });
-    });
   };
 
   /**
@@ -1943,7 +1925,6 @@ export const createWorkflowStore = () => {
     updateEdge,
     removeEdge,
     updateTrigger,
-    setEnabled,
     clearAllTriggers,
     getJobBodyYText,
     updatePositions,

--- a/assets/js/collaborative-editor/types/workflow.ts
+++ b/assets/js/collaborative-editor/types/workflow.ts
@@ -136,7 +136,6 @@ export namespace Workflow {
     selectedEdgeId: string | null;
 
     // Computed/derived state
-    enabled: boolean | null; // Computed from triggers
     selectedNode: Workflow.Job | Workflow.Trigger | null;
     selectedEdge: Workflow.Edge | null;
 
@@ -170,7 +169,6 @@ export namespace Workflow {
     addJob: (job: Partial<Session.Job>) => void;
     removeJob: (id: string) => void;
     updateTrigger: (id: string, updates: Partial<Session.Trigger>) => void;
-    setEnabled: (enabled: boolean) => void;
 
     // Pattern 3: Direct immer update only (local UI state)
     selectJob: (id: string | null) => void;

--- a/assets/test/collaborative-editor/components/CollaborativeEditor.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/CollaborativeEditor.keyboard.test.tsx
@@ -335,10 +335,6 @@ vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
     canRun: true,
     tooltipMessage: '',
   }),
-  useWorkflowEnabled: () => ({
-    enabled: true,
-    setEnabled: vi.fn(),
-  }),
   useCanSave: () => ({
     canSave: true,
     tooltipMessage: '',

--- a/assets/test/collaborative-editor/components/ide/FullScreenIDE.docs-panel.test.tsx
+++ b/assets/test/collaborative-editor/components/ide/FullScreenIDE.docs-panel.test.tsx
@@ -211,10 +211,6 @@ vi.mock('../../../../js/collaborative-editor/hooks/useWorkflow', () => ({
     currentNode: { node: null, type: null, id: null },
     selectNode: vi.fn(),
   }),
-  useWorkflowEnabled: () => ({
-    enabled: true,
-    setEnabled: vi.fn(),
-  }),
   useWorkflowActions: () => ({
     selectJob: vi.fn(),
     saveWorkflow: vi.fn(),

--- a/assets/test/collaborative-editor/components/ide/FullScreenIDE.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/ide/FullScreenIDE.keyboard.test.tsx
@@ -301,10 +301,6 @@ vi.mock('../../../../js/collaborative-editor/hooks/useWorkflow', () => ({
     selectNode: vi.fn(),
     selectedNodeId: null,
   }),
-  useWorkflowEnabled: () => ({
-    enabled: true,
-    setEnabled: vi.fn(),
-  }),
   useWorkflowSettingsErrors: () => ({
     hasErrors: false,
   }),

--- a/assets/test/collaborative-editor/components/inspector/TriggerInspector.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/TriggerInspector.test.tsx
@@ -191,63 +191,11 @@ describe('TriggerInspector - Footer Button States', () => {
       }
     );
 
-    // Footer should be rendered with toggle and run button
-    expect(screen.getByLabelText(/enabled/i)).toBeInTheDocument();
+    // Footer should be rendered with the run button.
+    // The standalone enabled toggle was removed; trigger enabled is now
+    // owned by the workflow lifecycle (Go live / Switch to draft).
+    expect(screen.queryByLabelText(/enabled/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
-  });
-
-  test('toggle is disabled in read-only mode', () => {
-    // beforeEach already sets read-only permissions
-    const trigger = workflowStore.getSnapshot().triggers[0];
-    const mockOnClose = vi.fn();
-    const mockOnOpenRunPanel = vi.fn();
-
-    render(
-      <TriggerInspector
-        trigger={trigger}
-        onClose={mockOnClose}
-        onOpenRunPanel={mockOnOpenRunPanel}
-      />,
-      {
-        wrapper: createWrapper(
-          workflowStore,
-          credentialStore,
-          sessionContextStore,
-          adaptorStore,
-          awarenessStore
-        ),
-      }
-    );
-
-    const toggle = screen.getByLabelText(/enabled/i);
-    expect(toggle).toBeDisabled();
-  });
-
-  test('toggle is disabled when user lacks edit permission', () => {
-    // beforeEach sets can_edit_workflow: false, which is what this test needs
-    const trigger = workflowStore.getSnapshot().triggers[0];
-    const mockOnClose = vi.fn();
-    const mockOnOpenRunPanel = vi.fn();
-
-    render(
-      <TriggerInspector
-        trigger={trigger}
-        onClose={mockOnClose}
-        onOpenRunPanel={mockOnOpenRunPanel}
-      />,
-      {
-        wrapper: createWrapper(
-          workflowStore,
-          credentialStore,
-          sessionContextStore,
-          adaptorStore,
-          awarenessStore
-        ),
-      }
-    );
-
-    const toggle = screen.getByLabelText(/enabled/i);
-    expect(toggle).toBeDisabled();
   });
 
   test('footer is rendered with all buttons visible', () => {
@@ -293,8 +241,8 @@ describe('TriggerInspector - Footer Button States', () => {
       }
     );
 
-    // Both toggle and run button should be present
-    expect(screen.getByLabelText(/enabled/i)).toBeInTheDocument();
+    // Only the run button should be present (no enabled toggle).
+    expect(screen.queryByLabelText(/enabled/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument();
   });
 });

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -613,7 +613,7 @@ defmodule Lightning.Projects.Provisioner do
 
   defp workflow_changeset(workflow, attrs, valid_project_credentials) do
     workflow
-    |> cast(attrs, [:id, :name, :delete, :deleted_at])
+    |> cast(attrs, [:id, :name, :state, :delete, :deleted_at])
     |> optimistic_lock(:lock_version)
     |> validate_required([:id])
     |> maybe_soft_delete_workflow()
@@ -621,7 +621,30 @@ defmodule Lightning.Projects.Provisioner do
     |> cast_assoc(:jobs, with: &job_changeset(&1, &2, valid_project_credentials))
     |> cast_assoc(:triggers, with: &trigger_changeset/2)
     |> cast_assoc(:edges, with: &edge_changeset/2)
+    |> maybe_infer_workflow_state(attrs)
     |> Workflow.validate()
+  end
+
+  defp maybe_infer_workflow_state(changeset, attrs) do
+    if state_present_in_attrs?(attrs) do
+      changeset
+    else
+      inferred = if any_trigger_enabled?(changeset), do: :live, else: :draft
+      put_change(changeset, :state, inferred)
+    end
+  end
+
+  defp state_present_in_attrs?(attrs) do
+    Map.has_key?(attrs, "state") or Map.has_key?(attrs, :state)
+  end
+
+  defp any_trigger_enabled?(changeset) do
+    changeset
+    |> get_assoc(:triggers)
+    |> Enum.reject(&(&1.action == :delete))
+    |> Enum.any?(fn trigger_changeset ->
+      get_field(trigger_changeset, :enabled) == true
+    end)
   end
 
   defp job_changeset(job, attrs, valid_project_credentials) do

--- a/lib/lightning_web/live/workflow_live/dashboard_components.ex
+++ b/lib/lightning_web/live/workflow_live/dashboard_components.ex
@@ -252,7 +252,7 @@ defmodule LightningWeb.WorkflowLive.DashboardComponents do
                     id={workflow.id}
                     type="toggle"
                     name="workflow_state"
-                    value={Helpers.workflow_enabled?(workflow)}
+                    value={workflow.state == :live}
                     tooltip={Helpers.workflow_state_tooltip(workflow)}
                     on_click="toggle_workflow_state"
                     value_key={workflow.id}

--- a/lib/lightning_web/live/workflow_live/index.ex
+++ b/lib/lightning_web/live/workflow_live/index.ex
@@ -6,9 +6,9 @@ defmodule LightningWeb.WorkflowLive.Index do
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.ProjectUsers
   alias Lightning.Workflows
+  alias Lightning.Workflows.WorkflowUsageLimiter
   alias LightningWeb.Live.Helpers.TableHelpers
   alias LightningWeb.WorkflowLive.DashboardComponents
-  alias LightningWeb.WorkflowLive.Helpers
 
   on_mount {LightningWeb.Hooks, :project_scope}
   on_mount {LightningWeb.Hooks, :check_limits}
@@ -220,9 +220,8 @@ defmodule LightningWeb.WorkflowLive.Index do
     query_params = build_query_params(search_term, sort_key, sort_direction)
 
     workflow_id
-    |> Workflows.get_workflow!(include: [:triggers])
-    |> Workflows.update_triggers_enabled_state(state)
-    |> Helpers.save_workflow(actor)
+    |> Workflows.get_workflow!()
+    |> transition_workflow_state(state, actor)
     |> case do
       {:ok, _workflow} ->
         {:noreply,
@@ -273,6 +272,21 @@ defmodule LightningWeb.WorkflowLive.Index do
        socket
        |> put_flash(:error, "You are not authorized to perform this action.")}
     end
+  end
+
+  defp transition_workflow_state(workflow, enable?, actor)
+       when enable? in [true, "true"] do
+    case WorkflowUsageLimiter.limit_workflow_activation(
+           true,
+           workflow.project_id
+         ) do
+      :ok -> Workflows.go_live(workflow, actor)
+      {:error, _reason, message} -> {:error, message}
+    end
+  end
+
+  defp transition_workflow_state(workflow, _disable?, actor) do
+    Workflows.switch_to_draft(workflow, actor)
   end
 
   defp build_query_params(search_term, sort_key, sort_direction) do

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -584,6 +584,59 @@ defmodule Lightning.Projects.ProvisionerTest do
     end
   end
 
+  describe "import_document/2 workflow state inference" do
+    setup do
+      Mox.verify_on_exit!()
+
+      Mox.stub(
+        Lightning.Extensions.MockUsageLimiter,
+        :limit_action,
+        fn _action, _context -> :ok end
+      )
+
+      %{user: insert(:user)}
+    end
+
+    test "infers :live when a trigger is enabled", %{user: user} do
+      %{body: body, project_id: project_id} = valid_document()
+
+      {:ok, %{id: ^project_id, workflows: [workflow]}} =
+        Provisioner.import_document(%Lightning.Projects.Project{}, user, body)
+
+      assert %{state: :live, triggers: [%{enabled: true}]} = workflow
+    end
+
+    test "infers :draft when all triggers are disabled", %{user: user} do
+      %{body: %{"workflows" => [workflow]} = body} = valid_document()
+
+      disabled_triggers =
+        Enum.map(workflow["triggers"], &Map.put(&1, "enabled", false))
+
+      body =
+        Map.put(body, "workflows", [
+          Map.put(workflow, "triggers", disabled_triggers)
+        ])
+
+      {:ok, %{workflows: [imported]}} =
+        Provisioner.import_document(%Lightning.Projects.Project{}, user, body)
+
+      assert %{state: :draft, triggers: [%{enabled: false}]} = imported
+    end
+
+    test "explicit state in attrs wins over inference", %{user: user} do
+      %{body: %{"workflows" => [workflow]} = body} = valid_document()
+
+      # Triggers are enabled (would infer :live) but state is explicitly :draft.
+      body =
+        Map.put(body, "workflows", [Map.put(workflow, "state", "draft")])
+
+      {:ok, %{workflows: [imported]}} =
+        Provisioner.import_document(%Lightning.Projects.Project{}, user, body)
+
+      assert %{state: :draft, triggers: [%{enabled: true}]} = imported
+    end
+  end
+
   describe "import_document/2 with an existing project" do
     setup do
       Mox.verify_on_exit!()

--- a/test/lightning_web/live/workflow_live/index_test.exs
+++ b/test/lightning_web/live/workflow_live/index_test.exs
@@ -315,6 +315,54 @@ defmodule LightningWeb.WorkflowLive.IndexTest do
       assert view |> has_element?("#new-workflow-button[type=button]")
       refute view |> has_element?("#new-workflow-button[type=button][disabled]")
     end
+
+    test "toggling a workflow keeps state and triggers coherent", %{
+      conn: conn,
+      project: project
+    } do
+      trigger = build(:trigger, type: :webhook, enabled: false)
+      job = build(:job)
+
+      workflow =
+        build(:workflow, project: project, state: :draft)
+        |> with_job(job)
+        |> with_trigger(trigger)
+        |> with_edge({trigger, job})
+        |> insert()
+
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}/w")
+
+      # Draft workflow: toggle is off.
+      refute view |> has_element?("##{workflow.id}[checked]")
+
+      # Enabling routes through go_live: state becomes :live and triggers enabled.
+      assert view
+             |> element("#toggle-control-#{workflow.id}")
+             |> render_click() =~ "Workflow updated"
+
+      assert %Lightning.Workflows.Workflow{
+               state: :live,
+               triggers: [%{enabled: true}]
+             } =
+               Lightning.Repo.get!(Lightning.Workflows.Workflow, workflow.id)
+               |> Lightning.Repo.preload(:triggers)
+
+      assert view |> has_element?("##{workflow.id}[checked]")
+
+      # Disabling routes through switch_to_draft: back to :draft, triggers off.
+      assert view
+             |> element("#toggle-control-#{workflow.id}")
+             |> render_click() =~ "Workflow updated"
+
+      assert %Lightning.Workflows.Workflow{
+               state: :draft,
+               triggers: [%{enabled: false}]
+             } =
+               Lightning.Repo.get!(Lightning.Workflows.Workflow, workflow.id)
+               |> Lightning.Repo.preload(:triggers)
+
+      refute view |> has_element?("##{workflow.id}[checked]")
+    end
   end
 
   describe "creating workflows" do


### PR DESCRIPTION
Closes a gap left by the lifecycle work: trigger enabled state could still be set directly, independently of a workflow's draft/live state. That allowed a draft workflow to run a live trigger against production, which contradicts the lifecycle contract that draft means "not processing data". Trigger enabled now follows the lifecycle, with go live and switch to draft as the only controls that change it.

## What changed

- The dashboard on/off toggle routes through go live / switch to draft, so a workflow's state and its triggers always move together. The activation usage limit that the old toggle enforced is preserved.
- The standalone enable controls in the collaborative editor (the header switch and the trigger inspector toggle) are removed. The draft/live badge plus go live / switch to draft now carry the full meaning. The dead client-side enable plumbing is removed as well, so the client can no longer desync triggers from state at all.
- On import, a workflow's state is inferred from its triggers when not explicitly provided. This keeps imported workflows coherent and fixes a real round-trip bug: a live workflow exported and re-imported (CLI deploy, GitHub sync, YAML) previously came back as a draft with its triggers disabled.

## Scope

The legacy LiveView editor toggle is intentionally left untouched since that editor is being sunsetted.

Three pieces that cannot be finished from this repo are tracked as follow-ups on the epic: carrying state in the project.yaml wire format (#4897), making the live read-only lock write-authoritative on the sync channel (#4898), and the AI prompt cleanup (#4899).

## Additional notes for the reviewer

