### PR TITLE
Fix a batch of flaky tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ assets/test-results
 .claude/settings.local.json
 test-results
 assets/coverage
+.scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to
   edits an already-saved workflow. Name-uniqueness validation now excludes the
   workflow being edited, so its own name isn't treated as a clash.
   [#5009](https://github.com/OpenFn/lightning/pull/5009)
+- `eligible_for_claim/0` now breaks ties with `id` after `priority` and
+  `inserted_at`, so two runs inserted in the same microsecond no longer get
+  claimed in a nondeterministic order.
 
 ## [2.18.1] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,26 @@ MIX_ENV=test mix test
 We also have `test.watch` installed which can be used to rerun the tests on file
 changes.
 
+##### Chasing flaky tests
+
+`bin/repeat_mix_test` runs the suite (or given files) repeatedly and records
+each run's first-pass result — unlike `bin/ci_tests`, it never retries, so a
+flake shows up instead of being papered over.
+
+```sh
+bin/repeat_mix_test 30 test/lightning/workflows_test.exs
+CI_TIMING=1 bin/repeat_mix_test 11   # cap schedulers and shorten assert_receive
+                                     # timeouts to match CircleCI
+```
+
+It uses its own test database (`MIX_TEST_PARTITION=flaky`) so a long loop can't
+collide with another checkout, and writes logs plus a `summary.tsv` to
+`.scratch/runs/<timestamp>/`.
+
+`bin/gather_ci_logs [N]` pulls the "Run Elixir tests" output from the last N
+`test_elixir` CircleCI jobs on `main` into `.scratch/ci-logs/`, flagging the
+builds that went green only because the retry pass saved them. Needs `jq`.
+
 ## Security and Standards
 
 We use a host of common Elixir static analysis tools to help us avoid common

--- a/bin/gather_ci_logs
+++ b/bin/gather_ci_logs
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# gather_ci_logs — fetch the "Run Elixir tests" step output from the last N
+# test_elixir CircleCI jobs and save de-ANSI'd logs into .scratch/ci-logs/.
+#
+# OpenFn/lightning is an OSS project on CircleCI, so the v1.1 API is readable
+# without a token. Every test_elixir job runs ./bin/ci_tests, which reruns
+# failed tests after the first pass — so a job can show "success" yet still have
+# flaked on the first run. We flag those: a log containing
+# "Renamed failed test report" means the retry path fired = first-run flake.
+#
+# Usage: bin/gather_ci_logs [N]              # N test_elixir jobs, default 20
+#        BRANCH=main bin/gather_ci_logs 20  # main only (default) — see BRANCH below
+#        BRANCH= bin/gather_ci_logs 20      # empty = all branches
+#
+# BRANCH defaults to "main". The 2026-06 pass sampled all branches and mistook
+# in-development bugs for flakes; main-only keeps the sample honest.
+#
+# Output: .scratch/ci-logs/
+#   build-<num>-<branch>.log   full de-ANSI'd "Run Elixir tests" step output
+#   index.tsv                  build, branch, date, outcome, flaky, log
+#
+set -uo pipefail
+
+N="${1:-20}"
+BRANCH="${BRANCH-main}"
+PROJECT="gh/OpenFn/lightning"
+API="https://circleci.com/api/v1.1/project/$PROJECT"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+OUT="$PROJECT_ROOT/.scratch/ci-logs"
+mkdir -p "$OUT"
+INDEX="$OUT/index.tsv"
+printf 'build\tbranch\tdate\toutcome\tflaky\tlog\n' > "$INDEX"
+
+strip_ansi() { sed -E 's/\x1b\[[0-9;]*[A-Za-z]//g; s/\r//g'; }
+
+echo "gather-ci-logs: collecting $N test_elixir jobs (branch=${BRANCH:-<all>}) -> $OUT"
+
+collected=0
+offset=0
+while [ "$collected" -lt "$N" ]; do
+  batch=$(curl -s --max-time 30 "$API?limit=100&offset=$offset&filter=completed" -H "Accept: application/json")
+  nums=$(echo "$batch" | jq -r --arg br "$BRANCH" \
+    '.[] | select(.workflows.job_name=="test_elixir") | select($br=="" or .branch==$br) | .build_num')
+  if [ -z "$nums" ]; then
+    echo "no more test_elixir builds at offset $offset"
+    break
+  fi
+  for num in $nums; do
+    [ "$collected" -ge "$N" ] && break
+    detail=$(curl -s --max-time 30 "$API/$num" -H "Accept: application/json")
+    branch=$(echo "$detail" | jq -r '.branch // "unknown"')
+    date=$(echo "$detail" | jq -r '.committer_date // "?"')
+    outcome=$(echo "$detail" | jq -r '.outcome // "?"')
+    url=$(echo "$detail" | jq -r '.steps[]?.actions[]? | select(.name=="Run Elixir tests") | .output_url' | head -1)
+    if [ -z "$url" ] || [ "$url" = "null" ]; then
+      echo "  build $num: no test step output, skip"
+      continue
+    fi
+    safe_branch="${branch//\//_}"
+    log="$OUT/build-${num}-${safe_branch}.log"
+    curl -s --max-time 90 "$url" | jq -r '.[].message' 2>/dev/null | strip_ansi > "$log"
+    if grep -q "Renamed failed test report" "$log"; then flaky="FLAKY"; else flaky="clean"; fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$num" "$branch" "$date" "$outcome" "$flaky" "$(basename "$log")" >> "$INDEX"
+    echo "  build $num ($branch) $outcome -> $flaky"
+    collected=$((collected + 1))
+  done
+  offset=$((offset + 100))
+done
+
+echo "=== collected $collected logs. index: $INDEX ==="
+column -t -s "$(printf '\t')" "$INDEX"

--- a/bin/repeat_mix_test
+++ b/bin/repeat_mix_test
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# repeat_mix_test — run `mix test` N times in the Lightning project, capturing
+# each run's combined stdout+stderr to a dated log. Surfaces first-run flakes by
+# repetition. Unlike bin/ci_tests it does NOT retry failed tests in-run — the
+# whole point is to see the raw first-run result every time.
+#
+# Usage:
+#   bin/repeat_mix_test [N] [test paths...]   # N defaults to 1 (safety)
+#   CI_TIMING=1 bin/repeat_mix_test 11         # full suite, CI scheduler/timing
+#   bin/repeat_mix_test 30 test/foo_test.exs   # loop just these files
+#
+# CI_TIMING=1 exports the same knobs CircleCI uses (.circleci/config.yml):
+#   ERL_FLAGS="+S 4:4"  (cap schedulers — CI runs less parallel than a dev box)
+#   ASSERT_RECEIVE_TIMEOUT="1000"
+# Use it to try to reproduce CI-only flakes locally.
+#
+# Output: .scratch/runs/<session-stamp>/
+#   run-NN-<stamp>.log   full combined output of each run
+#   summary.tsv          run, exit, seed, tests, failures, duration_s, log
+#
+set -uo pipefail
+
+N="${1:-1}"
+shift || true
+TARGETS=("$@")
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+RUNS_ROOT="$PROJECT_ROOT/.scratch/runs"
+
+stamp() { date +%Y%m%dT%H%M%S; }
+
+SESSION="$(stamp)"
+SESSION_DIR="$RUNS_ROOT/$SESSION"
+mkdir -p "$SESSION_DIR"
+SUMMARY="$SESSION_DIR/summary.tsv"
+printf 'run\texit\tseed\ttests\tfailures\tduration_s\tlog\n' > "$SUMMARY"
+
+# Namespaces the test DB (config/test.exs:40 suffixes TEST_DATABASE_NAME with it),
+# so long repeat loops can't collide with another worktree or session using
+# lightning_test. The `test` alias (mix.exs:226) creates it on first run.
+export MIX_TEST_PARTITION="${MIX_TEST_PARTITION:-flaky}"
+
+if [ "${CI_TIMING:-0}" = "1" ]; then
+  export ERL_FLAGS="+S 4:4"
+  export ASSERT_RECEIVE_TIMEOUT="1000"
+fi
+
+cd "$PROJECT_ROOT" || { echo "cannot cd to $PROJECT_ROOT" >&2; exit 1; }
+
+echo "repeat_mix_test: N=$N  session=$SESSION  ci_timing=${CI_TIMING:-0}  db=lightning_test${MIX_TEST_PARTITION}  targets=${TARGETS[*]:-<full suite>}"
+echo "logs -> $SESSION_DIR"
+
+for i in $(seq 1 "$N"); do
+  RUN=$(printf '%02d' "$i")
+  RSTAMP="$(stamp)"
+  LOG="$SESSION_DIR/run-${RUN}-${RSTAMP}.log"
+  START=$(date +%s)
+  echo "=== run $i/$N @ $RSTAMP (ci_timing=${CI_TIMING:-0}) ===" | tee "$LOG"
+  MIX_ENV=test mix test "${TARGETS[@]}" >>"$LOG" 2>&1
+  EC=$?
+  END=$(date +%s)
+  DUR=$((END - START))
+  SEED=$(grep -oE 'seed: [0-9]+' "$LOG" | head -1 | grep -oE '[0-9]+')
+  LINE=$(grep -oE '[0-9]+ tests?, [0-9]+ failures?' "$LOG" | tail -1)
+  TESTS=$(echo "$LINE" | grep -oE '^[0-9]+')
+  FAILS=$(echo "$LINE" | grep -oE '[0-9]+ failures?' | grep -oE '[0-9]+')
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$i" "$EC" "${SEED:-?}" "${TESTS:-?}" "${FAILS:-0}" "$DUR" "$(basename "$LOG")" >> "$SUMMARY"
+  echo "  -> exit=$EC seed=${SEED:-?} ${LINE:-(no summary line)} ${DUR}s"
+done
+
+echo "=== done. summary: $SUMMARY ==="
+cat "$SUMMARY"

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,7 +31,10 @@ ownership_timeout =
   end
 
 # On certain machines we get db queue timeouts, so we raise `queue_target`
-# from 50 to 100 to give the DBConnection some room to respond.
+# and `queue_interval` to give the DBConnection more room to respond. This
+# matters most for `async: false` tests, where Sandbox's shared-connection
+# mode funnels every process (including a subprocess worker's WebSocket
+# channels) through a single physical connection, so `pool_size` doesn't help.
 config :lightning, Lightning.Repo,
   username: "postgres",
   password: "postgres",
@@ -40,7 +43,8 @@ config :lightning, Lightning.Repo,
     "#{System.get_env("TEST_DATABASE_NAME", "lightning_test")}#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 15,
-  queue_target: 100,
+  queue_target: 200,
+  queue_interval: 2_000,
   ownership_timeout: ownership_timeout
 
 config :lightning, Lightning.Vault,

--- a/lib/lightning/runs/query.ex
+++ b/lib/lightning/runs/query.ex
@@ -177,7 +177,7 @@ defmodule Lightning.Runs.Query do
     Run
     |> with_cte("subset", as: ^available_within_concurrency_limits())
     |> join(:inner, [r], subset in fragment(~s("subset")), on: r.id == subset.id)
-    |> order_by([r], asc: r.priority, asc: r.inserted_at)
+    |> order_by([r], asc: r.priority, asc: r.inserted_at, asc: r.id)
   end
 
   @doc """

--- a/lib/lightning/runtime/runtime_manager.ex
+++ b/lib/lightning/runtime/runtime_manager.ex
@@ -134,7 +134,8 @@ defmodule Lightning.Runtime.RuntimeManager do
             runtime_os_pid: nil,
             runtime_client: __MODULE__,
             buffer: [],
-            config: nil
+            config: nil,
+            exit_status: nil
 
   # credo:disable-for-next-line
   @behaviour RuntimeClient
@@ -176,12 +177,12 @@ defmodule Lightning.Runtime.RuntimeManager do
   def handle_info({port, {:exit_status, status}}, %{runtime_port: port} = state) do
     Logger.error("Runtime exited with status: #{status}")
     # Data may arrive after exit status on line mode
-    {:noreply, state, 0}
+    {:noreply, %{state | exit_status: status}, 0}
   end
 
   @impl GenServer
   def handle_info(:timeout, state) do
-    {:stop, :premature_termination, state}
+    {:stop, premature_termination(state), state}
   end
 
   @impl GenServer
@@ -207,7 +208,7 @@ defmodule Lightning.Runtime.RuntimeManager do
         %{runtime_port: port, buffer: buffer} = state
       ) do
     log_buffer([data | buffer])
-    {:stop, :premature_termination, %{state | buffer: []}}
+    {:stop, premature_termination(state), %{state | buffer: []}}
   end
 
   @impl GenServer
@@ -217,7 +218,7 @@ defmodule Lightning.Runtime.RuntimeManager do
       ) do
     Logger.debug("Runtime port was stopped with reason: #{reason}")
 
-    {:stop, :premature_termination, state}
+    {:stop, premature_termination(state), state}
   end
 
   @impl GenServer
@@ -231,6 +232,7 @@ defmodule Lightning.Runtime.RuntimeManager do
         %{runtime_client: runtime_client} = state
       ) do
     if reason not in [:timeout, :premature_termination] and
+         not match?({:premature_termination, _}, reason) and
          state.runtime_port do
       Port.connect(state.runtime_port, self())
       runtime_client.stop_runtime(state)
@@ -299,6 +301,13 @@ defmodule Lightning.Runtime.RuntimeManager do
         handle_pending_msg(port, [])
     end
   end
+
+  # Carries the worker's exit status into the stop reason, so a monitoring
+  # process learns why the runtime died and not just that it did.
+  defp premature_termination(%{exit_status: nil}), do: :premature_termination
+
+  defp premature_termination(%{exit_status: status}),
+    do: {:premature_termination, status}
 
   defp log_buffer(buffer) do
     buffer |> Enum.reverse() |> IO.iodata_to_binary() |> Logger.info()

--- a/lib/lightning/version_control/github_client.ex
+++ b/lib/lightning/version_control/github_client.ex
@@ -202,6 +202,9 @@ defmodule Lightning.VersionControl.GithubClient do
 
         {:ok, %{status: 403, body: %{"message" => message} = resp}} ->
           {:error, GithubError.api_error(message, resp)}
+
+        {:error, reason} ->
+          {:error, reason}
       end
     end
   end

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -180,6 +180,7 @@ defmodule Lightning.VersionControl do
         join: s in assoc(w, :snapshots),
         on: s.lock_version == w.lock_version,
         where: w.project_id == ^project_id and is_nil(w.deleted_at),
+        order_by: s.id,
         select: s.id
 
     Repo.all(current_query)

--- a/lib/lightning/version_control/version_control.ex
+++ b/lib/lightning/version_control/version_control.ex
@@ -182,7 +182,7 @@ defmodule Lightning.VersionControl do
         where: w.project_id == ^project_id and is_nil(w.deleted_at),
         select: s.id
 
-    Repo.all(current_query) |> Enum.reverse()
+    Repo.all(current_query)
   end
 
   defp maybe_add_snapshots(inputs, snapshot_ids) do

--- a/test/integration/web_and_worker_test.exs
+++ b/test/integration/web_and_worker_test.exs
@@ -26,18 +26,29 @@ defmodule Lightning.WebAndWorkerTest do
       Lightning.Extensions.UsageLimiter
     )
 
-    start_runtime_manager()
+    # The worker subprocess logs at :debug via RuntimeManager; without this its
+    # startup output (adaptor installs, connection failures) is dropped before
+    # `capture_log` can hold onto it for a failing test's report.
+    level = Logger.level()
+    Logger.configure(level: :debug)
+    on_exit(fn -> Logger.configure(level: level) end)
+
+    runtime_manager = start_runtime_manager()
 
     uri = LightningWeb.Endpoint.url()
 
-    %{uri: uri}
+    %{uri: uri, runtime_manager: runtime_manager}
   end
 
   describe "webhook triggered runs" do
     setup [:register_and_log_in_superuser, :stub_rate_limiter_ok]
 
     @tag :integration
-    test "complete a run on a complex workflow with parallel jobs", %{uri: uri} do
+    @tag timeout: 120_000
+    test "complete a run on a complex workflow with parallel jobs", %{
+      uri: uri,
+      runtime_manager: runtime_manager
+    } do
       project = insert(:project)
 
       %{triggers: [%{id: webhook_trigger_id}], edges: edges} =
@@ -59,13 +70,7 @@ defmodule Lightning.WebAndWorkerTest do
       webhook_body = %{"x" => 1}
 
       response =
-        Tesla.client(
-          [
-            {Tesla.Middleware.BaseUrl, uri},
-            Tesla.Middleware.JSON
-          ],
-          {Tesla.Adapter.Finch, name: Lightning.Finch}
-        )
+        build_tesla_client(uri)
         |> Tesla.post!("/i/#{webhook_trigger_id}", webhook_body)
 
       assert response.status == 200
@@ -79,8 +84,7 @@ defmodule Lightning.WebAndWorkerTest do
 
       assert %{id: run_id, steps: []} = Runs.get(run.id, include: [:steps])
 
-      assert_receive %Events.RunUpdated{run: %{id: ^run_id, state: :success}},
-                     115_000
+      await_run_success(run_id, runtime_manager)
 
       assert %{state: :success} = WorkOrders.get(workorder_id)
 
@@ -1005,10 +1009,14 @@ defmodule Lightning.WebAndWorkerTest do
     end
   end
 
+  # The server side (handle_delayed_response/2) can legitimately wait up to
+  # `webhook_response_timeout_ms` (30s by default). Finch's HTTP1 default
+  # receive_timeout is 15s, so the client was aborting requests the server
+  # was still correctly waiting on. Give the client more room than the server.
   defp build_tesla_client(uri) do
     Tesla.client(
       [{Tesla.Middleware.BaseUrl, uri}, Tesla.Middleware.JSON],
-      {Tesla.Adapter.Finch, name: Lightning.Finch}
+      {Tesla.Adapter.Finch, name: Lightning.Finch, receive_timeout: 35_000}
     )
   end
 
@@ -1074,7 +1082,33 @@ defmodule Lightning.WebAndWorkerTest do
         worker_secret: Lightning.Config.worker_secret()
       )
 
-    start_supervised!({RuntimeManager, opts}, restart: :transient)
+    start_supervised!({RuntimeManager, opts}, restart: :temporary)
+  end
+
+  # A dead RuntimeManager means the Node worker never started (or exited), so
+  # fail immediately with its reason instead of blocking for the full window.
+  defp await_run_success(run_id, runtime_manager) do
+    ref = Process.monitor(runtime_manager)
+
+    receive do
+      %Events.RunUpdated{run: %{id: ^run_id, state: :success}} ->
+        Process.demonitor(ref, [:flush])
+
+      {:DOWN, ^ref, :process, _pid, :noproc} ->
+        flunk(
+          "runtime manager had already exited before the run started - " <>
+            "see the captured log for the worker's exit status"
+        )
+
+      {:DOWN, ^ref, :process, _pid, reason} ->
+        flunk("runtime manager exited: #{inspect(reason)}")
+    after
+      115_000 ->
+        flunk(
+          "run #{run_id} did not succeed within 115s. Mailbox: " <>
+            inspect(Process.info(self(), :messages))
+        )
+    end
   end
 
   defp select_dataclip_body(uuid) do

--- a/test/integration/workflow_edge_cases_test.exs
+++ b/test/integration/workflow_edge_cases_test.exs
@@ -47,7 +47,7 @@ defmodule Lightning.WorkflowEdgeCasesTest do
   # ---------------------------------------------------------------------------
 
   @tag :integration
-  @tag timeout: 10_000
+  @tag timeout: 120_000
   test "job that returns 42 completes successfully", %{uri: uri} do
     job_body = """
     fn(state => {

--- a/test/lightning/collections_test.exs
+++ b/test/lightning/collections_test.exs
@@ -219,7 +219,7 @@ defmodule Lightning.CollectionsTest do
                |> Repo.preload(collection: :project)
     end
 
-    test "returns matching items for the given collection sorted by inserted_at" do
+    test "returns matching items for the given collection sorted by id" do
       collection = insert(:collection)
 
       insert(:collection_item, key: "rkeynomatch", collection: collection)
@@ -235,8 +235,7 @@ defmodule Lightning.CollectionsTest do
 
       get_items = Collections.get_all(collection, %{limit: 50}, "rkeymatch*")
 
-      assert List.last(get_items) ==
-               Enum.sort_by(items, & &1.inserted_at) |> List.last()
+      assert List.last(get_items) == Enum.max_by(items, & &1.id)
 
       assert MapSet.new(get_items) == MapSet.new(items)
     end

--- a/test/lightning/credentials/schema_test.exs
+++ b/test/lightning/credentials/schema_test.exs
@@ -138,7 +138,7 @@ defmodule Lightning.Credentials.SchemaTest do
         with_log(fn -> Schema.new(schema_map) end)
 
       assert schema.types == %{count: :float, label: :string}
-      refute log =~ "count"
+      refute log =~ "Unknown JSON Schema type"
 
       schema_map = put_in(schema_map["properties"]["count"]["type"], "Bogus")
 
@@ -186,7 +186,7 @@ defmodule Lightning.Credentials.SchemaTest do
                items: {:array, :string}
              }
 
-      assert log == ""
+      refute log =~ "Unknown JSON Schema type"
     end
 
     test "resolves anyOf types by picking the first concrete type" do

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -456,24 +456,17 @@ defmodule Lightning.InvocationTest do
     test "doesn't return a dataclip if the wrong text is entered" do
       %{jobs: [job1 | _rest]} = insert(:complex_workflow)
 
-      [%{id: dataclip_id} | _ignored] =
-        Enum.map(1..10, fn _i ->
-          insert(:dataclip) |> tap(&insert(:step, input_dataclip: &1, job: job1))
-        end)
-
-      # replace the actual 3rd character with some random number
-      prefix = String.slice(dataclip_id, 0, 2) <> "4"
+      dataclip = insert(:dataclip, id: "11111111-1111-1111-1111-111111111111")
+      insert(:step, input_dataclip: dataclip, job: job1)
 
       dataclips =
         Invocation.list_dataclips_for_job(
           job1,
-          %{id_prefix: prefix},
+          %{id_prefix: "222"},
           limit: 10
         )
 
-      # ensure that the dataclip isn't found:
-      # i.e., refute that writing "ab4" matches a dataclip with UUID prefix "ab7"
-      refute Enum.any?(dataclips, &(&1.id == dataclip_id))
+      refute Enum.any?(dataclips, &(&1.id == dataclip.id))
     end
 
     test "filters out wiped dataclips" do

--- a/test/lightning/runs/query_test.exs
+++ b/test/lightning/runs/query_test.exs
@@ -543,6 +543,7 @@ defmodule Lightning.Runs.QueryTest do
                 where:
                   r.state == :available and
                     wf.project_id in ^[red.project.id, cyan.project.id],
+                order_by: [asc: r.inserted_at],
                 limit: 7,
                 select: r,
                 update: []

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -2384,12 +2384,7 @@ defmodule Lightning.Projects.SandboxesTest do
     end
 
     test "uses PURGE_DELETED_AFTER_DAYS to compute the grace period" do
-      previous = Application.get_env(:lightning, :purge_deleted_after_days)
-      Application.put_env(:lightning, :purge_deleted_after_days, 7)
-
-      on_exit(fn ->
-        Application.put_env(:lightning, :purge_deleted_after_days, previous)
-      end)
+      Mox.stub(Lightning.MockConfig, :purge_deleted_after_days, fn -> 7 end)
 
       actor = insert(:user)
       parent = insert(:project, name: "parent")
@@ -2404,12 +2399,7 @@ defmodule Lightning.Projects.SandboxesTest do
     end
 
     test "schedules at now when PURGE_DELETED_AFTER_DAYS is nil" do
-      previous = Application.get_env(:lightning, :purge_deleted_after_days)
-      Application.put_env(:lightning, :purge_deleted_after_days, nil)
-
-      on_exit(fn ->
-        Application.put_env(:lightning, :purge_deleted_after_days, previous)
-      end)
+      Mox.stub(Lightning.MockConfig, :purge_deleted_after_days, fn -> nil end)
 
       actor = insert(:user)
       parent = insert(:project, name: "parent")

--- a/test/lightning/vault_test.exs
+++ b/test/lightning/vault_test.exs
@@ -1,36 +1,28 @@
 defmodule Lightning.VaultTest do
   use ExUnit.Case, async: true
 
-  # Change the log level to something higher than the logged error
-  # from Vault, so we don't pollute our test output.
-  setup do
-    current_level = Logger.level()
-    Logger.configure(level: :emergency)
-
-    on_exit(fn ->
-      Logger.configure(level: current_level)
-    end)
-  end
-
-  @tag :capture_log
   test "enforces a primary encryption key" do
-    assert_raise RuntimeError, ~r/Primary encryption key not found/, fn ->
-      Lightning.Vault.init([])
-    end
+    # Vault logs an error for each of these; capture at :emergency so it
+    # doesn't pollute test output.
+    ExUnit.CaptureLog.with_log([level: :emergency], fn ->
+      assert_raise RuntimeError, ~r/Primary encryption key not found/, fn ->
+        Lightning.Vault.init([])
+      end
 
-    assert_raise RuntimeError,
-                 ~r/Encountered an error when decoding the primary encryption key./,
-                 fn ->
-                   Lightning.Vault.init(primary_encryption_key: "xxx")
-                 end
+      assert_raise RuntimeError,
+                   ~r/Encountered an error when decoding the primary encryption key./,
+                   fn ->
+                     Lightning.Vault.init(primary_encryption_key: "xxx")
+                   end
 
-    assert_raise RuntimeError,
-                 ~r/Primary encryption key is invalid/,
-                 fn ->
-                   Lightning.Vault.init(
-                     primary_encryption_key:
-                       48 |> :crypto.strong_rand_bytes() |> Base.encode64()
-                   )
-                 end
+      assert_raise RuntimeError,
+                   ~r/Primary encryption key is invalid/,
+                   fn ->
+                     Lightning.Vault.init(
+                       primary_encryption_key:
+                         48 |> :crypto.strong_rand_bytes() |> Base.encode64()
+                     )
+                   end
+    end)
   end
 end

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -596,6 +596,10 @@ defmodule Lightning.VersionControlTest do
         :ok
       end)
 
+      expect_create_installation_token(repo_connection.github_installation_id)
+      expect_get_repo(repo_connection.repo)
+      expect_create_workflow_dispatch(repo_connection.repo, "openfn-pull.yml")
+
       VersionControl.initiate_sync(repo_connection, commit_message)
     end
 
@@ -728,41 +732,26 @@ defmodule Lightning.VersionControlTest do
 
       expect_create_installation_token(installation_id)
 
-      Lightning.Tesla.Mock
-      |> expect(
-        :call,
-        fn %{
-             url: "https://api.github.com/installation/repositories",
-             query: [page: 1, per_page: 100]
-           },
-           _opts ->
-          {:ok,
-           %Tesla.Env{
-             status: 200,
-             body: %{
-               "total_count" => Enum.count(expected_repos),
-               "repositories" => first_100_repos
-             }
-           }}
-        end
-      )
-      |> expect(
-        :call,
-        fn %{
-             url: "https://api.github.com/installation/repositories",
-             query: [page: 2, per_page: 100]
-           },
-           _opts ->
-          {:ok,
-           %Tesla.Env{
-             status: 200,
-             body: %{
-               "total_count" => Enum.count(expected_repos),
-               "repositories" => next_batch
-             }
-           }}
-        end
-      )
+      expect(Lightning.Tesla.Mock, :call, 2, fn %{
+                                                  url:
+                                                    "https://api.github.com/installation/repositories",
+                                                  query: [
+                                                    page: page,
+                                                    per_page: 100
+                                                  ]
+                                                },
+                                                _opts ->
+        repositories = if page == 1, do: first_100_repos, else: next_batch
+
+        {:ok,
+         %Tesla.Env{
+           status: 200,
+           body: %{
+             "total_count" => Enum.count(expected_repos),
+             "repositories" => repositories
+           }
+         }}
+      end)
 
       expected_result = %{
         "total_count" => Enum.count(expected_repos),
@@ -798,56 +787,45 @@ defmodule Lightning.VersionControlTest do
 
       expect_create_installation_token(installation_id)
 
-      Lightning.Tesla.Mock
-      |> expect(
-        :call,
-        fn %{
-             url: "https://api.github.com/installation/repositories",
-             query: [page: 1, per_page: 100]
-           },
-           _opts ->
-          {:ok,
-           %Tesla.Env{
-             status: 200,
-             body: %{
-               "total_count" => total_repo_count,
-               "repositories" => first_100_repos
-             }
-           }}
+      expect(Lightning.Tesla.Mock, :call, 3, fn %{
+                                                  url:
+                                                    "https://api.github.com/installation/repositories",
+                                                  query: [
+                                                    page: page,
+                                                    per_page: 100
+                                                  ]
+                                                },
+                                                _opts ->
+        case page do
+          1 ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: %{
+                 "total_count" => total_repo_count,
+                 "repositories" => first_100_repos
+               }
+             }}
+
+          2 ->
+            # We're failing to return the 2nd batch
+            {:ok,
+             %Tesla.Env{
+               status: 403,
+               body: %{"message" => "some error maybe spike"}
+             }}
+
+          3 ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: %{
+                 "total_count" => total_repo_count,
+                 "repositories" => last_batch
+               }
+             }}
         end
