### PR TITLE
Name webhook trigger's URL at configuration time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 
 ### Added
 
+- Webhook triggers can be given a custom URL path, so an endpoint's URL is known
+  before it is deployed. A trigger with a path of `facility-001` in project
+  `abc-123` answers at `/i/abc-123/facility-001`. Set it in the trigger panel,
+  in `project.yaml`, or through the workflows API. Existing `/i/<trigger-id>`
+  URLs are unchanged. [#4952](https://github.com/OpenFn/lightning/issues/4952)
 - The workflow title in the editor breadcrumbs is now clickable, returning to
   the root workflow editor view: it closes the full IDE (equivalent to its close
   button), closes any other open panel, deselects the current node, and drops

--- a/assets/js/collaborative-editor/adapters/YAMLStateToYDoc.ts
+++ b/assets/js/collaborative-editor/adapters/YAMLStateToYDoc.ts
@@ -78,6 +78,13 @@ export class YAMLStateToYDoc {
     }
 
     if (trigger.type === 'webhook') {
+      // Only when the spec said something. An absent key means "leave it
+      // alone", matching the provisioner, so applying a spec that never
+      // mentions the path cannot clear a live URL.
+      if (trigger.custom_path !== undefined) {
+        triggerMap.set('custom_path', trigger.custom_path);
+      }
+
       triggerMap.set('webhook_reply', trigger.webhook_reply ?? null);
       triggerMap.set(
         'webhook_response_config',
@@ -136,10 +143,36 @@ export class YAMLStateToYDoc {
 
       // 3. Clear and populate triggers array
       const triggersArray = ydoc.getArray('triggers');
+
+      // What each trigger currently holds, so a spec that never mentions the
+      // path keeps it rather than blanking a live URL on the next edit.
+      const existingPaths = new Map<string, unknown>();
+      triggersArray.toArray().forEach(entry => {
+        const map = entry as Y.Map<unknown>;
+        const id = map.get('id');
+        if (typeof id === 'string' && map.has('custom_path')) {
+          existingPaths.set(id, map.get('custom_path'));
+        }
+      });
+
       triggersArray.delete(0, triggersArray.length);
-      const transformedTriggers = workflowState.triggers.map(trigger =>
-        this.transformTrigger(trigger)
-      );
+      const transformedTriggers = workflowState.triggers.map(trigger => {
+        const map = this.transformTrigger(trigger);
+
+        // Asks the source, not the map. `map` is not in the document yet, so
+        // `set` writes to prelim content while `has` reads the still-empty
+        // `_map` and always answers false, which would let an existing path
+        // beat the one the spec just stated.
+        if (
+          trigger.type === 'webhook' &&
+          trigger.custom_path === undefined &&
+          existingPaths.has(trigger.id)
+        ) {
+          map.set('custom_path', existingPaths.get(trigger.id));
+        }
+
+        return map;
+      });
       triggersArray.push(transformedTriggers);
 
       // 4. Clear and populate edges array

--- a/assets/js/collaborative-editor/components/inspector/trigger/TriggerEditWizard.tsx
+++ b/assets/js/collaborative-editor/components/inspector/trigger/TriggerEditWizard.tsx
@@ -64,6 +64,7 @@ export function TriggerEditWizard({
 
   const {
     draft,
+    pathUnchanged,
     mergeDraft,
     draftAuthMethodIds,
     setDraftAuthMethodIds,
@@ -111,6 +112,7 @@ export function TriggerEditWizard({
         return (
           <WebhookConfigureStep
             draft={draft}
+            pathUnchanged={pathUnchanged}
             mergeDraft={mergeDraft}
             draftAuthMethodIds={draftAuthMethodIds}
             setDraftAuthMethodIds={setDraftAuthMethodIds}

--- a/assets/js/collaborative-editor/components/inspector/trigger/TriggerPicker.tsx
+++ b/assets/js/collaborative-editor/components/inspector/trigger/TriggerPicker.tsx
@@ -79,7 +79,14 @@ export function TriggerPicker({
     if (draft.type !== type) {
       // Drop `enabled` from the defaults so the draft keeps the trigger's
       // current enabled state — a type change must not re-enable a disabled one.
-      const { enabled: _enabled, ...defaults } = createDefaultTrigger(type);
+      // `custom_path` goes the same way: switching to cron and back within one
+      // session would otherwise write a null over a live endpoint's name.
+      const {
+        enabled: _enabled,
+        custom_path: _customPath,
+        ...defaults
+      } = createDefaultTrigger(type);
+
       mergeDraft(defaults as Partial<Workflow.Trigger>);
     }
     onReturnToChoose();

--- a/assets/js/collaborative-editor/components/inspector/trigger/WebhookConfigureStep.tsx
+++ b/assets/js/collaborative-editor/components/inspector/trigger/WebhookConfigureStep.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import {
+  isValidCustomPath,
+  toCustomPath,
+} from '#/collaborative-editor/types/trigger';
 import { cn } from '#/utils/cn';
 
 import { useLiveViewActions } from '../../../contexts/LiveViewActionsContext';
@@ -7,7 +11,10 @@ import {
   usePermissions,
   useSessionContext,
 } from '../../../hooks/useSessionContext';
-import { useWorkflowReadOnly } from '../../../hooks/useWorkflow';
+import {
+  useWorkflowReadOnly,
+  useWorkflowState,
+} from '../../../hooks/useWorkflow';
 import type { WebhookAuthMethod } from '../../../types/sessionContext';
 import type { Workflow } from '../../../types/workflow';
 import { InspectorLayout } from '../InspectorLayout';
@@ -16,6 +23,12 @@ import { ResponseTypeSelect } from './ResponseTypeSelect';
 import { WebhookAuthMethodSelect } from './WebhookAuthMethodSelect';
 import { WizardBreadcrumb } from './WizardBreadcrumb';
 import { WizardFooter } from './WizardFooter';
+
+const inputClass = cn(
+  'block w-full rounded-lg border border-gray-200 px-3 py-2 text-sm',
+  'focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500',
+  'disabled:cursor-not-allowed disabled:opacity-50'
+);
 
 const codeInputClass = cn(
   'block w-full rounded-lg border border-gray-200 bg-white px-3 py-2',
@@ -32,6 +45,12 @@ type ResponseConfig = {
 interface WebhookConfigureStepProps {
   /** The local trigger draft. */
   draft: Workflow.Trigger;
+  /**
+   * Whether the path is the one the trigger opened with, from
+   * `useTriggerDraft`. Taken rather than recomputed: the step and the save have
+   * to agree, or Finish refuses with nothing on screen marked wrong.
+   */
+  pathUnchanged: boolean;
   /** Shallow-merge updates into the draft. */
   mergeDraft: (updates: Partial<Workflow.Trigger>) => void;
   /** The local, uncommitted auth-method id set. */
@@ -64,6 +83,7 @@ function hasResponseConfig(config: ResponseConfig): boolean {
  */
 export function WebhookConfigureStep({
   draft,
+  pathUnchanged,
   mergeDraft,
   draftAuthMethodIds,
   setDraftAuthMethodIds,
@@ -76,6 +96,7 @@ export function WebhookConfigureStep({
 }: WebhookConfigureStepProps) {
   const permissions = usePermissions();
   const { webhookAuthMethods } = useSessionContext();
+  const workflowName = useWorkflowState(state => state.workflow?.name ?? null);
   const { pushEvent } = useLiveViewActions();
   const { isReadOnly } = useWorkflowReadOnly();
   // Default to no-write until permissions load. During the loading window we
@@ -113,6 +134,43 @@ export function WebhookConfigureStep({
   }, [pushEvent]);
 
   const config = draft.webhook_response_config ?? null;
+  const customPath = draft.type === 'webhook' ? (draft.custom_path ?? '') : '';
+
+  // Kept as typed; the draft holds what it derives to.
+  const [typedPath, setTypedPath] = useState(customPath);
+
+  // A suggestion, not a write: empty still means "keep the generated URL".
+  const suggestedPath = toCustomPath(workflowName ?? '') || 'facility-001';
+
+  // Uniqueness is server-only. Shown while the path is still the one it
+  // complained about, since the draft's copy never updates.
+  const serverPathError = pathUnchanged
+    ? (draft.errors?.['custom_path']?.[0] ?? null)
+    : null;
+
+  const customPathError = (() => {
+    // An untouched path is not judged: its only fix is the rename that would
+    // retire the live URL.
+    if (pathUnchanged || customPath === '') return serverPathError;
+
+    // Held as typed rather than cleared, so the save refuses.
+    if (toCustomPath(customPath) === '') {
+      return 'That name has no letters or numbers in it.';
+    }
+
+    if (isValidCustomPath(customPath)) return serverPathError;
+
+    if (customPath.length > 255) {
+      return 'Too long. Keep it to 255 characters or fewer.';
+    }
+
+    if (/^[a-z0-9_-]+$/.test(customPath)) {
+      return 'A UUID cannot be used as a path.';
+    }
+
+    return 'Use lowercase letters, numbers, hyphens and underscores only.';
+  })();
+
   const isAfterCompletion = draft.webhook_reply === 'after_completion';
 
   const projectAuthMethods = useMemo<WebhookAuthMethod[]>(
@@ -140,6 +198,80 @@ export function WebhookConfigureStep({
             if (target === 'choose') onBack();
           }}
         />
+
+        {/* Label, description, control: the order Response Type uses. */}
+        <div className="space-y-1">
+          <label
+            htmlFor="webhook-custom-path"
+            className="block text-sm font-medium text-slate-800"
+          >
+            Custom URL path
+          </label>
+          <p
+            id="webhook-custom-path-hint"
+            className="block text-xs text-slate-500"
+          >
+            Names this endpoint so you know its URL before you deploy. Leave
+            blank to keep the generated one.
+          </p>
+
+          <input
+            id="webhook-custom-path"
+            type="text"
+            placeholder={suggestedPath}
+            spellCheck={false}
+            autoComplete="off"
+            disabled={isReadOnly}
+            value={typedPath}
+            onChange={e => {
+              // Keep what was typed, store what it becomes, the way the
+              // project form treats a project name.
+              const typed = e.target.value;
+              setTypedPath(typed);
+
+              const derived = toCustomPath(typed);
+
+              if (typed !== '' && derived === '') {
+                // Null would read as "cleared" and retire a live URL, so the
+                // raw value goes in for the schema to refuse.
+                mergeDraft({ custom_path: typed });
+                return;
+              }
+
+              mergeDraft({ custom_path: derived === '' ? null : derived });
+            }}
+            aria-invalid={customPathError ? true : undefined}
+            aria-describedby={
+              customPathError
+                ? 'webhook-custom-path-hint webhook-custom-path-error'
+                : 'webhook-custom-path-hint'
+            }
+            className={cn(
+              inputClass,
+              'mt-1 font-mono',
+              customPathError &&
+                'border-red-300 focus:border-red-500 focus:ring-red-500'
+            )}
+          />
+          {customPathError ? (
+            <p
+              id="webhook-custom-path-error"
+              className="block text-xs text-red-600"
+            >
+              {customPathError}
+            </p>
+          ) : typedPath !== '' &&
+            customPath !== '' &&
+            customPath !== typedPath ? (
+            <p className="block text-xs text-slate-500">
+              This will be named{' '}
+              <span className="rounded border border-slate-300 bg-yellow-100 px-1 font-mono">
+                {customPath}
+              </span>
+              .
+            </p>
+          ) : null}
+        </div>
 
         {/* Response Type */}
         <div className="space-y-1">

--- a/assets/js/collaborative-editor/components/inspector/trigger/WebhookShowPanel.tsx
+++ b/assets/js/collaborative-editor/components/inspector/trigger/WebhookShowPanel.tsx
@@ -71,6 +71,7 @@ export function WebhookShowPanel({
       ? 'none configured'
       : `${authCount} configured`;
 
+  const pathError = trigger.errors?.['custom_path']?.[0] ?? null;
   const responseConfig = trigger.webhook_response_config;
   const isAfterCompletion = trigger.webhook_reply === 'after_completion';
   const responseType = isAfterCompletion ? ON_COMPLETE : IMMEDIATELY;
@@ -102,6 +103,16 @@ export function WebhookShowPanel({
           copyText={copyText}
           onCopy={url => void copyToClipboard(url)}
         />
+
+        {/* Uniqueness is only knowable on the server, and it answers after the
+            wizard has already closed. The URL above falls back to the generated
+            one while the name is refused, so it is the endpoint that works. */}
+        {pathError ? (
+          <p className="-mt-4 block text-xs text-red-600">
+            The custom path was not saved: {pathError}. The URL above is this
+            trigger's generated one, which does work.
+          </p>
+        ) : null}
 
         {/* Authentication */}
         <div>

--- a/assets/js/collaborative-editor/components/inspector/trigger/useTriggerDraft.ts
+++ b/assets/js/collaborative-editor/components/inspector/trigger/useTriggerDraft.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { TriggerSchema } from '#/collaborative-editor/types/trigger';
+import { TriggerDraftSchema } from '#/collaborative-editor/types/trigger';
 
 import { useWorkflowActions } from '../../../hooks/useWorkflow';
 import type { Workflow } from '../../../types/workflow';
@@ -24,6 +24,12 @@ export interface UseTriggerDraftOptions {
  * Return shape of the {@link useTriggerDraft} hook.
  */
 export interface UseTriggerDraftResult {
+  /**
+   * Whether the path is the one the trigger opened with. False when it is
+   * being changed, and false when the trigger is becoming a webhook, since a
+   * path that meant nothing on a cron row is about to become a live URL.
+   */
+  pathUnchanged: boolean;
   /** The local, uncommitted trigger draft. */
   draft: Workflow.Trigger;
   /** Shallow-merges `updates` into the draft. Never touches the Y.Doc. */
@@ -151,18 +157,46 @@ export function useTriggerDraft(
     return triggerChanged || authIdsChanged;
   }, [draft, authIdsChanged]);
 
+  // Judge only what the user changed, so a pre-migration path does not block
+  // edits to anything else.
+  const baselineCustomPath = baselineRef.current.custom_path ?? null;
+
+  // Becoming a webhook makes a path that meant nothing on a cron or kafka
+  // trigger into a live URL, and the server validates it then. Leaving it out
+  // here would close the wizard on a save the server refuses.
+  const becomingWebhook =
+    draft.type === 'webhook' && baselineRef.current.type !== 'webhook';
+
+  const pathUnchanged =
+    !becomingWebhook && (draft.custom_path ?? null) === baselineCustomPath;
+
+  const draftIssues = useMemo(() => {
+    const result = TriggerDraftSchema.safeParse(draft);
+    if (result.success) return [];
+
+    return result.error.issues.filter(
+      issue => !(pathUnchanged && issue.path[0] === 'custom_path')
+    );
+  }, [draft, pathUnchanged]);
+
+  // The path reports against its own field, so the footer points at it rather
+  // than repeating it. Silence would leave Finish doing nothing when the field
+  // is scrolled behind an open disclosure.
   const validationError = useMemo(() => {
-    const result = TriggerSchema.safeParse(draft);
-    if (result.success) return null;
-    return result.error.issues[0]?.message ?? 'Invalid trigger configuration';
-  }, [draft]);
+    const elsewhere = draftIssues.find(
+      issue => issue.path[0] !== 'custom_path'
+    );
+
+    if (elsewhere) return elsewhere.message;
+    if (draftIssues.length > 0) return 'Fix the highlighted field to finish.';
+
+    return null;
+  }, [draftIssues]);
 
   const commit = useCallback(async (): Promise<{ ok: boolean }> => {
-    const result = TriggerSchema.safeParse(draft);
-
     // Invalid draft: do not persist. `validationError` (derived above) already
     // reflects the failure for the caller to surface.
-    if (!result.success) {
+    if (draftIssues.length > 0) {
       return { ok: false };
     }
 
@@ -190,6 +224,7 @@ export function useTriggerDraft(
     return { ok: true };
   }, [
     draft,
+    draftIssues,
     trigger.id,
     updateTrigger,
     authIdsChanged,
@@ -198,6 +233,7 @@ export function useTriggerDraft(
   ]);
 
   return {
+    pathUnchanged,
     draft,
     mergeDraft,
     draftAuthMethodIds,

--- a/assets/js/collaborative-editor/components/inspector/trigger/useWebhookTrigger.ts
+++ b/assets/js/collaborative-editor/components/inspector/trigger/useWebhookTrigger.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect } from 'react';
 
 import { useCopyToClipboard } from '#/collaborative-editor/hooks/useCopyToClipboard';
+import { isValidCustomPath } from '#/collaborative-editor/types/trigger';
 
 import { channelRequest } from '../../../hooks/useChannel';
 import { useSession } from '../../../hooks/useSession';
+import { useProject } from '../../../hooks/useSessionContext';
 import {
   useWorkflowActions,
   useWorkflowState,
@@ -16,7 +18,10 @@ import type { Workflow } from '../../../types/workflow';
  * Return shape of the {@link useWebhookTrigger} hook.
  */
 export interface UseWebhookTriggerResult {
-  /** The webhook ingest URL for this trigger (`<origin>/i/<trigger.id>`). */
+  /**
+   * The webhook ingest URL for this trigger: `<origin>/i/<project.id>/<path>`
+   * when it has a custom path, `<origin>/i/<trigger.id>` otherwise.
+   */
   webhookUrl: string;
   /** Display text for the copy button ('' | 'Copied!' | 'Failed'). */
   copyText: string;
@@ -55,6 +60,7 @@ export function useWebhookTrigger(
   const { requestTriggerAuthMethods } = useWorkflowActions();
   const { copyText, copyToClipboard } = useCopyToClipboard();
   const { provider } = useSession();
+  const project = useProject();
   const channel = provider?.channel;
 
   const activeTriggerAuthMethods = useWorkflowState(
@@ -80,10 +86,25 @@ export function useWebhookTrigger(
     activeTriggerAuthMethods === null ||
     activeTriggerAuthMethods.trigger_id !== trigger.id;
 
-  const webhookUrl = new URL(
-    `/i/${trigger.id}`,
-    window.location.origin
-  ).toString();
+  const customPath =
+    trigger.type === 'webhook' ? (trigger.custom_path ?? null) : null;
+
+  // A refused path is not this trigger's. It stays in the Y.Doc, and a duplicate
+  // resolves to whichever workflow legitimately owns it.
+  const rejected = Boolean(trigger.errors?.['custom_path']?.length);
+
+  // Only a path the lookup can match. A legacy one holding a slash is stored
+  // verbatim but is not addressable, so the generated URL is the one that works.
+  const addressable =
+    !rejected && customPath !== null && isValidCustomPath(customPath);
+
+  // Not encoded: the plug runs before the router and compares raw segments.
+  const path =
+    addressable && project?.id
+      ? `/i/${project.id}/${customPath}`
+      : `/i/${trigger.id}`;
+
+  const webhookUrl = new URL(path, window.location.origin).toString();
 
   const commitAuthMethods = useCallback(
     async (ids: string[]) => {

--- a/assets/js/collaborative-editor/types/session.ts
+++ b/assets/js/collaborative-editor/types/session.ts
@@ -68,6 +68,7 @@ export namespace Session {
     id: string;
     type: string;
     enabled: boolean;
+    custom_path: string | null;
     cron_expression: string | null;
     has_auth_method: boolean;
     webhook_reply: 'before_start' | 'after_completion' | null;

--- a/assets/js/collaborative-editor/types/trigger.ts
+++ b/assets/js/collaborative-editor/types/trigger.ts
@@ -17,6 +17,7 @@ const baseTriggerSchema = z.object({
 // Webhook trigger schema
 const webhookTriggerSchema = baseTriggerSchema.extend({
   type: z.literal('webhook'),
+  custom_path: z.string().nullable().default(null),
   cron_expression: z.null().default(null),
   cron_cursor_job_id: z.null().default(null),
   kafka_configuration: z.null().default(null),
@@ -36,6 +37,9 @@ const webhookTriggerSchema = baseTriggerSchema.extend({
 // Cron trigger schema with professional validation using cron-validator
 const cronTriggerSchema = baseTriggerSchema.extend({
   type: z.literal('cron'),
+  // Serialised for every trigger type; a pre-migration row can hold one here.
+  // Accept and ignore rather than failing the whole workflow parse.
+  custom_path: z.string().nullable().default(null),
   cron_expression: z
     .string()
     .min(1, 'Cron expression is required')
@@ -108,6 +112,8 @@ const kafkaConfigSchema = z
 // Kafka trigger schema
 const kafkaTriggerSchema = baseTriggerSchema.extend({
   type: z.literal('kafka'),
+  // See the note on the cron schema.
+  custom_path: z.string().nullable().default(null),
   cron_expression: z.null().default(null),
   cron_cursor_job_id: z.null().default(null),
   kafka_configuration: kafkaConfigSchema,
@@ -127,6 +133,56 @@ export const TriggerSchema = z.discriminatedUnion('type', [
 
 export type Trigger = z.infer<typeof TriggerSchema>;
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Mirrors the server rule in `Lightning.Workflows.Trigger`. */
+export const isValidCustomPath = (path: string): boolean =>
+  /^[a-z0-9_-]{1,255}$/.test(path) && !UUID_RE.test(path);
+
+/**
+ * Derives a usable path, the way the project form derives a project name from
+ * `raw_name`. Narrower: a webhook path is `[a-z0-9_-]` only.
+ */
+export const toCustomPath = (typed: string): string => {
+  // Deriving would strip hyphens off a value the server accepts.
+  if (isValidCustomPath(typed)) return typed;
+
+  return typed
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
+
+/**
+ * What a user is allowed to write. `TriggerSchema` stays permissive because it
+ * also parses what the server sends, including pre-migration paths.
+ */
+export const TriggerDraftSchema = TriggerSchema.superRefine((trigger, ctx) => {
+  // Blank is no path, which is how the server reads it too.
+  if (trigger.type !== 'webhook') return;
+  if (trigger.custom_path == null || trigger.custom_path === '') return;
+
+  if (!/^[a-z0-9_-]{1,255}$/.test(trigger.custom_path)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['custom_path'],
+      message:
+        'Custom URL path: use lowercase letters, numbers, hyphens and underscores only.',
+    });
+    return;
+  }
+
+  // A UUID-shaped path resolves against trigger ids, so it is unreachable.
+  if (UUID_RE.test(trigger.custom_path)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['custom_path'],
+      message: 'Custom URL path: cannot be a UUID.',
+    });
+  }
+});
+
 /**
  * Helper function to create default trigger values by type
  */
@@ -142,6 +198,7 @@ export const createDefaultTrigger = (
       return {
         ...base,
         type: 'webhook' as const,
+        custom_path: null,
         cron_expression: null,
         cron_cursor_job_id: null,
         kafka_configuration: null,
@@ -153,6 +210,7 @@ export const createDefaultTrigger = (
       return {
         ...base,
         type: 'cron' as const,
+        custom_path: null,
         cron_expression: '0 0 * * *', // Daily at midnight default
         cron_cursor_job_id: null,
         kafka_configuration: null,
@@ -163,6 +221,7 @@ export const createDefaultTrigger = (
       return {
         ...base,
         type: 'kafka' as const,
+        custom_path: null,
         cron_expression: null,
         cron_cursor_job_id: null,
         kafka_configuration: {

--- a/assets/js/yaml/schema/workflow-spec.json
+++ b/assets/js/yaml/schema/workflow-spec.json
@@ -4,10 +4,16 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "name": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "jobs": {
       "type": "object",
@@ -15,11 +21,27 @@
         "^.*$": {
           "type": "object",
           "properties": {
-            "id": { "type": ["string", "null"] },
-            "name": { "type": "string" },
-            "adaptor": { "type": "string" },
-            "body": { "type": "string" },
-            "credential": { "type": ["string", "null"] },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "adaptor": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "credential": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "pos": {
               "type": "object",
               "properties": {
@@ -32,7 +54,11 @@
               }
             }
           },
-          "required": ["name", "adaptor", "body"],
+          "required": [
+            "name",
+            "adaptor",
+            "body"
+          ],
           "additionalProperties": false
         }
       },
@@ -44,10 +70,19 @@
         "^.*$": {
           "type": "object",
           "properties": {
-            "id": { "type": ["string", "null"] },
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "type": "string",
-              "enum": ["cron", "webhook", "kafka"]
+              "enum": [
+                "cron",
+                "webhook",
+                "kafka"
+              ]
             },
             "enabled": {
               "type": "boolean"
@@ -56,17 +91,40 @@
               "type": "string"
             },
             "cron_cursor_job": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "webhook_reply": {
-              "type": ["string", "null"],
-              "enum": ["before_start", "after_completion", null]
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "before_start",
+                "after_completion",
+                null
+              ]
             },
             "webhook_response_config": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
-                "success_code": { "type": ["integer", "null"] },
-                "error_code": { "type": ["integer", "null"] }
+                "success_code": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "error_code": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
               },
               "additionalProperties": false
             },
@@ -80,25 +138,46 @@
                   "type": "number"
                 }
               }
+            },
+            "custom_path": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["type", "enabled"],
+          "required": [
+            "type",
+            "enabled"
+          ],
           "additionalProperties": false,
           "oneOf": [
             {
               "properties": {
-                "type": { "const": "webhook" }
+                "type": {
+                  "const": "webhook"
+                }
               }
             },
             {
               "properties": {
-                "type": { "const": "cron" },
-                "cron_expression": { "type": "string" }
+                "type": {
+                  "const": "cron"
+                },
+                "cron_expression": {
+                  "type": "string"
+                }
               },
-              "required": ["cron_expression"]
+              "required": [
+                "cron_expression"
+              ]
             },
             {
-              "properties": { "type": { "const": "kafka" } }
+              "properties": {
+                "type": {
+                  "const": "kafka"
+                }
+              }
             }
           ]
         }
@@ -111,22 +190,52 @@
         "^.*$": {
           "type": "object",
           "properties": {
-            "id": { "type": ["string", "null"] },
-            "source_trigger": { "type": "string" },
-            "source_job": { "type": "string" },
-            "target_job": { "type": "string" },
-            "condition_type": { "type": "string" },
-            "condition_label": { "type": "string" },
-            "condition_expression": { "type": ["string", "null"] },
-            "enabled": { "type": "boolean" }
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_trigger": {
+              "type": "string"
+            },
+            "source_job": {
+              "type": "string"
+            },
+            "target_job": {
+              "type": "string"
+            },
+            "condition_type": {
+              "type": "string"
+            },
+            "condition_label": {
+              "type": "string"
+            },
+            "condition_expression": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": "boolean"
+            }
           },
-          "required": ["target_job", "condition_type", "enabled"],
+          "required": [
+            "target_job",
+            "condition_type",
+            "enabled"
+          ],
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     }
   },
-  "required": ["jobs", "triggers", "edges"],
+  "required": [
+    "jobs",
+    "triggers",
+    "edges"
+  ],
   "additionalProperties": false
 }

--- a/assets/js/yaml/types.ts
+++ b/assets/js/yaml/types.ts
@@ -28,6 +28,7 @@ export type StateWebhookTrigger = {
   id: string;
   enabled: boolean;
   type: 'webhook';
+  custom_path?: string | null;
   webhook_reply: 'before_start' | 'after_completion' | null | undefined;
   webhook_response_config?: {
     success_code?: number | null;
@@ -100,6 +101,8 @@ export type SpecWebhookTrigger = {
   id?: string;
   type: 'webhook';
   enabled: boolean;
+  /** Names the endpoint, so its URL is `/i/<project-id>/<custom_path>`. */
+  custom_path?: string | null;
   webhook_reply: string | null;
   webhook_response_config?: WebhookResponseConfig | null;
   pos: Position | undefined;

--- a/assets/js/yaml/util.ts
+++ b/assets/js/yaml/util.ts
@@ -1,6 +1,7 @@
 import Ajv, { type ErrorObject } from 'ajv';
 import YAML from 'yaml';
 
+import { isValidCustomPath } from '../collaborative-editor/types/trigger';
 import type { Workflow } from '../collaborative-editor/types/workflow';
 import { randomUUID } from '../common';
 
@@ -11,6 +12,7 @@ import type {
   SpecEdge,
   SpecJob,
   SpecTrigger,
+  SpecWebhookTrigger,
   StateEdge,
   StateJob,
   StateTrigger,
@@ -81,6 +83,18 @@ export const convertWorkflowStateToSpec = (
     }
 
     if (trigger.type === 'webhook') {
+      const webhookDetails = triggerDetails as SpecWebhookTrigger;
+
+      // Per-project identity, so it goes with the ids when stripped for a
+      // template. And only one the server would accept, or the import fails.
+      if (
+        includeIds &&
+        trigger.custom_path &&
+        isValidCustomPath(trigger.custom_path)
+      ) {
+        webhookDetails.custom_path = trigger.custom_path;
+      }
+
       triggerDetails.webhook_reply = trigger.webhook_reply ?? null;
       const config = trigger.webhook_response_config;
       if (
@@ -197,6 +211,11 @@ export const convertWorkflowSpecToState = (
         id: uId,
         type: 'webhook',
         enabled,
+        // Spread, so an absent key stays absent and reads as "unchanged"
+        // rather than as a clear.
+        ...(specTrigger.custom_path !== undefined && {
+          custom_path: specTrigger.custom_path,
+        }),
         webhook_reply: specTrigger.webhook_reply,
         webhook_response_config: specTrigger.webhook_response_config ?? null,
       };

--- a/assets/test/collaborative-editor/__helpers__/triggerInspectorHelpers.tsx
+++ b/assets/test/collaborative-editor/__helpers__/triggerInspectorHelpers.tsx
@@ -42,6 +42,8 @@ import { createMockSocket } from './sessionStoreHelpers';
 // ---------------------------------------------------------------------------
 
 export interface TriggerTestHarnessOptions {
+  /** Project on the session context. Defaults to none. */
+  project?: { id: string; name: string } | null;
   /** Whether the session-context emits can_edit_workflow=true (default: true). */
   canEdit?: boolean;
   /**
@@ -117,6 +119,7 @@ export async function createTriggerTestHarness(
     canWriteWebhookAuthMethod = canEdit,
     kafkaEnabled = false,
     webhookAuthMethods = [],
+    project = null,
     workflowStore,
     liveViewActions,
   } = options;
@@ -160,7 +163,7 @@ export async function createTriggerTestHarness(
       }
     )._test.emit('session_context', {
       user: null,
-      project: null,
+      project,
       config: {
         require_email_verification: false,
         kafka_triggers_enabled: kafkaEnabled,

--- a/assets/test/collaborative-editor/adapters/YAMLStateToYDoc.test.ts
+++ b/assets/test/collaborative-editor/adapters/YAMLStateToYDoc.test.ts
@@ -641,4 +641,120 @@ describe('YAMLStateToYDoc', () => {
       expect(ydoc.getMap('positions').size).toBe(3);
     });
   });
+
+  describe('custom_path', () => {
+    const stateWith = (trigger: Record<string, unknown>) => ({
+      id: 'workflow-test',
+      name: 'Test',
+      jobs: [],
+      triggers: [trigger],
+      edges: [],
+      positions: null,
+    });
+
+    const triggerMapFrom = (trigger: Record<string, unknown>) => {
+      YAMLStateToYDoc.applyToYDoc(ydoc, stateWith(trigger) as never);
+      return ydoc.getArray('triggers').get(0) as Y.Map<unknown>;
+    };
+
+    test('carries a path the spec states', () => {
+      const map = triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: 'facility-001',
+        webhook_reply: null,
+      });
+
+      expect(map.get('custom_path')).toBe('facility-001');
+    });
+
+    test('leaves the key absent when the spec never mentions it', () => {
+      // Absent means "unchanged", the way the serializer reads it.
+      const map = triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        webhook_reply: null,
+      });
+
+      expect(map.has('custom_path')).toBe(false);
+    });
+
+    test('keeps an existing path when the spec omits it', () => {
+      // An AI answer or a template export need not mention the path.
+      triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: 'facility-001',
+        webhook_reply: null,
+      });
+
+      const map = triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        webhook_reply: null,
+      });
+
+      expect(map.get('custom_path')).toBe('facility-001');
+    });
+
+    test('a stated path beats the one already there', () => {
+      // The guard has to ask the spec, not the freshly built map: reads on a
+      // map that is not in the document yet always answer false, which would
+      // silently drop a rename.
+      triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: 'facility-001',
+        webhook_reply: null,
+      });
+
+      const map = triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: 'facility-002',
+        webhook_reply: null,
+      });
+
+      expect(map.get('custom_path')).toBe('facility-002');
+    });
+
+    test('an explicit null clears a path already there', () => {
+      triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: 'facility-001',
+        webhook_reply: null,
+      });
+
+      const map = triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: null,
+        webhook_reply: null,
+      });
+
+      expect(map.get('custom_path')).toBeNull();
+    });
+
+    test('carries an explicit null as a clear', () => {
+      const map = triggerMapFrom({
+        id: 't1',
+        type: 'webhook',
+        enabled: true,
+        custom_path: null,
+        webhook_reply: null,
+      });
+
+      expect(map.has('custom_path')).toBe(true);
+      expect(map.get('custom_path')).toBeNull();
+    });
+  });
 });

--- a/assets/test/collaborative-editor/components/inspector/trigger/WebhookConfigureStep.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/trigger/WebhookConfigureStep.test.tsx
@@ -49,6 +49,7 @@ function makeReadyWorkflowStore(): WorkflowStoreInstance {
   });
   const workflowMap = ydoc.getMap('workflow');
   workflowMap.set('id', 'workflow-1');
+  workflowMap.set('name', 'ET EMR Facility 003');
   workflowMap.set('lock_version', 1);
   workflowMap.set('deleted_at', null);
   return createConnectedWorkflowStore(ydoc);
@@ -78,6 +79,7 @@ function makeWebhookDraft(
     cron_expression: null,
     cron_cursor_job_id: null,
     kafka_configuration: null,
+    custom_path: null,
     webhook_reply: 'before_start',
     webhook_response_config: null,
     ...overrides,
@@ -99,6 +101,10 @@ interface SetupOptions {
   canWriteWebhookAuthMethod?: boolean;
   /** Project-level auth methods available to attach. Defaults to none. */
   webhookAuthMethods?: WebhookAuthMethod[];
+  /** Project on the session context, for the custom-path URL prefix. */
+  project?: { id: string; name: string } | null;
+  /** Whether the path is the one the trigger opened with. */
+  pathUnchanged?: boolean;
 }
 
 async function setup({
@@ -110,11 +116,14 @@ async function setup({
   initialExpand,
   canWriteWebhookAuthMethod = true,
   webhookAuthMethods = [],
+  project = null,
+  pathUnchanged = false,
 }: SetupOptions = {}) {
   const { wrapper } = await createTriggerTestHarness({
     canEdit: true,
     canWriteWebhookAuthMethod,
     webhookAuthMethods,
+    project,
     workflowStore: makeReadyWorkflowStore(),
     liveViewActions: mockLiveViewActions,
   });
@@ -127,6 +136,7 @@ async function setup({
   render(
     <WebhookConfigureStep
       draft={draft}
+      pathUnchanged={pathUnchanged}
       mergeDraft={mergeDraft}
       draftAuthMethodIds={draftAuthMethodIds}
       setDraftAuthMethodIds={setDraftAuthMethodIds}
@@ -258,6 +268,7 @@ describe('WebhookConfigureStep', () => {
       const { unmount } = render(
         <WebhookConfigureStep
           draft={makeWebhookDraft()}
+          pathUnchanged={false}
           mergeDraft={vi.fn()}
           draftAuthMethodIds={[]}
           setDraftAuthMethodIds={vi.fn()}
@@ -441,5 +452,275 @@ describe('WebhookConfigureStep', () => {
         screen.getByLabelText('Authentication credential 1')
       ).not.toBeDisabled();
     });
+  });
+});
+
+describe('WebhookConfigureStep — custom URL path', () => {
+  const PROJECT = {
+    id: '33333333-3333-4333-8333-333333333333',
+    name: 'ET EMR',
+  };
+  test('suggests the workflow name', async () => {
+    // Offered, not written: an empty field still keeps the generated URL.
+    await setup({ project: PROJECT });
+
+    expect(screen.getByLabelText('Custom URL path')).toHaveAttribute(
+      'placeholder',
+      'et-emr-facility-003'
+    );
+  });
+
+  test('shows the current path', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'facility-001' }),
+      pathUnchanged: true,
+    });
+
+    expect(screen.getByLabelText('Custom URL path')).toHaveValue(
+      'facility-001'
+    );
+  });
+
+  test('leaves the URL to the panel that already shows it', async () => {
+    // The show panel owns the URL and its copy button.
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'facility-001' }),
+      pathUnchanged: true,
+    });
+
+    expect(screen.queryByText(new RegExp(`/i/${PROJECT.id}/`))).toBeNull();
+  });
+
+  test('keeps what is typed and stores what it derives to', async () => {
+    const mergeDraft = vi.fn();
+    await setup({ project: PROJECT, mergeDraft });
+
+    const input = screen.getByLabelText('Custom URL path');
+
+    fireEvent.change(input, { target: { value: 'ET EMR Facility 003' } });
+
+    expect(input).toHaveValue('ET EMR Facility 003');
+
+    expect(mergeDraft).toHaveBeenCalledWith({
+      custom_path: 'et-emr-facility-003',
+    });
+  });
+
+  test('says what the typed value will be named', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'et-emr-facility-003' }),
+      pathUnchanged: true,
+    });
+
+    fireEvent.change(screen.getByLabelText('Custom URL path'), {
+      target: { value: 'ET EMR Facility 003' },
+    });
+
+    expect(screen.getByText(/will be named/i)).toBeInTheDocument();
+    expect(screen.getByText('et-emr-facility-003')).toBeInTheDocument();
+  });
+
+  test('derives the way the project form derives a name', async () => {
+    const mergeDraft = vi.fn();
+    await setup({ project: PROJECT, mergeDraft });
+
+    const input = screen.getByLabelText('Custom URL path');
+
+    fireEvent.change(input, { target: { value: 'orders.v1?x=2' } });
+    expect(mergeDraft).toHaveBeenCalledWith({ custom_path: 'orders-v1-x-2' });
+
+    fireEvent.change(input, { target: { value: '  spaced  ' } });
+    expect(mergeDraft).toHaveBeenCalledWith({ custom_path: 'spaced' });
+
+    // Nothing survives, so the raw value is held for the save to refuse rather
+    // than being read as "cleared".
+    fireEvent.change(input, { target: { value: '...' } });
+    expect(mergeDraft).toHaveBeenCalledWith({ custom_path: '...' });
+  });
+
+  test('clearing the field clears the path', async () => {
+    const mergeDraft = vi.fn();
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'facility-001' }),
+      pathUnchanged: true,
+      mergeDraft,
+    });
+
+    fireEvent.change(screen.getByLabelText('Custom URL path'), {
+      target: { value: '' },
+    });
+
+    expect(mergeDraft).toHaveBeenCalledWith({ custom_path: null });
+  });
+
+  test('flags a path the server would reject', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'orders/intake' }),
+      pathUnchanged: false,
+    });
+
+    const input = screen.getByLabelText('Custom URL path');
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(
+      screen.getByText(/lowercase letters, numbers, hyphens and underscores/i)
+    ).toBeInTheDocument();
+  });
+
+  test('flags a legacy path when the trigger is becoming a webhook', async () => {
+    // The step and the hook have to agree, or Finish refuses with nothing
+    // marked wrong.
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'orders.v1' }),
+      pathUnchanged: false,
+    });
+
+    expect(screen.getByLabelText('Custom URL path')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+  });
+
+  test('does not flag a legacy path the user has not changed', async () => {
+    // Saving is allowed while the path is left alone.
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'orders.v1' }),
+      pathUnchanged: true,
+    });
+
+    expect(screen.getByLabelText('Custom URL path')).not.toHaveAttribute(
+      'aria-invalid'
+    );
+  });
+
+  test('flags it once the user changes it', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'orders.v2' }),
+      pathUnchanged: false,
+    });
+
+    expect(screen.getByLabelText('Custom URL path')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+  });
+
+  test('holds a name that derives to nothing instead of clearing', async () => {
+    // Every character strips away. Storing null would read as "cleared".
+    const mergeDraft = vi.fn();
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'facility-001' }),
+      pathUnchanged: true,
+      mergeDraft,
+    });
+
+    fireEvent.change(screen.getByLabelText('Custom URL path'), {
+      target: { value: '...' },
+    });
+
+    expect(mergeDraft).toHaveBeenCalledWith({ custom_path: '...' });
+  });
+
+  test('flags a stored name that derives to nothing', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: '...' }),
+      pathUnchanged: false,
+    });
+
+    const input = screen.getByLabelText('Custom URL path');
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText(/no letters or numbers/i)).toBeInTheDocument();
+    expect(screen.queryByText(/will be named/i)).toBeNull();
+  });
+
+  test('drops a server error once the path is edited', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({
+        custom_path: 'facility-002',
+        errors: { custom_path: ['is already used by another workflow'] },
+      }),
+      pathUnchanged: false,
+    });
+
+    expect(screen.queryByText(/already used/i)).toBeNull();
+  });
+
+  test('says when a path is too long, not that the characters are wrong', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'a'.repeat(256) }),
+      pathUnchanged: false,
+    });
+
+    expect(screen.getByText(/255 characters or fewer/i)).toBeInTheDocument();
+  });
+
+  test('shows an error the server sent back for the path', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({
+        custom_path: 'facility-001',
+        errors: {
+          custom_path: ['is already used by another workflow in this project'],
+        },
+      }),
+      pathUnchanged: true,
+    });
+
+    expect(
+      screen.getByText(/already used by another workflow/i)
+    ).toBeInTheDocument();
+  });
+
+  test('links the error to the field for screen readers', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'orders/intake' }),
+      pathUnchanged: false,
+    });
+
+    expect(screen.getByLabelText('Custom URL path')).toHaveAttribute(
+      'aria-describedby',
+      'webhook-custom-path-hint webhook-custom-path-error'
+    );
+  });
+
+  test('flags a UUID typed as a path', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({
+        custom_path: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      }),
+      pathUnchanged: false,
+    });
+
+    const input = screen.getByLabelText('Custom URL path');
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText(/cannot be used as a path/i)).toBeInTheDocument();
+  });
+
+  test('accepts a sixteen-character name', async () => {
+    await setup({
+      project: PROJECT,
+      draft: makeWebhookDraft({ custom_path: 'orders_intake_v1' }),
+      pathUnchanged: false,
+    });
+
+    const input = screen.getByLabelText('Custom URL path');
+
+    expect(input).not.toHaveAttribute('aria-invalid');
   });
 });

