### PR TITLE
Display sandbox projects with ancestor chain in credentials UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to
 - `eligible_for_claim/0` now breaks ties with `id` after `priority` and
   `inserted_at`, so two runs inserted in the same microsecond no longer get
   claimed in a nondeterministic order.
+- Sandboxes in the credentials page's "Projects with access" column and in the
+  credential and OAuth client project pickers are now labelled with their parent
+  project, e.g. `parent/sandbox`, so they can be told apart from top-level
+  projects. [#5110](https://github.com/OpenFn/lightning/pull/5110)
 
 ## [2.18.1] - 2026-08-28
 

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -329,8 +329,37 @@ defmodule Lightning.Projects do
   so that `Project.display_name/1` can walk to the root.
 
   Fetches the entire chain in a single recursive CTE query.
+
+  When given a list of projects, the ancestor chains for every project in the
+  list are fetched in a single query.
   """
   @spec preload_ancestors(Project.t()) :: Project.t()
+  @spec preload_ancestors([Project.t()]) :: [Project.t()]
+  def preload_ancestors(projects) when is_list(projects) do
+    parent_ids =
+      projects
+      |> Enum.reject(&(is_nil(&1.parent_id) or match?(%Project{}, &1.parent)))
+      |> Enum.map(& &1.parent_id)
+      |> Enum.uniq()
+
+    ancestors_by_id =
+      case parent_ids do
+        [] -> %{}
+        ids -> ids |> list_ancestors() |> Map.new(&{&1.id, &1})
+      end
+
+    Enum.map(projects, fn
+      %Project{parent_id: nil} = p ->
+        p
+
+      %Project{parent: %Project{}} = p ->
+        preload_ancestors(p)
+
+      %Project{parent_id: parent_id} = p ->
+        %{p | parent: nest_ancestors(parent_id, ancestors_by_id)}
+    end)
+  end
+
   def preload_ancestors(%Project{parent_id: nil} = p), do: p
 
   def preload_ancestors(%Project{parent: %Project{} = parent} = p) do
@@ -340,19 +369,19 @@ defmodule Lightning.Projects do
   def preload_ancestors(%Project{parent_id: parent_id} = p)
       when is_binary(parent_id) do
     ancestors_by_id =
-      parent_id
+      [parent_id]
       |> list_ancestors()
       |> Map.new(&{&1.id, &1})
 
     %{p | parent: nest_ancestors(parent_id, ancestors_by_id)}
   end
 
-  defp list_ancestors(start_id) do
+  defp list_ancestors(start_ids) when is_list(start_ids) do
     max_depth = max_project_tree_depth()
 
     initial =
       from(p in Project,
-        where: p.id == ^start_id,
+        where: p.id in ^start_ids,
         select: %{id: p.id, parent_id: p.parent_id, depth: 0}
       )
 

--- a/lib/lightning_web/live/components/credentials.ex
+++ b/lib/lightning_web/live/components/credentials.ex
@@ -179,7 +179,7 @@ defmodule LightningWeb.Components.Credentials do
             :for={project <- @selected_projects}
             class="inline-flex items-center gap-1 rounded-md bg-blue-100 px-4 mr-1 py-2 mb-2 text-gray-600"
           >
-            {project.name}
+            {project_label(project)}
             <button
               id={"#{@remove_project_id}-#{project.id}"}
               phx-target={@phx_target}
@@ -187,7 +187,7 @@ defmodule LightningWeb.Components.Credentials do
               phx-click="remove_selected_project"
               type="button"
               class="group relative -mr-1 h-3.5 w-3.5 rounded-sm hover:bg-gray-500/20"
-              {if(@workflows_using_credentials[project.id], do: %{"data-confirm": "Warning: This credential is in use by the following workflows: #{Enum.join(@workflows_using_credentials[project.id], ", ")}. If you revoke access to the \"#{project.name}\" project, runs for those workflows will probably fail until you provide a new credential. Are you sure you want to revoke access?"}, else: %{})}
+              {if(@workflows_using_credentials[project.id], do: %{"data-confirm": "Warning: This credential is in use by the following workflows: #{Enum.join(@workflows_using_credentials[project.id], ", ")}. If you revoke access to the \"#{project_label(project)}\" project, runs for those workflows will probably fail until you provide a new credential. Are you sure you want to revoke access?"}, else: %{})}
             >
               <span class="sr-only">Remove</span>
               <Heroicons.x_mark solid class="w-4 h-4" />
@@ -201,10 +201,18 @@ defmodule LightningWeb.Components.Credentials do
   end
 
   defp map_projects_for_select(projects) do
-    Enum.map(projects, fn %{id: id, name: name} ->
-      {name, id}
+    Enum.map(projects, fn %{id: id} = project ->
+      {project_label(project), id}
     end)
   end
+
+  # Sandboxes are labelled with their ancestor chain (`parent/sandbox`) so
+  # they are distinguishable from top-level projects. Falls back to the bare
+  # name when the ancestors are not loaded.
+  defp project_label(%Lightning.Projects.Project{} = project),
+    do: Lightning.Projects.Project.display_name(project)
+
+  defp project_label(%{name: name}), do: name
 
   attr :id, :string, required: true
 

--- a/lib/lightning_web/live/credential_live/credential_form_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_form_component.ex
@@ -1382,6 +1382,7 @@ defmodule LightningWeb.CredentialLive.CredentialFormComponent do
       |> Ecto.Changeset.get_assoc(:project_credentials, :struct)
       |> Lightning.Repo.preload(:project)
       |> Enum.map(fn poc -> poc.project end)
+      |> Lightning.Projects.preload_ancestors()
 
     workflows_using_credentials =
       changeset

--- a/lib/lightning_web/live/credential_live/credential_index_component.ex
+++ b/lib/lightning_web/live/credential_live/credential_index_component.ex
@@ -405,11 +405,14 @@ defmodule LightningWeb.CredentialLive.CredentialIndexComponent do
   end
 
   defp list_credentials(user_or_project) do
-    user_or_project
-    |> Credentials.list_credentials()
-    |> Enum.map(fn credential ->
+    credentials = Credentials.list_credentials(user_or_project)
+    display_names = project_display_names(credentials)
+
+    Enum.map(credentials, fn credential ->
       project_names =
-        Map.get(credential, :projects, []) |> Enum.map(fn p -> p.name end)
+        credential
+        |> Map.get(:projects, [])
+        |> Enum.map(&Map.fetch!(display_names, &1.id))
 
       environment_names =
         credential
@@ -423,18 +426,31 @@ defmodule LightningWeb.CredentialLive.CredentialIndexComponent do
   end
 
   defp list_clients(user_or_project) do
-    user_or_project
-    |> OauthClients.list_clients()
-    |> Enum.map(fn c ->
+    clients = OauthClients.list_clients(user_or_project)
+    display_names = project_display_names(clients)
+
+    Enum.map(clients, fn c ->
       project_names =
         if c.global,
           do: ["GLOBAL"],
           else:
-            Map.get(c, :projects, [])
-            |> Enum.map(fn p -> p.name end)
+            c
+            |> Map.get(:projects, [])
+            |> Enum.map(&Map.fetch!(display_names, &1.id))
 
       Map.put(c, :project_names, project_names)
     end)
+  end
+
+  # Sandboxes are shown with their ancestors (e.g. `parent/sandbox`) so they
+  # can be told apart from top-level projects. Ancestors for every project
+  # across all records are loaded in one query.
+  defp project_display_names(records) do
+    records
+    |> Enum.flat_map(&Map.get(&1, :projects, []))
+    |> Enum.uniq_by(& &1.id)
+    |> Lightning.Projects.preload_ancestors()
+    |> Map.new(&{&1.id, Lightning.Projects.Project.display_name(&1)})
   end
 
   defp delete_action(assigns) do

--- a/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
+++ b/lib/lightning_web/live/credential_live/oauth_client_form_component.ex
@@ -43,6 +43,7 @@ defmodule LightningWeb.CredentialLive.OauthClientFormComponent do
       |> Ecto.Changeset.get_assoc(:project_oauth_clients, :struct)
       |> Lightning.Repo.preload(:project)
       |> Enum.map(fn poc -> poc.project end)
+      |> Lightning.Projects.preload_ancestors()
 
     available_projects =
       Helpers.filter_available_projects(

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -4176,6 +4176,42 @@ defmodule Lightning.ProjectsTest do
     end
   end
 
+  describe "preload_ancestors/1" do
+    test "loads the full parent chain for a single sandbox" do
+      root = insert(:project, name: "root")
+      middle = insert(:project, name: "middle", parent: root)
+      leaf = insert(:project, name: "leaf", parent: middle)
+
+      loaded = Project |> Repo.get!(leaf.id) |> Projects.preload_ancestors()
+
+      assert %Project{parent: %Project{parent: %Project{parent: nil}}} = loaded
+      assert loaded.parent.id == middle.id
+      assert loaded.parent.parent.id == root.id
+      assert Project.display_name(loaded) == "root/middle/leaf"
+    end
+
+    test "loads ancestors for every project in a list" do
+      root = insert(:project, name: "root")
+      middle = insert(:project, name: "middle", parent: root)
+      leaf = insert(:project, name: "leaf", parent: middle)
+      other_root = insert(:project, name: "other")
+      other_sandbox = insert(:project, name: "other-sandbox", parent: other_root)
+
+      [leaf, other_sandbox, root] =
+        [leaf.id, other_sandbox.id, root.id]
+        |> Enum.map(&Repo.get!(Project, &1))
+        |> Projects.preload_ancestors()
+
+      assert Project.display_name(leaf) == "root/middle/leaf"
+      assert Project.display_name(other_sandbox) == "other/other-sandbox"
+      assert Project.display_name(root) == "root"
+    end
+
+    test "returns an empty list unchanged" do
+      assert Projects.preload_ancestors([]) == []
+    end
+  end
+
   describe "display_name_within_access_root/2" do
     test "returns the project name alone when access_root is the project itself" do
       project = insert(:project, name: "acme-workspace")

--- a/test/lightning_web/live/credential_live_test.exs
+++ b/test/lightning_web/live/credential_live_test.exs
@@ -42,6 +42,17 @@ defmodule LightningWeb.CredentialLiveTest do
   setup :register_and_log_in_user
   setup :create_project_for_current_user
 
+  # Text of the "Projects with access" chips on the table row for `name`.
+  defp project_chips(html, table_selector, name) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("#{table_selector} tr")
+    |> Enum.find(&(Floki.text(&1) =~ name))
+    |> Floki.find("td span.bg-primary-50")
+    |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+    |> Enum.sort()
+  end
+
   defp get_decoded_state(url) when is_nil(url) do
     [
       "test",
@@ -106,6 +117,80 @@ defmodule LightningWeb.CredentialLiveTest do
       assert html =~ "Environment"
       assert html =~ credential.schema
       assert html =~ credential.name
+    end
+
+    test "labels sandboxes with their parent project name", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "testy-project",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      sandbox = insert(:project, name: "sandy-sandbox", parent: parent)
+
+      credential = insert(:credential, user: user)
+      insert(:project_credential, project: parent, credential: credential)
+      insert(:project_credential, project: sandbox, credential: credential)
+
+      {:ok, view, html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      assert project_chips(html, "#credentials-table", credential.name) == [
+               "testy-project",
+               "testy-project/sandy-sandbox"
+             ]
+
+      open_edit_credential_modal(view, credential.id)
+
+      assert view
+             |> element(
+               "#remove-project-credential-button-#{credential.id}-#{sandbox.id}"
+             )
+             |> has_element?()
+
+      assert render(view) =~ "testy-project/sandy-sandbox"
+    end
+
+    test "keeps soft-deleted sandboxes but hides purged ones", %{
+      conn: conn,
+      user: user
+    } do
+      parent =
+        insert(:project,
+          name: "testy-project",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      sandbox =
+        insert(:project,
+          name: "sandy-sandbox",
+          parent: parent,
+          scheduled_deletion:
+            DateTime.utc_now()
+            |> DateTime.add(7, :day)
+            |> DateTime.truncate(:second)
+        )
+
+      credential = insert(:credential, user: user)
+      insert(:project_credential, project: parent, credential: credential)
+      insert(:project_credential, project: sandbox, credential: credential)
+
+      {:ok, _view, html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      assert project_chips(html, "#credentials-table", credential.name) == [
+               "testy-project",
+               "testy-project/sandy-sandbox"
+             ]
+
+      {:ok, _deleted} = Lightning.Projects.delete_project(sandbox)
+
+      {:ok, _view, html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      assert project_chips(html, "#credentials-table", credential.name) == [
+               "testy-project"
+             ]
     end
 
     test "ensure support user only sees credentials they own on /credentials", %{

--- a/test/lightning_web/live/oauth_clients_live_test.exs
+++ b/test/lightning_web/live/oauth_clients_live_test.exs
@@ -126,6 +126,33 @@ defmodule LightningWeb.OauthClientsLiveTest do
   setup :create_project_for_current_user
 
   describe "List" do
+    test "labels sandboxes with their parent project name", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      sandbox = insert(:project, name: "sandy-sandbox", parent: project)
+
+      client =
+        insert(:oauth_client,
+          user: user,
+          project_oauth_clients: [%{project: project}, %{project: sandbox}]
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/credentials", on_error: :raise)
+
+      chips =
+        html
+        |> Floki.parse_document!()
+        |> Floki.find("#oauth-clients-table tr")
+        |> Enum.find(&(Floki.text(&1) =~ client.name))
+        |> Floki.find("td span.bg-primary-50")
+        |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+        |> Enum.sort()
+
+      assert chips == [project.name, "#{project.name}/sandy-sandbox"]
+    end
+
     @tag :skip
     test "list all created oauth clients", %{
       conn: conn,


### PR DESCRIPTION
## Description

This PR fixes how sandboxes are listed in the credentials UI. The "Projects with access" column on the credentials page, the OAuth clients table, and the project chips in the credential and OAuth client forms showed sandboxes by bare name, so a sandbox looked identical to a top-level project. Sandboxes are now labelled with their ancestor chain, e.g. `parent/sandbox`, matching the convention used by `Project.display_name/1` in the breadcrumbs and project picker.

Key changes:

1. `Projects.preload_ancestors/1` now also accepts a list of projects and loads every ancestor chain in a single recursive CTE query, so the credentials page does not issue one query per sandbox.
2. `CredentialIndexComponent` resolves display names once for all distinct projects across credentials and OAuth clients.
3. The shared `projects_picker` component and the credential / OAuth client form components label selected projects, dropdown options, and the revoke-access confirmation with the ancestor chain.
4. Deletion behaviour is unchanged but now covered by tests: purging a project removes its `project_credentials`, so purged sandboxes drop out of the list, while soft-deleted sandboxes remain visible during their grace period.

Closes [CON-147](https://linear.app/openfn/issue/CON-147)

## Validation steps

1. Create a project and a sandbox under it.
2. Create a credential and grant both the parent and the sandbox access.
3. On `/credentials`, check the credential row shows chips `parent-name` and `parent-name/sandbox-name`.
4. Open the credential's edit modal and check the selected project chip for the sandbox shows `parent-name/sandbox-name`.
5. Schedule the sandbox for deletion and confirm it still appears; purge it and confirm it disappears.
6. Repeat step 3 with an OAuth client granted to the parent and sandbox.

## Additional notes for the reviewer

1. The Linear ticket describes the convention as `parent:sandbox` with a colon. The existing `Project.display_name/1`, breadcrumbs, and project picker all join with `/`, so this PR follows the slash for consistency. Switching to a colon would be a one-line change in `Project.display_name/1`.
2. No authorization changes: the lists only render projects the credential or client is already associated with.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QvkXbFNgyfpGMBosr4qP1