-      )
-      |> expect(
-        :call,
-        fn %{
-             url: "https://api.github.com/installation/repositories",
-             query: [page: 2, per_page: 100]
-           },
-           _opts ->
-          # We're failing to return the 2nd batch
-          {:ok,
-           %Tesla.Env{
-             status: 403,
-             body: %{"message" => "some error maybe spike"}
-           }}
-        end
-      )
-      |> expect(
-        :call,
-        fn %{
-             url: "https://api.github.com/installation/repositories",
-             query: [page: 3, per_page: 100]
-           },
-           _opts ->
-          {:ok,
-           %Tesla.Env{
-             status: 200,
-             body: %{
-               "total_count" => total_repo_count,
-               "repositories" => last_batch
-             }
-           }}
-        end
-      )
+      end)
 
       expected_result = %{
         "total_count" => total_repo_count,

--- a/test/lightning/version_control_test.exs
+++ b/test/lightning/version_control_test.exs
@@ -17,11 +17,10 @@ defmodule Lightning.VersionControlTest do
   import Lightning.GithubHelpers
   import Mox
 
-  :verify_on_exit!
+  setup :verify_on_exit!
 
   describe "create_github_connection/2" do
     test "user with valid oauth token creates connection successfully" do
-      Mox.verify_on_exit!()
       project = insert(:project)
       user = user_with_valid_github_oauth()
 
@@ -42,45 +41,11 @@ defmodule Lightning.VersionControlTest do
 
       expected_branch = %{"name" => "somebranch"}
 
-      # push pull.yml
-      expect_get_repo(expected_repo["full_name"], 200, expected_repo)
-      expect_create_blob(expected_repo["full_name"])
-
-      expect_get_commit(
-        expected_repo["full_name"],
-        expected_repo["default_branch"]
-      )
-
-      expect_create_tree(expected_repo["full_name"])
-      expect_create_commit(expected_repo["full_name"])
-
-      expect_update_ref(
-        expected_repo["full_name"],
-        expected_repo["default_branch"]
-      )
-
-      # push deploy.yml + config.json
-      # deploy.yml blob
-      expect_create_blob(expected_repo["full_name"])
-      # config.json blob
-      expect_create_blob(expected_repo["full_name"])
-      expect_get_commit(expected_repo["full_name"], expected_branch["name"])
-      expect_create_tree(expected_repo["full_name"])
-      expect_create_commit(expected_repo["full_name"])
-      expect_update_ref(expected_repo["full_name"], expected_branch["name"])
-
-      # write secret
-      expect_get_public_key(expected_repo["full_name"])
-      secret_name = "OPENFN_#{String.replace(project.id, "-", "_")}_API_KEY"
-      expect_create_repo_secret(expected_repo["full_name"], secret_name)
-
-      # initialize sync
-      expect_create_installation_token(expected_installation["id"])
-      expect_get_repo(expected_repo["full_name"], 200, expected_repo)
-
-      expect_create_workflow_dispatch(
-        expected_repo["full_name"],
-        "openfn-pull.yml"
+      expect_full_github_connection_flow(
+        expected_repo,
+        expected_branch["name"],
+        project.id,
+        expected_installation["id"]
       )
 
       params = %{
@@ -154,45 +119,11 @@ defmodule Lightning.VersionControlTest do
 
       expected_branch = %{"name" => branch}
 
-      # push pull.yml
-      expect_get_repo(expected_repo["full_name"], 200, expected_repo)
-      expect_create_blob(expected_repo["full_name"])
-
-      expect_get_commit(
-        expected_repo["full_name"],
-        expected_repo["default_branch"]
-      )
-
-      expect_create_tree(expected_repo["full_name"])
-      expect_create_commit(expected_repo["full_name"])
-
-      expect_update_ref(
-        expected_repo["full_name"],
-        expected_repo["default_branch"]
-      )
-
-      # push deploy.yml + config.json
-      # deploy.yml blob
-      expect_create_blob(expected_repo["full_name"])
-      # config.json blob
-      expect_create_blob(expected_repo["full_name"])
-      expect_get_commit(expected_repo["full_name"], expected_branch["name"])
-      expect_create_tree(expected_repo["full_name"])
-      expect_create_commit(expected_repo["full_name"])
-      expect_update_ref(expected_repo["full_name"], expected_branch["name"])
-
-      # write secret
-      expect_get_public_key(expected_repo["full_name"])
-      secret_name = "OPENFN_#{String.replace(project_id, "-", "_")}_API_KEY"
-      expect_create_repo_secret(expected_repo["full_name"], secret_name)
-
-      # initialize sync
-      expect_create_installation_token(expected_installation["id"])
-      expect_get_repo(expected_repo["full_name"], 200, expected_repo)
-
-      expect_create_workflow_dispatch(
-        expected_repo["full_name"],
-        "openfn-pull.yml"
+      expect_full_github_connection_flow(
+        expected_repo,
+        expected_branch["name"],
+        project_id,
+        expected_installation["id"]
       )
 
       params = %{
@@ -249,7 +180,6 @@ defmodule Lightning.VersionControlTest do
 
   describe "remove_github_connection/2" do
     test "user with a valid oauth token can successfully remove a connection" do
-      Mox.verify_on_exit!()
       project = insert(:project)
       user = user_with_valid_github_oauth()
 
@@ -450,22 +380,9 @@ defmodule Lightning.VersionControlTest do
 
   describe "fetch_user_access_token/1" do
     test "returns ok for an access token that is still active" do
-      active_token = %{
-        "access_token" => "access-token",
-        "refresh_token" => "refresh-token",
-        "expires_at" => DateTime.utc_now() |> DateTime.add(20),
-        "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(20)
-      }
+      user = user_with_valid_github_oauth()
 
-      # reload so that we can get the token as they are from the db
-      user =
-        insert(:user, github_oauth_token: active_token)
-        |> Lightning.Repo.reload!()
-
-      expected_token = active_token["access_token"]
-
-      assert {:ok, ^expected_token} =
-               VersionControl.fetch_user_access_token(user)
+      assert {:ok, "access-token"} = VersionControl.fetch_user_access_token(user)
     end
 
     test "returns ok for an access token that has no expiry" do
@@ -563,8 +480,6 @@ defmodule Lightning.VersionControlTest do
 
   describe "initiate_sync/2" do
     setup do
-      verify_on_exit!()
-
       project = insert(:project)
 
       workflow = insert(:simple_workflow, project: project)
@@ -629,20 +544,10 @@ defmodule Lightning.VersionControlTest do
       expect_create_installation_token(repo_connection.github_installation_id)
       expect_get_repo(repo_connection.repo)
 
-      expect_create_workflow_dispatch_with_request_body(
-        repo_connection.repo,
-        "openfn-pull.yml",
-        %{
-          ref: "main",
-          inputs: %{
-            projectId: repo_connection.project_id,
-            apiSecretName: api_secret_name(repo_connection),
-            branch: repo_connection.branch,
-            pathToConfig: path_to_config(repo_connection),
-            commitMessage: commit_message,
-            snapshots: "#{other_snapshot.id} #{snapshot.id}"
-          }
-        }
+      expect_workflow_dispatch_with_snapshots(
+        repo_connection,
+        commit_message,
+        [snapshot.id, other_snapshot.id]
       )
 
       assert :ok = VersionControl.initiate_sync(repo_connection, commit_message)
@@ -662,20 +567,10 @@ defmodule Lightning.VersionControlTest do
       expect_create_installation_token(yaml_connection.github_installation_id)
       expect_get_repo(yaml_connection.repo)
 
-      expect_create_workflow_dispatch_with_request_body(
-        yaml_connection.repo,
-        "openfn-pull.yml",
-        %{
-          ref: "main",
-          inputs: %{
-            projectId: yaml_connection.project_id,
-            apiSecretName: api_secret_name(yaml_connection),
-            branch: yaml_connection.branch,
-            pathToConfig: path_to_config(yaml_connection),
-            commitMessage: commit_message,
-            snapshots: "#{other_snapshot.id} #{snapshot.id}"
-          }
-        }
+      expect_workflow_dispatch_with_snapshots(
+        yaml_connection,
+        commit_message,
+        [snapshot.id, other_snapshot.id]
       )
 
       assert :ok = VersionControl.initiate_sync(yaml_connection, commit_message)
@@ -690,6 +585,44 @@ defmodule Lightning.VersionControlTest do
     defp path_to_config(repo_connection) do
       ProjectRepoConnection.config_path(repo_connection)
       |> Path.relative_to(".")
+    end
+
+    # list_snapshots_for_project/1 doesn't order its query, so the
+    # snapshots ids can arrive in either order; assert the set, not a
+    # sequence.
+    defp expect_workflow_dispatch_with_snapshots(
+           repo_connection,
+           commit_message,
+           snapshot_ids
+         ) do
+      repo = repo_connection.repo
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn %{
+                                                   url:
+                                                     "https://api.github.com/repos/" <>
+                                                       ^repo <>
+                                                       "/actions/workflows/openfn-pull.yml/dispatches",
+                                                   body: body
+                                                 },
+                                                 _opts ->
+        decoded = Jason.decode!(body)
+        inputs = decoded["inputs"]
+
+        assert decoded["ref"] == "main"
+
+        assert inputs["snapshots"] |> String.split() |> Enum.sort() ==
+                 Enum.sort(snapshot_ids)
+
+        assert Map.delete(inputs, "snapshots") == %{
+                 "projectId" => repo_connection.project_id,
+                 "apiSecretName" => api_secret_name(repo_connection),
+                 "branch" => repo_connection.branch,
+                 "pathToConfig" => path_to_config(repo_connection),
+                 "commitMessage" => commit_message
+               }
+
+        {:ok, %Tesla.Env{status: 204, body: ""}}
+      end)
     end
   end
 
@@ -845,8 +778,6 @@ defmodule Lightning.VersionControlTest do
 
   describe "config file blob content" do
     setup do
-      Mox.verify_on_exit!()
-
       project = insert(:project)
       user = user_with_valid_github_oauth()
 
@@ -875,16 +806,6 @@ defmodule Lightning.VersionControlTest do
        expected_repo: expected_repo}
     end
 
-    defp setup_github_mocks(repo, expected_repo) do
-      expect_get_repo(repo, 200, expected_repo)
-      expect_create_blob(repo)
-      expect_get_commit(repo, expected_repo["default_branch"])
-      expect_create_tree(repo)
-      expect_create_commit(repo)
-      expect_update_ref(repo, expected_repo["default_branch"])
-      expect_create_blob(repo)
-    end
-
     test "pushes JSON config blob when sync_version is false (default)", %{
       project: project,
       user: user,
@@ -894,31 +815,26 @@ defmodule Lightning.VersionControlTest do
       base_params: base_params,
       expected_repo: expected_repo
     } do
-      setup_github_mocks(repo, expected_repo)
+      expect_full_github_connection_flow(
+        expected_repo,
+        branch,
+        project.id,
+        installation_id,
+        config_blob_expectation: fn ->
+          Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+            assert env.url == "https://api.github.com/repos/#{repo}/git/blobs"
+            body = Jason.decode!(env.body)
 
-      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
-        assert env.url == "https://api.github.com/repos/#{repo}/git/blobs"
-        body = Jason.decode!(env.body)
+            assert body["content"] =~
+                     "\"statePath\": \"openfn-#{project.id}-state.json\""
 
-        assert body["content"] =~
-                 "\"statePath\": \"openfn-#{project.id}-state.json\""
+            assert body["content"] =~
+                     "\"specPath\": \"openfn-#{project.id}-spec.yaml\""
 
-        assert body["content"] =~
-                 "\"specPath\": \"openfn-#{project.id}-spec.yaml\""
-
-        {:ok, %Tesla.Env{status: 201, body: %{"sha" => "3a0f8"}}}
-      end)
-
-      secret_name = "OPENFN_#{String.replace(project.id, "-", "_")}_API_KEY"
-      expect_get_commit(repo, branch)
-      expect_create_tree(repo)
-      expect_create_commit(repo)
-      expect_update_ref(repo, branch)
-      expect_get_public_key(repo)
-      expect_create_repo_secret(repo, secret_name)
-      expect_create_installation_token(installation_id)
-      expect_get_repo(repo, 200, expected_repo)
-      expect_create_workflow_dispatch(repo, "openfn-pull.yml")
+            {:ok, %Tesla.Env{status: 201, body: %{"sha" => "3a0f8"}}}
+          end)
+        end
+      )
 
       assert {:ok, _} =
                VersionControl.create_github_connection(base_params, user)
@@ -933,41 +849,86 @@ defmodule Lightning.VersionControlTest do
       base_params: base_params,
       expected_repo: expected_repo
     } do
-      setup_github_mocks(repo, expected_repo)
-
-      Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
-        assert env.url == "https://api.github.com/repos/#{repo}/git/blobs"
-        body = Jason.decode!(env.body)
-        assert body["content"] =~ "project:"
-        assert body["content"] =~ "uuid: #{project.id}"
-        assert body["content"] =~ LightningWeb.Endpoint.url()
-        {:ok, %Tesla.Env{status: 201, body: %{"sha" => "3a0f8"}}}
-      end)
-
-      secret_name = "OPENFN_#{String.replace(project.id, "-", "_")}_API_KEY"
-      expect_get_commit(repo, branch)
-      expect_create_tree(repo)
-      expect_create_commit(repo)
-      expect_update_ref(repo, branch)
-      expect_get_public_key(repo)
-      expect_create_repo_secret(repo, secret_name)
-      expect_create_installation_token(installation_id)
-      expect_get_repo(repo, 200, expected_repo)
-      expect_create_workflow_dispatch(repo, "openfn-pull.yml")
+      expect_full_github_connection_flow(
+        expected_repo,
+        branch,
+        project.id,
+        installation_id,
+        config_blob_expectation: fn ->
+          Mox.expect(Lightning.Tesla.Mock, :call, fn env, _opts ->
+            assert env.url == "https://api.github.com/repos/#{repo}/git/blobs"
+            body = Jason.decode!(env.body)
+            assert body["content"] =~ "project:"
+            assert body["content"] =~ "uuid: #{project.id}"
+            assert body["content"] =~ LightningWeb.Endpoint.url()
+            {:ok, %Tesla.Env{status: 201, body: %{"sha" => "3a0f8"}}}
+          end)
+        end
+      )
 
       params = Map.put(base_params, "sync_version", "true")
       assert {:ok, _} = VersionControl.create_github_connection(params, user)
     end
   end
 
-  defp user_with_valid_github_oauth do
-    active_token = %{
-      "access_token" => "access-token",
-      "refresh_token" => "refresh-token",
-      "expires_at" => DateTime.utc_now() |> DateTime.add(500),
-      "refresh_token_expires_at" => DateTime.utc_now() |> DateTime.add(500)
-    }
+  # These 17 expectations share one Mox FIFO queue on the same mocked
+  # function, so registration order here must match the call order
+  # create_github_connection/2 actually makes.
+  #
+  # `config_blob_expectation` overrides the config.json blob call (the 8th
+  # of the 17) for tests that assert on its request body; it defaults to
+  # the plain expect_create_blob/1 behaviour.
+  defp expect_full_github_connection_flow(
+         expected_repo,
+         branch,
+         project_id,
+         installation_id,
+         opts \\ []
+       ) do
+    repo = expected_repo["full_name"]
+    default_branch = expected_repo["default_branch"]
 
-    insert(:user, github_oauth_token: active_token) |> Lightning.Repo.reload()
+    config_blob_expectation =
+      Keyword.get(opts, :config_blob_expectation, fn ->
+        expect_create_blob(repo)
+      end)
+
+    # push pull.yml
+    expect_get_repo(repo, 200, expected_repo)
+    expect_create_blob(repo)
+    expect_get_commit(repo, default_branch)
+    expect_create_tree(repo)
+    expect_create_commit(repo)
+    expect_update_ref(repo, default_branch)
+
+    # push deploy.yml + config.json
+    # deploy.yml blob
+    expect_create_blob(repo)
+    # config.json blob
+    config_blob_expectation.()
+    expect_get_commit(repo, branch)
+    expect_create_tree(repo)
+    expect_create_commit(repo)
+    expect_update_ref(repo, branch)
+
+    # write secret
+    expect_get_public_key(repo)
+    expect_create_repo_secret(repo, api_secret_name(%{project_id: project_id}))
+
+    # initiate sync
+    expect_create_installation_token(installation_id)
+    expect_get_repo(repo, 200, expected_repo)
+    expect_create_workflow_dispatch(repo, "openfn-pull.yml")
+  end
+
+  defp user_with_valid_github_oauth do
+    # github_oauth_token is an encrypted map field: after an update the
+    # in-memory struct still holds the raw terms we set (e.g. DateTime
+    # structs), not the JSON-round-tripped string map that comes back
+    # from a real DB read. Reload so callers get a token shaped the way
+    # it actually looks when loaded from storage.
+    insert(:user)
+    |> set_valid_github_oauth_token!()
+    |> Lightning.Repo.reload!()
   end
 end

--- a/test/lightning_web/controllers/api/workflows_controller_test.exs
+++ b/test/lightning_web/controllers/api/workflows_controller_test.exs
@@ -347,7 +347,7 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
              } =
                saved_workflow = get_saved_workflow(response_workflow["id"])
 
