### PR TITLE
Record why the assistant failed on the message

### DIFF
--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -32,7 +32,19 @@ defmodule Lightning.AiAssistant do
   @title_max_length 40
   @success_status_range 200..299
 
+  # What a user sees when the reason is ours and not fit to show them.
+  @internal_failure "Something went wrong. Please try again."
+
   @type opts :: keyword()
+
+  @typedoc """
+  Why a streamed query failed.
+
+  A bare string is already written for a user to read. `{:internal, text}` is
+  ours and is not: the caller logs it and shows something else.
+  """
+  @type stream_error ::
+          String.t() | {:internal, String.t()} | Ecto.Changeset.t()
 
   @doc """
   Checks if the AI assistant feature is enabled via application configuration.
@@ -782,7 +794,7 @@ defmodule Lightning.AiAssistant do
   - `{:error, reason}` - Query failed, reason is either a string error message or changeset
   """
   @spec query_stream(ChatSession.t(), String.t(), opts()) ::
-          {:ok, ChatSession.t()} | {:error, String.t() | Ecto.Changeset.t()}
+          {:ok, ChatSession.t()} | {:error, stream_error()}
   def query_stream(session, content, opts \\ []) do
     Logger.metadata(prompt_size: byte_size(content), session_id: session.id)
 
@@ -871,7 +883,7 @@ defmodule Lightning.AiAssistant do
   - `{:error, reason}` - Generation failed, reason is either a string error message or changeset
   """
   @spec query_workflow_stream(ChatSession.t(), String.t(), opts()) ::
-          {:ok, ChatSession.t()} | {:error, String.t() | Ecto.Changeset.t()}
+          {:ok, ChatSession.t()} | {:error, stream_error()}
   def query_workflow_stream(session, content, opts \\ []) do
     code = Keyword.get(opts, :code)
     errors = Keyword.get(opts, :errors)
@@ -903,7 +915,7 @@ defmodule Lightning.AiAssistant do
   Uses the same streaming pipeline as job_chat and workflow_chat.
   """
   @spec query_global_stream(ChatSession.t(), String.t(), opts()) ::
-          {:ok, ChatSession.t()} | {:error, String.t() | Ecto.Changeset.t()}
+          {:ok, ChatSession.t()} | {:error, stream_error()}
   def query_global_stream(session, content, opts \\ []) do
     workflow_yaml = Keyword.get(opts, :workflow_yaml)
     page = Keyword.get(opts, :page)
@@ -1092,12 +1104,17 @@ defmodule Lightning.AiAssistant do
     end
   rescue
     e ->
