### PR TITLE
Fix flaky tests caused by gen_workflow_hash leaking the logger level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to
 - `eligible_for_claim/0` now breaks ties with `id` after `priority` and
   `inserted_at`, so two runs inserted in the same microsecond no longer get
   claimed in a nondeterministic order.
+- `mix lightning.gen_workflow_hash` no longer lowers the VM-wide logger level
+  when called in-process, which silenced log assertions in unrelated tests and
+  made them fail depending on run order.
+  [#5060](https://github.com/OpenFn/lightning/pull/5060)
 
 ## [2.18.1] - 2026-08-28
 

--- a/lib/mix/tasks/gen_workflow_hash.ex
+++ b/lib/mix/tasks/gen_workflow_hash.ex
@@ -27,8 +27,6 @@ defmodule Mix.Tasks.Lightning.GenWorkflowHash do
   alias Lightning.Workflows
   alias Lightning.WorkflowVersions
 
-  require Logger
-
   @impl Mix.Task
   def run(args) do
     {opts, positional, invalid} =
@@ -54,14 +52,14 @@ defmodule Mix.Tasks.Lightning.GenWorkflowHash do
     end
   end
 
+  # The Logger level is global to the VM and never restored, so only quieten it
+  # when this task owns the boot — in-process the repo is already up.
   defp start_repo do
-    Logger.configure(level: :error)
-    Mix.Task.run("app.config")
-    {:ok, _} = Application.ensure_all_started(:ecto_sql)
-
-    case Lightning.Repo.start_link(pool_size: 1) do
-      {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
+    if is_nil(Process.whereis(Lightning.Repo)) do
+      Logger.configure(level: :error)
+      Mix.Task.run("app.config")
+      {:ok, _} = Application.ensure_all_started(:ecto_sql)
+      {:ok, _} = Lightning.Repo.start_link(pool_size: 1)
     end
   end
 

--- a/test/mix/tasks/gen_workflow_hash_test.exs
+++ b/test/mix/tasks/gen_workflow_hash_test.exs
@@ -30,6 +30,19 @@ defmodule Mix.Tasks.Lightning.GenWorkflowHashTest do
       refute String.match?(output, ~r/^[a-f0-9]{12}$/)
     end
 
+    test "leaves the logger level alone when the repo is already running" do
+      workflow = build_workflow()
+      previous_level = Logger.level()
+      on_exit(fn -> Logger.configure(level: previous_level) end)
+      # Deliberately not the suite level, so a task that quietens the logger
+      # fails here rather than coincidentally restoring what config/test.exs set.
+      Logger.configure(level: :info)
+
+      run([workflow.id])
+
+      assert Logger.level() == :info
+    end
+
     test "raises when the workflow does not exist" do
       id = Ecto.UUID.generate()
 


### PR DESCRIPTION
## Description

This task turns the logging volume down so its output is just the hash. There is one volume setting for the whole program, and the task never turned it back up.

Run from a terminal, that's harmless. The task prints a hash and the program exits a second later, taking the setting with it.

The test suite is different. It's one long-running program, and it calls this task as an ordinary function. So the task muted logging, and then thousands of later tests ran with it still muted. Any test checking "did this log a warning?" got nothing back, and which tests broke depended on the seed.

The fix is one question. Did this task start the program, or was it already running?

```elixir
defp start_repo do
  if is_nil(Process.whereis(Lightning.Repo)) do
    Logger.configure(level: :error)
    Mix.Task.run("app.config")
    {:ok, _} = Application.ensure_all_started(:ecto_sql)
    {:ok, _} = Lightning.Repo.start_link(pool_size: 1)
  end
end
```

No Repo running means we're a fresh CLI invocation, so the task starts what it needs and quietens the logger as before. A Repo already running means we're a guest inside the test suite, so the task does nothing and leaves the setting alone.

That also makes the old `{:error, {:already_started, _pid}}` clause unreachable, so it's gone.

The `Logger.configure` line has to stay for the CLI. Ecto logs every query at `:debug` (`config/config.exs:19`), dev sets no logger level, and Logger writes to stdout, so without it `[debug] QUERY OK` lines land in the same stream as the hash. In tests it was never doing anything useful, since the suite already runs at `:warning`.

Same root cause as #5099, where the shared setting is the problem, but a different fix. That PR swapped in `with_log`, which gets the same quietening scoped to one capture. Here there was nothing worth scoping, since the quietening was useless in tests anyway, so the call is just skipped.

## Validation steps

1. `mix test test/mix/tasks/gen_workflow_hash_test.exs` passes. Against the old version the new test fails with `left: :error, right: :info`, so it catches the regression rather than passing by accident.
2. `mix test` passes.
3. `mix lightning.gen_workflow_hash <uuid>` still prints only the hash.

## Additional notes for the reviewer

1. Only the test path changes. Running the task from a terminal behaves as before.
2. Two files still change the shared setting, tracked under OFN-4525: `resolver_test.exs` and `workflow_channel_test.exs`. Worth a heads-up for whoever takes that ticket, because the #5099 swap won't work on them. Both turn the volume *up* to catch `:info`/`:debug` logs that the suite's `:warning` setting would otherwise drop, and `with_log(level: ...)` can't do that. The message is discarded before the capture ever sees it.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