-      assert encode_decode(response_workflow) == encode_decode(saved_workflow)
+      assert_response(response_workflow)
 
       assert Map.take(hd(workflow.edges), [:condition_type, :enabled]) ==
                Map.take(edge, [:condition_type, :enabled])
@@ -384,7 +384,7 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
 
       assert saved_workflow = get_saved_workflow(response_workflow["id"])
 
-      assert response_workflow == encode_decode(saved_workflow)
+      assert_response(response_workflow)
 
       assert pluck_to_mapset(workflow.edges, [:condition_type, :enabled]) ==
                pluck_to_mapset(saved_workflow.edges, [:condition_type, :enabled])
@@ -453,8 +453,15 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
 
       saved_workflow = get_saved_workflow(response_workflow["id"])
 
-      assert encode_decode(response_workflow) |> remove_timestamps() ==
-               encode_decode(saved_workflow) |> remove_timestamps()
+      merged = encode_decode(response_workflow) |> remove_timestamps()
+      saved = encode_decode(saved_workflow) |> remove_timestamps()
+
+      assert MapSet.new(merged["jobs"]) == MapSet.new(saved["jobs"])
+      assert MapSet.new(merged["edges"]) == MapSet.new(saved["edges"])
+      assert MapSet.new(merged["triggers"]) == MapSet.new(saved["triggers"])
+
+      assert Map.drop(merged, ["jobs", "edges", "triggers"]) ==
+               Map.drop(saved, ["jobs", "edges", "triggers"])
     end
 
     test "returns 422 when an edge has invalid condition_type", %{
@@ -932,7 +939,7 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
 
       saved_workflow = get_saved_workflow(workflow)
 
-      assert encode_decode(response_workflow) == encode_decode(saved_workflow)
+      assert_response(response_workflow)
 
       assert workflow
              |> Map.merge(patch)
@@ -980,15 +987,19 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
 
       saved_workflow = get_saved_workflow(workflow)
 
-      assert encode_decode(response_workflow) == encode_decode(saved_workflow)
+      assert_response(response_workflow)
 
-      assert workflow
-             |> Map.merge(patch)
-             |> encode_decode()
-             |> remove_timestamps() ==
-               saved_workflow
-               |> encode_decode()
-               |> remove_timestamps()
+      merged =
+        workflow |> Map.merge(patch) |> encode_decode() |> remove_timestamps()
+
+      saved = saved_workflow |> encode_decode() |> remove_timestamps()
+
+      assert MapSet.new(merged["jobs"]) == MapSet.new(saved["jobs"])
+      assert MapSet.new(merged["edges"]) == MapSet.new(saved["edges"])
+      assert MapSet.new(merged["triggers"]) == MapSet.new(saved["triggers"])
+
+      assert Map.drop(merged, ["jobs", "edges", "triggers"]) ==
+               Map.drop(saved, ["jobs", "edges", "triggers"])
     end
 
     test "Adds a disconnected/orphan job", %{conn: conn, project: project} do
@@ -1485,15 +1496,23 @@ defmodule LightningWeb.API.WorkflowsControllerTest do
 
       assert_response(response_workflow)
 
-      saved_workflow =
+      saved =
         get_saved_workflow(response_workflow["id"])
         |> encode_decode()
         |> remove_timestamps()
 
-      assert workflow
-             |> Map.merge(complete_update)
-             |> encode_decode()
-             |> remove_timestamps() == saved_workflow
+      merged =
+        workflow
+        |> Map.merge(complete_update)
+        |> encode_decode()
+        |> remove_timestamps()
+
+      assert MapSet.new(merged["jobs"]) == MapSet.new(saved["jobs"])
+      assert MapSet.new(merged["edges"]) == MapSet.new(saved["edges"])
+      assert MapSet.new(merged["triggers"]) == MapSet.new(saved["triggers"])
+
+      assert Map.drop(merged, ["jobs", "edges", "triggers"]) ==
+               Map.drop(saved, ["jobs", "edges", "triggers"])
     end
 
     test "updates completely a workflow with disconnected job", %{

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -588,12 +588,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
     test "delete modal mentions the configured grace period when no purge window is set",
          %{conn: conn, parent: parent, sb1: sb1} do
-      previous = Application.get_env(:lightning, :purge_deleted_after_days)
-      Application.put_env(:lightning, :purge_deleted_after_days, nil)
-
-      on_exit(fn ->
-        Application.put_env(:lightning, :purge_deleted_after_days, previous)
-      end)
+      Mox.stub(Lightning.MockConfig, :purge_deleted_after_days, fn -> nil end)
 
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
 
@@ -607,12 +602,7 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
     test "delete modal uses singular '1 day' when grace period is one day",
          %{conn: conn, parent: parent, sb1: sb1} do
-      previous = Application.get_env(:lightning, :purge_deleted_after_days)
-      Application.put_env(:lightning, :purge_deleted_after_days, 1)
-
-      on_exit(fn ->
-        Application.put_env(:lightning, :purge_deleted_after_days, previous)
-      end)
+      Mox.stub(Lightning.MockConfig, :purge_deleted_after_days, fn -> 1 end)
 
       {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
 


### PR DESCRIPTION
## Description

This PR fixes a batch of flaky tests found while chasing CI flakiness, plus
two small correctness bugs that surfaced along the way (a missing tiebreak
in run claiming, and an unhandled transport error in the GitHub client).

Covers OFN-4523, OFN-4524, OFN-4526, OFN-4527, OFN-4529, OFN-4530, OFN-4532,
OFN-4535.

## Validation steps

1. `mix test` should be green.
2. `bin/repeat_mix_test <file>` on any of the touched test files (30x+) to
   confirm no more flakes.

## Additional notes for the reviewer

1. OFN-4525 (sweep the suite for the same "assumed order" pattern elsewhere)
   is called out but left out of scope, tracked separately.

## AI Usage

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