-      broadcast_streaming_error(
-        session.id,
-        "Streaming failed: #{Exception.message(e)}"
+      # Exception text belongs in the log, not the panel. It can carry module
+      # and function names, SQL detail, or a whole inspected payload, and the
+      # caller persists what it is handed.
+      Logger.error(
+        "[AI Assistant] Stream failed for session #{session.id}: " <>
+          Exception.message(e)
       )
 
-      {:error, Exception.message(e)}
+      broadcast_streaming_error(session.id, @internal_failure)
+
+      {:error, {:internal, Exception.message(e)}}
   catch
     :exit, reason ->
       message = "Streaming connection lost"

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -67,6 +67,10 @@ defmodule Lightning.AiAssistant.ChatMessage do
   # rows that get re-serialized on every channel join.
   @max_response_segments 200
 
+  # A sentence, not a story. Bounded because the column is read back and
+  # re-sent on every channel join.
+  @max_failure_message_length 500
+
   @type role() :: :user | :assistant
   @type status() :: :pending | :processing | :success | :error | :cancelled
 
@@ -98,6 +102,26 @@ defmodule Lightning.AiAssistant.ChatMessage do
 
     field :status, Ecto.Enum,
       values: [:pending, :processing, :success, :error, :cancelled]
+
+    # Why a message failed, kept alongside the status rather than broadcast.
+    # The failure people care about most is a deploy interrupting a run, and
+    # that is exactly when the browser reconnects to a different node - a
+    # PubSub-only signal is gone by then. It is also often written by a
+    # different process than the one that failed.
+    field :failure_category, Ecto.Enum,
+      values: [
+        :upstream_unavailable,
+        :upstream_error,
+        :timeout,
+        :interrupted,
+        :abandoned,
+        :incomplete_response,
+        :internal
+      ]
+
+    # User-facing prose only. Raw error terms and upstream response bodies go
+    # to the log, never here - they can carry internal hostnames or stack traces.
+    field :failure_message, :string
 
     field :is_deleted, :boolean, default: false
     field :is_public, :boolean, default: true
@@ -138,6 +162,8 @@ defmodule Lightning.AiAssistant.ChatMessage do
       :code,
       :role,
       :status,
+      :failure_category,
+      :failure_message,
       :is_deleted,
       :is_public,
       :meta,
@@ -149,6 +175,7 @@ defmodule Lightning.AiAssistant.ChatMessage do
     |> validate_length(:response_segments, max: @max_response_segments)
     |> validate_required([:content, :role])
     |> validate_length(:content, min: 1, max: 10_000)
+    |> validate_length(:failure_message, max: @max_failure_message_length)
     |> maybe_put_user_assoc(attrs[:user] || attrs["user"])
     |> maybe_put_job_assoc(attrs[:job] || attrs["job"])
     |> maybe_require_user()
@@ -157,6 +184,9 @@ defmodule Lightning.AiAssistant.ChatMessage do
 
   @doc "Maximum number of segments accepted on a message."
   def max_response_segments, do: @max_response_segments
+
+  @doc "Maximum length of a message's `failure_message`."
+  def max_failure_message_length, do: @max_failure_message_length
 
   @doc """
   Creates a changeset for updating message status.

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -136,7 +136,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
           ChatMessage.t()
         ) ::
           {:ok, AiAssistant.ChatSession.t()}
-          | {:error, String.t() | Ecto.Changeset.t()}
+          | {:error, AiAssistant.stream_error()}
   defp dispatch_message_processing(session, message) do
     if global_chat?(session) do
       process_global_message(session, message)
@@ -156,7 +156,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
   @spec process_global_message(AiAssistant.ChatSession.t(), ChatMessage.t()) ::
           {:ok, AiAssistant.ChatSession.t()}
-          | {:error, String.t() | Ecto.Changeset.t()}
+          | {:error, AiAssistant.stream_error()}
   defp process_global_message(session, message) do
     workflow_yaml = message.code
     page = get_in(session.meta, ["message_options", "page"])
@@ -188,7 +188,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   @spec handle_processing_result(
           ChatMessage.t(),
           {:ok, AiAssistant.ChatSession.t()}
-          | {:error, String.t() | Ecto.Changeset.t()}
+          | {:error, AiAssistant.stream_error()}
         ) :: {:ok, AiAssistant.ChatSession.t()} | {:error, String.t()}
   defp handle_processing_result(message, result) do
     case result do
@@ -200,7 +200,11 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:ok, _updated_session, _updated_message} =
-          update_message_status(message, :error)
+          update_message_status(
+            message,
+            :error,
+            {:internal, "Something went wrong. Please try again."}
+          )
 
         Logger.error(
           "[MessageProcessor] Failed to save assistant response for message " <>
@@ -209,9 +213,29 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
         {:error, "Failed to save assistant response"}
 
-      {:error, error_message} ->
+      # Something raised on our side. The text describes our internals, so the
+      # user gets the generic sentence instead. It is not logged again here:
+      # whoever raised it already logged the exception, and each extra
+      # Logger.error is a second Sentry event for one failure.
+      {:error, {:internal, raw}} ->
         {:ok, _updated_session, _updated_message} =
-          update_message_status(message, :error)
+          update_message_status(
+            message,
+            :error,
+            {:internal, "Something went wrong. Please try again."}
+          )
+
+        {:error, raw}
+
+      {:error, error_message} ->
+        # The strings built by handle_error_response are already written for a
+        # user to read.
+        {:ok, _updated_session, _updated_message} =
+          update_message_status(
+            message,
+            :error,
+            {:upstream_error, error_message}
+          )
 
         {:error, error_message}
     end
@@ -220,7 +244,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   @doc false
   @spec process_job_message(AiAssistant.ChatSession.t(), ChatMessage.t()) ::
           {:ok, AiAssistant.ChatSession.t()}
-          | {:error, String.t() | Ecto.Changeset.t()}
+          | {:error, AiAssistant.stream_error()}
   defp process_job_message(session, message) do
     enriched_session = AiAssistant.enrich_session_with_job_context(session)
 
@@ -278,7 +302,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   @doc false
   @spec process_workflow_message(AiAssistant.ChatSession.t(), ChatMessage.t()) ::
           {:ok, AiAssistant.ChatSession.t()}
-          | {:error, String.t() | Ecto.Changeset.t()}
+          | {:error, AiAssistant.stream_error()}
   defp process_workflow_message(session, message) do
     code = message.code || workflow_code_from_session(session)
 
@@ -320,11 +344,12 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   """
   @spec update_message_status(
           ChatMessage.t(),
-          atom()
+          atom(),
+          {atom(), String.t()} | nil
         ) ::
           {:ok, ChatSession.t(), ChatMessage.t()}
-  def update_message_status(message, status) do
-    changes = build_status_changes(status)
+  def update_message_status(message, status, failure \\ nil) do
+    changes = status |> build_status_changes() |> put_failure(failure)
 
     updated_message =
       message
@@ -359,6 +384,20 @@ defmodule Lightning.AiAssistant.MessageProcessor do
       status: :error,
       processing_completed_at: DateTime.utc_now()
     }
+  end
+
+  defp put_failure(changes, nil), do: changes
+
+  # Clamped here rather than in the changeset, because this writes through
+  # Ecto.Changeset.change/2, which applies no validation at all. The column is
+  # read back and re-sent on every channel join, so an unbounded string would
+  # be paid for on each one.
+  defp put_failure(changes, {category, message}) do
+    Map.merge(changes, %{
+      failure_category: category,
+      failure_message:
+        String.slice(message, 0, ChatMessage.max_failure_message_length())
+    })
   end
 
   @doc false
@@ -410,8 +449,16 @@ defmodule Lightning.AiAssistant.MessageProcessor do
           "[AI Assistant] Updating message #{message_id} to error status after exception"
         )
 
+        failure =
+          if timeout? do
+            {:timeout,
+             "The assistant took too long to respond. Please try again."}
+          else
+            {:internal, "Something went wrong. Please try again."}
+          end
+
         {:ok, _updated_session, _updated_message} =
-          update_message_status(message, :error)
+          update_message_status(message, :error, failure)
 
       %ChatMessage{id: message_id, status: status} ->
         Logger.debug(
@@ -495,7 +542,13 @@ defmodule Lightning.AiAssistant.MessageProcessor do
               "[AI Assistant] Updating message #{message_id} to error status after stop=#{other}"
             )
 
-            {:ok, _sess, _msg} = update_message_status(message, :error)
+            {:ok, _sess, _msg} =
+              update_message_status(
+                message,
+                :error,
+                {:interrupted,
+                 "The assistant was interrupted before it finished. Please try again."}
+              )
 
           _ ->
             :ok

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -293,10 +293,12 @@ defmodule LightningWeb.AiAssistantChannel do
             |> Enum.find(fn msg -> msg.role == :user end)
 
           if user_message do
-            broadcast(socket, "message_error", %{
-              message_id: user_message.id,
-              status: "error"
-            })
+            broadcast(
+              socket,
+              "message_error",
+              %{message_id: user_message.id, status: "error"}
+              |> put_failure(user_message)
+            )
           end
 
         :failed ->
@@ -874,6 +876,18 @@ defmodule LightningWeb.AiAssistantChannel do
       job_id: job_id,
       from_global: from_global
     }
+    |> put_failure(message)
+  end
+
+  # Only present on a failed message, so a reconnecting client sees the same
+  # reason as one that was watching when it happened.
+  defp put_failure(payload, %{failure_category: nil}), do: payload
+
+  defp put_failure(payload, message) do
+    Map.merge(payload, %{
+      failure_category: to_string(message.failure_category),
+      failure_message: message.failure_message
+    })
   end
 
   defp format_user(nil), do: nil

--- a/priv/repo/migrations/20260815144311_add_failure_reason_to_ai_chat_messages.exs
+++ b/priv/repo/migrations/20260815144311_add_failure_reason_to_ai_chat_messages.exs
@@ -1,0 +1,10 @@
+defmodule Lightning.Repo.Migrations.AddFailureReasonToAiChatMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ai_chat_messages) do
+      add :failure_category, :string
+      add :failure_message, :text
+    end
+  end
+end

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -2628,11 +2628,15 @@ defmodule Lightning.AiAssistantTest do
         {:ok, %Tesla.Env{status: 200, body: raising_stream}}
       end)
 
