### PR TITLE
Remove unreachable streamed AI error-body branch

### DIFF
--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1259,11 +1259,9 @@ defmodule Lightning.AiAssistant do
 
   defp handle_error_response(error_response, session) do
     case error_response do
-      {:ok, %Tesla.Env{status: status, body: body}}
+      {:ok, %Tesla.Env{status: status}}
       when status not in @success_status_range ->
-        error_message =
-          error_message_from_body(body) ||
-            "AI server returned an error (HTTP #{status})."
+        error_message = "AI server returned an error (HTTP #{status})."
 
         Logger.error(
           "AI query failed for session #{session.id}: #{error_message}"
@@ -1287,13 +1285,6 @@ defmodule Lightning.AiAssistant do
         {:error, "Oops! Something went wrong. Please try again."}
     end
   end
-
-  # Streaming requests carry a lazy Stream (a fun or %Stream{} struct) as the
-  # body, so error responses can't be indexed like decoded JSON maps.
-  defp error_message_from_body(body) when is_map(body) and not is_struct(body),
-    do: body["message"]
-
-  defp error_message_from_body(_body), do: nil
 
   defp build_job_message(body) do
     message = body["history"] |> Enum.reverse() |> hd()

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -2579,7 +2579,7 @@ defmodule Lightning.AiAssistantTest do
          }}
       end)
 
-      assert {:error, "Bad request"} =
+      assert {:error, "AI server returned an error (HTTP 400)."} =
                AiAssistant.query_stream(session, "test")
     end
 
@@ -2768,7 +2768,7 @@ defmodule Lightning.AiAssistantTest do
          }}
       end)
 
-      assert {:error, "Internal error"} =
+      assert {:error, "AI server returned an error (HTTP 500)."} =
                AiAssistant.query_workflow_stream(
                  session,
                  "create workflow"
@@ -3075,7 +3075,7 @@ defmodule Lightning.AiAssistantTest do
          }}
       end)
 
-      assert {:error, "Internal error"} =
+      assert {:error, "AI server returned an error (HTTP 500)."} =
                AiAssistant.query_global_stream(session, "test")
     end
 


### PR DESCRIPTION
<details>

<summary>AI Disclaimer</summary>

This pull request was primarily developed with assistance from OpenAI Codex (GPT-5.6 Luna Max), an AI coding agent. For this PR, Codex analyzed issue #5083, inspected the relevant OpenFn Lightning code and tests, implemented the focused fix, and ran the affected test suite under the supervision of jmtdev0.

Human involvement in this PR was very low.

If you do not agree with the use of AI assistance or with the level of human involvement in this PR, please feel free to disregard it, close it, or request changes. I will fully respect that decision.

</details>

## Description

This PR removes the unreachable error_message_from_body/1 branch from AI assistant error handling. Assistant calls now stream responses, so the response body is lazy and cannot be indexed as the legacy decoded map. Failed requests now use the local HTTP status message consistently.

Closes #5083

## Validation steps

1. Run MIX_ENV=test mix deps.get && mix deps.compile && mix test test/lightning/ai_assistant/ai_assistant_test.exs in the Docker development environment.
   - 112 tests, 0 failures.
2. Run git diff --check.
3. mix format --check-formatted was checked; it reports pre-existing formatting differences in other parts of these existing files, so no unrelated formatting changes were included.

## Additional notes for the reviewer

1. The change is intentionally scoped to deleting the unreachable body-message fallback and updating the three affected expectations.
2. This change does not alter authorization behavior.
3. The PR is ready for maintainer review.

## AI Usage

Please disclose whether AI was used anywhere in this PR:

- [ ] I have used Claude Code
- [x] I have used another model
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have performed an AI review of my code.
- [x] Related authorization policies are not applicable to this error-message-only change.
- [ ] I have updated the changelog.
- [x] I have ticked a box in AI usage in this PR.

