### PR TITLE
Batch dataclip retention wiping so it stops timing out on large backlogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to
 - `eligible_for_claim/0` now breaks ties with `id` after `priority` and
   `inserted_at`, so two runs inserted in the same microsecond no longer get
   claimed in a nondeterministic order.
+- Dataclip retention wiping now runs in batches instead of one unbatched update,
+  so projects with a large backlog of eligible dataclips no longer time out the
+  retention job.
 
 ## [2.18.2] - 2026-09-02
 

--- a/bin/bootstrap.d/style.sh
+++ b/bin/bootstrap.d/style.sh
@@ -26,6 +26,14 @@ step() { printf '%s==>%s %s%s%s\n' "$BOLD" "$RESET" "$BOLD" "$*" "$RESET"; }
 # ok: green success line.
 ok() { printf '%s%s%s\n' "$GREEN" "$*" "$RESET"; }
 
+# note: cyan status line, for a script's own narration (as opposed to
+# whatever it shells out to) so the two are easy to tell apart in scrollback.
+note() { printf '%s%s%s\n' "$CYAN" "$*" "$RESET"; }
+
+# hint: cyan suggestion, to stderr. Not a warning — nothing is wrong, this is
+# just "here's a flag/command you might want."
+hint() { printf '%sHint:%s %s\n' "$CYAN" "$RESET" "$*" >&2; }
+
 # warn: yellow advisory, to stderr.
 warn() { printf '%sWarning:%s %s\n' "$YELLOW" "$RESET" "$*" >&2; }
 

