### PR TITLE
Remove support for string-encoded dataclips in step:complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to
   button), closes any other open panel, deselects the current node, and drops
   any run-viewing context, landing on the bare canvas.
   [#4984](https://github.com/OpenFn/lightning/pull/4984)
+- `step:complete` now accepts `output_dataclip` as a decoded value, not just a
+  JSON string, while staying compatible with workers that still send a string.
+  [#5098](https://github.com/OpenFn/lightning/pull/5098)
 
 ### Changed
 

--- a/lib/lightning/runs/handlers.ex
+++ b/lib/lightning/runs/handlers.ex
@@ -561,11 +561,21 @@ defmodule Lightning.Runs.Handlers do
       |> Repo.insert()
     end
 
-    # For back compat: older workers JSON-encode output_dataclip into a string before sending
-    # it (Lightning then decodes it); newer workers send the value already
-    # decoded.
-    defp maybe_decode_dataclip(value) when is_binary(value),
-      do: Jason.decode!(value)
+    # For back compat: older workers JSON-encode output_dataclip into a string
+    # before sending it (Lightning then decodes it); newer workers send the
+    # value already decoded. A bare string is ambiguous either way — e.g. a
+    # job can legitimately return "24", "true", or "{}" as its literal state
+    # — so we try to parse it as JSON and, if that fails, fall back to the
+    # string as-is. This can misclassify a literal string that happens to
+    # look like JSON (a job returning the string "24" ends up stored as the
+    # number 24), but returning a bare string as step state is already an
+    # edge case we're comfortable accepting the ambiguity on for now.
+    defp maybe_decode_dataclip(value) when is_binary(value) do
+      case Jason.decode(value) do
+        {:ok, decoded} -> decoded
+        {:error, _} -> value
+      end
+    end
 
     defp maybe_decode_dataclip(value), do: value
 

--- a/lib/lightning/runs/handlers.ex
+++ b/lib/lightning/runs/handlers.ex
@@ -406,9 +406,8 @@ defmodule Lightning.Runs.Handlers do
     @moduledoc """
     Schema to validate the input attributes of a completed step.
 
-    `output_dataclip` may arrive either as a JSON-encoded string (older
-    workers) or already decoded — a map, list, or scalar (newer workers).
-    See `maybe_decode_dataclip/1`. Map values are stored as-is; non-map
+    `output_dataclip` arrives already decoded (a map, list, or scalar) rather
+    than as a JSON-encoded string. Map values are stored as-is; non-map
     values are wrapped as `%{"value" => x}` before persistence.
     """
     use Lightning.Schema
@@ -555,29 +554,11 @@ defmodule Lightning.Runs.Handlers do
       Dataclip.new(%{
         id: dataclip_id,
         project_id: project_id,
-        body: output_dataclip |> maybe_decode_dataclip() |> ensure_map(),
+        body: output_dataclip |> ensure_map(),
         type: :step_result
       })
       |> Repo.insert()
     end
-
-    # For back compat: older workers JSON-encode output_dataclip into a string
-    # before sending it (Lightning then decodes it); newer workers send the
-    # value already decoded. A bare string is ambiguous either way — e.g. a
-    # job can legitimately return "24", "true", or "{}" as its literal state
-    # — so we try to parse it as JSON and, if that fails, fall back to the
-    # string as-is. This can misclassify a literal string that happens to
-    # look like JSON (a job returning the string "24" ends up stored as the
-    # number 24), but returning a bare string as step state is already an
-    # edge case we're comfortable accepting the ambiguity on for now.
-    defp maybe_decode_dataclip(value) when is_binary(value) do
-      case Jason.decode(value) do
-        {:ok, decoded} -> decoded
-        {:error, _} -> value
-      end
-    end
-
-    defp maybe_decode_dataclip(value), do: value
 
     defp ensure_map(%{} = map), do: map
     defp ensure_map(value), do: %{"value" => value}

--- a/lib/lightning/runs/handlers.ex
+++ b/lib/lightning/runs/handlers.ex
@@ -405,6 +405,11 @@ defmodule Lightning.Runs.Handlers do
   defmodule CompleteStep do
     @moduledoc """
     Schema to validate the input attributes of a completed step.
+
+    `output_dataclip` may arrive either as a JSON-encoded string (older
+    workers) or already decoded — a map, list, or scalar (newer workers).
+    See `maybe_decode_dataclip/1`. Map values are stored as-is; non-map
+    values are wrapped as `%{"value" => x}` before persistence.
     """
     use Lightning.Schema
     import Ecto.Query
@@ -415,7 +420,7 @@ defmodule Lightning.Runs.Handlers do
     embedded_schema do
       field :project_id, Ecto.UUID
       field :run_id, Ecto.UUID
-      field :output_dataclip, :string
+      field :output_dataclip, :any, virtual: true
       field :output_dataclip_id, Ecto.UUID
       field :reason, :string
       field :error_type, :string
@@ -550,11 +555,19 @@ defmodule Lightning.Runs.Handlers do
       Dataclip.new(%{
         id: dataclip_id,
         project_id: project_id,
-        body: output_dataclip |> Jason.decode!() |> ensure_map(),
+        body: output_dataclip |> maybe_decode_dataclip() |> ensure_map(),
         type: :step_result
       })
       |> Repo.insert()
     end
+
+    # For back compat: older workers JSON-encode output_dataclip into a string before sending
+    # it (Lightning then decodes it); newer workers send the value already
+    # decoded.
+    defp maybe_decode_dataclip(value) when is_binary(value),
+      do: Jason.decode!(value)
+
+    defp maybe_decode_dataclip(value), do: value
 
     defp ensure_map(%{} = map), do: map
     defp ensure_map(value), do: %{"value" => value}

--- a/lib/lightning/setup_utils.ex
+++ b/lib/lightning/setup_utils.ex
@@ -508,7 +508,7 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Done in 223ms! ✨
           """),
         input_dataclip_id: dataclip.id,
-        output_dataclip: %{data: http_body, references: []} |> Jason.encode!()
+        output_dataclip: %{"data" => http_body, "references" => []}
       },
       %{
         job_id: send_to_openhim.id,
@@ -532,7 +532,7 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Writing output to /tmp/output-1686840746-126941-i2yb2g.json
           [CLI] ✔ Done in 223ms! ✨
           """),
-        output_dataclip: %{data: http_body, references: []} |> Jason.encode!()
+        output_dataclip: %{"data" => http_body, "references" => []}
       },
       %{
         job_id: notify_upload_successful.id,
@@ -556,7 +556,7 @@ defmodule Lightning.SetupUtils do
           [CLI] ✔ Writing output to /tmp/output-1686840747-126941-16ewhef.json
           [CLI] ✔ Done in 209ms! ✨
           """),
-        output_dataclip: %{data: http_body, references: []} |> Jason.encode!()
+        output_dataclip: %{"data" => http_body, "references" => []}
       }
     ]
 
@@ -733,20 +733,18 @@ defmodule Lightning.SetupUtils do
             [CMP] ℹ Added export * statement for @openfn/language-dhis2@latest
           """),
         input_dataclip_id: input_dataclip.id,
