### PR TITLE
fix: (WIP) cross-project IDOR fix in workflow

### DIFF
--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -128,13 +128,15 @@ defmodule Lightning.Workflows do
 
   Returns `nil` if the workflow does not exist or is not in the project.
   """
-  def get_workflow_for_project(id, project_id, opts \\ []) do
-    include = Keyword.get(opts, :include, [])
+  def get_workflow_for_project(project, id, opts \\ [])
 
-    Workflow
-    |> where([w], w.id == ^id and w.project_id == ^project_id)
-    |> preload(^include)
-    |> Repo.one()
+  def get_workflow_for_project(%Project{} = project, id, opts) do
+    if Lightning.Validators.valid_uuid?(id) do
+      id
+      |> get_workflow_query(opts)
+      |> where([w], w.project_id == ^project.id)
+      |> Repo.one()
+    end
   end
 
   defp get_workflow_query(id, opts) do
@@ -143,21 +145,6 @@ defmodule Lightning.Workflows do
     Workflow
     |> where(id: ^id)
     |> preload(^include)
-  end
-
-  @doc """
-  Gets a workflow by id, scoped to the given project.
-
-  Returns `nil` when the id is malformed, missing, or belongs to another
-  project, so it can't be used to read or mutate a workflow across projects.
-  """
-  def get_workflow_for_project(%Project{} = project, id, opts \\ []) do
-    if Lightning.Validators.valid_uuid?(id) do
-      id
-      |> get_workflow_query(opts)
-      |> where([w], w.project_id == ^project.id)
-      |> Repo.one()
-    end
   end
 
   @spec save_workflow(

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -123,6 +123,20 @@ defmodule Lightning.Workflows do
     get_workflow_query(id, opts) |> Repo.one()
   end
 
+  @doc """
+  Gets a single workflow scoped to a project with optional preloads.
+
+  Returns `nil` if the workflow does not exist or is not in the project.
+  """
+  def get_workflow_for_project(id, project_id, opts \\ []) do
+    include = Keyword.get(opts, :include, [])
+
+    Workflow
+    |> where([w], w.id == ^id and w.project_id == ^project_id)
+    |> preload(^include)
+    |> Repo.one()
+  end
+
   defp get_workflow_query(id, opts) do
     include = Keyword.get(opts, :include, [])
 

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -322,7 +322,7 @@ defmodule LightningWeb.WorkflowChannel do
   def handle_in(
         "request_run_steps",
         %{"run_id" => run_id},
-        %{assigns: %{project: project}} = socket
+        %{assigns: %{project: project, workflow: workflow}} = socket
       ) do
     async_task(socket, "request_run_steps", fn ->
       case Lightning.Invocation.get_run_with_steps(run_id) do
@@ -330,8 +330,9 @@ defmodule LightningWeb.WorkflowChannel do
           {:error, %{reason: "run_not_found"}}
 
         run ->
-          # Verify run belongs to this project's workflows
-          if run.work_order.workflow.project_id == project.id do
+          # Verify run belongs to this project and currently loaded workflow.
+          if run.work_order.workflow.project_id == project.id &&
+               run.work_order.workflow_id == workflow.id do
             {:ok, format_run_steps_for_client(run)}
           else
             {:error, %{reason: "unauthorized"}}

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -8,6 +8,7 @@ defmodule LightningWeb.RunLive.Show do
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.ProjectUsers
   alias Lightning.Projects
+  alias Lightning.Runs
   alias LightningWeb.Components.Tabbed
   alias LightningWeb.Components.Viewers
   alias LightningWeb.RunLive.CancelHelper
@@ -312,40 +313,48 @@ defmodule LightningWeb.RunLive.Show do
     %{current_user: user, project_user: project_user, project: project} =
       socket.assigns
 
-    can_run_workflow =
-      ProjectUsers
-      |> Permissions.can?(
-        :run_workflow,
-        user,
-        project
-      )
+    case Runs.get_for_project(id, project.id) do
+      nil ->
+        {:ok, redirect(socket, to: "/projects")}
 
-    {:ok,
-     socket
-     |> assign(
-       active_menu_item: :runs,
-       page_title: "Run",
-       id: id,
-       selected_step_id: nil,
-       steps: []
-     )
-     |> assign(:input_dataclip, nil)
-     |> assign(:output_dataclip, nil)
-     |> assign(:run, AsyncResult.loading())
-     |> assign(:log_lines, AsyncResult.loading())
-     |> assign(:log_lines_empty?, true)
-     |> assign(
-       can_edit_data_retention:
-         Permissions.can?(
-           ProjectUsers,
-           :edit_data_retention,
-           user,
-           project_user
+      _run ->
+        can_run_workflow =
+          ProjectUsers
+          |> Permissions.can?(
+            :run_workflow,
+            user,
+            project
+          )
+
+        {:ok,
+         socket
+         |> assign(
+           active_menu_item: :runs,
+           page_title: "Run",
+           id: id,
+           selected_step_id: nil,
+           steps: []
          )
-     )
-     |> assign(can_run_workflow: can_run_workflow)
-     |> assign(admin_contacts: Projects.list_project_admin_emails(project.id))
-     |> get_run_async(id, project.id)}
+         |> assign(:input_dataclip, nil)
+         |> assign(:output_dataclip, nil)
+         |> assign(:run, AsyncResult.loading())
+         |> assign(:log_lines, AsyncResult.loading())
+         |> assign(:log_lines_empty?, true)
+         |> assign(
+           can_edit_data_retention:
+             Permissions.can?(
+               ProjectUsers,
+               :edit_data_retention,
+               user,
+               project_user
+             )
+         )
+         |> assign(can_run_workflow: can_run_workflow)
+         |> assign(
+           admin_contacts: Projects.list_project_admin_emails(project.id)
+         )
+         |> get_run_async(id, project.id)}
+    end
   end
 
   def handle_steps_change(socket) do

--- a/lib/lightning_web/live/run_live/show.ex
+++ b/lib/lightning_web/live/run_live/show.ex
@@ -315,7 +315,10 @@ defmodule LightningWeb.RunLive.Show do
 
     case Runs.get_for_project(id, project.id) do
       nil ->
-        {:ok, redirect(socket, to: "/projects")}
+        {:ok,
+         socket
+         |> put_flash(:error, "#{project.name} has no run with ID #{id}.")
+         |> redirect(to: "/projects")}
 
       _run ->
         can_run_workflow =

--- a/lib/lightning_web/live/run_live/streaming.ex
+++ b/lib/lightning_web/live/run_live/streaming.ex
@@ -175,7 +175,6 @@ defmodule LightningWeb.RunLive.Streaming do
            run: AsyncResult.ok(run, updated_run),
            # set the initial set of steps
            steps: updated_run.steps |> sort_steps(),
-           project: updated_run.workflow.project,
            workflow: updated_run.workflow
          )
          |> assign_async(

--- a/lib/lightning_web/live/workflow_live/collaborate.ex
+++ b/lib/lightning_web/live/workflow_live/collaborate.ex
@@ -407,7 +407,7 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
   defp workflow_assigns(params, project) do
     case params do
       %{"id" => workflow_id} ->
-        case Workflows.get_workflow_for_project(workflow_id, project.id) do
+        case Workflows.get_workflow_for_project(project, workflow_id) do
           nil ->
             :not_found
 

--- a/lib/lightning_web/live/workflow_live/collaborate.ex
+++ b/lib/lightning_web/live/workflow_live/collaborate.ex
@@ -78,11 +78,20 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
 
   defp maybe_load_initial_run_data(socket, %{"run" => run_id})
        when is_binary(run_id) do
-    %{project: project} = socket.assigns
+    %{project: project, workflow_id: workflow_id} = socket.assigns
 
-    case Lightning.Runs.get_for_project(run_id, project.id, include: [:steps]) do
-      nil -> socket
-      run -> assign(socket, initial_run_data: build_run_data(run))
+    case Lightning.Runs.get_for_project(run_id, project.id,
+           include: [:steps, :work_order]
+         ) do
+      %{work_order: %{workflow_id: ^workflow_id}} = run ->
+        assign(socket, initial_run_data: build_run_data(run))
+
+      _ ->
+        put_flash(
+          socket,
+          :error,
+          "#{project.name} has no run with ID #{run_id} for this workflow."
+        )
     end
   end
 

--- a/lib/lightning_web/live/workflow_live/collaborate.ex
+++ b/lib/lightning_web/live/workflow_live/collaborate.ex
@@ -33,27 +33,34 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
         %{assigns: %{project: project, access_root: access_root}} = socket
       ) do
     is_sandbox? = Project.sandbox?(project)
+    workflow_assigns = workflow_assigns(params, project)
 
-    {:ok,
-     socket
-     |> assign(workflow_assigns(params, project))
-     |> assign(
-       active_menu_item: :overview,
-       project: project,
-       project_display_name:
-         Projects.display_name_within_access_root(project, access_root),
-       project_is_sandbox: is_sandbox?,
-       root_project_id: if(is_sandbox?, do: access_root.id),
-       root_project_name: if(is_sandbox?, do: access_root.name),
-       show_credential_modal: false,
-       credential_schema: nil,
-       credential_to_edit: nil,
-       new_credential_project_credentials:
-         CredentialLive.Helpers.default_project_credentials(project),
-       show_webhook_auth_modal: false,
-       webhook_auth_method: nil,
-       ai_assistant_enabled: AiAssistant.enabled?()
-     )}
+    case workflow_assigns do
+      :not_found ->
+        {:ok, redirect(socket, to: "/projects")}
+
+      workflow_assigns ->
+        {:ok,
+         socket
+         |> assign(workflow_assigns)
+         |> assign(
+           active_menu_item: :overview,
+           project: project,
+           project_display_name:
+             Projects.display_name_within_access_root(project, access_root),
+           project_is_sandbox: is_sandbox?,
+           root_project_id: if(is_sandbox?, do: access_root.id),
+           root_project_name: if(is_sandbox?, do: access_root.name),
+           show_credential_modal: false,
+           credential_schema: nil,
+           credential_to_edit: nil,
+           new_credential_project_credentials:
+             CredentialLive.Helpers.default_project_credentials(project),
+           show_webhook_auth_modal: false,
+           webhook_auth_method: nil,
+           ai_assistant_enabled: AiAssistant.enabled?()
+         )}
+    end
   end
 
   @impl true
@@ -391,14 +398,18 @@ defmodule LightningWeb.WorkflowLive.Collaborate do
   defp workflow_assigns(params, project) do
     case params do
       %{"id" => workflow_id} ->
-        workflow = Workflows.get_workflow!(workflow_id)
+        case Workflows.get_workflow_for_project(workflow_id, project.id) do
+          nil ->
+            :not_found
 
-        %{
-          workflow: workflow,
-          workflow_id: workflow_id,
-          is_new_workflow: false,
-          page_title: "Collaborate on #{workflow.name}"
-        }
+          workflow ->
+            %{
+              workflow: workflow,
+              workflow_id: workflow_id,
+              is_new_workflow: false,
+              page_title: "Collaborate on #{workflow.name}"
+            }
+        end
 
       _other ->
         workflow_id = Ecto.UUID.generate()

--- a/test/lightning/work_orders_test.exs
+++ b/test/lightning/work_orders_test.exs
@@ -2996,6 +2996,59 @@ defmodule Lightning.WorkOrdersTest do
       # 1 from specific query + up to 20 from main query
       assert length(results) <= 21
     end
+
+    test "does not include run workorder when run_id belongs to a different workflow",
+         %{
+           workflow: workflow,
+           trigger: trigger,
+           snapshot: snapshot
+         } do
+      other_workflow = insert(:simple_workflow)
+      other_trigger = hd(other_workflow.triggers)
+      {:ok, other_snapshot} = Lightning.Workflows.Snapshot.create(other_workflow)
+      other_dataclip = insert(:dataclip)
+
+      other_workorder =
+        insert(:workorder,
+          workflow: other_workflow,
+          trigger: other_trigger,
+          dataclip: other_dataclip,
+          snapshot: other_snapshot
+        )
+
+      other_run =
+        insert(:run,
+          work_order: other_workorder,
+          dataclip: other_dataclip,
+          starting_trigger: other_trigger,
+          snapshot: other_snapshot
+        )
+
+      own_dataclip = insert(:dataclip)
+
+      own_workorder =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: own_dataclip,
+          snapshot: snapshot,
+          runs: [
+            %{
+              dataclip: own_dataclip,
+              starting_trigger: trigger,
+              snapshot: snapshot,
+              state: :available
+            }
+          ]
+        )
+
+      results = WorkOrders.get_workorders_with_runs(workflow.id, other_run.id)
+      result_ids = Enum.map(results, & &1.id)
+
+      assert own_workorder.id in result_ids
+      refute other_workorder.id in result_ids
+      assert Enum.all?(results, &(&1.workflow_id == workflow.id))
+    end
   end
 
   describe "cancel_many/2" do

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -2042,6 +2042,27 @@ defmodule LightningWeb.WorkflowChannelTest do
       ref = push(socket, "request_run_steps", %{"run_id" => run.id})
       assert_reply ref, :error, %{reason: "unauthorized"}
     end
+
+    test "returns error for run from different workflow in same project", %{
+      socket: socket,
+      project: project
+    } do
+      other_workflow = insert(:workflow, project: project)
+      other_workflow = with_snapshot(other_workflow)
+      job = insert(:job, workflow: other_workflow)
+      dataclip = insert(:dataclip, project: project)
+      work_order = insert(:workorder, workflow: other_workflow)
+
+      run =
+        insert(:run,
+          work_order: work_order,
+          starting_job: job,
+          dataclip: dataclip
+        )
+
+      ref = push(socket, "request_run_steps", %{"run_id" => run.id})
+      assert_reply ref, :error, %{reason: "unauthorized"}
+    end
   end
 
   describe "real-time history updates" do


### PR DESCRIPTION
## Description

This PR fixes IDOR-style access gaps where users could load resources from another project by URL/query param,
especially in project-scoped routes and workflow history context. This affects routes related to runs and workflows specifically

Closes #5014

## Validation steps

1. Check run show IDOR denial:
    - Open /projects/<PROJECT_A_ID>/runs/<RUN_B_ID> where RUN_B_ID belongs to another project.
    - Expected: denied access and redirect (with the run not found alert).

2. Check workflow run-param IDOR denial:
    - Open /projects/<PROJECT_A_ID>/w/<WORKFLOW_A_ID>?run=<RUN_B_ID> where RUN_B_ID is from another
      project or another workflow.

    - Expected: run is not loaded into recent history context, and an alert is shown for invalid run-
      for-workflow.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [ ] I have used Claude Code
- [ x I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