--- a/assets/test/collaborative-editor/components/inspector/trigger/WebhookShowPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/trigger/WebhookShowPanel.test.tsx
@@ -225,4 +225,51 @@ describe('WebhookShowPanel', () => {
       });
     });
   });
+
+  describe('a path the server rejected', () => {
+    test('says so, since the wizard closed before the answer arrived', async () => {
+      const trigger = {
+        ...makeWebhookTrigger(),
+        custom_path: 'facility-001',
+        errors: {
+          custom_path: ['is already used by another workflow in this project'],
+        },
+      } as Workflow.Trigger;
+
+      await setup(trigger, createConnectedWorkflowStore(ydoc, []));
+
+      expect(
+        screen.getByText(/already used by another workflow/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/custom path was not saved/i)
+      ).toBeInTheDocument();
+    });
+
+    test('offers the generated URL, not the name the server refused', () => {
+      // The refused path is still in the Y.Doc, and for a duplicate it resolves
+      // to whichever workflow legitimately owns it. Offering it would hand out
+      // a URL that posts into the wrong workflow.
+      const trigger = {
+        ...makeWebhookTrigger(),
+        custom_path: 'facility-001',
+        errors: {
+          custom_path: ['is already used by another workflow in this project'],
+        },
+      } as Workflow.Trigger;
+
+      return setup(trigger, createConnectedWorkflowStore(ydoc, [])).then(() => {
+        expect(
+          screen.getByText(`${window.location.origin}/i/${TRIGGER_ID}`)
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/facility-001/)).toBeNull();
+      });
+    });
+
+    test('stays quiet when there is no error', async () => {
+      await setup(makeWebhookTrigger(), createConnectedWorkflowStore(ydoc, []));
+
+      expect(screen.queryByText(/custom path was not saved/i)).toBeNull();
+    });
+  });
 });

