### PR TITLE
Return 422 instead of 500 when workflow create body omits edges, jobs, or triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to
 
 ### Fixed
 
+- The workflows REST API now returns a 422 validation error instead of a 500
+  when a create request omits `edges`, `jobs`, or `triggers` from the body
+  rather than sending them as empty lists.
+  [#4982](https://github.com/OpenFn/lightning/issues/4982)
 - Sandbox merge no longer deletes a workflow that was added to the project after
   the sandbox was branched. Such workflows were never part of the sandbox, so
   they are excluded from the merge screen entirely. Workflows deleted inside the

--- a/lib/lightning_web/controllers/api/workflows_controller.ex
+++ b/lib/lightning_web/controllers/api/workflows_controller.ex
@@ -413,6 +413,14 @@ defmodule LightningWeb.API.WorkflowsController do
        ),
        do: validate_workflow(edges, jobs, triggers, ids_map)
 
+  defp validate_workflow(%{} = params, ids_map) do
+    edges = Map.get(params, "edges", [])
+    jobs = Map.get(params, "jobs", [])
+    triggers = Map.get(params, "triggers", [])
+
+    validate_workflow(edges, jobs, triggers, ids_map)
+  end
+
   defp validate_workflow(edges, jobs, triggers, ids_map) do
     # {:ok, _ids} <- validate_ids(edges),
     with {:ok, triggers_ids} <- validate_ids(triggers),

--- a/test/lightning_web/controllers/api/workflows_controller_test.exs
+++ b/test/lightning_web/controllers/api/workflows_controller_test.exs
@@ -745,6 +745,25 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
              }
     end
 
+    test "returns 422 when edges, jobs and triggers are omitted", %{
+      conn: conn,
+      project: project
+    } do
+      conn =
+        post(
+          conn,
+          ~p"/api/projects/#{project.id}/workflows",
+          Jason.encode!(%{name: "workflow without children"})
+        )
+
+      assert json_response(conn, 422) == %{
+               "id" => nil,
+               "errors" => %{
+                 "edges" => ["Missing edge with source_trigger_id."]
+               }
+             }
+    end
+
     test "returns 422 when edges has multiple source triggers", %{
       conn: conn,
       project: project


### PR DESCRIPTION
## Description

This PR fixes a crash in the workflows REST API. `POST /api/projects/:project_id/workflows` raised an unhandled `FunctionClauseError` (a 500) instead of a validation error when the request body left out `edges`, `jobs`, or `triggers` entirely, rather than sending them as empty lists.

`validate_workflow/2` only had a map clause matching when all three keys were present, so a create body missing any of them matched no clause. The update path is unaffected because it builds a changeset first, which always has those fields via schema defaults. Only create validates the raw params map directly.

The fix adds a fallback clause that defaults the missing keys to `[]` and routes through the existing validation, which already returns a proper 422 (`"Missing edge with source_trigger_id."`) for a workflow with no edges.

Closes #4982

## Validation steps

1. `POST /api/projects/:project_id/workflows` with a body of just `{"name": "..."}` (no `edges`/`jobs`/`triggers`).
2. Before this change the response is a 500; after it, a 422 with the edges validation error.
3. The added test `returns 422 when edges, jobs and triggers are omitted` covers this in `workflows_controller_test.exs`.

## Additional notes for the reviewer

1. I couldn't run the full ExUnit suite here (it needs Postgres and full deps compilation), so the regression test is written to mirror the neighbouring `returns 422 when edges misses a source trigger` case and the empty-list path was traced by hand to confirm it lands on `{:error, :edges_misses_a_trigger}` and the existing `reply_422`. Please run it in CI.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ ] I have used another model
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [ ] I have ticked a box in "AI usage" in this PR
