### PR TITLE
Make database name configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,13 @@
 # using `env $(cat .env | grep -v "#" | xargs )` set the database url directly:
 # DATABASE_URL=postgres://hello:password@localhost/lightning_dev
 
+# Override the dev and test database names without passing DATABASE_URL on every
+# command. Useful when running multiple checkouts or related repos against the
+# same Postgres instance, so each uses its own database. Both default to the
+# names above.
+# DEV_DATABASE_NAME=lightning_dev
+# TEST_DATABASE_NAME=lightning_test
+
 # ==============================================================================
 
 # Generate secure keys, see ./DEPLOYMENT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to
   than 100, this will result in failures.
 - Replaced the legacy editor with the collaborative editor for all users
   [#4402](https://github.com/OpenFn/lightning/issues/4402)
+- Made dev and test database names configurable via `DEV_DATABASE_NAME` and
+  `TEST_DATABASE_NAME` environment variables
+  [#4963](https://github.com/OpenFn/lightning/pull/4693)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to
   [#4402](https://github.com/OpenFn/lightning/issues/4402)
 - Made dev and test database names configurable via `DEV_DATABASE_NAME` and
   `TEST_DATABASE_NAME` environment variables
-  [#4963](https://github.com/OpenFn/lightning/pull/4693)
+  [#4963](https://github.com/OpenFn/lightning/pull/4963)
 
 ### Fixed
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,7 +7,7 @@ config :lightning, Lightning.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "lightning_dev",
+  database: System.get_env("DEV_DATABASE_NAME", "lightning_dev"),
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -36,7 +36,9 @@ config :lightning, Lightning.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "lightning_test#{System.get_env("MIX_TEST_PARTITION")}",
+  database:
+    System.get_env("TEST_DATABASE_NAME", "lightning_test") <>
+      "#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 15,
   queue_target: 100,

--- a/config/test.exs
+++ b/config/test.exs
@@ -37,8 +37,7 @@ config :lightning, Lightning.Repo,
   password: "postgres",
   hostname: "localhost",
   database:
-    System.get_env("TEST_DATABASE_NAME", "lightning_test") <>
-      "#{System.get_env("MIX_TEST_PARTITION")}",
+    "#{System.get_env("TEST_DATABASE_NAME", "lightning_test")}#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 15,
   queue_target: 100,


### PR DESCRIPTION
Lifted out of https://github.com/OpenFn/lightning/pull/4603

Please merge or close. I barely know what this is - I'm just saving Stu's work

From @stuartc's notes:

> makes dev/test database names configurable via DEV_DATABASE_NAME and
TEST_DATABASE_NAME environment variables (defaulting to the existing names).
This is useful when working on multiple checkouts or related repos (e.g.
lightning and thunderbolt) simultaneously, allowing each to use separate
databases without conflicts. Without this, developers need to pass
DATABASE_URL on every command or risk collisions between repos sharing the
same Postgres instance.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