--- a/assets/test/collaborative-editor/components/inspector/trigger/useTriggerDraft.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/trigger/useTriggerDraft.test.tsx
@@ -373,4 +373,177 @@ describe('useTriggerDraft', () => {
       expect(result.current.isDirty).toBe(false);
     });
   });
+
+  describe('custom path', () => {
+    test('refuses to commit a path the server would reject', async () => {
+      const { result } = renderDraft();
+
+      act(() => {
+        result.current.mergeDraft({ custom_path: 'orders/intake' });
+      });
+
+      expect(result.current.validationError).toMatch(/highlighted field/i);
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: false });
+      expect(
+        workflowStore.getSnapshot().triggers[0]?.custom_path ?? null
+      ).toBeNull();
+    });
+
+    test('refuses a UUID as a path', async () => {
+      const { result } = renderDraft();
+
+      act(() => {
+        result.current.mergeDraft({
+          custom_path: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        });
+      });
+
+      expect(result.current.validationError).toMatch(/highlighted field/i);
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: false });
+    });
+
+    test('a path left over from before the rules does not block other edits', async () => {
+      ydoc.getArray('triggers').get(0).set('custom_path', 'orders.v1');
+      const legacyTrigger = workflowStore.getSnapshot().triggers[0];
+
+      const { result } = renderHook(
+        () =>
+          useTriggerDraft(legacyTrigger, {
+            initialAuthMethodIds: [],
+            commitAuthMethods,
+          }),
+        { wrapper: createWrapper(workflowStore) }
+      );
+
+      act(() => {
+        result.current.mergeDraft({ webhook_reply: 'after_completion' });
+      });
+
+      expect(result.current.validationError).toBeNull();
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: true });
+    });
+
+    test('but touching that path still blocks the save', async () => {
+      ydoc.getArray('triggers').get(0).set('custom_path', 'orders.v1');
+      const legacyTrigger = workflowStore.getSnapshot().triggers[0];
+
+      const { result } = renderHook(
+        () =>
+          useTriggerDraft(legacyTrigger, {
+            initialAuthMethodIds: [],
+            commitAuthMethods,
+          }),
+        { wrapper: createWrapper(workflowStore) }
+      );
+
+      act(() => {
+        result.current.mergeDraft({ custom_path: 'orders.v2' });
+      });
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: false });
+    });
+
+    test('refuses to save a name that derives to nothing', async () => {
+      // The regression the display-only fix missed: the field showed an error
+      // while commit still returned ok and wrote the clear.
+      ydoc.getArray('triggers').get(0).set('custom_path', 'facility-001');
+      const seeded = workflowStore.getSnapshot().triggers[0];
+
+      const { result } = renderHook(
+        () =>
+          useTriggerDraft(seeded, {
+            initialAuthMethodIds: [],
+            commitAuthMethods,
+          }),
+        { wrapper: createWrapper(workflowStore) }
+      );
+
+      act(() => {
+        result.current.mergeDraft({ custom_path: '...' });
+      });
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: false });
+      expect(workflowStore.getSnapshot().triggers[0]?.custom_path).toBe(
+        'facility-001'
+      );
+    });
+
+    test('refuses to become a webhook on a path the server would reject', async () => {
+      // A path that meant nothing on a cron row becomes a live URL, and the
+      // server checks it then.
+      ydoc.getArray('triggers').get(0).set('type', 'cron');
+      ydoc.getArray('triggers').get(0).set('cron_expression', '0 0 * * *');
+      ydoc.getArray('triggers').get(0).set('custom_path', 'Orders.v1');
+      const cron = workflowStore.getSnapshot().triggers[0];
+
+      const { result } = renderHook(
+        () =>
+          useTriggerDraft(cron, {
+            initialAuthMethodIds: [],
+            commitAuthMethods,
+          }),
+        { wrapper: createWrapper(workflowStore) }
+      );
+
+      act(() => {
+        result.current.mergeDraft({
+          type: 'webhook',
+          cron_expression: null,
+          webhook_reply: 'before_start',
+        });
+      });
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: false });
+    });
+
+    test('commits a valid path', async () => {
+      const { result } = renderDraft();
+
+      act(() => {
+        result.current.mergeDraft({ custom_path: 'facility-001' });
+      });
+
+      expect(result.current.validationError).toBeNull();
+
+      let outcome: { ok: boolean } | undefined;
+      await act(async () => {
+        outcome = await result.current.commit();
+      });
+
+      expect(outcome).toEqual({ ok: true });
+    });
+  });
 });

--- a/assets/test/collaborative-editor/components/inspector/trigger/useWebhookTrigger.test.tsx
+++ b/assets/test/collaborative-editor/components/inspector/trigger/useWebhookTrigger.test.tsx
@@ -22,6 +22,7 @@ import {
 import { createTriggerTestHarness } from '../../../__helpers__/triggerInspectorHelpers';
 
 const TRIGGER_ID = '11111111-1111-4111-8111-111111111111';
+const PROJECT = { id: '22222222-2222-4222-8222-222222222222', name: 'ET EMR' };
 
 function createWebhookTriggerYDoc(): Y.Doc {
   const ydoc = new Y.Doc();
@@ -71,6 +72,77 @@ describe('useWebhookTrigger', () => {
     await waitFor(() => {
       expect(requestSpy).toHaveBeenCalledWith(TRIGGER_ID);
     });
+  });
+
+  test('addresses a custom path within its project', async () => {
+    ydoc.getArray('triggers').get(0).set('custom_path', 'facility-001');
+    const withPath = workflowStore.getSnapshot().triggers[0];
+
+    const { wrapper } = await createTriggerTestHarness({
+      workflowStore,
+      project: PROJECT,
+    });
+
+    const { result } = renderHook(() => useWebhookTrigger(withPath), {
+      wrapper,
+    });
+
+    expect(result.current.webhookUrl).toBe(
+      `${window.location.origin}/i/${PROJECT.id}/facility-001`
+    );
+  });
+
+  test('leaves a usable path raw', async () => {
+    // The server compares raw segments, so encoding here would stop a path
+    // holding a percent sequence from matching.
+    ydoc.getArray('triggers').get(0).set('custom_path', 'facility-001');
+    const withPath = workflowStore.getSnapshot().triggers[0];
+
+    const { wrapper } = await createTriggerTestHarness({
+      workflowStore,
+      project: PROJECT,
+    });
+
+    const { result } = renderHook(() => useWebhookTrigger(withPath), {
+      wrapper,
+    });
+
+    expect(result.current.webhookUrl).toBe(
+      `${window.location.origin}/i/${PROJECT.id}/facility-001`
+    );
+  });
+
+  test('shows the generated URL when the stored path is not addressable', async () => {
+    // Stored verbatim, but the lookup only matches one segment, so this URL
+    // would 404 and hide the one that works.
+    ydoc.getArray('triggers').get(0).set('custom_path', 'v1/orders');
+    const legacy = workflowStore.getSnapshot().triggers[0];
+
+    const { wrapper } = await createTriggerTestHarness({
+      workflowStore,
+      project: PROJECT,
+    });
+
+    const { result } = renderHook(() => useWebhookTrigger(legacy), { wrapper });
+
+    expect(result.current.webhookUrl).toBe(
+      `${window.location.origin}/i/${TRIGGER_ID}`
+    );
+  });
+
+  test('falls back to the trigger id when the project is unknown', async () => {
+    ydoc.getArray('triggers').get(0).set('custom_path', 'facility-001');
+    const withPath = workflowStore.getSnapshot().triggers[0];
+
+    const { wrapper } = await createTriggerTestHarness({ workflowStore });
+
+    const { result } = renderHook(() => useWebhookTrigger(withPath), {
+      wrapper,
+    });
+
+    expect(result.current.webhookUrl).toBe(
+      `${window.location.origin}/i/${TRIGGER_ID}`
+    );
   });
 
   test('commitAuthMethods issues the update channel request', async () => {

--- a/assets/test/collaborative-editor/types/trigger.test.ts
+++ b/assets/test/collaborative-editor/types/trigger.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `TriggerSchema` parses what the server sends, including pre-migration rows.
+ * `TriggerDraftSchema` is the stricter rule for what a user may write.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  TriggerDraftSchema,
+  TriggerSchema,
+  isValidCustomPath,
+  toCustomPath,
+} from '../../../js/collaborative-editor/types/trigger';
+
+const TRIGGER_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('TriggerSchema', () => {
+  test('accepts a custom_path on a cron trigger', () => {
+    // Serialised for every type, so rejecting it fails the whole parse.
+    const result = TriggerSchema.safeParse({
+      id: TRIGGER_ID,
+      type: 'cron',
+      enabled: true,
+      cron_expression: '0 0 * * *',
+      custom_path: 'orders.v1',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts a webhook path the current rules would reject', () => {
+    const result = TriggerSchema.safeParse({
+      id: TRIGGER_ID,
+      type: 'webhook',
+      enabled: true,
+      custom_path: 'orders.v1',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('TriggerDraftSchema', () => {
+  const webhook = (custom_path: string | null) => ({
+    id: TRIGGER_ID,
+    type: 'webhook' as const,
+    enabled: true,
+    custom_path,
+  });
+
+  test('accepts a usable path, and no path at all', () => {
+    expect(TriggerDraftSchema.safeParse(webhook('facility-001')).success).toBe(
+      true
+    );
+    expect(TriggerDraftSchema.safeParse(webhook(null)).success).toBe(true);
+    expect(
+      TriggerDraftSchema.safeParse(webhook('orders_intake_v1')).success
+    ).toBe(true);
+  });
+
+  test('rejects what the server rejects', () => {
+    for (const path of [
+      'Orders Intake',
+      'orders/intake',
+      'orders.v1',
+      'ORDERS',
+      '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    ]) {
+      expect(TriggerDraftSchema.safeParse(webhook(path)).success).toBe(false);
+    }
+  });
+});
+
+describe('toCustomPath', () => {
+  test('leaves an already usable path alone', () => {
+    // Deriving would strip the hyphens off values the server accepts.
+    expect(toCustomPath('facility-001')).toBe('facility-001');
+    expect(toCustomPath('-')).toBe('-');
+    expect(toCustomPath('_leading')).toBe('_leading');
+  });
+
+  test('derives one where it can', () => {
+    expect(toCustomPath('ET EMR Facility 003')).toBe('et-emr-facility-003');
+    expect(toCustomPath('orders.v1?x=2')).toBe('orders-v1-x-2');
+    expect(toCustomPath('  spaced  ')).toBe('spaced');
+  });
+
+  test('returns nothing when nothing in it is usable', () => {
+    expect(toCustomPath('...')).toBe('');
+    expect(toCustomPath('!!!')).toBe('');
+  });
+});
+
+describe('isValidCustomPath', () => {
+  test('matches the draft rule', () => {
+    expect(isValidCustomPath('et-emr_facility-001')).toBe(true);
+    expect(isValidCustomPath('orders_intake_v1')).toBe(true);
+    expect(isValidCustomPath('orders.v1')).toBe(false);
+    expect(isValidCustomPath('3fa85f64-5717-4562-b3fc-2c963f66afa6')).toBe(
+      false
+    );
+  });
+});

--- a/assets/test/yaml/util.test.ts
+++ b/assets/test/yaml/util.test.ts
@@ -155,6 +155,129 @@ describe('convertWorkflowSpecToState', () => {
 
       expect(convertedSpec.triggers.webhook.enabled).toBe(false);
     });
+
+    test('keeps a webhook custom_path through the round trip', () => {
+      // This used to drop the name silently on the way back in.
+      const originalSpec = {
+        name: 'Test Workflow',
+        jobs: {
+          'job-1': {
+            name: 'Job 1',
+            adaptor: '@openfn/language-common@latest',
+            body: 'fn(state => state)',
+          },
+        },
+        triggers: {
+          webhook: {
+            type: 'webhook',
+            enabled: true,
+            custom_path: 'et-emr-facility-001',
+          },
+        },
+        edges: {
+          'webhook->job-1': {
+            source_trigger: 'webhook',
+            target_job: 'job-1',
+            condition_type: 'always',
+          },
+        },
+      };
+
+      const state = convertWorkflowSpecToState(originalSpec);
+      const convertedSpec = convertWorkflowStateToSpec(state, true);
+
+      expect(convertedSpec.triggers.webhook.custom_path).toBe(
+        'et-emr-facility-001'
+      );
+    });
+
+    test('strips custom_path when ids are stripped, as for a template', () => {
+      // A path is per-project identity, so a template must not carry one.
+      const originalSpec = {
+        name: 'Test Workflow',
+        jobs: {
+          'job-1': {
+            name: 'Job 1',
+            adaptor: '@openfn/language-common@latest',
+            body: 'fn(state => state)',
+          },
+        },
+        triggers: {
+          webhook: {
+            type: 'webhook',
+            enabled: true,
+            custom_path: 'et-emr-facility-001',
+          },
+        },
+        edges: {
+          'webhook->job-1': {
+            source_trigger: 'webhook',
+            target_job: 'job-1',
+            condition_type: 'always',
+          },
+        },
+      };
+
+      const state = convertWorkflowSpecToState(originalSpec);
+      const convertedSpec = convertWorkflowStateToSpec(state, false);
+
+      expect('custom_path' in convertedSpec.triggers.webhook).toBe(false);
+    });
+
+    test('does not export a path the server would reject on import', () => {
+      // A pre-migration path would fail the import it is deployed into.
+      const originalSpec = {
+        name: 'Test Workflow',
+        jobs: {
+          'job-1': {
+            name: 'Job 1',
+            adaptor: '@openfn/language-common@latest',
+            body: 'fn(state => state)',
+          },
+        },
+        triggers: {
+          webhook: { type: 'webhook', enabled: true, custom_path: 'Order.v1' },
+        },
+        edges: {
+          'webhook->job-1': {
+            source_trigger: 'webhook',
+            target_job: 'job-1',
+            condition_type: 'always',
+          },
+        },
+      };
+
+      const state = convertWorkflowSpecToState(originalSpec);
+      const convertedSpec = convertWorkflowStateToSpec(state, true);
+
+      expect('custom_path' in convertedSpec.triggers.webhook).toBe(false);
+    });
+
+    test('omits custom_path when there is none', () => {
+      const originalSpec = {
+        name: 'Test Workflow',
+        jobs: {
+          'job-1': {
+            name: 'Job 1',
+            adaptor: '@openfn/language-common@latest',
+            body: 'fn(state => state)',
+          },
+        },
+        triggers: { webhook: { type: 'webhook', enabled: true } },
+        edges: {
+          'webhook->job-1': {
+            source_trigger: 'webhook',
+            target_job: 'job-1',
+            condition_type: 'always',
+          },
+        },
+      };
+
+      const state = convertWorkflowSpecToState(originalSpec);
+      const convertedSpec = convertWorkflowStateToSpec(state, true);
+
+      expect('custom_path' in convertedSpec.triggers.webhook).toBe(false);
+    });
   });
 });
 

--- a/lib/lightning/collaboration/workflow_reconciler.ex
+++ b/lib/lightning/collaboration/workflow_reconciler.ex
@@ -182,7 +182,7 @@ defmodule Lightning.Collaboration.WorkflowReconciler do
          _workflow
        ) do
     changes =
-      ~w(cron_expression enabled type)a |> pluck_fields(cs)
+      ~w(custom_path cron_expression enabled type)a |> pluck_fields(cs)
 
     item =
       Doc.get_array(doc, "triggers") |> find_in_array(cs.data.id)

--- a/lib/lightning/collaboration/workflow_serializer.ex
+++ b/lib/lightning/collaboration/workflow_serializer.ex
@@ -224,6 +224,7 @@ defmodule Lightning.Collaboration.WorkflowSerializer do
           "kafka_configuration" => kafka_configuration,
           "cron_expression" => trigger.cron_expression,
           "cron_cursor_job_id" => trigger.cron_cursor_job_id,
+          "custom_path" => trigger.custom_path,
           "enabled" => trigger.enabled,
           "id" => trigger.id,
           "type" => trigger.type |> to_string(),
@@ -285,8 +286,8 @@ defmodule Lightning.Collaboration.WorkflowSerializer do
     |> Enum.map(fn trigger ->
       trigger
       |> Map.take(
-        ~w(id type enabled cron_expression cron_cursor_job_id webhook_reply
-           kafka_configuration webhook_response_config)
+        ~w(id type enabled cron_expression cron_cursor_job_id custom_path
+           webhook_reply kafka_configuration webhook_response_config)
       )
       |> normalize_kafka_configuration()
       |> normalize_webhook_response_config()

--- a/lib/lightning/export_utils.ex
+++ b/lib/lightning/export_utils.ex
@@ -34,6 +34,7 @@ defmodule Lightning.ExportUtils do
     job: [:name, :adaptor, :credential, :globals, :body],
     trigger: [
       :type,
+      :custom_path,
       :webhook_reply,
       :webhook_response_config,
       :cron_expression,
@@ -127,8 +128,21 @@ defmodule Lightning.ExportUtils do
 
       :webhook ->
         base
+        |> maybe_put_custom_path(trigger.custom_path)
         |> maybe_put_webhook_reply(trigger.webhook_reply)
         |> maybe_put_webhook_response_config(trigger.webhook_response_config)
+    end
+  end
+
+  defp maybe_put_custom_path(map, nil), do: map
+
+  defp maybe_put_custom_path(map, custom_path) do
+    # A pre-migration path would fail validation on deploy elsewhere and take
+    # the whole run with it.
+    if Lightning.Workflows.Trigger.valid_custom_path?(custom_path) do
+      Map.put(map, :custom_path, custom_path)
+    else
+      map
     end
   end
 
@@ -246,6 +260,10 @@ defmodule Lightning.ExportUtils do
         "#{k}: '#{v}'"
 
       :cron_expression ->
+        "#{k}: '#{v}'"
+
+      # Quoted, or an all-digit path round trips as an integer.
+      :custom_path ->
         "#{k}: '#{v}'"
 
       :condition_expression ->

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -8,6 +8,7 @@ defmodule Lightning.Projects.MergeProjects do
 
   alias Lightning.Projects.Project
   alias Lightning.Repo
+  alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
   alias Lightning.Workflows.WorkflowVersion
   alias Lightning.WorkflowVersions
@@ -701,6 +702,9 @@ defmodule Lightning.Projects.MergeProjects do
               :type,
               :kafka_configuration
             ])
+            |> drop_unusable_custom_path(
+              Enum.find(target_triggers, &(&1.id == mapped_id))
+            )
             |> Map.put(:id, mapped_id)
             |> stringify_keys()
 
@@ -977,6 +981,7 @@ defmodule Lightning.Projects.MergeProjects do
           :type,
           :kafka_configuration
         ])
+        |> drop_unusable_custom_path()
         |> Map.put(:id, Map.fetch!(node_mappings, trigger.id))
         |> stringify_keys()
       end)
@@ -1117,4 +1122,30 @@ defmodule Lightning.Projects.MergeProjects do
       fn {_workflow_id, hash} -> hash end
     )
   end
+
+  # A pre-migration path can fail the changeset and take the whole merge with
+  # it, so the merged trigger falls back to its generated URL. A name another
+  # workflow in the target already holds is left to fail on the unique index,
+  # rather than dropped, since dropping it discards the name the user chose.
+  defp drop_unusable_custom_path(trigger, target \\ nil)
+
+  defp drop_unusable_custom_path(%{custom_path: nil} = trigger, _target),
+    do: trigger
+
+  defp drop_unusable_custom_path(%{custom_path: path} = trigger, target) do
+    cond do
+      Trigger.valid_custom_path?(path) ->
+        trigger
+
+      # The target already holds this value, so sending it is not a change.
+      # Dropping it would be, and would take a live URL off the target.
+      target && Map.get(target, :custom_path) == path ->
+        trigger
+
+      true ->
+        %{trigger | custom_path: nil}
+    end
+  end
+
+  defp drop_unusable_custom_path(trigger, _target), do: trigger
 end

--- a/lib/lightning/projects/provisioner.ex
+++ b/lib/lightning/projects/provisioner.ex
@@ -83,12 +83,16 @@ defmodule Lightning.Projects.Provisioner do
              build_import_changeset(project, user_or_repo_connection, data),
            edges_to_cleanup <-
              edges_referencing_deleted_jobs(project_changeset),
+           # Before the insert, or a workflow being dropped in this same
+           # document still holds the name the incoming one wants.
+           :ok <- release_paths_of_soft_deleted_workflows(project_changeset),
            {:ok, %{workflows: workflows} = project} <-
              Repo.insert_or_update(project_changeset, allow_stale: allow_stale),
            :ok <- check_credential_scoping(project, project_changeset),
            :ok <- cleanup_orphaned_edges(edges_to_cleanup),
            :ok <-
              disable_triggers_for_soft_deleted_workflows(project_changeset),
+           :ok <- release_paths_of_hidden_workflows(project),
            :ok <- notify_kafka_for_soft_deleted_workflows(project_changeset),
            :ok <- handle_collection_deletion(project_changeset),
            updated_project <- preload_dependencies(project),
@@ -757,10 +761,26 @@ defmodule Lightning.Projects.Provisioner do
     )
     |> Trigger.validate()
     |> cast(attrs, [:delete])
+    |> reject_server_owned_trigger_params(attrs)
     |> validate_required([:id])
     |> unique_constraint(:id, name: :triggers_pkey)
     |> validate_extraneous_params()
     |> maybe_mark_for_deletion()
+  end
+
+  # `validate_extraneous_params/2` builds its allow-list from `changeset.types`,
+  # so adding these as schema fields silently started accepting them.
+  defp reject_server_owned_trigger_params(changeset, attrs) do
+    Enum.reduce([:project_id, :legacy_bare_path], changeset, fn field, acc ->
+      key = to_string(field)
+
+      if is_map(attrs) and
+           (Map.has_key?(attrs, key) or Map.has_key?(attrs, field)) do
+        add_error(acc, :base, "extraneous parameters: %{params}", params: key)
+      else
+        acc
+      end
+    end)
   end
 
   defp kafka_config_changeset(kafka_config, attrs) do
@@ -910,18 +930,58 @@ defmodule Lightning.Projects.Provisioner do
     |> Workflows.notify_kafka_triggers_for_workflows()
   end
 
+  # A hidden row must not keep a name reserved. Released whatever the trigger's
+  # enabled state, and before the insert so one document can drop a workflow and
+  # claim its path in the same breath.
+  defp release_paths_of_soft_deleted_workflows(project_changeset) do
+    case soft_deleted_workflow_ids(project_changeset) do
+      [] ->
+        :ok
+
+      ids ->
+        from(t in Trigger, where: t.workflow_id in ^ids)
+        |> Repo.update_all(set: [custom_path: nil, legacy_bare_path: false])
+
+        :ok
+    end
+  end
+
+  # Project-wide and after the write: a checked-in yaml can still name the path
+  # of a workflow deleted since, and the cast would put it back on a row nobody
+  # can see. Disabled rows only, since webhook ingest ignores `deleted_at` and a
+  # hidden workflow with an enabled trigger is still serving.
+  defp release_paths_of_hidden_workflows(%Project{id: project_id}) do
+    from(t in Trigger,
+      join: w in Workflow,
+      on: w.id == t.workflow_id,
+      where:
+        w.project_id == ^project_id and not is_nil(w.deleted_at) and
+          not t.enabled and not is_nil(t.custom_path)
+    )
+    |> Repo.update_all(set: [custom_path: nil, legacy_bare_path: false])
+
+    :ok
+  end
+
+  defp soft_deleted_workflow_ids(project_changeset) do
+    project_changeset
+    |> get_assoc(:workflows)
+    |> Enum.filter(fn cs ->
+      cs.action == :update and not is_nil(get_change(cs, :deleted_at))
+    end)
+    |> Enum.map(&get_field(&1, :id))
+  end
+
   defp disable_triggers_for_soft_deleted_workflows(project_changeset) do
-    deleted_workflow_ids =
-      project_changeset
-      |> get_assoc(:workflows)
-      |> Enum.filter(fn cs ->
-        cs.action == :update and not is_nil(get_change(cs, :deleted_at))
-      end)
-      |> Enum.map(&get_field(&1, :id))
+    deleted_workflow_ids = soft_deleted_workflow_ids(project_changeset)
 
     if deleted_workflow_ids == [] do
       :ok
     else
+      # Released whatever the trigger's state, or a hidden row keeps the name.
+      from(t in Trigger, where: t.workflow_id in ^deleted_workflow_ids)
+      |> Repo.update_all(set: [custom_path: nil, legacy_bare_path: false])
+
       from(t in Trigger,
         where: t.workflow_id in ^deleted_workflow_ids and t.enabled
       )

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -994,10 +994,7 @@ defmodule Lightning.Projects.Sandboxes do
             end
         }
 
-        {:ok, sandbox_trigger} =
-          %Trigger{}
-          |> Trigger.changeset(sandbox_trigger_attrs)
-          |> Repo.insert()
+        {:ok, sandbox_trigger} = insert_sandbox_trigger(sandbox_trigger_attrs)
 
         if parent_trigger.webhook_auth_methods &&
              parent_trigger.webhook_auth_methods != [] do
@@ -1015,6 +1012,45 @@ defmodule Lightning.Projects.Sandboxes do
       end)
     end)
     |> Map.new()
