### PR TITLE
Invalidate stale YAML validation after edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to
 
 ### Fixed
 
+- YAML imports now invalidate validation state immediately when pasted content
+  changes or the input mode switches, so Create cannot persist stale workflow
+  content.
+  [#5023](https://github.com/OpenFn/lightning/issues/5023)
+
 - `APOLLO_TIMEOUT` now governs every request to Apollo, including the streaming
   requests all AI chats use. Streaming previously read an internal timeout key
   that no environment could set, so it was always 120s regardless of

--- a/assets/js/collaborative-editor/components/YAMLImportModal.tsx
+++ b/assets/js/collaborative-editor/components/YAMLImportModal.tsx
@@ -68,9 +68,12 @@ function YAMLImportContent({ onClose, onSuccess }: YAMLImportContentProps) {
   const [validatedState, setValidatedState] =
     useState<YAMLWorkflowState | null>(null);
   const [mode, setMode] = useState<'upload' | 'paste'>('upload');
+  const validationVersion = useRef(0);
 
   const debouncedValidate = useRef(
-    pDebounce((content: string) => {
+    pDebounce((content: string, version: number) => {
+      if (version !== validationVersion.current) return;
+
       if (!content.trim()) {
         setImportState('initial');
         setErrors([]);
@@ -99,18 +102,30 @@ function YAMLImportContent({ onClose, onSuccess }: YAMLImportContentProps) {
   );
 
   const validateYAML = useCallback((content: string) => {
-    void debouncedValidate.current(content);
+    const version = ++validationVersion.current;
+    void debouncedValidate.current(content, version);
   }, []);
 
   const handleYAMLChange = (content: string) => {
     setYamlContent(content);
+    setImportState(content.trim() ? 'parsing' : 'initial');
+    setErrors([]);
+    setValidatedState(null);
     void validateYAML(content);
   };
 
   const handleFileUpload = (content: string) => {
     setMode('paste');
-    setYamlContent(content);
-    void validateYAML(content);
+    handleYAMLChange(content);
+  };
+
+  const handleModeToggle = () => {
+    setMode(mode === 'upload' ? 'paste' : 'upload');
+    setYamlContent('');
+    setImportState('initial');
+    setErrors([]);
+    setValidatedState(null);
+    validationVersion.current += 1;
   };
 
   const handleSave = async () => {
@@ -158,7 +173,7 @@ function YAMLImportContent({ onClose, onSuccess }: YAMLImportContentProps) {
         <h2 className="text-xl font-medium text-gray-900">Import a workflow</h2>
         <button
           type="button"
-          onClick={() => setMode(mode === 'upload' ? 'paste' : 'upload')}
+          onClick={handleModeToggle}
           className="rounded-full border border-gray-300 px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
         >
           {mode === 'upload' ? 'Paste text' : 'Upload a file'}

--- a/assets/test/collaborative-editor/components/yaml-import/YAMLImportModal.test.tsx
+++ b/assets/test/collaborative-editor/components/yaml-import/YAMLImportModal.test.tsx
@@ -67,7 +67,7 @@ vi.mock('../../../../js/collaborative-editor/lib/notifications', () => ({
 
 const mockCloseYAMLImportModal = vi.fn();
 const mockDismissLandingScreen = vi.fn();
-const mockShowYAMLImportModal = vi.fn();
+const mockShowYAMLImportModal = vi.fn<() => boolean>();
 
 vi.mock('../../../../js/collaborative-editor/hooks/useUI', () => ({
   useUICommands: () => ({
@@ -203,6 +203,26 @@ describe('YAMLImportModal', () => {
       );
     });
 
+    test('disables Create immediately when YAML changes', async () => {
+      renderModal();
+      switchToPasteMode();
+      enterYAML(validYAML);
+
+      await waitFor(
+        () =>
+          expect(
+            screen.getByRole('button', { name: /Create/i })
+          ).not.toBeDisabled(),
+        { timeout: 500 }
+      );
+
+      enterYAML(validYAML.replace('Test Workflow', 'Updated Workflow'));
+
+      expect(
+        screen.getByRole('button', { name: /Validating/i })
+      ).toBeDisabled();
+    });
+
     test('keeps Create disabled for invalid YAML', async () => {
       renderModal();
       switchToPasteMode();
@@ -215,6 +235,25 @@ describe('YAMLImportModal', () => {
           ).toBeDisabled(),
         { timeout: 500 }
       );
+    });
+
+    test('clears validation state and errors when switching input modes', async () => {
+      renderModal();
+      switchToPasteMode();
+      enterYAML('invalid: [syntax');
+
+      await waitFor(
+        () => expect(screen.getByText(/Validation Error/i)).toBeInTheDocument(),
+        { timeout: 500 }
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Upload a file/i }));
+
+      expect(screen.getByRole('button', { name: /Create/i })).toBeDisabled();
+      expect(
+        screen.queryByPlaceholderText(/Paste your YAML content here/i)
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Validation Error/i)).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Invalidate pending YAML validations when the editor content or input mode changes.
- Clear stale parsing, validation, and error state immediately after a relevant edit.
- Ignore debounced validation results that belong to an older editor version.
- Add regression coverage for rapid edits and mode changes.

Fixes #5023

## Validation

- YAML import tests: 12 passing
- Prettier
- Focused ESLint
- git diff --check

The full frontend validation was not run because the repository environment is missing the phoenix_live_view/constants dependency and contains unrelated baseline TypeScript errors.

<details>
<summary>AI Disclaimer</summary>

This pull request was primarily developed with assistance from OpenAI Codex, an AI coding agent. For this PR, Codex analyzed issue #5023, inspected the relevant OpenFn Lightning code, implemented the fix, added the regression tests, and ran the reported validation commands under the supervision of jmtdev0.

Human involvement in this PR was very low.

If you do not agree with the use of AI assistance or with the level of human involvement in this PR, please feel free to disregard it, close it, or request changes. I will fully respect that decision.

</details>
