### PR TITLE
Exclude sandbox projects from credential's project list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to
 
 ### Fixed
 
+- A credential's "Projects with access" list no longer includes sandbox
+  projects. Credentials propagate to descendant sandboxes automatically so runs
+  there keep working, but showing every sandbox in this list was redundant and
+  included ones already merged and deleted.
+  [#4014](https://github.com/OpenFn/lightning/issues/4014)
+
 - `APOLLO_TIMEOUT` now governs every request to Apollo, including the streaming
   requests all AI chats use. Streaming previously read an internal timeout key
   that no environment could set, so it was always 120s regardless of

--- a/lib/lightning_web/live/credential_live/credential_index_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_index_component.ex
@@ -409,7 +409,9 @@ defmodule LightningWeb.CredentialLive.CredentialIndexComponent do
     |> Credentials.list_credentials()
     |> Enum.map(fn credential ->
       project_names =
-        Map.get(credential, :projects, []) |> Enum.map(fn p -> p.name end)
+        Map.get(credential, :projects, [])
+        |> Enum.reject(&Lightning.Projects.Project.sandbox?/1)
+        |> Enum.map(fn p -> p.name end)
 
       environment_names =
         credential

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -108,6 +108,37 @@ defmodule LightningWeb.CredentialLiveTest do
       assert html =~ credential.name
     end
 
+    test "excludes sandbox projects from the projects with access list", %{
+      conn: conn,
+      user: user,
+      project: parent_project
+    } do
+      {:ok, sandbox} =
+        Lightning.Projects.provision_sandbox(parent_project, user, %{
+          name: "sandbox-project",
+          env: "staging"
+        })
+
+      credential =
+        insert(:credential,
+          user: user,
+          project_credentials: [%{project_id: parent_project.id}]
+        )
+
+      {:ok, index_live, _html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      table_text =
+        index_live
+        |> element("#credentials-table")
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.text()
+
+      assert table_text =~ credential.name
+      assert table_text =~ parent_project.name
+      refute table_text =~ sandbox.name
+    end
+
     test "ensure support user only sees credentials they own on /credentials", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
## Description

Excludes sandbox projects from a credential's "Projects with access" list
on the Settings > Credentials page. Credentials automatically propagate to
descendant sandboxes so runs there keep working, but that full propagation
tree was being shown in this list, including sandboxes already merged and
deleted. The list now shows only the top-level projects the credential is
actually granted to.

Closes #4014

## Validation steps

1. Create a project, grant a credential access to it.
2. Provision a sandbox off that project.
3. Go to Settings > Credentials — the sandbox no longer appears in the
   credential's "Projects with access" list; the parent project still does.
4. Existing API behavior for querying a sandbox's own credentials directly
   (`GET /api/projects/:sandbox_id/credentials`) is unaffected — that's a
   different, intentional code path and was verified unchanged.

## Additional notes for the reviewer

This only touches the display list in
`CredentialIndexComponent.list_credentials/1`. It doesn't touch
`Credentials.list_credentials/1` (the shared context query used by the API),
the sandbox-propagation logic, or any authorization checks — full
credential and API test suites pass unchanged.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [x] I have implemented and tested all related authorization policies
- [x] I have updated the changelog
- [x] I have ticked a box in "AI usage" in this PR