+  end
+
+  # A parent can hold a pre-migration path the clone's changeset rejects. The
+  # clone is written without it and the value copied in directly. Verbatim
+  # matters: an empty clone would clear the parent's path on promote.
+  defp insert_sandbox_trigger(attrs) do
+    # `mode: :savepoint` so a DB-level failure leaves the retry below usable.
+    %Trigger{}
+    |> Trigger.changeset(attrs)
+    |> Repo.insert(mode: :savepoint)
+    |> case do
+      {:ok, trigger} ->
+        {:ok, trigger}
+
+      {:error, changeset} ->
+        # Only a format failure. The other two rules keyed to `:custom_path`,
+        # a duplicate and a missing project, must not end with the path being
+        # written back. Neither is reachable through a provision today.
+        if Trigger.custom_path_shape_error?(changeset) do
+          insert_with_legacy_custom_path(attrs)
+        else
+          {:error, changeset}
+        end
+    end
+  end
+
+  defp insert_with_legacy_custom_path(attrs) do
+    with {:ok, trigger} <-
+           %Trigger{}
+           |> Trigger.changeset(%{attrs | custom_path: nil})
+           |> Repo.insert() do
+      {1, _} =
+        Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: attrs.custom_path]
+        )
+
+      {:ok, %{trigger | custom_path: attrs.custom_path}}
+    end
   end
 
   defp clone_workflow_edges(sandbox, parent) do

--- a/lib/lightning/workflow_versions.ex
+++ b/lib/lightning/workflow_versions.ex
@@ -21,6 +21,7 @@ defmodule Lightning.WorkflowVersions do
   alias Ecto.Multi
   alias Lightning.Repo
   alias Lightning.Validators.Hex
+  alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Triggers.WebhookResponseConfig
   alias Lightning.Workflows.Workflow
   alias Lightning.Workflows.WorkflowVersion
@@ -301,6 +302,7 @@ defmodule Lightning.WorkflowVersions do
       |> Enum.reduce([], fn trigger, acc ->
         hash_list =
           trigger
+          |> hashable_custom_path()
           |> Map.take(trigger_keys)
           |> Enum.sort_by(fn {k, _v} -> k end)
           |> Enum.map(fn {_k, v} -> serialize_value(v) end)
@@ -345,6 +347,20 @@ defmodule Lightning.WorkflowVersions do
       jobs_hash_list,
       edges_hash_list
     ])
+  end
+
+  # Only a path the app would export. `ProvisioningJSON` and `ExportUtils` drop
+  # one the naming rules reject, so the CLI never sees it, and hashing it here
+  # would leave the two disagreeing forever on a grandfathered row. A path on a
+  # cron or kafka trigger never served a URL, so it is not content either.
+  defp hashable_custom_path(trigger) do
+    webhook? = Map.get(trigger, :type) in [:webhook, "webhook"]
+
+    if webhook? and Trigger.valid_custom_path?(Map.get(trigger, :custom_path)) do
+      trigger
+    else
+      Map.put(trigger, :custom_path, nil)
+    end
   end
 
   defp serialize_value(%WebhookResponseConfig{} = val) do