-      assert {:error, "boom"} =
+      # Tagged, so the caller knows this text is ours and not for the user.
+      assert {:error, {:internal, "boom"}} =
                AiAssistant.query_stream(session, "test")
 
       assert_received {:ai_assistant, :streaming_error,
-                       %{error: "Streaming failed: boom", session_id: _}}
+                       %{
+                         error: "Something went wrong. Please try again.",
+                         session_id: _
+                       }}
     end
 
     test "handles exit signals during stream processing (e.g. Mint transport errors)",

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -333,6 +333,46 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       assert assistant_msg.response_segments == []
     end
 
+    # A raise on our side is the one failure whose text must not reach the
+    # panel: it carries module names, SQL detail and inspected payloads.
+    test "an exception mid-stream is recorded without its text", %{
+      user: user,
+      project: project
+    } do
+      session = insert(:chat_session, user: user, project: project)
+
+      {:ok, updated_session} =
+        AiAssistant.save_message(session, %{
+          role: :user,
+          content: "help",
+          user: user
+        })
+
+      user_message = Enum.find(updated_session.messages, &(&1.role == :user))
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn _env, _opts ->
+        raising =
+          Stream.map([:boom], fn _ ->
+            raise "postgrex disconnected on internal-host-7"
+          end)
+
+        {:ok, %Tesla.Env{status: 200, body: raising}}
+      end)
+
+      assert :ok =
+               perform_job(MessageProcessor, %{"message_id" => user_message.id})
+
+      reloaded = Repo.get!(ChatMessage, user_message.id)
+
+      assert reloaded.status == :error
+      assert reloaded.failure_category == :internal
+
+      assert reloaded.failure_message ==
+               "Something went wrong. Please try again."
+
+      refute reloaded.failure_message =~ "internal-host-7"
+    end
+
     test "persists the segments timeline alongside the flat response",
          %{user: user, project: project} do
       workflow = insert(:workflow, project: project)

--- a/test/lightning/oban_manager_test.exs
+++ b/test/lightning/oban_manager_test.exs
@@ -399,7 +399,14 @@ defmodule Lightning.ObanManagerTest do
         )
       end)
 
-      assert Repo.get!(ChatMessage, message.id).status == :error
+      reloaded = Repo.get!(ChatMessage, message.id)
+
+      assert reloaded.status == :error
+
+      # Recorded on the row rather than only broadcast: a deploy is the common
+      # cause, and that is exactly when the browser reconnects somewhere else.
+      assert reloaded.failure_category == :interrupted
+      assert reloaded.failure_message =~ "interrupted"
     end
 
     test "ignores stop for non-AI queues" do


### PR DESCRIPTION
## Description

Every AI chat failure looks the same, to the user and to us. A hung Apollo, a dropped connection and a deploy interrupting a run all end as one generic error, so people retry a hard-down service forever and support cannot tell from a screenshot which happened.

Closes #5125

The reasons already exist as sentences meant for a person to read, and were logged and thrown away: the channel only ever sent a message id and the word error. They now live on the message, as a category to group by and a sentence to show.

Columns rather than a broadcast, because the failure that matters most is a deploy interrupting a run, and that is exactly when the browser reconnects to a different node with the broadcast long gone.

**This is the plumbing, not the visible change.** Nothing in the frontend reads either field yet. What it buys is that the reason is recorded, survives a reconnect, and reaches the client.

The sentence is user-facing prose only; raw error terms stay in the log, where they cannot leak an internal hostname or a stack trace into the chat panel. It is bounded, since it is written through `change/2`, which validates nothing, and re-sent on every channel join.

## Validation steps

1. Stop Apollo (or point `APOLLO_ENDPOINT` at a port nothing is listening on), then send a message from the assistant panel.
2. The panel shows its usual error, unchanged. The new part is on the row, so read it in IEx:
   ```elixir
   import Ecto.Query
   Lightning.Repo.one(
     from m in Lightning.AiAssistant.ChatMessage,
       order_by: [desc: m.inserted_at], limit: 1
   ) |> Map.take([:status, :failure_category, :failure_message])
   ```
   You should get a category and a sentence written for a person, not an error term.
3. Make a service raise mid-answer and repeat. The exception text should be in the server log and *not* in `failure_message`.

## Additional notes for the reviewer

Nothing in the frontend reads the two new columns yet, so no user sees anything different once this merges. The reason has to survive a reconnect before anything can show it.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) 
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR
