### PR TITLE
fix: Recover GitHub installation lookup from invalid OAuth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to
 
 ### Fixed
 
+- GitHub Sync now refreshes and retries a rejected OAuth token once when loading
+  app installations, and directs users to reconnect their account when recovery
+  is not possible. [#4972](https://github.com/OpenFn/lightning/issues/4972)
 - The AI assistant no longer appends " 1" to a workflow's name each time it
   edits an already-saved workflow. Name-uniqueness validation now excludes the
   workflow being edited, so its own name isn't treated as a clash.

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -196,14 +196,80 @@ defmodule Lightning.VersionControl do
   def fetch_user_installations(user) do
     with {:ok, access_token} <- fetch_user_access_token(user),
          {:ok, client} <- GithubClient.build_bearer_client(access_token) do
-      case GithubClient.get_installations(client) do
-        {:ok, %{body: body}} ->
-          {:ok, body}
+      case request_user_installations(client) do
+        {:unauthorized, body} ->
+          refresh_and_retry_user_installations(user, body)
 
-        {:error, %{body: body}} ->
-          {:error, body}
+        result ->
+          result
       end
     end
+  end
+
+  defp request_user_installations(client) do
+    case GithubClient.get_installations(client) do
+      {:ok, %{body: body}} ->
+        {:ok, body}
+
+      {:error, %{status: 401, body: body}} ->
+        {:unauthorized, body}
+
+      {:error, %{body: body}} ->
+        {:error, body}
+    end
+  end
+
+  defp refresh_and_retry_user_installations(user, unauthorized_body) do
+    with %User{} = user <- Repo.reload(user),
+         {:ok, refresh_token} <- usable_refresh_token(user.github_oauth_token),
+         {:ok, refreshed_token} <- refresh_oauth_token(refresh_token),
+         {:ok, _user} <- save_oauth_token(user, refreshed_token, notify: false),
+         {:ok, client} <-
+           GithubClient.build_bearer_client(refreshed_token["access_token"]) do
+      case request_user_installations(client) do
+        {:unauthorized, body} -> {:error, invalid_oauth_token(body)}
+        result -> result
+      end
+    else
+      _error -> {:error, invalid_oauth_token(unauthorized_body)}
+    end
+  end
+
+  defp usable_refresh_token(%{"refresh_token" => refresh_token} = token)
+       when is_binary(refresh_token) and refresh_token != "" do
+    case token["refresh_token_expires_at"] do
+      nil ->
+        {:ok, refresh_token}
+
+      expiry ->
+        if oauth_expiry_valid?(expiry),
+          do: {:ok, refresh_token},
+          else: {:error, :expired_refresh_token}
+    end
+  end
+
+  defp usable_refresh_token(_token), do: {:error, :missing_refresh_token}
+
+  defp oauth_expiry_valid?(%DateTime{} = expiry) do
+    DateTime.after?(expiry, DateTime.utc_now())
+  end
+
+  defp oauth_expiry_valid?(expiry) when is_binary(expiry) do
+    case DateTime.from_iso8601(expiry) do
+      {:ok, expiry, _offset} -> oauth_expiry_valid?(expiry)
+      {:error, _reason} -> false
+    end
+  end
+
+  defp oauth_expiry_valid?(_expiry), do: false
+
+  defp invalid_oauth_token(body) do
+    meta = if is_map(body), do: body, else: %{response: body}
+
+    GithubError.invalid_oauth_token(
+      "GitHub rejected the OAuth access token",
+      meta
+    )
   end
 
   def fetch_installation_repos(installation_id) do

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -8,6 +8,7 @@ defmodule Lightning.VersionControlTest do
   alias Lightning.Extensions.UsageLimiting.Context
   alias Lightning.Repo
   alias Lightning.VersionControl
+  alias Lightning.VersionControl.GithubError
   alias Lightning.VersionControl.ProjectRepoConnection
   alias Lightning.Workflows.Snapshot
 
@@ -686,6 +687,183 @@ defmodule Lightning.VersionControlTest do
     defp path_to_config(repo_connection) do
       ProjectRepoConnection.config_path(repo_connection)
       |> Path.relative_to(".")
+    end
+  end
+
+  describe "fetch_user_installations/1" do
+    test "refreshes a rejected access token, persists it, and retries once" do
+      user = user_with_valid_github_oauth()
+
+      refreshed_token = %{
+        "access_token" => "refreshed-access-token",
+        "refresh_token" => "refreshed-refresh-token",
+        "expires_in" => 3600,
+        "refresh_token_expires_in" => 7200
+      }
+
+      installations = %{
+        "installations" => [
+          %{"id" => 1234, "account" => %{"type" => "User", "login" => "user"}}
+        ]
+      }
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://api.github.com/user/installations"
+        assert {"authorization", "Bearer access-token"} in env.headers
+        {:ok, %Tesla.Env{status: 401, body: %{"message" => "Bad credentials"}}}
+      end)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://github.com/login/oauth/access_token"
+        {:ok, %Tesla.Env{status: 200, body: refreshed_token}}
+      end)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://api.github.com/user/installations"
+        assert {"authorization", "Bearer refreshed-access-token"} in env.headers
+        {:ok, %Tesla.Env{status: 200, body: installations}}
+      end)
+
+      assert {:ok, ^installations} =
+               VersionControl.fetch_user_installations(user)
+
+      updated_user = Repo.reload!(user)
+
+      assert updated_user.github_oauth_token["access_token"] ==
+               "refreshed-access-token"
+
+      assert updated_user.github_oauth_token["refresh_token"] ==
+               "refreshed-refresh-token"
+    end
+
+    test "uses the rotated refresh token after a proactive token refresh" do
+      user =
+        insert(:user,
+          github_oauth_token: %{
+            "access_token" => "expired-access-token",
+            "refresh_token" => "refresh-0",
+            "expires_at" => DateTime.utc_now() |> DateTime.add(-20),
+            "refresh_token_expires_at" =>
+              DateTime.utc_now() |> DateTime.add(500)
+          }
+        )
+        |> Repo.reload!()
+
+      proactively_refreshed_token = %{
+        "access_token" => "access-1",
+        "refresh_token" => "refresh-1",
+        "expires_in" => 3600,
+        "refresh_token_expires_in" => 7200
+      }
+
+      recovered_token = %{
+        "access_token" => "access-2",
+        "refresh_token" => "refresh-2",
+        "expires_in" => 3600,
+        "refresh_token_expires_in" => 7200
+      }
+
+      installations = %{
+        "installations" => [
+          %{"id" => 1234, "account" => %{"type" => "User", "login" => "user"}}
+        ]
+      }
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://github.com/login/oauth/access_token"
+        assert env.query[:refresh_token] == "refresh-0"
+        {:ok, %Tesla.Env{status: 200, body: proactively_refreshed_token}}
+      end)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://api.github.com/user/installations"
+        assert {"authorization", "Bearer access-1"} in env.headers
+        {:ok, %Tesla.Env{status: 401, body: %{"message" => "Bad credentials"}}}
+      end)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://github.com/login/oauth/access_token"
+        assert env.query[:refresh_token] == "refresh-1"
+        {:ok, %Tesla.Env{status: 200, body: recovered_token}}
+      end)
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://api.github.com/user/installations"
+        assert {"authorization", "Bearer access-2"} in env.headers
+        {:ok, %Tesla.Env{status: 200, body: installations}}
+      end)
+
+      assert {:ok, ^installations} =
+               VersionControl.fetch_user_installations(user)
+
+      updated_user = Repo.reload!(user)
+
+      assert updated_user.github_oauth_token["access_token"] == "access-2"
+      assert updated_user.github_oauth_token["refresh_token"] == "refresh-2"
+    end
+
+    test "returns invalid oauth token when the grant cannot be refreshed" do
+      user =
+        insert(:user,
+          github_oauth_token: %{"access_token" => "access-token"}
+        )
+
+      expect_get_user_installations(401, %{"message" => "Bad credentials"})
+
+      assert {:error, %GithubError{code: :invalid_oauth_token}} =
+               VersionControl.fetch_user_installations(user)
+    end
+
+    test "returns invalid oauth token when GitHub rejects the refresh" do
+      user = user_with_valid_github_oauth()
+
+      expect_get_user_installations(401, %{"message" => "Bad credentials"})
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://github.com/login/oauth/access_token"
+
+        {:ok,
+         %Tesla.Env{
+           status: 200,
+           body: %{"error" => "bad_refresh_token"}
+         }}
+      end)
+
+      assert {:error, %GithubError{code: :invalid_oauth_token}} =
+               VersionControl.fetch_user_installations(user)
+    end
+
+    test "stops after the retried installations request is unauthorized" do
+      user = user_with_valid_github_oauth()
+
+      expect_get_user_installations(401, %{"message" => "Bad credentials"})
+
+      refreshed_token = %{
+        "access_token" => "refreshed-access-token",
+        "refresh_token" => "refreshed-refresh-token",
+        "expires_in" => 3600,
+        "refresh_token_expires_in" => 7200
+      }
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://github.com/login/oauth/access_token"
+        {:ok, %Tesla.Env{status: 200, body: refreshed_token}}
+      end)
+
+      expect_get_user_installations(401, %{"message" => "Still unauthorized"})
+
+      assert {:error, %GithubError{code: :invalid_oauth_token}} =
+               VersionControl.fetch_user_installations(user)
+    end
+
+    test "returns non-authentication errors without refreshing" do
+      user = user_with_valid_github_oauth()
+      error_body = %{"message" => "Internal Server Error"}
+
+      expect_get_user_installations(500, error_body)
+
+      assert {:error, ^error_body} =
+               VersionControl.fetch_user_installations(user)
     end
   end
 

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -709,7 +709,7 @@ defmodule Lightning.VersionControlTest do
 
       Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
         assert env.url == "https://api.github.com/user/installations"
-        assert {"authorization", "Bearer access-token"} in env.headers
+        assert {"Authorization", "Bearer access-token"} in env.headers
         {:ok, %Tesla.Env{status: 401, body: %{"message" => "Bad credentials"}}}
       end)
 
@@ -720,7 +720,7 @@ defmodule Lightning.VersionControlTest do
 
       Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
         assert env.url == "https://api.github.com/user/installations"
-        assert {"authorization", "Bearer refreshed-access-token"} in env.headers
+        assert {"Authorization", "Bearer refreshed-access-token"} in env.headers
         {:ok, %Tesla.Env{status: 200, body: installations}}
       end)
 
@@ -743,8 +743,7 @@ defmodule Lightning.VersionControlTest do
             "access_token" => "expired-access-token",
             "refresh_token" => "refresh-0",
             "expires_at" => DateTime.utc_now() |> DateTime.add(-20),
-            "refresh_token_expires_at" =>
-              DateTime.utc_now() |> DateTime.add(500)
+            "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(500)
           }
         )
         |> Repo.reload!()
@@ -777,7 +776,7 @@ defmodule Lightning.VersionControlTest do
 
       Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
         assert env.url == "https://api.github.com/user/installations"
-        assert {"authorization", "Bearer access-1"} in env.headers
+        assert {"Authorization", "Bearer access-1"} in env.headers
         {:ok, %Tesla.Env{status: 401, body: %{"message" => "Bad credentials"}}}
       end)
 