--- a/lib/lightning/workflow_versions.ex
+++ b/lib/lightning/workflow_versions.ex
@@ -273,6 +273,7 @@ defmodule Lightning.WorkflowVersions do
 
     trigger_keys = [
       :type,
+      :custom_path,
       :cron_expression,
       :enabled,
       :webhook_reply,

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -850,7 +850,9 @@ defmodule Lightning.Workflows do
     |> Multi.update_all(
       :disable_triggers,
       workflow_triggers_query,
-      set: [enabled: false]
+      # The path goes with the workflow's name, or a hidden row keeps it
+      # reserved against a replacement.
+      set: [enabled: false, custom_path: nil, legacy_bare_path: false]
     )
     |> Repo.transaction()
     |> tap(fn result ->
@@ -937,20 +939,67 @@ defmodule Lightning.Workflows do
   end
 
   @doc """
-  Gets a single Webhook Trigger by its `custom_path` or `id`.
-  """
-  def get_webhook_trigger(path, opts \\ []) when is_binary(path) do
-    preloads = opts |> Keyword.get(:include, [])
+  Gets a single Webhook Trigger from the segments of an `/i/` request path.
 
-    from(t in Trigger,
-      where:
-        fragment(
-          "coalesce(?, ?)",
-          t.custom_path,
-          type(t.id, :string)
-        ) == ^path and t.type == :webhook,
-      preload: ^preloads
-    )
+  Tried in order, and no step can match more than one row, so a request can
+  never fail on an ambiguous path:
+
+    1. A project id and a custom path, when there is a second segment.
+    2. The first segment as a trigger id.
+    3. A bare custom path, for the triggers that held one before paths were
+       namespaced. That set is fixed at migration time and never grows.
+
+  Trailing segments are ignored: `/i/<trigger-uuid>/Patient` posts to the same
+  trigger as `/i/<trigger-uuid>`.
+  """
+  @spec get_webhook_trigger([String.t()], keyword()) :: Trigger.t() | nil
+  def get_webhook_trigger(segments, opts \\ [])
+
+  # Ordered so the likely answer is the first query. A request carrying a second
+  # segment is almost always the namespaced form, and one carrying none can only
+  # be an id or a legacy bare path.
+  def get_webhook_trigger([first | rest], opts) do
+    case cast_uuid(first) do
+      {:ok, id} when rest != [] ->
+        by_project_path(id, rest, opts) || by_trigger_id(id, opts) ||
+          by_legacy_path(first, opts)
+
+      {:ok, id} ->
+        by_trigger_id(id, opts) || by_legacy_path(first, opts)
+
+      :error ->
+        by_legacy_path(first, opts)
+    end
+  end
+
+  def get_webhook_trigger(_segments, _opts), do: nil
+
+  # `Ecto.UUID.cast/1` also accepts any 16-byte binary as a raw UUID, which
+  # would swallow a 16-character custom path like `orders_intake_v1`. Only the
+  # 36-character textual form is a URL segment we mean to read as an id.
+  defp cast_uuid(<<_::288>> = segment), do: Ecto.UUID.cast(segment)
+  defp cast_uuid(_segment), do: :error
+
+  defp by_trigger_id(id, opts) do
+    Trigger |> where([t], t.id == ^id) |> fetch_webhook(opts)
+  end
+
+  defp by_project_path(project_id, [custom_path | _rest], opts) do
+    Trigger
+    |> where([t], t.project_id == ^project_id and t.custom_path == ^custom_path)
+    |> fetch_webhook(opts)
+  end
+
+  defp by_legacy_path(custom_path, opts) do
+    Trigger
+    |> where([t], t.legacy_bare_path and t.custom_path == ^custom_path)
+    |> fetch_webhook(opts)
+  end
+
+  defp fetch_webhook(query, opts) do
+    query
+    |> where([t], t.type == :webhook)
+    |> preload(^Keyword.get(opts, :include, []))
     |> Repo.one()
   end
 

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -114,8 +114,15 @@ defmodule Lightning.Workflows.Snapshot do
   end
 
   @job_fields Lightning.Workflows.Job.__schema__(:fields) -- [:workflow_id]
+  # `project_id` is denormalised routing state rather than workflow content, and
+  # it is constant for a workflow, so it is excluded like `workflow_id`.
   @trigger_fields Lightning.Workflows.Trigger.__schema__(:fields) --
-                    [:workflow_id, :webhook_response_config]
+                    [
+                      :workflow_id,
+                      :project_id,
+                      :legacy_bare_path,
+                      :webhook_response_config
+                    ]
   @edge_fields Lightning.Workflows.Edge.__schema__(:fields) -- [:workflow_id]
 
   defp job_changeset(schema, params) do

--- a/lib/lightning/workflows/trigger.ex
+++ b/lib/lightning/workflows/trigger.ex
@@ -26,6 +26,9 @@ defmodule Lightning.Workflows.Trigger do
   @type trigger_type :: :webhook | :cron
 
   @trigger_types [:webhook, :cron, :kafka]
+  # `\z` not `$`, which in PCRE also matches before a trailing newline.
+  @custom_path_format ~r/\A[a-z0-9_-]+\z/
+  @custom_path_max 255
   @webhook_reply_types [:before_start, :after_completion, :custom]
 
   @derive {Jason.Encoder,
@@ -51,6 +54,14 @@ defmodule Lightning.Workflows.Trigger do
     belongs_to :workflow, Workflow
     belongs_to :cron_cursor_job, Job
 
+    # Denormalised from the workflow so a custom path is unique within its
+    # project. Held there by a composite FK, and never cast from user input.
+    field :project_id, :binary_id
+
+    # Set once by the migration, for triggers that already answered at a bare
+    # `/i/<path>`. Never cast from params, so the set can only shrink.
+    field :legacy_bare_path, :boolean, default: false
+
     has_many :edges, Lightning.Workflows.Edge, foreign_key: :source_trigger_id
 
     field :type, Ecto.Enum, values: @trigger_types, default: :webhook
@@ -71,8 +82,55 @@ defmodule Lightning.Workflows.Trigger do
   end
 
   def new(attrs) do
+    # `change/2` applies whatever it is handed, so the two fields the bare-URL
+    # design rests on are stripped here the same way `cast_changeset/2` refuses
+    # to cast them.
+    attrs = Map.drop(attrs, [:project_id, :legacy_bare_path])
+
     change(%__MODULE__{}, Map.merge(attrs, %{id: Ecto.UUID.generate()}))
     |> change(attrs)
+    |> validate_custom_path()
+    |> clear_legacy_bare_path_on_rename()
+    |> put_project_id()
+    |> put_constraints()
+  end
+
+  @doc """
+  Whether a string is usable as a webhook's custom path.
+
+  Asked by anything that copies a path written before these rules existed.
+  """
+  @spec valid_custom_path?(term()) :: boolean()
+  def valid_custom_path?(path) when is_binary(path) do
+    String.length(path) <= @custom_path_max and
+      Regex.match?(@custom_path_format, path) and
+      not uuid_shaped?(path)
+  end
+
+  def valid_custom_path?(_path), do: false
+
+  defp uuid_shaped?(<<_::288>> = path),
+    do: match?({:ok, _}, Ecto.UUID.cast(path))
+
+  defp uuid_shaped?(_path), do: false
+
+  @doc """
+  Whether a rejected changeset failed only on the shape of its custom path.
+
+  A duplicate or a missing project also report against `:custom_path`, and
+  neither may be answered by inserting without the path, since the path would
+  be written back afterwards.
+  """
+  @spec custom_path_shape_error?(Ecto.Changeset.t()) :: boolean()
+  def custom_path_shape_error?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn
+      {:custom_path, {_message, meta}} ->
+        Keyword.get(meta, :validation) in [:format, :length] or
+          Keyword.get(meta, :custom_path_shape) == true
+
+      _other ->
+        false
+    end)
   end
 
   @doc """
@@ -121,12 +179,132 @@ defmodule Lightning.Workflows.Trigger do
     |> validate_required([:type])
     |> assoc_constraint(:workflow)
     |> validate_by_type()
+    |> validate_custom_path()
+    # After the trim, so a padded path is judged on what would be stored.
+    |> revalidate_custom_path_on_type_change()
+    |> put_project_id()
     |> validate_uuid([:id, :workflow_id, :cron_cursor_job_id])
-    |> unique_constraint(:id, name: "triggers_pkey")
+    |> clear_legacy_bare_path_on_rename()
+    |> put_constraints()
+    |> foreign_key_constraint(:project_id,
+      name: :triggers_workflow_id_project_id_fkey,
+      message: "does not match the trigger's workflow"
+    )
     |> foreign_key_constraint(:cron_cursor_job_id,
       name: "triggers_cron_cursor_job_id_fkey",
       message: "cursor job doesn't exist, or is not in the same workflow"
     )
+  end
+
+  defp put_constraints(changeset) do
+    changeset
+    |> unique_constraint(:id, name: "triggers_pkey")
+    |> unique_constraint([:project_id, :custom_path],
+      name: :triggers_project_id_custom_path_index,
+      error_key: :custom_path,
+      message: "is already used by another workflow in this project"
+    )
+    |> unique_constraint(:custom_path,
+      name: :triggers_legacy_bare_path_index,
+      message: "is already in use"
+    )
+  end
+
+  # A grandfathered bare URL belongs to the name it was grandfathered on.
+  defp clear_legacy_bare_path_on_rename(changeset) do
+    # Ecto drops a change equal to the stored value, so the equal case does not
+    # arise today. Compared anyway, so a no-op save cannot retire a live URL.
+    case fetch_change(changeset, :custom_path) do
+      {:ok, renamed} ->
+        if renamed == changeset.data.custom_path do
+          changeset
+        else
+          # `force_change/3`: the struct in hand may be stale.
+          force_change(changeset, :legacy_bare_path, false)
+        end
+
+      _unchanged ->
+        changeset
+    end
+  end
+
+  # Resolved inside the insert transaction, so any caller with a workflow gets
+  # it without knowing to. The composite FK rejects a wrong value.
+  defp put_project_id(changeset) do
+    prepare_changes(changeset, fn changeset ->
+      changeset
+      |> resolve_project_id()
+      |> require_project_for_custom_path()
+    end)
+  end
+
+  defp resolve_project_id(changeset) do
+    workflow_id = get_field(changeset, :workflow_id)
+
+    if is_nil(get_field(changeset, :project_id)) and not is_nil(workflow_id) do
+      case changeset.repo.get(Workflow, workflow_id) do
+        %Workflow{project_id: project_id} ->
+          put_change(changeset, :project_id, project_id)
+
+        nil ->
+          changeset
+      end
+    else
+      changeset
+    end
+  end
+
+  # Without a project a path is both unreachable and unconstrained. Checked
+  # after the project is resolved, since most callers never set it.
+  defp require_project_for_custom_path(changeset) do
+    if get_field(changeset, :custom_path) &&
+         is_nil(get_field(changeset, :project_id)) do
+      add_error(
+        changeset,
+        :custom_path,
+        "needs a project, which comes from the trigger's workflow"
+      )
+    else
+      changeset
+    end
+  end
+
+  # UUID-shaped paths are rejected because `Workflows.get_webhook_trigger/2`
+  # resolves those against trigger ids, so one would be unreachable.
+  defp validate_custom_path(changeset) do
+    changeset
+    |> update_change(:custom_path, fn
+      path when is_binary(path) ->
+        case String.trim(path) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      other ->
+        other
+    end)
+    |> validate_length(:custom_path, max: @custom_path_max)
+    |> validate_format(:custom_path, @custom_path_format,
+      message:
+        "must only contain lowercase letters, numbers, hyphens and underscores"
+    )
+    |> validate_change(:custom_path, fn :custom_path, path ->
+      # `Ecto.UUID.cast/1` accepts any 16-byte binary, which would reject an
+      # ordinary name like `orders_intake_v1`.
+      case path do
+        <<_::288>> ->
+          case Ecto.UUID.cast(path) do
+            {:ok, _} ->
+              [custom_path: {"cannot be a UUID", custom_path_shape: true}]
+
+            :error ->
+              []
+          end
+
+        _shorter_or_longer ->
+          []
+      end
+    end)
   end
 
   defp validate_cron(changeset, _options \\ []) do
@@ -148,6 +326,8 @@ defmodule Lightning.Workflows.Trigger do
     changeset
     |> fetch_field!(:type)
     |> case do
+      # A cron or kafka row can hold a never-validated path. Becoming a webhook
+      # would make it a live URL, so it is checked in and dropped out.
       :webhook ->
         changeset
         |> put_change(:cron_expression, nil)
@@ -158,6 +338,7 @@ defmodule Lightning.Workflows.Trigger do
 
       :cron ->
         changeset
+        |> put_change(:custom_path, nil)
         |> put_default(:cron_expression, "0 0 * * *")
         |> validate_cron()
         |> put_change(:kafka_configuration, nil)
@@ -166,6 +347,7 @@ defmodule Lightning.Workflows.Trigger do
 
       :kafka ->
         changeset
+        |> put_change(:custom_path, nil)
         |> put_change(:cron_expression, nil)
         |> put_change(:cron_cursor_job_id, nil)
         |> validate_required([:kafka_configuration])
@@ -174,6 +356,23 @@ defmodule Lightning.Workflows.Trigger do
 
       nil ->
         changeset
+    end
+  end
+
+  # For a stored path nobody touched. A changed one is already validated, and
+  # judging it twice would report a UUID as a character problem.
+  defp revalidate_custom_path_on_type_change(changeset) do
+    with :error <- fetch_change(changeset, :custom_path),
+         {:ok, :webhook} <- fetch_change(changeset, :type),
+         path when is_binary(path) <- get_field(changeset, :custom_path),
+         false <- valid_custom_path?(path) do
+      add_error(
+        changeset,
+        :custom_path,
+        "must only contain lowercase letters, numbers, hyphens and underscores"
+      )
+    else
+      _usable_or_not_a_webhook -> changeset
     end
   end
 

--- a/lib/lightning_web/controllers/api/provisioning_json.ex
+++ b/lib/lightning_web/controllers/api/provisioning_json.ex
@@ -119,9 +119,9 @@ defmodule LightningWeb.API.ProvisioningJSON do
         |> drop_keys_with_nil_value()
 
     trigger
-    |> Map.take(
-      ~w(id type cron_expression enabled webhook_reply cron_cursor_job_id)a
-    )
+    |> Map.take(~w(id type custom_path cron_expression enabled webhook_reply
+         cron_cursor_job_id)a)
+    |> drop_unusable_custom_path()
     |> Map.put(:kafka_configuration, kafka_configuration)
     |> Map.put(:webhook_response_config, webhook_response_config)
     |> drop_keys_with_nil_value()
@@ -284,4 +284,18 @@ defmodule LightningWeb.API.ProvisioningJSON do
   defp find_item_by_id(items, id) do
     Enum.find(items, fn item -> item.id == id end)
   end
+
+  # A path written before the naming rules would fail validation when this
+  # document is deployed into another project and take the whole run with it,
+  # the same guard `ExportUtils` and `MergeProjects` apply.
+  defp drop_unusable_custom_path(%{custom_path: path} = trigger)
+       when is_binary(path) do
+    if Lightning.Workflows.Trigger.valid_custom_path?(path) do
+      trigger
+    else
+      Map.delete(trigger, :custom_path)
+    end
+  end
+
+  defp drop_unusable_custom_path(trigger), do: trigger
 end

--- a/lib/lightning_web/plugs/webhook_auth.ex
+++ b/lib/lightning_web/plugs/webhook_auth.ex
@@ -23,9 +23,10 @@ defmodule LightningWeb.Plugs.WebhookAuth do
     and returns the connection unchanged so upstream CORS handling can respond.
     This avoids doing DB lookups or emitting 401/404 on preflight requests.
 
-  - **Auth flow:** For non-`OPTIONS` requests whose path matches `/i/:webhook`,
-    this plug:
-      1. Looks up the webhook trigger (with `workflow` and `edges`) and its
+  - **Auth flow:** For non-`OPTIONS` requests under `/i/`, this plug:
+      1. Looks up the webhook trigger from the path segments, either
+         `/i/<trigger-uuid>` or `/i/<project-uuid>/<custom-path>`, (with
+         `workflow` and `edges`) and its
          `webhook_auth_methods`, wrapped in `Lightning.Retry.with_webhook_retry/2`
          so transient DB errors are retried.
       2. If the trigger is missing → responds **404** `{"error":"webhook_not_found"}`.
@@ -43,11 +44,11 @@ defmodule LightningWeb.Plugs.WebhookAuth do
 
   def call(conn, _opts) do
     case conn.path_info do
-      ["i" | [webhook | _rest]] ->
+      ["i" | segments] when segments != [] ->
         Retry.with_webhook_retry(
           fn ->
             trigger =
-              Workflows.get_webhook_trigger(webhook,
+              Workflows.get_webhook_trigger(segments,
                 include: [:workflow, :edges, :webhook_auth_methods]
               )
 
@@ -56,7 +57,7 @@ defmodule LightningWeb.Plugs.WebhookAuth do
             {:ok, validate_auth(trigger, methods, conn)}
           end,
           retry_on: &Retry.retriable_error?/1,
-          context: %{op: :webhook_auth_lookup, webhook: webhook}
+          context: %{op: :webhook_auth_lookup, webhook: log_key(segments)}
         )
         |> case do
           {:ok, %Plug.Conn{} = conn} ->
@@ -66,7 +67,7 @@ defmodule LightningWeb.Plugs.WebhookAuth do
             LightningWeb.Utils.respond_service_unavailable(
               conn,
               error,
-              %{op: :webhook_auth_lookup, webhook: webhook},
+              %{op: :webhook_auth_lookup, webhook: log_key(segments)},
               message:
                 "Temporary database issue during webhook lookup. Please retry in %{s}s."
             )
@@ -76,6 +77,11 @@ defmodule LightningWeb.Plugs.WebhookAuth do
         conn
     end
   end
+
+  # The first segment only. It is always the address, a trigger id or a bare
+  # path. The second is address in the namespaced form but caller data in
+  # `/i/<trigger-id>/Patient`, and that is where record identifiers turn up.
+  defp log_key(segments), do: segments |> Enum.take(1) |> Enum.join("/")
 
   defp validate_auth(nil, _methods, conn), do: not_found_response(conn)
 

--- a/priv/repo/migrations/20260827133000_namespace_trigger_custom_paths_by_project.exs
+++ b/priv/repo/migrations/20260827133000_namespace_trigger_custom_paths_by_project.exs
@@ -1,0 +1,125 @@
+defmodule Lightning.Repo.Migrations.NamespaceTriggerCustomPathsByProject do
+  use Ecto.Migration
+
+  @moduledoc """
+  A webhook's custom path is unique within its project, since the public URL
+  carries the project id. Triggers only know their workflow, so the project is
+  denormalised onto the trigger and held there by a composite foreign key: the
+  pair must match a real `(workflows.id, workflows.project_id)`, and moving a
+  workflow between projects carries its triggers along.
+
+  `project_id` is nullable because it only scopes a custom path. A trigger
+  without one is reached by its id and needs no project. `Trigger.changeset/2`
+  requires the two together.
+
+  `legacy_bare_path` marks the rows that already answer at `/i/<path>`, from
+  before paths were namespaced.
+  """
+
+  def up do
+    create unique_index(:workflows, [:id, :project_id], name: :workflows_id_project_id_index)
+
+    alter table(:triggers) do
+      add :project_id, :binary_id
+      add :legacy_bare_path, :boolean, null: false, default: false
+    end
+
+    execute("""
+    UPDATE triggers t
+    SET project_id = w.project_id
+    FROM workflows w
+    WHERE w.id = t.workflow_id
+    """)
+
+    execute("""
+    ALTER TABLE triggers
+    ADD CONSTRAINT triggers_workflow_id_project_id_fkey
+    FOREIGN KEY (workflow_id, project_id)
+    REFERENCES workflows (id, project_id)
+    ON UPDATE CASCADE ON DELETE CASCADE
+    """)
+
+    # Soft-deleted workflows are never purged, so a hidden row would refuse its
+    # name to a replacement forever. Disabled rows only: webhook ingest ignores
+    # `workflows.deleted_at`, so a hidden workflow with an enabled trigger is
+    # still serving, and `down/0` cannot put a cleared value back.
+    execute("""
+    UPDATE triggers SET custom_path = NULL, legacy_bare_path = false
+    WHERE enabled = false
+      AND workflow_id IN (
+        SELECT id FROM workflows WHERE deleted_at IS NOT NULL
+      )
+    """)
+
+    # A bare `/i/<path>` was the only way to address a custom path before this,
+    # and those URLs are in other people's systems. The set is fixed here and
+    # never grows, so nobody can claim a bare URL out from under an existing one.
+    execute("""
+    UPDATE triggers SET legacy_bare_path = true
+    WHERE custom_path IS NOT NULL AND type = 'webhook'
+    """)
+
+    # Nothing enforced uniqueness before. Webhooks only: a stale path on a cron
+    # or kafka row never served a URL and must not outrank one that does. These
+    # duplicates already 500d on the old lookup, so the oldest keeps the name and
+    # the rest fall back to their generated URL rather than aborting.
+    execute("""
+    UPDATE triggers SET custom_path = NULL, legacy_bare_path = false
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT id,
+               row_number() OVER (
+                 PARTITION BY project_id, custom_path ORDER BY inserted_at, id
+               ) AS rn
+        FROM triggers
+        WHERE custom_path IS NOT NULL AND type = 'webhook'
+      ) ranked
+      WHERE ranked.rn > 1
+    )
+    """)
+
+    create unique_index(:triggers, [:project_id, :custom_path],
+             where: "custom_path IS NOT NULL AND type = 'webhook'",
+             name: :triggers_project_id_custom_path_index
+           )
+
+    # A bare path was never unique across projects either. The oldest holder
+    # keeps the bare URL; the rest keep their namespaced one.
+    execute("""
+    UPDATE triggers SET legacy_bare_path = false
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT id,
+               row_number() OVER (
+                 PARTITION BY custom_path ORDER BY inserted_at, id
+               ) AS rn
+        FROM triggers
+        WHERE legacy_bare_path
+      ) ranked
+      WHERE ranked.rn > 1
+    )
+    """)
+
+    create unique_index(:triggers, [:custom_path],
+             where: "legacy_bare_path",
+             name: :triggers_legacy_bare_path_index
+           )
+  end
+
+  def down do
+    drop_if_exists index(:triggers, [:custom_path], name: :triggers_legacy_bare_path_index)
+
+    drop_if_exists index(:triggers, [:project_id, :custom_path],
+                     name: :triggers_project_id_custom_path_index
+                   )
+
+    execute("ALTER TABLE triggers DROP CONSTRAINT IF EXISTS triggers_workflow_id_project_id_fkey")
+
+    alter table(:triggers) do
+      remove :legacy_bare_path
+      remove :project_id
+    end
+
+    drop_if_exists index(:workflows, [:id, :project_id], name: :workflows_id_project_id_index)
+  end
+end

--- a/priv/static/workflow-api.yaml
+++ b/priv/static/workflow-api.yaml
@@ -273,6 +273,13 @@ components:
           type: string
         custom_path:
           type: string
+          description: >-
+            Names this webhook's endpoint so the URL is known before deploying.
+            The public URL is /i/{project_id}/{custom_path}. Unique within the
+            project. Lowercase letters, numbers, hyphens and underscores, and
+            not a UUID. The generated /i/{trigger_id} URL keeps working
+            whether or not this is set.
+          example: et-emr-facility-001
         cron_expression:
           type: string
         type:

--- a/test/lightning/collaboration/workflow_serializer_test.exs
+++ b/test/lightning/collaboration/workflow_serializer_test.exs
@@ -760,6 +760,7 @@ defmodule Lightning.Collaboration.WorkflowSerializerTest do
                "enabled" => true,
                "cron_expression" => nil,
                "cron_cursor_job_id" => nil,
+               "custom_path" => nil,
                "kafka_configuration" => nil,
                "webhook_reply" => "before_start",
                "webhook_response_config" => nil
@@ -983,6 +984,7 @@ defmodule Lightning.Collaboration.WorkflowSerializerTest do
                "enabled" => original_trigger.enabled,
                "cron_expression" => original_trigger.cron_expression,
                "cron_cursor_job_id" => original_trigger.cron_cursor_job_id,
+               "custom_path" => nil,
                "kafka_configuration" => nil,
                "webhook_reply" => nil,
                "webhook_response_config" => nil
@@ -1295,6 +1297,7 @@ defmodule Lightning.Collaboration.WorkflowSerializerTest do
                "enabled" => true,
                "cron_expression" => "0 */6 * * *",
                "cron_cursor_job_id" => original_trigger.cron_cursor_job_id,
+               "custom_path" => nil,
                "kafka_configuration" => nil,
                "webhook_reply" => nil,
                "webhook_response_config" => nil

--- a/test/lightning/projects/provisioner_test.exs
+++ b/test/lightning/projects/provisioner_test.exs
@@ -75,6 +75,31 @@ defmodule Lightning.Projects.ProvisionerTest do
              }
     end
 
+    test "with server-owned trigger fields" do
+      %{body: body} = valid_document()
+
+      for field <- ["project_id", "legacy_bare_path"] do
+        tampered =
+          Map.update!(body, "workflows", fn workflows ->
+            Enum.map(workflows, fn workflow ->
+              Map.update!(workflow, "triggers", fn [trigger] ->
+                [Map.put(trigger, field, "anything")]
+              end)
+            end)
+          end)
+
+        changeset =
+          Provisioner.parse_document(%Lightning.Projects.Project{}, tampered)
+
+        refute changeset.valid?
+
+        assert %{workflows: [%{triggers: [%{base: [error]}]}]} =
+                 flatten_errors(changeset)
+
+        assert error == "extraneous parameters: #{field}"
+      end
+    end
+
     test "with sensitive kafka trigger fields" do
       %{body: body} = valid_document()
 

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -1,6 +1,8 @@
 defmodule Lightning.ProjectsTest do
   use Lightning.DataCase, async: true
 
+  import Ecto.Query
+
   import Lightning.AccountsFixtures
   import Lightning.Factories
   import Lightning.ProjectsFixtures
@@ -1226,6 +1228,60 @@ defmodule Lightning.ProjectsTest do
       {:ok, generated_yaml} = Projects.export_project(:yaml, project.id)
 
       assert generated_yaml == expected_yaml
+    end
+
+    test "includes a webhook's custom path, and omits it when unset" do
+      project = insert(:project, name: "et-emr")
+      workflow = insert(:workflow, project: project, name: "facility 1")
+
+      insert(:trigger,
+        workflow: workflow,
+        type: :webhook,
+        enabled: true,
+        custom_path: "et-emr-facility-001"
+      )
+
+      assert {:ok, yaml} = Projects.export_project(:yaml, project.id)
+      assert yaml =~ "custom_path: 'et-emr-facility-001'"
+
+      bare_project = insert(:project, name: "bare")
+      bare_workflow = insert(:workflow, project: bare_project, name: "w")
+      insert(:trigger, workflow: bare_workflow, type: :webhook, enabled: true)
+
+      assert {:ok, bare_yaml} = Projects.export_project(:yaml, bare_project.id)
+      refute bare_yaml =~ "custom_path"
+    end
+
+    test "quotes an all-digit path so it survives a round trip" do
+      project = insert(:project, name: "digits")
+      workflow = insert(:workflow, project: project, name: "w")
+
+      insert(:trigger,
+        workflow: workflow,
+        type: :webhook,
+        enabled: true,
+        custom_path: "12345"
+      )
+
+      assert {:ok, yaml} = Projects.export_project(:yaml, project.id)
+
+      # Unquoted it parses back as an integer and the whole deploy fails.
+      assert yaml =~ "custom_path: '12345'"
+    end
+
+    test "omits a legacy path that would fail a deploy elsewhere" do
+      project = insert(:project, name: "legacy")
+      workflow = insert(:workflow, project: project, name: "w")
+      trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Lightning.Workflows.Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: "orders.v1"]
+        )
+
+      assert {:ok, yaml} = Projects.export_project(:yaml, project.id)
+      refute yaml =~ "orders.v1"
     end
 
     test "adds quotes to values with special charaters" do

--- a/test/lightning/workflow_versions_test.exs
+++ b/test/lightning/workflow_versions_test.exs
@@ -401,6 +401,37 @@ defmodule Lightning.WorkflowVersionsTest do
       assert Regex.match?(~r/^[a-f0-9]{12}$/, hash1)
     end
 
+    test "a webhook custom path moves the hash, and no path leaves it alone" do
+      workflow = insert(:workflow, name: "Test")
+
+      trigger =
+        insert(:trigger, workflow: workflow, type: :webhook, custom_path: nil)
+
+      insert(:job, workflow: workflow, name: "Job A", body: "code")
+
+      without_path =
+        workflow |> Repo.preload([:triggers, :jobs, :edges], force: true)
+
+      # A nil serialises to "" and the parts are concatenated, so hashing the
+      # key costs nothing for the workflows that have no path. @openfn/project
+      # skips undefined for the same reason, which keeps the two sides equal.
+      assert WorkflowVersions.canonical_form(without_path) ==
+               "Testtruewebhookbefore_start@openfn/language-common@latestcodeJob A"
+
+      Repo.update_all(
+        from(x in Lightning.Workflows.Trigger, where: x.id == ^trigger.id),
+        set: [custom_path: "facility-001"]
+      )
+
+      with_path =
+        workflow |> Repo.preload([:triggers, :jobs, :edges], force: true)
+
+      assert WorkflowVersions.canonical_form(with_path) =~ "facility-001"
+
+      refute WorkflowVersions.generate_hash(without_path) ==
+               WorkflowVersions.generate_hash(with_path)
+    end
+
     test "generates different hashes for different workflow structures" do
       project = insert(:project)
 

--- a/test/lightning/workflow_versions_test.exs
+++ b/test/lightning/workflow_versions_test.exs
@@ -432,6 +432,57 @@ defmodule Lightning.WorkflowVersionsTest do
                WorkflowVersions.generate_hash(with_path)
     end
 
+    test "a path the app would not export is not hashed" do
+      # `ProvisioningJSON` drops a pre-migration path, so the CLI never sees
+      # one. Hashing it would leave the two disagreeing on every pull, forever,
+      # for exactly the rows the grandfathering exists to keep working.
+      workflow = insert(:workflow, name: "Test")
+
+      trigger =
+        insert(:trigger, workflow: workflow, type: :webhook, custom_path: nil)
+
+      insert(:job, workflow: workflow, name: "Job A", body: "code")
+
+      pathless = Repo.preload(workflow, [:triggers, :jobs, :edges], force: true)
+      expected = WorkflowVersions.generate_hash(pathless)
+
+      Repo.update_all(
+        from(x in Lightning.Workflows.Trigger, where: x.id == ^trigger.id),
+        set: [custom_path: "Fhir.Patient"]
+      )
+
+      legacy = Repo.preload(workflow, [:triggers, :jobs, :edges], force: true)
+
+      assert WorkflowVersions.generate_hash(legacy) == expected
+    end
+
+    test "a path on a cron trigger is not hashed" do
+      # It never served a URL, so it is not workflow content. Left over from
+      # before the column was validated.
+      workflow = insert(:workflow, name: "Test")
+
+      trigger =
+        insert(:trigger,
+          workflow: workflow,
+          type: :cron,
+          cron_expression: "0 0 * * *"
+        )
+
+      insert(:job, workflow: workflow, name: "Job A", body: "code")
+
+      pathless = Repo.preload(workflow, [:triggers, :jobs, :edges], force: true)
+      expected = WorkflowVersions.generate_hash(pathless)
+
+      Repo.update_all(
+        from(x in Lightning.Workflows.Trigger, where: x.id == ^trigger.id),
+        set: [custom_path: "old-name"]
+      )
+
+      stale = Repo.preload(workflow, [:triggers, :jobs, :edges], force: true)
+
+      assert WorkflowVersions.generate_hash(stale) == expected
+    end
+
     test "generates different hashes for different workflow structures" do
       project = insert(:project)
 

--- a/test/lightning/workflows/trigger_custom_path_test.exs
+++ b/test/lightning/workflows/trigger_custom_path_test.exs
@@ -1,0 +1,171 @@
+defmodule Lightning.Workflows.TriggerCustomPathTest do
+  use Lightning.DataCase, async: true
+
+  import Lightning.Factories
+
+  alias Lightning.Workflows.Trigger
+
+  # `Sandboxes` retries an insert without the path when, and only when, this
+  # says the path was refused on its shape. Getting it wrong the other way
+  # would write a duplicate path back with `update_all`.
+  describe "custom_path_shape_error?/1" do
+    test "is true for a path refused on its characters" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          custom_path: "some/legacy/path"
+        })
+
+      assert Trigger.custom_path_shape_error?(changeset)
+    end
+
+    test "is true for a path refused on its length" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          custom_path: String.duplicate("a", 256)
+        })
+
+      assert Trigger.custom_path_shape_error?(changeset)
+    end
+
+    test "is true for a UUID-shaped path" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          custom_path: Ecto.UUID.generate()
+        })
+
+      assert Trigger.custom_path_shape_error?(changeset)
+    end
+
+    test "is false for a path already used in the project" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+      insert(:trigger, type: :webhook, workflow: workflow, custom_path: "taken")
+
+      other_workflow = insert(:workflow, project: project)
+
+      assert {:error, changeset} =
+               %Trigger{}
+               |> Trigger.changeset(%{
+                 type: :webhook,
+                 workflow_id: other_workflow.id,
+                 custom_path: "taken"
+               })
+               |> Lightning.Repo.insert()
+
+      assert Keyword.has_key?(changeset.errors, :custom_path)
+      refute Trigger.custom_path_shape_error?(changeset)
+    end
+
+    test "is false for a path whose trigger has no project" do
+      assert {:error, changeset} =
+               %Trigger{}
+               |> Trigger.changeset(%{
+                 type: :webhook,
+                 workflow_id: Ecto.UUID.generate(),
+                 custom_path: "orphan"
+               })
+               |> Lightning.Repo.insert()
+
+      assert Keyword.has_key?(changeset.errors, :custom_path)
+      refute Trigger.custom_path_shape_error?(changeset)
+    end
+
+    test "is false when the failure is on another field" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :cron,
+          cron_expression: "not a cron expression"
+        })
+
+      refute changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :custom_path)
+      refute Trigger.custom_path_shape_error?(changeset)
+    end
+  end
+
+  describe "changeset/2 trimming and shape" do
+    test "a blank path clears a path that was set" do
+      stored = %Trigger{type: :webhook, custom_path: "orders"}
+
+      for blank <- ["", "   ", "\t"] do
+        changeset = Trigger.changeset(stored, %{custom_path: blank})
+
+        assert changeset.valid?
+        assert Ecto.Changeset.fetch_change(changeset, :custom_path) == {:ok, nil}
+      end
+    end
+
+    test "a blank path on a new trigger leaves it with none" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{type: :webhook, custom_path: "   "})
+
+      assert changeset.valid?
+      refute Ecto.Changeset.get_field(changeset, :custom_path)
+    end
+
+    test "a path is stored trimmed" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          custom_path: "  facility-001  "
+        })
+
+      assert changeset.valid?
+
+      assert Ecto.Changeset.get_change(changeset, :custom_path) ==
+               "facility-001"
+    end
+
+    test "a 36-character path that is not a UUID is allowed" do
+      # The length a UUID happens to be. Only a real one is refused, since only
+      # a real one would resolve against a trigger id.
+      path = String.duplicate("a", 36)
+
+      changeset =
+        Trigger.changeset(%Trigger{}, %{type: :webhook, custom_path: path})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :custom_path) == path
+    end
+  end
+
+  describe "changeset/2 and a grandfathered bare path" do
+    setup do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+
+      trigger =
+        insert(:trigger,
+          type: :webhook,
+          workflow: workflow,
+          custom_path: "orders"
+        )
+
+      Lightning.Repo.update_all(
+        Ecto.Query.from(t in Trigger, where: t.id == ^trigger.id),
+        set: [legacy_bare_path: true]
+      )
+
+      %{trigger: Lightning.Repo.reload!(trigger)}
+    end
+
+    test "survives a write that trims back to the stored path", %{
+      trigger: trigger
+    } do
+      changeset = Trigger.changeset(trigger, %{custom_path: "  orders  "})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :legacy_bare_path)
+    end
+
+    test "is dropped by a real rename", %{trigger: trigger} do
+      changeset = Trigger.changeset(trigger, %{custom_path: "orders-v2"})
+
+      assert changeset.valid?
+      refute Ecto.Changeset.get_field(changeset, :legacy_bare_path)
+    end
+  end
+end

