### PR TITLE
Route the "Build with AI" landing prompt through the global assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to
 
 ### Changed
 
+- Creating a workflow with "Build with AI" from the new-workflow landing screen
+  now sends the prompt to the global AI assistant instead of the workflow
+  template chat. Follow-up messages in the conversation behave as before.
+  [#5040](https://github.com/OpenFn/lightning/issues/5040)
+
 - Remove the unreachable, non-streaming code in the AI assistant
   [#5046](https://github.com/OpenFn/lightning/issues/5046)
 

--- a/assets/js/collaborative-editor/hooks/useAIInitialMessage.ts
+++ b/assets/js/collaborative-editor/hooks/useAIInitialMessage.ts
@@ -7,6 +7,12 @@
  * - Prepares the workflow context
  * - Initiates the AI connection with the message
  * - Clears the initial message after sending
+ *
+ * The landing prompt always routes through the GLOBAL assistant (#5040):
+ * the auto-send carries `use_global_assistant: true` (plus the `page`
+ * context Apollo expects), mirroring a manual global send. This only
+ * affects the first, auto-sent message — follow-up messages keep
+ * consulting the ChatInput global-assistant checkbox as before.
  */
 
 import { useEffect, useRef } from 'react';
@@ -97,7 +103,10 @@ export function useAIInitialMessage({
       const { mode, context } = aiMode;
       const { workflow, jobs, triggers, edges, positions } = workflowData;
 
-      let finalContext: JobCodeContext | WorkflowTemplateContext = {
+      let finalContext: (JobCodeContext | WorkflowTemplateContext) & {
+        use_global_assistant?: boolean;
+        page?: string;
+      } = {
         ...context,
         content: initialMessage,
       };
@@ -120,6 +129,16 @@ export function useAIInitialMessage({
             };
           }
         }
+
+        // The landing prompt is always handled by the global assistant.
+        // Mirror the manual global send in AIAssistantPanelWrapper: set the
+        // flag plus the `page` Apollo receives as context (the workflow is
+        // not saved yet, so its name may just be the default placeholder).
+        finalContext = {
+          ...finalContext,
+          use_global_assistant: true,
+          page: `workflows/${workflow?.name || 'workflow'}`,
+        };
       }
 
       // Initialize store with context including content

--- a/assets/test/collaborative-editor/hooks/useAIInitialMessage.test.tsx
+++ b/assets/test/collaborative-editor/hooks/useAIInitialMessage.test.tsx
@@ -197,6 +197,32 @@ describe('useAIInitialMessage', () => {
     expect(mockClearInitialMessage).toHaveBeenCalled();
   });
 
+  it('routes the landing prompt through the global assistant', () => {
+    renderHook(() =>
+      useAIInitialMessage({
+        initialMessage: 'Create a workflow for DHIS2',
+        aiMode: workflowTemplateMode,
+        sessionId: null,
+        connectionState: 'disconnected',
+        isAIAssistantPanelOpen: true,
+        aiStore: mockAiStore as AIAssistantStoreInstance,
+        workflowData: defaultWorkflowData,
+        updateSearchParams: mockUpdateSearchParams,
+        clearAIAssistantInitialMessage: mockClearInitialMessage,
+      })
+    );
+
+    // The auto-sent landing message always uses the global assistant and
+    // carries the page context Apollo expects (mirroring a manual global send)
+    expect(mockAiStore.connect).toHaveBeenCalledWith(
+      'workflow_template',
+      expect.objectContaining({
+        use_global_assistant: true,
+        page: 'workflows/Test Workflow',
+      })
+    );
+  });
+
   it('sends initial message in job_code mode', () => {
     renderHook(() =>
       useAIInitialMessage({
@@ -218,6 +244,11 @@ describe('useAIInitialMessage', () => {
         job_id: 'job-1',
         content: 'Help me with this job',
       })
+    );
+    // Forced global routing only applies to workflow_template (landing) sends
+    expect(mockAiStore.connect).toHaveBeenCalledWith(
+      'job_code',
+      expect.not.objectContaining({ use_global_assistant: true })
     );
     expect(mockUpdateSearchParams).toHaveBeenCalledWith({
       'j-chat': 'new',
@@ -343,11 +374,14 @@ describe('useAIInitialMessage', () => {
       })
     );
 
-    // Should still connect, just without workflow code
+    // Should still connect, just without workflow code; global routing still
+    // applies, with the page falling back to a generic name
     expect(mockAiStore.connect).toHaveBeenCalledWith(
       'workflow_template',
       expect.objectContaining({
         content: 'Create a workflow',
+        use_global_assistant: true,
+        page: 'workflows/workflow',
       })
     );
   });

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -156,16 +156,40 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     page = get_in(session.meta, ["message_options", "page"])
 
     if workflow_yaml in [nil, ""] do
-      Logger.warning(
-        "[AI Assistant] Global chat message #{message.id} has no workflow YAML; " <>
-          "Apollo will receive no workflow context (session #{session.id}, page #{inspect(page)})"
-      )
+      log_missing_workflow_yaml(session, message, page)
     end
 
     AiAssistant.query_global_stream(session, message.content,
       workflow_yaml: workflow_yaml,
       page: page
     )
+  end
+
+  # A brand-new workflow legitimately has no YAML yet (e.g. the "Build with
+  # AI" landing prompt fires before the workflow is ever saved), so log that
+  # at info. Only a session bound to an existing workflow with no YAML
+  # indicates something actually went wrong.
+  defp log_missing_workflow_yaml(session, message, page) do
+    if saved_workflow?(session) do
+      Logger.warning(
+        "[AI Assistant] Global chat message #{message.id} has no workflow YAML; " <>
+          "Apollo will receive no workflow context (session #{session.id}, page #{inspect(page)})"
+      )
+    else
+      Logger.info(
+        "[AI Assistant] Global chat message #{message.id} is for a new workflow, " <>
+          "no YAML to attach (session #{session.id}, page #{inspect(page)})"
+      )
+    end
+  end
+
+  # A session is only ever bound (workflow_id set) to a workflow that existed
+  # in the DB at bind time; unsaved workflows are tracked via the
+  # meta["unsaved_workflow"] marker with workflow_id left nil, and the marker
+  # is swapped for the real workflow_id when the workflow is first saved.
+  defp saved_workflow?(session) do
+    not is_nil(session.workflow_id) and
+      is_nil(get_in(session.meta, ["unsaved_workflow"]))
   end
 
   @spec job_chat?(AiAssistant.ChatSession.t(), ChatMessage.t()) :: boolean()

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -333,6 +333,121 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       assert assistant_msg.response_segments == []
     end
 
+    test "logs at info, not warning, when a brand-new unsaved workflow has no YAML",
+         %{user: user, project: project} do
+      # The "Build with AI" landing flow: the workflow only exists client-side,
+      # so the session carries the unsaved_workflow marker and no workflow_id.
+      global_meta = %{
+        "message_options" => %{
+          "use_global_assistant" => true,
+          "page" => "workflows/Untitled workflow"
+        },
+        "unsaved_workflow" => %{"id" => Ecto.UUID.generate(), "is_new" => true}
+      }
+
+      session =
+        insert(:chat_session,
+          user: user,
+          session_type: "workflow_template",
+          project: project,
+          workflow: nil,
+          job_id: nil,
+          meta: global_meta
+        )
+
+      {:ok, updated_session} =
+        AiAssistant.save_message(
+          session,
+          %{role: :user, content: "build me a workflow", user: user},
+          meta: global_meta
+        )
+
+      user_message = Enum.find(updated_session.messages, &(&1.role == :user))
+      assert user_message.code == nil
+
+      Mox.stub(
+        Lightning.Tesla.Mock,
+        :call,
+        Lightning.AiAssistantHelpers.streaming_or_sync_response(%{
+          "response" => "Global response",
+          "attachments" => [],
+          "usage" => %{}
+        })
+      )
+
+      # The test env logger level is :warning; let this module's info line
+      # through so we can assert on it.
+      Logger.put_module_level(MessageProcessor, :info)
+      on_exit(fn -> Logger.delete_module_level(MessageProcessor) end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok =
+                   perform_job(MessageProcessor, %{
+                     "message_id" => user_message.id
+                   })
+        end)
+
+      # A brand-new workflow legitimately has no YAML: no warning...
+      refute log =~ "has no workflow YAML"
+      # ...just an honest info line.
+      assert log =~ "[info]"
+      assert log =~ "is for a new workflow, no YAML to attach"
+    end
+
+    test "still warns when a session bound to an existing workflow has no YAML",
+         %{user: user, project: project} do
+      workflow = insert(:workflow, project: project)
+
+      global_meta = %{
+        "message_options" => %{
+          "use_global_assistant" => true,
+          "page" => "workflows/Existing workflow"
+        }
+      }
+
+      session =
+        insert(:chat_session,
+          user: user,
+          session_type: "workflow_template",
+          project: project,
+          workflow: workflow,
+          job_id: nil,
+          meta: global_meta
+        )
+
+      {:ok, updated_session} =
+        AiAssistant.save_message(
+          session,
+          %{role: :user, content: "help with my workflow", user: user},
+          meta: global_meta
+        )
+
+      user_message = Enum.find(updated_session.messages, &(&1.role == :user))
+      assert user_message.code == nil
+
+      Mox.stub(
+        Lightning.Tesla.Mock,
+        :call,
+        Lightning.AiAssistantHelpers.streaming_or_sync_response(%{
+          "response" => "Global response",
+          "attachments" => [],
+          "usage" => %{}
+        })
+      )
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok =
+                   perform_job(MessageProcessor, %{
+                     "message_id" => user_message.id
+                   })
+        end)
+
+      assert log =~ "has no workflow YAML"
+      refute log =~ "no YAML to attach"
+    end
+
     test "persists the segments timeline alongside the flat response",
          %{user: user, project: project} do
       workflow = insert(:workflow, project: project)

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -3910,5 +3910,75 @@ defmodule LightningWeb.AiAssistantChannelTest do
       # ...and the message carries no job_id, even though a step was open.
       assert user_msg.job_id == nil
     end
+
+    test "join with use_global_assistant and an unsaved workflow_id creates a global-routed session",
+         %{socket: socket, project: project} do
+      Mox.stub(
+        Lightning.Extensions.MockUsageLimiter,
+        :increment_ai_usage,
+        fn _, _ -> Ecto.Multi.new() end
+      )
+
+      # The "Build with AI" landing flow joins with a client-generated
+      # workflow id that has no DB row yet.
+      unsaved_workflow_id = Ecto.UUID.generate()
+
+      params = %{
+        "project_id" => project.id,
+        "workflow_id" => unsaved_workflow_id,
+        "content" => "Build a workflow that syncs DHIS2 to a spreadsheet",
+        "use_global_assistant" => true,
+        "page" => "workflows/Untitled workflow"
+      }
+
+      # Oban runs inline in tests, so the first message is processed during
+      # the join itself — it must hit the global chat endpoint.
+      Mox.expect(Lightning.Tesla.Mock, :call, fn %{url: url}, _opts ->
+        assert url =~ "/services/global_chat/stream"
+
+        body =
+          Jason.encode!(%{
+            "response" => "Global response",
+            "attachments" => [],
+            "usage" => %{}
+          })
+
+        {:ok,
+         %Tesla.Env{
+           status: 200,
+           headers: [{"content-type", "text/event-stream"}],
+           body: "event: complete\ndata: #{body}\n\n"
+         }}
+      end)
+
+      assert {:ok, response, _socket} =
+               subscribe_and_join(
+                 socket,
+                 AiAssistantChannel,
+                 "ai_assistant:workflow_template:new",
+                 params
+               )
+
+      assert response.session_type == "workflow_template"
+
+      session = AiAssistant.get_session!(response.session_id)
+
+      # The workflow doesn't exist yet, so the session stays unbound and
+      # records the client-generated id in meta...
+      assert session.workflow_id == nil
+      assert session.meta["unsaved_workflow"]["id"] == unsaved_workflow_id
+
+      # ...while still carrying the global routing options.
+      assert session.meta["message_options"]["use_global_assistant"] == true
+
+      assert session.meta["message_options"]["page"] ==
+               "workflows/Untitled workflow"
+
+      # The global endpoint's reply came back as the assistant message.
+      assistant_msg = Enum.find(session.messages, &(&1.role == :assistant))
+      assert assistant_msg != nil
+      assert assistant_msg.content == "Global response"
+      assert assistant_msg.meta == %{"from_global" => true}
+    end
   end
 end


### PR DESCRIPTION
## Description

Creating a workflow with the "Build with AI" box now routes through the global assistant instead of workflow-template chat.

This is purely a routing change: no UI changes at all. The global-assistant checkbox in the chat input is untouched, and follow-up messages in the conversation keep consulting it exactly as before (a conversation can already switch assistants between turns via the checkbox, so this stays consistent with that).

Nice side effect: the streaming status updates from #4969 live on the global endpoint, so users now see what the assistant is doing while their workflow is being created.

Closes #5040

## Implementation Details

- The landing prompt's auto-send carries the global-assistant flag (plus the page context Apollo expects), mirroring what a manual global send does. Only that path is affected.
- The backend join already handled global sessions for not-yet-saved workflows correctly, so no routing changes were needed there.
- The "no workflow YAML" warning would have fired on every single creation (a brand-new workflow legitimately has nothing to attach), so it's now an info line for new workflows and stays a warning for saved ones, where missing YAML genuinely means something went wrong.

## Validation steps

1. Create a workflow via "Build with AI" and watch the server log: the request goes to the global chat service, with an info line (not a warning) about the new workflow having no YAML.
2. Continue the conversation with the checkbox unticked: follow-ups go through workflow-template chat as before.
3. Tick the checkbox on a follow-up: it routes global, as before.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
