### PR TITLE
Global AI Assistant: fixes to applied changes and code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ and this project adheres to
   the reply itself, beside the diffs that did not land, and offers to try
   again. It used to fall back to a raw YAML panel.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
+- A failed apply is now remembered, so reloading no longer turns it back into
+  a success. The reply kept its diff blocks and offered to undo changes that
+  had never landed. A retry that works clears the record.
+  [#5118](https://github.com/OpenFn/lightning/issues/5118)
 - Editing an open step with the global assistant no longer puts a diff in the
   code editor. The change is already applied, so the diff read as a proposal
   to accept or reject when the only control was a close button, and reloading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ and this project adheres to
 
 ### Fixed
 
+- The global assistant no longer offers to paste a reply's code block into
+  whichever job you have open. It applies its own changes and shows them as
+  diffs, so those blocks are data it quoted back or work it has already done.
+  [#5118](https://github.com/OpenFn/lightning/issues/5118)
+
 - Changing a webhook trigger's custom path now marks the workflow as unsaved, so
   the Save button offers to save it. The unsaved-changes check did not look at
   the field, so the edit could be lost by navigating away.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to
 - AI assistant code blocks share the surface the workflow diffs use, so a reply
   and the diff below it no longer read as two different products.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
+- A global assistant reply whose changes could not be applied now says so on
+  the reply itself, beside the diffs that did not land, and offers to try
+  again. It used to fall back to a raw YAML panel.
+  [#5118](https://github.com/OpenFn/lightning/issues/5118)
 
 - Changing a webhook trigger's custom path now marks the workflow as unsaved, so
   the Save button offers to save it. The unsaved-changes check did not look at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to
   whichever job you have open. It applies its own changes and shows them as
   diffs, so those blocks are data it quoted back or work it has already done.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
+- AI assistant code blocks share the surface the workflow diffs use, so a reply
+  and the diff below it no longer read as two different products.
+  [#5118](https://github.com/OpenFn/lightning/issues/5118)
 
 - Changing a webhook trigger's custom path now marks the workflow as unsaved, so
   the Save button offers to save it. The unsaved-changes check did not look at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@ and this project adheres to
   the reply itself, beside the diffs that did not land, and offers to try
   again. It used to fall back to a raw YAML panel.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
+- Editing an open step with the global assistant no longer puts a diff in the
+  code editor. The change is already applied, so the diff read as a proposal
+  to accept or reject when the only control was a close button, and reloading
+  revealed the change had been written all along.
+  [#5118](https://github.com/OpenFn/lightning/issues/5118)
 
 - Changing a webhook trigger's custom path now marks the workflow as unsaved, so
   the Save button offers to save it. The unsaved-changes check did not look at

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1050,12 +1050,10 @@
       @apply mt-4;
     }
 
-    pre {
-      @apply text-slate-200 bg-slate-700 rounded-md p-2 my-2 overflow-x-auto;
-
-      code {
-        @apply text-sm leading-3;
-      }
+    /* Code blocks are styled on the element in MessageList, matching the
+       workflow diff blocks, so the two read as one surface. */
+    pre code {
+      @apply text-xs;
     }
   }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1050,10 +1050,12 @@
       @apply mt-4;
     }
 
-    /* Code blocks are styled on the element in MessageList, matching the
-       workflow diff blocks, so the two read as one surface. */
-    pre code {
-      @apply text-xs;
+    pre {
+      @apply text-slate-200 bg-slate-700 rounded-md p-2 my-2 overflow-x-auto;
+
+      code {
+        @apply text-sm leading-3;
+      }
     }
   }
 

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -679,7 +679,6 @@ export function AIAssistantPanelWrapper({
     launchApply,
     failedApplyMessageIds,
     handlePreviewJobCode,
-    handlePreviewGlobalStep,
     handleApplyJobCode,
   } = useAIWorkflowApplications({
     sessionId,
@@ -721,19 +720,19 @@ export function AIAssistantPanelWrapper({
     streamingApplyActions,
   });
 
-  // Route auto-preview to the right handler: global messages carry a full
-  // workflow YAML (the open step's diff is extracted from it), job-code
-  // messages carry the job body directly.
+  // A global reply is not a proposal. Its changes are applied as they arrive,
+  // so showing the open step's diff in the editor offered an accept-or-reject
+  // choice that had already been made, with only a close button to make it
+  // with. The panel's diff blocks are the record of what changed, and Undo is
+  // how it gets taken back. Job chat still previews: there the code is a
+  // proposal and Apply is what lands it.
   const handleAutoPreview = useCallback(
     (code: string, messageId: string) => {
       const message = messages.find(m => m.id === messageId);
-      if (message?.from_global) {
-        handlePreviewGlobalStep(code, messageId);
-      } else {
-        handlePreviewJobCode(code, messageId);
-      }
+      if (message?.from_global) return;
+      handlePreviewJobCode(code, messageId);
     },
-    [messages, handlePreviewGlobalStep, handlePreviewJobCode]
+    [messages, handlePreviewJobCode]
   );
 
   // Auto-preview job code when AI responds with code

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -163,6 +163,7 @@ export function AIAssistantPanelWrapper({
     retryMessage: retryMessageViaChannel,
     updateContext: updateContextViaChannel,
     reportApplyFailure,
+    reportApplyApplied,
   } = useAISessionCommands();
   const messages = useAIMessages();
   const isLoading = useAIIsLoading();
@@ -699,6 +700,7 @@ export function AIAssistantPanelWrapper({
     onValidationError,
     onCanvasApplied: appliedCanvas.record,
     onApplyFailure: reportApplyFailure,
+    onApplyApplied: reportApplyApplied,
     workflowActions: {
       importWorkflow,
       startApplyingWorkflow,

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -95,6 +95,21 @@ import { MessageList } from './MessageList';
  * - Persists width in localStorage
  * - Syncs open/closed state with URL query param (?chat=true)
  */
+/**
+ * Add pastes into the open job, so it only makes sense when the answer was
+ * written for that job. Global replies are page-independent and apply their own
+ * changes, and a reply carrying a code field has its own Apply.
+ */
+export const showAddButtons = ({
+  page,
+  isGlobal,
+  hasCodeMessage,
+}: {
+  page: string | undefined;
+  isGlobal: boolean;
+  hasCodeMessage: boolean;
+}): boolean => page === 'job_code' && !isGlobal && !hasCodeMessage;
+
 export function AIAssistantPanelWrapper({
   aiAssistantEnabled = false,
 }: {
@@ -876,12 +891,13 @@ export function AIAssistantPanelWrapper({
                     : undefined
                 }
                 previewingMessageId={previewingMessageId}
-                showAddButtons={
-                  aiMode?.page === 'job_code'
-                    ? // For job_code: hide ADD buttons when message has code field
-                      !messages.some(m => m.role === 'assistant' && m.code)
-                    : false
-                }
+                showAddButtons={showAddButtons({
+                  page: aiMode?.page,
+                  isGlobal: isGlobalAssistantActive,
+                  hasCodeMessage: messages.some(
+                    m => m.role === 'assistant' && m.code
+                  ),
+                })}
                 showApplyButton={
                   aiMode?.page === 'workflow_template' ||
                   (aiMode?.page === 'job_code' && messages.some(m => m.code))

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -722,12 +722,11 @@ export function AIAssistantPanelWrapper({
     streamingApplyActions,
   });
 
-  // A global reply is not a proposal. Its changes are applied as they arrive,
-  // so showing the open step's diff in the editor offered an accept-or-reject
-  // choice that had already been made, with only a close button to make it
-  // with. The panel's diff blocks are the record of what changed, and Undo is
-  // how it gets taken back. Job chat still previews: there the code is a
-  // proposal and Apply is what lands it.
+  // A global reply is not a proposal: its changes are applied as they arrive,
+  // so a diff in the editor offered a choice already made, with only a close
+  // button to make it with. The panel's diff blocks are the record, and the
+  // footer's revert takes it back. Job chat still previews, where the code
+  // really is a proposal.
   const handleAutoPreview = useCallback(
     (code: string, messageId: string) => {
       const message = messages.find(m => m.id === messageId);

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -928,11 +928,13 @@ export function AIAssistantPanelWrapper({
         isOpen={isConfirmOpen}
         onClose={cancelUndoChanges}
         onConfirm={confirmUndoChanges}
-        title="Overwrite changes to the workflow?"
-        // Neutral about whose changes they are: a collaborator's edits are
-        // taken by the same whole-document replace.
-        description="The workflow has been edited since the assistant applied these changes. Continuing replaces the whole workflow, discarding those edits."
-        confirmLabel="Continue"
+        title="Undo replaces the whole workflow"
+        // States what undo does rather than claiming edits exist. The check
+        // behind this dialog also fires when it simply cannot tell, after a
+        // reload has lost the record of how the canvas was left, so copy that
+        // asserts the workflow has changed is wrong about half the time.
+        description="It goes back to how it was before this reply, so anything changed since will be lost."
+        confirmLabel="Undo anyway"
         variant="danger"
       />
     </div>

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -3,6 +3,11 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import { useCopyToClipboard } from '#/collaborative-editor/hooks/useCopyToClipboard';
+import {
+  TOKEN_CLASS,
+  tokenizeJs,
+  tokenizeJson,
+} from '../utils/highlightJs';
 import { cn } from '#/utils/cn';
 
 import type {
@@ -29,7 +34,7 @@ import {
 } from './WorkflowDiffBlocks';
 
 const PROSE_CLASSES =
-  'text-sm text-gray-700 leading-relaxed prose prose-sm max-w-none prose-headings:font-medium prose-h1:text-lg prose-h1:text-gray-900 prose-h1:mb-3 prose-h2:text-base prose-h2:text-gray-900 prose-h2:mb-2 prose-h2:mt-5 prose-h3:text-sm prose-h3:text-gray-900 prose-h3:mb-2 prose-h3:font-semibold prose-p:mb-3 prose-p:last:mb-0 prose-p:text-gray-700 prose-ul:list-disc prose-ul:pl-5 prose-ul:mb-3 prose-ul:space-y-1 prose-ol:list-decimal prose-ol:pl-5 prose-ol:mb-3 prose-ol:space-y-1 prose-li:text-gray-700 prose-strong:font-medium prose-strong:text-gray-900 prose-em:italic prose-a:text-primary-600 prose-a:hover:text-primary-700 prose-a:underline prose-a:font-normal prose-code:px-1.5 prose-code:py-0.5 prose-code:bg-gray-100 prose-code:text-gray-800 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal prose-code:before:content-none prose-code:after:content-none prose-pre:rounded-md prose-pre:bg-slate-100 prose-pre:border-2 prose-pre:border-slate-200 prose-pre:text-slate-800 prose-pre:p-4 prose-pre:overflow-x-auto prose-pre:text-xs prose-pre:font-mono prose-pre:mb-4';
+  'text-sm text-gray-700 leading-relaxed prose prose-sm max-w-none prose-headings:font-medium prose-h1:text-lg prose-h1:text-gray-900 prose-h1:mb-3 prose-h2:text-base prose-h2:text-gray-900 prose-h2:mb-2 prose-h2:mt-5 prose-h3:text-sm prose-h3:text-gray-900 prose-h3:mb-2 prose-h3:font-semibold prose-p:mb-3 prose-p:last:mb-0 prose-p:text-gray-700 prose-ul:list-disc prose-ul:pl-5 prose-ul:mb-3 prose-ul:space-y-1 prose-ol:list-decimal prose-ol:pl-5 prose-ol:mb-3 prose-ol:space-y-1 prose-li:text-gray-700 prose-strong:font-medium prose-strong:text-gray-900 prose-em:italic prose-a:text-primary-600 prose-a:hover:text-primary-700 prose-a:underline prose-a:font-normal prose-code:px-1.5 prose-code:py-0.5 prose-code:bg-gray-100 prose-code:text-gray-800 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal prose-code:before:content-none prose-code:after:content-none prose-pre:mb-4';
 
 /**
  * Three-dot bouncing "typing" indicator, shared by the pre-text loading
@@ -58,12 +63,41 @@ const StatusSegmentRow = ({ content }: { content: string }) => (
  * Custom code block component for react-markdown
  * Renders code with COPY/ADD action buttons
  */
+/** Source with the diff blocks' palette, or plain when the language is unread. */
+const highlight = (source: string, language?: string | undefined) => {
+  const tokenizer =
+    language === 'javascript' || language === 'js'
+      ? tokenizeJs
+      : language === 'json'
+        ? tokenizeJson
+        : null;
+
+  // A fence usually opens and closes on its own line, so the content arrives
+  // with a blank row at each end that renders as an empty box.
+  const trimmed = source.replace(/^\n+/, '').replace(/\s+$/, '');
+
+  if (!tokenizer) return trimmed;
+
+  return tokenizer(trimmed).map((tokens, line) => (
+    <div key={line}>
+      {tokens.map((token, n) => (
+        <span key={n} className={TOKEN_CLASS[token.kind]}>
+          {token.text}
+        </span>
+      ))}
+    </div>
+  ));
+};
+
 const CodeBlock = ({
   children,
+  language,
   showAddButtons,
   isWriteDisabled = false,
 }: {
   children: string;
+  /** Fence language, when the reply gave one. Only JavaScript is highlighted. */
+  language?: string | undefined;
   showAddButtons?: boolean;
   /** Whether Add button is disabled due to readonly mode */
   isWriteDisabled?: boolean;
@@ -105,8 +139,13 @@ const CodeBlock = ({
   );
 
   return (
-    <pre className="relative group">
-      <code>{children}</code>
+    <pre className="relative group px-3 py-2 my-2 bg-white text-[#1f2328] border border-[#d1d9e0] rounded-md text-xs font-mono leading-5 [font-variant-ligatures:none] whitespace-pre-wrap break-words">
+      {/* The message body styles inline code as a grey chip, and that variant
+          beats a plain utility here. Block, too: an inline box holding block
+          rows paints its background either side of them. */}
+      <code className="block !bg-transparent !p-0 !rounded-none text-inherit">
+        {highlight(children, language)}
+      </code>
       <div className="code-actions absolute top-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
         <button
           type="button"
@@ -168,6 +207,7 @@ const MarkdownContent = ({
             if (isCodeBlock || (children && String(children).includes('\n'))) {
               return (
                 <CodeBlock
+                  language={codeClassName?.replace('language-', '')}
                   showAddButtons={showAddButtons ?? false}
                   isWriteDisabled={isWriteDisabled}
                 >

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -1170,8 +1170,7 @@ export function MessageList({
                       button is the only way out. */}
                     {!isStreaming(message) &&
                       message.code &&
-                      (!isGlobalReply(message) ||
-                        failedApplyMessageIds?.has(message.id)) && (
+                      !isGlobalReply(message) && (
                         <div className="rounded-lg overflow-hidden border border-gray-200 bg-white">
                           <div
                             className={cn(
@@ -1262,6 +1261,42 @@ export function MessageList({
                         }}
                       />
                     )}
+
+                    {/* The diff blocks read as a record of what changed, so a
+                        reply whose apply was rejected has to say so where they
+                        are. The retry is the same import, not a YAML dump: the
+                        blocks are the global assistant's whole representation
+                        of the change and the panel was removed for that. */}
+                    {isGlobalReply(message) &&
+                      failedApplyMessageIds?.has(message.id) && (
+                        <div
+                          className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200"
+                          data-testid="ai-apply-failed"
+                        >
+                          <span className="hero-exclamation-circle h-4 w-4 text-red-600 flex-shrink-0" />
+                          <span className="text-sm text-red-700 flex-1">
+                            These changes were not applied to the canvas.
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              onApplyWorkflow?.(message.code!, message.id);
+                            }}
+                            disabled={isWriteDisabled || !!applyingMessageId}
+                            className={cn(
+                              'inline-flex items-center gap-1.5 px-3 py-1.5',
+                              'text-xs font-medium rounded-md',
+                              'bg-red-100 text-red-700 hover:bg-red-200',
+                              'transition-colors duration-150',
+                              'disabled:opacity-50 disabled:cursor-not-allowed',
+                              'focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1'
+                            )}
+                          >
+                            <span className="hero-arrow-path h-3.5 w-3.5" />
+                            Try again
+                          </button>
+                        </div>
+                      )}
 
                     {!isStreaming(message) &&
                       message.status === 'error' &&

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -96,7 +96,7 @@ const CodeBlock = ({
   isWriteDisabled = false,
 }: {
   children: string;
-  /** Fence language, when the reply gave one. Only JavaScript is highlighted. */
+  /** Fence language, when the reply gave one. */
   language?: string | undefined;
   showAddButtons?: boolean;
   /** Whether Add button is disabled due to readonly mode */

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -3,11 +3,7 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import { useCopyToClipboard } from '#/collaborative-editor/hooks/useCopyToClipboard';
-import {
-  TOKEN_CLASS,
-  tokenizeJs,
-  tokenizeJson,
-} from '../utils/highlightJs';
+import { TOKEN_CLASS, tokenizeJs, tokenizeJson } from '../utils/highlightJs';
 import { cn } from '#/utils/cn';
 
 import type {
@@ -79,7 +75,10 @@ const highlight = (source: string, language?: string | undefined) => {
   if (!tokenizer) return trimmed;
 
   return tokenizer(trimmed).map((tokens, line) => (
+    // A blank line has no tokens, and an empty div has no line box, so the
+    // row would collapse and the code would lose its shape.
     <div key={line}>
+      {tokens.length === 0 && '\u00a0'}
       {tokens.map((token, n) => (
         <span key={n} className={TOKEN_CLASS[token.kind]}>
           {token.text}
@@ -1270,7 +1269,7 @@ export function MessageList({
                             onClick={() => {
                               onApplyWorkflow?.(message.code!, message.id);
                             }}
-                            disabled={isWriteDisabled || !!applyingMessageId}
+                            disabled={isWriteDisabled || !onApplyWorkflow}
                             className={cn(
                               'inline-flex items-center gap-1.5 px-3 py-1.5',
                               'text-xs font-medium rounded-md',

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -470,7 +470,13 @@ const WorkflowReplyTimeline = ({
 };
 
 /** Restores the workflow to before a reply's changes, or back to after them */
-const UndoChangesButton = ({
+/**
+ * Takes back everything a reply did, not the block it happens to sit near.
+ *
+ * Lives in the reply's footer beside Copy: it belongs to the whole reply, and
+ * against the diff blocks it read as the last one's control.
+ */
+const RevertReplyButton = ({
   undone,
   onClick,
 }: {
@@ -481,15 +487,15 @@ const UndoChangesButton = ({
     type="button"
     data-testid="undo-changes-button"
     onClick={onClick}
-    className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 py-1 text-xs font-medium text-gray-700 inset-ring inset-ring-gray-300 hover:inset-ring-gray-400"
+    className="flex items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors duration-200"
   >
     <span
       className={cn(
-        'h-3.5 w-3.5',
+        'h-3 w-3',
         undone ? 'hero-arrow-uturn-right' : 'hero-arrow-uturn-left'
       )}
     />
-    {undone ? 'Redo these changes' : 'Undo these changes'}
+    <span>{undone ? 'Restore this reply' : 'Revert this reply'}</span>
   </button>
 );
 
@@ -1244,24 +1250,6 @@ export function MessageList({
                         </div>
                       )}
 
-                    {canUndoChanges(message) && (
-                      <UndoChangesButton
-                        undone={undoneMessageId === message.id}
-                        onClick={() => {
-                          const redoing = undoneMessageId === message.id;
-                          onUndoChanges?.(
-                            message.id,
-                            redoing
-                              ? message.code!
-                              : beforeYamlByMessageId.get(message.id)!,
-                            // Redo restores the reply's own YAML, which the
-                            // model wrote; undo restores our own serializer's.
-                            { fromModel: redoing }
-                          );
-                        }}
-                      />
-                    )}
-
                     {/* The diff blocks read as a record of what changed, so a
                         reply whose apply was rejected has to say so where they
                         are. The retry is the same import, not a YAML dump: the
@@ -1382,6 +1370,27 @@ export function MessageList({
                           {copiedMessageId === message.id ? 'Copied' : 'Copy'}
                         </span>
                       </button>
+                      {canUndoChanges(message) && (
+                        <>
+                          <span>•</span>
+                          <RevertReplyButton
+                            undone={undoneMessageId === message.id}
+                            onClick={() => {
+                              const redoing = undoneMessageId === message.id;
+                              onUndoChanges?.(
+                                message.id,
+                                redoing
+                                  ? message.code!
+                                  : beforeYamlByMessageId.get(message.id)!,
+                                // Redo restores the reply's own YAML, which
+                                // the model wrote; undo restores our own
+                                // serializer's.
+                                { fromModel: redoing }
+                              );
+                            }}
+                          />
+                        </>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/assets/js/collaborative-editor/components/WorkflowDiffBlocks.tsx
+++ b/assets/js/collaborative-editor/components/WorkflowDiffBlocks.tsx
@@ -399,7 +399,7 @@ export const StructureBlock = ({ rows }: { rows: StructuralChange[] }) => (
     defaultExpanded
     testId="structure-block"
   >
-    <div className="bg-slate-100 text-slate-800 py-2 overflow-x-auto text-xs font-mono leading-5">
+    <div className="bg-white text-[#1f2328] py-2 overflow-x-auto text-xs font-mono leading-5 [font-variant-ligatures:none]">
       {rows.map((row, index) => {
         const marker = structureMarker[row.change];
         return (

--- a/assets/js/collaborative-editor/hooks/useAIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/hooks/useAIChannelRegistry.ts
@@ -174,6 +174,11 @@ export const useAISessionCommands = () => {
     registry.reportApplyFailure(topic, details);
   };
 
+  const reportApplyApplied = (messageId: string) => {
+    if (!registry || !topic) return;
+    registry.reportApplyApplied(topic, messageId);
+  };
+
   const loadSessions = (offset = 0, limit = 20) => {
     if (!registry || !topic) {
       console.warn('Cannot load sessions: registry or topic not available');
@@ -202,6 +207,7 @@ export const useAISessionCommands = () => {
     sendMessage,
     retryMessage,
     reportApplyFailure,
+    reportApplyApplied,
     loadSessions,
     updateContext,
     isConnected,

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -61,6 +61,7 @@ export function useAIWorkflowApplications({
   onValidationError,
   onCanvasApplied,
   onApplyFailure,
+  onApplyApplied,
   workflowActions,
   monacoRef,
   jobs,
@@ -106,6 +107,8 @@ export function useAIWorkflowApplications({
    * Report that a reply's workflow never reached the canvas. Best effort and
    * never surfaced to the user: they are already being told it failed.
    */
+  /** Clears a recorded failure once the same changes land. */
+  onApplyApplied?: (messageId: string) => void;
   onApplyFailure?: (details: {
     messageId: string;
     stage: 'parse' | 'validate_ids' | 'import' | 'save';
@@ -416,6 +419,27 @@ export function useAIWorkflowApplications({
     Set<string>
   >(() => new Set());
 
+  // Messages whose recorded failure has already been read. A retry that works
+  // removes the id, and the flag on the loaded message stays true until the
+  // server confirms, so without this the notice would come straight back.
+  const seededFailuresRef = useRef<Set<string>>(new Set());
+
+
+
+  useEffect(() => {
+    const unseen = (currentSession?.messages ?? []).filter(
+      message => message.apply_failed && !seededFailuresRef.current.has(message.id)
+    );
+    if (unseen.length === 0) return;
+
+    for (const message of unseen) seededFailuresRef.current.add(message.id);
+    setFailedApplyMessageIds(previous => {
+      const next = new Set(previous);
+      for (const message of unseen) next.add(message.id);
+      return next;
+    });
+  }, [currentSession?.messages]);
+
   const launchApply = useCallback(
     (messageId: string, code: string) => {
       if (inFlightApplyRef.current.has(messageId)) return;
@@ -433,6 +457,10 @@ export function useAIWorkflowApplications({
           setFailedApplyMessageIds(previous => {
             const failed = outcome === 'failed';
             if (failed === previous.has(messageId)) return previous;
+            // Only when it was recorded as failed: an ordinary first apply
+            // has nothing to clear and the server should not be told about
+            // every successful import.
+            if (!failed) onApplyApplied?.(messageId);
             const next = new Set(previous);
             if (failed) next.add(messageId);
             else next.delete(messageId);
@@ -443,7 +471,7 @@ export function useAIWorkflowApplications({
         }
       })();
     },
-    [handleApplyWorkflow, appliedMessageIdsRef]
+    [handleApplyWorkflow, appliedMessageIdsRef, onApplyApplied]
   );
 
   /**

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -522,81 +522,6 @@ export function useAIWorkflowApplications({
    * Shows a diff only when the open step's body actually changed; clears any
    * stale diff otherwise.
    */
-  const handlePreviewGlobalStep = useCallback(
-    (yaml: string, messageId: string) => {
-      if (!aiMode || aiMode.page !== 'job_code') return; // only when a step is open
-      const jobId = (aiMode.context as JobCodeContext).job_id;
-      if (!jobId) return;
-
-      // Same dedup guards as handlePreviewJobCode
-      if (previewingMessageId === messageId) return;
-      if (previewingMessageId === STREAMING_MESSAGE_ID) {
-        setPreviewingMessageId(messageId);
-        return;
-      }
-
-      const currentJob = jobs.find(j => j.id === jobId);
-      const currentBody = currentJob?.body ?? '';
-
-      let newBody: string | undefined;
-      try {
-        const spec = parseWorkflowYAML(yaml);
-        // ids from the YAML are preserved, so we match the open step by id
-        const state = convertWorkflowSpecToState(spec);
-        newBody = state.jobs.find(j => j.id === jobId)?.body;
-      } catch (error) {
-        console.error(
-          '[AI Assistant] Failed to parse global workflow YAML:',
-          error
-        );
-        notifications.alert({
-          title: 'Could not preview step',
-          description:
-            error instanceof Error
-              ? error.message
-              : 'The AI server returned invalid workflow YAML.',
-        });
-        return;
-      }
-
-      if (newBody === undefined) {
-        // Open step's id wasn't in the YAML, so the server likely didn't preserve it
-        console.warn(
-          '[AI Assistant] Open step not found in global workflow YAML',
-          { jobId }
-        );
-        notifications.warning({
-          title: 'Could not preview this step',
-          description: `Step "${
-            currentJob?.name ?? jobId
-          }" was not found in the AI response (id: ${jobId}). Its ID may not have been preserved by the server.`,
-        });
-        if (previewingMessageId) monacoRef?.current?.clearDiff();
-        return;
-      }
-
-      if (newBody === currentBody) {
-        // open step genuinely unchanged -> ensure no stale diff is shown
-        if (previewingMessageId) monacoRef?.current?.clearDiff();
-        return;
-      }
-
-      const monaco = monacoRef?.current;
-      if (previewingMessageId && monaco) monaco.clearDiff();
-      if (monaco) {
-        monaco.showDiff(currentBody, newBody);
-        setPreviewingMessageId(messageId);
-      }
-    },
-    [aiMode, jobs, previewingMessageId, monacoRef, setPreviewingMessageId]
-  );
-
-  /**
-   * Apply job code to Y.Doc
-   *
-   * Updates the job body in Y.Doc, which syncs to all collaborators.
-   * Clears any active diff preview and shows success notification.
-   */
   const handleApplyJobCode = useCallback(
     async (code: string, messageId: string) => {
       if (!aiMode || aiMode.page !== 'job_code') {
@@ -809,7 +734,6 @@ export function useAIWorkflowApplications({
     launchApply,
     failedApplyMessageIds,
     handlePreviewJobCode,
-    handlePreviewGlobalStep,
     handleApplyJobCode,
   };
 }

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowApplications.ts
@@ -424,20 +424,22 @@ export function useAIWorkflowApplications({
   // server confirms, so without this the notice would come straight back.
   const seededFailuresRef = useRef<Set<string>>(new Set());
 
-
+  // Mirrors the state so an outcome can be compared without reading it inside
+  // an updater.
+  const failedApplyRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const unseen = (currentSession?.messages ?? []).filter(
-      message => message.apply_failed && !seededFailuresRef.current.has(message.id)
+      message =>
+        message.apply_failed && !seededFailuresRef.current.has(message.id)
     );
     if (unseen.length === 0) return;
 
-    for (const message of unseen) seededFailuresRef.current.add(message.id);
-    setFailedApplyMessageIds(previous => {
-      const next = new Set(previous);
-      for (const message of unseen) next.add(message.id);
-      return next;
-    });
+    for (const message of unseen) {
+      seededFailuresRef.current.add(message.id);
+      failedApplyRef.current.add(message.id);
+    }
+    setFailedApplyMessageIds(new Set(failedApplyRef.current));
   }, [currentSession?.messages]);
 
   const launchApply = useCallback(
@@ -454,18 +456,27 @@ export function useAIWorkflowApplications({
           }
           // A failed import is never retried automatically, so the reply is
           // a dead end unless the user is given the manual button back.
-          setFailedApplyMessageIds(previous => {
-            const failed = outcome === 'failed';
-            if (failed === previous.has(messageId)) return previous;
-            // Only when it was recorded as failed: an ordinary first apply
-            // has nothing to clear and the server should not be told about
+          const failed = outcome === 'failed';
+          const wasFailed = failedApplyRef.current.has(messageId);
+
+          if (failed !== wasFailed) {
+            // Outside the state updater: React may run an updater more than
+            // once, and each run would push again.
+            //
+            // Only when it was recorded as failed. An ordinary first apply
+            // has nothing to clear, and the server should not hear about
             // every successful import.
             if (!failed) onApplyApplied?.(messageId);
-            const next = new Set(previous);
-            if (failed) next.add(messageId);
-            else next.delete(messageId);
-            return next;
-          });
+
+            if (failed) failedApplyRef.current.add(messageId);
+            else failedApplyRef.current.delete(messageId);
+            // Read, either way: the flag on a loaded message stays true until
+            // the server confirms the clear, and the seeding effect would put
+            // the notice straight back.
+            seededFailuresRef.current.add(messageId);
+
+            setFailedApplyMessageIds(new Set(failedApplyRef.current));
+          }
         } finally {
           inFlightApplyRef.current.delete(messageId);
         }
@@ -543,12 +554,9 @@ export function useAIWorkflowApplications({
   );
 
   /**
-   * Preview the open job's diff from a global full-workflow YAML message
+   * Write an assistant's job code into the open job.
    *
-   * Mirrors handlePreviewJobCode, but extracts the open job's body from the
-   * workflow YAML (global messages carry the whole workflow in `code`).
-   * Shows a diff only when the open step's body actually changed; clears any
-   * stale diff otherwise.
+   * Job chat only: the code is a proposal there, and this is what lands it.
    */
   const handleApplyJobCode = useCallback(
     async (code: string, messageId: string) => {

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -552,6 +552,23 @@ export class AIChannelRegistry {
       });
   }
 
+  /**
+   * Clears a recorded apply failure once the same changes land.
+   *
+   * Best effort, like the failure report: a clear that does not arrive leaves
+   * a stale notice on the next load, which is the safer way to be wrong.
+   */
+  reportApplyApplied(topic: string, messageId: string): void {
+    const entry = this.channels.get(topic);
+    if (!entry) return;
+
+    entry.channel
+      .push('apply_applied', { message_id: messageId })
+      .receive('error', (response: unknown) => {
+        logger.warn('Could not clear a recorded apply failure', response);
+      });
+  }
+
   retryMessage(topic: string, messageId: string): void {
     const entry = this.channels.get(topic);
 

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -96,6 +96,8 @@ export interface Message {
    * messages carry a full workflow YAML in `code` and never a `job_id`.
    */
   from_global?: boolean;
+  /** Recorded server-side when this reply's changes never reached the canvas. */
+  apply_failed?: boolean;
   /**
    * Interleaved text/status timeline for global assistant replies.
    * `null`/absent for legacy and non-global messages (render flat `content`).

--- a/assets/js/collaborative-editor/utils/highlightJs.ts
+++ b/assets/js/collaborative-editor/utils/highlightJs.ts
@@ -19,6 +19,7 @@
 import './prismManual';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-json';
 
 export type TokenKind =
   | 'comment'
@@ -27,6 +28,7 @@ export type TokenKind =
   | 'keyword'
   | 'function'
   | 'operator'
+  | 'property'
   | 'plain';
 
 export interface Token {
@@ -60,6 +62,7 @@ const KIND_BY_PRISM_TYPE: Record<string, TokenKind> = {
   'maybe-class-name': 'function',
   operator: 'operator',
   punctuation: 'operator',
+  property: 'property',
   arrow: 'operator',
 };
 
@@ -104,9 +107,9 @@ const flatten = (
  * it covers, each part keeping the same kind, so the result renders directly
  * row by row.
  */
-export const tokenizeJs = (source: string): Token[][] => {
+const tokenize = (source: string, grammar: string): Token[][] => {
   const flat: Token[] = [];
-  flatten(Prism.tokenize(source, Prism.languages['javascript']), 'plain', flat);
+  flatten(Prism.tokenize(source, Prism.languages[grammar]!), 'plain', flat);
 
   const lines: Token[][] = [];
   let current: Token[] = [];
@@ -126,6 +129,12 @@ export const tokenizeJs = (source: string): Token[][] => {
   return lines;
 };
 
+export const tokenizeJs = (source: string): Token[][] =>
+  tokenize(source, 'javascript');
+
+export const tokenizeJson = (source: string): Token[][] =>
+  tokenize(source, 'json');
+
 /**
  * Token colours, taken from GitHub's Primer light theme rather than
  * approximated with the nearest Tailwind shade.
@@ -141,5 +150,7 @@ export const TOKEN_CLASS: Record<TokenKind, string> = {
   keyword: 'text-[#cf222e]',
   function: 'text-[#8250df]',
   operator: 'text-[#1f2328]',
+  // JSON keys, which Primer tints the same blue it uses for numbers.
+  property: 'text-[#0550ae]',
   plain: 'text-[#1f2328]',
 };

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -404,6 +404,51 @@ describe('MessageList', () => {
       expect(screen.getByText('Add')).toBeInTheDocument();
     });
 
+    it('highlights a javascript block with the same palette as the diffs', () => {
+      const messages = [
+        createMockAIMessage({
+          role: 'assistant',
+          content: '```javascript\nconst x = "hi";\n```',
+        }),
+      ];
+
+      const { container } = render(<MessageList messages={messages} />);
+
+      // Primer's keyword and string colours, the ones the diff blocks use, so
+      // a reply and the diff below it read as one surface.
+      expect(container.querySelector('.text-\\[\\#cf222e\\]')).not.toBeNull();
+      expect(container.querySelector('.text-\\[\\#0a3069\\]')).not.toBeNull();
+    });
+
+    it('highlights a json block, which is what the assistant actually sends', () => {
+      const messages = [
+        createMockAIMessage({
+          role: 'assistant',
+          content: '```json\n{ "apiKey": "string" }\n```',
+        }),
+      ];
+
+      const { container } = render(<MessageList messages={messages} />);
+
+      // Keys take Primer's blue, values its string colour.
+      expect(container.querySelector('.text-\\[\\#0550ae\\]')).not.toBeNull();
+      expect(container.querySelector('.text-\\[\\#0a3069\\]')).not.toBeNull();
+    });
+
+    it('leaves a block it cannot read as plain text', () => {
+      const messages = [
+        createMockAIMessage({
+          role: 'assistant',
+          content: '```yaml\napiKey: "string"\n```',
+        }),
+      ];
+
+      const { container } = render(<MessageList messages={messages} />);
+
+      expect(screen.getByText(/apiKey/)).toBeInTheDocument();
+      expect(container.querySelector('.text-\\[\\#cf222e\\]')).toBeNull();
+    });
+
     it('should not show Add button when showAddButtons is false', () => {
       const messages = [
         createMockAIMessage({

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -1395,7 +1395,7 @@ describe('MessageList', () => {
       ).toBeLessThan(screen.getAllByTestId('diff-block').length);
     });
 
-    it('gives a global reply its Apply button back when the apply failed', () => {
+    it('says so on the reply when the apply failed, and offers a retry', () => {
       const messages = [
         createMockAIMessage({
           id: 'msg-user',
@@ -1412,23 +1412,41 @@ describe('MessageList', () => {
         }),
       ];
 
-      // Global replies auto-apply and normally show no panel, but a failed
-      // import is never retried, so without this the reply is a dead end.
+      const onApplyWorkflow = vi.fn();
+
       const { rerender } = render(
-        <MessageList messages={messages} showApplyButton />
+        <MessageList
+          messages={messages}
+          showApplyButton
+          onApplyWorkflow={onApplyWorkflow}
+        />
       );
-      expect(
-        screen.queryByTestId('apply-workflow-button')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('ai-apply-failed')).not.toBeInTheDocument();
 
       rerender(
         <MessageList
           messages={messages}
           showApplyButton
+          onApplyWorkflow={onApplyWorkflow}
           failedApplyMessageIds={new Set(['msg-global'])}
         />
       );
-      expect(screen.getByTestId('apply-workflow-button')).toBeInTheDocument();
+
+      // The diff blocks read as a record of what changed, so a reply whose
+      // apply was rejected has to say so where they are.
+      expect(screen.getByTestId('ai-apply-failed')).toBeInTheDocument();
+      // And the recovery is the same import, not the raw YAML panel the
+      // global assistant deliberately does without.
+      expect(
+        screen.queryByTestId('apply-workflow-button')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('generated-code')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      expect(onApplyWorkflow).toHaveBeenCalledWith(
+        messages[1]!.code,
+        'msg-global'
+      );
     });
 
     it('renders no diff blocks for a global reply that errored', () => {

--- a/assets/test/collaborative-editor/components/MessageList.undoChanges.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.undoChanges.test.tsx
@@ -90,7 +90,7 @@ describe('MessageList - undo applied changes', () => {
     );
 
     const button = screen.getByTestId('undo-changes-button');
-    expect(button).toHaveTextContent('Redo these changes');
+    expect(button).toHaveTextContent('Restore this reply');
 
     await userEvent.click(button);
     // Redo restores the reply's own YAML, which the model wrote

--- a/assets/test/collaborative-editor/components/showAddButtons.test.ts
+++ b/assets/test/collaborative-editor/components/showAddButtons.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { showAddButtons } from '#/collaborative-editor/components/AIAssistantPanelWrapper';
+
+describe('showAddButtons', () => {
+  const base = { page: 'job_code', isGlobal: false, hasCodeMessage: false };
+
+  it('offers Add for a job chat reply on the job page', () => {
+    expect(showAddButtons(base)).toBe(true);
+  });
+
+  it('does not offer Add for a global reply, even on the job page', () => {
+    // Add pastes into the open job. A global reply applies its own changes and
+    // shows them as diffs, so its code blocks are data it quoted back or work
+    // it has already done, and the open job is not what they are about.
+    expect(showAddButtons({ ...base, isGlobal: true })).toBe(false);
+  });
+
+  it('does not offer Add away from the job page', () => {
+    expect(showAddButtons({ ...base, page: 'workflow_template' })).toBe(false);
+    expect(showAddButtons({ ...base, page: undefined })).toBe(false);
+  });
+
+  it('does not offer Add when the reply carries its own code to apply', () => {
+    expect(showAddButtons({ ...base, hasCodeMessage: true })).toBe(false);
+  });
+});

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.globalStep.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.globalStep.test.ts
@@ -167,6 +167,25 @@ describe('useAIWorkflowApplications - global messages', () => {
     mockYamlJobBody('new body');
   });
 
+  describe('a failure the server recorded', () => {
+    it('is read back on load, so a reload still knows it never landed', () => {
+      const message = createGlobalMessage();
+      const { result } = renderApplications({
+        currentSession: { messages: [{ ...message, apply_failed: true }] },
+      });
+
+      expect(result.current.failedApplyMessageIds.has(message.id)).toBe(true);
+    });
+
+    it('is not read back for a reply that applied cleanly', () => {
+      const { result } = renderApplications({
+        currentSession: { messages: [createGlobalMessage()] },
+      });
+
+      expect(result.current.failedApplyMessageIds.size).toBe(0);
+    });
+  });
+
   describe('handleApplyWorkflow with global messages', () => {
     it('applies a global message while a job is open (job_code mode)', async () => {
       const globalMessage = createGlobalMessage();

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.globalStep.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowApplications.globalStep.test.ts
@@ -3,8 +3,11 @@
  *
  * Tests behavior specific to global AI assistant messages (full workflow
  * YAML, `from_global: true`, no job_id):
- * - handlePreviewGlobalStep: per-step diff extracted from the workflow YAML
  * - handleApplyWorkflow: relaxed mode guard for global messages only
+ *
+ * The editor is no longer given a per-step diff for a global reply: those
+ * changes are applied as they arrive, so the diff offered a choice that had
+ * already been made.
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
@@ -162,91 +165,6 @@ describe('useAIWorkflowApplications - global messages', () => {
       return { name: 'Test Workflow', jobs: {}, triggers: {}, edges: {} };
     });
     mockYamlJobBody('new body');
-  });
-
-  describe('handlePreviewGlobalStep', () => {
-    it('shows a diff when the open step body changed in the YAML', () => {
-      const { result } = renderApplications();
-
-      result.current.handlePreviewGlobalStep('name: Test Workflow', 'msg-1');
-
-      expect(mockShowDiff).toHaveBeenCalledWith('old body', 'new body');
-      expect(mockSetPreviewingMessageId).toHaveBeenCalledWith('msg-1');
-    });
-
-    it('shows no diff and clears a stale one when the open step is unchanged', () => {
-      mockYamlJobBody('old body'); // same as current job body
-
-      const { result } = renderApplications({
-        previewingMessageId: 'previous-msg',
-      });
-
-      result.current.handlePreviewGlobalStep('name: Test Workflow', 'msg-1');
-
-      expect(mockClearDiff).toHaveBeenCalled();
-      expect(mockShowDiff).not.toHaveBeenCalled();
-      expect(mockSetPreviewingMessageId).not.toHaveBeenCalled();
-    });
-
-    it('warns when the open step is missing from the YAML (id not preserved)', () => {
-      vi.mocked(convertWorkflowSpecToState).mockReturnValue({
-        id: 'wf-1',
-        name: 'Test Workflow',
-        jobs: [],
-        triggers: [],
-        edges: [],
-        positions: null,
-      });
-
-      const { result } = renderApplications();
-
-      result.current.handlePreviewGlobalStep('name: Test Workflow', 'msg-1');
-
-      expect(mockShowDiff).not.toHaveBeenCalled();
-      expect(mockSetPreviewingMessageId).not.toHaveBeenCalled();
-      expect(notifications.warning).toHaveBeenCalled();
-    });
-
-    it('alerts for invalid YAML', () => {
-      const { result } = renderApplications();
-
-      result.current.handlePreviewGlobalStep('invalid yaml', 'msg-1');
-
-      expect(mockShowDiff).not.toHaveBeenCalled();
-      expect(mockClearDiff).not.toHaveBeenCalled();
-      expect(mockSetPreviewingMessageId).not.toHaveBeenCalled();
-      expect(notifications.alert).toHaveBeenCalled();
-    });
-
-    it('does nothing when no job is open (workflow_template mode)', () => {
-      const { result } = renderApplications({
-        aiMode: createMockAIMode('workflow_template'),
-        page: 'workflow_template',
-      });
-
-      result.current.handlePreviewGlobalStep('name: Test Workflow', 'msg-1');
-
-      expect(parseWorkflowYAML).not.toHaveBeenCalled();
-      expect(mockShowDiff).not.toHaveBeenCalled();
-    });
-
-    it('deduplicates previews like handlePreviewJobCode', () => {
-      // Already previewing this message -> no-op
-      const { result } = renderApplications({
-        previewingMessageId: 'msg-1',
-      });
-      result.current.handlePreviewGlobalStep('name: Test Workflow', 'msg-1');
-      expect(mockShowDiff).not.toHaveBeenCalled();
-      expect(mockSetPreviewingMessageId).not.toHaveBeenCalled();
-
-      // Streaming preview already shown -> only swap the message id
-      const { result: streaming } = renderApplications({
-        previewingMessageId: '__streaming__',
-      });
-      streaming.current.handlePreviewGlobalStep('name: Test Workflow', 'msg-1');
-      expect(mockShowDiff).not.toHaveBeenCalled();
-      expect(mockSetPreviewingMessageId).toHaveBeenCalledWith('msg-1');
-    });
   });
 
   describe('handleApplyWorkflow with global messages', () => {

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -764,6 +764,40 @@ defmodule Lightning.AiAssistant do
   end
 
   @doc """
+  Records whether a reply's changes reached the canvas.
+
+  The apply happens in the browser, so nothing else knows it failed. Without
+  this the reply reads as a success on the next page load: its diff blocks
+  stand as a record of changes that never landed, and it offers to undo them.
+
+  Clearing on a later success is half the point, so a retry that works leaves
+  nothing behind.
+  """
+  @spec set_apply_failed(Ecto.UUID.t(), boolean()) ::
+          {:ok, ChatMessage.t()} | {:error, :not_found | Changeset.t()}
+  def set_apply_failed(message_id, failed?) do
+    case Repo.get(ChatMessage, message_id) do
+      nil ->
+        {:error, :not_found}
+
+      message ->
+        meta = message.meta || %{}
+
+        meta =
+          if failed?,
+            do: Map.put(meta, "apply_failed", true),
+            else: Map.delete(meta, "apply_failed")
+
+        # change/2 rather than the full changeset: this only touches an
+        # internal flag, and the message's own validations need associations
+        # this path has no reason to load.
+        message
+        |> Changeset.change(meta: meta)
+        |> Repo.update()
+    end
+  end
+
+  @doc """
   Queries the AI service for job-specific code assistance with streaming.
 
   Sends a user query to the Apollo AI service along with job context

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -773,27 +773,31 @@ defmodule Lightning.AiAssistant do
   Clearing on a later success is half the point, so a retry that works leaves
   nothing behind.
   """
-  @spec set_apply_failed(Ecto.UUID.t(), boolean()) ::
+  @spec set_apply_failed(Ecto.UUID.t(), Ecto.UUID.t(), boolean()) ::
           {:ok, ChatMessage.t()} | {:error, :not_found | Changeset.t()}
-  def set_apply_failed(message_id, failed?) do
-    case Repo.get(ChatMessage, message_id) do
-      nil ->
-        {:error, :not_found}
+  def set_apply_failed(session_id, message_id, failed?) do
+    # Cast before the lookup: the id comes from the browser, and the streaming
+    # apply reports failures against a pseudo-id that is not a uuid at all.
+    # Scoped to the session for the same reason retry_message is: a read-level
+    # frame must not reach a message in someone else's project.
+    with {:ok, uuid} <- Ecto.UUID.cast(message_id),
+         %ChatMessage{chat_session_id: ^session_id} = message <-
+           Repo.get(ChatMessage, uuid) do
+      meta = message.meta || %{}
 
-      message ->
-        meta = message.meta || %{}
+      meta =
+        if failed?,
+          do: Map.put(meta, "apply_failed", true),
+          else: Map.delete(meta, "apply_failed")
 
-        meta =
-          if failed?,
-            do: Map.put(meta, "apply_failed", true),
-            else: Map.delete(meta, "apply_failed")
-
-        # change/2 rather than the full changeset: this only touches an
-        # internal flag, and the message's own validations need associations
-        # this path has no reason to load.
-        message
-        |> Changeset.change(meta: meta)
-        |> Repo.update()
+      # change/2 rather than the full changeset: this only touches an
+      # internal flag, and the message's own validations need associations
+      # this path has no reason to load.
+      message
+      |> Changeset.change(meta: meta)
+      |> Repo.update()
+    else
+      _ -> {:error, :not_found}
     end
   end
 

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -184,6 +184,19 @@ defmodule LightningWeb.AiAssistantChannel do
         }
       )
 
+      # Recorded on the message as well as reported: the apply happens in the
+      # browser, so a reload has no other way to know the changes never landed.
+      mark_apply(params["message_id"], true)
+
+      {:reply, :ok, socket}
+    end)
+  end
+
+  @impl true
+  def handle_in("apply_applied", params, socket) do
+    with_authorized_frame(socket, :read, fn _session ->
+      mark_apply(params["message_id"], false)
+
       {:reply, :ok, socket}
     end)
   end
@@ -1033,6 +1046,12 @@ defmodule LightningWeb.AiAssistantChannel do
     }
   end
 
+  defp mark_apply(message_id, failed?) when is_binary(message_id) do
+    AiAssistant.set_apply_failed(message_id, failed?)
+  end
+
+  defp mark_apply(_message_id, _failed?), do: :ok
+
   defp format_messages(messages) do
     Enum.map(messages, &format_message/1)
   end
@@ -1061,7 +1080,8 @@ defmodule LightningWeb.AiAssistantChannel do
       user_id: message.user_id,
       user: format_user(message.user),
       job_id: job_id,
-      from_global: from_global
+      from_global: from_global,
+      apply_failed: match?(%{"apply_failed" => true}, message.meta)
     }
   end
 

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -186,7 +186,7 @@ defmodule LightningWeb.AiAssistantChannel do
 
       # Recorded on the message as well as reported: the apply happens in the
       # browser, so a reload has no other way to know the changes never landed.
-      mark_apply(params["message_id"], true)
+      mark_apply(socket, params["message_id"], true)
 
       {:reply, :ok, socket}
     end)
@@ -195,7 +195,7 @@ defmodule LightningWeb.AiAssistantChannel do
   @impl true
   def handle_in("apply_applied", params, socket) do
     with_authorized_frame(socket, :read, fn _session ->
-      mark_apply(params["message_id"], false)
+      mark_apply(socket, params["message_id"], false)
 
       {:reply, :ok, socket}
     end)
@@ -1046,11 +1046,15 @@ defmodule LightningWeb.AiAssistantChannel do
     }
   end
 
-  defp mark_apply(message_id, failed?) when is_binary(message_id) do
-    AiAssistant.set_apply_failed(message_id, failed?)
+  defp mark_apply(socket, message_id, failed?) when is_binary(message_id) do
+    AiAssistant.set_apply_failed(
+      socket.assigns.session_id,
+      message_id,
+      failed?
+    )
   end
 
-  defp mark_apply(_message_id, _failed?), do: :ok
+  defp mark_apply(_socket, _message_id, _failed?), do: :ok
 
   defp format_messages(messages) do
     Enum.map(messages, &format_message/1)

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -220,7 +220,7 @@ defmodule LightningWeb.AiAssistantChannelTest do
           %{}
         )
 
-      %{joined: socket}
+      %{joined: socket, session: session}
     end
 
     test "accepts a report of a failed apply", %{joined: socket} do
@@ -248,6 +248,30 @@ defmodule LightningWeb.AiAssistantChannelTest do
         })
 
       assert_reply ref, :ok
+    end
+
+    test "records the failure on the message, and clears it on a later success",
+         %{joined: socket, session: session} do
+      message = hd(session.messages)
+
+      ref =
+        push(socket, "apply_failed", %{
+          "message_id" => message.id,
+          "stage" => "import",
+          "is_new_workflow" => false
+        })
+
+      assert_reply ref, :ok
+
+      # The apply happens in the browser, so without this a reload has no way
+      # to know the changes never landed.
+      assert %{"apply_failed" => true} = Repo.reload!(message).meta
+
+      ref = push(socket, "apply_applied", %{"message_id" => message.id})
+      assert_reply ref, :ok
+
+      # A retry that works has to leave nothing behind.
+      refute Map.has_key?(Repo.reload!(message).meta, "apply_failed")
     end
 
     test "accepts a report with fields missing", %{joined: socket} do

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -274,6 +274,41 @@ defmodule LightningWeb.AiAssistantChannelTest do
       refute Map.has_key?(Repo.reload!(message).meta, "apply_failed")
     end
 
+    test "survives the pseudo-id a streaming apply reports against", %{
+      joined: socket
+    } do
+      # A mid-stream apply has no saved message, so the client reports the
+      # failure against "__streaming__". Looking that up as a uuid took the
+      # channel down with it.
+      ref =
+        push(socket, "apply_failed", %{
+          "message_id" => "__streaming__",
+          "stage" => "import",
+          "is_new_workflow" => false
+        })
+
+      assert_reply ref, :ok
+    end
+
+    test "will not mark a message belonging to another session", %{
+      joined: socket,
+      user: user,
+      job: job
+    } do
+      {:ok, other} = AiAssistant.create_session(job, user, "Elsewhere", [])
+      stranger = hd(other.messages)
+
+      ref =
+        push(socket, "apply_failed", %{
+          "message_id" => stranger.id,
+          "stage" => "import",
+          "is_new_workflow" => false
+        })
+
+      assert_reply ref, :ok
+      refute Map.has_key?(Repo.reload!(stranger).meta, "apply_failed")
+    end
+
     test "accepts a report with fields missing", %{joined: socket} do
       ref = push(socket, "apply_failed", %{})
 


### PR DESCRIPTION
## Description

Six fixes to the global assistant, all found by using it. Each is its own commit, which carries the reasoning.

- The Add button no longer appears on a global reply's code blocks. It pastes into whichever job the editor has open, which is right for job chat and wrong here: a global reply has already applied its changes.
- Code blocks share the surface the diff blocks use, so a reply and the diff below it no longer read as two different products. The tokenizer is extended to JSON, which is what the assistant sends when it quotes run data back.
- Editing an open step no longer puts a diff over the code editor. The change was already applied, so the diff offered an accept-or-reject choice that had no accept button.
- A failed apply says so on the reply, beside the diffs that did not land, and offers a retry. It used to fall back to a raw YAML panel.
- That failure is recorded on the message, so a reload no longer turns it back into a success. A retry that works clears it.
- The revert control moved into the reply's footer. Under the last diff block it read as that block's control, when it replaces the whole workflow.

Closes #5118

## Validation steps

1. Open a job, tick Global assistant and Send scrubbed I/O, and ask about the input. The data block should offer Copy and no Add, in the same light surface as a diff block.
2. Untick Global assistant and ask for code. Add comes back and pastes into the editor.
3. Ask the global assistant to change the step you have open. The code changes; no diff overlay appears.
4. Revert a reply from its footer, then click again to restore it.

## Additional notes for the reviewer

The apply outcome lives in `message.meta` and comes back as `apply_failed`, derived the way `from_global` already is, so there is no migration. Both channel handlers cast the message id and check it belongs to the session; each has a test that fails without it.

Restoring the workflow to any point a conversation reached is https://github.com/OpenFn/lightning/issues/5120, not this PR.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