--- a/test/lightning/workflows/trigger_path_migration_test.exs
+++ b/test/lightning/workflows/trigger_path_migration_test.exs
@@ -1,0 +1,260 @@
+defmodule Lightning.Workflows.TriggerPathMigrationTest do
+  @moduledoc """
+  The migration that namespaces custom paths decides which URLs keep working.
+  Its data steps have no other coverage, so they are read straight out of the
+  migration file and run against rows in the state they would find. Reading the
+  file rather than copying the SQL means an edit to the migration is an edit to
+  what this tests.
+  """
+  use Lightning.DataCase, async: false
+
+  import Ecto.Query
+  import Lightning.Factories
+
+  alias Lightning.Repo
+  alias Lightning.Workflows.Trigger
+
+  @migration "priv/repo/migrations/20260827133000_namespace_trigger_custom_paths_by_project.exs"
+
+  # Every UPDATE the migration runs, in order: backfill project_id, release
+  # paths held by already-deleted workflows, mark the rows that had a bare URL,
+  # dedupe within a project, dedupe bare URLs across projects.
+  defp data_steps do
+    File.read!(@migration)
+    |> then(&Regex.scan(~r/execute\("""\n(\s*UPDATE.*?)\n\s*"""\)/s, &1))
+    |> Enum.map(fn [_whole, sql] -> String.trim(sql) end)
+  end
+
+  # The indexes come down first and go back up afterwards. Rebuilding them is
+  # the assertion: a surviving duplicate makes index creation raise.
+  defp run_data_steps do
+    for sql <- data_steps(), do: Repo.query!(sql)
+
+    Repo.query!("""
+    CREATE UNIQUE INDEX triggers_project_id_custom_path_index
+    ON triggers (project_id, custom_path)
+    WHERE custom_path IS NOT NULL AND type = 'webhook'
+    """)
+
+    Repo.query!("""
+    CREATE UNIQUE INDEX triggers_legacy_bare_path_index
+    ON triggers (custom_path) WHERE legacy_bare_path
+    """)
+
+    :ok
+  end
+
+  # Puts a trigger back into the state the migration would find it in.
+  defp as_before_migration(trigger, attrs) do
+    {1, _} =
+      Repo.update_all(
+        from(t in Trigger, where: t.id == ^trigger.id),
+        set: Keyword.put(attrs, :legacy_bare_path, false)
+      )
+
+    trigger
+  end
+
+  defp reload(trigger), do: Repo.get!(Trigger, trigger.id)
+
+  setup do
+    # The table as the migration finds it: no unique indexes, nothing marked.
+    Repo.query!("DROP INDEX triggers_legacy_bare_path_index")
+    Repo.query!("DROP INDEX triggers_project_id_custom_path_index")
+    Repo.update_all(Trigger, set: [legacy_bare_path: false])
+    :ok
+  end
+
+  test "reads every data step out of the migration" do
+    # A guard on the extraction itself: if the migration grows or loses a step,
+    # this test is running something different from what it thinks.
+    assert length(data_steps()) == 5
+  end
+
+  test "releases a path held by an already-deleted workflow" do
+    # Soft-deleted workflows are never purged.
+    project = insert(:project)
+
+    deleted =
+      insert(:workflow,
+        project: project,
+        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+    trigger =
+      insert(:trigger, workflow: deleted, type: :webhook, enabled: false)
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    assert reload(trigger).custom_path == nil
+    refute reload(trigger).legacy_bare_path
+  end
+
+  test "spares a deleted workflow whose trigger is still serving" do
+    # Webhook ingest ignores `deleted_at`, so clearing this would 404 a live
+    # endpoint with no way to put the value back.
+    project = insert(:project)
+
+    deleted =
+      insert(:workflow,
+        project: project,
+        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+    trigger =
+      insert(:trigger, workflow: deleted, type: :webhook, enabled: true)
+      |> as_before_migration(custom_path: "still-live")
+
+    run_data_steps()
+
+    assert reload(trigger).custom_path == "still-live"
+  end
+
+  test "a live workflow can then take that name" do
+    project = insert(:project)
+
+    deleted =
+      insert(:workflow,
+        project: project,
+        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+    insert(:trigger, workflow: deleted, type: :webhook, enabled: false)
+    |> as_before_migration(custom_path: "orders")
+
+    live = insert(:workflow, project: project)
+
+    replacement =
+      insert(:trigger, workflow: live, type: :webhook)
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    assert reload(replacement).custom_path == "orders"
+    assert reload(replacement).legacy_bare_path
+  end
+
+  test "grandfathers a webhook that already had a bare URL" do
+    workflow = insert(:workflow, project: insert(:project))
+
+    trigger =
+      insert(:trigger, workflow: workflow, type: :webhook)
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    assert reload(trigger).legacy_bare_path
+    assert reload(trigger).custom_path == "orders"
+  end
+
+  test "leaves a webhook with no path alone" do
+    workflow = insert(:workflow, project: insert(:project))
+    trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+    run_data_steps()
+
+    refute reload(trigger).legacy_bare_path
+  end
+
+  test "ignores a stale path on a cron trigger" do
+    # A path on a cron row never served a URL.
+    workflow = insert(:workflow, project: insert(:project))
+
+    cron =
+      insert(:trigger, workflow: workflow, type: :cron)
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    refute reload(cron).legacy_bare_path
+  end
+
+  test "a stale cron path does not outrank a webhook holding the same one" do
+    project = insert(:project)
+    cron_workflow = insert(:workflow, project: project)
+    webhook_workflow = insert(:workflow, project: project)
+
+    # The cron row is older, so a type-blind dedupe would keep it and strip the
+    # webhook that is actually serving traffic.
+    cron =
+      insert(:trigger,
+        workflow: cron_workflow,
+        type: :cron,
+        inserted_at: ~U[2023-01-01 00:00:00Z]
+      )
+      |> as_before_migration(custom_path: "orders")
+
+    webhook =
+      insert(:trigger,
+        workflow: webhook_workflow,
+        type: :webhook,
+        inserted_at: ~U[2024-01-01 00:00:00Z]
+      )
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    assert reload(webhook).custom_path == "orders"
+    assert reload(webhook).legacy_bare_path
+    assert reload(cron).custom_path == "orders"
+    refute reload(cron).legacy_bare_path
+  end
+
+  test "within a project the oldest webhook keeps a duplicated path" do
+    project = insert(:project)
+
+    older =
+      insert(:trigger,
+        workflow: insert(:workflow, project: project),
+        type: :webhook,
+        inserted_at: ~U[2023-01-01 00:00:00Z]
+      )
+      |> as_before_migration(custom_path: "orders")
+
+    newer =
+      insert(:trigger,
+        workflow: insert(:workflow, project: project),
+        type: :webhook,
+        inserted_at: ~U[2024-01-01 00:00:00Z]
+      )
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    assert reload(older).custom_path == "orders"
+    assert reload(older).legacy_bare_path
+
+    # The duplicate falls back to its generated URL rather than aborting the
+    # migration on the unique index.
+    assert reload(newer).custom_path == nil
+    refute reload(newer).legacy_bare_path
+  end
+
+  test "across projects both keep the path, the oldest keeps the bare URL" do
+    older =
+      insert(:trigger,
+        workflow: insert(:workflow, project: insert(:project)),
+        type: :webhook,
+        inserted_at: ~U[2023-01-01 00:00:00Z]
+      )
+      |> as_before_migration(custom_path: "orders")
+
+    newer =
+      insert(:trigger,
+        workflow: insert(:workflow, project: insert(:project)),
+        type: :webhook,
+        inserted_at: ~U[2024-01-01 00:00:00Z]
+      )
+      |> as_before_migration(custom_path: "orders")
+
+    run_data_steps()
+
+    assert reload(older).custom_path == "orders"
+    assert reload(older).legacy_bare_path
+
+    # Namespacing means the newer one keeps its path, just not the bare URL.
+    assert reload(newer).custom_path == "orders"
+    refute reload(newer).legacy_bare_path
+  end
+end

--- a/test/lightning/workflows/webhook_lookup_queries_test.exs
+++ b/test/lightning/workflows/webhook_lookup_queries_test.exs
@@ -1,0 +1,89 @@
+defmodule Lightning.Workflows.WebhookLookupQueriesTest do
+  @moduledoc """
+  Webhook ingest is the hottest path in the app, so the number of queries a
+  lookup costs is pinned rather than assumed.
+
+  `async: false` because the telemetry handler sees every process's queries.
+  """
+  use Lightning.DataCase, async: false
+
+  import Lightning.Factories
+
+  alias Lightning.Workflows
+  alias Lightning.Workflows.Trigger
+
+  defp webhook_trigger(attrs \\ []) do
+    project = insert(:project)
+    workflow = insert(:workflow, project: project)
+
+    trigger =
+      insert(
+        :trigger,
+        Keyword.merge([workflow: workflow, type: :webhook, enabled: true], attrs)
+      )
+
+    {project, trigger}
+  end
+
+  defp count_queries(fun) do
+    ref = make_ref()
+    parent = self()
+    name = "count-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      name,
+      [:lightning, :repo, :query],
+      fn _event, _measures, meta, _config ->
+        if meta[:source] == "triggers", do: send(parent, {ref, :query})
+      end,
+      nil
+    )
+
+    fun.()
+    :telemetry.detach(name)
+
+    drain(ref, 0)
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, :query} -> drain(ref, acc + 1)
+    after
+      0 -> acc
+    end
+  end
+
+  test "the namespaced URL is one query" do
+    {project, _trigger} = webhook_trigger(custom_path: "facility-001")
+
+    assert count_queries(fn ->
+             Workflows.get_webhook_trigger([project.id, "facility-001"])
+           end) == 1
+  end
+
+  test "the generated URL is one query" do
+    {_project, trigger} = webhook_trigger()
+
+    assert count_queries(fn ->
+             Workflows.get_webhook_trigger([trigger.id])
+           end) == 1
+  end
+
+  test "the generated URL with a trailing segment costs one more" do
+    # The long-standing /i/<id>/Patient habit pays for the namespaced form
+    # being tried first, which is the shape this feature creates.
+    {_project, trigger} = webhook_trigger()
+
+    assert count_queries(fn ->
+             Workflows.get_webhook_trigger([trigger.id, "Patient"])
+           end) == 2
+  end
+
+  test "a miss costs no more than three" do
+    assert count_queries(fn ->
+             Workflows.get_webhook_trigger([Ecto.UUID.generate(), "nope"])
+           end) <= 3
+
+    assert Trigger
+  end
+end

--- a/test/lightning/workflows/webhook_trigger_path_test.exs
+++ b/test/lightning/workflows/webhook_trigger_path_test.exs
@@ -1,0 +1,980 @@
+defmodule Lightning.Workflows.WebhookTriggerPathTest do
+  use LightningWeb.ConnCase, async: true
+
+  import Ecto.Query
+  import Plug.Test
+  import Lightning.Factories
+
+  alias Lightning.Workflows
+  alias Lightning.Workflows.Trigger
+  alias LightningWeb.Plugs.WebhookAuth
+
+  @moduletag capture_log: true
+
+  defp webhook_trigger(attrs \\ []) do
+    project = Keyword.get_lazy(attrs, :project, fn -> insert(:project) end)
+    workflow = insert(:workflow, project: project)
+
+    trigger =
+      insert(
+        :trigger,
+        Keyword.merge(
+          [workflow: workflow, type: :webhook, enabled: true],
+          Keyword.delete(attrs, :project)
+        )
+      )
+
+    {project, trigger}
+  end
+
+  # Only the migration sets this, so tests standing in for pre-existing data
+  # write it directly.
+  defp grandfather(trigger) do
+    {1, _} =
+      Lightning.Repo.update_all(
+        from(t in Trigger, where: t.id == ^trigger.id),
+        set: [legacy_bare_path: true]
+      )
+
+    trigger
+  end
+
+  describe "get_webhook_trigger/2" do
+    test "resolves a trigger by its generated id" do
+      {_project, trigger} = webhook_trigger()
+
+      assert Workflows.get_webhook_trigger([trigger.id]).id == trigger.id
+    end
+
+    test "resolves a custom path within its project" do
+      {project, trigger} = webhook_trigger(custom_path: "facility-001")
+
+      assert Workflows.get_webhook_trigger([project.id, "facility-001"]).id ==
+               trigger.id
+    end
+
+    test "keeps the generated id URL working once a custom path is set" do
+      {project, trigger} = webhook_trigger(custom_path: "facility-001")
+
+      assert Workflows.get_webhook_trigger([trigger.id]).id == trigger.id
+
+      assert Workflows.get_webhook_trigger([project.id, "facility-001"]).id ==
+               trigger.id
+    end
+
+    test "the same custom path in two projects does not collide" do
+      {project_a, trigger_a} = webhook_trigger(custom_path: "facility-001")
+      {project_b, trigger_b} = webhook_trigger(custom_path: "facility-001")
+
+      refute trigger_a.id == trigger_b.id
+
+      assert Workflows.get_webhook_trigger([project_a.id, "facility-001"]).id ==
+               trigger_a.id
+
+      assert Workflows.get_webhook_trigger([project_b.id, "facility-001"]).id ==
+               trigger_b.id
+    end
+
+    test "a custom path cannot shadow another trigger's generated id URL" do
+      {_project, victim} = webhook_trigger()
+      {other_project, _} = webhook_trigger()
+
+      workflow = insert(:workflow, project: other_project)
+
+      assert {:error, changeset} =
+               %Trigger{}
+               |> Trigger.changeset(%{
+                 workflow_id: workflow.id,
+                 type: :webhook,
+                 custom_path: victim.id
+               })
+               |> Lightning.Repo.insert()
+
+      assert "cannot be a UUID" in errors_on(changeset).custom_path
+      assert Workflows.get_webhook_trigger([victim.id]).id == victim.id
+    end
+
+    test "ignores cron triggers" do
+      workflow = insert(:workflow, project: insert(:project))
+      trigger = insert(:trigger, workflow: workflow, type: :cron)
+
+      assert Workflows.get_webhook_trigger([trigger.id]) == nil
+    end
+
+    test "a 16-character path is a name, not a raw UUID" do
+      # Ecto.UUID.cast/1 accepts any 16-byte binary, so this used to be read as
+      # a trigger id and rejected on write.
+      {project, trigger} = webhook_trigger(custom_path: "orders_intake_v1")
+
+      assert trigger.custom_path == "orders_intake_v1"
+
+      assert Workflows.get_webhook_trigger([project.id, "orders_intake_v1"]).id ==
+               trigger.id
+    end
+
+    test "ignores trailing segments for both URL forms" do
+      {project, trigger} = webhook_trigger(custom_path: "facility-001")
+
+      assert Workflows.get_webhook_trigger([trigger.id, "Patient"]).id ==
+               trigger.id
+
+      assert Workflows.get_webhook_trigger([
+               project.id,
+               "facility-001",
+               "Patient"
+             ]).id == trigger.id
+    end
+
+    test "answers a bare path only for a trigger that already held that URL" do
+      {_project, trigger} = webhook_trigger(custom_path: "facility-001")
+
+      assert Workflows.get_webhook_trigger(["facility-001"]) == nil
+
+      grandfather(trigger)
+
+      assert Workflows.get_webhook_trigger(["facility-001"]).id == trigger.id
+    end
+
+    test "renaming a grandfathered path gives up the bare URL" do
+      {project, trigger} = webhook_trigger(custom_path: "orders")
+      grandfather(trigger)
+
+      assert Workflows.get_webhook_trigger(["orders"]).id == trigger.id
+
+      {:ok, renamed} =
+        trigger
+        |> Trigger.changeset(%{custom_path: "invoices"})
+        |> Lightning.Repo.update()
+
+      refute renamed.legacy_bare_path
+      assert Workflows.get_webhook_trigger(["invoices"]) == nil
+
+      assert Workflows.get_webhook_trigger([project.id, "invoices"]).id ==
+               trigger.id
+    end
+
+    test "resubmitting the same path keeps the bare URL" do
+      # Trimming can leave a change registered whose value equals the row's.
+      # Treating that as a rename would retire a URL that never moved.
+      {_project, trigger} = webhook_trigger(custom_path: "orders")
+      grandfather(trigger)
+
+      assert {:ok, saved} =
+               Lightning.Repo.get!(Trigger, trigger.id)
+               |> Trigger.changeset(%{custom_path: "  orders  "})
+               |> Lightning.Repo.update()
+
+      assert saved.custom_path == "orders"
+      assert saved.legacy_bare_path
+      assert Workflows.get_webhook_trigger(["orders"]).id == trigger.id
+    end
+
+    test "a rename onto another project's bare URL does not take it" do
+      {_incumbent_project, incumbent} = webhook_trigger(custom_path: "orders")
+      grandfather(incumbent)
+
+      {other_project, other} = webhook_trigger(custom_path: "invoices")
+      grandfather(other)
+
+      # Allowed: two projects may both name a path `orders`. Renaming just
+      # gives up the bare URL that came with the old name.
+      assert {:ok, renamed} =
+               other
+               |> Trigger.changeset(%{custom_path: "orders"})
+               |> Lightning.Repo.update()
+
+      refute renamed.legacy_bare_path
+      assert Workflows.get_webhook_trigger(["orders"]).id == incumbent.id
+
+      assert Workflows.get_webhook_trigger([other_project.id, "orders"]).id ==
+               other.id
+    end
+
+    test "a grandfathered path that looks like a UUID still resolves" do
+      {_project, trigger} = webhook_trigger()
+      uuid_path = Ecto.UUID.generate()
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: uuid_path, legacy_bare_path: true]
+        )
+
+      assert Workflows.get_webhook_trigger([uuid_path]).id == trigger.id
+    end
+
+    test "a cron trigger's stale path never answers a webhook URL" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+      cron = insert(:trigger, workflow: workflow, type: :cron)
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^cron.id),
+          set: [custom_path: "orders", legacy_bare_path: true]
+        )
+
+      assert Workflows.get_webhook_trigger(["orders"]) == nil
+      assert Workflows.get_webhook_trigger([project.id, "orders"]) == nil
+    end
+
+    test "a newer project cannot take an existing bare URL" do
+      {_incumbent_project, incumbent} =
+        webhook_trigger(custom_path: "facility-001")
+
+      grandfather(incumbent)
+
+      {squatter_project, squatter} = webhook_trigger(custom_path: "facility-001")
+
+      assert Workflows.get_webhook_trigger(["facility-001"]).id == incumbent.id
+
+      assert Workflows.get_webhook_trigger([squatter_project.id, "facility-001"]).id ==
+               squatter.id
+    end
+
+    test "returns nil for unknown, malformed and over-long paths" do
+      assert Workflows.get_webhook_trigger(["nothing-here"]) == nil
+      assert Workflows.get_webhook_trigger([Ecto.UUID.generate()]) == nil
+      assert Workflows.get_webhook_trigger(["not-a-uuid", "facility-001"]) == nil
+      assert Workflows.get_webhook_trigger([]) == nil
+      assert Workflows.get_webhook_trigger(["a", "b", "c"]) == nil
+    end
+  end
+
+  describe "the /i/ plug" do
+    test "resolves the generated URL" do
+      {_project, trigger} = webhook_trigger()
+
+      conn = conn(:post, "/i/#{trigger.id}", %{"a" => 1}) |> WebhookAuth.call([])
+
+      refute conn.halted
+      assert conn.assigns[:trigger].id == trigger.id
+    end
+
+    test "resolves a project-namespaced custom path" do
+      {project, trigger} = webhook_trigger(custom_path: "facility-001")
+
+      conn =
+        conn(:post, "/i/#{project.id}/facility-001", %{"a" => 1})
+        |> WebhookAuth.call([])
+
+      refute conn.halted
+      assert conn.assigns[:trigger].id == trigger.id
+    end
+
+    test "resolves a grandfathered bare custom path" do
+      {_project, trigger} = webhook_trigger(custom_path: "facility-001")
+      grandfather(trigger)
+
+      conn = conn(:post, "/i/facility-001", %{}) |> WebhookAuth.call([])
+
+      refute conn.halted
+      assert conn.assigns[:trigger].id == trigger.id
+    end
+
+    test "matches a legacy path against the raw URL segment" do
+      # `conn.path_info` is not percent-decoded, so a stored path containing a
+      # percent sequence is reached by sending it verbatim.
+      {project, trigger} = webhook_trigger()
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: "a%20b"]
+        )
+
+      conn =
+        conn(:post, "/i/#{project.id}/a%20b", %{}) |> WebhookAuth.call([])
+
+      refute conn.halted
+      assert conn.assigns[:trigger].id == trigger.id
+    end
+
+    test "404s a bare custom path that was never a bare URL" do
+      {_project, _trigger} = webhook_trigger(custom_path: "facility-001")
+
+      conn = conn(:post, "/i/facility-001", %{}) |> WebhookAuth.call([])
+
+      assert conn.status == 404
+    end
+  end
+
+  describe "valid_custom_path?/1" do
+    test "accepts what the changeset accepts" do
+      assert Trigger.valid_custom_path?("facility-001")
+      assert Trigger.valid_custom_path?("orders_intake_v1")
+    end
+
+    test "rejects a trailing newline" do
+      # `$` also matches before a final newline in PCRE, so this would have been
+      # called usable and then silently trimmed on the way through.
+      refute Trigger.valid_custom_path?("orders\n")
+    end
+
+    test "rejects what the changeset rejects" do
+      refute Trigger.valid_custom_path?("orders.v1")
+      refute Trigger.valid_custom_path?("Orders")
+      refute Trigger.valid_custom_path?(Ecto.UUID.generate())
+      refute Trigger.valid_custom_path?(String.duplicate("a", 256))
+      refute Trigger.valid_custom_path?(nil)
+    end
+  end
+
+  describe "custom_path" do
+    test "is unique within a project" do
+      {project, _first} = webhook_trigger(custom_path: "facility-001")
+      workflow = insert(:workflow, project: project)
+
+      assert {:error, changeset} =
+               %Trigger{}
+               |> Trigger.changeset(%{
+                 workflow_id: workflow.id,
+                 type: :webhook,
+                 custom_path: "facility-001"
+               })
+               |> Lightning.Repo.insert()
+
+      assert "is already used by another workflow in this project" in errors_on(
+               changeset
+             ).custom_path
+    end
+
+    test "accepts lowercase letters, numbers, hyphens and underscores" do
+      {_project, trigger} = webhook_trigger(custom_path: "et-emr_facility-001")
+
+      assert trigger.custom_path == "et-emr_facility-001"
+    end
+
+    test "rejects characters that would not survive a URL segment" do
+      for path <- ["Orders Intake", "orders/intake", "orders?a=1", "ORDERS"] do
+        changeset =
+          Trigger.changeset(%Trigger{}, %{type: :webhook, custom_path: path})
+
+        assert %{custom_path: [_ | _]} = errors_on(changeset),
+               "expected #{inspect(path)} to be rejected"
+      end
+    end
+
+    test "rejects a path longer than 255 characters" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          custom_path: String.duplicate("a", 256)
+        })
+
+      assert %{custom_path: [_ | _]} = errors_on(changeset)
+    end
+
+    test "a rejected path reports against the field the form renders" do
+      workflow = insert(:workflow, project: insert(:project))
+
+      assert {:error, changeset} =
+               %Trigger{}
+               |> Trigger.changeset(%{
+                 workflow_id: workflow.id,
+                 type: :webhook,
+                 custom_path: "Orders Intake"
+               })
+               |> Lightning.Repo.insert()
+
+      assert Map.has_key?(errors_on(changeset), :custom_path)
+      refute Map.has_key?(errors_on(changeset), :project_id)
+    end
+
+    test "build_trigger/1 reports a duplicate rather than raising" do
+      {project, _first} = webhook_trigger(custom_path: "facility-001")
+      workflow = insert(:workflow, project: project)
+
+      assert {:error, changeset} =
+               Workflows.build_trigger(%{
+                 type: :webhook,
+                 workflow_id: workflow.id,
+                 custom_path: "facility-001"
+               })
+
+      assert Map.has_key?(errors_on(changeset), :custom_path)
+    end
+
+    test "build_trigger/1 validates the path like the changeset does" do
+      workflow = insert(:workflow, project: insert(:project))
+
+      assert {:error, changeset} =
+               Workflows.build_trigger(%{
+                 type: :webhook,
+                 workflow_id: workflow.id,
+                 custom_path: "Orders Intake"
+               })
+
+      assert Map.has_key?(errors_on(changeset), :custom_path)
+    end
+
+    test "treats a blank path as no path" do
+      changeset =
+        Trigger.changeset(%Trigger{}, %{type: :webhook, custom_path: "   "})
+
+      assert Ecto.Changeset.get_field(changeset, :custom_path) == nil
+    end
+  end
+
+  describe "a sandbox of a project with a custom path" do
+    test "keeps the path and gets its own URL" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+
+      workflow = insert(:workflow, project: parent)
+
+      parent_trigger =
+        insert(:trigger,
+          workflow: workflow,
+          type: :webhook,
+          enabled: true,
+          custom_path: "facility-001"
+        )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      assert Workflows.get_webhook_trigger([parent.id, "facility-001"]).id ==
+               parent_trigger.id
+
+      sandbox_trigger =
+        Workflows.get_webhook_trigger([sandbox.id, "facility-001"])
+
+      assert sandbox_trigger
+      refute sandbox_trigger.id == parent_trigger.id
+    end
+  end
+
+  describe "a legacy path the new rules reject" do
+    test "does not stop a sandbox being provisioned" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+
+      workflow = insert(:workflow, project: parent)
+      trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+      # Paths written before the naming rules existed were never validated, so
+      # write one the way the old code could.
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: "some/legacy/path"]
+        )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      # The clone carries the parent's path verbatim, so promoting it back is a
+      # no-op rather than an instruction to clear the parent's path.
+      assert Lightning.Repo.get!(Trigger, trigger.id).custom_path ==
+               "some/legacy/path"
+
+      [clone] =
+        Lightning.Repo.all(
+          from(t in Trigger, where: t.project_id == ^sandbox.id)
+        )
+
+      assert clone.custom_path == "some/legacy/path"
+    end
+
+    test "survives a round trip through a sandbox" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+
+      workflow = insert(:workflow, project: parent, name: "Alpha")
+      job = insert(:job, workflow: workflow)
+      trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+      insert(:edge,
+        workflow: workflow,
+        source_trigger: trigger,
+        target_job: job,
+        condition_type: :always
+      )
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: "orders.v1", legacy_bare_path: true]
+        )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      assert {:ok, _} =
+               Lightning.Projects.Sandboxes.merge(sandbox, parent, actor)
+
+      after_promote = Lightning.Repo.get!(Trigger, trigger.id)
+
+      assert after_promote.custom_path == "orders.v1"
+      assert after_promote.legacy_bare_path
+      assert Workflows.get_webhook_trigger(["orders.v1"]).id == trigger.id
+    end
+  end
+
+  describe "merging a sandbox that carries a legacy path" do
+    test "does not fail the merge" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+      workflow = insert(:workflow, project: parent, name: "Alpha")
+      job = insert(:job, workflow: workflow)
+      trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+      insert(:edge,
+        workflow: workflow,
+        source_trigger: trigger,
+        target_job: job,
+        condition_type: :always
+      )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      [sandbox_workflow] =
+        Lightning.Repo.all(
+          from(w in Lightning.Workflows.Workflow,
+            where: w.project_id == ^sandbox.id
+          )
+        )
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.workflow_id == ^sandbox_workflow.id),
+          set: [custom_path: "v1/orders"]
+        )
+
+      assert {:ok, _merged} =
+               Lightning.Projects.Sandboxes.merge(sandbox, parent, actor)
+
+      # The parent's trigger is left on its generated URL rather than the
+      # merge failing outright.
+      assert Lightning.Repo.get!(Trigger, trigger.id).custom_path == nil
+    end
+  end
+
+  describe "a legacy path on a workflow nobody merged" do
+    test "survives a merge of a different workflow" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+
+      merged = insert(:workflow, project: parent, name: "Merged")
+      merged_job = insert(:job, workflow: merged)
+      merged_trigger = insert(:trigger, workflow: merged, type: :webhook)
+
+      insert(:edge,
+        workflow: merged,
+        source_trigger: merged_trigger,
+        target_job: merged_job,
+        condition_type: :always
+      )
+
+      bystander = insert(:workflow, project: parent, name: "Bystander")
+      bystander_job = insert(:job, workflow: bystander)
+      bystander_trigger = insert(:trigger, workflow: bystander, type: :webhook)
+
+      insert(:edge,
+        workflow: bystander,
+        source_trigger: bystander_trigger,
+        target_job: bystander_job,
+        condition_type: :always
+      )
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^bystander_trigger.id),
+          set: [custom_path: "orders.v1", legacy_bare_path: true]
+        )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      [sandbox_merged] =
+        Lightning.Repo.all(
+          from(w in Lightning.Workflows.Workflow,
+            where: w.project_id == ^sandbox.id and w.name == "Merged"
+          )
+        )
+
+      assert {:ok, _} =
+               Lightning.Projects.Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_workflow_ids: [sandbox_merged.id]
+               })
+
+      untouched = Lightning.Repo.get!(Trigger, bystander_trigger.id)
+
+      assert untouched.custom_path == "orders.v1"
+      assert untouched.legacy_bare_path
+
+      assert Workflows.get_webhook_trigger(["orders.v1"]).id ==
+               bystander_trigger.id
+    end
+  end
+
+  describe "a merge that would collide on a path" do
+    test "fails rather than corrupting either side" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+
+      incumbent = insert(:workflow, project: parent, name: "Incumbent")
+      incumbent_job = insert(:job, workflow: incumbent)
+
+      incumbent_trigger =
+        insert(:trigger,
+          workflow: incumbent,
+          type: :webhook,
+          custom_path: "orders"
+        )
+
+      insert(:edge,
+        workflow: incumbent,
+        source_trigger: incumbent_trigger,
+        target_job: incumbent_job,
+        condition_type: :always
+      )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      # The sandbox's clone of the incumbent gives up the name, so a new
+      # workflow in the sandbox can take it. The parent still holds it.
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger,
+            where: t.project_id == ^sandbox.id and t.custom_path == "orders"
+          ),
+          set: [custom_path: nil]
+        )
+
+      newcomer = insert(:workflow, project: sandbox, name: "Newcomer")
+      newcomer_job = insert(:job, workflow: newcomer)
+
+      newcomer_trigger =
+        insert(:trigger, workflow: newcomer, type: :webhook)
+
+      insert(:edge,
+        workflow: newcomer,
+        source_trigger: newcomer_trigger,
+        target_job: newcomer_job,
+        condition_type: :always
+      )
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^newcomer_trigger.id),
+          set: [custom_path: "orders"]
+        )
+
+      # The incoming trigger lands on a name already taken and the unique index
+      # stops it. Dropping the path instead would discard the user's name.
+      assert {:error, :merge_failed} =
+               Lightning.Projects.Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_workflow_ids: [newcomer.id]
+               })
+
+      assert Lightning.Repo.get!(Trigger, incumbent_trigger.id).custom_path ==
+               "orders"
+
+      assert Workflows.get_webhook_trigger([parent.id, "orders"]).id ==
+               incumbent_trigger.id
+    end
+  end
+
+  describe "deleting a workflow" do
+    test "frees its path for a replacement" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project, name: "Facility 1")
+      trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: "facility-001", legacy_bare_path: true]
+        )
+
+      assert {:ok, _} =
+               Workflows.mark_for_deletion(workflow, insert(:user))
+
+      # A hidden row holding the name would refuse it to the replacement,
+      # naming a workflow the user can no longer see.
+      replacement = insert(:workflow, project: project, name: "Facility 1 v2")
+
+      assert {:ok, taken_over} =
+               %Trigger{}
+               |> Trigger.changeset(%{
+                 workflow_id: replacement.id,
+                 type: :webhook,
+                 custom_path: "facility-001"
+               })
+               |> Lightning.Repo.insert()
+
+      assert Workflows.get_webhook_trigger([project.id, "facility-001"]).id ==
+               taken_over.id
+    end
+  end
+
+  describe "a merge that replaces a trigger on the same path" do
+    test "succeeds" do
+      actor = insert(:user)
+      parent = insert(:project, name: "parent")
+      insert(:project_user, project: parent, user: actor, role: :owner)
+
+      workflow = insert(:workflow, project: parent, name: "Alpha")
+      job = insert(:job, workflow: workflow)
+      trigger = insert(:trigger, workflow: workflow, type: :webhook)
+
+      insert(:edge,
+        workflow: workflow,
+        source_trigger: trigger,
+        target_job: job,
+        condition_type: :always
+      )
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^trigger.id),
+          set: [custom_path: "orders"]
+        )
+
+      assert {:ok, sandbox} =
+               Lightning.Projects.Sandboxes.provision(parent, actor, %{
+                 name: "sb"
+               })
+
+      [sandbox_workflow] =
+        Lightning.Repo.all(
+          from(w in Lightning.Workflows.Workflow,
+            where: w.project_id == ^sandbox.id
+          )
+        )
+
+      [sandbox_job] =
+        Lightning.Repo.all(
+          from(j in Lightning.Workflows.Job,
+            where: j.workflow_id == ^sandbox_workflow.id
+          )
+        )
+
+      # The incoming trigger has a new id, so the merge inserts it while the old
+      # one still holds the path.
+      Lightning.Repo.delete_all(
+        from(e in Lightning.Workflows.Edge,
+          where: e.workflow_id == ^sandbox_workflow.id
+        )
+      )
+
+      Lightning.Repo.delete_all(
+        from(t in Trigger, where: t.workflow_id == ^sandbox_workflow.id)
+      )
+
+      replacement =
+        insert(:trigger,
+          workflow: sandbox_workflow,
+          type: :webhook,
+          custom_path: "orders"
+        )
+
+      insert(:edge,
+        workflow: sandbox_workflow,
+        source_trigger: replacement,
+        target_job: sandbox_job,
+        condition_type: :always
+      )
+
+      assert {:ok, _} =
+               Lightning.Projects.Sandboxes.merge(sandbox, parent, actor)
+
+      assert Workflows.get_webhook_trigger([parent.id, "orders"])
+    end
+  end
+
+  describe "one deploy that drops a workflow and claims its path" do
+    test "succeeds" do
+      # Renaming a workflow file while keeping its webhook path is this shape.
+      # The release has to happen before the insert or the unique index stops
+      # the whole deploy.
+      user = insert(:user)
+      project = insert(:project)
+      insert(:project_user, project: project, user: user, role: :owner)
+
+      old_workflow = insert(:workflow, project: project, name: "Facility 1")
+      old_trigger = insert(:trigger, workflow: old_workflow, type: :webhook)
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^old_trigger.id),
+          set: [custom_path: "facility-001"]
+        )
+
+      new_workflow_id = Ecto.UUID.generate()
+      new_trigger_id = Ecto.UUID.generate()
+      new_job_id = Ecto.UUID.generate()
+
+      body = %{
+        "id" => project.id,
+        "name" => project.name,
+        "workflows" => [
+          %{"id" => old_workflow.id, "delete" => true},
+          %{
+            "id" => new_workflow_id,
+            "name" => "Facility 1 renamed",
+            "jobs" => [
+              %{
+                "id" => new_job_id,
+                "name" => "step",
+                "body" => "fn(s => s)",
+                "adaptor" => "@openfn/language-common@latest"
+              }
+            ],
+            "triggers" => [
+              %{
+                "id" => new_trigger_id,
+                "type" => "webhook",
+                "enabled" => true,
+                "custom_path" => "facility-001"
+              }
+            ],
+            "edges" => [
+              %{
+                "id" => Ecto.UUID.generate(),
+                "source_trigger_id" => new_trigger_id,
+                "target_job_id" => new_job_id,
+                "condition_type" => "always",
+                "enabled" => true
+              }
+            ]
+          }
+        ]
+      }
+
+      assert {:ok, _} =
+               Lightning.Projects.Provisioner.import_document(
+                 project,
+                 user,
+                 body
+               )
+
+      assert Workflows.get_webhook_trigger([project.id, "facility-001"]).id ==
+               new_trigger_id
+    end
+  end
+
+  describe "changing a trigger's type" do
+    test "revalidates a path that was never checked" do
+      # The migration leaves custom_path on cron rows, where it meant nothing.
+      # Becoming a webhook would make it a live URL unvalidated.
+      workflow = insert(:workflow, project: insert(:project))
+      cron = insert(:trigger, workflow: workflow, type: :cron)
+
+      {1, _} =
+        Lightning.Repo.update_all(
+          from(t in Trigger, where: t.id == ^cron.id),
+          set: [custom_path: "Orders.v1"]
+        )
+
+      assert {:error, changeset} =
+               Lightning.Repo.get!(Trigger, cron.id)
+               |> Trigger.changeset(%{type: :webhook})
+               |> Lightning.Repo.update()
+
+      assert Map.has_key?(errors_on(changeset), :custom_path)
+    end
+
+    test "drops a meaningless path when becoming a cron trigger" do
+      workflow = insert(:workflow, project: insert(:project))
+
+      trigger =
+        insert(:trigger,
+          workflow: workflow,
+          type: :webhook,
+          custom_path: "facility-001"
+        )
+
+      assert {:ok, saved} =
+               trigger
+               |> Trigger.changeset(%{type: :cron, cron_expression: "0 0 * * *"})
+               |> Lightning.Repo.update()
+
+      assert saved.custom_path == nil
+    end
+  end
+
+  describe "project_id" do
+    test "is copied from the workflow when a workflow is saved" do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+      trigger_id = Ecto.UUID.generate()
+
+      {:ok, workflow} =
+        workflow
+        |> Lightning.Repo.preload([:triggers, :jobs, :edges])
+        |> Lightning.Workflows.Workflow.changeset(%{
+          triggers: [%{id: trigger_id, type: :webhook, enabled: true}]
+        })
+        |> Lightning.Repo.update()
+
+      [trigger] = Lightning.Repo.preload(workflow, :triggers).triggers
+
+      assert trigger.project_id == project.id
+    end
+
+    test "new/1 ignores project_id and legacy_bare_path from its attrs" do
+      workflow = insert(:workflow, project: insert(:project))
+      other_project = insert(:project)
+
+      assert {:ok, trigger} =
+               Workflows.build_trigger(%{
+                 type: :webhook,
+                 workflow_id: workflow.id,
+                 project_id: other_project.id,
+                 legacy_bare_path: true
+               })
+
+      assert trigger.project_id == workflow.project_id
+      refute trigger.legacy_bare_path
+    end
+
+    test "legacy_bare_path cannot be granted from params" do
+      # Only the migration marks a bare URL. If this were settable, anyone could
+      # claim an instance-wide URL for their own project.
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          custom_path: "facility-001",
+          legacy_bare_path: true
+        })
+
+      # Never true. It is forced to false alongside the path it would apply to.
+      refute Ecto.Changeset.get_field(changeset, :legacy_bare_path)
+    end
+
+    test "cannot be set from params" do
+      other_project = insert(:project)
+
+      changeset =
+        Trigger.changeset(%Trigger{}, %{
+          type: :webhook,
+          project_id: other_project.id
+        })
+
+      assert Ecto.Changeset.get_change(changeset, :project_id) == nil
+    end
+  end
+end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -1598,14 +1598,19 @@ defmodule Lightning.WorkflowsTest do
       %{triggers: [trigger]} =
         insert(:simple_workflow) |> Repo.preload(:triggers)
 
-      assert Workflows.get_webhook_trigger(trigger.id).id == trigger.id
+      assert Workflows.get_webhook_trigger([trigger.id]).id == trigger.id
 
       Ecto.Changeset.change(trigger, custom_path: "foo")
       |> Lightning.Repo.update!()
 
-      assert Workflows.get_webhook_trigger(trigger.id) == nil
+      # Setting a custom path adds a URL rather than replacing one, so anything
+      # already posting to the generated URL keeps working.
+      assert Workflows.get_webhook_trigger([trigger.id]).id == trigger.id
 
-      assert Workflows.get_webhook_trigger("foo").id == trigger.id
+      workflow = Repo.get!(Lightning.Workflows.Workflow, trigger.workflow_id)
+
+      assert Workflows.get_webhook_trigger([workflow.project_id, "foo"]).id ==
+               trigger.id
     end
 
     test "get_webhook_trigger/1 does not return a trigger when type is cron" do
@@ -1617,13 +1622,13 @@ defmodule Lightning.WorkflowsTest do
       |> Lightning.Repo.update!()
 
       # Should not return the trigger even though the ID matches
-      assert Workflows.get_webhook_trigger(trigger.id) == nil
+      assert Workflows.get_webhook_trigger([trigger.id]) == nil
 
       # Set a custom path and verify it still doesn't return
       Ecto.Changeset.change(trigger, custom_path: "cron_path")
       |> Lightning.Repo.update!()
 
-      assert Workflows.get_webhook_trigger("cron_path") == nil
+      assert Workflows.get_webhook_trigger([trigger.id, "cron_path"]) == nil
     end
 
     test "get_jobs_for_cron_execution/0 returns jobs to run for a given time" do
@@ -1656,24 +1661,30 @@ defmodule Lightning.WorkflowsTest do
     end
   end
 
-  describe "get_webhook_trigger/1" do
+  describe "get_webhook_trigger/2" do
     test "returns a trigger when a matching custom_path is provided" do
-      trigger = insert(:trigger, custom_path: "some_path")
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+      trigger = insert(:trigger, workflow: workflow, custom_path: "some_path")
 
       assert trigger |> unload_relation(:workflow) ==
-               Workflows.get_webhook_trigger("some_path")
+               Workflows.get_webhook_trigger([project.id, "some_path"])
     end
 
     test "returns a trigger when a matching id is provided" do
       trigger = insert(:trigger)
 
       assert trigger |> unload_relation(:workflow) ==
-               Workflows.get_webhook_trigger(trigger.id)
+               Workflows.get_webhook_trigger([trigger.id])
     end
 
     test "returns nil when no matching trigger is found" do
-      insert(:trigger, custom_path: "some_path")
-      assert Workflows.get_webhook_trigger("non_existent_path") == nil
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+      insert(:trigger, workflow: workflow, custom_path: "some_path")
+
+      assert Workflows.get_webhook_trigger([project.id, "non_existent_path"]) ==
+               nil
     end
   end
 

--- a/test/lightning_web/controllers/api/provisioning_controller_test.exs
+++ b/test/lightning_web/controllers/api/provisioning_controller_test.exs
@@ -1001,6 +1001,49 @@ defmodule LightningWeb.API.ProvisioningControllerTest do
     end
   end
 
+  describe "as_json/1 and a trigger's custom path" do
+    setup do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+
+      trigger =
+        insert(:trigger, type: :webhook, workflow: workflow, custom_path: nil)
+
+      %{trigger: trigger, workflow: workflow}
+    end
+
+    defp rendered_trigger(trigger, path) do
+      Lightning.Repo.update_all(
+        from(t in Lightning.Workflows.Trigger, where: t.id == ^trigger.id),
+        set: [custom_path: path]
+      )
+
+      trigger
+      |> Lightning.Repo.reload!()
+      |> ProvisioningJSON.as_json()
+    end
+
+    test "is rendered when it is one the server would accept", %{
+      trigger: trigger
+    } do
+      assert %{custom_path: "facility-001"} =
+               rendered_trigger(trigger, "facility-001")
+    end
+
+    test "is dropped when it predates the naming rules", %{trigger: trigger} do
+      # Deploying this document into another project would fail validation and
+      # take the whole import with it.
+      refute Map.has_key?(
+               rendered_trigger(trigger, "some/legacy/path"),
+               :custom_path
+             )
+    end
+
+    test "is absent when there is none", %{trigger: trigger} do
+      refute Map.has_key?(rendered_trigger(trigger, nil), :custom_path)
+    end
+  end
+
   describe "post (with an API token)" do
     setup [:assign_bearer_for_api]
 

--- a/test/lightning_web/controllers/webhooks_controller_test.exs
+++ b/test/lightning_web/controllers/webhooks_controller_test.exs
@@ -165,6 +165,57 @@ defmodule LightningWeb.WebhooksControllerTest do
                ~s({\"path\": [\"i\", \"#{trigger_id}\"], \"method\": \"POST\", \"headers\": {\"content-type\": \"multipart/mixed; boundary=plug_conn_test\"}, \"query_params\": {}})
     end
 
+    test "creates a pending workorder from a project-namespaced custom path", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      %{triggers: [%{id: trigger_id} = trigger]} =
+        insert(:simple_workflow, project: project)
+        |> Lightning.Repo.preload(:triggers)
+        |> with_snapshot()
+
+      {:ok, _} =
+        trigger
+        |> Lightning.Workflows.Trigger.changeset(%{
+          custom_path: "et-emr-facility-001"
+        })
+        |> Repo.update()
+
+      conn =
+        post(conn, "/i/#{project.id}/et-emr-facility-001", %{"foo" => "bar"})
+
+      assert %{"work_order_id" => work_order_id} = json_response(conn, 200)
+
+      assert %{trigger: %{id: ^trigger_id}, state: :pending} =
+               WorkOrders.get(work_order_id, include: [:trigger])
+    end
+
+    test "the generated URL still works once a custom path is set", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      %{triggers: [%{id: trigger_id} = trigger]} =
+        insert(:simple_workflow, project: project)
+        |> Lightning.Repo.preload(:triggers)
+        |> with_snapshot()
+
+      {:ok, _} =
+        trigger
+        |> Lightning.Workflows.Trigger.changeset(%{
+          custom_path: "et-emr-facility-001"
+        })
+        |> Repo.update()
+
+      conn = post(conn, "/i/#{trigger_id}", %{"foo" => "bar"})
+
+      assert %{"work_order_id" => work_order_id} = json_response(conn, 200)
+
+      assert %{trigger: %{id: ^trigger_id}} =
+               WorkOrders.get(work_order_id, include: [:trigger])
+    end
+
     test "creates a pending workorder with a valid trigger and an additional path",
          %{conn: conn} do
       %{triggers: [%{id: trigger_id}]} =

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -82,7 +82,23 @@ defmodule Lightning.Factories do
     trigger
     |> merge_attributes(attrs)
     |> evaluate_lazy_attributes()
+    |> put_trigger_project_id()
   end
+
+  # Triggers carry their workflow's project. Production code fills it in inside
+  # the insert transaction, which factories bypass.
+  defp put_trigger_project_id(%{project_id: project_id} = trigger)
+       when not is_nil(project_id),
+       do: trigger
+
+  defp put_trigger_project_id(
+         %{workflow: %Lightning.Workflows.Workflow{} = workflow} = trigger
+       ) do
+    {workflow, project_id} = ensure_project_id(workflow)
+    %{trigger | workflow: workflow, project_id: project_id}
+  end
+
+  defp put_trigger_project_id(trigger), do: trigger
 
   def edge_factory do
     %Lightning.Workflows.Edge{
@@ -621,15 +637,36 @@ defmodule Lightning.Factories do
   end
 
   def with_trigger(workflow, trigger) do
+    {workflow, project_id} = ensure_project_id(workflow)
+
     %{
       workflow
       | triggers:
           merge_assoc(
             workflow.triggers,
-            merge_attributes(trigger, %{workflow: nil})
+            merge_attributes(trigger, %{workflow: nil, project_id: project_id})
           )
     }
   end
+
+  # As above, but the id has to exist before the workflow and its triggers are
+  # written, so an unsaved project gets one here.
+  defp ensure_project_id(%{project_id: project_id} = workflow)
+       when not is_nil(project_id),
+       do: {workflow, project_id}
+
+  defp ensure_project_id(%{project: %{id: project_id}} = workflow)
+       when not is_nil(project_id),
+       do: {workflow, project_id}
+
+  defp ensure_project_id(
+         %{project: %Lightning.Projects.Project{} = project} = workflow
+       ) do
+    project_id = Ecto.UUID.generate()
+    {%{workflow | project: %{project | id: project_id}}, project_id}
+  end
+
+  defp ensure_project_id(workflow), do: {workflow, nil}
 
   def with_edge(workflow, source_target, extra \\ %{})
 


### PR DESCRIPTION
## Description

This PR lets you name a webhook trigger's URL path, so you know the endpoint before you deploy. A trigger with a path of `facility-001` in project `abc-123` answers at `/i/abc-123/facility-001`. You can set it in the trigger panel, in `project.yaml`, or through the workflows API.

This came from deploying the same workflows to roughly a hundred facilities. Today that means deploying first, then opening a hundred workflows and copying a hundred generated UUIDs by hand. Now the names go in the deployment templates, and the integrators get the full list before anything is deployed.

The path namespaces on the project id rather than the project name, which is what we agreed in the requirements session. Project names are mutable and not unique, so a name in a URL is a contract that breaks on a rename. Namespacing on the project also means a path only has to be unique within its project, so a sandbox clone keeps the parent's path and answers on its own project's URL, which is what #4937 asks for.

Every URL already in the wild keeps working. `/i/<trigger-id>` is tried first and never changes. Paths that were addressable bare at `/i/<path>` before this are marked by the migration and keep answering there, and that set can only shrink.

The workflow version hash now includes the path, so a workflow whose only change is its endpoint name is no longer reported as unchanged. A workflow without a path hashes exactly as it did, and `@openfn/project` hashes the same key in OpenFn/kit#1511, so the two stay in step.

Closes #4952.

## Validation steps

1. Open a workflow, click the webhook trigger, click Edit. Type `facility-001` into Custom URL path and click Finish. The webhook URL on the show panel becomes `/i/<project-id>/facility-001`.
2. `curl -X POST localhost:4000/i/<project-id>/facility-001 -d '{}' -H 'content-type: application/json'` creates a work order. So does the old `/i/<trigger-id>` URL.
3. Type `Orders Intake` in the field. It tells you it will be named `orders-intake`. Type `!!!` and it goes red and refuses to save. Type a name another workflow in the project already uses and the save reports it against the field.
4. Export the project to YAML. The trigger carries `custom_path`. Deploy it back with `openfn deploy` (needs OpenFn/kit#1511) and the path survives.

## Additional notes for the reviewer

1. `triggers.custom_path` has existed since many years now with no validation, no uniqueness and no UI, and the lookup resolved it with `coalesce(custom_path, id)` through `Repo.one`. Any user could point a path in their own project at another project's trigger id and permanently 500 that project's live endpoint. I reproduced it before fixing it. Production has no `custom_path` rows; self-hosted instances may.
2. The migration's data steps have no test, because there is no migration-test harness in the repo.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR

