### PR TITLE
Add repeat_mix_test and gather_ci_logs to bin/

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,26 @@ MIX_ENV=test mix test
 We also have `test.watch` installed which can be used to rerun the tests on file
 changes.
 
+##### Chasing flaky tests
+
+`bin/repeat_mix_test` runs the suite (or given files) repeatedly and records
+each run's first-pass result — unlike `bin/ci_tests`, it never retries, so a
+flake shows up instead of being papered over.
+
+```sh
+bin/repeat_mix_test 30 test/lightning/workflows_test.exs
+CI_TIMING=1 bin/repeat_mix_test 11   # cap schedulers and shorten assert_receive
+                                     # timeouts to match CircleCI
+```
+
+It uses its own test database (`MIX_TEST_PARTITION=flaky`) so a long loop can't
+collide with another checkout, and writes logs plus a `summary.tsv` to
+`.scratch/runs/<timestamp>/`.
+
+`bin/gather_ci_logs [N]` pulls the "Run Elixir tests" output from the last N
+`test_elixir` CircleCI jobs on `main` into `.scratch/ci-logs/`, flagging the
+builds that went green only because the retry pass saved them. Needs `jq`.
+
 ## Security and Standards
 
 We use a host of common Elixir static analysis tools to help us avoid common

--- a/bin/gather_ci_logs
+++ b/bin/gather_ci_logs
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# gather_ci_logs — fetch the "Run Elixir tests" step output from the last N
+# test_elixir CircleCI jobs and save de-ANSI'd logs into .scratch/ci-logs/.
+#
+# OpenFn/lightning is an OSS project on CircleCI, so the v1.1 API is readable
+# without a token. Every test_elixir job runs ./bin/ci_tests, which reruns
+# failed tests after the first pass — so a job can show "success" yet still have
+# flaked on the first run. We flag those: a log containing
+# "Renamed failed test report" means the retry path fired = first-run flake.
+#
+# Usage: bin/gather_ci_logs [N]              # N test_elixir jobs, default 20
+#        BRANCH=main bin/gather_ci_logs 20  # main only (default) — see BRANCH below
+#        BRANCH= bin/gather_ci_logs 20      # empty = all branches
+#
+# BRANCH defaults to "main". The 2026-06 pass sampled all branches and mistook
+# in-development bugs for flakes; main-only keeps the sample honest.
+#
+# Output: .scratch/ci-logs/
+#   build-<num>-<branch>.log   full de-ANSI'd "Run Elixir tests" step output
+#   index.tsv                  build, branch, date, outcome, flaky, log
+#
+set -uo pipefail
+
+N="${1:-20}"
+BRANCH="${BRANCH-main}"
+PROJECT="gh/OpenFn/lightning"
+API="https://circleci.com/api/v1.1/project/$PROJECT"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+OUT="$PROJECT_ROOT/.scratch/ci-logs"
+mkdir -p "$OUT"
+INDEX="$OUT/index.tsv"
+printf 'build\tbranch\tdate\toutcome\tflaky\tlog\n' > "$INDEX"
+
+strip_ansi() { sed -E 's/\x1b\[[0-9;]*[A-Za-z]//g; s/\r//g'; }
+
+echo "gather-ci-logs: collecting $N test_elixir jobs (branch=${BRANCH:-<all>}) -> $OUT"
+
+collected=0
+offset=0
+while [ "$collected" -lt "$N" ]; do
+  batch=$(curl -s --max-time 30 "$API?limit=100&offset=$offset&filter=completed" -H "Accept: application/json")
+  nums=$(echo "$batch" | jq -r --arg br "$BRANCH" \
+    '.[] | select(.workflows.job_name=="test_elixir") | select($br=="" or .branch==$br) | .build_num')
+  if [ -z "$nums" ]; then
+    echo "no more test_elixir builds at offset $offset"
+    break
+  fi
+  for num in $nums; do
+    [ "$collected" -ge "$N" ] && break
+    detail=$(curl -s --max-time 30 "$API/$num" -H "Accept: application/json")
+    branch=$(echo "$detail" | jq -r '.branch // "unknown"')
+    date=$(echo "$detail" | jq -r '.committer_date // "?"')
+    outcome=$(echo "$detail" | jq -r '.outcome // "?"')
+    url=$(echo "$detail" | jq -r '.steps[]?.actions[]? | select(.name=="Run Elixir tests") | .output_url' | head -1)
+    if [ -z "$url" ] || [ "$url" = "null" ]; then
+      echo "  build $num: no test step output, skip"
+      continue
+    fi
+    safe_branch="${branch//\//_}"
+    log="$OUT/build-${num}-${safe_branch}.log"
+    curl -s --max-time 90 "$url" | jq -r '.[].message' 2>/dev/null | strip_ansi > "$log"
+    if grep -q "Renamed failed test report" "$log"; then flaky="FLAKY"; else flaky="clean"; fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$num" "$branch" "$date" "$outcome" "$flaky" "$(basename "$log")" >> "$INDEX"
+    echo "  build $num ($branch) $outcome -> $flaky"
+    collected=$((collected + 1))
+  done
+  offset=$((offset + 100))
+done
+
+echo "=== collected $collected logs. index: $INDEX ==="
+column -t -s "$(printf '\t')" "$INDEX"

--- a/bin/repeat_mix_test
+++ b/bin/repeat_mix_test
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# repeat_mix_test — run `mix test` N times in the Lightning project, capturing
+# each run's combined stdout+stderr to a dated log. Surfaces first-run flakes by
+# repetition. Unlike bin/ci_tests it does NOT retry failed tests in-run — the
+# whole point is to see the raw first-run result every time.
+#
+# Usage:
+#   bin/repeat_mix_test [N] [test paths...]   # N defaults to 1 (safety)
+#   CI_TIMING=1 bin/repeat_mix_test 11         # full suite, CI scheduler/timing
+#   bin/repeat_mix_test 30 test/foo_test.exs   # loop just these files
+#
+# CI_TIMING=1 exports the same knobs CircleCI uses (.circleci/config.yml):
+#   ERL_FLAGS="+S 4:4"  (cap schedulers — CI runs less parallel than a dev box)
+#   ASSERT_RECEIVE_TIMEOUT="1000"
+# Use it to try to reproduce CI-only flakes locally.
+#
+# Output: .scratch/runs/<session-stamp>/
+#   run-NN-<stamp>.log   full combined output of each run
+#   summary.tsv          run, exit, seed, tests, failures, duration_s, log
+#
+set -uo pipefail
+
+N="${1:-1}"
+shift || true
+TARGETS=("$@")
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+RUNS_ROOT="$PROJECT_ROOT/.scratch/runs"
+
+stamp() { date +%Y%m%dT%H%M%S; }
+
+SESSION="$(stamp)"
+SESSION_DIR="$RUNS_ROOT/$SESSION"
+mkdir -p "$SESSION_DIR"
+SUMMARY="$SESSION_DIR/summary.tsv"
+printf 'run\texit\tseed\ttests\tfailures\tduration_s\tlog\n' > "$SUMMARY"
+
+# Namespaces the test DB (config/test.exs:40 suffixes TEST_DATABASE_NAME with it),
+# so long repeat loops can't collide with another worktree or session using
+# lightning_test. The `test` alias (mix.exs:226) creates it on first run.
+export MIX_TEST_PARTITION="${MIX_TEST_PARTITION:-flaky}"
+
+if [ "${CI_TIMING:-0}" = "1" ]; then
+  export ERL_FLAGS="+S 4:4"
+  export ASSERT_RECEIVE_TIMEOUT="1000"
+fi
+
+cd "$PROJECT_ROOT" || { echo "cannot cd to $PROJECT_ROOT" >&2; exit 1; }
+
+echo "repeat_mix_test: N=$N  session=$SESSION  ci_timing=${CI_TIMING:-0}  db=lightning_test${MIX_TEST_PARTITION}  targets=${TARGETS[*]:-<full suite>}"
+echo "logs -> $SESSION_DIR"
+
+for i in $(seq 1 "$N"); do
+  RUN=$(printf '%02d' "$i")
+  RSTAMP="$(stamp)"
+  LOG="$SESSION_DIR/run-${RUN}-${RSTAMP}.log"
+  START=$(date +%s)
+  echo "=== run $i/$N @ $RSTAMP (ci_timing=${CI_TIMING:-0}) ===" | tee "$LOG"
+  MIX_ENV=test mix test "${TARGETS[@]}" >>"$LOG" 2>&1
+  EC=$?
+  END=$(date +%s)
+  DUR=$((END - START))
+  SEED=$(grep -oE 'seed: [0-9]+' "$LOG" | head -1 | grep -oE '[0-9]+')
+  LINE=$(grep -oE '[0-9]+ tests?, [0-9]+ failures?' "$LOG" | tail -1)
+  TESTS=$(echo "$LINE" | grep -oE '^[0-9]+')
+  FAILS=$(echo "$LINE" | grep -oE '[0-9]+ failures?' | grep -oE '[0-9]+')
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$i" "$EC" "${SEED:-?}" "${TESTS:-?}" "${FAILS:-0}" "$DUR" "$(basename "$LOG")" >> "$SUMMARY"
+  echo "  -> exit=$EC seed=${SEED:-?} ${LINE:-(no summary line)} ${DUR}s"
+done
+
+echo "=== done. summary: $SUMMARY ==="
+cat "$SUMMARY"


### PR DESCRIPTION
## Description

This PR adds two flaky-test scripts to `bin/`. They lived in one person's gitignored `.scratch/`, so they existed on one laptop only. Every issue in the test-stability Linear project ends with a verify command nobody else could run. Now they are ordinary tooling.

`bin/repeat_mix_test <count> [files...]` loops `mix test` and records each run's first-pass result. Unlike `bin/ci_tests` it never retries, so a flake surfaces instead of being papered over by the retry pass. `CI_TIMING=1` caps schedulers to `+S 4:4` and sets `ASSERT_RECEIVE_TIMEOUT=1000` to match `.circleci/config.yml`, for reproducing CI-only flakes locally. It uses its own test database via `MIX_TEST_PARTITION=flaky`, so a long loop cannot collide with another checkout.

`bin/gather_ci_logs [N]` pulls the "Run Elixir tests" step output from the last N `test_elixir` CircleCI jobs on `main` into `.scratch/ci-logs/`, flagging builds that only went green because the retry pass saved them. Requires `jq`.

Both write to `.scratch/`, which is gitignored. Documented under README's "Run the tests" section.

Only change made when relocating the scripts: the output directories. They previously wrote next to themselves, which in `bin/` would have dumped logs into `bin/`. They now derive the project root via `git rev-parse --show-toplevel` (worktree-safe) and write to `.scratch/runs` and `.scratch/ci-logs`.

Fixes OFN-4523

## Validation steps

1. Run `bin/repeat_mix_test 2 test/lightning/config_test.exs`. Expect 2 runs and a `summary.tsv` under `.scratch/runs/`.
2. Run `bin/gather_ci_logs 5`. Expect logs under `.scratch/ci-logs/`, with retry-rescued builds flagged. Needs `jq` and CircleCI API access.
3. Check the "Run the tests" section of the README reads correctly.

## Additional notes for the reviewer

1. Both scripts pass `bash -n`. `bin/repeat_mix_test 2 test/lightning/config_test.exs` was run and gave 2 clean runs plus a correct `summary.tsv`.
2. `bin/gather_ci_logs` was not run in this session, as it hits the CircleCI API. It was smoke-tested on 2026-08-25.
3. Base branch is `find-flaky-tests`, not `main`.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) — not applicable, no application code changes.
- [ ] I have updated the **changelog**. — not applicable, developer tooling only, nothing user-facing.
- [x] I have ticked a box in "AI usage" in this PR
