### PR TITLE
feat: send sales notification on SSO register

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -224,6 +224,11 @@
 # https://impact.openfn.org. Use the below if you wish to change that.
 # USAGE_TRACKER_HOST=https://impact.openfn.org
 
+# Optional. When set, a fire-and-forget POST is sent to this OpenFn workflow
+# webhook whenever a user signs up via SSO (feeds the sales/CRM pipeline).
+# Leave unset to disable (self-hosted instances typically don't need this).
+# OPENFN_TRIGGER_URL=https://app.openfn.org/i/your-webhook-uuid
+
 # Restrict the number of days that reports will be generated for with each run of
 # `Lightning.UsageTracking.DayWorker. This will only have a noticeable effect in
 # cases where there is a backlog (e.g when the Worker has not run for an extended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 ### Added
 
+- Notify a configurable webhook on SSO signup, via the optional
+  `OPENFN_TRIGGER_URL`. [#4961](https://github.com/OpenFn/lightning/issues/4961)
 - Report monthly active users (MAU) — distinct users active in the trailing 30
   days — in the usage tracker submission, alongside the existing 90-day active
   user count. Reported at both instance and project level, and bumps the usage

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,6 +14,7 @@ config :tesla, Mix.Tasks.Lightning.InstallAdaptorIcons, adapter: Tesla.Mock
 
 config :tesla, Lightning.UsageTracking.Client, adapter: Tesla.Mock
 config :tesla, Lightning.UsageTracking.GithubClient, adapter: Tesla.Mock
+config :tesla, Lightning.Accounts.SsoRegistrationNotifier, adapter: Tesla.Mock
 
 # Configure your database
 #

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -12,6 +12,7 @@ defmodule Lightning.Accounts do
   alias Ecto.Changeset
   alias Ecto.Multi
   alias Lightning.Accounts.Events
+  alias Lightning.Accounts.SsoRegistrationNotifier
   alias Lightning.Accounts.User
   alias Lightning.Accounts.UserBackupCode
   alias Lightning.Accounts.UserIdentity
@@ -332,6 +333,7 @@ defmodule Lightning.Accounts do
     |> tap(fn result ->
       with {:ok, user} <- result do
         Events.user_registered(user)
+        SsoRegistrationNotifier.enqueue(user)
       end
     end)
   end

--- a/lib/lightning/accounts/sso_registration_notifier.ex
+++ b/lib/lightning/accounts/sso_registration_notifier.ex
@@ -8,7 +8,7 @@ defmodule Lightning.Accounts.SsoRegistrationNotifier do
   """
   use Oban.Worker,
     queue: :background,
-    max_attempts: 3
+    max_attempts: 1
 
   alias Lightning.Accounts.User
   alias Tesla.Multipart
@@ -36,6 +36,13 @@ defmodule Lightning.Accounts.SsoRegistrationNotifier do
     end
 
     :ok
+  rescue
+    error ->
+      Logger.warning(
+        "Could not enqueue SSO registration notify: #{inspect(error)}"
+      )
+
+      :ok
   end
 
   @impl Oban.Worker
@@ -61,8 +68,6 @@ defmodule Lightning.Accounts.SsoRegistrationNotifier do
         :ok
 
       {:ok, %Tesla.Env{status: status}} ->
-        # Fire-and-forget: log but don't fail the registration flow. Retrying
-        # a non-2xx is harmless, so let Oban retry up to max_attempts.
         Logger.warning("OpenFn registration notify returned status #{status}")
 
         {:error, :unexpected_status}

--- a/lib/lightning/accounts/sso_registration_notifier.ex
+++ b/lib/lightning/accounts/sso_registration_notifier.ex
@@ -1,0 +1,116 @@
+defmodule Lightning.Accounts.SsoRegistrationNotifier do
+  @moduledoc """
+  Fire-and-forget notification to the OpenFn registration workflow trigger when
+  a user signs up via SSO.
+
+  The webhook expects a `multipart/form-data` body with string values; missing
+  fields are sent as empty strings so the downstream mapping stays stable.
+  """
+  use Oban.Worker,
+    queue: :background,
+    max_attempts: 3
+
+  alias Lightning.Accounts.User
+  alias Tesla.Multipart
+
+  require Logger
+
+  @doc """
+  Enqueues a registration notification for the given user.
+
+  No-op (returns `:ok`) when `OPENFN_TRIGGER_URL` is not configured, so
+  self-hosted instances are unaffected.
+  """
+  @spec enqueue(User.t()) :: :ok
+  def enqueue(%User{} = user) do
+    if Lightning.Config.openfn_trigger_url() do
+      changeset =
+        new(%{
+          "new_user_id" => user.id,
+          "email" => user.email,
+          "first_name" => user.first_name,
+          "last_name" => user.last_name
+        })
+
+      Oban.insert(Lightning.Oban, changeset)
+    end
+
+    :ok
+  end
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    case Lightning.Config.openfn_trigger_url() do
+      url when is_binary(url) and url != "" ->
+        post(url, args)
+
+      _ ->
+        Logger.info(
+          "OPENFN_TRIGGER_URL not set; skipping SSO registration notify"
+        )
+
+        :ok
+    end
+  end
+
+  defp post(url, args) do
+    multipart = build_multipart(args)
+
+    case Tesla.post(client(), url, multipart) do
+      {:ok, %Tesla.Env{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %Tesla.Env{status: status}} ->
+        # Fire-and-forget: log but don't fail the registration flow. Retrying
+        # a non-2xx is harmless, so let Oban retry up to max_attempts.
+        Logger.warning("OpenFn registration notify returned status #{status}")
+
+        {:error, :unexpected_status}
+
+      {:error, reason} ->
+        Logger.warning("OpenFn registration notify failed: #{inspect(reason)}")
+
+        {:error, reason}
+    end
+  end
+
+  # All values are strings; fields we don't have are sent as empty strings.
+  defp build_multipart(args) do
+    first_name = Map.get(args, "first_name")
+    last_name = Map.get(args, "last_name")
+
+    name =
+      [first_name, last_name]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join(" ")
+
+    [
+      {"type", "registration"},
+      {"email", Map.get(args, "email")},
+      {"name", name},
+      {"firstName", first_name},
+      {"lastName", last_name},
+      {"new_user_id", Map.get(args, "new_user_id")},
+      {"project_id", ""},
+      {"contactPreference", ""},
+      {"industry", ""},
+      {"phone", ""},
+      {"organization", ""},
+      {"role", ""},
+      {"websiteUrl", ""},
+      {"intention", ""},
+      {"adaptors", ""}
+    ]
+    |> Enum.reduce(Multipart.new(), fn {key, value}, mp ->
+      Multipart.add_field(mp, key, to_string(value || ""))
+    end)
+  end
+
+  defp client do
+    Tesla.client([], adapter())
+  end
+
+  defp adapter do
+    Application.get_env(:tesla, __MODULE__, [])[:adapter]
+  end
+end

--- a/lib/lightning/config.ex
+++ b/lib/lightning/config.ex
@@ -216,6 +216,12 @@ defmodule Lightning.Config do
     end
 
     @impl true
+    def openfn_trigger_url do
+      Application.get_env(:lightning, :openfn_trigger, [])
+      |> Keyword.get(:url)
+    end
+
+    @impl true
     def usage_tracking_cron_opts do
       opts = usage_tracking()
 
@@ -518,6 +524,7 @@ defmodule Lightning.Config do
   @callback usage_tracking_enabled?() :: boolean()
   @callback usage_tracking_host() :: String.t()
   @callback usage_tracking_run_chunk_size() :: integer()
+  @callback openfn_trigger_url() :: String.t() | nil
   @callback worker_secret() :: binary() | nil
   @callback worker_token_signer() :: Joken.Signer.t()
   @callback adaptor_registry() :: Keyword.t()
@@ -699,6 +706,10 @@ defmodule Lightning.Config do
 
   def usage_tracking_run_chunk_size do
     impl().usage_tracking_run_chunk_size()
+  end
+
+  def openfn_trigger_url do
+    impl().openfn_trigger_url()
   end
 
   def kafka_triggers_enabled? do

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -765,6 +765,9 @@ defmodule Lightning.Config.Bootstrap do
       daily_batch_size: env!("USAGE_TRACKING_DAILY_BATCH_SIZE", :integer, 10),
       run_chunk_size: env!("USAGE_TRACKING_RUN_CHUNK_SIZE", :integer, 100)
 
+    config :lightning, :openfn_trigger,
+      url: env!("OPENFN_TRIGGER_URL", :string, nil)
+
     config :lightning, :kafka_triggers,
       alternate_storage_enabled:
         env!(

--- a/test/lightning/accounts/sso_registration_notifier_test.exs
+++ b/test/lightning/accounts/sso_registration_notifier_test.exs
@@ -1,0 +1,117 @@
+defmodule Lightning.Accounts.SsoRegistrationNotifierTest do
+  use Lightning.DataCase, async: false
+
+  import Tesla.Mock
+
+  alias Lightning.Accounts.SsoRegistrationNotifier
+
+  @url "https://example.test/i/test-webhook"
+
+  setup do
+    previous = Application.get_env(:lightning, :openfn_trigger)
+    Application.put_env(:lightning, :openfn_trigger, url: @url)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:lightning, :openfn_trigger, previous)
+      else
+        Application.delete_env(:lightning, :openfn_trigger)
+      end
+    end)
+
+    :ok
+  end
+
+  # Extract multipart form fields as a %{name => value} map from a Tesla request.
+  defp form_fields(%Tesla.Multipart{parts: parts}) do
+    Map.new(parts, fn part ->
+      {Keyword.get(part.dispositions, :name), part.body}
+    end)
+  end
+
+  describe "perform/1" do
+    test "posts a multipart registration payload with all fields" do
+      test_pid = self()
+
+      mock_global(fn %{method: :post, url: @url, body: body} ->
+        send(test_pid, {:posted, form_fields(body)})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      args = %{
+        "new_user_id" => "usr_123",
+        "email" => "ada@example.org",
+        "first_name" => "Ada",
+        "last_name" => "Lovelace"
+      }
+
+      assert :ok = perform_job(SsoRegistrationNotifier, args)
+
+      assert_received {:posted, fields}
+
+      assert fields["type"] == "registration"
+      assert fields["email"] == "ada@example.org"
+      assert fields["name"] == "Ada Lovelace"
+      assert fields["firstName"] == "Ada"
+      assert fields["lastName"] == "Lovelace"
+      assert fields["new_user_id"] == "usr_123"
+
+      # Keys are always sent, even when empty.
+      for key <- ~w(project_id contactPreference industry phone organization
+                    role websiteUrl intention adaptors) do
+        assert fields[key] == "", "expected #{key} to be an empty string"
+      end
+    end
+
+    test "derives name from only the parts present, sends missing as empty" do
+      test_pid = self()
+
+      mock_global(fn %{method: :post, body: body} ->
+        send(test_pid, {:posted, form_fields(body)})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      args = %{
+        "new_user_id" => "usr_1",
+        "email" => "solo@example.org",
+        "first_name" => "Solo",
+        "last_name" => nil
+      }
+
+      assert :ok = perform_job(SsoRegistrationNotifier, args)
+
+      assert_received {:posted, fields}
+      assert fields["name"] == "Solo"
+      assert fields["lastName"] == ""
+    end
+
+    test "returns an error on a non-2xx response so Oban can retry" do
+      mock_global(fn %{method: :post} -> %Tesla.Env{status: 500, body: ""} end)
+
+      assert {:error, :unexpected_status} =
+               perform_job(SsoRegistrationNotifier, %{
+                 "new_user_id" => "usr_1",
+                 "email" => "x@example.org"
+               })
+    end
+
+    test "skips (returns :ok) when the trigger url is not configured" do
+      Application.delete_env(:lightning, :openfn_trigger)
+
+      assert :ok =
+               perform_job(SsoRegistrationNotifier, %{"new_user_id" => "usr_1"})
+    end
+  end
+
+  describe "enqueue/1" do
+    test "is a no-op when the trigger url is not configured" do
+      Application.delete_env(:lightning, :openfn_trigger)
+
+      user = Lightning.AccountsFixtures.user_fixture()
+
+      # No Tesla.Mock is set, so any outbound call would fail; returning :ok
+      # without raising proves nothing was posted.
+      assert :ok = SsoRegistrationNotifier.enqueue(user)
+    end
+  end
+end

--- a/test/lightning/accounts/sso_registration_notifier_test.exs
+++ b/test/lightning/accounts/sso_registration_notifier_test.exs
@@ -3,6 +3,7 @@ defmodule Lightning.Accounts.SsoRegistrationNotifierTest do
 
   import Tesla.Mock
 
+  alias Lightning.Accounts
   alias Lightning.Accounts.SsoRegistrationNotifier
 
   @url "https://example.test/i/test-webhook"
@@ -33,7 +34,7 @@ defmodule Lightning.Accounts.SsoRegistrationNotifierTest do
     test "posts a multipart registration payload with all fields" do
       test_pid = self()
 
-      mock_global(fn %{method: :post, url: @url, body: body} ->
+      mock(fn %{method: :post, url: @url, body: body} ->
         send(test_pid, {:posted, form_fields(body)})
         %Tesla.Env{status: 200, body: ""}
       end)
@@ -66,7 +67,7 @@ defmodule Lightning.Accounts.SsoRegistrationNotifierTest do
     test "derives name from only the parts present, sends missing as empty" do
       test_pid = self()
 
-      mock_global(fn %{method: :post, body: body} ->
+      mock(fn %{method: :post, body: body} ->
         send(test_pid, {:posted, form_fields(body)})
         %Tesla.Env{status: 200, body: ""}
       end)
@@ -85,8 +86,8 @@ defmodule Lightning.Accounts.SsoRegistrationNotifierTest do
       assert fields["lastName"] == ""
     end
 
-    test "returns an error on a non-2xx response so Oban can retry" do
-      mock_global(fn %{method: :post} -> %Tesla.Env{status: 500, body: ""} end)
+    test "returns an error on a non-2xx response" do
+      mock(fn %{method: :post} -> %Tesla.Env{status: 500, body: ""} end)
 
       assert {:error, :unexpected_status} =
                perform_job(SsoRegistrationNotifier, %{
@@ -112,6 +113,31 @@ defmodule Lightning.Accounts.SsoRegistrationNotifierTest do
       # No Tesla.Mock is set, so any outbound call would fail; returning :ok
       # without raising proves nothing was posted.
       assert :ok = SsoRegistrationNotifier.enqueue(user)
+    end
+  end
+
+  describe "register_user_from_sso/3 integration" do
+    test "notifies the OpenFn trigger after a successful SSO registration" do
+      test_pid = self()
+
+      mock(fn %{method: :post, url: @url, body: body} ->
+        send(test_pid, {:notified, form_fields(body)})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      email = "sso-#{System.unique_integer([:positive])}@example.org"
+
+      assert {:ok, user} =
+               Accounts.register_user_from_sso(
+                 %{email: email, first_name: "Sso", last_name: "User"},
+                 "github",
+                 "notify-1"
+               )
+
+      assert_received {:notified, fields}
+      assert fields["type"] == "registration"
+      assert fields["email"] == email
+      assert fields["new_user_id"] == user.id
     end
   end
 end

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -310,6 +310,47 @@ defmodule Lightning.AccountsTest do
       # The user insert is rolled back with the failed identity link
       refute Accounts.get_user_by_email(email)
     end
+
+    test "notifies the OpenFn trigger when OPENFN_TRIGGER_URL is configured" do
+      url = "https://example.test/i/test-webhook"
+      previous = Application.get_env(:lightning, :openfn_trigger)
+      Application.put_env(:lightning, :openfn_trigger, url: url)
+
+      on_exit(fn ->
+        if previous do
+          Application.put_env(:lightning, :openfn_trigger, previous)
+        else
+          Application.delete_env(:lightning, :openfn_trigger)
+        end
+      end)
+
+      test_pid = self()
+
+      Tesla.Mock.mock_global(fn %{method: :post, url: ^url, body: body} ->
+        send(test_pid, {:notified, body})
+        %Tesla.Env{status: 200, body: ""}
+      end)
+
+      email = unique_user_email()
+
+      assert {:ok, user} =
+               Accounts.register_user_from_sso(
+                 %{email: email, first_name: "Sso", last_name: "User"},
+                 "github",
+                 "notify-1"
+               )
+
+      assert_receive {:notified, %Tesla.Multipart{parts: parts}}
+
+      fields =
+        Map.new(parts, fn part ->
+          {Keyword.get(part.dispositions, :name), part.body}
+        end)
+
+      assert fields["type"] == "registration"
+      assert fields["email"] == email
+      assert fields["new_user_id"] == user.id
+    end
   end
 
   describe "list_user_identities/1" do

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -310,47 +310,6 @@ defmodule Lightning.AccountsTest do
       # The user insert is rolled back with the failed identity link
       refute Accounts.get_user_by_email(email)
     end
-
-    test "notifies the OpenFn trigger when OPENFN_TRIGGER_URL is configured" do
-      url = "https://example.test/i/test-webhook"
-      previous = Application.get_env(:lightning, :openfn_trigger)
-      Application.put_env(:lightning, :openfn_trigger, url: url)
-
-      on_exit(fn ->
-        if previous do
-          Application.put_env(:lightning, :openfn_trigger, previous)
-        else
-          Application.delete_env(:lightning, :openfn_trigger)
-        end
-      end)
-
-      test_pid = self()
-
-      Tesla.Mock.mock_global(fn %{method: :post, url: ^url, body: body} ->
-        send(test_pid, {:notified, body})
-        %Tesla.Env{status: 200, body: ""}
-      end)
-
-      email = unique_user_email()
-
-      assert {:ok, user} =
-               Accounts.register_user_from_sso(
-                 %{email: email, first_name: "Sso", last_name: "User"},
-                 "github",
-                 "notify-1"
-               )
-
-      assert_receive {:notified, %Tesla.Multipart{parts: parts}}
-
-      fields =
-        Map.new(parts, fn part ->
-          {Keyword.get(part.dispositions, :name), part.body}
-        end)
-
-      assert fields["type"] == "registration"
-      assert fields["email"] == email
-      assert fields["new_user_id"] == user.id
-    end
   end
 
   describe "list_user_identities/1" do


### PR DESCRIPTION
## Description

This PR adds a webhook call for all newly registered users via SSO

Closes OpenFn/thunderbolt#671

## Validation steps

1. Create a webhook trigger that logs what comes to it.
2. Set that webhook URL as the `OPENFN_TRIGGER_URL`
3. Now create a new user account via SSO and validate whether the account creation data is found in your trigger workflow

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