-        output_dataclip:
-          %{
-            data: %{
-              spreadsheetId: "wv5ftwhte",
-              tableRange: "A3:D3",
-              updates: %{
-                updatedCells: 4
-              }
-            },
-            references: [
-              %{}
-            ]
-          }
-          |> Jason.encode!()
+        output_dataclip: %{
+          "data" => %{
+            "spreadsheetId" => "wv5ftwhte",
+            "tableRange" => "A3:D3",
+            "updates" => %{
+              "updatedCells" => 4
+            }
+          },
+          "references" => [
+            %{}
+          ]
+        }
       },
       %{
         job_id: upload_to_google_sheet.id,

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -412,6 +412,35 @@ defmodule Lightning.RunsTest do
         Runs.complete_step(%{
           step_id: step.id,
           reason: "success",
+          output_dataclip: %{"foo" => "bar"},
+          output_dataclip_id: Ecto.UUID.generate(),
+          run_id: run.id,
+          project_id: workflow.project_id
+        })
+
+      step =
+        step
+        |> Repo.preload(output_dataclip: Invocation.Query.dataclip_with_body())
+
+      assert step.exit_reason == "success"
+      assert Jason.decode!(step.output_dataclip.body) == %{"foo" => "bar"}
+    end
+
+    test "accepts a JSON-encoded string output_dataclip, for backward compatibility with older workers" do
+      dataclip = insert(:dataclip)
+      %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
+
+      %{runs: [run]} =
+        work_order_for(trigger, workflow: workflow, dataclip: dataclip)
+        |> insert()
+
+      step =
+        insert(:step, runs: [run], job: job, input_dataclip: dataclip)
+
+      {:ok, step} =
+        Runs.complete_step(%{
+          step_id: step.id,
+          reason: "success",
           output_dataclip: ~s({"foo": "bar"}),
           output_dataclip_id: Ecto.UUID.generate(),
           run_id: run.id,
@@ -446,7 +475,7 @@ defmodule Lightning.RunsTest do
                Runs.complete_step(%{
                  step_id: step.id,
                  reason: "success",
-                 output_dataclip: ~s({"deferred": "indexword"}),
+                 output_dataclip: %{"deferred" => "indexword"},
                  output_dataclip_id: output_dataclip_id,
                  run_id: run.id,
                  project_id: workflow.project_id
@@ -491,7 +520,7 @@ defmodule Lightning.RunsTest do
           %{
             step_id: step.id,
             reason: "success",
-            output_dataclip: ~s({"foo": "bar"}),
+            output_dataclip: %{"foo" => "bar"},
             output_dataclip_id: Ecto.UUID.generate(),
             run_id: run.id,
             project_id: workflow.project_id
@@ -538,7 +567,7 @@ defmodule Lightning.RunsTest do
                Runs.complete_step(%{
                  step_id: Ecto.UUID.generate(),
                  reason: "success",
-                 output_dataclip: ~s({"foo": "bar"}),
+                 output_dataclip: %{"foo" => "bar"},
                  output_dataclip_id: Ecto.UUID.generate(),
                  run_id: run.id,
                  project_id: workflow.project_id

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -455,6 +455,35 @@ defmodule Lightning.RunsTest do
       assert Jason.decode!(step.output_dataclip.body) == %{"foo" => "bar"}
     end
 
+    test "wraps a JSON-encoded scalar output_dataclip in %{\"value\" => x}" do
+      dataclip = insert(:dataclip)
+      %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
+
+      %{runs: [run]} =
+        work_order_for(trigger, workflow: workflow, dataclip: dataclip)
+        |> insert()
+
+      step =
+        insert(:step, runs: [run], job: job, input_dataclip: dataclip)
+
+      {:ok, step} =
+        Runs.complete_step(%{
+          step_id: step.id,
+          reason: "success",
+          output_dataclip: ~s(42),
+          output_dataclip_id: Ecto.UUID.generate(),
+          run_id: run.id,
+          project_id: workflow.project_id
+        })
+
+      step =
+        step
+        |> Repo.preload(output_dataclip: Invocation.Query.dataclip_with_body())
+
+      assert step.exit_reason == "success"
+      assert Jason.decode!(step.output_dataclip.body) == %{"value" => 42}
+    end
+
     # Regression for #4800: dataclip inserts no longer build the search_vector
     # synchronously (the AFTER INSERT trigger was dropped). Saving an output
     # dataclip via the handler must succeed and the row must be retrievable with

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -484,7 +484,7 @@ defmodule Lightning.RunsTest do
       assert Jason.decode!(step.output_dataclip.body) == %{"value" => 42}
     end
 
-    test "raises when output_dataclip is a plain string that isn't valid JSON" do
+    test "wraps a plain string output_dataclip that isn't valid JSON in %{\"value\" => x}" do
       dataclip = insert(:dataclip)
       %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
 
@@ -495,7 +495,7 @@ defmodule Lightning.RunsTest do
       step =
         insert(:step, runs: [run], job: job, input_dataclip: dataclip)
 
-      assert_raise Jason.DecodeError, fn ->
+      {:ok, step} =
         Runs.complete_step(%{
           step_id: step.id,
           reason: "success",
@@ -504,7 +504,13 @@ defmodule Lightning.RunsTest do
           run_id: run.id,
           project_id: workflow.project_id
         })
-      end
+
+      step =
+        step
+        |> Repo.preload(output_dataclip: Invocation.Query.dataclip_with_body())
+
+      assert step.exit_reason == "success"
+      assert Jason.decode!(step.output_dataclip.body) == %{"value" => "abc-123"}
     end
 
     # Regression for #4800: dataclip inserts no longer build the search_vector

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -484,6 +484,29 @@ defmodule Lightning.RunsTest do
       assert Jason.decode!(step.output_dataclip.body) == %{"value" => 42}
     end
 
+    test "raises when output_dataclip is a plain string that isn't valid JSON" do
+      dataclip = insert(:dataclip)
+      %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
+
+      %{runs: [run]} =
+        work_order_for(trigger, workflow: workflow, dataclip: dataclip)
+        |> insert()
+
+      step =
+        insert(:step, runs: [run], job: job, input_dataclip: dataclip)
+
+      assert_raise Jason.DecodeError, fn ->
+        Runs.complete_step(%{
+          step_id: step.id,
+          reason: "success",
+          output_dataclip: "abc-123",
+          output_dataclip_id: Ecto.UUID.generate(),
+          run_id: run.id,
+          project_id: workflow.project_id
+        })
+      end
+    end
+
     # Regression for #4800: dataclip inserts no longer build the search_vector
     # synchronously (the AFTER INSERT trigger was dropped). Saving an output
     # dataclip via the handler must succeed and the row must be retrievable with

--- a/test/lightning/runs_test.exs
+++ b/test/lightning/runs_test.exs
@@ -426,7 +426,7 @@ defmodule Lightning.RunsTest do
       assert Jason.decode!(step.output_dataclip.body) == %{"foo" => "bar"}
     end
 
-    test "accepts a JSON-encoded string output_dataclip, for backward compatibility with older workers" do
+    test "wraps a scalar output_dataclip in %{\"value\" => x}" do
       dataclip = insert(:dataclip)
       %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
 
@@ -441,36 +441,7 @@ defmodule Lightning.RunsTest do
         Runs.complete_step(%{
           step_id: step.id,
           reason: "success",
-          output_dataclip: ~s({"foo": "bar"}),
-          output_dataclip_id: Ecto.UUID.generate(),
-          run_id: run.id,
-          project_id: workflow.project_id
-        })
-
-      step =
-        step
-        |> Repo.preload(output_dataclip: Invocation.Query.dataclip_with_body())
-
-      assert step.exit_reason == "success"
-      assert Jason.decode!(step.output_dataclip.body) == %{"foo" => "bar"}
-    end
-
-    test "wraps a JSON-encoded scalar output_dataclip in %{\"value\" => x}" do
-      dataclip = insert(:dataclip)
-      %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
-
-      %{runs: [run]} =
-        work_order_for(trigger, workflow: workflow, dataclip: dataclip)
-        |> insert()
-
-      step =
-        insert(:step, runs: [run], job: job, input_dataclip: dataclip)
-
-      {:ok, step} =
-        Runs.complete_step(%{
-          step_id: step.id,
-          reason: "success",
-          output_dataclip: ~s(42),
+          output_dataclip: 42,
           output_dataclip_id: Ecto.UUID.generate(),
           run_id: run.id,
           project_id: workflow.project_id
@@ -482,35 +453,6 @@ defmodule Lightning.RunsTest do
 
       assert step.exit_reason == "success"
       assert Jason.decode!(step.output_dataclip.body) == %{"value" => 42}
-    end
-
-    test "wraps a plain string output_dataclip that isn't valid JSON in %{\"value\" => x}" do
-      dataclip = insert(:dataclip)
-      %{triggers: [trigger], jobs: [job]} = workflow = insert(:simple_workflow)
-
-      %{runs: [run]} =
-        work_order_for(trigger, workflow: workflow, dataclip: dataclip)
-        |> insert()
-
-      step =
-        insert(:step, runs: [run], job: job, input_dataclip: dataclip)
-
-      {:ok, step} =
-        Runs.complete_step(%{
-          step_id: step.id,
-          reason: "success",
-          output_dataclip: "abc-123",
-          output_dataclip_id: Ecto.UUID.generate(),
-          run_id: run.id,
-          project_id: workflow.project_id
-        })
-
-      step =
-        step
-        |> Repo.preload(output_dataclip: Invocation.Query.dataclip_with_body())
-
-      assert step.exit_reason == "success"
-      assert Jason.decode!(step.output_dataclip.body) == %{"value" => "abc-123"}
     end
 
     # Regression for #4800: dataclip inserts no longer build the search_vector

--- a/test/lightning_web/channels/run_channel_test.exs
+++ b/test/lightning_web/channels/run_channel_test.exs
@@ -976,7 +976,7 @@ defmodule LightningWeb.RunChannelTest do
         push(socket, "step:complete", %{
           "step_id" => step.id,
           "output_dataclip_id" => Ecto.UUID.generate(),
-          "output_dataclip" => ~s({"foo": "bar"}),
+          "output_dataclip" => %{"foo" => "bar"},
           "reason" => "normal",
           "timestamp" => to_string(timestamp)
         })
@@ -1001,7 +1001,7 @@ defmodule LightningWeb.RunChannelTest do
         push(socket, "step:complete", %{
           "step_id" => step.id,
           "output_dataclip_id" => Ecto.UUID.generate(),
-          "output_dataclip" => ~s({"foo": "bar"}),
+          "output_dataclip" => %{"foo" => "bar"},
           "reason" => "normal"
         })
 
@@ -1021,7 +1021,7 @@ defmodule LightningWeb.RunChannelTest do
         push(socket, "step:complete", %{
           "step_id" => step.id,
           "output_dataclip_id" => Ecto.UUID.generate(),
-          "output_dataclip" => ~s({"foo": "bar"}),
+          "output_dataclip" => %{"foo" => "bar"},
           "reason" => "fail"
         })
 
@@ -1043,7 +1043,7 @@ defmodule LightningWeb.RunChannelTest do
         push(socket, "step:complete", %{
           "step_id" => step_id,
           "output_dataclip_id" => dataclip_id,
-          "output_dataclip" => ~s({"foo": "bar"}),
+          "output_dataclip" => %{"foo" => "bar"},
           "reason" => "normal"
         })
 
@@ -1078,7 +1078,7 @@ defmodule LightningWeb.RunChannelTest do
         push(socket, "step:complete", %{
           "step_id" => step_id,
           "output_dataclip_id" => dataclip_id,
-          "output_dataclip" => ~s({"foo": "bar"}),
+          "output_dataclip" => %{"foo" => "bar"},
           "reason" => "normal"
         })
 
@@ -1105,7 +1105,7 @@ defmodule LightningWeb.RunChannelTest do
       ref =
         push(socket, "step:complete", %{
           "step_id" => step_id,
-          "output_dataclip" => ~s({"foo": "bar"}),
+          "output_dataclip" => %{"foo" => "bar"},
           "reason" => "normal"
         })
 
@@ -1124,7 +1124,7 @@ defmodule LightningWeb.RunChannelTest do
         push(socket, "step:complete", %{
           "step_id" => foreign_step.id,
           "output_dataclip_id" => output_dataclip_id,
-          "output_dataclip" => ~s({"leaked": "data"}),
+          "output_dataclip" => %{"leaked" => "data"},
           "reason" => "fail"
         })
 
@@ -2446,7 +2446,7 @@ defmodule LightningWeb.RunChannelTest do
       %{
         "step_id" => step.id,
         "output_dataclip_id" => Ecto.UUID.generate(),
-        "output_dataclip" => ~s({"foo": "bar"}),
+        "output_dataclip" => %{"foo" => "bar"},
         "reason" => "normal"
       }
       |> maybe_put("webhook_response", Keyword.get(opts, :webhook_response))
@@ -2956,7 +2956,7 @@ defmodule LightningWeb.RunChannelTest do
         Lightning.Runs.complete_step(
           %{
             "step_id" => step.id,
-            "output_dataclip" => Jason.encode!(%{"foo" => "bar"}),
+            "output_dataclip" => %{"foo" => "bar"},
             "output_dataclip_id" => Ecto.UUID.generate(),
             "reason" => "success",
             "finished_at" => DateTime.utc_now(),

--- a/test/lightning_web/live/run_live/show_test.exs
+++ b/test/lightning_web/live/run_live/show_test.exs
@@ -163,7 +163,7 @@ defmodule LightningWeb.RunLive.ShowTest do
           run_id: run_id,
           project_id: project.id,
           step_id: step.id,
-          output_dataclip: ~s({"y": 2}),
+          output_dataclip: %{"y" => 2},
           output_dataclip_id: output_dataclip_id = Ecto.UUID.generate(),
           reason: "success"
         })
@@ -207,7 +207,7 @@ defmodule LightningWeb.RunLive.ShowTest do
           run_id: run_id,
           project_id: project.id,
           step_id: step_2.id,
-          output_dataclip: ~s({"z": 2}),
+          output_dataclip: %{"z" => 2},
           output_dataclip_id: step_2_output_dataclip_id = Ecto.UUID.generate(),
           reason: "success"
         })
@@ -281,7 +281,7 @@ defmodule LightningWeb.RunLive.ShowTest do
           run_id: run_id,
           project_id: project.id,
           step_id: step.id,
-          output_dataclip: ~s({"result": 42}),
+          output_dataclip: %{"result" => 42},
           output_dataclip_id: output_dataclip_id = Ecto.UUID.generate(),
           reason: "success"
         })
@@ -465,7 +465,7 @@ defmodule LightningWeb.RunLive.ShowTest do
         run_id: run_id,
         project_id: project.id,
         step_id: step.id,
-        output_dataclip: ~s({"y": 2}),
+        output_dataclip: %{"y" => 2},
         output_dataclip_id: Ecto.UUID.generate(),
         reason: "success"
       })


### PR DESCRIPTION
DO NOT MERGE

## Description

In https://github.com/OpenFn/lightning/pull/5098 we added functionality to support dataclips being sent as JSON (where as previously they were sent as a JSON encoded string)

This PR removes the "maybe" and forces step:complete to treat the dataclip as an object.

We cannot merge this until we've had a major bump of the worker and found some resolution to https://github.com/OpenFn/lightning/issues/5103

## Validation steps

1.Run a workflow
1. Ensure that the output of each step is correct (not an object with `{ value }` wrapper)
1. Ensure that scalar (number, string, boolean) return value are all handled with `{  value }` wrapper 


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
