### PR TITLE
Enable Hex dependency cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ and this project adheres to
   than an application error.
   [#4947](https://github.com/OpenFn/lightning/issues/4947)
 
+### Security
+
+- Enabled Hex's dependency cooldown (`hex: [cooldown: "1w"]`), so newly-resolved
+  dependency versions must have existed for at least a week before Hex will pull
+  them in, mitigating supply-chain attacks that get caught and retired within
+  days. Normal builds against an intact `mix.lock` are unaffected.
+  `bin/bootstrap` now enforces Hex `>= 2.5.0`, which is required for the
+  cooldown to take effect.
+  [#4971](https://github.com/OpenFn/lightning/pull/4971)
+
 ## [2.16.8] - 2026-07-01
 
 ## [2.16.8-pre] - 2026-06-18

--- a/bin/bootstrap.d/common.sh
+++ b/bin/bootstrap.d/common.sh
@@ -151,6 +151,30 @@ ensure_tool_versions() {
   fi
 }
 
+# Dependency cooldown (mix.exs `hex: [cooldown: ...]`) is silently ignored by
+# Hex older than 2.5.0, giving false confidence. Enforce the minimum here.
+ensure_hex_version() {
+  local required="2.5.0"
+  local have
+  have="$(mix hex.info 2>/dev/null | awk '/^Hex:/ {print $2}')"
+
+  if [[ -n "$have" ]] && printf '%s\n%s\n' "$required" "$have" | sort -V -C; then
+    echo "  Hex: $have (>= $required, dependency cooldown active)"
+    return
+  fi
+
+  echo "  Hex ${have:-<none>} is older than $required; upgrading for dependency cooldown support..."
+  mix local.hex --force
+
+  have="$(mix hex.info 2>/dev/null | awk '/^Hex:/ {print $2}')"
+  if [[ -z "$have" ]] || ! printf '%s\n%s\n' "$required" "$have" | sort -V -C; then
+    echo "Failed to obtain Hex >= $required (found ${have:-<none>})." >&2
+    echo "The dependency cooldown in mix.exs will be silently ignored without it." >&2
+    exit 1
+  fi
+  echo "  Hex upgraded to $have"
+}
+
 run_bootstrap() {
   echo "Gathering environment information..."
   echo "Platform: $OS $ARCH"
@@ -181,6 +205,7 @@ run_bootstrap() {
   echo "Setting up Elixir environment..."
   mix local.hex --if-missing --force
   mix local.rebar --if-missing --force
+  ensure_hex_version
 
   echo "Installing Elixir dependencies..."
   mix deps.get

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -911,8 +911,10 @@ defmodule LightningWeb.SandboxLive.Index do
     # a merge never silently deletes them, and removal is opt-in.
     deleted_entries =
       target_workflows
-      |> Enum.reject(fn wf -> MapSet.member?(source_workflow_names, wf.name) end)
-      |> Enum.reject(fn wf -> workflow_added_after_fork?(wf, source) end)
+      |> Enum.reject(fn wf ->
+        MapSet.member?(source_workflow_names, wf.name) or
+          workflow_added_after_fork?(wf, source)
+      end)
       |> Enum.map(fn wf ->
         %MergeWorkflow{
           id: wf.id,

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule Lightning.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
+      hex: [cooldown: "1w"],
       dialyzer: [
         plt_add_apps: [:mix],
         plt_local_path: "priv/plts/",


### PR DESCRIPTION
## Description

This PR _adds_ Hex 2.5.0's dependency [release-age cooldown](https://hexdocs.pm/hex/Mix.Tasks.Hex.html) to Lightning.

Setting `hex: [cooldown: "1w"]` in `mix.exs` means Hex won't resolve to a package version until it has existed for at least a week. This mitigates the common supply-chain attack where a compromised release is pulled into builds before anyone notices and retires it — most such incidents are caught within days. Lightning only consumes dependencies (it doesn't publish), so this only affects what we pull in, never what we ship.

Day-to-day impact is basically nil: `mix deps.get` against an intact `mix.lock` bypasses the cooldown entirely, so normal builds and CI are unchanged. The cooldown only bites when resolving something new (`mix deps.update`, adding a dep, or `deps.get` after unlocking). Security fixes for a dep we're already locked to re-resolve past the cooldown automatically; a genuinely urgent fresh fix can be forced for a single command with `HEX_COOLDOWN=0d mix deps.update <pkg>`.

The catch: **Hex older than 2.5.0 silently ignores the config**, giving false confidence. So:
- `bin/bootstrap` now enforces Hex `>= 2.5.0` for local dev, auto-upgrading and failing fast if it can't.
- CI/Docker already installs the latest Hex via `mix local.hex --force`, so it's covered.


## Validation steps

1. On a machine with Hex `< 2.5.0`, run `bin/bootstrap` and confirm it upgrades Hex and reports `>= 2.5.0`.
2. With Hex `>= 2.5.0`, run `mix deps.get` against the committed `mix.lock` and confirm it resolves unchanged (cooldown does not bite locked versions).
3. Run `mix hex.outdated` and confirm any versions inside the 1-week window are annotated `(cooldown)`.

## Additional notes for the reviewer

1. Value chosen is `1w` — covers all-but-one of the analysed supply-chain incidents while costing us almost nothing for an app that doesn't ship on every dependency bump.
2. `ensure_hex_version` in `bin/bootstrap.d/common.sh` uses `sort -V` so it treats e.g. 2.10 as newer than 2.5.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
