### PR TITLE
Handle deleted workflows and snapshot failures in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to
   project is opt-in. [#4919](https://github.com/OpenFn/lightning/issues/4919)
 - Fixed an issue where LOCAL_ADAPTORS is not respected by install_schemas task
   [#4943](https://github.com/OpenFn/lightning/issues/4943)
+- Return clean API errors when a workflow is deleted during save or its snapshot
+  cannot be saved, instead of allowing the workflows controller to crash.
+  [#4960](https://github.com/OpenFn/lightning/issues/4960)
 - Prevent AI Assistant channel joins from crashing when a chat references a
   deleted workflow or project. Missing records now fail authorization cleanly.
   [#4914](https://github.com/OpenFn/lightning/issues/4914)

--- a/lib/lightning_web/controllers/api/workflows_controller.ex
+++ b/lib/lightning_web/controllers/api/workflows_controller.ex
@@ -562,6 +562,19 @@ defmodule LightningWeb.API.WorkflowsController do
     |> json(%{id: workflow_id, errors: ["Not Found"]})
   end
 
+  defp maybe_handle_error(conn, {:error, :workflow_deleted}, workflow_id),
+    do: maybe_handle_error(conn, {:error, :not_found}, workflow_id)
+
+  defp maybe_handle_error(conn, {:error, reason}, workflow_id)
+       when reason in [:snapshot_failed, false] do
+    conn
+    |> put_status(:internal_server_error)
+    |> json(%{
+      id: workflow_id,
+      errors: ["Could not save the workflow snapshot."]
+    })
+  end
+
   defp maybe_handle_error(_conn, result, _workflow_id) when is_map(result),
     do: result
 

--- a/test/lightning_web/controllers/api/workflows_controller_test.exs
+++ b/test/lightning_web/controllers/api/workflows_controller_test.exs
@@ -998,6 +998,55 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
                |> json_response(404)
     end
 
+    test "returns 404 when the workflow is deleted before update", %{
+      conn: conn,
+      project: project
+    } do
+      workflow = insert(:simple_workflow, project: project)
+
+      workflow =
+        workflow
+        |> Ecto.Changeset.change(
+          deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+        |> Repo.update!()
+
+      assert %{"id" => workflow_id, "errors" => ["Not Found"]} =
+               conn
+               |> patch(
+                 ~p"/api/projects/#{project.id}/workflows/#{workflow.id}",
+                 Jason.encode!(%{name: "work1.1"})
+               )
+               |> json_response(404)
+
+      assert workflow_id == workflow.id
+    end
+
+    test "returns 500 when the workflow snapshot cannot be saved", %{
+      conn: conn,
+      project: project
+    } do
+      workflow = insert(:simple_workflow, project: project)
+
+      insert(:snapshot,
+        workflow: workflow,
+        lock_version: workflow.lock_version + 1
+      )
+
+      assert %{
+               "id" => workflow_id,
+               "errors" => ["Could not save the workflow snapshot."]
+             } =
+               conn
+               |> patch(
+                 ~p"/api/projects/#{project.id}/workflows/#{workflow.id}",
+                 Jason.encode!(%{name: "work1.1"})
+               )
+               |> json_response(500)
+
+      assert workflow_id == workflow.id
+    end
+
     test "returns 409 when the workflow is being edited on the UI" do
       %{conn: conn, user: user} =
         register_and_log_in_user(%{conn: Phoenix.ConnTest.build_conn()})


### PR DESCRIPTION
## Description

This PR fixes the workflows REST API so failures from `save_workflow/3` are
returned as proper HTTP responses instead of falling through as raw tuples and
crashing the Phoenix controller.

The controller now:

- Returns `404 Not Found` when a workflow is soft-deleted between fetch and
  save.
- Returns `500 Internal Server Error` when saving the workflow snapshot fails.
- Accepts both the current `false` snapshot failure value and the clearer
  `:snapshot_failed` value introduced by the related save-workflow work.

It also adds regression coverage and an Unreleased changelog entry.

Closes #4960

## Validation steps

1. Run `mix test test/lightning_web/controllers/api/workflows_controller_test.exs`.
2. Confirm the workflow update tests report `57 tests, 0 failures`.
3. Review the deleted-workflow case and confirm it returns `404` with
   `errors: ["Not Found"]`.
4. Review the snapshot-failure case and confirm it returns `500` with a clear
   snapshot error instead of crashing the controller.

Validated with:

- `mix test test/lightning_web/controllers/api/workflows_controller_test.exs`
- `mix compile --warnings-as-errors`
- `git diff --check`

## Additional notes for the reviewer

1. The root cause was the final tuple fallback in `maybe_handle_error/3`, which
   returned these unhandled failures unchanged. Phoenix controllers must return
   a connection or a valid response, so the raw tuple caused the request to
   crash.
2. The current `save_workflow/3` implementation returns `false` for a snapshot
   failure, while the clearer `:snapshot_failed` atom is used by the related
   change discussed in PR #4918. Handling both keeps this fix correct for the
   current branch and forward-compatible with that naming improvement.
3. There is no separate POST regression test because POST and PATCH both pass
   through the same `maybe_handle_error/3` clauses. Triggering a snapshot
   collision during creation would require artificial database setup and would
   test a different failure mechanism rather than a different controller
   contract. The two PATCH tests cover both distinct error responses directly.
4. The response choices follow the issue's suggested semantics: deleted
   resources return `404`, while a snapshot persistence failure returns `500`.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [x] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
  *Not applicable: this PR only changes error handling after the existing authorization checks.*
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage"

*This PR was developed by Codex with jmtdev0's supervision.*
