### PR TITLE
Say why a stream stopped, and give each wait its own setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,15 +57,16 @@ and this project adheres to
   complete response"; they now read as three different things.
   [#4882](https://github.com/OpenFn/lightning/issues/4882)
 
-- `APOLLO_TIMEOUT` is replaced by `APOLLO_CONNECT_TIMEOUT_MS`,
-  `APOLLO_IDLE_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`, which bound reaching
-  Apollo, a silence part-way through an answer, and a whole request. One number
-  had to be sized for the longest of those, so a broken path took as long to
-  notice as a slow answer. Setting the old name now logs a warning at boot
-  saying it is ignored. The idle default of 30s assumes Apollo v3.1.1 or later,
-  which sends a keepalive every 15s. On an older Apollo a working stream can go
-  quiet for longer than that, so raise `APOLLO_IDLE_TIMEOUT_MS` or upgrade
-  Apollo. [#4882](https://github.com/OpenFn/lightning/issues/4882)
+- `APOLLO_TIMEOUT` is renamed `APOLLO_IDLE_TIMEOUT_MS`, and joined by
+  `APOLLO_CONNECT_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`. The old setting
+  only ever measured silence. Connecting used a fixed five seconds you could not
+  change, and nothing bounded a whole request at the HTTP layer, so a slow but
+  steady stream ran until Oban killed the job. Setting the old name now logs a
+  warning at boot saying it is ignored. The idle default drops to 30s, which
+  assumes Apollo v3.1.1 or later and its 15s keepalive; on an older Apollo a
+  working stream can go quiet for longer than that, so raise
+  `APOLLO_IDLE_TIMEOUT_MS` or upgrade Apollo.
+  [#4882](https://github.com/OpenFn/lightning/issues/4882)
 
 - The AI assistant no longer appends " 1" to a workflow's name each time it
   edits an already-saved workflow. Name-uniqueness validation now excludes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,18 @@ and this project adheres to
 
 ### Fixed
 
-- `APOLLO_TIMEOUT` now governs every request to Apollo, including the streaming
-  requests all AI chats use. Streaming previously read an internal timeout key
-  that no environment could set, so it was always 120s regardless of
-  configuration; that dead key is removed.
-  [#5043](https://github.com/OpenFn/lightning/pull/5043)
+- A failed AI stream now says which way it failed. A hung Apollo, a severed
+  connection and a genuinely short answer all read as "Stream ended without
+  complete response"; they now read as three different things.
+  [#4882](https://github.com/OpenFn/lightning/issues/4882)
+
+- `APOLLO_TIMEOUT` is replaced by `APOLLO_CONNECT_TIMEOUT_MS`,
+  `APOLLO_IDLE_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`, which bound
+  reaching Apollo, a silence part-way through an answer, and a whole request.
+  One number had to be sized for the longest of those, so a broken path took as
+  long to notice as a slow answer. Setting the old name now logs a warning at
+  boot saying it is ignored.
+  [#4882](https://github.com/OpenFn/lightning/issues/4882)
 
 - The AI assistant no longer appends " 1" to a workflow's name each time it
   edits an already-saved workflow. Name-uniqueness validation now excludes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,12 +58,14 @@ and this project adheres to
   [#4882](https://github.com/OpenFn/lightning/issues/4882)
 
 - `APOLLO_TIMEOUT` is replaced by `APOLLO_CONNECT_TIMEOUT_MS`,
-  `APOLLO_IDLE_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`, which bound
-  reaching Apollo, a silence part-way through an answer, and a whole request.
-  One number had to be sized for the longest of those, so a broken path took as
-  long to notice as a slow answer. Setting the old name now logs a warning at
-  boot saying it is ignored.
-  [#4882](https://github.com/OpenFn/lightning/issues/4882)
+  `APOLLO_IDLE_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`, which bound reaching
+  Apollo, a silence part-way through an answer, and a whole request. One number
+  had to be sized for the longest of those, so a broken path took as long to
+  notice as a slow answer. Setting the old name now logs a warning at boot
+  saying it is ignored. The idle default of 30s assumes Apollo v3.1.1 or later,
+  which sends a keepalive every 15s. On an older Apollo a working stream can go
+  quiet for longer than that, so raise `APOLLO_IDLE_TIMEOUT_MS` or upgrade
+  Apollo. [#4882](https://github.com/OpenFn/lightning/issues/4882)
 
 - The AI assistant no longer appends " 1" to a workflow's name each time it
   edits an already-saved workflow. Name-uniqueness validation now excludes the

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -255,7 +255,9 @@ Three optional variables control how long Lightning waits on Apollo. Each one
 has a default, so set them only if those defaults do not suit your deployment.
 
 - `APOLLO_CONNECT_TIMEOUT_MS` - how long to wait to reach Apollo at all.
-  Defaults to 5000.
+  Defaults to 5000. Reaching Apollo happens inside the idle budget, so a value
+  above `APOLLO_IDLE_TIMEOUT_MS` never takes effect; Lightning warns at boot if
+  you set one.
 - `APOLLO_IDLE_TIMEOUT_MS` - the longest acceptable silence, both before the
   first byte of an answer and between the chunks that follow. Defaults to 30000.
 - `APOLLO_REQUEST_TIMEOUT_MS` - the longest one whole request may take, however
@@ -266,8 +268,9 @@ The idle default assumes Apollo v3.1.1 or later, which sends a keepalive every
 is thinking, and 30 seconds will cut it off, so raise `APOLLO_IDLE_TIMEOUT_MS`
 or upgrade Apollo.
 
-`APOLLO_TIMEOUT` used to cover all three of these. It is no longer read, and
-Lightning logs a warning at boot if it is still set.
+`APOLLO_TIMEOUT` is the old name for `APOLLO_IDLE_TIMEOUT_MS`. It only ever
+covered the silence, never the other two. It is no longer read, and Lightning
+logs a warning at boot if it is still set.
 
 ### Kafka Triggers
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -251,6 +251,24 @@ The following environment variables are required:
   an Anthropic key.
 - `APOLLO_ENDPOINT` - the endpoint for the OpenFn Apollo AI service.
 
+Three optional variables control how long Lightning waits on Apollo. Each one
+has a default, so set them only if those defaults do not suit your deployment.
+
+- `APOLLO_CONNECT_TIMEOUT_MS` - how long to wait to reach Apollo at all.
+  Defaults to 5000.
+- `APOLLO_IDLE_TIMEOUT_MS` - the longest acceptable silence, both before the
+  first byte of an answer and between the chunks that follow. Defaults to 30000.
+- `APOLLO_REQUEST_TIMEOUT_MS` - the longest one whole request may take, however
+  steadily it is streaming. Defaults to 300000.
+
+The idle default assumes Apollo v3.1.1 or later, which sends a keepalive every
+15 seconds. On an older Apollo a stream can go quiet for minutes while a model
+is thinking, and 30 seconds will cut it off, so raise `APOLLO_IDLE_TIMEOUT_MS`
+or upgrade Apollo.
+
+`APOLLO_TIMEOUT` used to cover all three of these. It is no longer read, and
+Lightning logs a warning at boot if it is still set.
+
 ### Kafka Triggers
 
 🧪 **Experimental**

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,3 +26,8 @@ ignore:
 
   # Mix tasks — one-shot CLI utilities, not exercised by the suite
   - "lib/mix/tasks/**"
+
+  # A copy of Tesla's Finch adapter, carried only until the upstream fix is
+  # released (tesla#912) and then deleted. Upstream owns and tests these
+  # branches; the two lines we changed have tests of our own.
+  - "lib/lightning/tesla/adapter/finch.ex"

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,9 +10,13 @@ import Config
 config :lightning,
   ecto_repos: [Lightning.Repo]
 
-# Apollo (AI assistant service) — see Config.Bootstrap for what the
-# timeout governs and how APOLLO_TIMEOUT overrides it.
-config :lightning, :apollo, timeout: 120_000
+# Apollo (AI assistant service). Compiled defaults so these are never nil;
+# Config.Bootstrap overrides them from the environment. See there for what
+# each one bounds.
+config :lightning, :apollo,
+  connect_timeout: 5_000,
+  idle_timeout: 30_000,
+  request_timeout: 300_000
 
 config :lightning, Lightning.Repo,
   types: Lightning.PostgrexTypes,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -129,7 +129,12 @@ config :lightning, :is_resettable_demo, true
 
 config :lightning, :auth_providers_allow_insecure_loopback, true
 
-config :lightning, :apollo, endpoint: "http://localhost:3000", timeout: 300_000
+config :lightning, :apollo,
+  endpoint: "http://localhost:3000",
+  # Generous locally: a dev Apollo may predate the keepalive, and a cold python
+  # start is slower than anything staging sees.
+  idle_timeout: 120_000,
+  request_timeout: 300_000
 
 # Philter's egress guard blocks private/loopback ranges by default; allow
 # localhost so channel proxies can reach services running on the dev machine.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -131,9 +131,9 @@ config :lightning, :auth_providers_allow_insecure_loopback, true
 
 config :lightning, :apollo,
   endpoint: "http://localhost:3000",
-  # Generous locally: a dev Apollo may predate the keepalive, and a cold python
-  # start is slower than anything staging sees.
-  idle_timeout: 120_000,
+  # Roomier than prod for a cold python start, but the sum of the three still
+  # has to sit under Oban's drain window or every boot warns about it.
+  idle_timeout: 40_000,
   request_timeout: 300_000
 
 # Philter's egress guard blocks private/loopback ranges by default; allow

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1134,8 +1134,10 @@ defmodule Lightning.AiAssistant do
   # The stream is the only place some of this exists. Apollo rebuilds the whole
   # reply in its `complete` payload, but if the stream dies before that arrives
   # the text the user just watched appear is gone unless we keep it here.
-  defp save_partial_response(_session, %{text: [], code: nil}) do
-    {:error, "Stream ended without complete response"}
+  # Nothing arrived that a reader could use. Status updates alone are not worth
+  # a message: they describe work that did not produce anything.
+  defp save_partial_response(_session, %{text: [], code: nil} = acc) do
+    {:error, acc.apollo_error || stream_failure_message()}
   end
 
   defp save_partial_response(session, %{text: text, code: code} = acc) do
@@ -1148,9 +1150,8 @@ defmodule Lightning.AiAssistant do
       |> String.trim()
       |> String.slice(0, ChatMessage.max_content_length())
 
-    message =
-      acc.apollo_error ||
-        "The assistant was cut off before it finished. Please try again."
+    # Apollo telling us beats anything we can infer from how the socket died.
+    message = acc.apollo_error || stream_failure_message()
 
     case save_message(
            session,
@@ -1176,6 +1177,45 @@ defmodule Lightning.AiAssistant do
 
         {:error, message}
     end
+  end
+
+  # The adapter records why a stream stopped; without it we only know that it
+  # did, which is how a hung Apollo, a severed connection and a short answer
+  # all came to report the same thing.
+  defp stream_failure_message do
+    case Lightning.Tesla.Adapter.Finch.take_stream_error() do
+      nil ->
+        "The assistant stopped before it finished. Please try again."
+
+      # Our own receive_timeout in the adapter, which reports a bare atom.
+      :timeout ->
+        transport_failure_message(:timeout)
+
+      # Anything Finch reports. It wraps Mint's error in a struct of its own,
+      # and both carry :reason, so the reason is taken out before it is matched
+      # on rather than matching one struct and missing the other.
+      %s{reason: reason}
+      when s in [Finch.TransportError, Mint.TransportError] ->
+        transport_failure_message(reason)
+
+      other ->
+        Logger.warning("[AI Assistant] Stream failed: #{inspect(other)}")
+        "The assistant stopped before it finished. Please try again."
+    end
+  end
+
+  # A silence long enough to give up on reaches us two ways, from our own
+  # adapter and from Finch, and both have to read the same to the user.
+  defp transport_failure_message(:timeout) do
+    "The assistant stopped responding partway through. Please try again."
+  end
+
+  defp transport_failure_message(reason) do
+    # inspect/1, not interpolation: a reason is not always an atom, and a
+    # tuple like {:tls_alert, _} has no String.Chars.
+    Logger.warning("[AI Assistant] Stream lost mid-response: #{inspect(reason)}")
+
+    "The connection to the assistant was lost. Please try again."
   end
 
   # Bridge event: complete — final payload (same shape as sync response)

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1250,7 +1250,7 @@ defmodule Lightning.AiAssistant do
       other ->
         Logger.warning(
           "[AI Assistant] Unreadable error event for session #{session_id}: " <>
-            inspect(other)
+            inspect(other, printable_limit: 128)
         )
     end
 
@@ -1415,13 +1415,31 @@ defmodule Lightning.AiAssistant do
         Logger.error("AI query timed out for session #{session.id}")
         {:error, "Request timed out. Please try again."}
 
+      # Finch wraps every Mint error in one of its own, so a bare atom only
+      # arrives from our adapter's own deadline. These are the same failures
+      # arriving by the other route, and they have to read the same.
+      {:error, %s{reason: :timeout}}
+      when s in [Finch.TransportError, Mint.TransportError] ->
+        Logger.error("AI query timed out for session #{session.id}")
+        {:error, "Request timed out. Please try again."}
+
       {:error, :econnrefused} ->
         Logger.error("Connection refused to AI server for session #{session.id}")
         {:error, "Unable to reach the AI server. Please try again later."}
 
+      {:error, %s{reason: reason}}
+      when s in [Finch.TransportError, Mint.TransportError] and
+             reason in [:econnrefused, :closed, :nxdomain] ->
+        Logger.error(
+          "Cannot reach AI server for session #{session.id}: #{inspect(reason)}"
+        )
+
+        {:error, "Unable to reach the AI server. Please try again later."}
+
       unexpected_error ->
         Logger.error(
-          "Unexpected error for session #{session.id}: #{inspect(unexpected_error)}"
+          "Unexpected error for session #{session.id}: " <>
+            inspect(unexpected_error, printable_limit: 128)
         )
 
         {:error, "Oops! Something went wrong. Please try again."}

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1209,6 +1209,10 @@ defmodule Lightning.AiAssistant do
 
   # A silence long enough to give up on reaches us two ways, from our own
   # adapter and from Finch, and both have to read the same to the user.
+  # APOLLO_REQUEST_TIMEOUT_MS lands here too: Finch reports the whole-request
+  # cap as the same :timeout, so a healthy answer cut off for running long
+  # reads as a stall. Nothing at this layer separates them, and neither does
+  # the log. How long the message took is the only thing that does.
   defp transport_failure_message(:timeout) do
     "The assistant stopped responding partway through. Please try again."
   end
@@ -1415,9 +1419,11 @@ defmodule Lightning.AiAssistant do
         Logger.error("AI query timed out for session #{session.id}")
         {:error, "Request timed out. Please try again."}
 
-      # Finch wraps every Mint error in one of its own, so a bare atom only
-      # arrives from our adapter's own deadline. These are the same failures
-      # arriving by the other route, and they have to read the same.
+      # One failure arriving two ways: a bare atom from our adapter's own
+      # deadline, and a struct from Finch. Finch wraps Mint's error before
+      # returning it, so Mint's struct should not reach here; it is named
+      # anyway because the cost is a word in a guard, and the cost of missing
+      # it is the generic error below.
       {:error, %s{reason: :timeout}}
       when s in [Finch.TransportError, Mint.TransportError] ->
         Logger.error("AI query timed out for session #{session.id}")

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1199,7 +1199,10 @@ defmodule Lightning.AiAssistant do
         transport_failure_message(reason)
 
       other ->
-        Logger.warning("[AI Assistant] Stream failed: #{inspect(other)}")
+        Logger.warning(
+          "[AI Assistant] Stream failed: #{inspect(other, printable_limit: 128)}"
+        )
+
         "The assistant stopped before it finished. Please try again."
     end
   end
@@ -1211,9 +1214,13 @@ defmodule Lightning.AiAssistant do
   end
 
   defp transport_failure_message(reason) do
-    # inspect/1, not interpolation: a reason is not always an atom, and a
-    # tuple like {:tls_alert, _} has no String.Chars.
-    Logger.warning("[AI Assistant] Stream lost mid-response: #{inspect(reason)}")
+    # inspect/1, not interpolation: a reason is not always an atom, and a tuple
+    # like {:tls_alert, _} has no String.Chars. Bounded because a reason can
+    # carry bytes off the socket, and those are the user's own data.
+    Logger.warning(
+      "[AI Assistant] Stream lost mid-response: " <>
+        inspect(reason, printable_limit: 128)
+    )
 
     "The connection to the assistant was lost. Please try again."
   end

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -69,12 +69,15 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   """
   @spec job_timeout() :: pos_integer()
   def job_timeout do
-    # This is the only bound on a run's total duration. The Finch timeout is
-    # per-chunk, so a stream that keeps sending never trips it - which is why
-    # this must stay below Oban's shutdown_grace_period. If it doesn't, an
-    # interrupted job is killed after its producer has already stopped, and no
-    # telemetry fires at all.
-    Lightning.Config.apollo(:timeout) + 10_000
+    # Sits just outside the transport's own worst case, so the HTTP layer gets
+    # to fail first and say why. request_timeout is only checked between reads,
+    # so it can overrun by up to one idle_timeout - hence adding both rather
+    # than a flat margin. Must stay below Oban's shutdown_grace_period: if it
+    # doesn't, an interrupted job is killed after its producer has stopped and
+    # no telemetry fires at all.
+    Lightning.Config.apollo(:connect_timeout) +
+      Lightning.Config.apollo(:request_timeout) +
+      Lightning.Config.apollo(:idle_timeout) + 10_000
   end
 
   @doc false

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -51,14 +51,10 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   end
 
   @doc """
-  Defines the job timeout based on Apollo configuration.
+  How long one AI job may run, in milliseconds.
 
-  Adds a 10-second buffer to the Apollo timeout to account for
-  network overhead and processing time.
-
-  ## Returns
-
-  Timeout in milliseconds
+  The three Apollo timeouts added together, plus a 10-second buffer, so the
+  transport gets to fail first and say why.
   """
   @impl Oban.Worker
   @spec timeout(Oban.Job.t()) :: pos_integer()

--- a/lib/lightning/apollo_client.ex
+++ b/lib/lightning/apollo_client.ex
@@ -182,11 +182,6 @@ defmodule Lightning.ApolloClient do
   end
 
   defp stream_client do
-    # receive_timeout bounds time-to-headers and each gap between SSE
-    # chunks, not total stream duration — the MessageProcessor job timeout
-    # bounds that.
-    timeout = Lightning.Config.apollo(:timeout)
-
     client_params = [
       {Tesla.Middleware.BaseUrl, Lightning.Config.apollo(:endpoint)},
       Tesla.Middleware.SSE,
@@ -196,7 +191,17 @@ defmodule Lightning.ApolloClient do
     if match?({Tesla.Adapter.Finch, _}, Application.get_env(:tesla, :adapter)) do
       Tesla.client(
         client_params,
-        {Tesla.Adapter.Finch, name: Lightning.Finch, receive_timeout: timeout}
+        # Our copy of Tesla's adapter, which keeps the reason a stream stopped
+        # instead of discarding it. See Lightning.Tesla.Adapter.Finch.
+        {
+          Lightning.Tesla.Adapter.Finch,
+          # The gap between chunks, not the length of the whole answer. A reply
+          # that keeps arriving never trips this - MessageProcessor's job
+          # timeout is what bounds total duration.
+          name: Lightning.Finch,
+          receive_timeout: Lightning.Config.apollo(:idle_timeout),
+          request_timeout: Lightning.Config.apollo(:request_timeout)
+        }
       )
     else
       Tesla.client(client_params)

--- a/lib/lightning/apollo_client.ex
+++ b/lib/lightning/apollo_client.ex
@@ -195,9 +195,9 @@ defmodule Lightning.ApolloClient do
         # instead of discarding it. See Lightning.Tesla.Adapter.Finch.
         {
           Lightning.Tesla.Adapter.Finch,
-          # The gap between chunks, not the length of the whole answer. A reply
-          # that keeps arriving never trips this - MessageProcessor's job
-          # timeout is what bounds total duration.
+          # Both the wait for the first byte and each gap after it, not the
+          # length of the whole answer. A reply that keeps arriving never
+          # trips this - MessageProcessor's job timeout bounds total duration.
           name: Lightning.Finch,
           receive_timeout: Lightning.Config.apollo(:idle_timeout),
           request_timeout: Lightning.Config.apollo(:request_timeout)

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -152,7 +152,7 @@ defmodule Lightning.Application do
         LightningWeb.Telemetry,
         # Start the PubSub system
         {Phoenix.PubSub, name: Lightning.PubSub},
-        {Finch, name: Lightning.Finch},
+        {Finch, name: Lightning.Finch, pools: apollo_pools()},
         auth_providers_cache_childspec,
         auth_provider_jwks_cache_childspec,
         {Lightning.Collaboration.Supervisor, []},
@@ -180,6 +180,51 @@ defmodule Lightning.Application do
     Supervisor.start_link(children, opts)
   end
 
+  # Finch already keys pools by {scheme, host, port}, so Apollo has its own
+  # either way. The only setting here that changes behaviour is the connect
+  # timeout; size and count restate Finch's defaults rather than shrink them,
+  # since an AI stream holds its connection for as long as the answer takes.
+  #
+  # http1 is Finch's default too, and is written out because this pool depends
+  # on it: :request_timeout is HTTP/1-only, and on http2 receive_timeout
+  # becomes a deadline for the whole request rather than the gap between
+  # chunks, which would silently cap the length of an answer. Pinned so a
+  # change to that default cannot quietly take both settings with it.
+  defp apollo_pools do
+    base = %{default: [size: 50, count: 1]}
+
+    endpoint = Lightning.Config.apollo(:endpoint)
+
+    if poolable_url?(endpoint) do
+      Map.put(base, endpoint,
+        protocols: [:http1],
+        size: 50,
+        count: 1,
+        conn_opts: [
+          transport_opts: [timeout: Lightning.Config.apollo(:connect_timeout)]
+        ]
+      )
+    else
+      base
+    end
+  end
+
+  # Finch raises on a key it cannot parse, which would take the node down at
+  # boot over a misconfigured endpoint. Everywhere else treats one of those as
+  # the assistant simply being switched off, so match that.
+  defp poolable_url?(endpoint) when is_binary(endpoint) do
+    case URI.parse(endpoint) do
+      %URI{scheme: scheme, host: host}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp poolable_url?(_endpoint), do: false
+
   # Oban stops its producer once the grace period expires and only then kills
   # whatever is still running, so a job that outlives the window is killed with
   # nothing left to report it. Its AI message would stay :processing until the
@@ -193,7 +238,7 @@ defmodule Lightning.Application do
       [AI Assistant] An AI job may run for #{ceiling}ms but Oban stops draining \
       after #{grace}ms. A deploy landing on a running job will kill it without \
       emitting telemetry, leaving its message :processing until the reaper runs.
-      Lower APOLLO_TIMEOUT or raise Oban's shutdown_grace_period.
+      Lower APOLLO_REQUEST_TIMEOUT_MS or raise Oban's shutdown_grace_period.
       """)
     end
   end

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -172,6 +172,7 @@ defmodule Lightning.Application do
       ]
       |> Enum.reject(&is_nil/1)
 
+    warn_if_apollo_timeout_still_set()
     warn_if_ai_jobs_outlive_the_drain_window()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -181,9 +182,11 @@ defmodule Lightning.Application do
   end
 
   # Finch already keys pools by {scheme, host, port}, so Apollo has its own
-  # either way. The only setting here that changes behaviour is the connect
-  # timeout; size and count restate Finch's defaults rather than shrink them,
-  # since an AI stream holds its connection for as long as the answer takes.
+  # either way, and size and count restate Finch's own defaults. Under the
+  # shipped configuration this changes nothing; it exists so that setting
+  # APOLLO_CONNECT_TIMEOUT_MS has somewhere to take effect, and so a change to
+  # Finch's defaults cannot quietly shrink a pool whose streams hold their
+  # connection for as long as an answer takes.
   #
   # http1 is Finch's default too, and is written out because this pool depends
   # on it: :request_timeout is HTTP/1-only, and on http2 receive_timeout
@@ -229,6 +232,17 @@ defmodule Lightning.Application do
   # whatever is still running, so a job that outlives the window is killed with
   # nothing left to report it. Its AI message would stay :processing until the
   # reaper picks it up, and no telemetry would fire.
+  # Left unread it would silently lift a ceiling an operator lowered on purpose.
+  defp warn_if_apollo_timeout_still_set do
+    if System.get_env("APOLLO_TIMEOUT") do
+      Logger.warning("""
+      [AI Assistant] APOLLO_TIMEOUT is no longer read and the value you set is \
+      being ignored. It is replaced by APOLLO_CONNECT_TIMEOUT_MS, \
+      APOLLO_IDLE_TIMEOUT_MS and APOLLO_REQUEST_TIMEOUT_MS.
+      """)
+    end
+  end
+
   defp warn_if_ai_jobs_outlive_the_drain_window do
     grace = Application.get_env(:lightning, Oban)[:shutdown_grace_period]
     ceiling = Lightning.AiAssistant.MessageProcessor.job_timeout()
@@ -238,7 +252,8 @@ defmodule Lightning.Application do
       [AI Assistant] An AI job may run for #{ceiling}ms but Oban stops draining \
       after #{grace}ms. A deploy landing on a running job will kill it without \
       emitting telemetry, leaving its message :processing until the reaper runs.
-      Lower APOLLO_REQUEST_TIMEOUT_MS or raise Oban's shutdown_grace_period.
+      Lower APOLLO_REQUEST_TIMEOUT_MS or APOLLO_IDLE_TIMEOUT_MS, or raise \
+      Oban's shutdown_grace_period.
       """)
     end
   end

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -193,7 +193,8 @@ defmodule Lightning.Application do
   # becomes a deadline for the whole request rather than the gap between
   # chunks, which would silently cap the length of an answer. Pinned so a
   # change to that default cannot quietly take both settings with it.
-  defp apollo_pools do
+  @doc false
+  def apollo_pools do
     base = %{default: [size: 50, count: 1]}
 
     endpoint = Lightning.Config.apollo(:endpoint)
@@ -228,13 +229,10 @@ defmodule Lightning.Application do
 
   defp poolable_url?(_endpoint), do: false
 
-  # Oban stops its producer once the grace period expires and only then kills
-  # whatever is still running, so a job that outlives the window is killed with
-  # nothing left to report it. Its AI message would stay :processing until the
-  # reaper picks it up, and no telemetry would fire.
   # Left unread it would silently lift a ceiling an operator lowered on purpose.
-  defp warn_if_apollo_timeout_still_set do
-    if System.get_env("APOLLO_TIMEOUT") do
+  @doc false
+  def warn_if_apollo_timeout_still_set do
+    if Application.get_env(:lightning, :apollo_timeout_env_still_set) do
       Logger.warning("""
       [AI Assistant] APOLLO_TIMEOUT is no longer read and the value you set is \
       being ignored. It is replaced by APOLLO_CONNECT_TIMEOUT_MS, \
@@ -243,7 +241,12 @@ defmodule Lightning.Application do
     end
   end
 
-  defp warn_if_ai_jobs_outlive_the_drain_window do
+  # Oban stops its producer once the grace period expires and only then kills
+  # whatever is still running, so a job that outlives the window is killed with
+  # nothing left to report it. Its AI message would stay :processing until the
+  # reaper picks it up, and no telemetry would fire.
+  @doc false
+  def warn_if_ai_jobs_outlive_the_drain_window do
     grace = Application.get_env(:lightning, Oban)[:shutdown_grace_period]
     ceiling = Lightning.AiAssistant.MessageProcessor.job_timeout()
 
@@ -252,8 +255,8 @@ defmodule Lightning.Application do
       [AI Assistant] An AI job may run for #{ceiling}ms but Oban stops draining \
       after #{grace}ms. A deploy landing on a running job will kill it without \
       emitting telemetry, leaving its message :processing until the reaper runs.
-      Lower APOLLO_REQUEST_TIMEOUT_MS or APOLLO_IDLE_TIMEOUT_MS, or raise \
-      Oban's shutdown_grace_period.
+      Lower APOLLO_CONNECT_TIMEOUT_MS, APOLLO_IDLE_TIMEOUT_MS or \
+      APOLLO_REQUEST_TIMEOUT_MS, or raise Oban's shutdown_grace_period.
       """)
     end
   end

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -173,6 +173,7 @@ defmodule Lightning.Application do
       |> Enum.reject(&is_nil/1)
 
     warn_if_apollo_timeout_still_set()
+    warn_if_connect_timeout_is_unreachable()
     warn_if_ai_jobs_outlive_the_drain_window()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -228,6 +229,26 @@ defmodule Lightning.Application do
   end
 
   defp poolable_url?(_endpoint), do: false
+
+  # Reaching Apollo happens inside the adapter's wait for the first byte, which
+  # the idle timeout bounds, so a connect timeout above it can never expire.
+  # Silently, and on the setting an operator most expects to control a slow or
+  # unreachable host.
+  @doc false
+  def warn_if_connect_timeout_is_unreachable do
+    connect = Lightning.Config.apollo(:connect_timeout)
+    idle = Lightning.Config.apollo(:idle_timeout)
+
+    if is_integer(connect) and is_integer(idle) and connect > idle do
+      Logger.warning("""
+      [AI Assistant] APOLLO_CONNECT_TIMEOUT_MS is #{connect}ms but \
+      APOLLO_IDLE_TIMEOUT_MS is #{idle}ms, and the wait to reach Apollo sits \
+      inside the idle budget. Connecting will give up after #{idle}ms whatever \
+      the connect setting says. Raise APOLLO_IDLE_TIMEOUT_MS to at least \
+      #{connect}ms, or lower APOLLO_CONNECT_TIMEOUT_MS.
+      """)
+    end
+  end
 
   # Left unread it would silently lift a ceiling an operator lowered on purpose.
   @doc false

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -131,6 +131,33 @@ defmodule Lightning.Config.Bootstrap do
           end
         end)
 
+    # How long to wait to reach Apollo at all.
+    apollo_connect_timeout =
+      env!(
+        "APOLLO_CONNECT_TIMEOUT_MS",
+        :integer,
+        Utils.get_env([:lightning, :apollo, :connect_timeout])
+      )
+
+    # Longest acceptable silence part-way through an answer. Apollo sends a
+    # keepalive every 15s from v3.1.1, so half a minute of nothing means the
+    # path is broken rather than that a model is thinking. Raise it if you run
+    # an older Apollo that has no keepalive.
+    apollo_idle_timeout =
+      env!(
+        "APOLLO_IDLE_TIMEOUT_MS",
+        :integer,
+        Utils.get_env([:lightning, :apollo, :idle_timeout])
+      )
+
+    # Longest one whole request may take, however steadily it is streaming.
+    apollo_request_timeout =
+      env!(
+        "APOLLO_REQUEST_TIMEOUT_MS",
+        :integer,
+        Utils.get_env([:lightning, :apollo, :request_timeout])
+      )
+
     config :lightning, :apollo,
       endpoint:
         env!(
@@ -138,18 +165,9 @@ defmodule Lightning.Config.Bootstrap do
           :string,
           Utils.get_env([:lightning, :apollo, :endpoint])
         ),
-      # APOLLO_TIMEOUT (ms) bounds every request to Apollo. For streaming
-      # (all AI chat) it is the time-to-headers and the max gap between SSE
-      # chunks — and because the AI job's total-runtime ceiling is derived
-      # from the same value, it effectively bounds the whole run too, so
-      # size it above the longest expected AI run. Unset, it falls back to
-      # the per-env compiled config.
-      timeout:
-        env!(
-          "APOLLO_TIMEOUT",
-          :integer,
-          Utils.get_env([:lightning, :apollo, :timeout])
-        ),
+      connect_timeout: apollo_connect_timeout,
+      idle_timeout: apollo_idle_timeout,
+      request_timeout: apollo_request_timeout,
       ai_assistant_api_key: env!("AI_ASSISTANT_API_KEY", :string, nil)
 
     config :lightning, Lightning.Runtime.RuntimeManager,

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -146,10 +146,11 @@ defmodule Lightning.Config.Bootstrap do
         Utils.get_env([:lightning, :apollo, :connect_timeout])
       )
 
-    # Longest acceptable silence part-way through an answer. Apollo sends a
-    # keepalive every 15s from v3.1.1, so half a minute of nothing means the
-    # path is broken rather than that a model is thinking. Raise it if you run
-    # an older Apollo that has no keepalive.
+    # Longest acceptable silence, both before the first byte of an answer and
+    # between the chunks after it. Apollo sends a keepalive every 15s from
+    # v3.1.1, so half a minute of nothing means the path is broken rather than
+    # that a model is thinking. Raise it if you run an older Apollo that has no
+    # keepalive.
     apollo_idle_timeout =
       env!(
         "APOLLO_IDLE_TIMEOUT_MS",

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -131,6 +131,13 @@ defmodule Lightning.Config.Bootstrap do
           end
         end)
 
+    # Read here rather than from System.get_env: envs come through Dotenvy, so
+    # a value set in a .env file never reaches the system environment. Recorded
+    # for the boot warning in Lightning.Application, where Logger is up.
+    config :lightning,
+           :apollo_timeout_env_still_set,
+           env!("APOLLO_TIMEOUT", :string, nil) != nil
+
     # How long to wait to reach Apollo at all.
     apollo_connect_timeout =
       env!(

--- a/lib/lightning/tesla/adapter/finch.ex
+++ b/lib/lightning/tesla/adapter/finch.ex
@@ -1,0 +1,164 @@
+defmodule Lightning.Tesla.Adapter.Finch do
+  @moduledoc """
+  Tesla's Finch adapter, with the failure reason preserved on a streamed
+  response.
+
+  Upstream's streaming path returns `nil` from its `Stream.unfold` for a
+  mid-stream error, a mid-stream timeout, and a clean end alike, discarding the
+  reason. Every AI chat therefore ended up reporting "Stream ended without
+  complete response" whatever had actually happened - a hung Apollo, a severed
+  connection, and a genuinely short answer were indistinguishable.
+
+  A sentinel inside the stream is not an option: `Tesla.Middleware.SSE`
+  concatenates elements as binaries and would fail on anything else. But the
+  `Stream.unfold` body runs in the calling process, so the reason is left in
+  that process's dictionary and read back with `take_stream_error/0` once the
+  stream has been consumed.
+
+  Also passes `:request_timeout` through to Finch, which the 1.18.3 we are
+  pinned to drops. That one is already fixed upstream, in 1.19.0 and later, so
+  a Tesla upgrade would cover it without this module.
+
+  Reported upstream as
+  [tesla#912](https://github.com/elixir-tesla/tesla/issues/912). Delete this
+  module once a release carries the fix; the reason will arrive as a raised
+  `Tesla.Error` rather than through `take_stream_error/0`, so the callers in
+  `Lightning.AiAssistant` change with it.
+  """
+
+  @behaviour Tesla.Adapter
+
+  @defaults [receive_timeout: 15_000]
+  @stream_error_key {__MODULE__, :stream_error}
+
+  @doc """
+  Why the last streamed response stopped, if it stopped badly.
+
+  Returns `nil` when the stream ended cleanly. Reading clears it, so a later
+  request cannot pick up an earlier one's failure.
+  """
+  @spec take_stream_error() :: term() | nil
+  def take_stream_error, do: Process.delete(@stream_error_key)
+
+  @impl Tesla.Adapter
+  def call(%Tesla.Env{} = env, opts) do
+    Process.delete(@stream_error_key)
+
+    opts = Tesla.Adapter.opts(@defaults, env, opts)
+
+    name = Keyword.fetch!(opts, :name)
+    url = Tesla.build_url(env)
+
+    req_opts =
+      Keyword.take(opts, [:pool_timeout, :receive_timeout, :request_timeout])
+
+    req = Finch.build(env.method, url, env.headers, env.body)
+
+    case request(req, name, req_opts, opts) do
+      {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
+        {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
+
+      {:error, %Mint.TransportError{reason: reason}} ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp request(req, name, req_opts, opts) do
+    case opts[:response] do
+      :stream -> stream(req, name, req_opts)
+      nil -> Finch.request(req, name, req_opts)
+      other -> raise "Unknown response option: #{inspect(other)}"
+    end
+  end
+
+  defp stream(req, name, opts) do
+    owner = self()
+    ref = make_ref()
+
+    fun = fn
+      {:status, status}, _acc ->
+        status
+
+      {:headers, headers}, status ->
+        send(owner, {ref, {:status, status, headers}})
+
+      {:data, data}, _acc ->
+        send(owner, {ref, {:data, data}})
+
+      {:trailers, trailers}, _acc ->
+        trailers
+
+      {:error, error}, _acc ->
+        send(owner, {ref, {:error, error}})
+
+      {:error, error, _}, _acc ->
+        send(owner, {ref, {:error, error}})
+    end
+
+    task =
+      Task.async(fn ->
+        req
+        |> Finch.stream(name, nil, fun, opts)
+        |> handle_stream_response(ref, owner)
+      end)
+
+    receive do
+      {^ref, {:status, status, headers}} ->
+        {:ok,
+         %Finch.Response{
+           status: status,
+           headers: headers,
+           body: body_stream(ref, task, opts)
+         }}
+
+      {^ref, {:error, error}} ->
+        Task.shutdown(task, :brutal_kill)
+        {:error, error}
+    after
+      opts[:receive_timeout] ->
+        Task.shutdown(task, :brutal_kill)
+        {:error, :timeout}
+    end
+  end
+
+  defp body_stream(ref, task, opts) do
+    Stream.unfold(nil, fn _ ->
+      receive do
+        {^ref, {:data, data}} ->
+          {data, nil}
+
+        {^ref, :eof} ->
+          Task.await(task)
+          nil
+
+        # The two clauses upstream discards. Both still halt the stream, so a
+        # consumer sees what it would on upstream; the difference is that the
+        # reason survives.
+        {^ref, {:error, error}} ->
+          Process.put(@stream_error_key, error)
+          Task.shutdown(task, :brutal_kill)
+          nil
+      after
+        opts[:receive_timeout] ->
+          Process.put(@stream_error_key, :timeout)
+          Task.shutdown(task, :brutal_kill)
+          nil
+      end
+    end)
+  end
+
+  # Upstream carries a third clause for a bare `{:error, reason}`. Finch.stream/5
+  # returns only `{:ok, acc}` or `{:error, exception, acc}`, so dialyzer proves
+  # that clause unreachable; it is left out rather than ignored. Restore it if a
+  # Finch upgrade widens the return.
+  defp handle_stream_response({:ok, _acc}, ref, owner) do
+    send(owner, {ref, :eof})
+  end
+
+  defp handle_stream_response({:error, error, _acc}, ref, owner) do
+    send(owner, {ref, {:error, error}})
+  end
+end

--- a/lib/lightning/tesla/adapter/finch.ex
+++ b/lib/lightning/tesla/adapter/finch.ex
@@ -1,7 +1,11 @@
 defmodule Lightning.Tesla.Adapter.Finch do
   @moduledoc """
-  Tesla's Finch adapter, with the failure reason preserved on a streamed
-  response.
+  Enough of Tesla's Finch adapter for the Apollo client, with the failure reason
+  preserved on a streamed response.
+
+  Not a faithful copy: it drops upstream's `build/4` clauses for multipart,
+  stream and function request bodies, so anything but a plain body raises here.
+  Apollo sends JSON.
 
   Upstream's streaming path returns `nil` from its `Stream.unfold` for a
   mid-stream error, a mid-stream timeout, and a clean end alike, discarding the
@@ -58,9 +62,9 @@ defmodule Lightning.Tesla.Adapter.Finch do
       {:ok, %Finch.Response{status: status, headers: headers, body: body}} ->
         {:ok, %Tesla.Env{env | status: status, headers: headers, body: body}}
 
-      {:error, %Mint.TransportError{reason: reason}} ->
-        {:error, reason}
-
+      # Upstream unwraps %Mint.TransportError{} here. Finch wraps every Mint
+      # transport error in one of its own before returning, so that clause
+      # cannot fire and is left out for the same reason as the one below.
       {:error, reason} ->
         {:error, reason}
     end

--- a/lib/lightning/tesla/adapter/finch.ex
+++ b/lib/lightning/tesla/adapter/finch.ex
@@ -4,8 +4,9 @@ defmodule Lightning.Tesla.Adapter.Finch do
   preserved on a streamed response.
 
   Not a faithful copy: it drops upstream's `build/4` clauses for multipart,
-  stream and function request bodies, so anything but a plain body raises here.
-  Apollo sends JSON.
+  stream and function request bodies, and hands the body to `Finch.build/4` as
+  it stands. Anything but a plain body therefore fails further down, in Mint,
+  rather than here. Apollo sends JSON.
 
   Upstream's streaming path returns `nil` from its `Stream.unfold` for a
   mid-stream error, a mid-stream timeout, and a clean end alike, discarding the
@@ -32,6 +33,9 @@ defmodule Lightning.Tesla.Adapter.Finch do
 
   @behaviour Tesla.Adapter
 
+  # receive_timeout covers two waits, not one: the wait for status and headers
+  # in stream/3, and each gap between chunks in body_stream/3. Whichever
+  # elapses first ends the request.
   @defaults [receive_timeout: 15_000]
   @stream_error_key {__MODULE__, :stream_error}
 
@@ -82,6 +86,10 @@ defmodule Lightning.Tesla.Adapter.Finch do
     owner = self()
     ref = make_ref()
 
+    # Upstream's callback carries two `{:error, _}` clauses. `Finch.stream/5`
+    # only ever passes `:status`, `:headers`, `:data` and `:trailers` to it and
+    # reports a failure through its return value, which handle_stream_response/3
+    # below reads. Those clauses cannot fire, so they are left out.
     fun = fn
       {:status, status}, _acc ->
         status
@@ -94,12 +102,6 @@ defmodule Lightning.Tesla.Adapter.Finch do
 
       {:trailers, trailers}, _acc ->
         trailers
-
-      {:error, error}, _acc ->
-        send(owner, {ref, {:error, error}})
-
-      {:error, error, _}, _acc ->
-        send(owner, {ref, {:error, error}})
     end
 
     task =

--- a/lib/lightning/tesla/adapter/finch.ex
+++ b/lib/lightning/tesla/adapter/finch.ex
@@ -68,7 +68,7 @@ defmodule Lightning.Tesla.Adapter.Finch do
 
       # Upstream unwraps %Mint.TransportError{} here. Finch wraps every Mint
       # transport error in one of its own before returning, so that clause
-      # cannot fire and is left out for the same reason as the one below.
+      # cannot fire and is left out.
       {:error, reason} ->
         {:error, reason}
     end

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -26,7 +26,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -98,7 +100,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -282,7 +286,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -362,7 +368,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -1367,7 +1375,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -1379,7 +1389,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> nil
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -1391,7 +1403,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> nil
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -1403,7 +1417,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> nil
           :ai_assistant_api_key -> nil
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -1415,7 +1431,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> 123
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -1427,7 +1445,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> 123
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -2070,7 +2090,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -2495,7 +2517,7 @@ defmodule Lightning.AiAssistantTest do
         {:ok, %Tesla.Env{status: 200, body: sse_stream}}
       end)
 
-      assert {:error, "Stream ended without complete response"} =
+      assert {:error, "The assistant stopped before it finished." <> _} =
                AiAssistant.query_stream(session, "test")
     end
 
@@ -2526,8 +2548,91 @@ defmodule Lightning.AiAssistantTest do
         {:ok, %Tesla.Env{status: 200, body: sse_stream}}
       end)
 
-      assert {:error, "Stream ended without complete response"} =
+      assert {:error, "The assistant stopped before it finished." <> _} =
                AiAssistant.query_stream(session, "test")
+    end
+
+    # The other end of keeping a partial: there has to be something worth
+    # keeping. A reply that produced nothing leaves no message behind, or the
+    # panel shows an empty one where the answer should be.
+    test "saves nothing when the stream dies before producing anything", %{
+      user: user,
+      workflow: %{jobs: [job_1 | _]}
+    } do
+      session =
+        insert(:chat_session,
+          user: user,
+          job: job_1,
+          messages: [
+            %{
+              role: :user,
+              content: "test",
+              user: user,
+              status: :pending,
+              inserted_at: DateTime.utc_now() |> DateTime.add(-1)
+            }
+          ]
+        )
+
+      expect(Lightning.Tesla.Mock, :call, fn _env, _opts ->
+        {:ok, %Tesla.Env{status: 200, body: []}}
+      end)
+
+      assert {:error, message} = AiAssistant.query_stream(session, "test")
+      assert message =~ "stopped before it finished"
+
+      refute Lightning.Repo.all(Lightning.AiAssistant.ChatMessage)
+             |> Enum.any?(&(&1.role == :assistant))
+    end
+
+    # The point of keeping the reason at all: a hung Apollo and a severed
+    # connection have to read differently, or there is nothing to act on.
+    #
+    # The reason is seeded straight into the process dictionary because that is
+    # where the adapter leaves it and where stream_failure_message/0 reads it.
+    # The adapter's own tests cover putting it there over a real socket; these
+    # cover what each value turns into for the person reading the panel.
+    for {name, reason, expected} <- [
+          {"our own receive_timeout", :timeout,
+           "stopped responding partway through"},
+          {"a timeout raised by Finch", %Finch.TransportError{reason: :timeout},
+           "stopped responding partway through"},
+          {"a dropped connection", %Finch.TransportError{reason: :closed},
+           "connection to the assistant was lost"},
+          {"a reason we do not recognise", {:something, :unexpected},
+           "stopped before it finished"}
+        ] do
+      test "#{name} is reported as \"#{expected}\"", %{
+        user: user,
+        workflow: %{jobs: [job_1 | _]}
+      } do
+        session =
+          insert(:chat_session,
+            user: user,
+            job: job_1,
+            messages: [
+              %{
+                role: :user,
+                content: "test",
+                user: user,
+                status: :pending,
+                inserted_at: DateTime.utc_now() |> DateTime.add(-1)
+              }
+            ]
+          )
+
+        Process.put(
+          {Lightning.Tesla.Adapter.Finch, :stream_error},
+          unquote(Macro.escape(reason))
+        )
+
+        expect(Lightning.Tesla.Mock, :call, fn _env, _opts ->
+          {:ok, %Tesla.Env{status: 200, body: []}}
+        end)
+
+        assert {:error, message} = AiAssistant.query_stream(session, "test")
+        assert message =~ unquote(expected)
+      end
     end
 
     test "keeps the text that arrived when the stream dies before completing",
@@ -2571,7 +2676,7 @@ defmodule Lightning.AiAssistantTest do
       end)
 
       assert {:error, message} = AiAssistant.query_stream(session, "test")
-      assert message =~ "cut off"
+      assert message =~ "stopped before it finished"
 
       saved =
         Lightning.Repo.all(Lightning.AiAssistant.ChatMessage)
@@ -2793,7 +2898,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 
@@ -2961,7 +3068,9 @@ defmodule Lightning.AiAssistantTest do
         case key do
           :endpoint -> "http://localhost:3000"
           :ai_assistant_api_key -> "api_key"
-          :timeout -> 5_000
+          :connect_timeout -> 1_000
+          :idle_timeout -> 5_000
+          :request_timeout -> 5_000
         end
       end)
 

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -2598,9 +2598,7 @@ defmodule Lightning.AiAssistantTest do
           {"a timeout raised by Finch", %Finch.TransportError{reason: :timeout},
            "stopped responding partway through"},
           {"a dropped connection", %Finch.TransportError{reason: :closed},
-           "connection to the assistant was lost"},
-          {"a reason we do not recognise", {:something, :unexpected},
-           "stopped before it finished"}
+           "connection to the assistant was lost"}
         ] do
       test "#{name} is reported as \"#{expected}\"", %{
         user: user,
@@ -2633,6 +2631,46 @@ defmodule Lightning.AiAssistantTest do
         assert {:error, message} = AiAssistant.query_stream(session, "test")
         assert message =~ unquote(expected)
       end
+    end
+
+    # Says the same thing to the user as a stream that simply stopped, so what
+    # separates them is the log: this one has a reason worth reading.
+    test "a reason we do not recognise is logged before it is generalised", %{
+      user: user,
+      workflow: %{jobs: [job_1 | _]}
+    } do
+      session =
+        insert(:chat_session,
+          user: user,
+          job: job_1,
+          messages: [
+            %{
+              role: :user,
+              content: "test",
+              user: user,
+              status: :pending,
+              inserted_at: DateTime.utc_now() |> DateTime.add(-1)
+            }
+          ]
+        )
+
+      Process.put(
+        {Lightning.Tesla.Adapter.Finch, :stream_error},
+        {:something, :unexpected}
+      )
+
+      expect(Lightning.Tesla.Mock, :call, fn _env, _opts ->
+        {:ok, %Tesla.Env{status: 200, body: []}}
+      end)
+
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:error, message} = AiAssistant.query_stream(session, "test")
+          assert message =~ "stopped before it finished"
+        end)
+
+      assert logs =~ "Stream failed"
+      assert logs =~ "something"
     end
 
     test "keeps the text that arrived when the stream dies before completing",

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -30,7 +30,9 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       case key do
         :endpoint -> "http://localhost:3000"
         :ai_assistant_api_key -> "test_api_key"
-        :timeout -> 5_000
+        :connect_timeout -> 1_000
+        :idle_timeout -> 5_000
+        :request_timeout -> 5_000
       end
     end)
 

--- a/test/lightning/apollo_client_test.exs
+++ b/test/lightning/apollo_client_test.exs
@@ -316,7 +316,9 @@ defmodule Lightning.ApolloClientTest do
       case key do
         :endpoint -> endpoint
         :ai_assistant_api_key -> api_key
-        :timeout -> 5_000
+        :connect_timeout -> 1_000
+        :idle_timeout -> 5_000
+        :request_timeout -> 5_000
       end
     end)
   end

--- a/test/lightning/application_test.exs
+++ b/test/lightning/application_test.exs
@@ -1,5 +1,8 @@
 defmodule Lightning.ApplicationTest do
-  use Lightning.DataCase, async: true
+  # Not async: these tests swap :lightning, :apollo and Oban's config, which
+  # every other test reads, and capture_log takes the whole Logger rather than
+  # just what this process emits.
+  use Lightning.DataCase, async: false
 
   alias Lightning.Config
 
@@ -151,7 +154,8 @@ defmodule Lightning.ApplicationTest do
           Lightning.Application.warn_if_apollo_timeout_still_set()
         end)
 
-      assert logs =~ "APOLLO_TIMEOUT is no longer read"
+      assert logs =~
+               "[AI Assistant] APOLLO_TIMEOUT is no longer read and the value you set is being ignored."
     end
 
     test "stays quiet when it is not" do
@@ -162,7 +166,7 @@ defmodule Lightning.ApplicationTest do
           Lightning.Application.warn_if_apollo_timeout_still_set()
         end)
 
-      refute logs =~ "APOLLO_TIMEOUT"
+      refute logs =~ "[AI Assistant] APOLLO_TIMEOUT is no longer read"
     end
 
     test "says so when an AI job can outlive Oban's drain window" do
@@ -178,7 +182,8 @@ defmodule Lightning.ApplicationTest do
           Lightning.Application.warn_if_ai_jobs_outlive_the_drain_window()
         end)
 
-      assert logs =~ "Oban stops draining"
+      assert logs =~
+               "[AI Assistant] An AI job may run for 645000ms but Oban stops draining"
     end
   end
 end

--- a/test/lightning/application_test.exs
+++ b/test/lightning/application_test.exs
@@ -169,6 +169,52 @@ defmodule Lightning.ApplicationTest do
       refute logs =~ "[AI Assistant] APOLLO_TIMEOUT is no longer read"
     end
 
+    test "says so when the connect timeout is above the idle timeout" do
+      put_temporary_env(:lightning, :apollo,
+        endpoint: "http://apollo.test:3000",
+        connect_timeout: 60_000,
+        idle_timeout: 30_000,
+        request_timeout: 300_000
+      )
+
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Lightning.Application.warn_if_connect_timeout_is_unreachable()
+        end)
+
+      assert logs =~
+               "[AI Assistant] APOLLO_CONNECT_TIMEOUT_MS is 60000ms but APOLLO_IDLE_TIMEOUT_MS is 30000ms"
+    end
+
+    test "stays quiet when the connect timeout fits inside the idle one" do
+      put_temporary_env(:lightning, :apollo,
+        endpoint: "http://apollo.test:3000",
+        connect_timeout: 5_000,
+        idle_timeout: 30_000,
+        request_timeout: 300_000
+      )
+
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Lightning.Application.warn_if_connect_timeout_is_unreachable()
+        end)
+
+      refute logs =~ "APOLLO_CONNECT_TIMEOUT_MS"
+    end
+
+    # No env fiddling on purpose: this reads the shipped defaults, so raising
+    # one of them past the drain window fails here rather than warning on every
+    # production boot. The margin is 345s against 360s.
+    test "stays quiet on the defaults we ship" do
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Lightning.Application.warn_if_ai_jobs_outlive_the_drain_window()
+          Lightning.Application.warn_if_connect_timeout_is_unreachable()
+        end)
+
+      assert logs == ""
+    end
+
     test "says so when an AI job can outlive Oban's drain window" do
       put_temporary_env(:lightning, :apollo,
         endpoint: "http://apollo.test:3000",

--- a/test/lightning/application_test.exs
+++ b/test/lightning/application_test.exs
@@ -104,4 +104,81 @@ defmodule Lightning.ApplicationTest do
       assert actual_topologies == input_topologies
     end
   end
+
+  describe ".apollo_pools/0" do
+    test "gives Apollo's endpoint a pool carrying the connect timeout" do
+      put_temporary_env(:lightning, :apollo,
+        endpoint: "http://apollo.test:3000",
+        connect_timeout: 1234,
+        idle_timeout: 30_000,
+        request_timeout: 300_000
+      )
+
+      pools = Lightning.Application.apollo_pools()
+
+      assert %{conn_opts: [transport_opts: [timeout: 1234]]} =
+               Map.new(pools["http://apollo.test:3000"])
+    end
+
+    # Finch raises on a key it cannot parse, which would take the node down at
+    # boot over a setting the rest of the app treats as the assistant simply
+    # being off.
+    for {name, endpoint} <- [
+          {"nothing configured", nil},
+          {"not a url at all", "how did this get here"},
+          {"a scheme Finch cannot pool", "ftp://apollo.test"},
+          {"no host", "http://"}
+        ] do
+      test "adds no pool when the endpoint is #{name}" do
+        put_temporary_env(:lightning, :apollo,
+          endpoint: unquote(endpoint),
+          connect_timeout: 5_000,
+          idle_timeout: 30_000,
+          request_timeout: 300_000
+        )
+
+        assert Map.keys(Lightning.Application.apollo_pools()) == [:default]
+      end
+    end
+  end
+
+  describe "boot warnings" do
+    test "says so when APOLLO_TIMEOUT is still set" do
+      put_temporary_env(:lightning, :apollo_timeout_env_still_set, true)
+
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Lightning.Application.warn_if_apollo_timeout_still_set()
+        end)
+
+      assert logs =~ "APOLLO_TIMEOUT is no longer read"
+    end
+
+    test "stays quiet when it is not" do
+      put_temporary_env(:lightning, :apollo_timeout_env_still_set, false)
+
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Lightning.Application.warn_if_apollo_timeout_still_set()
+        end)
+
+      refute logs =~ "APOLLO_TIMEOUT"
+    end
+
+    test "says so when an AI job can outlive Oban's drain window" do
+      put_temporary_env(:lightning, :apollo,
+        endpoint: "http://apollo.test:3000",
+        connect_timeout: 5_000,
+        idle_timeout: 30_000,
+        request_timeout: :timer.minutes(10)
+      )
+
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Lightning.Application.warn_if_ai_jobs_outlive_the_drain_window()
+        end)
+
+      assert logs =~ "Oban stops draining"
+    end
+  end
 end

--- a/test/lightning/config/bootstrap_test.exs
+++ b/test/lightning/config/bootstrap_test.exs
@@ -731,6 +731,49 @@ defmodule Lightning.Config.BootstrapTest do
     end
   end
 
+  describe "apollo timeouts" do
+    test "fall back to the compiled defaults" do
+      Dotenvy.source([%{}])
+      Bootstrap.configure()
+
+      apollo = get_env(:lightning, :apollo)
+
+      assert apollo[:connect_timeout] == 5_000
+      assert apollo[:idle_timeout] == 30_000
+      assert apollo[:request_timeout] == 300_000
+    end
+
+    # The names are the contract DEPLOYMENT.md documents; a typo in one would
+    # fall back to its default and ship without a failure anywhere.
+    test "each one is read from its own variable" do
+      Dotenvy.source([
+        %{
+          "APOLLO_CONNECT_TIMEOUT_MS" => "1000",
+          "APOLLO_IDLE_TIMEOUT_MS" => "2000",
+          "APOLLO_REQUEST_TIMEOUT_MS" => "3000"
+        }
+      ])
+
+      Bootstrap.configure()
+
+      apollo = get_env(:lightning, :apollo)
+
+      assert apollo[:connect_timeout] == 1_000
+      assert apollo[:idle_timeout] == 2_000
+      assert apollo[:request_timeout] == 3_000
+    end
+
+    test "records APOLLO_TIMEOUT only when it is set" do
+      Dotenvy.source([%{}])
+      Bootstrap.configure()
+      refute get_env(:lightning, :apollo_timeout_env_still_set)
+
+      Dotenvy.source([%{"APOLLO_TIMEOUT" => "120000"}])
+      Bootstrap.configure()
+      assert get_env(:lightning, :apollo_timeout_env_still_set)
+    end
+  end
+
   describe "claim_work_mem" do
     test "defaults to nil" do
       Dotenvy.source([%{}])

--- a/test/lightning/tesla/adapter/finch_test.exs
+++ b/test/lightning/tesla/adapter/finch_test.exs
@@ -1,0 +1,131 @@
+defmodule Lightning.Tesla.Adapter.FinchTest do
+  @moduledoc """
+  Exercises the streaming path over a real socket.
+
+  Everything else in the suite runs against `Lightning.Tesla.Mock`, which never
+  drives Tesla's lazy body stream, so none of this is reachable from there. A
+  raw listener is used rather than Bypass because these tests deliberately hang
+  up mid-response: Bypass links its plug to the test process, so a plug dying on
+  the closed socket takes the test with it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Lightning.Tesla.Adapter.Finch, as: Adapter
+
+  # Deliberately not tight. :receive_timeout covers the wait for the response
+  # headers as well as the wait between chunks, so a value chosen to make the
+  # test quick expires on the headers instead when the machine is busy, and
+  # Tesla.get/2 returns {:error, :timeout} before the body stream is reached.
+  # A second is still far below the ten the servers below stay silent for.
+  @quiet_timeout 1_000
+
+  defp listener do
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listen)
+    {listen, port}
+  end
+
+  defp headers do
+    [
+      "HTTP/1.1 200 OK\r\n",
+      "Content-Type: text/event-stream\r\n",
+      "Transfer-Encoding: chunked\r\n\r\n"
+    ]
+  end
+
+  defp encode(chunk) do
+    [Integer.to_string(byte_size(chunk), 16), "\r\n", chunk, "\r\n"]
+  end
+
+  # Sends one chunk then holds the connection open in silence. Unlinked on
+  # purpose - see the moduledoc.
+  defp stalling_server(chunk, hold_ms) do
+    {listen, port} = listener()
+
+    spawn(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen)
+      {:ok, _request} = :gen_tcp.recv(socket, 0)
+      :gen_tcp.send(socket, [headers(), encode(chunk)])
+      Process.sleep(hold_ms)
+      :gen_tcp.close(socket)
+      :gen_tcp.close(listen)
+    end)
+
+    port
+  end
+
+  defp complete_server(chunks) do
+    {listen, port} = listener()
+
+    spawn(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen)
+      {:ok, _request} = :gen_tcp.recv(socket, 0)
+
+      :gen_tcp.send(socket, [headers(), Enum.map(chunks, &encode/1), "0\r\n\r\n"])
+
+      Process.sleep(50)
+      :gen_tcp.close(socket)
+      :gen_tcp.close(listen)
+    end)
+
+    port
+  end
+
+  defp drain(port, opts) do
+    client =
+      Tesla.client(
+        [{Tesla.Middleware.BaseUrl, "http://localhost:#{port}"}],
+        {Adapter,
+         Keyword.merge([name: Lightning.Finch, response: :stream], opts)}
+      )
+
+    {:ok, env} = Tesla.get(client, "/stream")
+    Enum.to_list(env.body)
+  end
+
+  test "a stream that completes leaves no failure behind" do
+    port = complete_server(["one", "two"])
+
+    chunks = drain(port, receive_timeout: 2_000)
+
+    assert Enum.join(chunks) == "onetwo"
+    assert Adapter.take_stream_error() == nil
+  end
+
+  test "a stream that goes quiet is reported as a timeout" do
+    port = stalling_server("partial", 10_000)
+
+    chunks = drain(port, receive_timeout: @quiet_timeout)
+
+    # What already arrived is still delivered: the stream halts, it does not
+    # raise. Upstream behaves the same - the difference is the reason below,
+    # which upstream throws away.
+    assert Enum.join(chunks) == "partial"
+    assert Adapter.take_stream_error() == :timeout
+  end
+
+  # The other way a stream dies, and the one that has to read differently to
+  # the user: the socket is gone rather than merely quiet.
+  test "a dropped connection is reported with its transport reason" do
+    port = stalling_server("partial", 200)
+
+    chunks = drain(port, receive_timeout: 10_000)
+
+    assert Enum.join(chunks) == "partial"
+
+    # Finch's own struct, wrapping Mint's. Not a %Mint.TransportError{}, which
+    # is why matching only on that one missed this entirely.
+    assert %Finch.TransportError{reason: :closed} = Adapter.take_stream_error()
+  end
+
+  test "reading the reason clears it, so the next request starts clean" do
+    port = stalling_server("partial", 10_000)
+
+    drain(port, receive_timeout: @quiet_timeout)
+
+    assert Adapter.take_stream_error() == :timeout
+    assert Adapter.take_stream_error() == nil
+  end
+end

--- a/test/lightning/tesla/adapter/finch_test.exs
+++ b/test/lightning/tesla/adapter/finch_test.exs
@@ -145,12 +145,24 @@ defmodule Lightning.Tesla.Adapter.FinchTest do
     assert %Finch.TransportError{reason: :closed} = Adapter.take_stream_error()
   end
 
-  test "reading the reason clears it, so the next request starts clean" do
+  test "reading the reason clears it" do
     port = stalling_server("partial", 10_000)
 
     drain(port, receive_timeout: @quiet_timeout)
 
     assert_went_quiet(Adapter.take_stream_error())
+    assert Adapter.take_stream_error() == nil
+  end
+
+  # Reading cannot be what guarantees this on its own: a stream that ends
+  # cleanly never reads, so only the delete on the way into call/2 stops the
+  # next request inheriting the last one's reason.
+  test "a failed reason nobody read does not reach the next request" do
+    drain(stalling_server("partial", 10_000), receive_timeout: @quiet_timeout)
+
+    chunks = drain(complete_server(["one", "two"]), receive_timeout: 2_000)
+
+    assert Enum.join(chunks) == "onetwo"
     assert Adapter.take_stream_error() == nil
   end
 

--- a/test/lightning/tesla/adapter/finch_test.exs
+++ b/test/lightning/tesla/adapter/finch_test.exs
@@ -19,12 +19,30 @@ defmodule Lightning.Tesla.Adapter.FinchTest do
   # A second is still far below the ten the servers below stay silent for.
   @quiet_timeout 1_000
 
-  defp listener do
+  # Accepts one connection, hands the socket to `fun`, then closes. The server
+  # is unlinked on purpose - see the moduledoc - so the test has to take it
+  # down itself: without on_exit, a server still sleeping out its hold time
+  # keeps an accepted socket open long after the test that started it passed.
+  defp serve(fun) do
     {:ok, listen} =
       :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
 
     {:ok, port} = :inet.port(listen)
-    {listen, port}
+
+    server =
+      spawn(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen)
+        {:ok, _request} = :gen_tcp.recv(socket, 0)
+        fun.(socket)
+        :gen_tcp.close(socket)
+      end)
+
+    on_exit(fn ->
+      Process.exit(server, :kill)
+      :gen_tcp.close(listen)
+    end)
+
+    port
   end
 
   defp headers do
@@ -39,60 +57,33 @@ defmodule Lightning.Tesla.Adapter.FinchTest do
     [Integer.to_string(byte_size(chunk), 16), "\r\n", chunk, "\r\n"]
   end
 
-  # Sends one chunk then holds the connection open in silence. Unlinked on
-  # purpose - see the moduledoc.
+  # Sends one chunk then holds the connection open in silence.
   defp stalling_server(chunk, hold_ms) do
-    {listen, port} = listener()
-
-    spawn(fn ->
-      {:ok, socket} = :gen_tcp.accept(listen)
-      {:ok, _request} = :gen_tcp.recv(socket, 0)
+    serve(fn socket ->
       :gen_tcp.send(socket, [headers(), encode(chunk)])
       Process.sleep(hold_ms)
-      :gen_tcp.close(socket)
-      :gen_tcp.close(listen)
     end)
-
-    port
   end
 
   # Never goes quiet for long, so only a deadline on the whole request can stop
-  # it. Unlinked on purpose - see the moduledoc.
+  # it.
   defp dripping_server(chunk, every_ms) do
-    {listen, port} = listener()
-
-    spawn(fn ->
-      {:ok, socket} = :gen_tcp.accept(listen)
-      {:ok, _request} = :gen_tcp.recv(socket, 0)
+    serve(fn socket ->
       :gen_tcp.send(socket, headers())
 
       Enum.each(1..40, fn _ ->
         :gen_tcp.send(socket, encode(chunk))
         Process.sleep(every_ms)
       end)
-
-      :gen_tcp.close(socket)
-      :gen_tcp.close(listen)
     end)
-
-    port
   end
 
   defp complete_server(chunks) do
-    {listen, port} = listener()
-
-    spawn(fn ->
-      {:ok, socket} = :gen_tcp.accept(listen)
-      {:ok, _request} = :gen_tcp.recv(socket, 0)
-
+    serve(fn socket ->
       :gen_tcp.send(socket, [headers(), Enum.map(chunks, &encode/1), "0\r\n\r\n"])
 
       Process.sleep(50)
-      :gen_tcp.close(socket)
-      :gen_tcp.close(listen)
     end)
-
-    port
   end
 
   defp drain(port, opts) do

--- a/test/lightning/tesla/adapter/finch_test.exs
+++ b/test/lightning/tesla/adapter/finch_test.exs
@@ -56,6 +56,28 @@ defmodule Lightning.Tesla.Adapter.FinchTest do
     port
   end
 
+  # Never goes quiet for long, so only a deadline on the whole request can stop
+  # it. Unlinked on purpose - see the moduledoc.
+  defp dripping_server(chunk, every_ms) do
+    {listen, port} = listener()
+
+    spawn(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen)
+      {:ok, _request} = :gen_tcp.recv(socket, 0)
+      :gen_tcp.send(socket, headers())
+
+      Enum.each(1..40, fn _ ->
+        :gen_tcp.send(socket, encode(chunk))
+        Process.sleep(every_ms)
+      end)
+
+      :gen_tcp.close(socket)
+      :gen_tcp.close(listen)
+    end)
+
+    port
+  end
+
   defp complete_server(chunks) do
     {listen, port} = listener()
 
@@ -103,7 +125,19 @@ defmodule Lightning.Tesla.Adapter.FinchTest do
     # raise. Upstream behaves the same - the difference is the reason below,
     # which upstream throws away.
     assert Enum.join(chunks) == "partial"
-    assert Adapter.take_stream_error() == :timeout
+    assert_went_quiet(Adapter.take_stream_error())
+  end
+
+  # The whole-request deadline, which upstream's adapter drops on the floor.
+  # Chunks keep arriving well inside receive_timeout, so nothing but
+  # request_timeout can end this.
+  test "a stream that never goes quiet is still bounded by the request" do
+    port = dripping_server("tick", 50)
+
+    chunks = drain(port, receive_timeout: 5_000, request_timeout: 400)
+
+    assert length(chunks) < 40
+    assert_went_quiet(Adapter.take_stream_error())
   end
 
   # The other way a stream dies, and the one that has to read differently to
@@ -125,7 +159,16 @@ defmodule Lightning.Tesla.Adapter.FinchTest do
 
     drain(port, receive_timeout: @quiet_timeout)
 
-    assert Adapter.take_stream_error() == :timeout
+    assert_went_quiet(Adapter.take_stream_error())
     assert Adapter.take_stream_error() == nil
+  end
+
+  # Finch's own deadline and ours are handed the same number, so whichever the
+  # scheduler reaches first decides whether the reason arrives as our bare atom
+  # or as Finch's struct around the same thing. Both say the stream went quiet,
+  # and both produce the same sentence for the user.
+  defp assert_went_quiet(reason) do
+    assert reason == :timeout or
+             match?(%Finch.TransportError{reason: :timeout}, reason)
   end
 end

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -29,7 +29,9 @@ defmodule LightningWeb.AiAssistantChannelTest do
       case key do
         :endpoint -> "http://localhost:3000"
         :ai_assistant_api_key -> "test_api_key"
-        :timeout -> 5_000
+        :connect_timeout -> 1_000
+        :idle_timeout -> 5_000
+        :request_timeout -> 5_000
       end
     end)
 

--- a/test/lightning_web/controllers/api/ai_assistant_controller_test.exs
+++ b/test/lightning_web/controllers/api/ai_assistant_controller_test.exs
@@ -18,7 +18,9 @@ defmodule LightningWeb.API.AiAssistantControllerTest do
       case key do
         :endpoint -> "http://localhost:3000"
         :ai_assistant_api_key -> "test_api_key"
-        :timeout -> 5_000
+        :connect_timeout -> 1_000
+        :idle_timeout -> 5_000
+        :request_timeout -> 5_000
       end
     end)
 


### PR DESCRIPTION
## Description

A hung Apollo, a severed connection and a genuinely short answer all logged "Stream ended without complete response". You could not tell them apart, which is what made the P2 behind #4882 slow to pin down. They now log as three different things, and the single timeout behind them becomes three settings that each bound one thing.

Closes #4882

Tesla's Finch adapter throws the reason away. Its stream returns `nil` for a mid-stream error, a mid-stream timeout and a clean end alike. We use our own copy of that adapter, which leaves the reason in the calling process to be read once the stream has been consumed. Upstream has since fixed this, so the copy goes when we bump Tesla, tracked in #5080.

`APOLLO_TIMEOUT` is renamed `APOLLO_IDLE_TIMEOUT_MS`, and joined by `APOLLO_CONNECT_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`. The old setting only ever measured silence. Connecting used a fixed five seconds you could not change, and nothing bounded a whole request at the HTTP layer, so a slow but steady stream ran until Oban killed the job. The old name now warns at boot that it is ignored, and so does a connect timeout set above the idle one, which can never expire.

The idle default drops from 120s to 30s. That assumes Apollo v3.1.1 or later and its 15s keepalive, so anyone on an older Apollo has to raise it. DEPLOYMENT.md says so.

Apollo also gets its own Finch pool. An AI stream holds a connection for the length of an answer, and sharing the default pool tied up connections other outbound calls were waiting on.

## Validation steps

1. Point `APOLLO_ENDPOINT` at something that accepts a connection and then goes quiet (`nc -l 3000` will do), set `APOLLO_IDLE_TIMEOUT_MS=5000`, and send the assistant a message. It gives up after about five seconds and the `[MessageProcessor] Failed to process message` log says the assistant stopped responding partway through.
2. Do it again, but kill the listener while it is waiting. The same log now says the connection was lost. Those two used to read the same.
3. Set `APOLLO_TIMEOUT` to anything and restart. The boot log warns that it is ignored and names the three settings that replaced it.

## Additional notes for the reviewer

`lib/lightning/tesla/adapter/finch.ex` is a copy of upstream's adapter and is most of the diff. It is not a faithful copy: it drops upstream's `build/4` clauses, which Apollo does not need, and the clauses that cannot fire against the Finch we pin. It is excluded from coverage, since only the lines we changed are ours to test.

The authorization box is unticked because nothing here is reachable by a user action with a role attached.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