--- a/bin/worktree
+++ b/bin/worktree
@@ -198,18 +198,18 @@ resolve_pr_branch() {
   repo_slug="$(sed -E 's#^git@[^:]+:##; s#^[a-z]+://[^/]+/##; s#\.git$##' <<<"$origin_url")"
   [[ -n "$repo_slug" ]] || die "Could not determine the GitHub OWNER/REPO from the origin remote."
 
-  echo "Resolving head branch for PR #$PR_NUMBER..."
+  note "Resolving head branch for PR #$PR_NUMBER..."
   if ! BRANCH="$(gh pr view "$PR_NUMBER" --repo "$repo_slug" \
     --json headRefName --jq .headRefName 2>/dev/null)" || [[ -z "$BRANCH" ]]; then
     die "Could not resolve PR #$PR_NUMBER (is gh authenticated, and does the PR exist?)"
   fi
-  echo "PR #$PR_NUMBER -> $BRANCH"
+  note "PR #$PR_NUMBER -> $BRANCH"
 
   # Fetch the PR head into a local branch of the same name if we don't already
   # have it. pull/<n>/head works for same-repo and fork PRs alike. An existing
   # local branch is reused as-is rather than force-updated.
   if branch_exists "$BRANCH"; then
-    echo "Local branch '$BRANCH' already exists; reusing it (not fetching PR head)."
+    note "Local branch '$BRANCH' already exists; reusing it (not fetching PR head)."
   else
     git -C "$SOURCE_ROOT" fetch origin "pull/$PR_NUMBER/head:$BRANCH"
   fi
@@ -311,7 +311,9 @@ on_exit() {
       echo "    git branch -D \"$BRANCH\"   # only if you also want the branch gone" >&2
     fi
   else
-    echo "Setup failed during $CURRENT_STEP (exit $status) — removing worktree: $TARGET" >&2
+    err "Setup failed during $CURRENT_STEP (exit $status)."
+    echo "Removing worktree: $TARGET" >&2
+    hint "Re-run with --no-clean to keep it in place next time."
     # cwd may be inside the worktree about to be removed.
     cd "$SOURCE_ROOT" 2>/dev/null || cd /
     git -C "$SOURCE_ROOT" worktree remove --force "$TARGET"
@@ -337,7 +339,7 @@ copy_env_files() {
   for env_file in .env .dev.env .dev.override.env; do
     if [[ -f "$SOURCE_ROOT/$env_file" ]]; then
       cp -p "$SOURCE_ROOT/$env_file" "$TARGET/$env_file"
-      echo "Copied $env_file"
+      note "Copied $env_file"
     fi
   done
 }
@@ -347,7 +349,7 @@ copy_env_files() {
 # ours; the EXIT trap can't fire afterwards, which is fine because setup is done.
 exec_run_cmd() {
   cd "$1"
-  echo "Running in $1"
+  note "Running in $1"
   exec "${RUN_CMD[@]}"
 }
 
@@ -386,7 +388,7 @@ main() {
   resolve_main_root
 
   if existing_target="$(find_worktree_for_branch "$BRANCH")"; then
-    echo "Branch '$BRANCH' already has a worktree:"
+    note "Branch '$BRANCH' already has a worktree:"
     echo "    $existing_target"
     [[ ${#RUN_CMD[@]} -eq 0 ]] || exec_run_cmd "$existing_target"
     exit 0

--- a/lib/lightning/invocation/query.ex
+++ b/lib/lightning/invocation/query.ex
@@ -302,6 +302,7 @@ defmodule Lightning.Invocation.Query do
     from(d in query,
       where: d.type in [:http_request, :step_result, :saved_input, :kafka],
       where: is_nil(d.name),
+      where: is_nil(d.wiped_at),
       update: [
         set: [request: nil, body: nil, wiped_at: ^Lightning.current_time()]
       ]

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -1676,14 +1676,55 @@ defmodule Lightning.Projects do
 
   defp wipe_dataclips_for(%Project{dataclip_retention_period: period} = project)
        when is_integer(period) do
-    update_query =
-      from d in Lightning.Invocation.Query.wipe_dataclips(),
+    batch_size = Config.activity_cleanup_chunk_size()
+    # Wiping only sets a column, it doesn't remove the row from the index like
+    # a delete would - so a small per-update batch re-walks a growing prefix
+    # of already-wiped rows on every iteration. Fetch a much larger slice of
+    # ids up front to amortise that walk, then apply the actual updates in
+    # batch_size-sized chunks by primary key.
+    fetch_size = batch_size * 100
+
+    eligible_query =
+      from d in Dataclip,
         where: d.project_id == ^project.id,
-        where: d.inserted_at < ago(^period, "day")
+        where: d.inserted_at < ago(^period, "day"),
+        where: d.type in [:http_request, :step_result, :saved_input, :kafka],
+        where: is_nil(d.name),
+        where: is_nil(d.wiped_at),
+        # Matches dataclips_pending_wipe_idx's sort column, so this is
+        # satisfied by the index scan itself - no extra Sort node, and each
+        # page still stops after fetch_size instead of scanning every
+        # eligible row to find an arbitrary top-N.
+        order_by: [asc: d.inserted_at],
+        select: d.id
 
-    {count, _} = Repo.update_all(update_query, [])
+    Stream.repeatedly(fn ->
+      ids =
+        eligible_query
+        |> limit(^fetch_size)
+        |> Repo.all(timeout: Config.default_ecto_database_timeout() * 10)
 
-    {:ok, count}
+      if ids == [], do: nil, else: ids
+    end)
+    |> Stream.take_while(& &1)
+    |> Enum.reduce(0, fn ids, acc ->
+      wiped =
+        ids
+        |> Enum.chunk_every(batch_size)
+        |> Enum.reduce(0, fn chunk, chunk_acc ->
+          {count, _} =
+            from(d in Dataclip, where: d.id in ^chunk)
+            |> Lightning.Invocation.Query.wipe_dataclips()
+            |> Repo.update_all([],
+              timeout: Config.default_ecto_database_timeout() * 10
+            )
+
+          chunk_acc + count
+        end)
+
+      acc + wiped
+    end)
+    |> then(&{:ok, &1})
   end
 
   defp wipe_dataclips_for(_project) do

--- a/priv/repo/migrations/20260904094625_add_partial_index_for_dataclip_wipe.exs
+++ b/priv/repo/migrations/20260904094625_add_partial_index_for_dataclip_wipe.exs
@@ -1,0 +1,42 @@
+defmodule Lightning.Repo.Migrations.AddPartialIndexForDataclipWipe do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # Retention's per-project wipe query filters on project_id + inserted_at
+    # and excludes already-wiped/named rows. Without this, only the plain
+    # project_id index applies and the rest falls to a row-by-row filter, so
+    # each pass re-walks every already-wiped row for that project. It is
+    # narrower than the plain project_id index because wiped and named rows
+    # drop out, but projects with no dataclip_retention_period never wipe, so
+    # it still carries every un-wiped unnamed dataclip they have.
+    # A failed CREATE INDEX CONCURRENTLY leaves an INVALID index that IF NOT
+    # EXISTS would skip on retry, silently leaving the dead index in place.
+    # Drop any invalid leftover first so a re-run rebuilds cleanly.
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname = 'dataclips_pending_wipe_idx'
+          AND NOT i.indisvalid
+      ) THEN
+        EXECUTE 'DROP INDEX dataclips_pending_wipe_idx';
+      END IF;
+    END $$;
+    """)
+
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS dataclips_pending_wipe_idx
+    ON dataclips (project_id, inserted_at)
+    WHERE wiped_at IS NULL AND name IS NULL
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS dataclips_pending_wipe_idx")
+  end
+end

--- a/test/lightning/projects_test.exs
+++ b/test/lightning/projects_test.exs
@@ -2288,6 +2288,71 @@ defmodule Lightning.ProjectsTest do
       refute is_nil(dataclip.wiped_at)
     end
 
+    test "wipes dataclips past the retention period across multiple batches" do
+      stub(Lightning.MockConfig, :activity_cleanup_chunk_size, fn -> 2 end)
+
+      project =
+        insert(:project,
+          history_retention_period: 14,
+          dataclip_retention_period: 10
+        )
+
+      dataclips =
+        for _ <- 1..5 do
+          insert(:dataclip,
+            project: project,
+            request: %{star: "sadio mane"},
+            type: :step_result,
+            body: %{team: "senegal"},
+            inserted_at: Timex.now() |> Timex.shift(days: -11)
+          )
+        end
+
+      :ok = Projects.perform(%Oban.Job{args: %{"type" => "data_retention"}})
+
+      for dataclip <- dataclips do
+        dataclip = dataclip_with_body_and_request(dataclip)
+
+        refute dataclip.request
+        refute dataclip.body
+        refute is_nil(dataclip.wiped_at)
+      end
+    end
+
+    test "wipes dataclips across multiple fetches of the outer batch loop" do
+      # fetch_size is batch_size * 100, so a chunk size of 1 means the outer
+      # loop must fetch twice to see all 101 rows - proving it re-fetches
+      # instead of stopping after the first page.
+      stub(Lightning.MockConfig, :activity_cleanup_chunk_size, fn -> 1 end)
+
+      project =
+        insert(:project,
+          history_retention_period: 14,
+          dataclip_retention_period: 10
+        )
+
+      dataclips =
+        for _ <- 1..101 do
+          insert(:dataclip,
+            project: project,
+            request: %{star: "sadio mane"},
+            type: :step_result,
+            body: %{team: "senegal"},
+            inserted_at: Timex.now() |> Timex.shift(days: -11)
+          )
+        end
+
+      :ok = Projects.perform(%Oban.Job{args: %{"type" => "data_retention"}})
+
+      for dataclip <- dataclips do
+        dataclip = dataclip_with_body_and_request(dataclip)
+
+        refute dataclip.request
+        refute dataclip.body
+        refute is_nil(dataclip.wiped_at)
+      end
+    end
+
     test "does not wipe dataclips having names" do
       project =
         insert(:project,


### PR DESCRIPTION
## Description

This PR fixes the `data_retention` Oban job timing out when a project has a large backlog of dataclips to wipe.

`wipe_dataclips_for/1` was a single unbatched `UPDATE ... WHERE project_id = ? AND inserted_at < ?`, which reliably hits Ecto's 15s query timeout once the eligible set gets large enough (confirmed on staging via `Postgrex.Error: query_canceled`, after enabling retention on some old QA/test projects that had none set and had accumulated ~1TB of dataclips). Production doesn't have this today, but any customer with tens of thousands of eligible dataclips, or who pulls their retention period back, would hit the same wall.

The fix pages through eligible dataclip ids (ordered by `inserted_at`, matching a new partial index) and applies the wipe in `activity_cleanup_chunk_size`-sized batches, so no single query does more work than a normal batch job.

Closes CON-158

## Validation steps

1. Seed a project with a large number of dataclips (more than a few `activity_cleanup_chunk_size` batches) with `inserted_at` older than the retention period.
2. Set `dataclip_retention_period` on the project and trigger the retention worker (or call `Lightning.Projects.wipe_dataclips_for/1` directly).
3. Confirm it completes without hitting the Ecto query timeout, and that the same rows get wiped as before (see `test/lightning/projects_test.exs` for the new coverage).
4. Run the migration and confirm `dataclips_pending_wipe_idx` is created; re-running it after a killed `CONCURRENTLY` build should self-heal rather than error.

## Additional notes for the reviewer

1. The migration adds a partial index shaped to match the new query (`project_id`, `inserted_at`, filtered on the wipeable types/`name`/`wiped_at` conditions) so the id-fetch stays index-backed instead of falling back to a scan.
2. `fetch_size` (id page size) is deliberately much larger than `batch_size` (update chunk size) - wiping only sets a column rather than deleting the row, so a small per-update batch would re-walk a growing prefix of already-wiped rows on every iteration.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
