### PR TITLE
AI-First Starting UX: Build with AI path

### DIFF
--- a/assets/js/collaborative-editor/CollaborativeEditor.tsx
+++ b/assets/js/collaborative-editor/CollaborativeEditor.tsx
@@ -183,16 +183,19 @@ function LandingScreenWrapper({
   aiAssistantEnabled: boolean;
 }) {
   const showLandingScreen = useShowLandingScreen();
-  const { openYAMLImportModal } = useUICommands();
+  const { openYAMLImportModal, dismissLandingScreen, openAIAssistantPanel } =
+    useUICommands();
 
   if (!showLandingScreen) return null;
 
   return (
     <>
-      {/* TODO-AI-FIRST Stubs — wired up in Issues #4857 (Build with AI), #4858 (Browse Templates) */}
       <LandingScreen
         aiAssistantEnabled={aiAssistantEnabled}
-        onBuildWithAI={() => {}}
+        onBuildWithAI={(prompt: string) => {
+          dismissLandingScreen();
+          openAIAssistantPanel(prompt);
+        }}
         onBuildFromScratch={() => {}}
         onBrowseTemplates={() => {}}
         onImportYAML={openYAMLImportModal}

--- a/assets/js/collaborative-editor/components/AIAssistantPanel.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 
 import { cn } from '#/utils/cn';
 
+import { Tooltip } from '../../components/Tooltip';
 import {
   useAIStorageKey,
   useAISessionType,
@@ -15,11 +16,10 @@ import { useSelectedStepId, useSelectedRunId } from '../hooks/useHistory';
 import { ChatInput } from './ChatInput';
 import { DisclaimerScreen } from './DisclaimerScreen';
 import { SessionList } from './SessionList';
-import { Tooltip } from '../../components/Tooltip';
 
 interface AIAssistantPanelProps {
   isOpen: boolean;
-  onClose: () => void;
+  onClose?: () => void;
   onNewConversation?: () => void;
   onSessionSelect?: (sessionId: string) => void;
   onShowSessions?: () => void;
@@ -233,7 +233,7 @@ export function AIAssistantPanel({
       if (onShowSessions) {
         onShowSessions();
       }
-    } else {
+    } else if (onClose) {
       onClose();
     }
   };
@@ -390,27 +390,31 @@ export function AIAssistantPanel({
                 </div>
               )}
             </div>
-            <Tooltip
-              content={sessionId ? 'Close current session' : 'Close assistant'}
-            >
-              <button
-                type="button"
-                onClick={handleClose}
-                className={cn(
-                  'inline-flex items-center justify-center',
-                  'h-8 w-8 rounded-md',
-                  'text-gray-400 hover:text-gray-600 hover:bg-gray-100',
-                  'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500',
-                  'transition-all duration-150',
-                  'flex-shrink-0'
-                )}
-                aria-label={
+            {onClose && (
+              <Tooltip
+                content={
                   sessionId ? 'Close current session' : 'Close assistant'
                 }
               >
-                <span className="hero-x-mark h-5 w-5" />
-              </button>
-            </Tooltip>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className={cn(
+                    'inline-flex items-center justify-center',
+                    'h-8 w-8 rounded-md',
+                    'text-gray-400 hover:text-gray-600 hover:bg-gray-100',
+                    'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500',
+                    'transition-all duration-150',
+                    'shrink-0'
+                  )}
+                  aria-label={
+                    sessionId ? 'Close current session' : 'Close assistant'
+                  }
+                >
+                  <span className="hero-x-mark h-5 w-5" />
+                </button>
+              </Tooltip>
+            )}
           </div>
         </div>
       </div>

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -103,6 +103,9 @@ export function AIAssistantPanelWrapper({
   const isPinnedVersion =
     currentVersion !== undefined && currentVersion !== null;
 
+  const { isReadOnly } = useWorkflowReadOnly();
+  const isNewWorkflow = useIsNewWorkflow();
+
   // Track IDE state changes to re-focus chat input when IDE closes
   const isIDEOpen = params.panel === 'editor';
   const [focusTrigger, setFocusTrigger] = useState(0);
@@ -128,7 +131,7 @@ export function AIAssistantPanelWrapper({
       toggleAIAssistantPanel();
     },
     0,
-    { enabled: !isPinnedVersion && aiAssistantEnabled }
+    { enabled: !isPinnedVersion && aiAssistantEnabled && !isNewWorkflow }
   );
 
   const aiStore = useAIStore();
@@ -157,10 +160,7 @@ export function AIAssistantPanelWrapper({
   const workflow = useWorkflowState(state => state.workflow);
   const limits = useLimits();
 
-  // Check readonly state and new workflow status
   // AI can apply changes if: not readonly OR is a new workflow (being created)
-  const { isReadOnly } = useWorkflowReadOnly();
-  const isNewWorkflow = useIsNewWorkflow();
   const canApplyChanges = !isReadOnly || isNewWorkflow;
   const isWriteDisabled = !canApplyChanges;
 
@@ -683,7 +683,7 @@ export function AIAssistantPanelWrapper({
           <div className="flex-1 overflow-hidden">
             <AIAssistantPanel
               isOpen={isAIAssistantPanelOpen}
-              onClose={handleClosePanel}
+              onClose={isNewWorkflow ? undefined : handleClosePanel}
               onNewConversation={handleNewConversation}
               onSessionSelect={handleSessionSelect}
               onShowSessions={handleShowSessions}

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -14,6 +14,8 @@ const getRandomStatus = () =>
     Math.floor(Math.random() * INITIAL_LOADING_STATUSES.length)
   ];
 
+import { randomUUID } from '#/common';
+
 import { useURLState } from '../../react/lib/use-url-state';
 import {
   useMonacoRef,
@@ -564,7 +566,7 @@ export function AIAssistantPanelWrapper({
   const onValidationError = useCallback(
     (errorMessage: string) => {
       const message: Message = {
-        id: crypto.randomUUID(),
+        id: randomUUID(),
         role: 'assistant',
         content: errorMessage,
         status: 'error',

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -574,6 +574,10 @@ export function AIAssistantPanelWrapper({
     [aiStore]
   );
 
+  // Track whether we applied via streaming so the auto-apply effect in the
+  // hook can skip the duplicate when the final new_message arrives
+  const appliedViaStreamingRef = useRef(false);
+
   // Hook to handle workflow/job code application logic
   const { handleApplyWorkflow, handlePreviewJobCode, handleApplyJobCode } =
     useAIWorkflowApplications({
@@ -607,6 +611,7 @@ export function AIAssistantPanelWrapper({
       previewingMessageId,
       setApplyingMessageId,
       appliedMessageIdsRef,
+      appliedViaStreamingRef,
     });
 
   // Auto-preview job code when AI responds with code
@@ -626,9 +631,6 @@ export function AIAssistantPanelWrapper({
   const appliedStreamingChangesRef = useRef<Record<string, unknown> | null>(
     null
   );
-  // Track whether we applied via streaming so we can skip the duplicate
-  // auto-apply when the final new_message arrives
-  const appliedViaStreamingRef = useRef(false);
   useEffect(() => {
     if (!streamingChanges || !canApplyChanges) return;
     // Avoid re-applying the same streaming changes object
@@ -644,7 +646,6 @@ export function AIAssistantPanelWrapper({
     } else if (aiMode?.page === 'job_code' && 'code' in streamingChanges) {
       const code = streamingChanges['code'] as string;
       if (code) {
-        appliedViaStreamingRef.current = true;
         handlePreviewJobCode(code, '__streaming__');
       }
     }
@@ -655,22 +656,6 @@ export function AIAssistantPanelWrapper({
     handleApplyWorkflow,
     handlePreviewJobCode,
   ]);
-
-  // When a new assistant message with code arrives after we already applied
-  // via streaming, mark it as already applied to prevent duplicate auto-apply
-  // and update previewingMessageId to the real ID to prevent diff flicker
-  useEffect(() => {
-    if (!appliedViaStreamingRef.current) return;
-
-    const latestAssistantMessage = [...messages]
-      .reverse()
-      .find(m => m.role === 'assistant' && m.code && m.status === 'success');
-
-    if (latestAssistantMessage) {
-      appliedMessageIdsRef.current.add(latestAssistantMessage.id);
-      appliedViaStreamingRef.current = false;
-    }
-  }, [messages, appliedMessageIdsRef]);
 
   return (
     <div

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const INITIAL_LOADING_STATUSES = [
   'Thinking about the question...',
@@ -26,6 +26,7 @@ import {
   useAISessionId,
   useAISessionType,
   useAIStore,
+  useAIStreamingApply,
   useAIStreamingChanges,
   useAIStreamingContent,
   useAIStreamingStatus,
@@ -574,9 +575,18 @@ export function AIAssistantPanelWrapper({
     [aiStore]
   );
 
-  // Track whether we applied via streaming so the auto-apply effect in the
-  // hook can skip the duplicate when the final new_message arrives
-  const appliedViaStreamingRef = useRef(false);
+  // Pending streaming apply record (YAML already imported during streaming),
+  // read by the hook's auto-apply effect to skip the duplicate import when
+  // the final new_message arrives with the same YAML
+  const streamingApply = useAIStreamingApply();
+  const streamingApplyActions = useMemo(
+    () => ({
+      set: aiStore._setStreamingApply,
+      setSaveFailed: aiStore._setStreamingApplySaveFailed,
+      clear: aiStore._clearStreamingApply,
+    }),
+    [aiStore]
+  );
 
   // Hook to handle workflow/job code application logic
   const { handleApplyWorkflow, handlePreviewJobCode, handleApplyJobCode } =
@@ -611,7 +621,8 @@ export function AIAssistantPanelWrapper({
       previewingMessageId,
       setApplyingMessageId,
       appliedMessageIdsRef,
-      appliedViaStreamingRef,
+      streamingApply,
+      streamingApplyActions,
     });
 
   // Auto-preview job code when AI responds with code
@@ -640,7 +651,8 @@ export function AIAssistantPanelWrapper({
     if (aiMode?.page === 'workflow_template' && 'yaml' in streamingChanges) {
       const yaml = streamingChanges['yaml'] as string;
       if (yaml) {
-        appliedViaStreamingRef.current = true;
+        // handleApplyWorkflow records the streaming apply in the store
+        // (after a successful import) so the final new_message can skip it
         void handleApplyWorkflow(yaml, '__streaming__');
       }
     } else if (aiMode?.page === 'job_code' && 'code' in streamingChanges) {

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -61,7 +61,7 @@ import {
   useWorkflowState,
 } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
-import type { JobCodeContext } from '../types/ai-assistant';
+import type { JobCodeContext, Message } from '../types/ai-assistant';
 import { Z_INDEX } from '../utils/constants';
 import {
   prepareWorkflowForSerialization,
@@ -548,6 +548,7 @@ export function AIAssistantPanelWrapper({
     startApplyingJobCode,
     doneApplyingJobCode,
     updateJob,
+    saveWorkflow,
   } = useWorkflowActions();
 
   // Get applying state from workflow store for disabling Apply button across all users
@@ -557,6 +558,20 @@ export function AIAssistantPanelWrapper({
   const isApplyingJobCode = useWorkflowState(state => state.isApplyingJobCode);
   const applyingJobCodeMessageId = useWorkflowState(
     state => state.applyingJobCodeMessageId
+  );
+
+  const onValidationError = useCallback(
+    (errorMessage: string) => {
+      const message: Message = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: errorMessage,
+        status: 'error',
+        inserted_at: new Date().toISOString(),
+      };
+      aiStore._addMessage(message);
+    },
+    [aiStore]
   );
 
   // Hook to handle workflow/job code application logic
@@ -573,6 +588,8 @@ export function AIAssistantPanelWrapper({
           : null,
       currentUserId: user?.id,
       aiMode,
+      isNewWorkflow,
+      onValidationError,
       workflowActions: {
         importWorkflow,
         startApplyingWorkflow,
@@ -580,6 +597,7 @@ export function AIAssistantPanelWrapper({
         startApplyingJobCode,
         doneApplyingJobCode,
         updateJob,
+        saveWorkflow,
       },
       monacoRef,
       jobs,

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -545,18 +545,34 @@ export function MessageList({
                 }
               >
                 <div className="space-y-3">
-                  <MarkdownContent
-                    content={
-                      isStreaming(message)
-                        ? message.content.replace(/\n+$/, '')
-                        : message.content
-                    }
-                    showAddButtons={
-                      !isStreaming(message) && showAddButtons && !message.code
-                    }
-                    isWriteDisabled={isWriteDisabled}
-                    className={PROSE_CLASSES}
-                  />
+                  {message.status === 'error' &&
+                  !isStreaming(message) &&
+                  message.content.trim() ? (
+                    <div
+                      className="rounded-lg border border-red-200 bg-red-50 px-3 py-2"
+                      data-testid="ai-validation-error"
+                    >
+                      <div className="flex items-start gap-2">
+                        <span className="hero-exclamation-circle h-4 w-4 text-red-600 flex-shrink-0 mt-0.5" />
+                        <p className="text-sm text-red-700 leading-relaxed">
+                          {message.content}
+                        </p>
+                      </div>
+                    </div>
+                  ) : (
+                    <MarkdownContent
+                      content={
+                        isStreaming(message)
+                          ? message.content.replace(/\n+$/, '')
+                          : message.content
+                      }
+                      showAddButtons={
+                        !isStreaming(message) && showAddButtons && !message.code
+                      }
+                      isWriteDisabled={isWriteDisabled}
+                      className={PROSE_CLASSES}
+                    />
+                  )}
 
                   {/* Status (e.g. "Generating code...") Apollo may stream
                       after the text answer, while we wait for code. Same
@@ -645,33 +661,35 @@ export function MessageList({
                     </div>
                   )}
 
-                  {!isStreaming(message) && message.status === 'error' && (
-                    <div
-                      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200"
-                      data-testid="ai-error-message"
-                    >
-                      <span className="hero-exclamation-circle h-4 w-4 text-red-600 flex-shrink-0" />
-                      <span className="text-sm text-red-700 flex-1">
-                        Failed to send message. Please try again.
-                      </span>
-                      {onRetryMessage && (
-                        <button
-                          type="button"
-                          onClick={() => onRetryMessage(message.id)}
-                          className={cn(
-                            'inline-flex items-center gap-1.5 px-3 py-1.5',
-                            'text-xs font-medium rounded-md',
-                            'bg-red-100 text-red-700 hover:bg-red-200',
-                            'transition-colors duration-150',
-                            'focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1'
-                          )}
-                        >
-                          <span className="hero-arrow-path h-3.5 w-3.5" />
-                          Retry
-                        </button>
-                      )}
-                    </div>
-                  )}
+                  {!isStreaming(message) &&
+                    message.status === 'error' &&
+                    !message.content.trim() && (
+                      <div
+                        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200"
+                        data-testid="ai-error-message"
+                      >
+                        <span className="hero-exclamation-circle h-4 w-4 text-red-600 flex-shrink-0" />
+                        <span className="text-sm text-red-700 flex-1">
+                          Failed to send message. Please try again.
+                        </span>
+                        {onRetryMessage && (
+                          <button
+                            type="button"
+                            onClick={() => onRetryMessage(message.id)}
+                            className={cn(
+                              'inline-flex items-center gap-1.5 px-3 py-1.5',
+                              'text-xs font-medium rounded-md',
+                              'bg-red-100 text-red-700 hover:bg-red-200',
+                              'transition-colors duration-150',
+                              'focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1'
+                            )}
+                          >
+                            <span className="hero-arrow-path h-3.5 w-3.5" />
+                            Retry
+                          </button>
+                        )}
+                      </div>
+                    )}
 
                   {!isStreaming(message) && message.status === 'processing' && (
                     <div className="flex items-center gap-2 text-gray-600">

--- a/assets/js/collaborative-editor/components/WorkflowEditor.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowEditor.tsx
@@ -505,6 +505,7 @@ export function WorkflowEditor({
         {/* Show placeholder when workflow is empty and landing screen is not covering it */}
         {isNewWorkflow &&
           !showLandingScreen &&
+          !isAIAssistantPanelOpen &&
           workflow.jobs.length === 0 &&
           workflow.triggers.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/assets/js/collaborative-editor/components/WorkflowEditor.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowEditor.tsx
@@ -133,6 +133,10 @@ export function WorkflowEditor({
   }, [isRunPanelOpen, runPanelContext, params, updateSearchParams]);
 
   useEffect(() => {
+    // On /new, URL params can't drive panel state — the landing screen is the
+    // only valid entry point and the canvas/panels shouldn't be reachable.
+    if (isNewWorkflow) return;
+
     const panelParam = params['panel'] ?? null;
 
     if (panelParam === 'run' && !isRunPanelOpen) {
@@ -187,6 +191,7 @@ export function WorkflowEditor({
       }, 0);
     }
   }, [
+    isNewWorkflow,
     params,
     isRunPanelOpen,
     currentNode.type,
@@ -365,6 +370,8 @@ export function WorkflowEditor({
     clearCanvas,
   ]);
 
+  // TODO-AI-FIRST (#4856): remove this entire method URL sync once the left-panel
+  // create flow (template/import/ai) is deleted — ?method= will no longer exist.
   // Sync method to URL (similar to AI panel's chat param sync)
   const isSyncingMethodRef = useRef(false);
   useEffect(() => {
@@ -379,7 +386,7 @@ export function WorkflowEditor({
     }, 0);
   }, [isCreateWorkflowPanelCollapsed, leftPanelMethod, updateSearchParams]);
 
-  const isIDEOpen = params['panel'] === 'editor';
+  const isIDEOpen = !isNewWorkflow && params['panel'] === 'editor';
   const selectedJobId = params['job'] ?? null;
 
   const handleCloseIDE = useCallback(() => {
@@ -390,11 +397,14 @@ export function WorkflowEditor({
     selectNode(null);
   };
 
+  // On /new, no nodes exist yet and the landing screen is the only valid UI.
+  // Block Inspector and IDE so URL params like ?panel=settings can't open them.
   const showInspector =
-    params['panel'] === 'settings' ||
-    params['panel'] === 'code' ||
-    params['panel'] === 'publish-template' ||
-    Boolean(currentNode.node);
+    !isNewWorkflow &&
+    (params['panel'] === 'settings' ||
+      params['panel'] === 'code' ||
+      params['panel'] === 'publish-template' ||
+      Boolean(currentNode.node));
 
   const handleMethodChange = (method: 'template' | 'import' | 'ai' | null) => {
     // Always clear template URL params when switching methods - start fresh each time
@@ -501,7 +511,9 @@ export function WorkflowEditor({
       <div className="flex-1 relative">
         <CollaborativeWorkflowDiagram inspectorId="inspector" />
 
-        {/* TODO-AI-FIRST: remove this placeholder once the landing screen (#4856) always covers the new-workflow state */}
+        {/* TODO-AI-FIRST (#4856): delete this entire placeholder block once the left-panel
+            create flow is removed — the landing screen always covers the new-workflow state
+            and this fallback UI (with its old Browse/AI/scratch buttons) should never appear */}
         {/* Show placeholder when workflow is empty and landing screen is not covering it */}
         {isNewWorkflow &&
           !showLandingScreen &&

--- a/assets/js/collaborative-editor/hooks/useAIAssistant.ts
+++ b/assets/js/collaborative-editor/hooks/useAIAssistant.ts
@@ -127,6 +127,18 @@ export const useAIStreamingChanges = () => {
 };
 
 /**
+ * Get the pending streaming apply record (YAML already imported to the
+ * canvas during streaming, awaiting the final new_message)
+ */
+export const useAIStreamingApply = () => {
+  const store = useAIStore();
+  return useSyncExternalStore(
+    store.subscribe,
+    store.withSelector(state => state.streamingApply)
+  );
+};
+
+/**
  * Get streaming status
  */
 export const useAIStreamingStatus = () => {

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -169,12 +169,6 @@ export function useAIWorkflowApplications({
     hasLoadedSessionRef.current = false;
   }, [sessionId]);
 
-  // Stable ref so the save-failure Retry toast always calls the latest version
-  // of handleApplyWorkflow rather than the one captured when the toast fired.
-  const handleApplyWorkflowRef = useRef<
-    ((yaml: string, messageId: string) => Promise<void>) | null
-  >(null);
-
   // Stable ref for save-only retries (importWorkflow already succeeded)
   const saveWorkflowRef = useRef<
     ((opts?: { silent?: boolean }) => Promise<unknown>) | null
@@ -319,8 +313,7 @@ export function useAIWorkflowApplications({
     ]
   );
 
-  // Keep refs pointing at the latest callbacks so Retry toast closures never go stale
-  handleApplyWorkflowRef.current = handleApplyWorkflow;
+  // Keep ref pointing at the latest callback so Retry toast closures never go stale
   saveWorkflowRef.current = saveWorkflow;
 
   /**

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -233,6 +233,7 @@ export function useAIWorkflowApplications({
             }
           } catch (saveError) {
             saveSucceeded = false;
+            if (appliedViaStreamingRef) appliedViaStreamingRef.current = false;
             console.error('[AI Assistant] Failed to save workflow:', saveError);
             notifications.alert({
               title: 'Failed to save workflow',

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -115,6 +115,7 @@ export function useAIWorkflowApplications({
   previewingMessageId,
   setApplyingMessageId,
   appliedMessageIdsRef,
+  appliedViaStreamingRef,
 }: {
   sessionId: string | null;
   page: SessionType | null;
@@ -143,6 +144,7 @@ export function useAIWorkflowApplications({
   previewingMessageId: string | null;
   setApplyingMessageId: (id: string | null) => void;
   appliedMessageIdsRef: React.MutableRefObject<Set<string>>;
+  appliedViaStreamingRef?: React.MutableRefObject<boolean>;
 }) {
   const {
     importWorkflow,
@@ -194,7 +196,6 @@ export function useAIWorkflowApplications({
       let saveSucceeded = true;
       try {
         const workflowSpec = parseWorkflowYAML(yaml);
-
         validateIds(workflowSpec);
 
         // IDs are already in the YAML from AI (sent with IDs, like legacy editor)
@@ -455,6 +456,16 @@ export function useAIWorkflowApplications({
       latestMessage?.code &&
       !appliedMessageIdsRef.current.has(latestMessage.id)
     ) {
+      appliedMessageIdsRef.current.add(latestMessage.id);
+
+      // Streaming already applied this YAML — skip the re-import to avoid
+      // a transient dirty state (Y.Doc write → unsaved red dot) between
+      // the import and save that would otherwise follow.
+      if (appliedViaStreamingRef?.current) {
+        appliedViaStreamingRef.current = false;
+        return;
+      }
+
       // Find the user message that triggered this AI response
       // Look for the most recent user message before this assistant message
       const latestMessageIndex = messages.findIndex(
@@ -472,8 +483,6 @@ export function useAIWorkflowApplications({
         precedingUserMessage?.user_id === currentUserId ||
         // Fallback: if no user_id on message (legacy), allow apply
         !precedingUserMessage?.user_id;
-
-      appliedMessageIdsRef.current.add(latestMessage.id);
 
       if (isCurrentUserAuthor) {
         void handleApplyWorkflow(latestMessage.code, latestMessage.id);

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -205,7 +205,27 @@ export function useAIWorkflowApplications({
     try {
       const saved = await saveWorkflow({ silent: true });
       if (!saved) {
-        throw new Error('Your connection was lost. Reconnect and try again.');
+        // saveWorkflow returns null (rather than throwing) when the socket
+        // is disconnected, so the wrapper shows no toast of its own for
+        // this case — surface one here.
+        streamingApplyActions.setSaveFailed(true);
+        notifications.alert({
+          // Stable id: repeated failures (auto-retry, Retry clicks) update
+          // the existing toast in place instead of stacking duplicates
+          id: SAVE_FAILED_TOAST_ID,
+          title: 'Failed to save workflow',
+          description: 'Your connection was lost. Reconnect and try again.',
+          duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
+          action: {
+            label: 'Retry',
+            onClick: () => {
+              // Failure re-shows this same persistent toast, so the user can
+              // keep retrying until the save lands
+              void saveNewWorkflowRef.current?.();
+            },
+          },
+        });
+        return false;
       }
       streamingApplyActions.setSaveFailed(false);
       // A retry may have succeeded while a failure toast was still showing
@@ -213,27 +233,11 @@ export function useAIWorkflowApplications({
       notifications.dismiss(SAVE_FAILED_TOAST_ID);
       return true;
     } catch (saveError) {
+      // Real save errors already surface their own toast (with Retry) from
+      // the saveWorkflow wrapper in useWorkflow.tsx — showing a second one
+      // here would double up on a single failure. Just track state.
       streamingApplyActions.setSaveFailed(true);
       console.error('[AI Assistant] Failed to save workflow:', saveError);
-      notifications.alert({
-        // Stable id: repeated failures (auto-retry, Retry clicks) update the
-        // existing toast in place instead of stacking duplicates
-        id: SAVE_FAILED_TOAST_ID,
-        title: 'Failed to save workflow',
-        description:
-          saveError instanceof Error
-            ? saveError.message
-            : 'Unknown error occurred',
-        duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
-        action: {
-          label: 'Retry',
-          onClick: () => {
-            // Failure re-shows this same persistent toast, so the user can
-            // keep retrying until the save lands
-            void saveNewWorkflowRef.current?.();
-          },
-        },
-      });
       return false;
     }
   }, [saveWorkflow, streamingApplyActions]);

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -17,10 +17,18 @@ import type {
   JobCodeContext,
   Message,
   SessionType,
+  StreamingApplyState,
   WorkflowTemplateContext,
 } from '../types/ai-assistant';
 
 import type { AIModeResult } from './useAIMode';
+
+/**
+ * Stable toast id for the "Failed to save workflow" alert so repeated
+ * failures update one toast instead of stacking, and a later success can
+ * dismiss it.
+ */
+const SAVE_FAILED_TOAST_ID = 'ai-workflow-save-failed';
 
 /**
  * Helper function to validate workflow IDs before applying
@@ -94,6 +102,8 @@ function validateIds(spec: Record<string, unknown>): void {
  * - Prevents duplicate applies in collaborative sessions
  * - Tracks applied messages to avoid re-applying on session load
  * - Only applies the latest message with code (skips intermediates)
+ * - Skips the final message's re-import when streaming already applied
+ *   the same YAML (streamingApply record in AIAssistantStore)
  *
  * Accepts raw dependencies (not callbacks) and creates callbacks internally
  * for cleaner usage and better memoization control.
@@ -115,7 +125,8 @@ export function useAIWorkflowApplications({
   previewingMessageId,
   setApplyingMessageId,
   appliedMessageIdsRef,
-  appliedViaStreamingRef,
+  streamingApply,
+  streamingApplyActions,
 }: {
   sessionId: string | null;
   page: SessionType | null;
@@ -144,7 +155,18 @@ export function useAIWorkflowApplications({
   previewingMessageId: string | null;
   setApplyingMessageId: (id: string | null) => void;
   appliedMessageIdsRef: React.MutableRefObject<Set<string>>;
-  appliedViaStreamingRef?: React.MutableRefObject<boolean>;
+  /**
+   * Pending streaming apply record from AIAssistantStore: the YAML already
+   * imported to the canvas during streaming (see StreamingApplyState).
+   * The auto-apply effect compares the final message's code against it to
+   * skip the duplicate import that would dirty the Y.Doc.
+   */
+  streamingApply: StreamingApplyState | null;
+  streamingApplyActions: {
+    set: (yaml: string) => void;
+    setSaveFailed: (saveFailed: boolean) => void;
+    clear: () => void;
+  };
 }) {
   const {
     importWorkflow,
@@ -169,10 +191,55 @@ export function useAIWorkflowApplications({
     hasLoadedSessionRef.current = false;
   }, [sessionId]);
 
-  // Stable ref for save-only retries (importWorkflow already succeeded)
-  const saveWorkflowRef = useRef<
-    ((opts?: { silent?: boolean }) => Promise<unknown>) | null
-  >(null);
+  // Stable ref so the Retry toast closure always calls the latest
+  // saveNewWorkflow (importWorkflow already succeeded; only the save retries)
+  const saveNewWorkflowRef = useRef<(() => Promise<boolean>) | null>(null);
+
+  /**
+   * Silently save a new workflow after an AI apply, with a persistent
+   * Retry toast on failure. Records the outcome on the pending streaming
+   * apply so the final new_message knows whether a save is still owed
+   * (no-op in the store when the apply didn't come from streaming).
+   */
+  const saveNewWorkflow = useCallback(async (): Promise<boolean> => {
+    try {
+      const saved = await saveWorkflow({ silent: true });
+      if (!saved) {
+        throw new Error('Your connection was lost. Reconnect and try again.');
+      }
+      streamingApplyActions.setSaveFailed(false);
+      // A retry may have succeeded while a failure toast was still showing
+      // (e.g. the final message settles the owed save) — dismiss it.
+      notifications.dismiss(SAVE_FAILED_TOAST_ID);
+      return true;
+    } catch (saveError) {
+      streamingApplyActions.setSaveFailed(true);
+      console.error('[AI Assistant] Failed to save workflow:', saveError);
+      notifications.alert({
+        // Stable id: repeated failures (auto-retry, Retry clicks) update the
+        // existing toast in place instead of stacking duplicates
+        id: SAVE_FAILED_TOAST_ID,
+        title: 'Failed to save workflow',
+        description:
+          saveError instanceof Error
+            ? saveError.message
+            : 'Unknown error occurred',
+        duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
+        action: {
+          label: 'Retry',
+          onClick: () => {
+            // Failure re-shows this same persistent toast, so the user can
+            // keep retrying until the save lands
+            void saveNewWorkflowRef.current?.();
+          },
+        },
+      });
+      return false;
+    }
+  }, [saveWorkflow, streamingApplyActions]);
+
+  // Keep ref pointing at the latest callback so Retry toast closures never go stale
+  saveNewWorkflowRef.current = saveNewWorkflow;
 
   /**
    * Apply workflow YAML to the canvas
@@ -193,6 +260,12 @@ export function useAIWorkflowApplications({
         return;
       }
       setApplyingMessageId(messageId);
+
+      // Any non-streaming apply supersedes a pending streaming apply — the
+      // canvas will no longer hold the streamed YAML after this import.
+      if (messageId !== '__streaming__') {
+        streamingApplyActions.clear();
+      }
 
       // Signal to all collaborators that we're starting to apply
       // Returns false if coordination failed (other users won't be notified)
@@ -217,62 +290,19 @@ export function useAIWorkflowApplications({
         await importWorkflow(workflowStateWithCreds);
         applySucceeded = true;
 
+        if (messageId === '__streaming__') {
+          // Record the applied YAML so the auto-apply effect can skip the
+          // duplicate import when the final new_message carries the same YAML.
+          // Set only after a successful import, so failed applies never
+          // leave a stale record behind.
+          streamingApplyActions.set(yaml);
+        }
+
         if (isNewWorkflow) {
-          try {
-            const saved = await saveWorkflow({ silent: true });
-            if (!saved) {
-              throw new Error(
-                'Your connection was lost. Reconnect and try again.'
-              );
-            }
-          } catch (saveError) {
-            saveSucceeded = false;
-            if (appliedViaStreamingRef) appliedViaStreamingRef.current = false;
-            console.error('[AI Assistant] Failed to save workflow:', saveError);
-            notifications.alert({
-              title: 'Failed to save workflow',
-              description:
-                saveError instanceof Error
-                  ? saveError.message
-                  : 'Unknown error occurred',
-              duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
-              action: {
-                label: 'Retry',
-                onClick: () => {
-                  void (async () => {
-                    try {
-                      const saved = await saveWorkflowRef.current?.({
-                        silent: true,
-                      });
-                      if (!saved)
-                        throw new Error(
-                          'Your connection was lost. Reconnect and try again.'
-                        );
-                    } catch (retryError: unknown) {
-                      console.error(
-                        '[AI Assistant] Retry save failed:',
-                        retryError
-                      );
-                      notifications.alert({
-                        title: 'Failed to save workflow',
-                        description:
-                          retryError instanceof Error
-                            ? retryError.message
-                            : 'Unknown error occurred',
-                      });
-                    }
-                  })();
-                },
-              },
-            });
-          }
+          saveSucceeded = await saveNewWorkflow();
         }
       } catch (error) {
         console.error('[AI Assistant] Failed to apply workflow:', error);
-
-        // If streaming set this ref before the apply failed, clear it so the
-        // next real new_message isn't silently skipped by the auto-apply guard.
-        if (appliedViaStreamingRef) appliedViaStreamingRef.current = false;
 
         const errorMessage =
           error instanceof Error ? error.message : 'Invalid workflow YAML';
@@ -309,12 +339,10 @@ export function useAIWorkflowApplications({
       setApplyingMessageId,
       isNewWorkflow,
       onValidationError,
-      saveWorkflow,
+      saveNewWorkflow,
+      streamingApplyActions,
     ]
   );
-
-  // Keep ref pointing at the latest callback so Retry toast closures never go stale
-  saveWorkflowRef.current = saveWorkflow;
 
   /**
    * Preview job code diff in Monaco editor
@@ -495,9 +523,10 @@ export function useAIWorkflowApplications({
       messagesWithCode.forEach(msg => {
         appliedMessageIdsRef.current.add(msg.id);
       });
-      // Streaming may have set this before the session finished loading.
-      // Clear it now so the guard doesn't silently skip the next real response.
-      if (appliedViaStreamingRef) appliedViaStreamingRef.current = false;
+      // Streaming may have applied before the session finished loading; the
+      // final message was seeded above, so the record will never be consumed.
+      // Drop it.
+      streamingApplyActions.clear();
       return;
     }
 
@@ -509,11 +538,16 @@ export function useAIWorkflowApplications({
     ) {
       appliedMessageIdsRef.current.add(latestMessage.id);
 
-      // Streaming already applied this YAML — skip the re-import to avoid
-      // a transient dirty state (Y.Doc write → unsaved red dot) between
-      // the import and save that would otherwise follow.
-      if (appliedViaStreamingRef?.current) {
-        appliedViaStreamingRef.current = false;
+      // Streaming already imported this exact YAML to the canvas — skip the
+      // re-import, which would only dirty the Y.Doc (unsaved red dot). If
+      // the streaming apply's save is still owed, settle it now. When the
+      // YAML differs (streaming apply failed, or the final response changed),
+      // fall through and apply normally.
+      if (streamingApply && streamingApply.yaml === latestMessage.code) {
+        streamingApplyActions.clear();
+        if (streamingApply.saveFailed) {
+          void saveNewWorkflow();
+        }
         return;
       }
 
@@ -548,6 +582,9 @@ export function useAIWorkflowApplications({
     canApplyChanges,
     currentUserId,
     appliedMessageIdsRef,
+    streamingApply,
+    streamingApplyActions,
+    saveNewWorkflow,
   ]);
 
   return {

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -238,7 +238,22 @@ export function useAIWorkflowApplications({
               duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
               action: {
                 label: 'Retry',
-                onClick: () => void saveWorkflowRef.current?.({ silent: true }),
+                onClick: () =>
+                  void saveWorkflowRef
+                    .current?.({ silent: true })
+                    ?.catch((retryError: unknown) => {
+                      console.error(
+                        '[AI Assistant] Retry save failed:',
+                        retryError
+                      );
+                      notifications.alert({
+                        title: 'Failed to save workflow',
+                        description:
+                          retryError instanceof Error
+                            ? retryError.message
+                            : 'Unknown error occurred',
+                      });
+                    }),
               },
             });
           }

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -246,6 +246,10 @@ export function useAIWorkflowApplications({
       } catch (error) {
         console.error('[AI Assistant] Failed to apply workflow:', error);
 
+        // If streaming set this ref before the apply failed, clear it so the
+        // next real new_message isn't silently skipped by the auto-apply guard.
+        if (appliedViaStreamingRef) appliedViaStreamingRef.current = false;
+
         const errorMessage =
           error instanceof Error ? error.message : 'Invalid workflow YAML';
 

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -175,6 +175,11 @@ export function useAIWorkflowApplications({
     ((yaml: string, messageId: string) => Promise<void>) | null
   >(null);
 
+  // Stable ref for save-only retries (importWorkflow already succeeded)
+  const saveWorkflowRef = useRef<
+    ((opts?: { silent?: boolean }) => Promise<unknown>) | null
+  >(null);
+
   /**
    * Apply workflow YAML to the canvas
    *
@@ -230,10 +235,10 @@ export function useAIWorkflowApplications({
                 saveError instanceof Error
                   ? saveError.message
                   : 'Unknown error occurred',
+              duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
               action: {
                 label: 'Retry',
-                onClick: () =>
-                  void handleApplyWorkflowRef.current?.(yaml, messageId),
+                onClick: () => void saveWorkflowRef.current?.({ silent: true }),
               },
             });
           }
@@ -280,8 +285,9 @@ export function useAIWorkflowApplications({
     ]
   );
 
-  // Keep ref pointing at the latest callback so the Retry toast closure never goes stale
+  // Keep refs pointing at the latest callbacks so Retry toast closures never go stale
   handleApplyWorkflowRef.current = handleApplyWorkflow;
+  saveWorkflowRef.current = saveWorkflow;
 
   /**
    * Preview job code diff in Monaco editor

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -169,6 +169,12 @@ export function useAIWorkflowApplications({
     hasLoadedSessionRef.current = false;
   }, [sessionId]);
 
+  // Stable ref so the save-failure Retry toast always calls the latest version
+  // of handleApplyWorkflow rather than the one captured when the toast fired.
+  const handleApplyWorkflowRef = useRef<
+    ((yaml: string, messageId: string) => Promise<void>) | null
+  >(null);
+
   /**
    * Apply workflow YAML to the canvas
    *
@@ -193,6 +199,9 @@ export function useAIWorkflowApplications({
       // Returns false if coordination failed (other users won't be notified)
       const coordinated = await startApplyingWorkflow(messageId);
 
+      // Track outcomes independently: applySucceeded covers parse/validate/import;
+      // saveSucceeded covers the subsequent save for new workflows.
+      let applySucceeded = false;
       let saveSucceeded = true;
       try {
         const workflowSpec = parseWorkflowYAML(yaml);
@@ -207,6 +216,7 @@ export function useAIWorkflowApplications({
         );
 
         await importWorkflow(workflowStateWithCreds);
+        applySucceeded = true;
 
         if (isNewWorkflow) {
           try {
@@ -222,7 +232,8 @@ export function useAIWorkflowApplications({
                   : 'Unknown error occurred',
               action: {
                 label: 'Retry',
-                onClick: () => void handleApplyWorkflow(yaml, messageId),
+                onClick: () =>
+                  void handleApplyWorkflowRef.current?.(yaml, messageId),
               },
             });
           }
@@ -243,13 +254,14 @@ export function useAIWorkflowApplications({
         }
       } finally {
         setApplyingMessageId(null);
-        // Only signal completion if we successfully coordinated
-        // (otherwise other users weren't notified of the start)
+        // Always signal completion when coordinated so collaborators aren't
+        // left stuck in "APPLYING..." state, even if apply itself failed.
         if (coordinated) {
           await doneApplyingWorkflow(messageId);
-          // Only fit-view on full success — skip if save failed so the canvas
-          // doesn't zoom in on an unpersisted workflow
-          if (saveSucceeded !== false) {
+          // Only fit-view when the canvas was actually updated and persisted.
+          // Skip when importWorkflow failed (applySucceeded false) or when
+          // save failed so we don't zoom in on an unpersisted workflow.
+          if (applySucceeded && saveSucceeded) {
             flowEvents.dispatch('fit-view');
           }
         }
@@ -267,6 +279,9 @@ export function useAIWorkflowApplications({
       saveWorkflow,
     ]
   );
+
+  // Keep ref pointing at the latest callback so the Retry toast closure never goes stale
+  handleApplyWorkflowRef.current = handleApplyWorkflow;
 
   /**
    * Preview job code diff in Monaco editor
@@ -447,6 +462,9 @@ export function useAIWorkflowApplications({
       messagesWithCode.forEach(msg => {
         appliedMessageIdsRef.current.add(msg.id);
       });
+      // Streaming may have set this before the session finished loading.
+      // Clear it now so the guard doesn't silently skip the next real response.
+      if (appliedViaStreamingRef) appliedViaStreamingRef.current = false;
       return;
     }
 

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -191,6 +191,7 @@ export function useAIWorkflowApplications({
       // Returns false if coordination failed (other users won't be notified)
       const coordinated = await startApplyingWorkflow(messageId);
 
+      let saveSucceeded = true;
       try {
         const workflowSpec = parseWorkflowYAML(yaml);
 
@@ -210,6 +211,7 @@ export function useAIWorkflowApplications({
           try {
             await saveWorkflow({ silent: true });
           } catch (saveError) {
+            saveSucceeded = false;
             console.error('[AI Assistant] Failed to save workflow:', saveError);
             notifications.alert({
               title: 'Failed to save workflow',
@@ -217,6 +219,10 @@ export function useAIWorkflowApplications({
                 saveError instanceof Error
                   ? saveError.message
                   : 'Unknown error occurred',
+              action: {
+                label: 'Retry',
+                onClick: () => void handleApplyWorkflow(yaml, messageId),
+              },
             });
           }
         }
@@ -240,7 +246,11 @@ export function useAIWorkflowApplications({
         // (otherwise other users weren't notified of the start)
         if (coordinated) {
           await doneApplyingWorkflow(messageId);
-          flowEvents.dispatch('fit-view');
+          // Only fit-view on full success — skip if save failed so the canvas
+          // doesn't zoom in on an unpersisted workflow
+          if (saveSucceeded !== false) {
+            flowEvents.dispatch('fit-view');
+          }
         }
       }
     },

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -225,7 +225,12 @@ export function useAIWorkflowApplications({
 
         if (isNewWorkflow) {
           try {
-            await saveWorkflow({ silent: true });
+            const saved = await saveWorkflow({ silent: true });
+            if (!saved) {
+              throw new Error(
+                'Your connection was lost. Reconnect and try again.'
+              );
+            }
           } catch (saveError) {
             saveSucceeded = false;
             console.error('[AI Assistant] Failed to save workflow:', saveError);
@@ -238,10 +243,17 @@ export function useAIWorkflowApplications({
               duration: Infinity, // toast only dismisses by clicking 'x' so the user definitely sees the error
               action: {
                 label: 'Retry',
-                onClick: () =>
-                  void saveWorkflowRef
-                    .current?.({ silent: true })
-                    ?.catch((retryError: unknown) => {
+                onClick: () => {
+                  void (async () => {
+                    try {
+                      const saved = await saveWorkflowRef.current?.({
+                        silent: true,
+                      });
+                      if (!saved)
+                        throw new Error(
+                          'Your connection was lost. Reconnect and try again.'
+                        );
+                    } catch (retryError: unknown) {
                       console.error(
                         '[AI Assistant] Retry save failed:',
                         retryError
@@ -253,7 +265,9 @@ export function useAIWorkflowApplications({
                             ? retryError.message
                             : 'Unknown error occurred',
                       });
-                    }),
+                    }
+                  })();
+                },
               },
             });
           }

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -104,6 +104,8 @@ export function useAIWorkflowApplications({
   currentSession,
   currentUserId,
   aiMode,
+  isNewWorkflow,
+  onValidationError,
   workflowActions,
   monacoRef,
   jobs,
@@ -122,6 +124,8 @@ export function useAIWorkflowApplications({
   } | null;
   currentUserId: string | undefined;
   aiMode: AIModeResult | null;
+  isNewWorkflow: boolean;
+  onValidationError?: (message: string) => void;
   workflowActions: {
     importWorkflow: (state: YAMLWorkflowState) => Promise<void>;
     startApplyingWorkflow: (messageId: string) => Promise<boolean>;
@@ -129,6 +133,7 @@ export function useAIWorkflowApplications({
     startApplyingJobCode: (messageId: string) => Promise<boolean>;
     doneApplyingJobCode: (messageId: string) => Promise<void>;
     updateJob: (jobId: string, updates: { body: string }) => void;
+    saveWorkflow: (options?: { silent?: boolean }) => Promise<unknown>;
   };
   monacoRef: RefObject<MonacoHandle> | null;
   jobs: Job[];
@@ -146,6 +151,7 @@ export function useAIWorkflowApplications({
     startApplyingJobCode,
     doneApplyingJobCode,
     updateJob,
+    saveWorkflow,
   } = workflowActions;
 
   /**
@@ -199,14 +205,35 @@ export function useAIWorkflowApplications({
         );
 
         await importWorkflow(workflowStateWithCreds);
+
+        if (isNewWorkflow) {
+          try {
+            await saveWorkflow({ silent: true });
+          } catch (saveError) {
+            console.error('[AI Assistant] Failed to save workflow:', saveError);
+            notifications.alert({
+              title: 'Failed to save workflow',
+              description:
+                saveError instanceof Error
+                  ? saveError.message
+                  : 'Unknown error occurred',
+            });
+          }
+        }
       } catch (error) {
         console.error('[AI Assistant] Failed to apply workflow:', error);
 
-        notifications.alert({
-          title: 'Failed to apply workflow',
-          description:
-            error instanceof Error ? error.message : 'Invalid workflow YAML',
-        });
+        const errorMessage =
+          error instanceof Error ? error.message : 'Invalid workflow YAML';
+
+        if (isNewWorkflow && onValidationError) {
+          onValidationError(errorMessage);
+        } else {
+          notifications.alert({
+            title: 'Failed to apply workflow',
+            description: errorMessage,
+          });
+        }
       } finally {
         setApplyingMessageId(null);
         // Only signal completion if we successfully coordinated
@@ -224,6 +251,9 @@ export function useAIWorkflowApplications({
       doneApplyingWorkflow,
       jobs,
       setApplyingMessageId,
+      isNewWorkflow,
+      onValidationError,
+      saveWorkflow,
     ]
   );
 

--- a/assets/js/collaborative-editor/hooks/useUI.ts
+++ b/assets/js/collaborative-editor/hooks/useUI.ts
@@ -11,6 +11,8 @@ import { StoreContext } from '../contexts/StoreProvider';
 import type { UIStoreInstance } from '../stores/createUIStore';
 import type { UIState } from '../types/ui';
 
+import { useIsNewWorkflow } from './useSessionContext';
+
 /**
  * Main hook for accessing the UIStore instance
  * Handles context access and error handling once
@@ -139,11 +141,16 @@ export const useIsCreateWorkflowPanelCollapsed = (): boolean => {
  * Hook to check if the landing screen overlay is visible
  */
 export const useShowLandingScreen = (): boolean => {
+  const isNewWorkflow = useIsNewWorkflow();
   const uiStore = useUIStore();
   const selectShowLandingScreen = uiStore.withSelector(
     state => state.showLandingScreen
   );
-  return useSyncExternalStore(uiStore.subscribe, selectShowLandingScreen);
+  const showLandingScreen = useSyncExternalStore(
+    uiStore.subscribe,
+    selectShowLandingScreen
+  );
+  return isNewWorkflow && showLandingScreen;
 };
 
 /**

--- a/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
+++ b/assets/js/collaborative-editor/stores/createAIAssistantStore.ts
@@ -89,6 +89,7 @@ export const createAIAssistantStore = (): AIAssistantStore => {
       streamingContent: null,
       streamingStatus: null,
       streamingChanges: null,
+      streamingApply: null,
       sessionList: [],
       sessionListLoading: false,
       sessionListPagination: null,
@@ -220,6 +221,7 @@ export const createAIAssistantStore = (): AIAssistantStore => {
       draft.streamingContent = null;
       draft.streamingStatus = null;
       draft.streamingChanges = null;
+      draft.streamingApply = null;
     });
 
     notify('clearSession');
@@ -235,6 +237,7 @@ export const createAIAssistantStore = (): AIAssistantStore => {
       draft.sessionId = sessionId;
       draft.messages = [];
       draft.isLoading = true;
+      draft.streamingApply = null;
     });
 
     notify('loadSession');
@@ -607,6 +610,56 @@ export const createAIAssistantStore = (): AIAssistantStore => {
   };
 
   /**
+   * Record that a workflow YAML was successfully imported to the canvas
+   * during streaming, so the auto-apply of the final new_message can skip
+   * the duplicate import when it carries the same YAML.
+   *
+   * Deliberately NOT cleared by _clearStreaming or disconnect: the final
+   * message may arrive after the stream ends (or after a reconnect), and
+   * the skip must still happen then. Cleared when the session changes or
+   * when the next final message with code is processed.
+   * @internal Called by useAIWorkflowApplications after a streaming import
+   */
+  const _setStreamingApply = (yaml: string) => {
+    state = produce(state, draft => {
+      draft.streamingApply = { yaml, saveFailed: false };
+    });
+    notify('_setStreamingApply');
+  };
+
+  /**
+   * Mark whether the post-import auto-save of a streaming apply failed
+   * (a save is still owed). No-op when no streaming apply is pending, so
+   * callers on shared save paths don't need to know whether the current
+   * apply came from streaming.
+   * @internal Called by useAIWorkflowApplications save/retry paths
+   */
+  const _setStreamingApplySaveFailed = (saveFailed: boolean) => {
+    if (!state.streamingApply) return;
+
+    state = produce(state, draft => {
+      if (draft.streamingApply) {
+        draft.streamingApply.saveFailed = saveFailed;
+      }
+    });
+    notify('_setStreamingApplySaveFailed');
+  };
+
+  /**
+   * Clear the pending streaming apply record.
+   * @internal Called by useAIWorkflowApplications on session load and when
+   * the next final message with code is processed
+   */
+  const _clearStreamingApply = () => {
+    if (!state.streamingApply) return;
+
+    state = produce(state, draft => {
+      draft.streamingApply = null;
+    });
+    notify('_clearStreamingApply');
+  };
+
+  /**
    * Connect to workflow channel to listen for AI session creation events.
    * When another user creates an AI session, we receive the event and update
    * our session list if it matches the current context.
@@ -683,6 +736,9 @@ export const createAIAssistantStore = (): AIAssistantStore => {
     setStreamingStatus,
     _setStreamingChanges,
     _clearStreaming,
+    _setStreamingApply,
+    _setStreamingApplySaveFailed,
+    _clearStreamingApply,
     _connectChannel,
   };
 };

--- a/assets/js/collaborative-editor/stores/createUIStore.ts
+++ b/assets/js/collaborative-editor/stores/createUIStore.ts
@@ -130,7 +130,7 @@ export const createUIStore = (isNewWorkflow: boolean = false): UIStore => {
       aiAssistantPanelOpen,
       aiAssistantInitialMessage: null,
       createWorkflowPanelCollapsed,
-      showLandingScreen: isNewWorkflow,
+      showLandingScreen: true,
       showYAMLImportModal: false,
       templatePanel: {
         templates: [],

--- a/assets/js/collaborative-editor/stores/createUIStore.ts
+++ b/assets/js/collaborative-editor/stores/createUIStore.ts
@@ -80,6 +80,18 @@ export const createUIStore = (isNewWorkflow: boolean = false): UIStore => {
     aiAssistantPanelOpen: boolean;
     createWorkflowPanelCollapsed: boolean;
   } => {
+    // TODO-AI-FIRST (#4856): once the left-panel create flow is fully removed,
+    // delete the method/hasMethod branch below and simplify to just the chat param.
+
+    // On /new the landing screen is the only valid entry point — ignore all URL
+    // params so ?chat=true or ?method=... can't bypass or corrupt it.
+    if (isNewWorkflow) {
+      return {
+        aiAssistantPanelOpen: false,
+        createWorkflowPanelCollapsed: true,
+      };
+    }
+
     try {
       const params = new URLSearchParams(window.location.search);
       const chatOpen = params.get('chat') === 'true';

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -122,6 +122,21 @@ export type ConnectionState =
   | 'error';
 
 /**
+ * Tracks a workflow YAML that was applied to the canvas early, during
+ * streaming, so the auto-apply of the final new_message can be skipped
+ * when it carries the same YAML (re-importing identical content dirties
+ * the Y.Doc and shows a false "unsaved changes" indicator).
+ *
+ * Only set after a successful import, so failed applies never need to
+ * reset it. `saveFailed` records that the post-import auto-save of a new
+ * workflow is still owed.
+ */
+export interface StreamingApplyState {
+  yaml: string;
+  saveFailed: boolean;
+}
+
+/**
  * AI Assistant state managed by the store
  */
 export interface AIAssistantState {
@@ -139,6 +154,7 @@ export interface AIAssistantState {
   streamingContent: string | null;
   streamingStatus: string | null;
   streamingChanges: Record<string, unknown> | null;
+  streamingApply: StreamingApplyState | null;
 
   sessionList: SessionSummary[];
   sessionListLoading: boolean;
@@ -202,6 +218,9 @@ export interface AIAssistantStore {
   setStreamingStatus: (text: string | null) => void;
   _setStreamingChanges: (changes: Record<string, unknown>) => void;
   _clearStreaming: () => void;
+  _setStreamingApply: (yaml: string) => void;
+  _setStreamingApplySaveFailed: (saveFailed: boolean) => void;
+  _clearStreamingApply: () => void;
   _connectChannel: (channelProvider: unknown) => () => void;
 }
 

--- a/assets/test/collaborative-editor/components/AIAssistantPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/AIAssistantPanel.test.tsx
@@ -777,4 +777,21 @@ describe('AIAssistantPanel', () => {
       expect(panel).toHaveClass('w-[400px]');
     });
   });
+
+  describe('Close button', () => {
+    it('is visible when onClose is provided', () => {
+      renderWithStore(<AIAssistantPanel isOpen={true} onClose={mockOnClose} />);
+
+      const closeButton = screen.getByRole('button', { name: /close/i });
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it('is absent when onClose is not provided', () => {
+      renderWithStore(<AIAssistantPanel isOpen={true} />);
+
+      expect(
+        screen.queryByRole('button', { name: /close/i })
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -196,11 +196,29 @@ describe('MessageList', () => {
   });
 
   describe('Message Status', () => {
-    it('should show error state for failed messages', () => {
+    it('should show error content in styled box for assistant error with content', () => {
       const messages = [
         createMockAIMessage({
           role: 'assistant',
-          content: 'Failed message',
+          content: 'YAML parse failed: unexpected token',
+          status: 'error',
+        }),
+      ];
+
+      render(<MessageList messages={messages} />);
+
+      // Non-empty content renders inline in a red validation error box
+      expect(screen.getByTestId('ai-validation-error')).toBeInTheDocument();
+      expect(
+        screen.getByText('YAML parse failed: unexpected token')
+      ).toBeInTheDocument();
+    });
+
+    it('should show "Failed to send message" banner for assistant error with no content', () => {
+      const messages = [
+        createMockAIMessage({
+          role: 'assistant',
+          content: '',
           status: 'error',
         }),
       ];

--- a/assets/test/collaborative-editor/components/WorkflowEditor.test.tsx
+++ b/assets/test/collaborative-editor/components/WorkflowEditor.test.tsx
@@ -128,8 +128,10 @@ vi.mock('../../../js/react/lib/use-url-state', () => ({
 }));
 
 // Mock session context hooks
+const mockIsNewWorkflow = vi.fn(() => false);
+
 vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
-  useIsNewWorkflow: () => false,
+  useIsNewWorkflow: () => mockIsNewWorkflow(),
   useProjectRepoConnection: () => undefined,
   useProject: () => ({
     id: 'project-1',
@@ -186,6 +188,8 @@ const mockIsRunPanelOpen = vi.fn(() => false);
 const mockRunPanelContext = vi.fn(() => null);
 const mockOpenRunPanel = vi.fn();
 const mockCloseRunPanel = vi.fn();
+const mockIsAIAssistantPanelOpen = vi.fn(() => false);
+const mockShowLandingScreen = vi.fn(() => false);
 
 vi.mock('../../../js/collaborative-editor/hooks/useUI', () => ({
   useIsRunPanelOpen: () => mockIsRunPanelOpen(),
@@ -209,8 +213,8 @@ vi.mock('../../../js/collaborative-editor/hooks/useUI', () => ({
     selectedTemplate: null,
   }),
   useIsCreateWorkflowPanelCollapsed: () => true,
-  useIsAIAssistantPanelOpen: () => false,
-  useShowLandingScreen: () => false,
+  useIsAIAssistantPanelOpen: () => mockIsAIAssistantPanelOpen(),
+  useShowLandingScreen: () => mockShowLandingScreen(),
 }));
 
 // Mock workflow hooks with controllable node selection
@@ -231,6 +235,7 @@ const mockSelectNode = vi.fn((node: any) => {
 // Mock canRun state
 let mockCanRun = true;
 let mockTooltipMessage = '';
+let mockWorkflowStateOverride: Partial<typeof mockWorkflow> | null = null;
 
 vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
   useNodeSelection: () => ({
@@ -245,11 +250,14 @@ vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
     saveWorkflow: vi.fn(),
   }),
   useWorkflowState: (selector: any) => {
+    const workflow = mockWorkflowStateOverride
+      ? { ...mockWorkflow, ...mockWorkflowStateOverride }
+      : mockWorkflow;
     const state = {
-      workflow: mockWorkflow,
-      jobs: mockWorkflow.jobs,
-      triggers: mockWorkflow.triggers,
-      edges: mockWorkflow.edges,
+      workflow,
+      jobs: workflow.jobs,
+      triggers: workflow.triggers,
+      edges: workflow.edges,
       positions: {},
     };
     return typeof selector === 'function' ? selector(state) : state;
@@ -277,6 +285,10 @@ describe('WorkflowEditor', () => {
     // Reset state
     mockIsRunPanelOpen.mockReturnValue(false);
     mockRunPanelContext.mockReturnValue(null);
+    mockIsNewWorkflow.mockReturnValue(false);
+    mockIsAIAssistantPanelOpen.mockReturnValue(false);
+    mockShowLandingScreen.mockReturnValue(false);
+    mockWorkflowStateOverride = null;
     currentNode = { type: null, node: null };
     mockRunHandler.mockClear();
     mockCanRun = true;
@@ -464,6 +476,38 @@ describe('WorkflowEditor', () => {
       const inspector = screen.queryByTestId('inspector');
       // We can't easily test CSS classes with JSDOM, so we just verify the structure exists
       expect(inspector).toBeInTheDocument();
+    });
+  });
+
+  describe('Empty workflow placeholder', () => {
+    test('shows placeholder when isNewWorkflow, panel closed, and canvas is empty', async () => {
+      mockIsNewWorkflow.mockReturnValue(true);
+      mockShowLandingScreen.mockReturnValue(false);
+      mockIsAIAssistantPanelOpen.mockReturnValue(false);
+      mockWorkflowStateOverride = { jobs: [], triggers: [], edges: [] };
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(screen.getByText('Create your workflow')).toBeInTheDocument();
+      });
+    });
+
+    test('suppresses placeholder when AI assistant panel is open', async () => {
+      mockIsNewWorkflow.mockReturnValue(true);
+      mockShowLandingScreen.mockReturnValue(false);
+      mockIsAIAssistantPanelOpen.mockReturnValue(true);
+      mockWorkflowStateOverride = { jobs: [], triggers: [], edges: [] };
+
+      renderWorkflowEditor();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('workflow-diagram')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText('Create your workflow')
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.autoApply.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.autoApply.test.ts
@@ -81,6 +81,12 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
 
   const mockSaveWorkflow = vi.fn(() => Promise.resolve());
 
+  const mockStreamingApplyActions = {
+    set: vi.fn(),
+    setSaveFailed: vi.fn(),
+    clear: vi.fn(),
+  };
+
   const mockWorkflowActions = {
     importWorkflow: mockImportWorkflow,
     startApplyingWorkflow: mockStartApplyingWorkflow,
@@ -173,6 +179,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
             setApplyingMessageId: mockSetApplyingMessageId,
             isNewWorkflow: false,
             appliedMessageIdsRef,
+            streamingApply: null,
+            streamingApplyActions: mockStreamingApplyActions,
           }),
         { initialProps: { currentSession: null } }
       );
@@ -244,6 +252,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -293,6 +303,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
             setApplyingMessageId: mockSetApplyingMessageId,
             isNewWorkflow: false,
             appliedMessageIdsRef,
+            streamingApply: null,
+            streamingApplyActions: mockStreamingApplyActions,
           }),
         { initialProps: { currentSession: null } }
       );
@@ -338,6 +350,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -377,6 +391,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -433,6 +449,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
             setApplyingMessageId: mockSetApplyingMessageId,
             isNewWorkflow: false,
             appliedMessageIdsRef,
+            streamingApply: null,
+            streamingApplyActions: mockStreamingApplyActions,
           }),
         { initialProps: { currentSession: null } }
       );

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.autoApply.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.autoApply.test.ts
@@ -79,6 +79,8 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
   const mockClearDiff = vi.fn();
   const mockShowDiff = vi.fn();
 
+  const mockSaveWorkflow = vi.fn(() => Promise.resolve());
+
   const mockWorkflowActions = {
     importWorkflow: mockImportWorkflow,
     startApplyingWorkflow: mockStartApplyingWorkflow,
@@ -86,6 +88,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
     startApplyingJobCode: mockStartApplyingJobCode,
     doneApplyingJobCode: mockDoneApplyingJobCode,
     updateJob: mockUpdateJob,
+    saveWorkflow: mockSaveWorkflow,
   };
 
   const createMockMonacoRef = () => ({
@@ -168,6 +171,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
             setPreviewingMessageId: mockSetPreviewingMessageId,
             previewingMessageId: null,
             setApplyingMessageId: mockSetApplyingMessageId,
+            isNewWorkflow: false,
             appliedMessageIdsRef,
           }),
         { initialProps: { currentSession: null } }
@@ -238,6 +242,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -286,6 +291,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
             setPreviewingMessageId: mockSetPreviewingMessageId,
             previewingMessageId: null,
             setApplyingMessageId: mockSetApplyingMessageId,
+            isNewWorkflow: false,
             appliedMessageIdsRef,
           }),
         { initialProps: { currentSession: null } }
@@ -330,6 +336,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -368,6 +375,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -423,6 +431,7 @@ describe('useAIWorkflowApplications - Auto-Application', () => {
             setPreviewingMessageId: mockSetPreviewingMessageId,
             previewingMessageId: null,
             setApplyingMessageId: mockSetApplyingMessageId,
+            isNewWorkflow: false,
             appliedMessageIdsRef,
           }),
         { initialProps: { currentSession: null } }

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.jobCode.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.jobCode.test.ts
@@ -39,6 +39,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
   const mockClearDiff = vi.fn();
   const mockShowDiff = vi.fn();
 
+  const mockSaveWorkflow = vi.fn(() => Promise.resolve());
+
   const mockWorkflowActions = {
     importWorkflow: mockImportWorkflow,
     startApplyingWorkflow: mockStartApplyingWorkflow,
@@ -46,6 +48,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
     startApplyingJobCode: mockStartApplyingJobCode,
     doneApplyingJobCode: mockDoneApplyingJobCode,
     updateJob: mockUpdateJob,
+    saveWorkflow: mockSaveWorkflow,
   };
 
   const createMockMonacoRef = () => ({
@@ -97,6 +100,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -125,6 +129,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -153,6 +158,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: 'msg-1', // Already previewing
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -182,6 +188,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: 'msg-1', // Existing preview
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -208,6 +215,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -238,6 +246,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -268,6 +277,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -301,6 +311,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -328,6 +339,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: 'msg-1',
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -356,6 +368,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -384,6 +397,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );
@@ -416,6 +430,7 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setPreviewingMessageId: mockSetPreviewingMessageId,
           previewingMessageId: null,
           setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
         })
       );

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.jobCode.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.jobCode.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../../js/collaborative-editor/lib/notifications', () => ({
   notifications: {
     alert: vi.fn(),
     success: vi.fn(),
+    dismiss: vi.fn(),
   },
 }));
 
@@ -40,6 +41,12 @@ describe('useAIWorkflowApplications - Job Code', () => {
   const mockShowDiff = vi.fn();
 
   const mockSaveWorkflow = vi.fn(() => Promise.resolve());
+
+  const mockStreamingApplyActions = {
+    set: vi.fn(),
+    setSaveFailed: vi.fn(),
+    clear: vi.fn(),
+  };
 
   const mockWorkflowActions = {
     importWorkflow: mockImportWorkflow,
@@ -102,6 +109,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -131,6 +140,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -160,6 +171,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -190,6 +203,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -217,6 +232,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -248,6 +265,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -279,6 +298,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -313,6 +334,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -341,6 +364,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -370,6 +395,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -399,6 +426,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 
@@ -432,6 +461,8 @@ describe('useAIWorkflowApplications - Job Code', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: false,
           appliedMessageIdsRef: { current: new Set() },
+          streamingApply: null,
+          streamingApplyActions: mockStreamingApplyActions,
         })
       );
 

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -530,10 +530,13 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
 
     await waitFor(() => {
       expect(mockImportWorkflow).toHaveBeenCalled();
-      expect(notifications.alert).toHaveBeenCalledWith({
-        title: 'Failed to save workflow',
-        description: 'Network error',
-      });
+      expect(notifications.alert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to save workflow',
+          description: 'Network error',
+          action: expect.objectContaining({ label: 'Retry' }) as object,
+        })
+      );
       expect(mockOnValidationError).not.toHaveBeenCalled();
     });
   });

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -841,7 +841,11 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
     });
   });
 
-  it('shows save-failure toast and does not call onValidationError when save rejects', async () => {
+  it('does not show its own toast and does not call onValidationError when save rejects', async () => {
+    // A rejected saveWorkflow is the real-save-failure path — in production
+    // this is the wrapped saveWorkflow from useWorkflow.tsx, which already
+    // shows its own "Failed to save workflow" toast and re-throws. Showing
+    // another one here would double up on a single failure.
     const failingSaveWorkflow = vi.fn(() =>
       Promise.reject(new Error('Network error'))
     );
@@ -876,10 +880,53 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
 
     await waitFor(() => {
       expect(mockImportWorkflow).toHaveBeenCalled();
+      expect(mockStreamingApplyActions.setSaveFailed).toHaveBeenCalledWith(
+        true
+      );
+    });
+    expect(notifications.alert).not.toHaveBeenCalled();
+    expect(mockOnValidationError).not.toHaveBeenCalled();
+  });
+
+  it('shows its own toast when save returns null (disconnected)', async () => {
+    // Disconnect is signalled by a null return, not a throw, so the
+    // saveWorkflow wrapper shows no toast of its own for this case.
+    const disconnectedSaveWorkflow = vi.fn(() => Promise.resolve(null));
+
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: disconnectedSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        onValidationError: mockOnValidationError,
+        appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
+      })
+    );
+
+    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalled();
       expect(notifications.alert).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'Failed to save workflow',
-          description: 'Network error',
+          description: 'Your connection was lost. Reconnect and try again.',
           action: expect.objectContaining({ label: 'Retry' }) as object,
         })
       );

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -561,6 +561,102 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
     });
   });
 
+  it('resets appliedViaStreamingRef during session-load so subsequent responses are not skipped', async () => {
+    const appliedMessageIdsRef = { current: new Set<string>() };
+    const appliedViaStreamingRef = { current: false };
+
+    const userMessage1 = {
+      id: 'user-msg-1',
+      role: 'user' as const,
+      content: 'Build me a workflow',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:00Z',
+      user_id: 'user-123',
+    };
+    const assistantMessage1 = {
+      id: 'msg-1',
+      role: 'assistant' as const,
+      content: 'Here is workflow 1',
+      code: 'name: Test 1',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:01Z',
+    };
+    const userMessage2 = {
+      id: 'user-msg-2',
+      role: 'user' as const,
+      content: 'Refine the workflow',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:02Z',
+      user_id: 'user-123',
+    };
+    const assistantMessage2 = {
+      id: 'msg-2',
+      role: 'assistant' as const,
+      content: 'Here is workflow 2',
+      code: 'name: Test 2',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:03Z',
+    };
+
+    type Props = {
+      currentSession: { messages: (typeof userMessage1)[] } | null;
+    };
+
+    const { rerender } = renderHook(
+      ({ currentSession }: Props) =>
+        useAIWorkflowApplications({
+          sessionId: 'session-1',
+          page: 'workflow_template',
+          currentSession,
+          currentUserId: 'user-123',
+          aiMode: createMockAIMode('workflow_template'),
+          workflowActions: mockWorkflowActions,
+          monacoRef: createMockMonacoRef(),
+          jobs: [],
+          canApplyChanges: true,
+          connectionState: 'connected' as ConnectionState,
+          setPreviewingMessageId: mockSetPreviewingMessageId,
+          previewingMessageId: null,
+          setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: true,
+          appliedMessageIdsRef,
+          appliedViaStreamingRef,
+        }),
+      { initialProps: { currentSession: null } }
+    );
+
+    // Simulate streaming having fired before the first new_message arrives
+    appliedViaStreamingRef.current = true;
+
+    // First new_message: session loading for the first time (hasLoadedSessionRef = false)
+    rerender({
+      currentSession: { messages: [userMessage1, assistantMessage1] },
+    });
+
+    await waitFor(() => {
+      // Session-load path marks messages applied but does not re-import
+      expect(mockImportWorkflow).not.toHaveBeenCalled();
+      // Fix: ref must be cleared so the next real response isn't skipped
+      expect(appliedViaStreamingRef.current).toBe(false);
+    });
+
+    // Second response arrives — ref is now false, so auto-apply proceeds
+    rerender({
+      currentSession: {
+        messages: [
+          userMessage1,
+          assistantMessage1,
+          userMessage2,
+          assistantMessage2,
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('shows save-failure toast and does not call onValidationError when save rejects', async () => {
     const failingSaveWorkflow = vi.fn(() =>
       Promise.reject(new Error('Network error'))

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -497,6 +497,70 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
     });
   });
 
+  it('skips auto-apply and marks message applied when appliedViaStreamingRef is set', async () => {
+    const appliedMessageIdsRef = { current: new Set<string>() };
+    const appliedViaStreamingRef = { current: false };
+
+    const userMessage = {
+      id: 'user-msg-1',
+      role: 'user' as const,
+      content: 'Build me a workflow',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:00Z',
+      user_id: 'user-123',
+    };
+
+    const assistantMessage = {
+      id: 'msg-1',
+      role: 'assistant' as const,
+      content: 'Here is your workflow',
+      code: 'name: Test',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:01Z',
+    };
+
+    type Props = {
+      currentSession: { messages: (typeof userMessage)[] } | null;
+    };
+
+    const { rerender } = renderHook(
+      ({ currentSession }: Props) =>
+        useAIWorkflowApplications({
+          sessionId: 'session-1',
+          page: 'workflow_template',
+          currentSession,
+          currentUserId: 'user-123',
+          aiMode: createMockAIMode('workflow_template'),
+          workflowActions: mockWorkflowActions,
+          monacoRef: createMockMonacoRef(),
+          jobs: [],
+          canApplyChanges: true,
+          connectionState: 'connected' as ConnectionState,
+          setPreviewingMessageId: mockSetPreviewingMessageId,
+          previewingMessageId: null,
+          setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: true,
+          appliedMessageIdsRef,
+          appliedViaStreamingRef,
+        }),
+      { initialProps: { currentSession: { messages: [userMessage] } } }
+    );
+
+    // Simulate streaming having already applied the YAML
+    appliedViaStreamingRef.current = true;
+
+    rerender({
+      currentSession: { messages: [userMessage, assistantMessage] },
+    });
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).not.toHaveBeenCalled();
+      expect(mockSaveWorkflow).not.toHaveBeenCalled();
+      expect(appliedMessageIdsRef.current.has('msg-1')).toBe(true);
+      expect(appliedViaStreamingRef.current).toBe(false);
+    });
+  });
+
   it('shows save-failure toast and does not call onValidationError when save rejects', async () => {
     const failingSaveWorkflow = vi.fn(() =>
       Promise.reject(new Error('Network error'))

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -9,6 +9,8 @@
  * - Collaborative coordination
  */
 
+/* TODO-AI-FIRST reduce this test file */
+
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -78,6 +78,7 @@ vi.mock('../../../js/collaborative-editor/lib/notifications', () => ({
   notifications: {
     alert: vi.fn(),
     success: vi.fn(),
+    dismiss: vi.fn(),
   },
 }));
 
@@ -96,6 +97,12 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
 
   const mockSaveWorkflow = vi.fn(() => Promise.resolve());
   const mockOnValidationError = vi.fn();
+
+  const mockStreamingApplyActions = {
+    set: vi.fn(),
+    setSaveFailed: vi.fn(),
+    clear: vi.fn(),
+  };
 
   const mockWorkflowActions = {
     importWorkflow: mockImportWorkflow,
@@ -155,6 +162,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -188,6 +197,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -222,6 +233,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -261,6 +274,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -295,6 +310,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -324,6 +341,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -357,6 +376,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -388,6 +409,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: true,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -424,6 +447,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -455,6 +480,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         isNewWorkflow: true,
         onValidationError: mockOnValidationError,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -484,6 +511,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -497,9 +526,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
     });
   });
 
-  it('skips auto-apply and marks message applied when appliedViaStreamingRef is set', async () => {
+  it('skips re-import when the final message matches the streaming apply record', async () => {
     const appliedMessageIdsRef = { current: new Set<string>() };
-    const appliedViaStreamingRef = { current: false };
 
     const userMessage = {
       id: 'user-msg-1',
@@ -521,10 +549,11 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
 
     type Props = {
       currentSession: { messages: (typeof userMessage)[] } | null;
+      streamingApply: { yaml: string; saveFailed: boolean } | null;
     };
 
     const { rerender } = renderHook(
-      ({ currentSession }: Props) =>
+      ({ currentSession, streamingApply }: Props) =>
         useAIWorkflowApplications({
           sessionId: 'session-1',
           page: 'workflow_template',
@@ -541,29 +570,175 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: true,
           appliedMessageIdsRef,
-          appliedViaStreamingRef,
+          streamingApply,
+          streamingApplyActions: mockStreamingApplyActions,
         }),
-      { initialProps: { currentSession: { messages: [userMessage] } } }
+      {
+        initialProps: {
+          currentSession: { messages: [userMessage] },
+          streamingApply: null,
+        },
+      }
     );
 
-    // Simulate streaming having already applied the YAML
-    appliedViaStreamingRef.current = true;
-
+    // Streaming already imported this exact YAML and saved successfully
     rerender({
       currentSession: { messages: [userMessage, assistantMessage] },
+      streamingApply: { yaml: 'name: Test', saveFailed: false },
     });
 
     await waitFor(() => {
-      expect(mockImportWorkflow).not.toHaveBeenCalled();
-      expect(mockSaveWorkflow).not.toHaveBeenCalled();
       expect(appliedMessageIdsRef.current.has('msg-1')).toBe(true);
-      expect(appliedViaStreamingRef.current).toBe(false);
+      expect(mockStreamingApplyActions.clear).toHaveBeenCalled();
     });
+    expect(mockImportWorkflow).not.toHaveBeenCalled();
+    expect(mockSaveWorkflow).not.toHaveBeenCalled();
   });
 
-  it('resets appliedViaStreamingRef during session-load so subsequent responses are not skipped', async () => {
+  it('retries the owed save without re-importing when the matching streaming apply is save-failed', async () => {
     const appliedMessageIdsRef = { current: new Set<string>() };
-    const appliedViaStreamingRef = { current: false };
+    const successfulSaveWorkflow = vi.fn(() => Promise.resolve(true));
+
+    const userMessage = {
+      id: 'user-msg-1',
+      role: 'user' as const,
+      content: 'Build me a workflow',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:00Z',
+      user_id: 'user-123',
+    };
+
+    const assistantMessage = {
+      id: 'msg-1',
+      role: 'assistant' as const,
+      content: 'Here is your workflow',
+      code: 'name: Test',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:01Z',
+    };
+
+    type Props = {
+      currentSession: { messages: (typeof userMessage)[] } | null;
+      streamingApply: { yaml: string; saveFailed: boolean } | null;
+    };
+
+    const { rerender } = renderHook(
+      ({ currentSession, streamingApply }: Props) =>
+        useAIWorkflowApplications({
+          sessionId: 'session-1',
+          page: 'workflow_template',
+          currentSession,
+          currentUserId: 'user-123',
+          aiMode: createMockAIMode('workflow_template'),
+          workflowActions: {
+            ...mockWorkflowActions,
+            saveWorkflow: successfulSaveWorkflow,
+          },
+          monacoRef: createMockMonacoRef(),
+          jobs: [],
+          canApplyChanges: true,
+          connectionState: 'connected' as ConnectionState,
+          setPreviewingMessageId: mockSetPreviewingMessageId,
+          previewingMessageId: null,
+          setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: true,
+          appliedMessageIdsRef,
+          streamingApply,
+          streamingApplyActions: mockStreamingApplyActions,
+        }),
+      {
+        initialProps: {
+          currentSession: { messages: [userMessage] },
+          streamingApply: null,
+        },
+      }
+    );
+
+    // Streaming imported the YAML but its save failed — a save is still owed
+    rerender({
+      currentSession: { messages: [userMessage, assistantMessage] },
+      streamingApply: { yaml: 'name: Test', saveFailed: true },
+    });
+
+    await waitFor(() => {
+      expect(successfulSaveWorkflow).toHaveBeenCalledWith({ silent: true });
+    });
+    expect(mockImportWorkflow).not.toHaveBeenCalled();
+    expect(mockStreamingApplyActions.clear).toHaveBeenCalled();
+    // Successful retry clears the owed-save flag
+    expect(mockStreamingApplyActions.setSaveFailed).toHaveBeenCalledWith(false);
+  });
+
+  it('applies normally when the final message YAML differs from the streaming apply record', async () => {
+    const appliedMessageIdsRef = { current: new Set<string>() };
+
+    const userMessage = {
+      id: 'user-msg-1',
+      role: 'user' as const,
+      content: 'Build me a workflow',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:00Z',
+      user_id: 'user-123',
+    };
+
+    const assistantMessage = {
+      id: 'msg-1',
+      role: 'assistant' as const,
+      content: 'Here is your workflow',
+      code: 'name: Test',
+      status: 'success' as const,
+      inserted_at: '2024-01-01T00:00:01Z',
+    };
+
+    type Props = {
+      currentSession: { messages: (typeof userMessage)[] } | null;
+      streamingApply: { yaml: string; saveFailed: boolean } | null;
+    };
+
+    const { rerender } = renderHook(
+      ({ currentSession, streamingApply }: Props) =>
+        useAIWorkflowApplications({
+          sessionId: 'session-1',
+          page: 'workflow_template',
+          currentSession,
+          currentUserId: 'user-123',
+          aiMode: createMockAIMode('workflow_template'),
+          workflowActions: mockWorkflowActions,
+          monacoRef: createMockMonacoRef(),
+          jobs: [],
+          canApplyChanges: true,
+          connectionState: 'connected' as ConnectionState,
+          setPreviewingMessageId: mockSetPreviewingMessageId,
+          previewingMessageId: null,
+          setApplyingMessageId: mockSetApplyingMessageId,
+          isNewWorkflow: false,
+          appliedMessageIdsRef,
+          streamingApply,
+          streamingApplyActions: mockStreamingApplyActions,
+        }),
+      {
+        initialProps: {
+          currentSession: { messages: [userMessage] },
+          streamingApply: null,
+        },
+      }
+    );
+
+    // Stale record: streaming applied different YAML than the final message
+    rerender({
+      currentSession: { messages: [userMessage, assistantMessage] },
+      streamingApply: { yaml: 'name: Something else', saveFailed: false },
+    });
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalledTimes(1);
+    });
+    // The non-streaming apply supersedes (and clears) the stale record
+    expect(mockStreamingApplyActions.clear).toHaveBeenCalled();
+  });
+
+  it('clears the streaming apply record during session-load seeding so later responses are not skipped', async () => {
+    const appliedMessageIdsRef = { current: new Set<string>() };
 
     const userMessage1 = {
       id: 'user-msg-1',
@@ -600,10 +775,11 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
 
     type Props = {
       currentSession: { messages: (typeof userMessage1)[] } | null;
+      streamingApply: { yaml: string; saveFailed: boolean } | null;
     };
 
     const { rerender } = renderHook(
-      ({ currentSession }: Props) =>
+      ({ currentSession, streamingApply }: Props) =>
         useAIWorkflowApplications({
           sessionId: 'session-1',
           page: 'workflow_template',
@@ -620,27 +796,32 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
           setApplyingMessageId: mockSetApplyingMessageId,
           isNewWorkflow: true,
           appliedMessageIdsRef,
-          appliedViaStreamingRef,
+          streamingApply,
+          streamingApplyActions: mockStreamingApplyActions,
         }),
-      { initialProps: { currentSession: null } }
+      {
+        initialProps: {
+          currentSession: null,
+          // Streaming fired before the session finished loading
+          streamingApply: { yaml: 'name: Test 1', saveFailed: false },
+        },
+      }
     );
-
-    // Simulate streaming having fired before the first new_message arrives
-    appliedViaStreamingRef.current = true;
 
     // First new_message: session loading for the first time (hasLoadedSessionRef = false)
     rerender({
       currentSession: { messages: [userMessage1, assistantMessage1] },
+      streamingApply: { yaml: 'name: Test 1', saveFailed: false },
     });
 
     await waitFor(() => {
-      // Session-load path marks messages applied but does not re-import
-      expect(mockImportWorkflow).not.toHaveBeenCalled();
-      // Fix: ref must be cleared so the next real response isn't skipped
-      expect(appliedViaStreamingRef.current).toBe(false);
+      // Session-load path marks messages applied but does not re-import;
+      // the streaming record is dropped, never consumed
+      expect(mockStreamingApplyActions.clear).toHaveBeenCalled();
     });
+    expect(mockImportWorkflow).not.toHaveBeenCalled();
 
-    // Second response arrives — ref is now false, so auto-apply proceeds
+    // Second response arrives — record cleared, so auto-apply proceeds
     rerender({
       currentSession: {
         messages: [
@@ -650,6 +831,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
           assistantMessage2,
         ],
       },
+      streamingApply: null,
     });
 
     await waitFor(() => {
@@ -683,6 +865,8 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         isNewWorkflow: true,
         onValidationError: mockOnValidationError,
         appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
@@ -701,8 +885,51 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
     });
   });
 
-  it('resets appliedViaStreamingRef when save rejects after a successful streaming apply', async () => {
-    const appliedViaStreamingRef = { current: true };
+  it('records the streaming apply only after a successful import', async () => {
+    const successfulSaveWorkflow = vi.fn(() => Promise.resolve(true));
+
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: successfulSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        appliedMessageIdsRef: { current: new Set() },
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
+      })
+    );
+
+    // Failed apply (parse error): the record is never set, so the final
+    // message applies normally with no reset needed anywhere
+    await result.current.handleApplyWorkflow('invalid yaml', '__streaming__');
+    expect(mockStreamingApplyActions.set).not.toHaveBeenCalled();
+
+    // Successful apply: recorded, and the save success marks no save owed
+    await result.current.handleApplyWorkflow('name: Test', '__streaming__');
+
+    await waitFor(() => {
+      expect(mockStreamingApplyActions.set).toHaveBeenCalledWith('name: Test');
+      expect(mockStreamingApplyActions.setSaveFailed).toHaveBeenCalledWith(
+        false
+      );
+    });
+  });
+
+  it('marks the streaming apply save-failed when save rejects', async () => {
     const failingSaveWorkflow = vi.fn(() =>
       Promise.reject(new Error('Network error'))
     );
@@ -727,20 +954,25 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: true,
         appliedMessageIdsRef: { current: new Set() },
-        appliedViaStreamingRef,
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
-    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+    await result.current.handleApplyWorkflow('name: Test', '__streaming__');
 
     await waitFor(() => {
       expect(mockImportWorkflow).toHaveBeenCalled();
-      expect(appliedViaStreamingRef.current).toBe(false);
+      // Recorded after the successful import, then flagged so the final
+      // message settles the owed save
+      expect(mockStreamingApplyActions.set).toHaveBeenCalledWith('name: Test');
+      expect(mockStreamingApplyActions.setSaveFailed).toHaveBeenCalledWith(
+        true
+      );
     });
   });
 
-  it('resets appliedViaStreamingRef when save returns null (disconnected) after a successful streaming apply', async () => {
-    const appliedViaStreamingRef = { current: true };
+  it('marks the streaming apply save-failed when save returns null (disconnected)', async () => {
     const disconnectedSaveWorkflow = vi.fn(() => Promise.resolve(null));
 
     const { result } = renderHook(() =>
@@ -763,15 +995,19 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setApplyingMessageId: mockSetApplyingMessageId,
         isNewWorkflow: true,
         appliedMessageIdsRef: { current: new Set() },
-        appliedViaStreamingRef,
+        streamingApply: null,
+        streamingApplyActions: mockStreamingApplyActions,
       })
     );
 
-    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+    await result.current.handleApplyWorkflow('name: Test', '__streaming__');
 
     await waitFor(() => {
       expect(mockImportWorkflow).toHaveBeenCalled();
-      expect(appliedViaStreamingRef.current).toBe(false);
+      expect(mockStreamingApplyActions.set).toHaveBeenCalledWith('name: Test');
+      expect(mockStreamingApplyActions.setSaveFailed).toHaveBeenCalledWith(
+        true
+      );
     });
   });
 });

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -94,6 +94,9 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
   const mockClearDiff = vi.fn();
   const mockShowDiff = vi.fn();
 
+  const mockSaveWorkflow = vi.fn(() => Promise.resolve());
+  const mockOnValidationError = vi.fn();
+
   const mockWorkflowActions = {
     importWorkflow: mockImportWorkflow,
     startApplyingWorkflow: mockStartApplyingWorkflow,
@@ -101,6 +104,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
     startApplyingJobCode: mockStartApplyingJobCode,
     doneApplyingJobCode: mockDoneApplyingJobCode,
     updateJob: mockUpdateJob,
+    saveWorkflow: mockSaveWorkflow,
   };
 
   const createMockMonacoRef = () => ({
@@ -149,6 +153,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -181,6 +186,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -214,6 +220,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -252,6 +259,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -285,6 +293,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -313,6 +322,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -345,6 +355,7 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
         setPreviewingMessageId: mockSetPreviewingMessageId,
         previewingMessageId: null,
         setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
         appliedMessageIdsRef: { current: new Set() },
       })
     );
@@ -353,6 +364,177 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
 
     await waitFor(() => {
       expect(mockDoneApplyingWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  it('auto-saves after importWorkflow when isNewWorkflow is true', async () => {
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: mockSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        appliedMessageIdsRef: { current: new Set() },
+      })
+    );
+
+    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalled();
+      expect(mockSaveWorkflow).toHaveBeenCalledWith({ silent: true });
+    });
+
+    const importOrder = mockImportWorkflow.mock.invocationCallOrder[0];
+    const saveOrder = mockSaveWorkflow.mock.invocationCallOrder[0];
+    expect(importOrder).toBeLessThan(saveOrder);
+  });
+
+  it('does not auto-save when isNewWorkflow is false', async () => {
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: mockSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
+        appliedMessageIdsRef: { current: new Set() },
+      })
+    );
+
+    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalled();
+    });
+
+    expect(mockSaveWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('routes validation error to onValidationError callback when isNewWorkflow is true', async () => {
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: mockWorkflowActions,
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        onValidationError: mockOnValidationError,
+        appliedMessageIdsRef: { current: new Set() },
+      })
+    );
+
+    await result.current.handleApplyWorkflow('invalid yaml', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockOnValidationError).toHaveBeenCalledWith(expect.any(String));
+      expect(notifications.alert).not.toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to toast for validation errors when isNewWorkflow is false', async () => {
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: mockWorkflowActions,
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: false,
+        appliedMessageIdsRef: { current: new Set() },
+      })
+    );
+
+    await result.current.handleApplyWorkflow('invalid yaml', 'msg-1');
+
+    await waitFor(() => {
+      expect(notifications.alert).toHaveBeenCalledWith({
+        title: 'Failed to apply workflow',
+        description: expect.any(String) as string,
+      });
+    });
+  });
+
+  it('shows save-failure toast and does not call onValidationError when save rejects', async () => {
+    const failingSaveWorkflow = vi.fn(() =>
+      Promise.reject(new Error('Network error'))
+    );
+
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: failingSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        onValidationError: mockOnValidationError,
+        appliedMessageIdsRef: { current: new Set() },
+      })
+    );
+
+    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalled();
+      expect(notifications.alert).toHaveBeenCalledWith({
+        title: 'Failed to save workflow',
+        description: 'Network error',
+      });
+      expect(mockOnValidationError).not.toHaveBeenCalled();
     });
   });
 });

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.workflow.test.ts
@@ -700,4 +700,78 @@ describe('useAIWorkflowApplications - handleApplyWorkflow', () => {
       expect(mockOnValidationError).not.toHaveBeenCalled();
     });
   });
+
+  it('resets appliedViaStreamingRef when save rejects after a successful streaming apply', async () => {
+    const appliedViaStreamingRef = { current: true };
+    const failingSaveWorkflow = vi.fn(() =>
+      Promise.reject(new Error('Network error'))
+    );
+
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: failingSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        appliedMessageIdsRef: { current: new Set() },
+        appliedViaStreamingRef,
+      })
+    );
+
+    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalled();
+      expect(appliedViaStreamingRef.current).toBe(false);
+    });
+  });
+
+  it('resets appliedViaStreamingRef when save returns null (disconnected) after a successful streaming apply', async () => {
+    const appliedViaStreamingRef = { current: true };
+    const disconnectedSaveWorkflow = vi.fn(() => Promise.resolve(null));
+
+    const { result } = renderHook(() =>
+      useAIWorkflowApplications({
+        sessionId: 'session-1',
+        page: 'workflow_template',
+        currentSession: null,
+        currentUserId: 'user-123',
+        aiMode: createMockAIMode('workflow_template'),
+        workflowActions: {
+          ...mockWorkflowActions,
+          saveWorkflow: disconnectedSaveWorkflow,
+        },
+        monacoRef: createMockMonacoRef(),
+        jobs: [],
+        canApplyChanges: true,
+        connectionState: 'connected' as ConnectionState,
+        setPreviewingMessageId: mockSetPreviewingMessageId,
+        previewingMessageId: null,
+        setApplyingMessageId: mockSetApplyingMessageId,
+        isNewWorkflow: true,
+        appliedMessageIdsRef: { current: new Set() },
+        appliedViaStreamingRef,
+      })
+    );
+
+    await result.current.handleApplyWorkflow('name: Test', 'msg-1');
+
+    await waitFor(() => {
+      expect(mockImportWorkflow).toHaveBeenCalled();
+      expect(appliedViaStreamingRef.current).toBe(false);
+    });
+  });
 });

--- a/assets/test/collaborative-editor/stores/createAIAssistantStore.test.ts
+++ b/assets/test/collaborative-editor/stores/createAIAssistantStore.test.ts
@@ -364,6 +364,48 @@ describe('createAIAssistantStore', () => {
     });
   });
 
+  describe('Streaming Apply', () => {
+    it('records, flags, and clears the streaming apply lifecycle', () => {
+      store._setStreamingApply('name: Test');
+      expect(store.getSnapshot().streamingApply).toEqual({
+        yaml: 'name: Test',
+        saveFailed: false,
+      });
+
+      store._setStreamingApplySaveFailed(true);
+      expect(store.getSnapshot().streamingApply?.saveFailed).toBe(true);
+
+      store._setStreamingApplySaveFailed(false);
+      expect(store.getSnapshot().streamingApply?.saveFailed).toBe(false);
+
+      store._clearStreamingApply();
+      expect(store.getSnapshot().streamingApply).toBeNull();
+    });
+
+    it('ignores saveFailed updates when no streaming apply is pending', () => {
+      store._setStreamingApplySaveFailed(true);
+
+      expect(store.getSnapshot().streamingApply).toBeNull();
+    });
+
+    it('is cleared on session change but survives stream-end and disconnect', () => {
+      // The final new_message may arrive after the stream ends or after a
+      // reconnect — the record must survive both so the duplicate import
+      // can still be skipped.
+      store._setStreamingApply('name: Test');
+      store._clearStreaming();
+      store.disconnect();
+      expect(store.getSnapshot().streamingApply).not.toBeNull();
+
+      store.loadSession('session-2');
+      expect(store.getSnapshot().streamingApply).toBeNull();
+
+      store._setStreamingApply('name: Test 2');
+      store.clearSession();
+      expect(store.getSnapshot().streamingApply).toBeNull();
+    });
+  });
+
   describe('State Subscriptions', () => {
     it('should notify subscribers on state changes', () => {
       const subscriber = vi.fn();

--- a/assets/test/collaborative-editor/stores/createUIStore.landing-screen.test.ts
+++ b/assets/test/collaborative-editor/stores/createUIStore.landing-screen.test.ts
@@ -3,6 +3,9 @@
  *
  * Tests the showLandingScreen initial state and dismissLandingScreen command
  * in isolation against the real createUIStore implementation.
+ *
+ * Note: showLandingScreen starts true in the store; the useShowLandingScreen
+ * hook gates visibility by also checking isNewWorkflow from SessionContextStore.
  */
 
 import { describe, expect, test } from 'vitest';
@@ -14,19 +17,9 @@ import { createUIStore } from '../../../js/collaborative-editor/stores/createUIS
 // =============================================================================
 
 describe('createUIStore — landing screen initial state', () => {
-  test('createUIStore(true) — showLandingScreen starts as true', () => {
-    const store = createUIStore(true);
-    expect(store.getSnapshot().showLandingScreen).toBe(true);
-  });
-
-  test('createUIStore(false) — showLandingScreen starts as false', () => {
-    const store = createUIStore(false);
-    expect(store.getSnapshot().showLandingScreen).toBe(false);
-  });
-
-  test('createUIStore() with no argument — showLandingScreen starts as false', () => {
+  test('showLandingScreen starts as true', () => {
     const store = createUIStore();
-    expect(store.getSnapshot().showLandingScreen).toBe(false);
+    expect(store.getSnapshot().showLandingScreen).toBe(true);
   });
 });
 
@@ -36,7 +29,7 @@ describe('createUIStore — landing screen initial state', () => {
 
 describe('createUIStore — dismissLandingScreen', () => {
   test('calling dismissLandingScreen() sets showLandingScreen to false', () => {
-    const store = createUIStore(true);
+    const store = createUIStore();
     expect(store.getSnapshot().showLandingScreen).toBe(true);
 
     store.dismissLandingScreen();
@@ -45,7 +38,8 @@ describe('createUIStore — dismissLandingScreen', () => {
   });
 
   test('calling dismissLandingScreen() on an already-dismissed store is a no-op', () => {
-    const store = createUIStore(false);
+    const store = createUIStore();
+    store.dismissLandingScreen();
     store.dismissLandingScreen();
     expect(store.getSnapshot().showLandingScreen).toBe(false);
   });


### PR DESCRIPTION
**What I need in this review:** Focus on the "Build with AI" path of the epic. Any big code organisation problems will be fixed in the clean up issue. 

### Description

This PR adds the "Build with AI path" of the #4848 AI-First Starting UX epic. 

How it works:
1. User goes to /new and types a prompt in the "Build with AI" textarea
2. Pressing Enter or clicking "Build it →" dismisses the landing screen and opens the AI panel with the prompt pre
sent
3. The canvas stays blank while the AI processes
4. When the AI returns YAML, it is auto-applied to the canvas and saved to the DB automatically — no "Create" button
5. The URL transitions from /new to /projects/{id}/w/{id} without a page reload

### Key decisions:

- **Auto-save is silent.** No "Workflow saved" toast fires on first creation — it would be noise in a flow the user didn't manually trigger.
- **Panel lock while unsaved.** The AI panel cannot be closed (⌘K disabled, close button hidden) while the workflow hasn't been saved yet. Closing it would leave the user on a blank canvas with no path forward.
- **Validation errors route to chat, not toasts.** If the AI returns invalid YAML, the error is injected as a message into the chat panel so the user can ask the AI to fix it, rather than hitting a dead-end toast.
- **Save failure shows a Retry button.** If the DB save fails, a toast fires with a Retry action that retries only the save — the YAML has already been applied to the canvas so re-importing it is unnecessary. Fit-view is skipped on failure so the canvas doesn't zoom into an unpersisted workflow.
-  **Streaming dedup via `appliedViaStreamingRef`**. The streaming `streamingChanges` event and the final `new_message` both carry the same YAML. The ref is set before the streaming apply and cleared by the auto-apply effect after skipping, preventing a double import. The ref is also reset on apply or save failure so the `new_message` path can retry if streaming failed.
- **URL params are blocked on /new**. Params like `?panel=run`, `?panel=editor`, `?panel=settings`, and `?chat=true` could open panels or bypass the landing screen before the user has done anything. The store ignores all URL params at init time when `isNewWorkflow=true`, and `WorkflowEditor` guards its URL→panel sync effect with the same flag. This prevents e.g. someone sharing a `/new?panel=run` link that skips straight to the run panel on a blank workflow.


Closes #4868

## Validation steps

1. Go to `/new`, type a prompt, press Enter — confirm landing screen dismisses, AI panel opens with prompt pre-sent
2. Wait for AI to return YAML — confirm workflow appears on canvas and URL updates to `/w/{id}` without a reload
3. While AI is processing, ⌘K  — should do nothing
4. After creation, confirm panel can be freely opened and closed
5. Test with a prompt that produces invalid YAML (might be hard to do - might have to hack it with Claude) — confirm error appears in the chat panel, canvas stays blank, panel stays locked

## Additional notes for the reviewer

1. What do you think about the toolbar appearing? Is the effect very jumpy and jarring? What could be the alternative? A completely read-only toolbar before save?
2. We are still working out how the disclaimer will work in this new flow. To be addressed in follow-up work.
3. There are still details to be ironed out. For example, you can still "View conversations" in AI tab before you have created a workflow. Still need to iron out other areas that you shouldn't be able to "get to" before a workflow is created. This can be done in follow-up work. 
4. I am not satisfied with the error handling flow, and might need help to tidy this up in some follow-on work for the AI assistant in general - from a Claude review: _the long tail of fix(useAIWorkflowApplications): ... commits (9+) is real evidence of implicit state churn, not just normal bug fixing. appliedViaStreamingRef alone is now reset from four different call sites for four different failure paths, alongside appliedMessageIdsRef and hasLoadedSessionRef tracking overlapping concerns. This is the classic shape of state that wants to be an explicit state machine (idle | streaming-applied | applying | save-failed) instead of booleans mutated ad hoc — worth a follow-up ticket before more logic piles on top._
5. When reviewing, make it clear that there is still some legacy code from the old "Create a new workflow" route using the side panel. This will be cleaned up in a follow up issue. 
7. **Landing screen gate is reactive, not static.** `createUIStore` is created once inside `useState` — on a slow connection the channel hasn't joined yet, so isNewWorkflow is false at init time. Initialising `showLandingScreen: true` always and moving the isNewWorkflow guard into `useShowLandingScreen` (which reads from the reactive `SessionContextStore`) means the landing screen correctly appears once the channel joins, even on slow connections.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
