### PR TITLE
Keep what arrived when a stream dies

### DIFF
--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1090,17 +1090,20 @@ defmodule Lightning.AiAssistant do
   # the full response payload.
 
   defp process_stream(session, body_stream, message_builder) do
-    complete_payload =
+    acc =
       body_stream
-      |> Enum.reduce(nil, fn sse_event, acc ->
-        handle_sse_event(session.id, sse_event, acc)
-      end)
+      |> Enum.reduce(
+        %{complete: nil, text: [], code: nil, apollo_error: nil},
+        fn sse_event, acc -> handle_sse_event(session.id, sse_event, acc) end
+      )
 
-    if complete_payload do
-      {message_attrs, opts} = message_builder.(complete_payload)
-      save_message(session, message_attrs, opts)
-    else
-      {:error, "Stream ended without complete response"}
+    case acc do
+      %{complete: payload} when is_map(payload) ->
+        {message_attrs, opts} = message_builder.(payload)
+        save_message(session, message_attrs, opts)
+
+      _ ->
+        save_partial_response(session, acc)
     end
   rescue
     e ->
@@ -1128,28 +1131,84 @@ defmodule Lightning.AiAssistant do
       {:error, message}
   end
 
+  # The stream is the only place some of this exists. Apollo rebuilds the whole
+  # reply in its `complete` payload, but if the stream dies before that arrives
+  # the text the user just watched appear is gone unless we keep it here.
+  defp save_partial_response(_session, %{text: [], code: nil}) do
+    {:error, "Stream ended without complete response"}
+  end
+
+  defp save_partial_response(session, %{text: text, code: code} = acc) do
+    # Clamped, because the whole point is to keep what arrived: a reply that
+    # ran past the column's limit would fail the changeset and lose the lot.
+    content =
+      text
+      |> Enum.reverse()
+      |> IO.iodata_to_binary()
+      |> String.trim()
+      |> String.slice(0, ChatMessage.max_content_length())
+
+    message =
+      acc.apollo_error ||
+        "The assistant was cut off before it finished. Please try again."
+
+    case save_message(
+           session,
+           %{
+             role: :assistant,
+             content: if(content == "", do: "(no response)", else: content),
+             status: :error,
+             failure_category: :incomplete_response,
+             failure_message: message
+           },
+           code: code
+         ) do
+      {:ok, _session} ->
+        {:error, message}
+
+      {:error, changeset} ->
+        # Losing the partial silently is the failure this function exists to
+        # prevent, so make it visible rather than reporting a plain stall.
+        Logger.error(
+          "[AI Assistant] Could not save partial response for session " <>
+            "#{session.id}: #{inspect(changeset.errors)}"
+        )
+
+        {:error, message}
+    end
+  end
+
   # Bridge event: complete — final payload (same shape as sync response)
-  defp handle_sse_event(_session_id, %{event: "complete", data: data}, _acc) do
+  defp handle_sse_event(_session_id, %{event: "complete", data: data}, acc) do
     case Jason.decode(data) do
-      {:ok, payload} when is_map(payload) -> payload
-      _ -> nil
+      {:ok, payload} when is_map(payload) -> %{acc | complete: payload}
+      _ -> acc
     end
   end
 
   # Bridge event: error
+  # Apollo having said it failed is worth recording, because it distinguishes a
+  # service that gave up from a socket that went quiet. Its text is not: Apollo
+  # wraps any unhandled exception as `str(e)`, which carries internal hostnames,
+  # upstream URLs and container paths. So the fact is kept and the words are
+  # not - they go to the log.
   defp handle_sse_event(session_id, %{event: "error", data: data}, acc) do
     case Jason.decode(data) do
-      {:ok, %{"message" => message}} ->
-        broadcast_streaming_error(session_id, message)
+      {:ok, %{"message" => message}} when is_binary(message) ->
+        Logger.warning(
+          "[AI Assistant] Apollo reported an error for session #{session_id}: " <>
+            message
+        )
 
-      {:ok, error} ->
-        broadcast_streaming_error(session_id, inspect(error))
-
-      _ ->
-        broadcast_streaming_error(session_id, data)
+      other ->
+        Logger.warning(
+          "[AI Assistant] Unreadable error event for session #{session_id}: " <>
+            inspect(other)
+        )
     end
 
-    acc
+    broadcast_streaming_error(session_id, @internal_failure)
+    %{acc | apollo_error: @internal_failure}
   end
 
   # Bridge event: changes — structured data (code edits or workflow YAML)
@@ -1158,12 +1217,14 @@ defmodule Lightning.AiAssistant do
     case Jason.decode(data) do
       {:ok, changes} when is_map(changes) ->
         broadcast_streaming_changes(session_id, changes)
+        # Workflow and global chat send the generated YAML here, ahead of the
+        # text. Keep it so a stream that dies late doesn't discard a workflow
+        # the user already watched appear.
+        %{acc | code: changes["yaml"] || acc.code}
 
       _ ->
-        :ok
+        acc
     end
-
-    acc
   end
 
   # Bridge event: status — a persistent, completed-action status, the same
@@ -1199,42 +1260,57 @@ defmodule Lightning.AiAssistant do
   defp handle_sse_event(session_id, %{data: data}, acc) do
     case Jason.decode(data) do
       {:ok, %{"type" => _} = event} ->
-        handle_stream_event(session_id, event)
+        handle_stream_event(session_id, event, acc)
 
       _ ->
-        :ok
+        acc
     end
-
-    acc
   end
 
   # Catch-all for anything unexpected
   defp handle_sse_event(_session_id, _event, acc), do: acc
 
-  defp handle_stream_event(session_id, %{
-         "type" => "content_block_delta",
-         "delta" => %{"type" => "text_delta", "text" => text}
-       }) do
+  defp handle_stream_event(
+         session_id,
+         %{
+           "type" => "content_block_delta",
+           "delta" => %{"type" => "text_delta", "text" => text}
+         },
+         acc
+       ) do
     broadcast_streaming_chunk(session_id, text)
+    # Prepended and reversed on save - cheaper than repeatedly appending to a
+    # binary for a reply that can run to thousands of chunks.
+    %{acc | text: [text | acc.text]}
   end
 
-  defp handle_stream_event(session_id, %{
-         "type" => "content_block_start",
-         "content_block" => %{"type" => "thinking"}
-       }) do
+  defp handle_stream_event(
+         session_id,
+         %{
+           "type" => "content_block_start",
+           "content_block" => %{"type" => "thinking"}
+         },
+         acc
+       ) do
     broadcast_streaming_status(session_id, "Thinking...")
+    acc
   end
 
   # Apollo sends discrete thinking blocks as progress updates
   # (e.g. "Searching documentation...", "Loading adaptor documentation...")
-  defp handle_stream_event(session_id, %{
-         "type" => "content_block_delta",
-         "delta" => %{"type" => "thinking_delta", "thinking" => text}
-       }) do
+  defp handle_stream_event(
+         session_id,
+         %{
+           "type" => "content_block_delta",
+           "delta" => %{"type" => "thinking_delta", "thinking" => text}
+         },
+         acc
+       ) do
     broadcast_streaming_status(session_id, text)
+    acc
   end
 
-  defp handle_stream_event(_session_id, _event), do: :ok
+  defp handle_stream_event(_session_id, _event, acc), do: acc
 
   defp broadcast_streaming_chunk(session_id, content) do
     Lightning.broadcast(

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -67,6 +67,8 @@ defmodule Lightning.AiAssistant.ChatMessage do
   # rows that get re-serialized on every channel join.
   @max_response_segments 200
 
+  @max_content_length 10_000
+
   # A sentence, not a story. Bounded because the column is read back and
   # re-sent on every channel join.
   @max_failure_message_length 500
@@ -174,7 +176,7 @@ defmodule Lightning.AiAssistant.ChatMessage do
     |> cast_embed(:response_segments)
     |> validate_length(:response_segments, max: @max_response_segments)
     |> validate_required([:content, :role])
-    |> validate_length(:content, min: 1, max: 10_000)
+    |> validate_length(:content, min: 1, max: @max_content_length)
     |> validate_length(:failure_message, max: @max_failure_message_length)
     |> maybe_put_user_assoc(attrs[:user] || attrs["user"])
     |> maybe_put_job_assoc(attrs[:job] || attrs["job"])
@@ -184,6 +186,9 @@ defmodule Lightning.AiAssistant.ChatMessage do
 
   @doc "Maximum number of segments accepted on a message."
   def max_response_segments, do: @max_response_segments
+
+  @doc "Maximum length of a message's `content`."
+  def max_content_length, do: @max_content_length
 
   @doc "Maximum length of a message's `failure_message`."
   def max_failure_message_length, do: @max_failure_message_length

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -288,6 +288,11 @@ defmodule LightningWeb.AiAssistantChannel do
           end
 
         :error ->
+          # A stream that died partway through still saves what arrived. Send
+          # it before the error, or the client clears its buffer and the reply
+          # the user watched appear vanishes until they reload.
+          broadcast_partial_answer(socket, updated_session)
+
           # Broadcast error state so all users can see and retry
           failed_message = failed_message(updated_session, failed_id)
 
@@ -873,6 +878,34 @@ defmodule LightningWeb.AiAssistantChannel do
       from_global: from_global
     }
     |> put_failure(message)
+  end
+
+  # Only an assistant message kept from a cut-off stream: a failed user message
+  # is already on screen, and a session whose newest assistant reply succeeded
+  # has nothing partial to send.
+  defp broadcast_partial_answer(socket, session) do
+    # Picked by role rather than by taking the last message. Messages are
+    # ordered by inserted_at and that is stored to the second, so a turn that
+    # dies quickly ties with the question that started it and can come back
+    # either way round. Taking the last one then finds the question, matches
+    # nothing here, and the answer the user watched appear is never sent - the
+    # loss this whole path exists to prevent.
+    #
+    # Re-sending is the safe direction: the client keys messages by id and
+    # ignores one it already has, so a partial kept from an earlier turn is
+    # dropped there rather than shown twice.
+    partial =
+      session.messages
+      |> Enum.filter(&(&1.role == :assistant))
+      |> List.last()
+
+    case partial do
+      %{failure_category: :incomplete_response} = partial ->
+        broadcast(socket, "new_message", %{message: format_message(partial)})
+
+      _ ->
+        :ok
+    end
   end
 
   # The broadcaster says which message it is reporting on. Falling back to the

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -2359,8 +2359,14 @@ defmodule Lightning.AiAssistantTest do
 
       assert {:ok, _} = AiAssistant.query_stream(session, "test")
 
+      # Apollo's own words do not reach the panel: it wraps any unhandled
+      # exception as str(e), which can carry hostnames and paths. The text goes
+      # to the log and the user gets the generic sentence.
       assert_received {:ai_assistant, :streaming_error,
-                       %{error: "rate limited", session_id: _}}
+                       %{error: error_text, session_id: _}}
+
+      assert error_text == "Something went wrong. Please try again."
+      refute error_text =~ "rate limited"
     end
 
     test "handles error event with non-message JSON", %{
@@ -2404,11 +2410,13 @@ defmodule Lightning.AiAssistantTest do
 
       assert {:ok, _} = AiAssistant.query_stream(session, "test")
 
-      # Non-message error JSON gets inspected
+      # An error payload we cannot read is not shown verbatim: it is Apollo's
+      # internal shape, not a sentence for the user.
       assert_received {:ai_assistant, :streaming_error,
                        %{error: error_text, session_id: _}}
 
-      assert error_text =~ "500"
+      assert error_text == "Something went wrong. Please try again."
+      refute error_text =~ "500"
     end
 
     test "handles error event with non-JSON data", %{
@@ -2452,8 +2460,12 @@ defmodule Lightning.AiAssistantTest do
 
       assert {:ok, _} = AiAssistant.query_stream(session, "test")
 
+      # Undecodable data is not passed through to the panel either.
       assert_received {:ai_assistant, :streaming_error,
-                       %{error: "raw error text", session_id: _}}
+                       %{
+                         error: "Something went wrong. Please try again.",
+                         session_id: _
+                       }}
     end
 
     test "returns error when stream has no complete event", %{
@@ -2516,6 +2528,102 @@ defmodule Lightning.AiAssistantTest do
 
       assert {:error, "Stream ended without complete response"} =
                AiAssistant.query_stream(session, "test")
+    end
+
+    test "keeps the text that arrived when the stream dies before completing",
+         %{user: user, workflow: %{jobs: [job_1 | _]}} do
+      session =
+        insert(:chat_session,
+          user: user,
+          job: job_1,
+          messages: [
+            %{
+              role: :user,
+              content: "test",
+              user: user,
+              status: :pending,
+              inserted_at: DateTime.utc_now() |> DateTime.add(-1)
+            }
+          ]
+        )
+
+      # Text the user has already watched appear, then nothing - no complete
+      # event ever arrives.
+      sse_stream = [
+        %{
+          data:
+            Jason.encode!(%{
+              "type" => "content_block_delta",
+              "delta" => %{"type" => "text_delta", "text" => "Here is "}
+            })
+        },
+        %{
+          data:
+            Jason.encode!(%{
+              "type" => "content_block_delta",
+              "delta" => %{"type" => "text_delta", "text" => "the answer"}
+            })
+        }
+      ]
+
+      expect(Lightning.Tesla.Mock, :call, fn _env, _opts ->
+        {:ok, %Tesla.Env{status: 200, body: sse_stream}}
+      end)
+
+      assert {:error, message} = AiAssistant.query_stream(session, "test")
+      assert message =~ "cut off"
+
+      saved =
+        Lightning.Repo.all(Lightning.AiAssistant.ChatMessage)
+        |> Enum.find(&(&1.role == :assistant))
+
+      assert saved.content == "Here is the answer"
+      assert saved.status == :error
+      assert saved.failure_category == :incomplete_response
+    end
+
+    test "keeps the workflow yaml when the stream dies after sending it", %{
+      user: user,
+      workflow: %{jobs: [job_1 | _]}
+    } do
+      session =
+        insert(:chat_session,
+          user: user,
+          job: job_1,
+          messages: [
+            %{
+              role: :user,
+              content: "test",
+              user: user,
+              status: :pending,
+              inserted_at: DateTime.utc_now() |> DateTime.add(-1)
+            }
+          ]
+        )
+
+      # Workflow and global chat put the yaml on the wire ahead of the text.
+      sse_stream = [
+        %{event: "changes", data: Jason.encode!(%{"yaml" => "name: my-flow"})},
+        %{
+          data:
+            Jason.encode!(%{
+              "type" => "content_block_delta",
+              "delta" => %{"type" => "text_delta", "text" => "Built it"}
+            })
+        }
+      ]
+
+      expect(Lightning.Tesla.Mock, :call, fn _env, _opts ->
+        {:ok, %Tesla.Env{status: 200, body: sse_stream}}
+      end)
+
+      assert {:error, _} = AiAssistant.query_stream(session, "test")
+
+      saved =
+        Lightning.Repo.all(Lightning.AiAssistant.ChatMessage)
+        |> Enum.find(&(&1.role == :assistant))
+
+      assert saved.code == "name: my-flow"
     end
 
     test "skips log events and unknown events", %{


### PR DESCRIPTION
## Description

A reply the user watched appear was thrown away the moment the stream failed. Every event except the final one returned the accumulator unchanged, so the saved message was built entirely from a `complete` event that never came: the panel typed out an answer and then replaced it with a red box.

Closes #5126

The accumulator now carries the text as it arrives, and the yaml that workflow and global chat send ahead of the text. If the stream ends without completing, whatever did arrive is saved as an assistant message marked incomplete rather than discarded. It is deliberately not presented as a finished answer, so the panel can show it as cut off and offer a retry. The content is clamped to the column's limit, because a reply that ran past it would fail the changeset and lose the lot.

Saving it is not enough on its own. The channel has to send it, and send it before the error, or the client clears its streaming buffer and the user only finds the reply again by reloading. That is a new `new_message` broadcast on the error path.

Apollo's own words stop reaching the panel and the row. Apollo wraps any unhandled exception as `str(e)`, which carries internal hostnames, upstream URLs and container paths. That it failed is worth recording, because it separates a service giving up from a socket going quiet; its words are not, so they go to the log and the user gets a sentence of ours. Three existing tests changed with it, since they asserted on Apollo's text.

Job chat's suggested code is not recoverable this way and is not attempted. It is assembled from the tool call after the model finishes, so when a stream dies mid-answer the code does not exist yet on either side. There is nothing to save rather than something being dropped.

Chunks are prepended and reversed once at the end rather than appended to a growing binary, since a long reply arrives as thousands of them.

## Validation steps

1. Ask the assistant something that produces a long answer, and watch the text stream in. Kill Apollo part-way through.
2. The text you had already watched appear should stay on screen, marked as cut off, with a retry — rather than being replaced by a red error. Reload the page and it should still be there.
3. Check the server log has Apollo's own error text, and that the panel never showed it.

## Additional notes for the reviewer

This is where Apollo's own error text stops reaching the panel. Three existing tests changed with it, since they asserted on Apollo's words.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) 
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR
