### PR TITLE
Ignore cowlib CVE-2026-43971 in hex.audit

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -66,18 +66,22 @@ defmodule Lightning.MixProject do
   defp elixirc_paths(_), do: ["lib"]
 
   # Advisories acknowledged for `mix hex.audit`. cowlib is the only one left, and
-  # it has no patched release (latest is 2.19.0). Note that both EEF records carry
-  # no `fixed` event, while the GitHub twin of CVE-2026-43969
-  # (GHSA-g2wm-735q-3f56) records `last_affected: 2.16.1` -- so 2.19.0 may
-  # already be unaffected and the EEF record simply lacks a fix event. IDs are
-  # matched against an advisory's primary ID or any alias, so the CVE form also
-  # silences the GHSA/EEF variants.
+  # it has no patched release (latest is 2.19.0, published 2026-07-28). cowlib
+  # is transitive: cowboy 2.18.0 requires `>= 2.19.0 and < 3.0.0`. None of the
+  # three EEF records carry a `fixed` event on their version range, while the
+  # GitHub twin of CVE-2026-43969 (GHSA-g2wm-735q-3f56) records
+  # `last_affected: 2.16.1` -- so 2.19.0 may already be unaffected and the EEF
+  # records simply lack a fix event. CVE-2026-43971 was published 2026-08-18 and
+  # its only fix is a git commit with no release on Hex yet. IDs are matched
+  # against an advisory's primary ID or any alias, so the CVE form also silences
+  # the GHSA/EEF variants. Drop these once cowlib ships a patched version.
   defp hex_audit do
     [
       ignore_advisories: [
         # cowlib
         "CVE-2026-43966",
-        "CVE-2026-43969"
+        "CVE-2026-43969",
+        "CVE-2026-43971"
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule Lightning.MixProject do
 
   # cowlib advisories we have checked and accepted. Each names a function on
   # cowlib's header-building path, and nothing in our tree calls any of them. The
-  # parse side of these modules IS reachable through cowboy_req, so recheck by
+  # parse side of two of them is reachable through cowboy_req, so recheck by
   # function rather than by module. No patched cowlib release exists yet. Hex
   # matches an advisory's primary ID or any alias, so the CVE form also silences
   # the GHSA and EEF variants. Detail in #5102.

--- a/mix.exs
+++ b/mix.exs
@@ -65,25 +65,10 @@ defmodule Lightning.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # Advisories acknowledged for `mix hex.audit`. All three are cowlib, and in
-  # each case the vulnerable function is unreachable from our dependency tree:
-  #
-  #   CVE-2026-43971  cow_link:link/1 -- nothing outside cowlib references the
-  #                   cow_link module at all, and we never build Link headers.
-  #   CVE-2026-43966  cow_http_struct_hd:escape_string/2 -- same, no references
-  #                   outside cowlib.
-  #   CVE-2026-43969  cow_cookie:cookie/1 -- cowboy_req only calls
-  #                   parse_cookie/1,2 and setcookie/3, never cookie/1. Its
-  #                   GitHub twin (GHSA-g2wm-735q-3f56) also records
-  #                   last_affected 2.16.1, so 2.19.0 is already past it.
-  #
-  # There is also nothing to upgrade to. cowlib 2.19.0 is the newest release on
-  # Hex (2026-07-28) and the CVE-2026-43971 fix is a git commit from 2026-08-18
-  # with no release behind it. cowlib is transitive: cowboy 2.18.0 requires
-  # `>= 2.19.0 and < 3.0.0`. IDs match an advisory's primary ID or any alias, so
-  # the CVE form also silences the GHSA/EEF variants. Recheck this list when
-  # cowlib next ships, and note that a new cowlib advisory would still fail the
-  # build, since these entries only silence these three IDs.
+  # cowlib advisories we have checked and accepted. None of the three vulnerable
+  # functions are reachable from our dependency tree, and there is no patched
+  # cowlib release to move to. Reasoning per advisory is in #5102. Recheck when
+  # cowlib next ships; a new advisory ID will still fail the build.
   defp hex_audit do
     [
       ignore_advisories: [

--- a/mix.exs
+++ b/mix.exs
@@ -65,16 +65,25 @@ defmodule Lightning.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # Advisories acknowledged for `mix hex.audit`. cowlib is the only one left, and
-  # it has no patched release (latest is 2.19.0, published 2026-07-28). cowlib
-  # is transitive: cowboy 2.18.0 requires `>= 2.19.0 and < 3.0.0`. None of the
-  # three EEF records carry a `fixed` event on their version range, while the
-  # GitHub twin of CVE-2026-43969 (GHSA-g2wm-735q-3f56) records
-  # `last_affected: 2.16.1` -- so 2.19.0 may already be unaffected and the EEF
-  # records simply lack a fix event. CVE-2026-43971 was published 2026-08-18 and
-  # its only fix is a git commit with no release on Hex yet. IDs are matched
-  # against an advisory's primary ID or any alias, so the CVE form also silences
-  # the GHSA/EEF variants. Drop these once cowlib ships a patched version.
+  # Advisories acknowledged for `mix hex.audit`. All three are cowlib, and in
+  # each case the vulnerable function is unreachable from our dependency tree:
+  #
+  #   CVE-2026-43971  cow_link:link/1 -- nothing outside cowlib references the
+  #                   cow_link module at all, and we never build Link headers.
+  #   CVE-2026-43966  cow_http_struct_hd:escape_string/2 -- same, no references
+  #                   outside cowlib.
+  #   CVE-2026-43969  cow_cookie:cookie/1 -- cowboy_req only calls
+  #                   parse_cookie/1,2 and setcookie/3, never cookie/1. Its
+  #                   GitHub twin (GHSA-g2wm-735q-3f56) also records
+  #                   last_affected 2.16.1, so 2.19.0 is already past it.
+  #
+  # There is also nothing to upgrade to. cowlib 2.19.0 is the newest release on
+  # Hex (2026-07-28) and the CVE-2026-43971 fix is a git commit from 2026-08-18
+  # with no release behind it. cowlib is transitive: cowboy 2.18.0 requires
+  # `>= 2.19.0 and < 3.0.0`. IDs match an advisory's primary ID or any alias, so
+  # the CVE form also silences the GHSA/EEF variants. Recheck this list when
+  # cowlib next ships, and note that a new cowlib advisory would still fail the
+  # build, since these entries only silence these three IDs.
   defp hex_audit do
     [
       ignore_advisories: [

--- a/mix.exs
+++ b/mix.exs
@@ -65,16 +65,21 @@ defmodule Lightning.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # cowlib advisories we have checked and accepted. None of the three vulnerable
-  # functions are reachable from our dependency tree, and there is no patched
-  # cowlib release to move to. Reasoning per advisory is in #5102. Recheck when
-  # cowlib next ships; a new advisory ID will still fail the build.
+  # cowlib advisories we have checked and accepted. Each names a function on
+  # cowlib's header-building path, and nothing in our tree calls any of them. The
+  # parse side of these modules IS reachable through cowboy_req, so recheck by
+  # function rather than by module. No patched cowlib release exists yet. Hex
+  # matches an advisory's primary ID or any alias, so the CVE form also silences
+  # the GHSA and EEF variants. Detail in #5102.
   defp hex_audit do
     [
       ignore_advisories: [
         # cowlib
+        # cow_http_struct_hd:escape_string/2
         "CVE-2026-43966",
+        # cow_cookie:cookie/1
         "CVE-2026-43969",
+        # cow_link:link/1
         "CVE-2026-43971"
       ]
     ]


### PR DESCRIPTION
## Description

Puts the lint job back to green. It has been red on `main` since 18 August, so every PR opened since has inherited a failing check.

`mix hex.audit` reports three cowlib advisories and our ignore list covered two, so CVE-2026-43971 fails the build. There is nothing to upgrade to, cowlib 2.19.0 is the newest release on Hex and predates the advisory. Suppressing is safe because all three name functions on cowlib's header building path and nothing in our tree calls them, so each ID now carries its function in the comment.

## Validation steps

1. `mix hex.audit` exits 0 with all three under "Ignored advisories". Note it only reports advisories on Hex 2.3 and up. CI runs `mix local.hex --force` so it gets the latest, but a local Hex 2.2.x says "No retired packages found" and passes either way. I checked against 2.5.1.
2. `mix format --check-formatted`, `mix credo --strict --all`, `mix sobelow --threshold medium` and `mix deps.audit --ignore-file .mix_audit.ignore` all pass. Those are the other four checks in the lint job.

## Additional notes for the reviewer

No changelog entry, this is build tooling.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code
- [ ] I have implemented and tested all related **authorization policies**.
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
