### PR TITLE
Bump bundled worker to 1.29.1 (release-2.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 ### Changed
 
+- Bumped bundled worker to version 1.29.1
 - The collaboration supervision tree is no longer tied to a single set of global
   process names. The registry, dynamic supervisor and `:pg` scope a tree owns
   are described by a `Lightning.Collaboration.Instance` struct whose defaults

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -59,7 +59,7 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
         "@eslint/js": "^9.21.0",
-        "@openfn/ws-worker": "^1.27.4",
+        "@openfn/ws-worker": "^1.29.1",
         "@playwright/test": "^1.55.0",
         "@redux-devtools/extension": "^3.3.0",
         "@testing-library/jest-dom": "^6.9.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@openfn/engine-multi": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-1.12.3.tgz",
-      "integrity": "sha512-J3V/fjaMae41hMzDQJ8zJofvySawOggbGYqKa8Pu4XvEFfYIm9BHlufdBl6O6zYlsh2BKFNeuE5BaZV+U9Tg3w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@openfn/engine-multi/-/engine-multi-1.13.0.tgz",
+      "integrity": "sha512-FtEoyYSc7HT2DOZfgF2W+Lc21W+Zs0+gqPMi7vOIfNAMnArYDhSblbI01W1R2EwoTJyiYSjQZ9/9pjgASluIMg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2278,9 +2278,9 @@
       }
     },
     "node_modules/@openfn/lexicon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@openfn/lexicon/-/lexicon-2.4.0.tgz",
-      "integrity": "sha512-a46A0UHvHBMeszh5nluvU8I4cAaT2nZRZ6gydl2INasW8CPQ5KRHhZx9ZmzgkuA8M2f3hvcmiLyD4j+iMdbGAw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@openfn/lexicon/-/lexicon-2.4.1.tgz",
+      "integrity": "sha512-n/BUwhQQ7DKOzxaeNuqu6xooQuoEa+6XXJQTX+1CESAknUPAkaXzmw5FERoZy+ta0xFKHCMhbeqdayAjHxWFww==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2319,16 +2319,16 @@
       }
     },
     "node_modules/@openfn/ws-worker": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-1.27.4.tgz",
-      "integrity": "sha512-gXxnrZPWHVOLkmH1Jh3ylhjcHc49dSVZLuQC+IJN3rGTZZrVGbJS9xB78yBYqQAQMoZTgLlmZCTJ8IInzdr3FA==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@openfn/ws-worker/-/ws-worker-1.29.1.tgz",
+      "integrity": "sha512-sbZLmA0fN5cRDzNhicvd6lfFgUMcEqPrJRDChqKTv7i1erw8g4z2y27hvozrJfT0ebhEImyuiZfKvYdMVpoMbg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@koa/bodyparser": "^6.1.0",
         "@koa/router": "^15.4.0",
-        "@openfn/engine-multi": "1.12.3",
-        "@openfn/lexicon": "^2.4.0",
+        "@openfn/engine-multi": "1.13.0",
+        "@openfn/lexicon": "^2.4.1",
         "@openfn/logger": "1.1.2",
         "@openfn/runtime": "1.9.5",
         "@sentry/node": "^10.44.0",
@@ -6122,9 +6122,9 @@
       }
     },
     "node_modules/ava/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6657,9 +6657,9 @@
       }
     },
     "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14806,9 +14806,9 @@
       }
     },
     "node_modules/supertap/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14856,9 +14856,9 @@
       }
     },
     "node_modules/supertap/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
     "@eslint/js": "^9.21.0",
-    "@openfn/ws-worker": "^1.27.4",
+    "@openfn/ws-worker": "^1.29.1",
     "@playwright/test": "^1.55.0",
     "@redux-devtools/extension": "^3.3.0",
     "@testing-library/jest-dom": "^6.9.0",

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -269,7 +269,7 @@ defmodule Lightning.WebAndWorkerTest do
 
       version_logs = pick_out_version_logs(run)
       assert version_logs["@openfn/language-http"] =~ "3.1.12"
-      assert version_logs["worker"] =~ "1.27"
+      assert version_logs["worker"] =~ "1.29"
       assert version_logs["node.js"] =~ "24.18"
       assert version_logs["@openfn/language-common"] == "3.0.2"
 


### PR DESCRIPTION
## Description

Bumps the bundled worker from 1.27.4 to 1.29.1 on `release-2.18.0`.

This is the other half of #5064. Lightning sends the new `meta` object, but only worker 1.29.1 maps it onto the `meta` global a job can read. Without this bump the release would bundle 1.27.4 and `meta.workOrderId` simply wouldn't appear, with nothing failing loudly - there's no version negotiation between Lightning and the worker.

Note this branch was on 1.27.4, not 1.29.0: the earlier bump (#5050) went to `main` and was never cherry-picked here.

Mirrors #5050 - the pin, the regenerated lock file, and the version the integration test asserts on. The lock file also moves engine-multi to 1.13.0 and lexicon, as transitive deps of the worker.

## Validation steps

1. Run a workflow from the bundled worker with `log(meta)` using common.
2. `meta` should include `workOrderId`, `workflowId` and `projectId` once #5064 is in.
3. `test/integration/web_and_worker_test.exs` asserts the worker version it sees, now 1.29.

## Additional notes for the reviewer

Worth merging after #5064 so the feature and the worker that supports it land together.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
