### PR TITLE
feat: add editable project user roles for owner and admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to
 
 - Migrated off the retired `earmark` markdown dependency in favour of `mdex`.
   [#4878](https://github.com/OpenFn/lightning/issues/4878)
+- Project settings now allow `owner` and `admin` users to edit collaborator
+  roles inline (viewer/editor/admin) without remove-and-readd. Owner rows and
+  self-role edits remain non-editable.
+  [#4993](https://github.com/OpenFn/lightning/pull/4993)
 - Removed the unused dev-only `phoenix_storybook` dependency, clearing its
   advisories from the `mix deps.audit` ignore list.
   [#4846](https://github.com/OpenFn/lightning/issues/4846)

--- a/lib/lightning/policies/project_users.ex
+++ b/lib/lightning/policies/project_users.ex
@@ -16,6 +16,7 @@ defmodule Lightning.Policies.ProjectUsers do
           | :edit_project
           | :delete_project
           | :add_project_user
+          | :edit_project_user_role
           | :remove_project_user
           | :delete_workflow
           | :create_workflow
@@ -88,6 +89,7 @@ defmodule Lightning.Policies.ProjectUsers do
              :edit_project,
              :edit_data_retention,
              :add_project_user,
+             :edit_project_user_role,
              :remove_project_user,
              :edit_run_settings,
              :create_collection
@@ -101,6 +103,7 @@ defmodule Lightning.Policies.ProjectUsers do
              :edit_project,
              :edit_data_retention,
              :add_project_user,
+             :edit_project_user_role,
              :remove_project_user,
              :edit_run_settings,
              :create_collection

--- a/lib/lightning_web/live/components/data_tables.ex
+++ b/lib/lightning_web/live/components/data_tables.ex
@@ -401,6 +401,7 @@ defmodule LightningWeb.Components.DataTables do
   attr :id, :string, required: true
   attr :project_users, :list, required: true
   attr :current_user, :map, required: true
+  attr :can_edit_project_user_role, :boolean, required: true
   attr :can_remove_project_user, :boolean, required: true
   attr :can_receive_failure_alerts, :boolean, required: true
 
@@ -437,7 +438,11 @@ defmodule LightningWeb.Components.DataTables do
                   </div>
                 </.td>
                 <.td>
-                  <.role project_user={project_user} />
+                  <.role
+                    project_user={project_user}
+                    current_user={@current_user}
+                    can_edit_project_user_role={@can_edit_project_user_role}
+                  />
                 </.td>
                 <.td>
                   <.failure_alert
@@ -471,8 +476,35 @@ defmodule LightningWeb.Components.DataTables do
   end
 
   defp role(assigns) do
+    editable? =
+      assigns.can_edit_project_user_role and
+        assigns.project_user.role != :owner and
+        assigns.project_user.user_id != assigns.current_user.id
+
+    assigns = assign(assigns, :editable?, editable?)
+
     ~H"""
-    {@project_user.role |> Atom.to_string() |> String.capitalize()}
+    <%= if @editable? do %>
+      <.form
+        :let={form}
+        for={%{"role" => @project_user.role}}
+        phx-change="set_role"
+        id={"role-#{@project_user.id}"}
+      >
+        <.input
+          type="hidden"
+          field={form[:project_user_id]}
+          value={@project_user.id}
+        />
+        <.input
+          type="select"
+          field={form[:role]}
+          options={[Viewer: "viewer", Editor: "editor", Admin: "admin"]}
+        />
+      </.form>
+    <% else %>
+      {@project_user.role |> Atom.to_string() |> String.capitalize()}
+    <% end %>
     """
   end
 

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -128,6 +128,13 @@ defmodule LightningWeb.ProjectLive.Settings do
           current_user,
           project
         ),
+      can_edit_project_user_role:
+        Permissions.can?(
+          :project_users,
+          :edit_project_user_role,
+          current_user,
+          project
+        ),
       can_remove_project_user:
         Permissions.can?(
           :project_users,
@@ -630,6 +637,45 @@ defmodule LightningWeb.ProjectLive.Settings do
   end
 
   def handle_event(
+        "set_role",
+        %{"project_user_id" => project_user_id, "role" => role},
+        %{assigns: assigns} = socket
+      ) do
+    project_user = Projects.get_project_user!(project_user_id)
+
+    cond do
+      project_user.project_id != assigns.project.id ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "You are not authorized to perform this action")}
+
+      !role_editable?(
+        project_user,
+        assigns.current_user,
+        assigns.can_edit_project_user_role
+      ) ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "You are not authorized to perform this action")}
+
+      true ->
+        changeset =
+          {%{role: project_user.role |> to_string()}, %{role: :string}}
+          |> Ecto.Changeset.cast(%{role: role}, [:role])
+          |> Ecto.Changeset.validate_inclusion(:role, ~w(viewer editor admin))
+
+        case Ecto.Changeset.get_change(changeset, :role) do
+          nil ->
+            {:noreply, socket}
+
+          role ->
+            Projects.update_project_user(project_user, %{role: role})
+            |> dispatch_flash(socket)
+        end
+    end
+  end
+
+  def handle_event(
         "remove_project_user",
         %{"project_user_id" => project_user_id},
         %{assigns: assigns} = socket
@@ -854,6 +900,15 @@ defmodule LightningWeb.ProjectLive.Settings do
 
   defp parent_admin?(project, %{user: %User{} = user}),
     do: Sandboxes.parent_admin?(project, user)
+
+  defp role_editable?(
+         project_user,
+         current_user,
+         can_edit_project_user_role
+       ) do
+    can_edit_project_user_role and project_user.role != :owner and
+      project_user.user_id != current_user.id
+  end
 
   defp user_has_valid_oauth_token(user) do
     VersionControl.oauth_token_valid?(user.github_oauth_token)

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -616,6 +616,7 @@
           id="collaborators"
           project_users={@project_users}
           current_user={@current_user}
+          can_edit_project_user_role={@can_edit_project_user_role}
           can_remove_project_user={@can_remove_project_user}
           can_receive_failure_alerts={@can_receive_failure_alerts}
         >

--- a/test/lightning/policies/project_user_permissions_test.exs
+++ b/test/lightning/policies/project_user_permissions_test.exs
@@ -110,6 +110,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         delete_workflow
         edit_workflow
         edit_project
+        edit_project_user_role
         write_webhook_auth_method
         create_project_credential
         run_workflow
@@ -139,6 +140,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
          } do
       ~w(
           edit_project
+          edit_project_user_role
           write_webhook_auth_method
         )a |> (&refute_can(ProjectUsers, &1, editor, project)).()
     end
@@ -155,6 +157,7 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
           delete_workflow
           edit_workflow
           edit_project
+          edit_project_user_role
           write_webhook_auth_method
           create_project_credential
           run_workflow
@@ -173,10 +176,20 @@ defmodule Lightning.Policies.ProjectUserPermissionsTest do
         delete_workflow
         edit_workflow
         edit_project
+        edit_project_user_role
         write_webhook_auth_method
         create_project_credential
         run_workflow
       )a |> (&assert_can(ProjectUsers, &1, owner, project)).()
+    end
+  end
+
+  describe "Non-members cannot edit collaborator roles" do
+    test "cannot edit collaborator roles", %{
+      intruder: intruder,
+      project: project
+    } do
+      refute_can(ProjectUsers, :edit_project_user_role, intruder, project)
     end
   end
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -4221,6 +4221,232 @@ defmodule LightningWeb.ProjectLiveTest do
       end
     end
 
+    test "owner/admin sees editable role control for eligible collaborators", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      owner = insert(:user)
+      admin = insert(:user)
+      editor = insert(:user)
+      viewer = insert(:user)
+
+      owner_project_user =
+        insert(:project_user, project: project, user: owner, role: :owner)
+
+      admin_project_user =
+        insert(:project_user, project: project, user: admin, role: :admin)
+
+      editor_project_user =
+        insert(:project_user, project: project, user: editor, role: :editor)
+
+      viewer_project_user =
+        insert(:project_user, project: project, user: viewer, role: :viewer)
+
+      for {role, user} <- [owner: owner, admin: admin] do
+        conn = log_in_user(conn, user)
+
+        {:ok, view, _html} =
+          live(conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+        editable_ids =
+          case role do
+            :owner ->
+              [
+                admin_project_user.id,
+                editor_project_user.id,
+                viewer_project_user.id
+              ]
+
+            :admin ->
+              [editor_project_user.id, viewer_project_user.id]
+          end
+
+        Enum.each(editable_ids, fn project_user_id ->
+          assert has_element?(view, "form#role-#{project_user_id}")
+        end)
+
+        refute has_element?(view, "form#role-#{owner_project_user.id}")
+      end
+    end
+
+    test "viewer/editor does not see editable role control", %{conn: conn} do
+      project = insert(:project)
+
+      owner = insert(:user)
+      editor = insert(:user)
+      viewer = insert(:user)
+
+      insert(:project_user, project: project, user: owner, role: :owner)
+      insert(:project_user, project: project, user: editor, role: :editor)
+      insert(:project_user, project: project, user: viewer, role: :viewer)
+
+      for user <- [viewer, editor] do
+        conn = log_in_user(conn, user)
+
+        {:ok, view, _html} =
+          live(conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+        refute has_element?(view, "form[id^='role-']")
+      end
+    end
+
+    test "owner row and self row remain non-editable", %{conn: conn} do
+      project = insert(:project)
+
+      owner = insert(:user)
+      admin = insert(:user)
+      editor = insert(:user)
+
+      owner_project_user =
+        insert(:project_user, project: project, user: owner, role: :owner)
+
+      admin_project_user =
+        insert(:project_user, project: project, user: admin, role: :admin)
+
+      editor_project_user =
+        insert(:project_user, project: project, user: editor, role: :editor)
+
+      owner_conn = log_in_user(conn, owner)
+
+      {:ok, owner_view, _html} =
+        live(owner_conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+      refute has_element?(owner_view, "form#role-#{owner_project_user.id}")
+      assert has_element?(owner_view, "form#role-#{admin_project_user.id}")
+      assert has_element?(owner_view, "form#role-#{editor_project_user.id}")
+
+      admin_conn = log_in_user(conn, admin)
+
+      {:ok, admin_view, _html} =
+        live(admin_conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+      refute has_element?(admin_view, "form#role-#{owner_project_user.id}")
+      refute has_element?(admin_view, "form#role-#{admin_project_user.id}")
+      assert has_element?(admin_view, "form#role-#{editor_project_user.id}")
+    end
+
+    test "valid role change persists and shows success flash", %{conn: conn} do
+      project = insert(:project)
+
+      owner = insert(:user)
+      viewer = insert(:user)
+
+      insert(:project_user, project: project, user: owner, role: :owner)
+
+      viewer_project_user =
+        insert(:project_user, project: project, user: viewer, role: :viewer)
+
+      conn = log_in_user(conn, owner)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+      html =
+        view
+        |> form(
+          "#role-#{viewer_project_user.id}",
+          %{"project_user_id" => viewer_project_user.id, "role" => "admin"}
+        )
+        |> render_change()
+
+      assert html =~ "Project user updated successfuly"
+
+      assert Repo.get!(Lightning.Projects.ProjectUser, viewer_project_user.id).role ==
+               :admin
+    end
+
+    test "unauthorized crafted event is rejected and DB remains unchanged", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      owner = insert(:user)
+      viewer = insert(:user)
+      target = insert(:user)
+
+      insert(:project_user, project: project, user: owner, role: :owner)
+      insert(:project_user, project: project, user: viewer, role: :viewer)
+
+      target_project_user =
+        insert(:project_user, project: project, user: target, role: :editor)
+
+      conn = log_in_user(conn, viewer)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+      html =
+        render_change(view, "set_role", %{
+          "project_user_id" => target_project_user.id,
+          "role" => "admin"
+        })
+
+      assert html =~ "You are not authorized to perform this action"
+
+      assert Repo.get!(Lightning.Projects.ProjectUser, target_project_user.id).role ==
+               :editor
+    end
+
+    test "invalid role payload is rejected and DB remains unchanged", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      owner = insert(:user)
+      viewer = insert(:user)
+
+      insert(:project_user, project: project, user: owner, role: :owner)
+
+      viewer_project_user =
+        insert(:project_user, project: project, user: viewer, role: :viewer)
+
+      conn = log_in_user(conn, owner)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project.id}/settings#collaboration")
+
+      html =
+        render_change(view, "set_role", %{
+          "project_user_id" => viewer_project_user.id,
+          "role" => "owner"
+        })
+
+      assert html =~ "Error when updating the project user"
+
+      assert Repo.get!(Lightning.Projects.ProjectUser, viewer_project_user.id).role ==
+               :viewer
+    end
+
+    test "cross-project project_user_id payload is rejected", %{conn: conn} do
+      project_a = insert(:project)
+      project_b = insert(:project)
+
+      owner = insert(:user)
+      target = insert(:user)
+
+      insert(:project_user, project: project_a, user: owner, role: :owner)
+
+      target_project_user =
+        insert(:project_user, project: project_b, user: target, role: :viewer)
+
+      conn = log_in_user(conn, owner)
+
+      {:ok, view, _html} =
+        live(conn, ~p"/projects/#{project_a.id}/settings#collaboration")
+
+      html =
+        render_change(view, "set_role", %{
+          "project_user_id" => target_project_user.id,
+          "role" => "admin"
+        })
+
+      assert html =~ "You are not authorized to perform this action"
+
+      assert Repo.get!(Lightning.Projects.ProjectUser, target_project_user.id).role ==
+               :viewer
+    end
+
     test "users cant see form to toggle failure alerts if limiter returns error",
          %{conn: conn} do
       %{id: project_id} = project = insert(:project)


### PR DESCRIPTION
## Description

This PR adds project role editing for collaborators in Project Settings (#collaboration). Users with permissions `owner` and `admin` can edit the collaborator permissions to be admin, editor, or viewer. Tests for the relevant permissions were also added.  

Closes #3603 

<img width="1371" height="908" alt="Screenshot 2026-07-20 at 12 14 55 AM" src="https://github.com/user-attachments/assets/f0f9c304-2b3f-4a0d-b8b9-33b332fcb09c" />

## Validation steps

1. Start the app locally and log in as a user with owner role on a project.
2. Go to Project Settings -> Collaboration.
3. Confirm role dropdown is shown for eligible collaborator rows.
4. Change a collaborator role viewer -> admin and verify that the success flash appears. The role should persist after refresh
5. Confirm owner row is not editable.
6. Confirm current user row is not editable.
7. Log in as editor (or viewer) and verify the dropdown lists are not available.

## Additional notes for the reviewer

1. Scope is limited to Project Settings collaborator role editing; no owner transfer was added.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [ ] I have used Claude Code
- [x] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
