### PR TITLE
Stop losing AI messages when a deploy interrupts them

### DIFF
--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -62,13 +62,19 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   """
   @impl Oban.Worker
   @spec timeout(Oban.Job.t()) :: pos_integer()
-  def timeout(_job) do
-    # The Finch receive_timeout on the streaming client is the primary
-    # timeout mechanism. The Oban worker timeout is a safety net that
-    # should be slightly longer.
-    timeout_ms = Lightning.Config.apollo(:timeout)
+  def timeout(_job), do: job_timeout()
 
-    timeout_ms + 10_000
+  @doc """
+  The same ceiling as `timeout/1`, for callers that have no job in hand.
+  """
+  @spec job_timeout() :: pos_integer()
+  def job_timeout do
+    # This is the only bound on a run's total duration. The Finch timeout is
+    # per-chunk, so a stream that keeps sending never trips it - which is why
+    # this must stay below Oban's shutdown_grace_period. If it doesn't, an
+    # interrupted job is killed after its producer has already stopped, and no
+    # telemetry fires at all.
+    Lightning.Config.apollo(:timeout) + 10_000
   end
 
   @doc false
@@ -379,7 +385,11 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     error = meta.error
     timeout? = is_map(error) and Map.get(error, :reason) == :timeout
 
-    Logger.error(~s"""
+    # A timeout is an upstream condition, not a fault of ours, and the Sentry
+    # capture below already treats it as a warning. Logging it at :error would
+    # raise a second, louder Sentry event for the same thing - see
+    # .claude/rules/logging.md.
+    Logger.log(if(timeout?, do: :warning, else: :error), ~s"""
     AI Assistant exception:
     Worker: #{job.worker}
     Type: #{if timeout?, do: "Timeout", else: "Error"}
@@ -388,8 +398,11 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     Duration: #{measure.duration / 1_000_000}ms
     """)
 
+    # get/2 rather than get!/2: a session deleted while its job was running would
+    # raise here, and a raise in a telemetry handler detaches it, silently ending
+    # Oban error reporting for the rest of the node's life.
     ChatMessage
-    |> Repo.get!(job.args["message_id"])
+    |> Repo.get(job.args["message_id"])
     |> case do
       %ChatMessage{id: message_id, status: status} = message
       when status in [:pending, :processing] ->
@@ -403,6 +416,11 @@ defmodule Lightning.AiAssistant.MessageProcessor do
       %ChatMessage{id: message_id, status: status} ->
         Logger.debug(
           "[AI Assistant] Message #{message_id} already has status: #{status}, skipping cleanup"
+        )
+
+      nil ->
+        Logger.debug(
+          "[AI Assistant] Message #{job.args["message_id"]} no longer exists, skipping cleanup"
         )
     end
 
@@ -457,7 +475,10 @@ defmodule Lightning.AiAssistant.MessageProcessor do
         :ok
 
       other ->
-        Logger.error("""
+        # Cancelled or discarded, most often because a deploy interrupted the
+        # job. Expected rather than faulty, and the Sentry capture below is
+        # already a warning.
+        Logger.warning("""
         AI Assistant stop (non-success):
         Worker: #{meta.job.worker}
         State: #{inspect(other)}
@@ -466,7 +487,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
         """)
 
         ChatMessage
-        |> Repo.get!(meta.job.args["message_id"])
+        |> Repo.get(meta.job.args["message_id"])
         |> case do
           %ChatMessage{id: message_id, status: status} = message
           when status in [:pending, :processing] ->

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -62,12 +62,19 @@ defmodule Lightning.Application do
       )
 
     :telemetry.attach_many(
-      "oban-errors",
-      [
-        [:oban, :circuit, :open],
-        [:oban, :circuit, :trip],
-        [:oban, :job, :exception]
-      ],
+      "oban-job-exception",
+      [[:oban, :job, :exception]],
+      &Lightning.ObanManager.handle_event/4,
+      nil
+    )
+
+    # Separate handler id from the exception one. :telemetry detaches a handler
+    # from every event in its attach_many the first time it raises, so sharing an
+    # id would let one bad :stop take exception reporting down with it until the
+    # next restart.
+    :telemetry.attach_many(
+      "oban-job-stop",
+      [[:oban, :job, :stop]],
       &Lightning.ObanManager.handle_event/4,
       nil
     )
@@ -165,10 +172,30 @@ defmodule Lightning.Application do
       ]
       |> Enum.reject(&is_nil/1)
 
+    warn_if_ai_jobs_outlive_the_drain_window()
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Lightning.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # Oban stops its producer once the grace period expires and only then kills
+  # whatever is still running, so a job that outlives the window is killed with
+  # nothing left to report it. Its AI message would stay :processing until the
+  # reaper picks it up, and no telemetry would fire.
+  defp warn_if_ai_jobs_outlive_the_drain_window do
+    grace = Application.get_env(:lightning, Oban)[:shutdown_grace_period]
+    ceiling = Lightning.AiAssistant.MessageProcessor.job_timeout()
+
+    if is_integer(grace) and is_integer(ceiling) and ceiling >= grace do
+      Logger.warning("""
+      [AI Assistant] An AI job may run for #{ceiling}ms but Oban stops draining \
+      after #{grace}ms. A deploy landing on a running job will kill it without \
+      emitting telemetry, leaving its message :processing until the reaper runs.
+      Lower APOLLO_TIMEOUT or raise Oban's shutdown_grace_period.
+      """)
+    end
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -306,7 +306,19 @@ defmodule Lightning.Config.Bootstrap do
       plugins: [
         {Oban.Plugins.Cron, crontab: all_cron}
       ],
-      shutdown_grace_period: :timer.minutes(2),
+      # Should exceed MessageProcessor.timeout/1: below it, an AI job interrupted
+      # by a deploy is killed after Oban's producer has stopped, so no telemetry
+      # fires and nothing reports the failure. Application start warns if that
+      # inverts.
+      #
+      # It only has that effect if the platform lets the node live that long.
+      # Kubernetes force-kills after terminationGracePeriodSeconds, which is
+      # unset in our manifests and so defaults to 30s - well short of this.
+      # Until that is raised a deploy landing on a running AI job still severs
+      # it, and StuckMessageReaper is what recovers the message rather than the
+      # :stop handler. Raising it trades slower rolling restarts for users
+      # keeping an in-flight answer.
+      shutdown_grace_period: :timer.minutes(6),
       dispatch_cooldown: 100,
       queues: [
         scheduler: 1,

--- a/test/lightning/oban_manager_test.exs
+++ b/test/lightning/oban_manager_test.exs
@@ -157,6 +157,33 @@ defmodule Lightning.ObanManagerTest do
       updated_message = Repo.get!(ChatMessage, message.id)
       assert updated_message.status == :success
     end
+
+    # A raise here detaches the handler from every event it registered for, so
+    # a message deleted mid-run would silently end Oban error reporting for the
+    # rest of the node's life.
+    test "survives a message deleted while its job was running", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      Repo.delete!(message)
+
+      error = %Oban.TimeoutError{reason: :timeout}
+      meta = %{job: oban_job, error: error, stacktrace: []}
+      measure = %{duration: 1_000, memory: 1_000, reductions: 1_000}
+
+      expect(Lightning.MockSentry, :capture_message, fn _, _ -> :ok end)
+
+      # Without the nil clause this raises CaseClauseError, so returning at all
+      # is the assertion.
+      capture_log(fn ->
+        assert ObanManager.handle_event(
+                 [:oban, :job, :exception],
+                 measure,
+                 meta,
+                 self()
+               )
+      end)
+    end
   end
 
   describe "handle_event/4 for other queues" do
@@ -292,6 +319,26 @@ defmodule Lightning.ObanManagerTest do
       assert reloaded.status == message.status
     end
 
+    # :stop fires for every successful job in every queue, so this is the
+    # busiest path we have. A raise here takes Oban reporting down with it.
+    test "survives a message deleted while its job was running", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      Repo.delete!(message)
+
+      expect(Lightning.MockSentry, :capture_message, fn _, _ -> :ok end)
+
+      capture_log(fn ->
+        assert ObanManager.handle_event(
+                 [:oban, :job, :stop],
+                 %{duration: 1_000, memory: 1_000, reductions: 1_000},
+                 %{job: oban_job, state: :cancelled},
+                 self()
+               )
+      end)
+    end
+
     test "marks message error on non-success stop and broadcasts", %{
       message: message,
       oban_job: oban_job
@@ -330,6 +377,29 @@ defmodule Lightning.ObanManagerTest do
       updated = Repo.get!(ChatMessage, message.id)
       assert updated.status == :error
       assert updated.processing_completed_at != nil
+    end
+
+    # Every other test here calls handle_event/4 directly, which passes whether
+    # or not the event is attached in Lightning.Application. This one emits the
+    # event instead.
+    test "runs when a :stop event is emitted, not only when called directly", %{
+      message: message,
+      oban_job: oban_job
+    } do
+      {:ok, _} =
+        Repo.update(Ecto.Changeset.change(message, %{status: :processing}))
+
+      expect(Lightning.MockSentry, :capture_message, fn _msg, _opts -> :ok end)
+
+      capture_log([level: :warning], fn ->
+        :telemetry.execute(
+          [:oban, :job, :stop],
+          %{duration: 2_000, memory: 2_000, reductions: 2_000},
+          %{job: oban_job, state: :cancelled}
+        )
+      end)
+
+      assert Repo.get!(ChatMessage, message.id).status == :error
     end
 
     test "ignores stop for non-AI queues" do


### PR DESCRIPTION
## Description

A deploy cuts off whatever is running. When that was an AI chat message, nothing said so: the message stayed `:processing` forever, the panel stayed locked for everyone in that session, and no error was raised. You only found it by looking at the row.

Closes #5124

Oban announces a job being stopped and we were not listening. The handler for it had been written and never attached. Attaching it needed three other things to be true.

It gets its own handler id rather than joining the exception one. `:telemetry` drops a handler from every event it registered for the first time it raises, so sharing an id would let one bad `:stop` take Oban exception reporting down with it until the next restart.

The two `[:oban, :circuit, _]` events go with it. Oban has not emitted them since 2.6, and there was no clause for them, so one arriving would have raised and detached everything.

The lookups become `get` rather than `get!`. `:stop` fires for every successful job in every queue, which is the busiest path we have, and a message deleted while its job ran would raise there and trigger exactly the detach above. Both paths now have a test that deletes the message first, since returning at all is what proves the clause is there.

The drain window moves from two minutes to six. It was shorter than an AI job's own ceiling, so a deploy landing on a running job killed it after Oban had already stopped the producer that would have reported it. That is no telemetry at all, and the one case attaching `:stop` cannot rescue. Application start now warns if that inverts again, and the ceiling is available on its own as `job_timeout/0` for the callers that have no job in hand.

Two log lines drop to warning: a timeout on the exception path, and a non-success stop. Both sat next to a Sentry capture deliberately set to warning, so the error level was raising a second and louder event for something the code had already judged not to be a fault.

The new test emits the event rather than calling the handler directly, the way the others do. That is why this was covered and still broken.

Part of #4260 (the other half is [#5071](https://github.com/OpenFn/lightning/pull/5071)).

## Validation steps

1. Open a workflow, open the AI assistant, and send a message. While it is still thinking, stop the server (Ctrl+C twice) and start it again. Reload the page: the message should show as failed with a retry, instead of the panel sitting on "..." forever.
2. In IEx, check the drain window is longer than a run can take, which is what makes the above work rather than relying on the sweep:

    ```elixir
     Application.get_env(:lightning, Oban) |> Keyword.get(:shutdown_grace_period)
     Lightning.AiAssistant.MessageProcessor.job_timeout()
     ```

     The first should be comfortably larger than the second.

3. Set `APOLLO_REQUEST_TIMEOUT_MS` high enough to invert those two and restart. There should be a warning at boot naming both.

## Additional notes for the reviewer

The two `[:oban, :circuit, _]` events are removed rather than given a clause. Oban has not emitted them since 2.6, so nothing should arrive on them; say so if you disagree.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR



