### PR TITLE
fix: return 400 instead of 500 on malformed OIDC callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to
 
 ### Fixed
 
+- Return a 400 instead of a 500 on malformed SSO callbacks. A request to
+  `/authenticate/callback` with no query string or an unexpected param
+  combination no longer raises `Phoenix.ActionClauseError`.
+  [#4806](https://github.com/OpenFn/lightning/issues/4806)
+
 ## [2.16.8-pre] - 2026-06-18
 
 ### Added

--- a/lib/lightning_web/controllers/oidc_controller.ex
+++ b/lib/lightning_web/controllers/oidc_controller.ex
@@ -89,6 +89,16 @@ defmodule LightningWeb.OidcController do
     close_browser_window(conn)
   end
 
+  # A callback that matches none of the expected shapes (no query string, an
+  # unexpected param combination, or bare-URL hits from scanners and crawlers)
+  # can't be tied back to a flow we started. Return a plain 400 rather than
+  # letting Phoenix raise an ActionClauseError and 500.
+  def new(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> text("Bad Request")
+  end
+
   @doc """
   Renders the confirmation page shown after a successful SSO callback that
   would create a brand-new account. We ask the user to confirm before

--- a/test/lightning_web/controllers/oidc_controller_test.exs
+++ b/test/lightning_web/controllers/oidc_controller_test.exs
@@ -1014,6 +1014,20 @@ defmodule LightningWeb.OidcControllerTest do
       )
     end
 
+    test "returns 400 for a callback with no params", %{conn: conn} do
+      response = get(conn, "/authenticate/callback")
+
+      assert response.status == 400
+      assert response.resp_body =~ "Bad Request"
+    end
+
+    test "returns 400 for an unexpected param combination", %{conn: conn} do
+      response = get(conn, "/authenticate/callback?foo=bar")
+
+      assert response.status == 400
+      assert response.resp_body =~ "Bad Request"
+    end
+
     defp perform_broadcast_test(conn, state, component_id, type, value, key) do
       response =
         conn


### PR DESCRIPTION
## Description

This PR fixes a 500 on malformed SSO callbacks.

`GET /authenticate/callback` is routed to `OidcController.new/2`, whose clauses
only match the known param shapes (`provider`+`code`+`state`, `state`+`code`,
`error`+`state`). A request with no query string, or any unexpected param
combination, matched no clause, so Phoenix raised `Phoenix.ActionClauseError`
and returned a 500. Bare-URL hits from scanners and crawlers made this a steady
trickle of unhandled exceptions.

Added a catch-all `new(conn, _params)` clause in
`lib/lightning_web/controllers/oidc_controller.ex` that returns a plain
`400 Bad Request` instead of raising.

Closes #4806

## Validation steps

1. Request `GET /authenticate/callback` with no query string and confirm a 400
   response (previously a 500 with an `ActionClauseError`).
2. Request `GET /authenticate/callback?foo=bar` and confirm a 400 response.
3. Confirm the valid flows are unchanged: `state`+`code` still broadcasts the
   code and `error`+`state` still broadcasts the error.

## Additional notes for the reviewer

1. Two controller tests cover the no-params and unexpected-param cases in
   `test/lightning_web/controllers/oidc_controller_test.exs`. The three valid
   callback clauses are untouched.
2. This endpoint is part of the unauthenticated SSO callback flow, so there are
   no authorization policies to exercise.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR

AI was used for assistance.
