### PR TITLE
Schedule sandbox deletion from Settings instead of hard-deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ and this project adheres to
 
 ### Fixed
 
+- Deleting a sandbox from its Settings page now schedules it for deletion with
+  the same 7-day grace period as deleting it from the sandbox list, instead of
+  destroying it immediately. The confirmation dialog also now warns about child
+  sandboxes being deleted too when deleting from Settings, matching the sandbox
+  list's existing warning.
+  [#5058](https://github.com/OpenFn/lightning/issues/5058)/[#4667](https://github.com/OpenFn/lightning/issues/4667)
+
 - `APOLLO_TIMEOUT` now governs every request to Apollo, including the streaming
   requests all AI chats use. Streaming previously read an internal timeout key
   that no environment could set, so it was always 120s regardless of

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -274,10 +274,20 @@ defmodule LightningWeb.ProjectLive.Settings do
           sandbox_confirm_changeset(socket.assigns.project)
         )
         |> assign(:confirm_delete_input, "")
+        |> assign(
+          :confirm_delete_descendants,
+          active_descendants(socket.assigns.project.id)
+        )
 
       true ->
         assign(socket, :page_title, "Project settings")
     end
+  end
+
+  defp active_descendants(sandbox_id) do
+    sandbox_id
+    |> Projects.list_descendants()
+    |> Enum.filter(&is_nil(&1.scheduled_deletion))
   end
 
   defp sandbox_confirm_changeset(sandbox, params \\ %{}) do
@@ -487,7 +497,7 @@ defmodule LightningWeb.ProjectLive.Settings do
       |> Map.put(:action, :validate)
 
     if changeset.valid? do
-      case Lightning.Projects.Sandboxes.delete_sandbox(
+      case Lightning.Projects.Sandboxes.schedule_sandbox_deletion(
              socket.assigns.project,
              socket.assigns.current_user
            ) do
@@ -495,7 +505,7 @@ defmodule LightningWeb.ProjectLive.Settings do
           socket
           |> put_flash(
             :info,
-            "Sandbox #{deleted.name} and all its associated descendants deleted"
+            "Sandbox #{deleted.name} scheduled for deletion."
           )
           |> push_navigate(to: ~p"/projects/#{socket.assigns.root_project.id}/w")
           |> noreply()

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -299,6 +299,7 @@
               sandbox={Map.put(@project, :is_current, true)}
               changeset={@confirm_delete_changeset}
               root_project={@root_project}
+              descendants={@confirm_delete_descendants}
             />
           <% end %>
           <%= if @live_action == :delete and @can_delete_project and not @sandbox? do %>

--- a/test/lightning_web/live/project_live/sandbox_settings_test.exs
+++ b/test/lightning_web/live/project_live/sandbox_settings_test.exs
@@ -124,7 +124,7 @@ defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
       refute html =~ "Delete project"
     end
 
-    test "delete sandbox flow calls delete_sandbox and redirects to root project",
+    test "delete sandbox flow calls schedule_sandbox_deletion and redirects to root project",
          %{conn: conn, sandbox: sandbox, parent: parent} do
       {:ok, view, _html} =
         live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
@@ -136,8 +136,25 @@ defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
       |> render_submit()
 
       flash = assert_redirected(view, ~p"/projects/#{parent.id}/w")
-      assert flash["info"] =~ "and all its associated descendants deleted"
-      assert is_nil(Lightning.Projects.get_project(sandbox.id))
+      assert flash["info"] =~ "scheduled for deletion"
+
+      reloaded = Lightning.Projects.get_project(sandbox.id)
+      assert reloaded
+      assert reloaded.scheduled_deletion
+    end
+
+    test "delete modal shows descendant warning when the sandbox has children",
+         %{conn: conn, sandbox: sandbox, user: user} do
+      insert(:project,
+        name: "child-sandbox",
+        parent: sandbox,
+        project_users: [%{user: user, role: :owner}]
+      )
+
+      {:ok, _view, html} =
+        live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
+
+      assert html =~ "Its child sandbox will also be deleted."
     end
 
     test "confirm-delete-validate marks the form invalid for a wrong name",
@@ -189,9 +206,13 @@ defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
       # Simulate an authorization mismatch by stubbing the sandbox delete call
       # to return :unauthorized while the settings page's own can_delete_project
       # gate allowed us through.
-      Mimic.expect(Lightning.Projects.Sandboxes, :delete_sandbox, fn _, _ ->
-        {:error, :unauthorized}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn _, _ ->
+          {:error, :unauthorized}
+        end
+      )
 
       view
       |> form("#confirm-delete-sandbox form",
@@ -209,9 +230,13 @@ defmodule LightningWeb.ProjectLive.SandboxSettingsTest do
       {:ok, view, _html} =
         live(conn, ~p"/projects/#{sandbox.id}/settings/delete")
 
-      Mimic.expect(Lightning.Projects.Sandboxes, :delete_sandbox, fn _, _ ->
-        {:error, :boom}
-      end)
+      Mimic.expect(
+        Lightning.Projects.Sandboxes,
+        :schedule_sandbox_deletion,
+        fn _, _ ->
+          {:error, :boom}
+        end
+      )
 
       view
       |> form("#confirm-delete-sandbox form",


### PR DESCRIPTION
## Description

Fixes the Settings-page sandbox delete flow, which was **permanently destroying**
a sandbox instead of scheduling it for deletion with the 7-day grace period.
Two bugs in the same flow:

1. The `confirm-delete` handler called `Sandboxes.delete_sandbox/2` (hard
   delete, immediate `Projects.delete_project/1`) instead of
   `Sandboxes.schedule_sandbox_deletion/2` (soft delete — sets
   `scheduled_deletion`, **recoverable** during the grace period), even
   though the shared confirmation dialog always tells the user the sandbox
   "will be retained... before being permanently removed." The sandbox
   card's delete flow already used the correct function; **only Settings
   was affected**.
2. That same shared dialog's "Its N child sandboxes will also be deleted"
   warning **never rendered from Settings**, because the `descendants` prop
   wasn't being passed through. #4670 added this warning to the sandbox
   card path back in May but never wired it into Settings, leaving #4667
   open and unaddressed since — this PR is the missing other half of that fix.

Closes #5058
Closes #4667

## Validation steps

1. Open a sandbox's Settings page → Danger zone → **Delete sandbox**.
2. Type the sandbox name to confirm, submit.
3. The sandbox is **no longer removed from the database instantly** — it now
   has `scheduled_deletion` set and is recoverable during the grace period,
   same as deleting from the sandbox card.
4. Create a sandbox with a child sandbox, delete the parent from its own
   Settings page — the "Its child sandbox will also be deleted" warning
   **now shows** (previously silent, per #4667).

## Additional notes for the reviewer

Small, isolated diff — 3 files (`settings.ex`, `settings.html.heex`,
`sandbox_settings_test.exs`). Redirect target (root project's workflow page)
is **intentionally unchanged** — it already matches what the shared modal
tells the user, unlike the sandbox card's own redirect target for
deeply-nested sandboxes (pre-existing, out of scope here). Full test suite
passes unchanged.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