@@ -789,7 +788,7 @@ defmodule Lightning.VersionControlTest do
 
       Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
         assert env.url == "https://api.github.com/user/installations"
-        assert {"authorization", "Bearer access-2"} in env.headers
+        assert {"Authorization", "Bearer access-2"} in env.headers
         {:ok, %Tesla.Env{status: 200, body: installations}}
       end)
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -4828,6 +4828,39 @@ defmodule LightningWeb.ProjectLiveTest do
       refute html =~ "Unable to load GitHub installations"
     end
 
+    test "shows reconnect guidance when GitHub rejects OAuth recovery", %{
+      conn: conn
+    } do
+      project = insert(:project)
+      {conn, user} = setup_project_user(conn, project, :admin)
+      set_valid_github_oauth_token!(user)
+
+      expect_get_user_installations(401, %{"message" => "Bad credentials"})
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+        assert env.url == "https://github.com/login/oauth/access_token"
+
+        {:ok,
+         %Tesla.Env{
+           status: 200,
+           body: %{"error" => "bad_refresh_token"}
+         }}
+      end)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/projects/#{project.id}/settings#vcs"
+        )
+
+      html = render_async(view)
+
+      assert html =~ "Your GitHub authentication has expired or is invalid"
+      assert has_element?(view, "a[href='/profile']", "Settings")
+      assert has_element?(view, "button[disabled] + #select-installations-input")
+      refute html =~ "Refresh the page or contact support"
+    end
+
     test "shows error banner when GitHub API returns an error", %{
       conn: conn
     } do


### PR DESCRIPTION
## Description

Extend the existing token lifecycle in `Lightning.VersionControl` so an installations request rejected with `401` gets one recovery attempt when the stored grant has a usable refresh token: refresh and persist the OAuth token, rebuild the bearer client, and retry the installations request exactly once. If refresh is unavailable or fails, or the retry is also unauthorized, return the existing `GithubError.invalid_oauth_token/2` contract so `GithubSyncComponent` renders its current profile/reconnect guidance; preserve the existing raw error behavior for non-authentication GitHub failures. Keep this logic in the production installation-fetch path rather than introducing a test-only seam, and record the user-visible fix in the changelog.

The project GitHub Sync settings load a user's installations through `Lightning.VersionControl.fetch_user_installations/1`, and the installation selector remains disabled when that asynchronous request fails. Locally expired access tokens are already refreshed, but a `401` returned by GitHub is reduced to an untyped response body, so the LiveComponent treats an authentication failure like a generic API outage. Users therefore receive refresh-or-contact-support guidance instead of an automatic recovery attempt or the existing invalid-token reconnect guidance.

Closes #4972

## Validation steps

This PR adds unit and LiveView tests covering the cases below. They are included in the diff but were not executed in my local environment, so CI is the first run.

1. A stored access token receives `401`, its valid refresh token produces a replacement token, and the single retried installations request succeeds; asserts the replacement is persisted and installations are returned.
2. A `401` cannot be refreshed because the grant is non-refreshable or GitHub rejects the refresh; asserts the result is an `:invalid_oauth_token` `GithubError` without repeatedly calling the installations endpoint.
3. The retried installations request also returns `401`; asserts the retry stops after one attempt and returns the typed invalid-token error.
4. A non-authentication response such as `500` remains a generic GitHub API failure and does not trigger token refresh.
5. Project Settings receives an unrecoverable installation authentication failure and renders the expired/invalid authentication banner with the profile reconnect link while leaving the installation selector disabled.

## Additional notes for the reviewer

The retry is deliberately capped at exactly one attempt so a persistently rejected grant cannot loop against the installations endpoint. Non-authentication failures are left on their existing path so this change does not alter behavior for GitHub outages.

## AI Usage

AI was used for assistance.

## Pre-submission checklist

- [x] I have ticked a box in "AI usage" in this PR
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) - not applicable: this change does not touch authorization policies.
