### PR TITLE
AI-First: Adds a template preview in the template modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to
   collisions, and shadowed entries are logged). Lets a private repo override or
   extend the canonical adaptors in local mode.
   [#4714](https://github.com/OpenFn/lightning/pull/4714)
+- The template browser now previews the selected template as a read-only diagram
+  before you commit to it. Picking a template from the list only previews it;
+  creating the workflow is a separate Create button. Templates whose definition
+  can't be read say so in the preview and can't be created.
+  [#4848](https://github.com/OpenFn/lightning/issues/4848)
 
 ### Changed
 
@@ -48,6 +53,10 @@ and this project adheres to
 - Replaced the full-screen AI disclaimer gate in the AI assistant with a
   persistent disclaimer footer shown in the chat input and landing screen.
   [#4911](https://github.com/OpenFn/lightning/issues/4911)
+- The template browser and YAML import modals now cover the left side menu
+  instead of sitting behind it, and the YAML file-type hints use the primary
+  colour rather than teal.
+  [#4848](https://github.com/OpenFn/lightning/issues/4848)
 - The credential revoke-access dialog now sorts the affected workflows
   alphabetically. The order was previously left to the database and not
   guaranteed. [#4954](https://github.com/OpenFn/lightning/issues/4954)

--- a/assets/js/collaborative-editor/components/ManualRunPanelErrorBoundary.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanelErrorBoundary.tsx
@@ -1,6 +1,8 @@
-import { Component, type ReactNode } from 'react';
+import { type ReactNode, useCallback } from 'react';
 
 import { notifications } from '../lib/notifications';
+
+import { ErrorBoundary } from './common/ErrorBoundary';
 
 interface Props {
   children: ReactNode;
@@ -8,24 +10,12 @@ interface Props {
   onClose?: () => void;
 }
 
-interface State {
-  hasError: boolean;
-  error: Error | null;
-}
-
 /**
  * Error boundary for ManualRunPanel
  *
  * Catches errors in the ManualRunPanel and its children, displaying a
- * user-friendly error message with options to retry or close the panel.
- *
- * Features:
- * - Displays error message from the caught error
- * - Provides "Try Again" button to reset error state
- * - Provides "Close Panel" button to exit the panel
- * - Logs errors to console for debugging
- * - Optionally calls onError callback for error reporting
- * - Shows toast notification when error occurs
+ * user-friendly error message with options to retry or close the panel. Also
+ * raises a toast, since the panel can be off-screen when it fails.
  *
  * @example
  * ```tsx
@@ -34,43 +24,28 @@ interface State {
  * </ManualRunPanelErrorBoundary>
  * ```
  */
-export class ManualRunPanelErrorBoundary extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
+export function ManualRunPanelErrorBoundary({
+  children,
+  onError,
+  onClose,
+}: Props) {
+  const handleError = useCallback(
+    (error: Error) => {
+      notifications.alert({
+        title: 'Error loading run panel',
+        description:
+          error.message || 'An unexpected error occurred. Please try again.',
+      });
+      onError?.(error);
+    },
+    [onError]
+  );
 
-  static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error };
-  }
-
-  override componentDidCatch(error: Error) {
-    console.error('ManualRunPanel error:', error);
-
-    // Show toast notification
-    notifications.alert({
-      title: 'Error loading run panel',
-      description:
-        error.message || 'An unexpected error occurred. Please try again.',
-    });
-
-    // Call optional error callback for error reporting
-    this.props.onError?.(error);
-  }
-
-  handleReset = () => {
-    this.setState({ hasError: false, error: null });
-  };
-
-  handleClose = () => {
-    // Reset error state before closing
-    this.setState({ hasError: false, error: null });
-    this.props.onClose?.();
-  };
-
-  override render() {
-    if (this.state.hasError) {
-      return (
+  return (
+    <ErrorBoundary
+      label="ManualRunPanel"
+      onError={handleError}
+      fallback={(error, reset) => (
         <div className="flex items-center justify-center h-full p-8">
           <div className="text-center max-w-md">
             <div className="mb-4">
@@ -94,13 +69,13 @@ export class ManualRunPanelErrorBoundary extends Component<Props, State> {
             </h3>
 
             <p className="text-sm text-gray-600 mb-6">
-              {this.state.error?.message ||
+              {error.message ||
                 'An unexpected error occurred while loading the run panel.'}
             </p>
 
             <div className="flex gap-3 justify-center">
               <button
-                onClick={this.handleReset}
+                onClick={reset}
                 className="px-4 py-2 bg-primary-600 text-white rounded
                   hover:bg-primary-700 focus:outline-none focus:ring-2
                   focus:ring-primary-500 focus:ring-offset-2"
@@ -108,9 +83,14 @@ export class ManualRunPanelErrorBoundary extends Component<Props, State> {
                 Try Again
               </button>
 
-              {this.props.onClose && (
+              {onClose && (
                 <button
-                  onClick={this.handleClose}
+                  onClick={() => {
+                    // Reset before closing so reopening the panel isn't stuck
+                    // on the error state.
+                    reset();
+                    onClose();
+                  }}
                   className="px-4 py-2 bg-gray-200 text-gray-900 rounded
                     hover:bg-gray-300 focus:outline-none focus:ring-2
                     focus:ring-gray-500 focus:ring-offset-2"
@@ -121,9 +101,9 @@ export class ManualRunPanelErrorBoundary extends Component<Props, State> {
             </div>
           </div>
         </div>
-      );
-    }
-
-    return this.props.children;
-  }
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
 }

--- a/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
+++ b/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '../types/template';
 import { filterTemplates, matchesQuery } from '../utils/filterTemplates';
 
+import { ActionButton } from './ds/ActionButton';
 import { TemplatePreview } from './TemplatePreview';
 
 export interface TemplateBrowserModalProps {
@@ -177,7 +178,7 @@ export function TemplateBrowserModal({
               </div>
 
               {previewed && (
-                <div className="flex items-end justify-between gap-4 border-t border-gray-200 bg-white/60 px-4 py-3">
+                <div className="flex items-center justify-between gap-4 border-t border-gray-200 bg-white/60 px-4 py-3">
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium text-gray-900">
                       {previewed.name}
@@ -188,17 +189,14 @@ export function TemplateBrowserModal({
                       </p>
                     )}
                   </div>
-                  <button
-                    type="button"
+                  <ActionButton
                     onClick={() => onSelect(previewed)}
                     disabled={isSaving}
-                    className="shrink-0 rounded-md bg-primary-600 px-3 py-2 text-sm font-medium text-white
-                      hover:bg-primary-500 transition-colors
-                      disabled:opacity-50 disabled:cursor-not-allowed
-                      focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                    loading={isSaving}
+                    className="shrink-0"
                   >
-                    {isSaving ? 'Creating...' : 'Use this template'}
-                  </button>
+                    {isSaving ? 'Creating...' : 'Create'}
+                  </ActionButton>
                 </div>
               )}
             </div>

--- a/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
+++ b/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
@@ -129,7 +129,7 @@ export function TemplateBrowserModal({
                 />
               </div>
 
-              <div className="mt-4 flex-1 min-h-0 overflow-y-auto pr-2">
+              <div className="mt-4 flex-1 min-h-0 overflow-y-auto thin-scrollbar pr-2">
                 {loading ? (
                   <p className="py-8 text-center text-sm text-gray-500">
                     Loading templates...

--- a/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
+++ b/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
@@ -1,6 +1,7 @@
 import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import { Tooltip } from '#/components/Tooltip';
 import { cn } from '#/utils/cn';
 
 import {
@@ -9,6 +10,7 @@ import {
   type WorkflowTemplate,
 } from '../types/template';
 import { filterTemplates, matchesQuery } from '../utils/filterTemplates';
+import { tryTemplateToWorkflowState } from '../utils/templateWorkflowState';
 
 import { ActionButton } from './ds/ActionButton';
 import { TemplatePreview } from './TemplatePreview';
@@ -60,7 +62,7 @@ export function TemplateBrowserModal({
 
   // The modal stays mounted, so reset on close rather than on unmount.
   useEffect(() => {
-    if (!isOpen) setPreviewedId(null);
+    if (isOpen) setPreviewedId(null);
   }, [isOpen]);
 
   // Never show an empty preview pane if there is something to show. Covers both
@@ -71,6 +73,15 @@ export function TemplateBrowserModal({
     if (!isOpen || hasPreview || firstVisibleId === null) return;
     setPreviewedId(firstVisibleId);
   }, [isOpen, hasPreview, firstVisibleId]);
+
+  // Don't offer Create for a template we already know we can't read: the
+  // preview is showing the user why, and clicking through would only reach the
+  // same parse failure and a vaguer toast. The preview parses this template
+  // too — same helper, so the two can't disagree about what's broken.
+  const previewError = useMemo(
+    () => (previewed ? tryTemplateToWorkflowState(previewed).error : null),
+    [previewed]
+  );
 
   return (
     <Dialog
@@ -110,7 +121,7 @@ export function TemplateBrowserModal({
           {/* Two panes: list on the left, preview on the right */}
           <div className="flex flex-1 min-h-0 gap-5 px-6 pb-6">
             {/* List pane */}
-            <div className="flex w-72 shrink-0 flex-col min-h-0">
+            <div className="w-72 shrink-0 flex flex-col min-h-0">
               <div className="relative">
                 <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
                   <span className="hero-magnifying-glass h-4 w-4 text-gray-400" />
@@ -189,14 +200,24 @@ export function TemplateBrowserModal({
                       </p>
                     )}
                   </div>
-                  <ActionButton
-                    onClick={() => onSelect(previewed)}
-                    disabled={isSaving}
-                    loading={isSaving}
-                    className="shrink-0"
+                  {/* Wrapped in a span because a disabled button emits no
+                      pointer events for the tooltip to hang off. */}
+                  <Tooltip
+                    content={
+                      previewError ? 'This template can’t be read.' : null
+                    }
+                    side="top"
                   >
-                    {isSaving ? 'Creating...' : 'Create'}
-                  </ActionButton>
+                    <span className="shrink-0">
+                      <ActionButton
+                        onClick={() => onSelect(previewed)}
+                        disabled={isSaving || previewError !== null}
+                        loading={isSaving}
+                      >
+                        {isSaving ? 'Creating...' : 'Create'}
+                      </ActionButton>
+                    </span>
+                  </Tooltip>
                 </div>
               )}
             </div>

--- a/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
+++ b/assets/js/collaborative-editor/components/TemplateBrowserModal.tsx
@@ -1,13 +1,16 @@
 import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
+import { useEffect, useState } from 'react';
 
 import { cn } from '#/utils/cn';
 
-import type {
-  BaseTemplate,
-  Template,
-  WorkflowTemplate,
+import {
+  isBaseTemplate,
+  type Template,
+  type WorkflowTemplate,
 } from '../types/template';
 import { filterTemplates, matchesQuery } from '../utils/filterTemplates';
+
+import { TemplatePreview } from './TemplatePreview';
 
 export interface TemplateBrowserModalProps {
   isOpen: boolean;
@@ -30,26 +33,49 @@ export function TemplateBrowserModal({
   searchQuery,
   onSearchChange,
 }: TemplateBrowserModalProps) {
-  const baseTemplates = templates.filter(
-    (t): t is BaseTemplate => (t as BaseTemplate).isBase === true
-  );
+  const baseTemplates = templates.filter(isBaseTemplate);
   const userTemplates = templates.filter(
-    (t): t is WorkflowTemplate => (t as BaseTemplate).isBase !== true
+    (t): t is WorkflowTemplate => !isBaseTemplate(t)
   );
   const q = searchQuery.trim();
   const filteredUserTemplates = filterTemplates(userTemplates, q);
   const anyBaseTemplateMatches =
     q.length > 0 && baseTemplates.some(t => matchesQuery(t, q));
 
-  let cols = 1;
-  if (templates.length > 6) cols = 3;
-  else if (templates.length > 3) cols = 2;
+  // Which template the preview pane is showing. Local rather than in UIStore:
+  // nothing outside this modal observes it, and it is meant to die with the
+  // modal. UIStore holds the fetched templates and the search query because
+  // those are shared and survive a close; this does not.
+  const [previewedId, setPreviewedId] = useState<string | null>(null);
+
+  // Base templates are always listed, search or not — they are the starting
+  // points we want to keep offering. Only user templates get filtered.
+  const visibleTemplates = [...baseTemplates, ...filteredUserTemplates];
+
+  // Only ever preview something the list is actually showing — otherwise a
+  // search that hides the previewed template leaves the pane, and the create
+  // button, pointing at a template the user can no longer see.
+  const previewed = visibleTemplates.find(t => t.id === previewedId) ?? null;
+
+  // The modal stays mounted, so reset on close rather than on unmount.
+  useEffect(() => {
+    if (!isOpen) setPreviewedId(null);
+  }, [isOpen]);
+
+  // Never show an empty preview pane if there is something to show. Covers both
+  // the initial open and a search having just hidden the previewed template.
+  const firstVisibleId = visibleTemplates[0]?.id ?? null;
+  const hasPreview = previewed !== null;
+  useEffect(() => {
+    if (!isOpen || hasPreview || firstVisibleId === null) return;
+    setPreviewedId(firstVisibleId);
+  }, [isOpen, hasPreview, firstVisibleId]);
 
   return (
     <Dialog
       open={isOpen}
       onClose={onClose}
-      className="relative z-20"
+      className="relative z-110"
       aria-label="Browse workflow templates"
     >
       <DialogBackdrop
@@ -61,15 +87,10 @@ export function TemplateBrowserModal({
         <DialogPanel
           transition
           className={cn(
-            'bg-white rounded-2xl shadow-2xl w-full flex flex-col h-[560px]',
+            'bg-white rounded-2xl shadow-2xl w-full flex flex-col h-[95%] max-h-180 max-w-5xl',
             'data-closed:opacity-0 data-closed:scale-95',
             'data-enter:duration-300 data-enter:ease-out',
-            'data-leave:duration-200 data-leave:ease-in',
-            {
-              'max-w-lg': cols === 1,
-              'max-w-2xl': cols === 2,
-              'max-w-[784px]': cols === 3,
-            }
+            'data-leave:duration-200 data-leave:ease-in'
           )}
         >
           {/* Header */}
@@ -85,73 +106,102 @@ export function TemplateBrowserModal({
             </button>
           </div>
 
-          {/* Search bar — fixed, does not scroll */}
-          <div className="px-6">
-            <div className="relative">
-              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
-                <span className="hero-magnifying-glass h-4 w-4 text-gray-400" />
-              </span>
-              <input
-                type="text"
-                aria-label="Search templates"
-                placeholder="Search templates"
-                value={searchQuery}
-                onChange={e => onSearchChange(e.target.value)}
-                disabled={loading}
-                className="w-full rounded-md border border-gray-200 py-2 pl-9 pr-3 text-sm
-                  text-gray-900 placeholder:text-gray-400
-                  focus:outline-none focus-visible:ring-1 focus-visible:border-gray-300 focus-visible:ring-gray-300
-                  disabled:opacity-50"
-              />
-            </div>
-          </div>
-
-          {/* Content — scrollable, fills remaining panel height */}
-          <div className="px-6 py-5 overflow-y-auto flex-1 min-h-0">
-            {loading ? (
-              <p className="text-sm text-gray-500 text-center py-8">
-                Loading templates...
-              </p>
-            ) : (
-              <div
-                className={cn('grid gap-x-4 gap-y-6', {
-                  'grid-cols-1': cols === 1,
-                  'grid-cols-2': cols === 2,
-                  'grid-cols-3': cols === 3,
-                })}
-              >
-                {/* Base templates are always shown unfiltered — intentional */}
-                {baseTemplates.map(template => (
-                  <TemplateSelectCard
-                    key={template.id}
-                    template={template}
-                    disabled={isSaving}
-                    onClick={() => onSelect(template)}
-                  />
-                ))}
-                {filteredUserTemplates.map(template => (
-                  <TemplateSelectCard
-                    key={template.id}
-                    template={template}
-                    disabled={isSaving}
-                    onClick={() => onSelect(template)}
-                  />
-                ))}
-                {userTemplates.length > 0 &&
-                  filteredUserTemplates.length === 0 &&
-                  searchQuery.trim() &&
-                  !anyBaseTemplateMatches && (
-                    <p
-                      className={cn('text-sm text-gray-500 py-2', {
-                        'col-span-2': cols === 2,
-                        'col-span-3': cols === 3,
-                      })}
-                    >
-                      No saved templates match your search.
-                    </p>
-                  )}
+          {/* Two panes: list on the left, preview on the right */}
+          <div className="flex flex-1 min-h-0 gap-5 px-6 pb-6">
+            {/* List pane */}
+            <div className="flex w-72 shrink-0 flex-col min-h-0">
+              <div className="relative">
+                <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
+                  <span className="hero-magnifying-glass h-4 w-4 text-gray-400" />
+                </span>
+                <input
+                  type="text"
+                  aria-label="Search templates"
+                  placeholder="Search templates"
+                  value={searchQuery}
+                  onChange={e => onSearchChange(e.target.value)}
+                  disabled={loading}
+                  className="w-full rounded-md border border-gray-200 py-2 pl-9 pr-3 text-sm
+                    text-gray-900 placeholder:text-gray-400
+                    focus:outline-none focus-visible:ring-1 focus-visible:border-gray-300 focus-visible:ring-gray-300
+                    disabled:opacity-50"
+                />
               </div>
-            )}
+
+              <div className="mt-4 flex-1 min-h-0 overflow-y-auto pr-2">
+                {loading ? (
+                  <p className="py-8 text-center text-sm text-gray-500">
+                    Loading templates...
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-4 py-1">
+                    {visibleTemplates.map(template => (
+                      <TemplateSelectCard
+                        key={template.id}
+                        template={template}
+                        selected={template.id === previewedId}
+                        disabled={isSaving}
+                        onClick={() => setPreviewedId(template.id)}
+                      />
+                    ))}
+                    {userTemplates.length > 0 &&
+                      filteredUserTemplates.length === 0 &&
+                      searchQuery.trim() &&
+                      !anyBaseTemplateMatches && (
+                        <p className="py-2 text-sm text-gray-500">
+                          No saved templates match your search.
+                        </p>
+                      )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Preview pane */}
+            <div className="flex flex-1 min-w-0 flex-col rounded-lg border border-gray-200 bg-gray-50">
+              <div className="flex-1 min-h-0">
+                {previewed ? (
+                  // Keyed so a template switch remounts rather than trying to
+                  // animate one graph into another. That means each selection
+                  // re-parses and re-lays-out from scratch, which is cheap at
+                  // template scale (a handful of nodes) and keeps the preview
+                  // free of any carried-over viewport or node state.
+                  <TemplatePreview key={previewed.id} template={previewed} />
+                ) : (
+                  <div className="flex h-full items-center justify-center p-6">
+                    <p className="text-sm text-gray-500">
+                      Select a template to preview it.
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {previewed && (
+                <div className="flex items-end justify-between gap-4 border-t border-gray-200 bg-white/60 px-4 py-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-gray-900">
+                      {previewed.name}
+                    </p>
+                    {previewed.description && (
+                      <p className="mt-0.5 line-clamp-2 text-sm text-gray-500">
+                        {previewed.description}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(previewed)}
+                    disabled={isSaving}
+                    className="shrink-0 rounded-md bg-primary-600 px-3 py-2 text-sm font-medium text-white
+                      hover:bg-primary-500 transition-colors
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                  >
+                    {isSaving ? 'Creating...' : 'Use this template'}
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </DialogPanel>
       </div>
@@ -161,12 +211,14 @@ export function TemplateBrowserModal({
 
 interface TemplateSelectCardProps {
   template: Template;
+  selected: boolean;
   disabled: boolean;
   onClick: () => void;
 }
 
 function TemplateSelectCard({
   template,
+  selected,
   disabled,
   onClick,
 }: TemplateSelectCardProps) {
@@ -175,10 +227,15 @@ function TemplateSelectCard({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="w-full h-full text-left rounded-lg border border-gray-200 bg-white p-3
-        hover:border-gray-300 hover:bg-gray-50 transition-colors
-        disabled:opacity-50 disabled:cursor-not-allowed
-        focus:outline-none focus-visible:ring-1 focus-visible:ring-gray-300 focus-visible:border-gray-300"
+      aria-pressed={selected}
+      className={cn(
+        'w-full text-left rounded-lg border bg-white p-3 transition-colors',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        'focus:outline-none focus-visible:ring-1 focus-visible:ring-gray-300',
+        selected
+          ? 'border-gray-400 ring-gray-400'
+          : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+      )}
     >
       <p className="text-sm font-medium text-gray-900">{template.name}</p>
       {template.description && (

--- a/assets/js/collaborative-editor/components/TemplateBrowserModalWrapper.tsx
+++ b/assets/js/collaborative-editor/components/TemplateBrowserModalWrapper.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import { parseWorkflowYAML, convertWorkflowSpecToState } from '../../yaml/util';
 import { fetchTemplates } from '../api/templates';
 import { BASE_TEMPLATES } from '../constants/baseTemplates';
 import { useActionLock } from '../hooks/useActionLock';
@@ -14,6 +13,7 @@ import { useCreateWorkflowFlow } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
 import { notifications } from '../lib/notifications';
 import type { Template } from '../types/template';
+import { templateToWorkflowState } from '../utils/templateWorkflowState';
 
 import { TemplateBrowserModal } from './TemplateBrowserModal';
 
@@ -86,7 +86,7 @@ export function TemplateBrowserModalWrapper() {
   const { run: handleSelect, isPending: isSaving } = useActionLock(
     async (template: Template) => {
       const created = await createWorkflowFrom(() =>
-        convertWorkflowSpecToState(parseWorkflowYAML(template.code))
+        templateToWorkflowState(template)
       );
       if (created) {
         closeTemplateBrowserModal();

--- a/assets/js/collaborative-editor/components/TemplatePreview.tsx
+++ b/assets/js/collaborative-editor/components/TemplatePreview.tsx
@@ -1,0 +1,199 @@
+/**
+ * Read-only diagram preview of a template, rendered straight from its YAML.
+ *
+ * This deliberately does NOT go through WorkflowStore, the Y.Doc, or the
+ * Phoenix channel. It reuses only the pure parts of the diagram stack —
+ * `fromWorkflow`, the Dagre `layout`, and the node/edge components — so a
+ * template can be looked at without a workflow existing anywhere. Browsing
+ * templates therefore has no side effects: nothing is created until the user
+ * explicitly asks for it.
+ *
+ * The preview draws shape only — node names, adaptors and how they connect.
+ * Job bodies are parsed and discarded.
+ */
+
+import {
+  type EdgeTypes,
+  type NodeTypes,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+} from '@xyflow/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { FIT_PADDING } from '#/workflow-diagram/constants';
+import edgeTypes from '#/workflow-diagram/edges';
+import layout from '#/workflow-diagram/layout';
+import nodeTypes from '#/workflow-diagram/nodes';
+import type { Flow, Lightning } from '#/workflow-diagram/types';
+import fromWorkflow from '#/workflow-diagram/util/from-workflow';
+
+import type { Template } from '../types/template';
+import { createEmptyRunInfo } from '../utils/runStepsTransformer';
+import { templateToWorkflowState } from '../utils/templateWorkflowState';
+
+import { ErrorBoundary } from './common/ErrorBoundary';
+
+const EMPTY_MODEL: Flow.Model = { nodes: [], edges: [] };
+
+export interface TemplatePreviewProps {
+  template: Template;
+}
+
+export function TemplatePreview({ template }: TemplatePreviewProps) {
+  // The boundary is the outermost layer on purpose: the preview is a nicety,
+  // and it must never be able to take the template browser — or the workflow
+  // creation path behind it — down with it. Callers key this component by
+  // template id, so switching template also resets a tripped boundary.
+  //
+  // Each preview gets its own ReactFlowProvider so it cannot share viewport or
+  // node state with the real canvas.
+  return (
+    <ErrorBoundary
+      label="Template preview"
+      // No retry: re-rendering the same template would fail the same way, and
+      // the user's way out is simply to pick another one.
+      fallback={() => (
+        <PreviewFallback message="This template can't be previewed." />
+      )}
+    >
+      <ReactFlowProvider>
+        <TemplatePreviewFlow template={template} />
+      </ReactFlowProvider>
+    </ErrorBoundary>
+  );
+}
+
+function PreviewFallback({
+  message,
+  detail,
+}: {
+  message: string;
+  detail?: string;
+}) {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-6">
+      <p className="text-center text-sm text-gray-500">
+        {message}
+        {detail && (
+          <>
+            <br />
+            <span className="text-xs text-gray-400">{detail}</span>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function TemplatePreviewFlow({ template }: TemplatePreviewProps) {
+  const flow = useReactFlow();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [model, setModel] = useState<Flow.Model>(EMPTY_MODEL);
+
+  // A user-published template can contain YAML we can't parse. That must not
+  // take the modal down with it.
+  const parsed = useMemo(() => {
+    try {
+      return {
+        state: templateToWorkflowState(template),
+        error: null as string | null,
+      };
+    } catch (error) {
+      return {
+        state: null,
+        error:
+          error instanceof Error
+            ? error.message
+            : "This template's definition could not be read.",
+      };
+    }
+  }, [template]);
+
+  useEffect(() => {
+    if (!parsed.state) {
+      setModel(EMPTY_MODEL);
+      return;
+    }
+
+    const { jobs, triggers, edges } = parsed.state;
+
+    // `disabled: true` suppresses the placeholder "+" affordances on nodes.
+    // Positions are passed empty so Dagre always lays the preview out fresh: a
+    // template's own `pos` values were authored against a full-size canvas, and
+    // reusing them here would push nodes out of this much smaller pane. The
+    // preview therefore shows the shape of the workflow, not the exact layout
+    // the user will land on after creating it.
+    // The cast is pre-existing type debt shared with WorkflowDiagram.tsx: the
+    // YAML state types and the diagram's Lightning.* types describe the same
+    // data but are declared separately.
+    const initial = fromWorkflow(
+      {
+        jobs,
+        triggers,
+        edges,
+        disabled: true,
+      } as unknown as Lightning.Workflow,
+      {},
+      EMPTY_MODEL,
+      createEmptyRunInfo(),
+      null
+    );
+
+    const rect = containerRef.current?.getBoundingClientRect();
+    void layout(
+      initial,
+      setModel,
+      flow,
+      { width: rect?.width ?? 0, height: rect?.height ?? 0 },
+      // `duration: false` skips interpolating the nodes into place — there is
+      // no previous layout to animate from.
+      //
+      // Deliberately no `forceFit`: framing the graph is left to ReactFlow's
+      // own `fitView` prop below. `forceFit` would fit on a fixed 20ms timer,
+      // which both races node measurement and outlives this component when the
+      // user switches template — ReactFlow instead holds the fit until the
+      // nodes are measured, then runs it once.
+      { duration: false }
+    );
+  }, [parsed, flow]);
+
+  if (parsed.error) {
+    return (
+      <PreviewFallback
+        message="This template can't be previewed."
+        detail={parsed.error}
+      />
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <ReactFlow
+        nodes={model.nodes}
+        edges={model.edges}
+        nodeTypes={nodeTypes as unknown as NodeTypes}
+        edgeTypes={edgeTypes as unknown as EdgeTypes}
+        proOptions={{ account: 'paid-pro', hideAttribution: true }}
+        // Read-only is a prop combination in ReactFlow, not a single flag.
+        nodesDraggable={false}
+        nodesConnectable={false}
+        nodesFocusable={false}
+        edgesFocusable={false}
+        elementsSelectable={false}
+        panOnDrag={false}
+        panOnScroll={false}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        zoomOnDoubleClick={false}
+        // Defaults to true, which traps page/modal scroll under the pointer.
+        preventScrolling={false}
+        deleteKeyCode={null}
+        fitView
+        fitViewOptions={{ padding: FIT_PADDING }}
+        maxZoom={1}
+        minZoom={0.2}
+      />
+    </div>
+  );
+}

--- a/assets/js/collaborative-editor/components/TemplatePreview.tsx
+++ b/assets/js/collaborative-editor/components/TemplatePreview.tsx
@@ -13,6 +13,7 @@
  */
 
 import {
+  Background,
   type EdgeTypes,
   type NodeTypes,
   ReactFlow,
@@ -193,7 +194,11 @@ function TemplatePreviewFlow({ template }: TemplatePreviewProps) {
         fitViewOptions={{ padding: FIT_PADDING }}
         maxZoom={1}
         minZoom={0.2}
-      />
+      >
+        {/* Propless, matching the real canvas, so the preview reads as the
+            same surface rather than a differently-styled one. */}
+        <Background />
+      </ReactFlow>
     </div>
   );
 }

--- a/assets/js/collaborative-editor/components/TemplatePreview.tsx
+++ b/assets/js/collaborative-editor/components/TemplatePreview.tsx
@@ -31,7 +31,7 @@ import fromWorkflow from '#/workflow-diagram/util/from-workflow';
 
 import type { Template } from '../types/template';
 import { createEmptyRunInfo } from '../utils/runStepsTransformer';
-import { templateToWorkflowState } from '../utils/templateWorkflowState';
+import { tryTemplateToWorkflowState } from '../utils/templateWorkflowState';
 
 import { ErrorBoundary } from './common/ErrorBoundary';
 
@@ -93,23 +93,12 @@ function TemplatePreviewFlow({ template }: TemplatePreviewProps) {
   const [model, setModel] = useState<Flow.Model>(EMPTY_MODEL);
 
   // A user-published template can contain YAML we can't parse. That must not
-  // take the modal down with it.
-  const parsed = useMemo(() => {
-    try {
-      return {
-        state: templateToWorkflowState(template),
-        error: null as string | null,
-      };
-    } catch (error) {
-      return {
-        state: null,
-        error:
-          error instanceof Error
-            ? error.message
-            : "This template's definition could not be read.",
-      };
-    }
-  }, [template]);
+  // take the modal down with it. The modal parses the same template to decide
+  // whether Create is offered at all, so both land on the same verdict.
+  const parsed = useMemo(
+    () => tryTemplateToWorkflowState(template),
+    [template]
+  );
 
   useEffect(() => {
     if (!parsed.state) {

--- a/assets/js/collaborative-editor/components/YAMLImportModal.tsx
+++ b/assets/js/collaborative-editor/components/YAMLImportModal.tsx
@@ -24,7 +24,7 @@ export function YAMLImportModal() {
     <Dialog
       open={isOpen}
       onClose={closeYAMLImportModal}
-      className="relative z-20"
+      className="relative z-110"
       aria-label="Import a workflow"
     >
       <DialogBackdrop

--- a/assets/js/collaborative-editor/components/YAMLImportModal.tsx
+++ b/assets/js/collaborative-editor/components/YAMLImportModal.tsx
@@ -10,6 +10,7 @@ import { useShowYAMLImportModal, useUICommands } from '../hooks/useUI';
 import { useCreateWorkflowFlow } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
 
+import { ActionButton } from './ds/ActionButton';
 import { ValidationErrorDisplay } from './yaml-import/ValidationErrorDisplay';
 import { YAMLCodeEditor } from './yaml-import/YAMLCodeEditor';
 import { YAMLFileDropzone } from './yaml-import/YAMLFileDropzone';
@@ -194,38 +195,15 @@ function YAMLImportContent({ onClose, onSuccess }: YAMLImportContentProps) {
         </button>
         <Tooltip content={tooltipMessage} side="top">
           <span>
-            <button
-              type="button"
+            <ActionButton
               onClick={() => {
                 void handleSave();
               }}
               disabled={isButtonDisabled}
-              className="rounded-full bg-gray-900 px-5 py-2 text-sm font-semibold text-white hover:bg-gray-700 disabled:hover:bg-gray-900 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-2 transition-colors"
+              loading={importState === 'parsing' || importState === 'importing'}
             >
-              {(importState === 'parsing' || importState === 'importing') && (
-                <svg
-                  className="animate-spin h-4 w-4"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  ></circle>
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  ></path>
-                </svg>
-              )}
               {buttonText}
-            </button>
+            </ActionButton>
           </span>
         </Tooltip>
       </div>

--- a/assets/js/collaborative-editor/components/common/ErrorBoundary.tsx
+++ b/assets/js/collaborative-editor/components/common/ErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { Component, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Names the failing area in the console log, e.g. "ManualRunPanel". Every
+   * boundary logs, so this is what tells them apart in a stack of them.
+   */
+  label: string;
+  /**
+   * Rendered in place of `children` once an error is caught. Receives `reset`
+   * so a fallback can offer a retry; boundaries whose fallback is terminal can
+   * ignore it.
+   */
+  fallback: (error: Error, reset: () => void) => ReactNode;
+  onError?: (error: Error) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * The one error boundary in the collaborative editor.
+ *
+ * React only lets class components catch render errors, so each boundary used
+ * to be hand-written — three near-identical classes differing only in their
+ * fallback markup. Everything except the markup lives here; callers supply a
+ * `fallback` and, where they need one, a named wrapper around this component.
+ *
+ * Note that this catches errors thrown during render, not in event handlers,
+ * effects that escape to a promise, or timers. Async failures still need their
+ * own handling at the call site.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  override state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error) {
+    console.error(`${this.props.label} error:`, error);
+    this.props.onError?.(error);
+  }
+
+  private readonly reset = () => {
+    this.setState({ error: null });
+  };
+
+  override render() {
+    const { error } = this.state;
+    if (error) return this.props.fallback(error, this.reset);
+    return this.props.children;
+  }
+}

--- a/assets/js/collaborative-editor/components/ds/ActionButton.tsx
+++ b/assets/js/collaborative-editor/components/ds/ActionButton.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '#/utils/cn';
+
+interface ActionButtonProps {
+  children: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  /** Renders a spinner and disables the button. */
+  loading?: boolean;
+  type?: 'button' | 'submit';
+  className?: string;
+}
+
+/**
+ * Primary action button for the new design system: the gray-900 pill used by
+ * the landing screen's modals. Distinct from `Button.tsx`, which is the older
+ * `primary-600` / `rounded-md` system still used across the inspector and
+ * header. The two coexist until the design system transition completes.
+ */
+export function ActionButton({
+  children,
+  onClick,
+  disabled = false,
+  loading = false,
+  type = 'button',
+  className,
+}: ActionButtonProps) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled || loading}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full bg-gray-900 px-5 py-2',
+        'text-sm font-semibold text-white transition-colors',
+        'hover:bg-gray-700',
+        'focus:outline-none focus-visible:ring focus-visible:ring-gray-300',
+        'disabled:opacity-40 disabled:hover:bg-gray-900 disabled:cursor-not-allowed',
+        className
+      )}
+    >
+      {loading && (
+        <svg
+          aria-hidden="true"
+          className="animate-spin h-4 w-4"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      )}
+      {children}
+    </button>
+  );
+}

--- a/assets/js/collaborative-editor/components/run-viewer/RunViewerErrorBoundary.tsx
+++ b/assets/js/collaborative-editor/components/run-viewer/RunViewerErrorBoundary.tsx
@@ -1,41 +1,24 @@
-import { Component, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
+
+import { ErrorBoundary } from '../common/ErrorBoundary';
 
 interface Props {
   children: ReactNode;
   onError?: (error: Error) => void;
 }
 
-interface State {
-  hasError: boolean;
-  error: Error | null;
-}
-
-export class RunViewerErrorBoundary extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static override getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error };
-  }
-
-  override componentDidCatch(error: Error) {
-    console.error('RunViewer error:', error);
-    this.props.onError?.(error);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
+export function RunViewerErrorBoundary({ children, onError }: Props) {
+  return (
+    <ErrorBoundary
+      label="RunViewer"
+      {...(onError ? { onError } : {})}
+      fallback={(error, reset) => (
         <div className="flex items-center justify-center h-full">
           <div className="text-center">
             <p className="text-red-600 font-semibold">Something went wrong</p>
-            <p className="text-sm text-gray-500 mt-1">
-              {this.state.error?.message}
-            </p>
+            <p className="text-sm text-gray-500 mt-1">{error.message}</p>
             <button
-              onClick={() => this.setState({ hasError: false, error: null })}
+              onClick={reset}
               className="mt-4 px-4 py-2 bg-primary-100
                 hover:bg-primary-200 rounded"
             >
@@ -43,9 +26,9 @@ export class RunViewerErrorBoundary extends Component<Props, State> {
             </button>
           </div>
         </div>
-      );
-    }
-
-    return this.props.children;
-  }
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
 }

--- a/assets/js/collaborative-editor/components/yaml-import/YAMLFileDropzone.tsx
+++ b/assets/js/collaborative-editor/components/yaml-import/YAMLFileDropzone.tsx
@@ -128,9 +128,9 @@ export function YAMLFileDropzone({ onUpload }: YAMLFileDropzoneProps) {
             Upload or drop a YAML file.
           </p>
           <p className="text-xs text-gray-500">
-            <span className="text-teal-500 font-medium">YML</span>
+            <span className="text-primary-500 font-medium">YML</span>
             {' or '}
-            <span className="text-teal-500 font-medium">YAML</span>
+            <span className="text-primary-500 font-medium">YAML</span>
             {', up to 8MB'}
           </p>
         </label>

--- a/assets/js/collaborative-editor/types/template.ts
+++ b/assets/js/collaborative-editor/types/template.ts
@@ -20,3 +20,12 @@ export interface BaseTemplate {
 }
 
 export type Template = WorkflowTemplate | BaseTemplate;
+
+/**
+ * `isBase` is the only field that distinguishes the templates we ship from the
+ * ones a user published, and the difference matters to the UI: base templates
+ * are always listed, and are labelled so users can tell them apart.
+ */
+export function isBaseTemplate(template: Template): template is BaseTemplate {
+  return 'isBase' in template && template.isBase;
+}

--- a/assets/js/collaborative-editor/utils/templateWorkflowState.ts
+++ b/assets/js/collaborative-editor/utils/templateWorkflowState.ts
@@ -16,3 +16,29 @@ import type { Template } from '../types/template';
 export function templateToWorkflowState(template: Template): WorkflowState {
   return convertWorkflowSpecToState(parseWorkflowYAML(template.code));
 }
+
+export type ParsedTemplate =
+  | { state: WorkflowState; error: null }
+  | { state: null; error: string };
+
+/**
+ * `templateToWorkflowState` with the throw turned into a value.
+ *
+ * The UI asks the same question in two places — the preview, to decide what to
+ * draw, and the browser modal, to decide whether Create can do anything — and
+ * both want the failure as data rather than an exception. Sharing this keeps
+ * them agreeing about which templates are broken.
+ */
+export function tryTemplateToWorkflowState(template: Template): ParsedTemplate {
+  try {
+    return { state: templateToWorkflowState(template), error: null };
+  } catch (error) {
+    return {
+      state: null,
+      error:
+        error instanceof Error
+          ? error.message
+          : "This template's definition could not be read.",
+    };
+  }
+}

--- a/assets/js/collaborative-editor/utils/templateWorkflowState.ts
+++ b/assets/js/collaborative-editor/utils/templateWorkflowState.ts
@@ -1,0 +1,18 @@
+import type { WorkflowState } from '../../yaml/types';
+import { convertWorkflowSpecToState, parseWorkflowYAML } from '../../yaml/util';
+import type { Template } from '../types/template';
+
+/**
+ * The single definition of what a template's YAML means.
+ *
+ * Both the read-only preview and the create path go through here, so what the
+ * preview draws is by construction what "Use this template" builds. Two
+ * separate call sites could drift apart in how they parse or normalise, and a
+ * preview that lies about the resulting workflow is worse than no preview.
+ *
+ * Throws on unparseable YAML — user-published templates can contain anything,
+ * so every caller has to decide what to do about that.
+ */
+export function templateToWorkflowState(template: Template): WorkflowState {
+  return convertWorkflowSpecToState(parseWorkflowYAML(template.code));
+}

--- a/assets/js/collaborative-editor/utils/templateWorkflowState.ts
+++ b/assets/js/collaborative-editor/utils/templateWorkflowState.ts
@@ -6,7 +6,7 @@ import type { Template } from '../types/template';
  * The single definition of what a template's YAML means.
  *
  * Both the read-only preview and the create path go through here, so what the
- * preview draws is by construction what "Use this template" builds. Two
+ * preview draws is by construction what Create builds. Two
  * separate call sites could drift apart in how they parse or normalise, and a
  * preview that lies about the resulting workflow is worse than no preview.
  *

--- a/assets/tailwind.config.ts
+++ b/assets/tailwind.config.ts
@@ -56,6 +56,26 @@ export default {
           '-ms-overflow-style': 'none',
           'scrollbar-width': 'none',
         },
+        // A scrollbar that still says "there is more below" without the
+        // chunky default track, which collides with rounded containers.
+        '.thin-scrollbar': {
+          'scrollbar-width': 'thin',
+          'scrollbar-color': '#d1d5db transparent',
+          '&::-webkit-scrollbar': {
+            width: '6px',
+            height: '6px',
+          },
+          '&::-webkit-scrollbar-track': {
+            background: 'transparent',
+          },
+          '&::-webkit-scrollbar-thumb': {
+            background: '#d1d5db',
+            borderRadius: '3px',
+          },
+          '&::-webkit-scrollbar-thumb:hover': {
+            background: '#9ca3af',
+          },
+        },
       });
     }),
     // Allows prefixing tailwind classes with LiveView classes to add rules

--- a/assets/test/collaborative-editor/components/TemplateBrowserModal.test.tsx
+++ b/assets/test/collaborative-editor/components/TemplateBrowserModal.test.tsx
@@ -29,12 +29,37 @@ function nextId(prefix: string) {
   return `${prefix}-${idCounter}`;
 }
 
+/**
+ * Templates default to YAML that actually parses, because the modal now reads
+ * it: Create is disabled for anything the preview can't render. Empty `code`
+ * would silently put every fixture in the broken state and the create-path
+ * tests would be asserting against a button that is disabled for the wrong
+ * reason.
+ */
+const PARSEABLE_YAML = `name: "Fixture"
+jobs:
+  Step:
+    name: Step
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn(state => state);
+triggers:
+  webhook:
+    type: webhook
+    enabled: true
+edges:
+  webhook->Step:
+    source_trigger: webhook
+    target_job: Step
+    condition_type: always
+    enabled: true`;
+
 function makeBaseTemplate(overrides: Partial<BaseTemplate> = {}): BaseTemplate {
   return {
     id: nextId('base'),
     name: 'Base Template',
     description: '',
-    code: '',
+    code: PARSEABLE_YAML,
     tags: [],
     isBase: true,
     ...overrides,
@@ -48,7 +73,7 @@ function makeUserTemplate(
     id: nextId('user'),
     name: 'User Template',
     description: null,
-    code: '',
+    code: PARSEABLE_YAML,
     positions: null,
     tags: [],
     workflow_id: null,
@@ -266,6 +291,38 @@ describe('TemplateBrowserModal', () => {
       expect(
         screen.getByRole('button', { name: 'Creating...' })
       ).toBeDisabled();
+    });
+  });
+
+  describe('unreadable template', () => {
+    test('disables create rather than letting it fail on the same YAML', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      const templates = [
+        makeBaseTemplate({ name: 'Broken', code: 'not: [valid workflow' }),
+      ];
+      await renderModal({ templates, onSelect });
+
+      const createButton = screen.getByRole('button', { name: 'Create' });
+      expect(createButton).toBeDisabled();
+
+      await user.click(createButton);
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    test('leaves create usable once a readable template is previewed', async () => {
+      const user = userEvent.setup();
+      const templates = [
+        makeBaseTemplate({ name: 'Broken', code: 'not: [valid workflow' }),
+        makeBaseTemplate({ name: 'Fine' }),
+      ];
+      await renderModal({ templates });
+
+      expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+
+      await user.click(screen.getByRole('button', { name: 'Fine' }));
+
+      expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
     });
   });
 

--- a/assets/test/collaborative-editor/components/TemplateBrowserModal.test.tsx
+++ b/assets/test/collaborative-editor/components/TemplateBrowserModal.test.tsx
@@ -4,9 +4,9 @@
  * `TemplateBrowserModal` is props-driven with no store/context, so it's
  * rendered directly. Filtering itself (name/description/tag matching) is
  * covered by `utils/filterTemplates.test.ts`; this file only asserts the
- * component's own rendering decisions: grid-column sizing, the "no results"
- * message's visibility conditions, disabled state while saving, and the
- * loading state.
+ * component's own rendering decisions: panel sizing, the "no results" message's
+ * visibility conditions, which template the preview pane points at, disabled
+ * state while saving, and the loading state.
  */
 
 import { act, render, screen } from '@testing-library/react';
@@ -77,62 +77,54 @@ async function renderModal(overrides: Partial<TemplateBrowserModalProps> = {}) {
   const view = render(<TemplateBrowserModal {...props} />);
   // Headless UI's enter transition resolves on a later tick; flush it here
   // so it doesn't leak into the next test as an act() warning.
-  await act(async () => {
-    await new Promise(resolve => setTimeout(resolve, 0));
-  });
-  return view;
+  const flush = async () => {
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+  };
+  await flush();
+
+  // The modal is fully props-driven, so state the parent owns — `searchQuery`
+  // above all — only changes via a re-render from outside.
+  const updateProps = async (next: Partial<TemplateBrowserModalProps>) => {
+    view.rerender(<TemplateBrowserModal {...props} {...next} />);
+    await flush();
+  };
+
+  return { ...view, updateProps };
 }
 
 describe('TemplateBrowserModal', () => {
-  describe('grid-column sizing', () => {
-    test.each<[number, string, string]>([
-      [0, 'max-w-lg', 'grid-cols-1'],
-      [3, 'max-w-lg', 'grid-cols-1'],
-      [4, 'max-w-2xl', 'grid-cols-2'],
-      [6, 'max-w-2xl', 'grid-cols-2'],
-      [7, 'max-w-[784px]', 'grid-cols-3'],
-    ])(
-      'with %i templates, panel gets "%s" and grid gets "%s"',
-      async (count, panelClass, gridClass) => {
-        const templates = makeBaseTemplates(count);
-        await renderModal({ templates });
+  describe('panel sizing', () => {
+    // The old responsive 1/2/3-column grid went away with the master-detail
+    // layout: the list is always a single column beside the preview pane, so
+    // the panel width no longer varies with template count.
+    test.each<number>([0, 3, 7])(
+      'panel is a fixed width regardless of template count (%i)',
+      async count => {
+        await renderModal({ templates: makeBaseTemplates(count) });
 
         // Headless UI renders the dialog into a portal appended to
         // document.body, so it lives outside render()'s `container`.
         const panel = document.querySelector('.shadow-2xl');
-        const grid = document.querySelector('.gap-x-4');
 
-        expect(panel?.className).toContain(panelClass);
-        expect(grid?.className).toContain(gridClass);
+        expect(panel?.className).toContain('max-w-5xl');
       }
     );
   });
 
   describe('"no results" message', () => {
-    test.each<[number, string | null]>([
-      [1, null],
-      [4, 'col-span-2'],
-      [7, 'col-span-3'],
-    ])(
-      'shows the message when nothing matches, with col-span matching cols (baseCount=%i)',
-      async (baseCount, expectedColSpan) => {
-        const templates = [
-          ...makeBaseTemplates(baseCount),
-          makeUserTemplate({ name: 'User Item' }),
-        ];
-        await renderModal({ templates, searchQuery: 'zzznomatch' });
+    test('shows the message when no user template matches', async () => {
+      const templates = [
+        ...makeBaseTemplates(2),
+        makeUserTemplate({ name: 'User Item' }),
+      ];
+      await renderModal({ templates, searchQuery: 'zzznomatch' });
 
-        const message = screen.getByText(
-          'No saved templates match your search.'
-        );
-        if (expectedColSpan) {
-          expect(message.className).toContain(expectedColSpan);
-        } else {
-          expect(message.className).not.toContain('col-span-2');
-          expect(message.className).not.toContain('col-span-3');
-        }
-      }
-    );
+      expect(
+        screen.getByText('No saved templates match your search.')
+      ).toBeInTheDocument();
+    });
 
     test('hides the message when there are no user templates at all', async () => {
       const templates = makeBaseTemplates(2);
@@ -177,6 +169,88 @@ describe('TemplateBrowserModal', () => {
     });
   });
 
+  describe('preview selection', () => {
+    test('previews the first template on open so the pane is never empty', async () => {
+      const templates = [
+        makeBaseTemplate({ name: 'Alpha' }),
+        makeUserTemplate({ name: 'Beta' }),
+      ];
+      await renderModal({ templates });
+
+      expect(screen.getByRole('button', { name: 'Alpha' })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Beta' })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    });
+
+    test('clicking a card previews it instead of creating a workflow', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      const templates = [
+        makeBaseTemplate({ name: 'Alpha' }),
+        makeUserTemplate({ name: 'Beta' }),
+      ];
+      await renderModal({ templates, onSelect });
+
+      await user.click(screen.getByRole('button', { name: 'Beta' }));
+
+      expect(screen.getByRole('button', { name: 'Beta' })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+      // The whole point of the preview: browsing is free of side effects.
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    test('"Use this template" creates from the previewed template', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      const templates = [
+        makeBaseTemplate({ name: 'Alpha' }),
+        makeUserTemplate({ name: 'Beta' }),
+      ];
+      await renderModal({ templates, onSelect });
+
+      await user.click(screen.getByRole('button', { name: 'Beta' }));
+      await user.click(
+        screen.getByRole('button', { name: 'Use this template' })
+      );
+
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(templates[1]);
+    });
+
+    test('re-points the preview when a search hides the previewed template', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      const templates = [
+        makeBaseTemplate({ name: 'Alpha' }),
+        makeUserTemplate({ name: 'Beta' }),
+      ];
+      const { updateProps } = await renderModal({ templates, onSelect });
+
+      await user.click(screen.getByRole('button', { name: 'Beta' }));
+      await updateProps({ searchQuery: 'zzznomatch' });
+
+      expect(
+        screen.queryByRole('button', { name: 'Beta' })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Alpha' })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+
+      // The real hazard: creating from a template the list no longer shows.
+      await user.click(
+        screen.getByRole('button', { name: 'Use this template' })
+      );
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(templates[0]);
+    });
+  });
+
   describe('disabled-during-save card state', () => {
     test('disables every template card while isSaving is true', async () => {
       const templates = [
@@ -189,21 +263,13 @@ describe('TemplateBrowserModal', () => {
       expect(screen.getByRole('button', { name: 'Beta' })).toBeDisabled();
     });
 
-    test('enables cards and calls onSelect with the clicked template when not saving', async () => {
-      const user = userEvent.setup();
-      const onSelect = vi.fn();
-      const templates = [
-        makeBaseTemplate({ name: 'Alpha' }),
-        makeUserTemplate({ name: 'Beta' }),
-      ];
-      await renderModal({ templates, onSelect });
+    test('disables the create button while isSaving is true', async () => {
+      const templates = [makeBaseTemplate({ name: 'Alpha' })];
+      await renderModal({ templates, isSaving: true });
 
-      const betaCard = screen.getByRole('button', { name: 'Beta' });
-      expect(betaCard).toBeEnabled();
-
-      await user.click(betaCard);
-
-      expect(onSelect).toHaveBeenCalledExactlyOnceWith(templates[1]);
+      expect(
+        screen.getByRole('button', { name: 'Creating...' })
+      ).toBeDisabled();
     });
   });
 

--- a/assets/test/collaborative-editor/components/TemplateBrowserModal.test.tsx
+++ b/assets/test/collaborative-editor/components/TemplateBrowserModal.test.tsx
@@ -206,7 +206,7 @@ describe('TemplateBrowserModal', () => {
       expect(onSelect).not.toHaveBeenCalled();
     });
 
-    test('"Use this template" creates from the previewed template', async () => {
+    test('"Create" creates from the previewed template', async () => {
       const user = userEvent.setup();
       const onSelect = vi.fn();
       const templates = [
@@ -216,9 +216,7 @@ describe('TemplateBrowserModal', () => {
       await renderModal({ templates, onSelect });
 
       await user.click(screen.getByRole('button', { name: 'Beta' }));
-      await user.click(
-        screen.getByRole('button', { name: 'Use this template' })
-      );
+      await user.click(screen.getByRole('button', { name: 'Create' }));
 
       expect(onSelect).toHaveBeenCalledExactlyOnceWith(templates[1]);
     });
@@ -244,9 +242,7 @@ describe('TemplateBrowserModal', () => {
       );
 
       // The real hazard: creating from a template the list no longer shows.
-      await user.click(
-        screen.getByRole('button', { name: 'Use this template' })
-      );
+      await user.click(screen.getByRole('button', { name: 'Create' }));
       expect(onSelect).toHaveBeenCalledExactlyOnceWith(templates[0]);
     });
   });

--- a/assets/test/collaborative-editor/components/TemplateBrowserModalWrapper.test.tsx
+++ b/assets/test/collaborative-editor/components/TemplateBrowserModalWrapper.test.tsx
@@ -120,13 +120,24 @@ function renderWrapper() {
   return render(<TemplateBrowserModalWrapper />);
 }
 
-async function clickFirstTemplate() {
+/**
+ * Creating from a template is a two-step interaction: clicking a card only
+ * previews it, so the workflow is created from the explicit button. Returns the
+ * create button, which is the control that disables while the save is in
+ * flight.
+ */
+async function createFromFirstTemplate() {
   const user = userEvent.setup();
   const card = await screen.findByRole('button', {
     name: /Event-based workflow/i,
   });
   await user.click(card);
-  return card;
+
+  const createButton = await screen.findByRole('button', {
+    name: 'Use this template',
+  });
+  await user.click(createButton);
+  return createButton;
 }
 
 describe('TemplateBrowserModalWrapper', () => {
@@ -140,7 +151,7 @@ describe('TemplateBrowserModalWrapper', () => {
   test('success: imports, saves with notify: error-only, closes the modal, and dismisses the landing screen', async () => {
     renderWrapper();
 
-    await clickFirstTemplate();
+    await createFromFirstTemplate();
 
     await waitFor(() => {
       expect(mockImportWorkflow).toHaveBeenCalledOnce();
@@ -154,11 +165,11 @@ describe('TemplateBrowserModalWrapper', () => {
     expect(importOrder).toBeLessThan(saveOrder);
   });
 
-  test('save rejection: modal stays open, no bespoke alert, and the card is re-enabled', async () => {
+  test('save rejection: modal stays open, no bespoke alert, and the create button is re-enabled', async () => {
     mockSaveWorkflow.mockRejectedValue(new Error('boom'));
     renderWrapper();
 
-    const card = await clickFirstTemplate();
+    const createButton = await createFromFirstTemplate();
 
     await waitFor(() => {
       expect(mockSaveWorkflow).toHaveBeenCalledWith({ notify: 'error-only' });
@@ -171,7 +182,7 @@ describe('TemplateBrowserModalWrapper', () => {
     expect(mockAlert).not.toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(card).not.toBeDisabled();
+      expect(createButton).not.toBeDisabled();
     });
   });
 
@@ -179,7 +190,7 @@ describe('TemplateBrowserModalWrapper', () => {
     mockIsConnected = false;
     renderWrapper();
 
-    await clickFirstTemplate();
+    await createFromFirstTemplate();
 
     await waitFor(() => {
       expect(mockAlert).toHaveBeenCalledWith({

--- a/assets/test/collaborative-editor/components/TemplateBrowserModalWrapper.test.tsx
+++ b/assets/test/collaborative-editor/components/TemplateBrowserModalWrapper.test.tsx
@@ -134,7 +134,7 @@ async function createFromFirstTemplate() {
   await user.click(card);
 
   const createButton = await screen.findByRole('button', {
-    name: 'Use this template',
+    name: 'Create',
   });
   await user.click(createButton);
   return createButton;

--- a/assets/test/collaborative-editor/components/TemplatePreview.test.tsx
+++ b/assets/test/collaborative-editor/components/TemplatePreview.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * TemplatePreview - read-only template diagram
+ *
+ * The point of these tests is as much architectural as behavioural: the
+ * component is rendered with NO StoreProvider, NO SessionProvider, NO Y.Doc and
+ * NO Phoenix channel. If a future change couples the preview to the
+ * collaborative editor's machinery, these tests stop compiling or start
+ * throwing — which is exactly the guard we want.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { TemplatePreview } from '#/collaborative-editor/components/TemplatePreview';
+import type { BaseTemplate } from '#/collaborative-editor/types/template';
+
+function makeTemplate(code: string): BaseTemplate {
+  return {
+    id: 'template-under-test',
+    name: 'Template',
+    description: '',
+    code,
+    tags: [],
+    isBase: true,
+  };
+}
+
+const VALID_YAML = `name: "Two step workflow"
+jobs:
+  Fetch-data:
+    name: Fetch data
+    adaptor: "@openfn/language-http@latest"
+    body: |
+      get('https://example.com');
+  Transform-data:
+    name: Transform data
+    adaptor: "@openfn/language-common@latest"
+    body: |
+      fn(state => state);
+triggers:
+  webhook:
+    type: webhook
+    enabled: true
+edges:
+  webhook->Fetch-data:
+    source_trigger: webhook
+    target_job: Fetch-data
+    condition_type: always
+    enabled: true
+  Fetch-data->Transform-data:
+    source_job: Fetch-data
+    target_job: Transform-data
+    condition_type: on_job_success
+    enabled: true`;
+
+describe('TemplatePreview', () => {
+  test('renders a node per job and trigger, with no editor providers present', async () => {
+    render(<TemplatePreview template={makeTemplate(VALID_YAML)} />);
+
+    // Layout is async, so the nodes appear on a later tick.
+    await waitFor(() => {
+      expect(screen.getByText('Fetch data')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Transform data')).toBeInTheDocument();
+    // Reusing the real Trigger node means we get its real labelling for free.
+    expect(screen.getByText('Webhook trigger')).toBeInTheDocument();
+  });
+
+  test('draws no editing affordances on the nodes', async () => {
+    const { container } = render(
+      <TemplatePreview template={makeTemplate(VALID_YAML)} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Fetch data')).toBeInTheDocument();
+    });
+
+    // The preview asks `fromWorkflow` for a disabled workflow, which is what
+    // suppresses the "+" connector on each job node. That request travels
+    // through an `as unknown as Lightning.Workflow` cast, so if the diagram
+    // ever renames or re-purposes the flag, TypeScript will NOT flag this file
+    // and the preview silently becomes interactive. This is the assertion that
+    // notices.
+    expect(
+      container.querySelector('[data-handleid="node-connector"]')
+    ).toBeNull();
+    expect(container.querySelector('.hero-plus')).toBeNull();
+  });
+
+  test('falls back to a message when the template YAML cannot be parsed', () => {
+    render(<TemplatePreview template={makeTemplate('not: [valid workflow')} />);
+
+    expect(screen.getByText(/can't be previewed/i)).toBeInTheDocument();
+  });
+
+  test('falls back rather than throwing when the YAML is empty', () => {
+    render(<TemplatePreview template={makeTemplate('')} />);
+
+    expect(screen.getByText(/can't be previewed/i)).toBeInTheDocument();
+  });
+});

--- a/assets/test/collaborative-editor/components/ds/ActionButton.test.tsx
+++ b/assets/test/collaborative-editor/components/ds/ActionButton.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * ActionButton - the new design system's primary action button.
+ *
+ * Only the `loading` implies-disabled rule carries logic; everything else is
+ * styling, which is deliberately not asserted here. Class-name assertions break
+ * on every Tailwind tweak without catching real regressions.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ActionButton } from '#/collaborative-editor/components/ds/ActionButton';
+
+describe('ActionButton', () => {
+  test('loading disables the button and suppresses clicks', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <ActionButton loading onClick={onClick}>
+        Create
+      </ActionButton>
+    );
+
+    const button = screen.getByRole('button', { name: 'Create' });
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('renders and clicks normally when idle', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<ActionButton onClick={onClick}>Create</ActionButton>);
+
+    const button = screen.getByRole('button', { name: 'Create' });
+    expect(button).toBeEnabled();
+
+    await user.click(button);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a template preview in `TemplateBrowserModal` as part of the AI first epic. The design was done mainly with Claude and should be improved/refined in an upcoming release: 

<img width="1510" height="822" alt="image" src="https://github.com/user-attachments/assets/3f89556b-3222-4726-9799-f6ccd3b718b9" />

While doing so, also did the following: 
- Created `ErrorBoundary`  to pull out logic used in now 3 places (`RunViewerErrorBoundary`, `ManualRunErrorBoundary` and now `TemplatePreview`)
- Updated z-index of yaml and templates modals to be z-110 so that it sits on the highest level
- Updated teal in yaml browser to be primary
- Pulled out the Action button in the yaml modal (and added to templates modal) in a new `ds` folder for new design system components

## Validation steps

1. Create a new workflow
2. Click Browse templates
3. Opens modal with a preview
4. Searching for a template will update the list of templates
5. If you have selected a template and then search for something that doesn't include that template, it will deselect
6. Clicking the template creates a new workflow with that template
7. Both the yaml import and templates modal now hide the left side menu as they sit on the highest level on the browser page.
8. The yaml links in the yaml import are now primary colour rather than teal

## Additional notes for the reviewer

n/a

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
