### PR TITLE
Clear AI messages abandoned in processing

### DIFF
--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -312,17 +312,47 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   @doc false
   @spec broadcast_status(
           String.t(),
-          atom() | {atom(), AiAssistant.ChatSession.t()}
+          atom() | {atom(), AiAssistant.ChatSession.t()},
+          Ecto.UUID.t() | nil
         ) :: :ok
-  defp broadcast_status(session_id, status) do
+  # message_id is carried so a listener does not have to guess which message
+  # this is about. It guessed by taking the newest, which is wrong the moment
+  # anything reports on an older one - the reaper clearing a message stranded
+  # several exchanges back would have marked the newest as failed instead.
+  defp broadcast_status(session_id, status, message_id) do
     Lightning.broadcast(
       "ai_session:#{session_id}",
       {:ai_assistant, :message_status_changed,
        %{
          status: status,
-         session_id: session_id
+         session_id: session_id,
+         message_id: message_id
        }}
     )
+  end
+
+  @doc """
+  Tells a session one of its messages has failed.
+
+  For callers that write the status themselves - the reaper uses a guarded
+  update rather than a read-modify-write - and so cannot go through
+  `update_message_status/3`.
+  """
+  @spec broadcast_message_error(Ecto.UUID.t(), Ecto.UUID.t()) :: :ok
+  def broadcast_message_error(session_id, message_id) do
+    # get/1 rather than get!/1: the reaper calls this per message inside an
+    # Enum.each, so a session deleted since it selected its candidates would
+    # raise and abandon the rest of the sweep. Nobody is listening to a
+    # deleted session anyway.
+    case AiAssistant.get_session(session_id) do
+      {:ok, session} ->
+        broadcast_status(session_id, {:error, session}, message_id)
+
+      {:error, :not_found} ->
+        :ok
+    end
+
+    :ok
   end
 
   @doc """
@@ -358,7 +388,11 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
     updated_session = AiAssistant.get_session!(updated_message.chat_session_id)
 
-    broadcast_status(updated_session.id, {status, updated_session})
+    broadcast_status(
+      updated_session.id,
+      {status, updated_session},
+      updated_message.id
+    )
 
     {:ok, updated_session, updated_message}
   end

--- a/lib/lightning/ai_assistant/stuck_message_reaper.ex
+++ b/lib/lightning/ai_assistant/stuck_message_reaper.ex
@@ -1,0 +1,114 @@
+defmodule Lightning.AiAssistant.StuckMessageReaper do
+  @moduledoc """
+  Marks AI chat messages abandoned in `:processing` as errored.
+
+  A message is left `:processing` forever when its job dies without emitting
+  telemetry. The main case is a deploy: Oban's watchman gives up after the
+  grace period, stops the producer, and only then kills the running task - so
+  the handler that would have reported it is already gone.
+
+  Until something clears it the panel stays locked for everyone in that
+  session, and nothing raises. `processing_started_at` is written when a
+  message starts; this is what reads it.
+  """
+
+  use Oban.Worker,
+    queue: :background,
+    priority: 1,
+    max_attempts: 3,
+    unique: [period: 290]
+
+  import Ecto.Query
+
+  alias Lightning.AiAssistant.ChatMessage
+  alias Lightning.AiAssistant.MessageProcessor
+  alias Lightning.Repo
+
+  require Logger
+
+  @worker "Lightning.AiAssistant.MessageProcessor"
+  @live_states ~w(available scheduled executing retryable)
+  @message "The assistant was interrupted before it finished. Please try again."
+  @batch_size 200
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    cutoff =
+      DateTime.utc_now()
+      |> DateTime.add(-grace_period_ms(), :millisecond)
+
+    candidates = stale_messages(cutoff)
+
+    # Read the live set after the candidates, never before: a job that starts
+    # in between appears here and is skipped, whereas the other order could
+    # reap a message whose job had only just begun.
+    live = live_message_ids(cutoff)
+
+    candidates
+    |> Enum.reject(&MapSet.member?(live, &1.id))
+    |> Enum.each(&reap/1)
+
+    :ok
+  end
+
+  defp stale_messages(cutoff) do
+    from(m in ChatMessage,
+      where: m.status == :processing,
+      where: m.processing_started_at < ^cutoff,
+      order_by: [asc: m.processing_started_at],
+      # Bounded because each one reaped loads its whole session to tell the
+      # panel. The backlog this worker exists for is exactly when that would
+      # be largest, and it runs on a single-slot queue; the oldest go first
+      # and the rest wait five minutes.
+      limit: @batch_size,
+      select: %{id: m.id, chat_session_id: m.chat_session_id}
+    )
+    |> Repo.all()
+  end
+
+  # Well clear of the longest a run can legitimately take, so a slow answer is
+  # never mistaken for an abandoned one.
+  defp grace_period_ms, do: MessageProcessor.job_timeout() + :timer.minutes(2)
+
+  defp live_message_ids(cutoff) do
+    from(j in Oban.Job,
+      where: j.worker == ^@worker and j.state in ^@live_states,
+      # An executing row only means the job is alive while it is fresh. Oban
+      # leaves the row executing when a node dies mid-job, and nothing here
+      # moves it out again: Cron is the only plugin configured, and Lifeline
+      # is what would rescue it. Counting a stale one as live would let an
+      # orphaned row shield its message from every future sweep, which is the
+      # exact case this worker exists to catch.
+      where: j.state != "executing" or j.attempted_at >= ^cutoff,
+      select: fragment("?->>'message_id'", j.args)
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp reap(%{id: id, chat_session_id: session_id}) do
+    now = DateTime.utc_now()
+
+    # Guarded update rather than a read-modify-write, so a job that finishes
+    # between the select above and this write keeps its own result.
+    {count, _} =
+      from(m in ChatMessage, where: m.id == ^id and m.status == :processing)
+      |> Repo.update_all(
+        set: [
+          status: :error,
+          failure_category: :abandoned,
+          failure_message: @message,
+          processing_completed_at: now,
+          updated_at: now
+        ]
+      )
+
+    if count == 1 do
+      Logger.warning(
+        "[AI Assistant] Reaped abandoned message #{id} (session #{session_id})"
+      )
+
+      MessageProcessor.broadcast_message_error(session_id, id)
+    end
+  end
+end

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -273,6 +273,7 @@ defmodule Lightning.Config.Bootstrap do
       {"* * * * *", Lightning.Workflows.Scheduler},
       {"* * * * *", ObanPruner},
       {"*/5 * * * *", Lightning.Janitor},
+      {"*/5 * * * *", Lightning.AiAssistant.StuckMessageReaper},
       {"0 10 * * *", Lightning.DigestEmailWorker,
        args: %{"type" => "daily_project_digest"}},
       {"0 10 * * 1", Lightning.DigestEmailWorker,

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -262,9 +262,11 @@ defmodule LightningWeb.AiAssistantChannel do
   @impl true
   def handle_info(
         {:ai_assistant, :message_status_changed,
-         %{status: {status, updated_session}, session_id: session_id}},
+         %{status: {status, updated_session}, session_id: session_id} = payload},
         socket
       ) do
+    failed_id = Map.get(payload, :message_id)
+
     if socket.assigns.session_id == session_id do
       case status do
         :processing ->
@@ -287,30 +289,24 @@ defmodule LightningWeb.AiAssistantChannel do
 
         :error ->
           # Broadcast error state so all users can see and retry
-          user_message =
-            updated_session.messages
-            |> Enum.reverse()
-            |> Enum.find(fn msg -> msg.role == :user end)
+          failed_message = failed_message(updated_session, failed_id)
 
-          if user_message do
+          if failed_message do
             broadcast(
               socket,
               "message_error",
-              %{message_id: user_message.id, status: "error"}
-              |> put_failure(user_message)
+              %{message_id: failed_message.id, status: "error"}
+              |> put_failure(failed_message)
             )
           end
 
         :failed ->
           # Handle failed status (similar to error)
-          user_message =
-            updated_session.messages
-            |> Enum.reverse()
-            |> Enum.find(fn msg -> msg.role == :user end)
+          failed_message = failed_message(updated_session, failed_id)
 
-          if user_message do
+          if failed_message do
             broadcast(socket, "message_error", %{
-              message_id: user_message.id,
+              message_id: failed_message.id,
               status: "failed"
             })
           end
@@ -877,6 +873,21 @@ defmodule LightningWeb.AiAssistantChannel do
       from_global: from_global
     }
     |> put_failure(message)
+  end
+
+  # The broadcaster says which message it is reporting on. Falling back to the
+  # newest user message is only right when nothing said - anything reporting on
+  # an older one, like the reaper clearing something stranded several exchanges
+  # back, would otherwise mark the wrong message failed.
+  defp failed_message(session, nil) do
+    session.messages
+    |> Enum.reverse()
+    |> Enum.find(fn msg -> msg.role == :user end)
+  end
+
+  defp failed_message(session, message_id) do
+    Enum.find(session.messages, fn msg -> msg.id == message_id end) ||
+      failed_message(session, nil)
   end
 
   # Only present on a failed message, so a reconnecting client sees the same

--- a/priv/repo/migrations/20260815145049_index_processing_ai_chat_messages.exs
+++ b/priv/repo/migrations/20260815145049_index_processing_ai_chat_messages.exs
@@ -1,0 +1,13 @@
+defmodule Lightning.Repo.Migrations.IndexProcessingAiChatMessages do
+  use Ecto.Migration
+
+  def change do
+    # The reaper scans for stale :processing messages every five minutes. That
+    # set should be empty almost always, so a partial index keeps the scan off
+    # the table.
+    create index(:ai_chat_messages, [:processing_started_at],
+             where: "status = 'processing'",
+             name: :ai_chat_messages_stuck_idx
+           )
+  end
+end

--- a/test/lightning/ai_assistant/stuck_message_reaper_test.exs
+++ b/test/lightning/ai_assistant/stuck_message_reaper_test.exs
@@ -1,0 +1,149 @@
+defmodule Lightning.AiAssistant.StuckMessageReaperTest do
+  use Lightning.DataCase, async: false
+
+  import Lightning.Factories
+
+  alias Lightning.AiAssistant.ChatMessage
+  alias Lightning.AiAssistant.MessageProcessor
+  alias Lightning.AiAssistant.StuckMessageReaper
+  alias Lightning.Repo
+
+  setup do
+    user = insert(:user)
+    project = insert(:project)
+    workflow = insert(:simple_workflow, project: project)
+
+    session =
+      insert(:chat_session,
+        user: user,
+        project: project,
+        workflow: workflow,
+        session_type: "workflow_template"
+      )
+
+    %{session: session, user: user}
+  end
+
+  defp processing_message(session, user, started_at) do
+    insert(:chat_message,
+      chat_session: session,
+      user: user,
+      role: :user,
+      content: "hello",
+      status: :processing,
+      processing_started_at: started_at
+    )
+  end
+
+  defp long_ago do
+    DateTime.utc_now()
+    |> DateTime.add(
+      -(MessageProcessor.timeout(nil) + :timer.minutes(10)),
+      :millisecond
+    )
+  end
+
+  test "clears a message abandoned in processing", %{
+    session: session,
+    user: user
+  } do
+    message = processing_message(session, user, long_ago())
+
+    assert :ok = StuckMessageReaper.perform(%Oban.Job{})
+
+    reloaded = Repo.get!(ChatMessage, message.id)
+    assert reloaded.status == :error
+    assert reloaded.failure_category == :abandoned
+    assert reloaded.processing_completed_at != nil
+  end
+
+  test "tells the session, so a watching panel unblocks", %{
+    session: session,
+    user: user
+  } do
+    processing_message(session, user, long_ago())
+    Lightning.subscribe("ai_session:#{session.id}")
+
+    assert :ok = StuckMessageReaper.perform(%Oban.Job{})
+
+    assert_receive {:ai_assistant, :message_status_changed,
+                    %{status: {:error, _session}}}
+  end
+
+  test "leaves a message whose job is still running", %{
+    session: session,
+    user: user
+  } do
+    message = processing_message(session, user, long_ago())
+
+    # Old enough to look abandoned, but Oban still has work for it - the job
+    # is simply taking longer than the reaper's grace period.
+    Repo.insert!(%Oban.Job{
+      worker: "Lightning.AiAssistant.MessageProcessor",
+      queue: "ai_assistant",
+      state: "executing",
+      attempted_at: DateTime.utc_now(),
+      args: %{"message_id" => message.id}
+    })
+
+    assert :ok = StuckMessageReaper.perform(%Oban.Job{})
+
+    assert Repo.get!(ChatMessage, message.id).status == :processing
+  end
+
+  test "reaps a message whose job row was orphaned mid-run", %{
+    session: session,
+    user: user
+  } do
+    message = processing_message(session, user, long_ago())
+
+    # A node that dies mid-job leaves the row executing, and nothing moves it
+    # out: Cron is the only plugin configured. Taking this at face value would
+    # shield the message from every future sweep, which is the case the reaper
+    # is for.
+    Repo.insert!(%Oban.Job{
+      worker: "Lightning.AiAssistant.MessageProcessor",
+      queue: "ai_assistant",
+      state: "executing",
+      attempted_at: long_ago(),
+      args: %{"message_id" => message.id}
+    })
+
+    assert :ok = StuckMessageReaper.perform(%Oban.Job{})
+
+    reaped = Repo.get!(ChatMessage, message.id)
+    assert reaped.status == :error
+    assert reaped.failure_category == :abandoned
+  end
+
+  test "leaves a message that started recently", %{
+    session: session,
+    user: user
+  } do
+    message = processing_message(session, user, DateTime.utc_now())
+
+    assert :ok = StuckMessageReaper.perform(%Oban.Job{})
+
+    assert Repo.get!(ChatMessage, message.id).status == :processing
+  end
+
+  test "does not overwrite a message that finished in the meantime", %{
+    session: session,
+    user: user
+  } do
+    message = processing_message(session, user, long_ago())
+
+    # Stands in for the job completing between the reaper's select and its
+    # write. The guarded update must find nothing to change.
+    {:ok, _} =
+      message
+      |> Ecto.Changeset.change(%{status: :success})
+      |> Repo.update()
+
+    assert :ok = StuckMessageReaper.perform(%Oban.Job{})
+
+    reloaded = Repo.get!(ChatMessage, message.id)
+    assert reloaded.status == :success
+    assert reloaded.failure_category == nil
+  end
+end


### PR DESCRIPTION
## Description

`processing_started_at` has been written on every message since it started processing, and read by nothing. This reads it.

A message is left processing forever when its job dies without emitting telemetry. Attaching Oban's stop event in [#5069](https://github.com/OpenFn/lightning/pull/5069) covers most of that, but not the case it cannot reach: when a job outlives the drain window, Oban stops the producer first and kills the task after, so there is nothing left to report it. Until something clears the row the panel stays locked for everyone in that session, and nothing raises.

Two guards decide what to reap, because neither is sound alone. Age is vulnerable to clock skew and to a queue that was paused. A live Oban job for the same message is the cross-node authority. The live set is read after the candidates, never before: a job starting in between then appears in it and is skipped, where the other order could reap a message whose job had only just begun.

The write is a guarded update rather than a read-modify-write, so a job that finishes between the select and the write keeps its own result. The grace period sits well clear of the longest a run can legitimately take, so a slow answer is never mistaken for an abandoned one, and a partial index keeps the every-five-minutes scan off the table. The sweep is batched at 200, since each message reaped loads its whole session to tell the panel and the backlog this exists for is exactly when that would be largest. Oldest go first and the rest wait for the next pass.

Reaping something also meant telling the panel which message it was about, which is the second half of this PR.

The broadcast now carries the message id. Without it a listener has to guess, and it guessed by taking the newest, so clearing a message stranded several exchanges back marked an unrelated later message as failed. `broadcast_status/3` carries the id, `broadcast_message_error/2` takes it, and the channel resolves it. Broadcasts that do not carry an id keep the old guess, so nothing else changes behaviour.

Closes #4260

## Validation steps

1. Leave a message stranded, as if its job died without saying so. In IEx:
   ```elixir
   import Ecto.Query
   msg = Lightning.Repo.one(from m in Lightning.AiAssistant.ChatMessage,
     order_by: [desc: m.inserted_at], limit: 1)
   Lightning.Repo.update_all(
     from(m in Lightning.AiAssistant.ChatMessage, where: m.id == ^msg.id),
     set: [status: :processing,
           processing_started_at: DateTime.add(DateTime.utc_now(), -3600)]
   )
   ```
   With that session open in the browser, the panel sits on "...".
2. Run the sweep by hand: `Lightning.AiAssistant.StuckMessageReaper.perform(%Oban.Job{})` The panel should unlock and the message show as failed.
3. For the second half, do the same in a session that has a *later* successful exchange. Only the stranded message should be marked failed; the newer one should be left alone. That is what the id on the broadcast is for.

## Additional notes for the reviewer

The second half changes which message the client is told failed. Broadcasts carrying no id keep the old "newest user message" guess, so only the reaper's path behaves differently.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) 
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR