### PR TITLE
Lint: fix credo error

### DIFF
--- a/assets/test/collaborative-editor/components/Header.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.test.tsx
@@ -6,7 +6,13 @@
  * proper integration within the Header component.
  */
 
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  cleanup as reactCleanup,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import type React from 'react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as Y from 'yjs';
@@ -42,20 +48,12 @@ vi.mock('../../../js/workflow-diagram/useAdaptorIcons', () => ({
   default: () => ({}),
 }));
 
-// =============================================================================
-// TEST ISOLATION
-// =============================================================================
-
-// `createTestSetup` stashes the store/channel cleanup for the test currently
-// running here, so a single top-level `afterEach` can tear it down. Without
-// this, subscriptions from one test's Y.Doc/channel/provider stay alive and
-// leak state (and pending `waitFor`/timers) into the next test.
-let activeCleanup: (() => void) | null = null;
+let storeCleanup: (() => void) | null = null;
 
 afterEach(() => {
-  activeCleanup?.();
-  activeCleanup = null;
-  cleanup();
+  storeCleanup?.();
+  storeCleanup = null;
+  reactCleanup();
   urlState.reset();
 });
 
@@ -153,9 +151,7 @@ async function createTestSetup(options: WrapperOptions = {}) {
     }
   );
 
-  // Track this test's cleanup so the top-level `afterEach` can always tear
-  // it down, even though most call sites never destructure `cleanup`.
-  activeCleanup = cleanup;
+  storeCleanup = cleanup;
 
   if (options.triggerSync) {
     // Trigger provider sync to enable save functionality

--- a/assets/test/collaborative-editor/components/Header.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.test.tsx
@@ -6,9 +6,9 @@
  * proper integration within the Header component.
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import type React from 'react';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as Y from 'yjs';
 
 import { Header } from '../../../js/collaborative-editor/components/Header';
@@ -41,6 +41,23 @@ vi.mock('../../../js/react/lib/use-url-state', () => ({
 vi.mock('../../../js/workflow-diagram/useAdaptorIcons', () => ({
   default: () => ({}),
 }));
+
+// =============================================================================
+// TEST ISOLATION
+// =============================================================================
+
+// `createTestSetup` stashes the store/channel cleanup for the test currently
+// running here, so a single top-level `afterEach` can tear it down. Without
+// this, subscriptions from one test's Y.Doc/channel/provider stay alive and
+// leak state (and pending `waitFor`/timers) into the next test.
+let activeCleanup: (() => void) | null = null;
+
+afterEach(() => {
+  activeCleanup?.();
+  activeCleanup = null;
+  cleanup();
+  urlState.reset();
+});
 
 // =============================================================================
 // TEST HELPERS
@@ -135,6 +152,10 @@ async function createTestSetup(options: WrapperOptions = {}) {
       emitSessionContext: true,
     }
   );
+
+  // Track this test's cleanup so the top-level `afterEach` can always tear
+  // it down, even though most call sites never destructure `cleanup`.
+  activeCleanup = cleanup;
 
   if (options.triggerSync) {
     // Trigger provider sync to enable save functionality
@@ -1383,9 +1404,8 @@ describe('Header - Keyboard Shortcuts', () => {
 // =============================================================================
 
 describe('Header - AI Assistant Button', () => {
-  beforeEach(() => {
-    urlState.reset();
-  });
+  // urlState is reset by the top-level `afterEach` above, so no
+  // block-local `beforeEach` is needed here.
 
   test('AI button is enabled by default when aiAssistantEnabled prop is true', async () => {
     const { wrapper, emitSessionContext } = await createTestSetup();

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -912,6 +912,7 @@ defmodule LightningWeb.SandboxLive.Index do
     deleted_entries =
       target_workflows
       |> Enum.reject(fn wf -> MapSet.member?(source_workflow_names, wf.name) end)
+      # credo:disable-for-next-line Credo.Check.Refactor.RejectReject
       |> Enum.reject(fn wf -> workflow_added_after_fork?(wf, source) end)
       |> Enum.map(fn wf ->
         %MergeWorkflow{

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -911,9 +911,10 @@ defmodule LightningWeb.SandboxLive.Index do
     # a merge never silently deletes them, and removal is opt-in.
     deleted_entries =
       target_workflows
-      |> Enum.reject(fn wf -> MapSet.member?(source_workflow_names, wf.name) end)
-      # credo:disable-for-next-line Credo.Check.Refactor.RejectReject
-      |> Enum.reject(fn wf -> workflow_added_after_fork?(wf, source) end)
+      |> Enum.reject(fn wf ->
+        MapSet.member?(source_workflow_names, wf.name) or
+          workflow_added_after_fork?(wf, source)
+      end)
       |> Enum.map(fn wf ->
         %MergeWorkflow{
           id: wf.id,


### PR DESCRIPTION
Our lint tests are failing for a bunch of reasons, but one of them is this credo error:

> One `Enum.reject/2` is more efficient than `Enum.reject/2 |> 
┃       Enum.reject/2`

Looking at the code in question I'm not too worried about performance, I think the code is clearer using two iterations.

Claude says this:

> our current code has a comment on line 907-911 explaining why target-only-added-after-fork workflows get dropped, and the two separate rejects read as two distinct filtering concerns ("drop ones still in the sandbox" then "drop ones added after the fork"). Merging them into a single or slightly blurs those two intents.  On a list of workflows the efficiency gain is negligible.

On that basis I've disabled credo for that line. Open to suggestions but I think this is quite reasonable.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
