### PR TITLE
Sandbox merge no longer deletes a parent workflow added after the fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to
 
 ### Fixed
 
+- Sandbox merge no longer deletes a workflow that was added to the project after
+  the sandbox was branched. Such workflows were never part of the sandbox, so
+  they are excluded from the merge screen entirely. Workflows deleted inside the
+  sandbox still appear and now default to kept, so removing them from the project
+  is opt-in. [#4919](https://github.com/OpenFn/lightning/issues/4919)
+
 ## [2.16.8] - 2026-07-01
 
 ## [2.16.8-pre] - 2026-06-18

--- a/lib/lightning_web/live/sandbox_live/components.ex
+++ b/lib/lightning_web/live/sandbox_live/components.ex
@@ -370,30 +370,38 @@ defmodule LightningWeb.SandboxLive.Components do
                 </span>
                 <span
                   :if={wf.is_changed && !wf.is_new && !wf.is_deleted}
+                  id={"merge-wf-changed-#{wf.id}"}
                   class="flex items-center gap-1 text-xs font-medium text-green-700"
-                  title="This workflow has been modified in the sandbox"
+                  phx-hook="Tooltip"
+                  aria-label="This workflow has been modified in the sandbox"
                 >
                   Changed
                 </span>
                 <span
                   :if={wf.is_diverged}
+                  id={"merge-wf-diverged-#{wf.id}"}
                   class="flex items-center gap-1 text-xs font-medium text-amber-700"
-                  title="This workflow was modified in the target project - this change will be lost"
+                  phx-hook="Tooltip"
+                  aria-label="This workflow was modified in the target project - this change will be lost"
                 >
                   <.icon name="hero-exclamation-triangle-mini" class="h-3.5 w-3.5" />
                   Diverged
                 </span>
                 <span
                   :if={wf.is_new}
+                  id={"merge-wf-new-#{wf.id}"}
                   class="flex items-center gap-1 text-xs font-medium text-blue-700"
-                  title="This workflow doesn't exist in the target — it will be created"
+                  phx-hook="Tooltip"
+                  aria-label="This workflow doesn't exist in the target — it will be created"
                 >
                   New
                 </span>
                 <span
                   :if={wf.is_deleted}
+                  id={"merge-wf-deleted-#{wf.id}"}
                   class="flex items-center gap-1 text-xs font-medium text-red-700"
-                  title="This workflow was deleted in the sandbox — selecting it will delete it from the target"
+                  phx-hook="Tooltip"
+                  aria-label="This workflow was deleted in the sandbox. Selecting it removes it from the project too."
                 >
                   Deleted in sandbox
                 </span>

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -14,7 +14,14 @@ defmodule LightningWeb.SandboxLive.Index do
   require Logger
 
   defmodule MergeWorkflow do
-    defstruct [:id, :name, :is_changed, :is_diverged, :is_new, :is_deleted]
+    defstruct [
+      :id,
+      :name,
+      :is_changed,
+      :is_diverged,
+      :is_new,
+      :is_deleted
+    ]
   end
 
   on_mount {LightningWeb.Hooks, :project_scope}
@@ -281,16 +288,23 @@ defmodule LightningWeb.SandboxLive.Index do
 
   @impl true
   def handle_event("toggle-workflow", %{"id" => workflow_id}, socket) do
-    selected = socket.assigns.merge_selected_workflow_ids
+    in_list? =
+      Enum.any?(socket.assigns.merge_source_workflows, &(&1.id == workflow_id))
 
-    new_selected =
-      if MapSet.member?(selected, workflow_id) do
-        MapSet.delete(selected, workflow_id)
-      else
-        MapSet.put(selected, workflow_id)
-      end
+    if in_list? do
+      selected = socket.assigns.merge_selected_workflow_ids
 
-    {:noreply, assign(socket, :merge_selected_workflow_ids, new_selected)}
+      new_selected =
+        if MapSet.member?(selected, workflow_id) do
+          MapSet.delete(selected, workflow_id)
+        else
+          MapSet.put(selected, workflow_id)
+        end
+
+      {:noreply, assign(socket, :merge_selected_workflow_ids, new_selected)}
+    else
+      {:noreply, socket}
+    end
   end
 
   @impl true
@@ -890,14 +904,20 @@ defmodule LightningWeb.SandboxLive.Index do
         }
       end)
 
+    # Target-only workflows are those in the project but absent from the sandbox.
+    # A workflow added to the project after the fork was never in this sandbox,
+    # so it is not part of the merge and is dropped from the list entirely. What
+    # remains are workflows deleted in the sandbox: they default to unchecked so
+    # a merge never silently deletes them, and removal is opt-in.
     deleted_entries =
       target_workflows
       |> Enum.reject(fn wf -> MapSet.member?(source_workflow_names, wf.name) end)
+      |> Enum.reject(fn wf -> workflow_added_after_fork?(wf, source) end)
       |> Enum.map(fn wf ->
         %MergeWorkflow{
           id: wf.id,
           name: wf.name,
-          is_changed: true,
+          is_changed: false,
           is_diverged: false,
           is_new: false,
           is_deleted: true
@@ -908,31 +928,36 @@ defmodule LightningWeb.SandboxLive.Index do
     |> Enum.sort_by(fn wf -> wf.name end)
   end
 
+  defp workflow_added_after_fork?(%{inserted_at: %DateTime{} = wf_inserted}, %{
+         inserted_at: %DateTime{} = fork_time
+       }) do
+    DateTime.compare(wf_inserted, fork_time) == :gt
+  end
+
+  defp workflow_added_after_fork?(_workflow, _source), do: false
+
+  # Always pass an explicit selection so unchecked target-only workflows are
+  # kept, not deleted. Only workflows deleted in the sandbox reach this list as
+  # target-only, and only the ones the user checks are removed.
   defp resolve_selected_workflow_ids(assigns) do
-    all_ids = MapSet.new(assigns.merge_source_workflows, fn wf -> wf.id end)
+    deleted_ids =
+      assigns.merge_source_workflows
+      |> Enum.filter(fn wf -> wf.is_deleted end)
+      |> MapSet.new(fn wf -> wf.id end)
 
-    if MapSet.equal?(assigns.merge_selected_workflow_ids, all_ids) do
-      {nil, nil}
-    else
-      deleted_ids =
-        assigns.merge_source_workflows
-        |> Enum.filter(fn wf -> wf.is_deleted end)
-        |> MapSet.new(fn wf -> wf.id end)
+    selected = assigns.merge_selected_workflow_ids
 
-      selected = assigns.merge_selected_workflow_ids
+    selected_source_ids =
+      selected
+      |> Enum.reject(&MapSet.member?(deleted_ids, &1))
+      |> Enum.to_list()
 
-      selected_source_ids =
-        selected
-        |> Enum.reject(&MapSet.member?(deleted_ids, &1))
-        |> Enum.to_list()
+    selected_deleted_ids =
+      selected
+      |> Enum.filter(&MapSet.member?(deleted_ids, &1))
+      |> Enum.to_list()
 
-      selected_deleted_ids =
-        selected
-        |> Enum.filter(&MapSet.member?(deleted_ids, &1))
-        |> Enum.to_list()
-
-      {selected_source_ids, selected_deleted_ids}
-    end
+    {selected_source_ids, selected_deleted_ids}
   end
 
   defp preload_merge_projects(source, nil),
@@ -991,17 +1016,11 @@ defmodule LightningWeb.SandboxLive.Index do
        ) do
     maybe_commit_to_github(target, "pre-merge commit")
 
-    opts =
-      if selected_workflow_ids do
-        %{
-          selected_workflow_ids: selected_workflow_ids,
-          deleted_target_workflow_ids: deleted_target_workflow_ids
-        }
-      else
-        %{}
-      end
-
-    opts = Map.put(opts, :selected_credential_ids, selected_credential_ids)
+    opts = %{
+      selected_workflow_ids: selected_workflow_ids,
+      deleted_target_workflow_ids: deleted_target_workflow_ids,
+      selected_credential_ids: selected_credential_ids
+    }
 
     case Sandboxes.merge(source, target, actor, opts) do
       {:ok, _updated_target} = success ->

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -3579,16 +3579,22 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       assert MapSet.member?(assigns.merge_selected_workflow_ids, changed_data.id)
     end
 
-    test "target-only workflows appear in list with is_deleted flag and badge",
+    test "target-only workflows appear in list unchecked by default",
          %{
            conn: conn,
            parent: parent,
            sandbox: sandbox
          } do
-      # Parent has "Alpha" and "Gamma" — sandbox only has "Alpha"
-      # so "Gamma" was deleted in the sandbox
+      # Gamma existed before the fork, so it is in the project but not the sandbox.
       _parent_alpha = insert(:workflow, project: parent, name: "Alpha")
-      _parent_gamma = insert(:workflow, project: parent, name: "Gamma")
+
+      _parent_gamma =
+        insert(:workflow,
+          project: parent,
+          name: "Gamma",
+          inserted_at: DateTime.add(sandbox.inserted_at, -3600, :second)
+        )
+
       _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
 
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
@@ -3603,16 +3609,140 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       gamma_data =
         Enum.find(assigns.merge_source_workflows, &(&1.name == "Gamma"))
 
-      assert gamma_data
-      assert gamma_data.is_deleted
-      refute gamma_data.is_new
-      refute gamma_data.is_diverged
+      assert %{
+               is_deleted: true,
+               is_new: false,
+               is_diverged: false,
+               is_changed: false
+             } = gamma_data
 
-      # The gamma workflow's ID in the list is the target (parent) workflow ID
-      assert MapSet.member?(assigns.merge_selected_workflow_ids, gamma_data.id)
+      refute MapSet.member?(assigns.merge_selected_workflow_ids, gamma_data.id)
 
-      # Badge shown in HTML
       assert html =~ "Deleted in sandbox"
+    end
+
+    test "target-only workflow added after the fork is hidden from the merge list",
+         %{conn: conn, parent: parent, sandbox: sandbox} do
+      _parent_alpha = insert(:workflow, project: parent, name: "Alpha")
+
+      _parent_added =
+        insert(:workflow,
+          project: parent,
+          name: "Added Later",
+          inserted_at: DateTime.add(sandbox.inserted_at, 3600, :second)
+        )
+
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      html =
+        view
+        |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+        |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      # A workflow added to the project after the fork is not part of this
+      # sandbox's merge, so it does not appear in the list at all.
+      refute Enum.any?(
+               assigns.merge_source_workflows,
+               &(&1.name == "Added Later")
+             )
+
+      refute html =~ "Added Later"
+    end
+
+    test "explicitly checking a target-only workflow deletes it on merge",
+         %{conn: conn, parent: parent, sandbox: sandbox} do
+      parent_alpha = insert(:workflow, project: parent, name: "Alpha")
+
+      parent_gamma =
+        insert(:workflow,
+          project: parent,
+          name: "Gamma",
+          inserted_at: DateTime.add(sandbox.inserted_at, -3600, :second)
+        )
+
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      render_click(view, "toggle-workflow", %{"id" => parent_gamma.id})
+
+      render_click(view, "confirm-merge", %{
+        "merge" => %{"target_id" => parent.id}
+      })
+
+      assert Lightning.Repo.reload(parent_gamma).deleted_at
+      refute Lightning.Repo.reload(parent_alpha).deleted_at
+    end
+
+    test "target-only workflow is kept when left unchecked on merge",
+         %{conn: conn, parent: parent, sandbox: sandbox} do
+      parent_alpha = insert(:workflow, project: parent, name: "Alpha")
+
+      parent_added =
+        insert(:workflow,
+          project: parent,
+          name: "Added Later",
+          inserted_at: DateTime.add(sandbox.inserted_at, 3600, :second)
+        )
+
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      render_click(view, "confirm-merge", %{
+        "merge" => %{"target_id" => parent.id}
+      })
+
+      refute Lightning.Repo.reload(parent_added).deleted_at
+      refute Lightning.Repo.reload(parent_alpha).deleted_at
+    end
+
+    test "target-only workflow added after the fork cannot be deleted even if toggled",
+         %{conn: conn, parent: parent, sandbox: sandbox} do
+      parent_alpha = insert(:workflow, project: parent, name: "Alpha")
+
+      parent_added =
+        insert(:workflow,
+          project: parent,
+          name: "Added Later",
+          inserted_at: DateTime.add(sandbox.inserted_at, 3600, :second)
+        )
+
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      # The workflow is not in the merge list, so a forced toggle event for it
+      # is ignored and it can never be selected for deletion.
+      render_click(view, "toggle-workflow", %{"id" => parent_added.id})
+
+      refute MapSet.member?(
+               :sys.get_state(view.pid).socket.assigns.merge_selected_workflow_ids,
+               parent_added.id
+             )
+
+      render_click(view, "confirm-merge", %{
+        "merge" => %{"target_id" => parent.id}
+      })
+
+      refute Lightning.Repo.reload(parent_added).deleted_at
+      refute Lightning.Repo.reload(parent_alpha).deleted_at
     end
 
     test "workflow selection UI shows per-row status badges", %{
@@ -4142,7 +4272,8 @@ defmodule LightningWeb.SandboxLive.IndexTest do
             apiSecretName: api_secret_name(parent),
             branch: repo_connection.branch,
             pathToConfig: path_to_config(repo_connection),
-            commitMessage: "Merged sandbox #{sandbox.name}"
+            commitMessage: "Merged sandbox #{sandbox.name}",
+            snapshots: "#{snapshot.id}"
           }
         }
       )
@@ -4209,7 +4340,8 @@ defmodule LightningWeb.SandboxLive.IndexTest do
             apiSecretName: api_secret_name(parent),
             branch: repo_connection.branch,
             pathToConfig: path_to_config(repo_connection),
-            commitMessage: "Merged sandbox #{sandbox.name}"
+            commitMessage: "Merged sandbox #{sandbox.name}",
+            snapshots: "#{snapshot.id}"
           }
         }
       )


### PR DESCRIPTION
## Description

This fixes a data-loss bug in the sandbox merge. A workflow added to a project after a sandbox was branched was flagged for deletion and pre-selected on the merge screen, so a routine merge could silently delete it.

The merge screen now excludes those workflows entirely: a workflow added to the project after the fork was never part of the sandbox, so it does not appear and the merge never touches it. Workflows deleted inside the sandbox still appear, default to unchecked, and are removed only if you explicitly select them, so deletion is opt-in and anything left unchecked is kept.

Closes #4919

## Validation steps

**Delete a workflow in the sandbox**

1. Create a project with one workflow, then create a sandbox from it.
2. In the sandbox, delete the workflow.
3. Open the sandbox's merge screen and select the project as the target.
4. Check that the workflow is listed as "Deleted in sandbox" and unchecked.
5. Merge without checking it. Check that the workflow still exists in the project.
6. Open the merge screen again, tick the workflow, and merge. Check that the workflow is now gone from the project.

**Add a workflow to the project after branching**

1. Create a project, then create a sandbox from it.
2. In the project, create a new workflow.
3. Open the sandbox's merge screen and select the project as the target.
4. Check that the new workflow is not listed.
5. Merge. Check that the new workflow still exists in the project.

**Merge normally**

1. In a sandbox, create a workflow and edit an existing one.
2. Open the merge screen and select the project as the target.
3. Check that both workflows are ticked.
4. Merge without changing the selection. Check that the new workflow is created in the project, the edit is applied, and no workflow was deleted.

## Additional notes for the reviewer

Telling a workflow added to the project after the fork apart from one deleted in the sandbox is inferred from the workflow's creation time relative to the sandbox, because fork lineage is not persisted yet. That inference only decides which workflows are shown; it never deletes anything on its own, so the fix is safe regardless of its accuracy. The deterministic follow-up, persisting fork lineage, is tracked in #4938.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
