### PR TITLE
Global assistant: attach the run you are looking at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,35 @@ and this project adheres to
 
 ### Changed
 
+- The AI assistant is the global assistant for everyone. It was behind the
+  experimental features setting and an opt-in tickbox on the chat input, and
+  both are gone: every message goes to it, and the badge naming which assistant
+  answered goes with them. Existing workflow conversations still open and read
+  as they always did, and replying in one moves it to the global assistant from
+  that message on.
+  [#5042](https://github.com/OpenFn/lightning/issues/5042)
+
+- The AI assistant's attachment tickboxes are now about the run you are looking
+  at, and they appear wherever you are. "Send run logs" and "Send run data" sit
+  above the message box on the canvas and in the run history as well as in the
+  step editor, and appear once a run is loaded rather than sitting greyed out.
+  "Send run data" now covers every step in the run rather than the one that
+  happened to be highlighted, and still sends the shape of the data with the
+  values removed. The "Press Enter to send" hint below the box is gone, since
+  the notice and the send button now share that row.
+  [#5037](https://github.com/OpenFn/lightning/issues/5037)
+
 - Runs on Erlang/OTP 28 and Elixir 1.18.4. OTP 27 only finishes normalising
   the first character of a string, which breaks names in many languages.
   Lightning does not normalise anything today, but #4577 adds it on every name,
   so the runtime moves first.
+
+### Removed
+
+- The AI assistant's "Send code" tickbox. The assistant reads your workflow to
+  answer anything about it, so the box did nothing except in one case, where it
+  looked like a choice and was not one.
+  [#5037](https://github.com/OpenFn/lightning/issues/5037)
 
 ### Added
 

--- a/assets/js/collaborative-editor/components/AIAssistantPanel.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanel.tsx
@@ -11,7 +11,7 @@ import {
   useAISessionListCommands,
   useAIWorkflowTemplateContext,
 } from '../hooks/useAIAssistant';
-import { useSelectedStepId, useSelectedRunId } from '../hooks/useHistory';
+import { useSelectedRunId } from '../hooks/useHistory';
 import { useIsNewWorkflow } from '../hooks/useSessionContext';
 
 import { ChatInput } from './ChatInput';
@@ -54,20 +54,12 @@ interface AIAssistantPanelProps {
    * AI assistant limit information
    */
   aiLimit?: { allowed: boolean; message: string | null } | null;
-  /** Show the experimental global assistant toggle */
-  showGlobalAssistantOption?: boolean;
-  /** Whether the global assistant checkbox is currently checked */
-  isGlobalAssistantActive?: boolean;
-  /** Callback when global assistant checkbox changes */
-  onGlobalAssistantChange?: (active: boolean) => void;
 }
 
 interface MessageOptions {
-  attach_code?: boolean;
   attach_logs?: boolean;
   attach_io_data?: boolean;
-  step_id?: string;
-  use_global_assistant?: boolean;
+  follow_run_id?: string;
 }
 
 /**
@@ -100,9 +92,6 @@ export function AIAssistantPanel({
   focusTrigger,
   connectionState = 'connected',
   aiLimit = null,
-  showGlobalAssistantOption = false,
-  isGlobalAssistantActive = false,
-  onGlobalAssistantChange,
 }: AIAssistantPanelProps) {
   const [view, setView] = useState<'chat' | 'sessions'>(
     sessionId ? 'chat' : 'sessions'
@@ -120,7 +109,6 @@ export function AIAssistantPanel({
   const hasSessionContext = useAIHasSessionContext();
   const hasCompletedSessionLoad = useAIHasCompletedSessionLoad();
   const { loadSessionList } = useAISessionListCommands();
-  const selectedStepId = useSelectedStepId();
   const selectedRunId = useSelectedRunId();
   const isNewWorkflow = useIsNewWorkflow();
 
@@ -269,24 +257,6 @@ export function AIAssistantPanel({
                 <h2 className="text-base font-semibold text-gray-900">
                   Assistant
                 </h2>
-                {page && (
-                  <span
-                    className={cn(
-                      'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-                      isGlobalAssistantActive
-                        ? 'bg-amber-100 text-amber-800'
-                        : page === 'job_code'
-                          ? 'bg-blue-100 text-blue-800'
-                          : 'bg-purple-100 text-purple-800'
-                    )}
-                  >
-                    {isGlobalAssistantActive
-                      ? 'Global (experimental)'
-                      : page === 'job_code'
-                        ? 'Job'
-                        : 'Workflow'}
-                  </span>
-                )}
               </div>
             </div>
           </div>
@@ -451,9 +421,6 @@ export function AIAssistantPanel({
           (view === 'sessions' &&
             (!hasSessionContext || !hasCompletedSessionLoad))
         }
-        showJobControls={page === 'job_code'}
-        showGlobalAssistantOption={showGlobalAssistantOption}
-        onGlobalAssistantChange={onGlobalAssistantChange}
         storageKey={storageKey}
         enableAutoFocus={
           isOpen &&
@@ -463,9 +430,7 @@ export function AIAssistantPanel({
         focusTrigger={(focusTrigger ?? 0) + internalFocusTrigger}
         placeholder={placeholderText}
         disabledMessage={disabledMessage}
-        selectedStepId={selectedStepId}
         selectedRunId={selectedRunId}
-        selectedJobId={selectedContextJobId ?? null}
       />
 
       {/* About AI Assistant Modal */}
@@ -527,10 +492,6 @@ export function AIAssistantPanel({
                 anytime
               </li>
               <li>
-                Sessions are separated by context - job sessions and workflow
-                sessions are kept separate
-              </li>
-              <li>
                 Press{' '}
                 <code className="px-1 py-0.5 bg-gray-100 rounded text-xs font-mono">
                   Enter
@@ -542,8 +503,8 @@ export function AIAssistantPanel({
                 for a new line
               </li>
               <li>
-                For jobs, you can choose to include your code and run logs with
-                each message
+                When you have a run open you can attach its logs and its data to
+                a message
               </li>
               <li>
                 Generated workflows appear as artifacts with Apply and Copy
@@ -603,14 +564,16 @@ export function AIAssistantPanel({
               privacy.
             </p>
             <p>
-              <strong>For workflow sessions:</strong> Your project context is
-              automatically included. Generated workflows can be applied
-              directly to the canvas with one click.
+              <strong>What it reads:</strong> your workflow, every time. It
+              needs the steps and their code to answer anything about them, and
+              changes it makes are applied to the canvas as they arrive.
             </p>
             <p>
-              <strong>For job sessions:</strong> You control what the Assistant
-              sees. Use the checkboxes to optionally include your job code and
-              run logs. By default, job code is included but logs are not.
+              <strong>What you attach:</strong> with a run open, two tickboxes
+              above the message box add that run to what you send. "Send run
+              logs" adds every log line. "Send run data" adds the shape of each
+              step's input and output, where the field names go as they are and
+              the values are replaced by their types.
             </p>
             <p>
               All chat sessions are shared with project collaborators. Everyone

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -54,7 +54,6 @@ import {
   useSession,
 } from '../hooks/useSession';
 import {
-  useExperimentalFeaturesEnabled,
   useIsNewWorkflow,
   useLimits,
   useProject,
@@ -179,8 +178,9 @@ export function AIAssistantPanelWrapper({
   const connectionState = useAIConnectionState();
   const isSessionConnected = useSession(selectIsConnected);
   const isSessionConnecting = useSession(selectIsConnecting);
-  const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled();
-  const [isGlobalAssistantActive, setIsGlobalAssistantActive] = useState(false);
+  // The global assistant is the only one the UI reaches. Every message is
+  // routed to it from here, so nothing downstream has to decide again.
+  const isGlobalAssistantActive = true;
   const workflowTemplateContext = useAIWorkflowTemplateContext();
   const project = useProject();
   const user = useUser();
@@ -383,73 +383,38 @@ export function AIAssistantPanelWrapper({
     (
       content: string,
       messageOptions?: {
-        attach_code?: boolean;
         attach_logs?: boolean;
         attach_io_data?: boolean;
-        step_id?: string;
         follow_run_id?: string;
-        use_global_assistant?: boolean;
       }
     ) => {
       const currentState = aiStore.getSnapshot();
-
-      // For job_code with attach_code, get CURRENT code from Y.Doc
-      let updatedAiMode = aiMode;
-      if (messageOptions?.attach_code && aiMode?.mode === 'job_code') {
-        const context = aiMode.context as JobCodeContext;
-        const jobId = context.job_id;
-
-        if (jobId) {
-          // Get fresh code from jobs array (backed by Y.Doc)
-          const currentJob = jobs.find(j => j.id === jobId);
-          if (currentJob) {
-            // Update aiMode with new context (don't mutate)
-            const projectId =
-              'project_id' in context
-                ? (context.project_id as string)
-                : project!.id;
-            updatedAiMode = {
-              ...aiMode,
-              context: {
-                ...context,
-                project_id: projectId,
-                job_body: currentJob.body,
-              },
-            };
-          }
-          // If job not found, fall back to existing context.job_body
-          // (job could be unsaved or deleted)
-        }
-      }
+      const attached = { ...messageOptions, use_global_assistant: true };
 
       // If no session exists, we need to include content in context for first message
-      if (!currentState.sessionId && updatedAiMode) {
-        const { mode, context, page } = updatedAiMode;
+      if (!currentState.sessionId && aiMode) {
+        const { mode, context, page } = aiMode;
 
         // Prepare context with content and message options for channel join
         let finalContext = {
           ...context,
           content,
-          // Include attach_code/attach_logs so backend knows to include them in first message
-          ...(messageOptions?.attach_code && { attach_code: true }),
-          ...(messageOptions?.attach_logs && { attach_logs: true }),
-          ...(messageOptions?.attach_io_data && { attach_io_data: true }),
-          ...(messageOptions?.step_id && { step_id: messageOptions.step_id }),
+          // Include the attachment flags so the backend knows to resolve them
+          // for the first message too
+          ...(attached.attach_logs && { attach_logs: true }),
+          ...(attached.attach_io_data && { attach_io_data: true }),
           // The first message needs the run the checkbox was gated on too,
           // otherwise session creation falls back to the URL param.
-          ...(messageOptions?.follow_run_id && {
-            follow_run_id: messageOptions.follow_run_id,
+          ...(attached.follow_run_id && {
+            follow_run_id: attached.follow_run_id,
           }),
-          ...(messageOptions?.use_global_assistant && {
+          ...(attached.use_global_assistant && {
             use_global_assistant: true,
           }),
         };
 
         // Add workflow YAML if in workflow mode or global assistant
-        if (
-          page === 'workflow_template' ||
-          messageOptions?.use_global_assistant
-        ) {
+        if (page === 'workflow_template' || attached.use_global_assistant) {
           const workflowData = prepareWorkflowForSerialization(
             workflow,
             jobs,
@@ -465,7 +430,7 @@ export function AIAssistantPanelWrapper({
           }
 
           // Derive page for global assistant routing
-          if (messageOptions?.use_global_assistant) {
+          if (attached.use_global_assistant) {
             const jobName = (context as JobCodeContext)?.job_name;
             const workflowName = workflow?.name || 'workflow';
             finalContext = {
@@ -497,22 +462,20 @@ export function AIAssistantPanelWrapper({
       // For existing sessions, prepare options and send
       let options:
         | {
-            attach_code?: boolean;
             attach_logs?: boolean;
             attach_io_data?: boolean;
-            step_id?: string;
             code?: string;
             use_global_assistant?: boolean;
             page?: string;
             follow_run_id?: string;
           }
         | undefined = {
-        ...messageOptions, // Include attach_code, attach_logs, attach_io_data, step_id
+        ...attached, // attach_logs, attach_io_data, follow_run_id
       };
 
       if (
         aiMode?.page === 'workflow_template' ||
-        messageOptions?.use_global_assistant
+        attached.use_global_assistant
       ) {
         const workflowData = prepareWorkflowForSerialization(
           workflow,
@@ -530,7 +493,7 @@ export function AIAssistantPanelWrapper({
         }
 
         // Derive page for global assistant routing
-        if (messageOptions?.use_global_assistant) {
+        if (attached.use_global_assistant) {
           const context = aiMode?.context as JobCodeContext;
           const jobName = context?.job_name;
           const workflowName = workflow?.name || 'workflow';
@@ -565,7 +528,6 @@ export function AIAssistantPanelWrapper({
       aiStore,
       aiMode,
       updateSearchParams,
-      project,
     ]
   );
 
@@ -577,10 +539,6 @@ export function AIAssistantPanelWrapper({
     },
     [aiStore, retryMessageViaChannel]
   );
-
-  const handleGlobalAssistantChange = useCallback((active: boolean) => {
-    setIsGlobalAssistantActive(active);
-  }, []);
 
   const [applyingMessageId, setApplyingMessageId] = useState<string | null>(
     null
@@ -772,16 +730,12 @@ export function AIAssistantPanelWrapper({
       ?.id;
     if (triggeringUserId && user?.id && triggeringUserId !== user.id) return;
 
-    // Workflow YAML applies to the shared Y.Doc, so global streams are
-    // page-independent: global chat streams it from the job code view too,
-    // and the diagram must be up to date whenever the user navigates there.
-    // Non-global workflow chat keeps its workflow_template-only gate (a
-    // stream can outlive a mid-stream switch to a job page).
+    // Workflow YAML applies to the shared Y.Doc, so a stream is
+    // page-independent: it can arrive while a step is open, and the diagram
+    // has to be right when the user navigates back to it.
     if ('yaml' in streamingChanges) {
       const yaml = streamingChanges['yaml'] as string;
-      const yamlCanApply =
-        isGlobalAssistantActive || aiMode?.page === 'workflow_template';
-      if (yaml && yamlCanApply) {
+      if (yaml) {
         appliedStreamingChangesRef.current = streamingChanges;
         // handleApplyWorkflow records the streaming apply in the store
         // (after a successful import) so the final new_message can skip it
@@ -849,9 +803,6 @@ export function AIAssistantPanelWrapper({
               focusTrigger={focusTrigger}
               connectionState={sessionId ? connectionState : 'connected'}
               aiLimit={limits.ai_assistant ?? null}
-              showGlobalAssistantOption={experimentalFeaturesEnabled}
-              isGlobalAssistantActive={isGlobalAssistantActive}
-              onGlobalAssistantChange={handleGlobalAssistantChange}
             >
               <MessageList
                 messages={messages}

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -178,8 +178,7 @@ export function AIAssistantPanelWrapper({
   const connectionState = useAIConnectionState();
   const isSessionConnected = useSession(selectIsConnected);
   const isSessionConnecting = useSession(selectIsConnecting);
-  // The global assistant is the only one the UI reaches. Every message is
-  // routed to it from here, so nothing downstream has to decide again.
+  // Routed from here so nothing downstream decides it again.
   const isGlobalAssistantActive = true;
   const workflowTemplateContext = useAIWorkflowTemplateContext();
   const project = useProject();
@@ -399,8 +398,6 @@ export function AIAssistantPanelWrapper({
         let finalContext = {
           ...context,
           content,
-          // Include the attachment flags so the backend knows to resolve them
-          // for the first message too
           ...(attached.attach_logs && { attach_logs: true }),
           ...(attached.attach_io_data && { attach_io_data: true }),
           // The first message needs the run the checkbox was gated on too,
@@ -730,9 +727,8 @@ export function AIAssistantPanelWrapper({
       ?.id;
     if (triggeringUserId && user?.id && triggeringUserId !== user.id) return;
 
-    // Workflow YAML applies to the shared Y.Doc, so a stream is
-    // page-independent: it can arrive while a step is open, and the diagram
-    // has to be right when the user navigates back to it.
+    // A stream can arrive while a step is open, and the diagram has to be
+    // right when the user navigates back to it.
     if ('yaml' in streamingChanges) {
       const yaml = streamingChanges['yaml'] as string;
       if (yaml) {

--- a/assets/js/collaborative-editor/components/ChatInput.tsx
+++ b/assets/js/collaborative-editor/components/ChatInput.tsx
@@ -33,10 +33,7 @@ interface MessageOptions {
   follow_run_id?: string;
 }
 
-/**
- * What the assistant can be given beyond the workflow, which it always reads.
- * Both are scoped to the run on screen, so both appear and disappear with it.
- */
+/** What can be attached beyond the workflow, which the assistant always reads. */
 const ATTACHMENTS = [
   {
     key: 'logs',
@@ -202,10 +199,8 @@ export function ChatInput({
     if (!input.trim() || isLoading || isDisabled) return;
 
     const options: MessageOptions = {};
-    // Both boxes describe the run in front of the user, so both hang off the
-    // same id. Sending it is what stops what we promise to attach and what the
-    // backend looks up from drifting: useAIMode reads the run from the URL, and
-    // LiveView push_patch strips that param.
+    // The run rides along so what we promise to attach and what the backend
+    // looks up cannot drift: LiveView push_patch strips the URL param.
     if (selectedRunId) {
       options.attach_logs = attachLogs;
       options.attach_io_data = attachIoData;

--- a/assets/js/collaborative-editor/components/ChatInput.tsx
+++ b/assets/js/collaborative-editor/components/ChatInput.tsx
@@ -13,12 +13,6 @@ interface ChatInputProps {
   isLoading?: boolean | undefined;
   /** Disabled state (separate from loading, e.g., due to limits) */
   isDisabled?: boolean | undefined;
-  /** Show job-specific controls (attach code, attach logs) */
-  showJobControls?: boolean | undefined;
-  /** Show the experimental global assistant toggle */
-  showGlobalAssistantOption?: boolean | undefined;
-  /** Callback when global assistant checkbox changes */
-  onGlobalAssistantChange?: ((active: boolean) => void) | undefined;
   /** Storage key for persisting checkbox preferences */
   storageKey?: string | undefined;
   /** Enable automatic focus management for the input */
@@ -29,21 +23,38 @@ interface ChatInputProps {
   placeholder?: string | undefined;
   /** Message to show in tooltip when input is disabled */
   disabledMessage?: string | undefined;
-  /** Selected step ID for attaching I/O data */
-  selectedStepId?: string | null;
-  /** Selected run ID for attaching logs */
+  /** The run both attachments are scoped to, and what gates them */
   selectedRunId?: string | null;
-  /** Selected job ID for attaching code */
-  selectedJobId?: string | null;
 }
 
 interface MessageOptions {
-  attach_code?: boolean;
   attach_logs?: boolean;
   attach_io_data?: boolean;
-  step_id?: string;
-  use_global_assistant?: boolean;
+  follow_run_id?: string;
 }
+
+/**
+ * What the assistant can be given beyond the workflow, which it always reads.
+ * Both are scoped to the run on screen, so both appear and disappear with it.
+ */
+const ATTACHMENTS = [
+  {
+    key: 'logs',
+    label: 'Send run logs',
+    description:
+      'Sends every log line from this run, so the assistant can see what ' +
+      'actually happened.',
+  },
+  {
+    key: 'data',
+    label: 'Send run data',
+    description:
+      "Sends the shape of every step's input and output. Field names go as " +
+      'they are; the values are replaced by their types.',
+  },
+] as const;
+
+type AttachmentKey = (typeof ATTACHMENTS)[number]['key'];
 
 const MIN_TEXTAREA_HEIGHT = 52;
 const MAX_TEXTAREA_HEIGHT = 200;
@@ -52,32 +63,14 @@ export function ChatInput({
   onSendMessage,
   isLoading = false,
   isDisabled = false,
-  showJobControls = false,
-  showGlobalAssistantOption = false,
-  onGlobalAssistantChange,
   storageKey,
   enableAutoFocus = false,
   focusTrigger,
   placeholder = 'Ask me anything...',
   disabledMessage,
-  selectedStepId,
   selectedRunId,
-  selectedJobId,
 }: ChatInputProps) {
   const [input, setInput] = useState('');
-
-  const [attachCode, setAttachCode] = useState(() => {
-    if (!storageKey) {
-      return true;
-    }
-    try {
-      const key = `${storageKey}:attach-code`;
-      const saved = localStorage.getItem(key);
-      return saved === null ? true : saved === 'true';
-    } catch {
-      return true;
-    }
-  });
 
   const [attachLogs, setAttachLogs] = useState(() => {
     if (!storageKey) {
@@ -97,7 +90,7 @@ export function ChatInput({
       return false;
     }
     try {
-      const key = `${storageKey}:attach-io-data`;
+      const key = `${storageKey}:attach-run-data`;
       const saved = localStorage.getItem(key);
       return saved === 'true';
     } catch {
@@ -105,19 +98,24 @@ export function ChatInput({
     }
   });
 
-  const [useGlobalAssistant, setUseGlobalAssistant] = useState(() => {
-    if (!storageKey) return false;
-    try {
-      return (
-        localStorage.getItem(`${storageKey}:use-global-assistant`) === 'true'
-      );
-    } catch {
-      return false;
-    }
-  });
-
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isLoadingFromStorageRef = useRef(false);
+
+  const attachmentState: Record<AttachmentKey, boolean> = {
+    logs: attachLogs,
+    data: attachIoData,
+  };
+
+  const toggleAttachment = (key: AttachmentKey) => {
+    switch (key) {
+      case 'logs':
+        setAttachLogs(current => !current);
+        break;
+      case 'data':
+        setAttachIoData(current => !current);
+        break;
+    }
+  };
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -137,15 +135,6 @@ export function ChatInput({
     isLoadingFromStorageRef.current = true;
 
     try {
-      const codeKey = `${storageKey}:attach-code`;
-      const savedCode = localStorage.getItem(codeKey);
-      const codeValue = savedCode === null ? true : savedCode === 'true';
-      setAttachCode(codeValue);
-    } catch {
-      // Ignore localStorage errors
-    }
-
-    try {
       const logsKey = `${storageKey}:attach-logs`;
       const savedLogs = localStorage.getItem(logsKey);
       const logsValue = savedLogs === 'true';
@@ -155,18 +144,10 @@ export function ChatInput({
     }
 
     try {
-      const ioDataKey = `${storageKey}:attach-io-data`;
+      const ioDataKey = `${storageKey}:attach-run-data`;
       const savedIoData = localStorage.getItem(ioDataKey);
       const ioDataValue = savedIoData === 'true';
       setAttachIoData(ioDataValue);
-    } catch {
-      // Ignore localStorage errors
-    }
-
-    try {
-      const globalValue =
-        localStorage.getItem(`${storageKey}:use-global-assistant`) === 'true';
-      setUseGlobalAssistant(globalValue);
     } catch {
       // Ignore localStorage errors
     }
@@ -175,16 +156,6 @@ export function ChatInput({
       isLoadingFromStorageRef.current = false;
     }, 0);
   }, [storageKey]);
-
-  useEffect(() => {
-    if (!storageKey) return;
-    if (isLoadingFromStorageRef.current) return;
-    try {
-      localStorage.setItem(`${storageKey}:attach-code`, String(attachCode));
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, [attachCode, storageKey]);
 
   useEffect(() => {
     if (!storageKey) return;
@@ -201,30 +172,13 @@ export function ChatInput({
     if (isLoadingFromStorageRef.current) return;
     try {
       localStorage.setItem(
-        `${storageKey}:attach-io-data`,
+        `${storageKey}:attach-run-data`,
         String(attachIoData)
       );
     } catch {
       // Ignore localStorage errors
     }
   }, [attachIoData, storageKey]);
-
-  useEffect(() => {
-    if (!storageKey) return;
-    if (isLoadingFromStorageRef.current) return;
-    try {
-      localStorage.setItem(
-        `${storageKey}:use-global-assistant`,
-        String(useGlobalAssistant)
-      );
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, [useGlobalAssistant, storageKey]);
-
-  useEffect(() => {
-    onGlobalAssistantChange?.(useGlobalAssistant);
-  }, [useGlobalAssistant, onGlobalAssistantChange]);
 
   useEffect(() => {
     if (enableAutoFocus && textareaRef.current) {
@@ -248,25 +202,14 @@ export function ChatInput({
     if (!input.trim() || isLoading || isDisabled) return;
 
     const options: MessageOptions = {};
-    if (showJobControls) {
-      if (selectedRunId) {
-        options.attach_logs = attachLogs;
-        // The run the checkbox was gated on, so what we promise to attach and
-        // what the backend looks up cannot drift. useAIMode reads the run from
-        // the URL, and LiveView push_patch strips that param.
-        options.follow_run_id = selectedRunId;
-      }
-      if (selectedJobId) {
-        options.attach_code = attachCode;
-      }
-      if (selectedStepId) {
-        options.attach_io_data = attachIoData;
-        options.step_id = selectedStepId;
-      }
-    }
-
-    if (showGlobalAssistantOption && useGlobalAssistant) {
-      options.use_global_assistant = true;
+    // Both boxes describe the run in front of the user, so both hang off the
+    // same id. Sending it is what stops what we promise to attach and what the
+    // backend looks up from drifting: useAIMode reads the run from the URL, and
+    // LiveView push_patch strips that param.
+    if (selectedRunId) {
+      options.attach_logs = attachLogs;
+      options.attach_io_data = attachIoData;
+      options.follow_run_id = selectedRunId;
     }
 
     onSendMessage?.(input.trim(), options);
@@ -304,6 +247,40 @@ export function ChatInput({
                     : 'border-gray-200 hover:border-gray-300'
                 )}
               >
+                {selectedRunId && (
+                  <div
+                    className="flex flex-wrap items-center gap-3 px-3 pt-3"
+                    data-testid="attached-context"
+                  >
+                    {ATTACHMENTS.map(({ key, label, description }) => (
+                      <Tooltip key={key} content={description} side="top">
+                        <label className="flex items-center gap-1.5 group cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={attachmentState[key]}
+                            onChange={() => {
+                              toggleAttachment(key);
+                            }}
+                            className={cn(
+                              'w-3.5 h-3.5 rounded border-gray-300',
+                              'text-primary-600 cursor-pointer',
+                              'focus:ring-primary-500 focus:ring-offset-0'
+                            )}
+                          />
+                          <span
+                            className={cn(
+                              'text-[11px] font-medium text-gray-600',
+                              'group-hover:text-gray-900'
+                            )}
+                          >
+                            {label}
+                          </span>
+                        </label>
+                      </Tooltip>
+                    ))}
+                  </div>
+                )}
+
                 <textarea
                   ref={textareaRef}
                   data-testid="chat-input"
@@ -328,173 +305,9 @@ export function ChatInput({
                   }}
                 />
 
-                <div className="flex items-center justify-between px-3 py-2 border-t border-gray-100">
-                  <div className="flex items-center gap-3">
-                    {showJobControls ? (
-                      <>
-                        <Tooltip
-                          content={
-                            selectedJobId
-                              ? undefined
-                              : 'Select a job to include code'
-                          }
-                          side="top"
-                        >
-                          <label
-                            className={cn(
-                              'flex items-center gap-1.5 group',
-                              selectedJobId
-                                ? 'cursor-pointer'
-                                : 'cursor-not-allowed opacity-50'
-                            )}
-                          >
-                            <input
-                              type="checkbox"
-                              // NOTE: Regardless of preferences, we show it
-                              // unchecked if no job is selected because code
-                              // can't be sent without a job
-                              checked={attachCode && !!selectedJobId}
-                              onChange={e => setAttachCode(e.target.checked)}
-                              disabled={!selectedJobId}
-                              className={cn(
-                                'w-3.5 h-3.5 rounded border-gray-300 text-primary-600',
-                                'focus:ring-primary-500 focus:ring-offset-0',
-                                selectedJobId
-                                  ? 'cursor-pointer'
-                                  : 'cursor-not-allowed'
-                              )}
-                            />
-                            <span
-                              className={cn(
-                                'text-[11px] font-medium',
-                                selectedJobId
-                                  ? 'text-gray-600 group-hover:text-gray-900'
-                                  : 'text-gray-400'
-                              )}
-                            >
-                              Send code
-                            </span>
-                          </label>
-                        </Tooltip>
-
-                        <Tooltip
-                          content={
-                            selectedRunId
-                              ? undefined
-                              : 'Select a run to include logs'
-                          }
-                          side="top"
-                        >
-                          <label
-                            className={cn(
-                              'flex items-center gap-1.5 group',
-                              selectedRunId
-                                ? 'cursor-pointer'
-                                : 'cursor-not-allowed opacity-50'
-                            )}
-                          >
-                            <input
-                              type="checkbox"
-                              // NOTE: Regardless of preferences, we show it
-                              // unchecked if no run is selected because logs
-                              // can't be sent without a run
-                              checked={attachLogs && !!selectedRunId}
-                              onChange={e => setAttachLogs(e.target.checked)}
-                              disabled={!selectedRunId}
-                              className={cn(
-                                'w-3.5 h-3.5 rounded border-gray-300 text-primary-600',
-                                'focus:ring-primary-500 focus:ring-offset-0',
-                                selectedRunId
-                                  ? 'cursor-pointer'
-                                  : 'cursor-not-allowed'
-                              )}
-                            />
-                            <span
-                              className={cn(
-                                'text-[11px] font-medium',
-                                selectedRunId
-                                  ? 'text-gray-600 group-hover:text-gray-900'
-                                  : 'text-gray-400'
-                              )}
-                            >
-                              Send logs
-                            </span>
-                          </label>
-                        </Tooltip>
-
-                        <Tooltip
-                          content={
-                            selectedStepId
-                              ? 'Include scrubbed I/O data structure (values removed)'
-                              : 'Select a step to include I/O data'
-                          }
-                          side="top"
-                        >
-                          <label
-                            className={cn(
-                              'flex items-center gap-1.5 group',
-                              selectedStepId
-                                ? 'cursor-pointer'
-                                : 'cursor-not-allowed opacity-50'
-                            )}
-                          >
-                            <input
-                              type="checkbox"
-                              // NOTE: Regardless of preferences, we show it
-                              // unchecked if no step is selected because I/O
-                              // can't be sent without a step
-                              checked={attachIoData && !!selectedStepId}
-                              onChange={e => setAttachIoData(e.target.checked)}
-                              disabled={!selectedStepId}
-                              className={cn(
-                                'w-3.5 h-3.5 rounded border-gray-300 text-primary-600',
-                                'focus:ring-primary-500 focus:ring-offset-0',
-                                selectedStepId
-                                  ? 'cursor-pointer'
-                                  : 'cursor-not-allowed'
-                              )}
-                            />
-                            <span
-                              className={cn(
-                                'text-[11px] font-medium',
-                                selectedStepId
-                                  ? 'text-gray-600 group-hover:text-gray-900'
-                                  : 'text-gray-400'
-                              )}
-                            >
-                              Send scrubbed I/O
-                            </span>
-                          </label>
-                        </Tooltip>
-                      </>
-                    ) : (
-                      <AIDisclaimerFooter />
-                    )}
-
-                    {showGlobalAssistantOption && (
-                      <Tooltip
-                        content="Route messages to the experimental global assistant"
-                        side="top"
-                      >
-                        <label className="flex items-center gap-1.5 group cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={useGlobalAssistant}
-                            onChange={e =>
-                              setUseGlobalAssistant(e.target.checked)
-                            }
-                            className={cn(
-                              'w-3.5 h-3.5 rounded border-amber-400 text-amber-600',
-                              'focus:ring-amber-500 focus:ring-offset-0',
-                              'cursor-pointer'
-                            )}
-                          />
-                          <span className="text-[11px] font-medium text-amber-600 group-hover:text-amber-700">
-                            Global assistant (experimental)
-                          </span>
-                        </label>
-                      </Tooltip>
-                    )}
+                <div className="flex items-center justify-between gap-3 px-3 pb-2">
+                  <div className="min-w-0">
+                    <AIDisclaimerFooter />
                   </div>
 
                   <button
@@ -522,20 +335,6 @@ export function ChatInput({
                     )}
                   </button>
                 </div>
-              </div>
-
-              <div className="mt-2 text-center">
-                <span className="text-[11px] text-gray-500">
-                  Press{' '}
-                  <kbd className="px-1 py-0.5 bg-gray-100 rounded text-[10px] font-medium border border-gray-200">
-                    Enter
-                  </kbd>{' '}
-                  to send,{' '}
-                  <kbd className="px-1 py-0.5 bg-gray-100 rounded text-[10px] font-medium border border-gray-200">
-                    Shift + Enter
-                  </kbd>{' '}
-                  for new line
-                </span>
               </div>
             </div>
           </Tooltip>

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -1013,14 +1013,7 @@ export function MessageList({
     return null;
   };
 
-  // Woven text/status timeline to render instead of flat content, or null.
-  // - Completed messages: persisted `response_segments` (global replies).
-  // - Streaming placeholder: live `streamingSegments`. Gated on the global
-  //   assistant being active as a deliberate blast-radius hold: job and
-  //   workflow chat are live services, and keeping their streaming render
-  //   on the flat `streamingContent` path means this PR cannot change what
-  //   they display. Only Apollo's global endpoint emits status segments
-  //   today; lift the gate when that changes.
+  // Only the global endpoint emits status segments today.
   const timelineSegments = (message: Message): ResponseSegment[] | null => {
     if (isStreaming(message)) {
       return isGlobalAssistantActive && streamingSegments?.length

--- a/assets/js/collaborative-editor/hooks/useAIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/hooks/useAIChannelRegistry.ts
@@ -125,7 +125,7 @@ export const buildChannelTopic = (
  * const { sendMessage, retryMessage, isConnected } = useAISessionCommands();
  *
  * const handleSend = () => {
- *   sendMessage('Hello AI!', { attach_code: true });
+ *   sendMessage('Hello AI!', { attach_logs: true });
  * };
  * ```
  */

--- a/assets/js/collaborative-editor/hooks/useAIInitialMessage.ts
+++ b/assets/js/collaborative-editor/hooks/useAIInitialMessage.ts
@@ -97,9 +97,13 @@ export function useAIInitialMessage({
       const { mode, context } = aiMode;
       const { workflow, jobs, triggers, edges, positions } = workflowData;
 
+      // The landing screen's first message is a message like any other, and
+      // there is one assistant for it to reach.
       let finalContext: JobCodeContext | WorkflowTemplateContext = {
         ...context,
         content: initialMessage,
+        use_global_assistant: true,
+        page: `workflows/${workflowData.workflow?.name ?? 'workflow'}`,
       };
 
       // Add workflow YAML if in workflow template mode
@@ -115,7 +119,7 @@ export function useAIInitialMessage({
           const workflowYAML = serializeWorkflowToYAML(serializedWorkflow);
           if (workflowYAML) {
             finalContext = {
-              ...(finalContext as WorkflowTemplateContext),
+              ...finalContext,
               code: workflowYAML,
             };
           }

--- a/assets/js/collaborative-editor/hooks/useAIMode.ts
+++ b/assets/js/collaborative-editor/hooks/useAIMode.ts
@@ -53,7 +53,6 @@ export function useAIMode(): AIModeResult | null {
       context = {
         ...context,
         job_id: selectedJobId,
-        attach_code: false,
         attach_logs: false,
       };
 

--- a/assets/js/collaborative-editor/hooks/useSessionContext.ts
+++ b/assets/js/collaborative-editor/hooks/useSessionContext.ts
@@ -275,22 +275,6 @@ export const useWorkflowTemplate = (): WorkflowTemplate | null => {
 };
 
 /**
- * Hook to check if the user has experimental features enabled
- */
-export const useExperimentalFeaturesEnabled = (): boolean => {
-  const sessionContextStore = useSessionContextStore();
-
-  const selectExperimentalFeaturesEnabled = sessionContextStore.withSelector(
-    state => state.experimentalFeaturesEnabled
-  );
-
-  return useSyncExternalStore(
-    sessionContextStore.subscribe,
-    selectExperimentalFeaturesEnabled
-  );
-};
-
-/**
  * Hook to access limits from session context
  * Returns limits object (empty object if not set)
  */

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -445,7 +445,7 @@ export class AIChannelRegistry {
    *
    * @param topic - Channel topic
    * @param content - Message content
-   * @param options - Message options (attach_code, attach_logs, etc.)
+   * @param options - Message options (attach_logs, attach_io_data, etc.)
    */
   sendMessage(topic: string, content: string, options?: MessageOptions): void {
     const entry = this.channels.get(topic);
@@ -1021,9 +1021,6 @@ export class AIChannelRegistry {
       // JobCodeContext
       params['job_id'] = context.job_id;
 
-      if (context.follow_run_id) {
-        params['follow_run_id'] = context.follow_run_id;
-      }
       if (context.job_name) {
         params['job_name'] = context.job_name;
       }
@@ -1041,18 +1038,6 @@ export class AIChannelRegistry {
       }
       if (context.content) {
         params['content'] = context.content;
-      }
-      if (context.attach_code) {
-        params['attach_code'] = true;
-      }
-      if (context.attach_logs) {
-        params['attach_logs'] = true;
-      }
-      if (context.attach_io_data) {
-        params['attach_io_data'] = true;
-      }
-      if (context.step_id) {
-        params['step_id'] = context.step_id;
       }
     } else {
       // WorkflowTemplateContext
@@ -1078,12 +1063,30 @@ export class AIChannelRegistry {
       params['code'] = context.code;
     }
 
+    // Run context the user ticked, for both context shapes. These used to be
+    // forwarded only when a step was open, so asking from the canvas lost the
+    // logs and data on the first turn: the join is the only way that message
+    // reaches the server, and later turns go through `new_message`, which
+    // always carried them. That is the same shape of bug as `code` above.
+    if ('follow_run_id' in context && context.follow_run_id) {
+      params['follow_run_id'] = context.follow_run_id;
+    }
+    if ('attach_logs' in context && context.attach_logs) {
+      params['attach_logs'] = true;
+    }
+    if ('attach_io_data' in context && context.attach_io_data) {
+      params['attach_io_data'] = true;
+    }
+    if ('step_id' in context && context.step_id) {
+      params['step_id'] = context.step_id;
+    }
+
     // Global assistant flags (applicable to both session types)
     if ('use_global_assistant' in context && context.use_global_assistant) {
       params['use_global_assistant'] = true;
     }
     if ('page' in context && context.page) {
-      params['page'] = context.page as string;
+      params['page'] = context.page;
     }
 
     return params;

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -1063,11 +1063,7 @@ export class AIChannelRegistry {
       params['code'] = context.code;
     }
 
-    // Run context the user ticked, for both context shapes. These used to be
-    // forwarded only when a step was open, so asking from the canvas lost the
-    // logs and data on the first turn: the join is the only way that message
-    // reaches the server, and later turns go through `new_message`, which
-    // always carried them. That is the same shape of bug as `code` above.
+    // For both context shapes, for the same reason as `code` above.
     if ('follow_run_id' in context && context.follow_run_id) {
       params['follow_run_id'] = context.follow_run_id;
     }

--- a/assets/js/collaborative-editor/stores/createSessionContextStore.ts
+++ b/assets/js/collaborative-editor/stores/createSessionContextStore.ts
@@ -121,7 +121,6 @@ export const createSessionContextStore = (
       versionsLoading: false,
       versionsError: null,
       workflow_template: null,
-      experimentalFeaturesEnabled: false,
       limits: {},
       isNewWorkflow,
       isLoading: false,
@@ -188,8 +187,6 @@ export const createSessionContextStore = (
         draft.projectRepoConnection = sessionContext.project_repo_connection;
         draft.webhookAuthMethods = sessionContext.webhook_auth_methods;
         draft.workflow_template = sessionContext.workflow_template;
-        draft.experimentalFeaturesEnabled =
-          sessionContext.experimental_features_enabled;
         draft.limits = sessionContext.limits;
         draft.isLoading = false;
         draft.error = null;

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -138,9 +138,8 @@ export type WorkflowTemplateContext =
       errors?: string;
       content?: string;
 
-      // The run the user attached, and what they attached from it. These ride
-      // on the channel join because that is the only way a session's first
-      // message reaches the server.
+      // Carried on the channel join, which is how a session's first message
+      // reaches the server.
       follow_run_id?: string;
       attach_logs?: boolean;
       attach_io_data?: boolean;

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -110,7 +110,6 @@ export interface Message {
  */
 export interface JobCodeContext {
   job_id: string;
-  attach_code?: boolean;
   attach_logs?: boolean;
   attach_io_data?: boolean;
   step_id?: string;
@@ -138,14 +137,25 @@ export type WorkflowTemplateContext =
       code?: string;
       errors?: string;
       content?: string;
+
+      // The run the user attached, and what they attached from it. These ride
+      // on the channel join because that is the only way a session's first
+      // message reaches the server.
+      follow_run_id?: string;
+      attach_logs?: boolean;
+      attach_io_data?: boolean;
+      step_id?: string;
+      use_global_assistant?: boolean;
+      page?: string;
     }
   | {
       job_id: string;
-      attach_code?: boolean;
       attach_logs?: boolean;
       attach_io_data?: boolean;
       step_id?: string;
       follow_run_id?: string;
+      use_global_assistant?: boolean;
+      page?: string;
       content?: string;
 
       job_name?: string;
@@ -334,7 +344,6 @@ export interface AIAssistantStore {
  * Options for sending a message
  */
 export interface MessageOptions {
-  attach_code?: boolean;
   attach_logs?: boolean;
   attach_io_data?: boolean;
   step_id?: string;

--- a/assets/js/collaborative-editor/types/sessionContext.ts
+++ b/assets/js/collaborative-editor/types/sessionContext.ts
@@ -102,7 +102,6 @@ export const SessionContextResponseSchema = z.object({
   project_repo_connection: ProjectRepoConnectionSchema.nullable(),
   webhook_auth_methods: z.array(WebhookAuthMethodSchema),
   workflow_template: WorkflowTemplateSchema.nullable(),
-  experimental_features_enabled: z.boolean().optional().default(false),
   limits: LimitsSchema.optional(),
   workflow: BaseWorkflowSchema.optional(),
 });
@@ -125,7 +124,6 @@ export interface SessionContextState {
   versionsLoading: boolean;
   versionsError: string | null;
   workflow_template: WorkflowTemplate | null;
-  experimentalFeaturesEnabled: boolean;
   limits: Limits;
   isNewWorkflow: boolean;
   isLoading: boolean;

--- a/assets/test/collaborative-editor/components/AIAssistantPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/AIAssistantPanel.test.tsx
@@ -134,37 +134,16 @@ describe('AIAssistantPanel', () => {
       expect(screen.getByText('Assistant')).toBeInTheDocument();
     });
 
-    it('should show Job mode badge when sessionType is job_code', () => {
+    it('should not name which assistant answered', () => {
+      // There is one, so the badge that told Job from Workflow from Global has
+      // nothing left to say.
       renderWithStore(
         <AIAssistantPanel isOpen={true} onClose={mockOnClose} page="job_code" />
       );
 
-      const badge = screen.getByText('Job');
-      expect(badge).toBeInTheDocument();
-      expect(badge).toHaveClass('bg-blue-100', 'text-blue-800');
-    });
-
-    it('should show Workflow mode badge when sessionType is workflow_template', () => {
-      renderWithStore(
-        <AIAssistantPanel
-          isOpen={true}
-          onClose={mockOnClose}
-          page="workflow_template"
-        />
-      );
-
-      const badge = screen.getByText('Workflow');
-      expect(badge).toBeInTheDocument();
-      expect(badge).toHaveClass('bg-purple-100', 'text-purple-800');
-    });
-
-    it('should not show mode badge when sessionType is null', () => {
-      renderWithStore(
-        <AIAssistantPanel isOpen={true} onClose={mockOnClose} page={null} />
-      );
-
       expect(screen.queryByText('Job')).not.toBeInTheDocument();
       expect(screen.queryByText('Workflow')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Global/)).not.toBeInTheDocument();
     });
 
     it('should render close button', () => {
@@ -628,7 +607,11 @@ describe('AIAssistantPanel', () => {
       expect(textarea).toBeDisabled();
     });
 
-    it('should show job controls when sessionType is job_code', () => {
+    it('should offer run context on the job page when a run is loaded', () => {
+      mockHistoryStore = createMockHistoryStore({}, {
+        id: 'run-123',
+      } as never);
+
       renderWithStore(
         <AIAssistantPanel
           isOpen={true}
@@ -638,10 +621,16 @@ describe('AIAssistantPanel', () => {
         />
       );
 
-      expect(screen.getByText(/Send code/)).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: /send run logs/i })
+      ).toBeInTheDocument();
     });
 
-    it('should not show job controls when sessionType is workflow_template', () => {
+    it('should offer the same on the canvas', () => {
+      mockHistoryStore = createMockHistoryStore({}, {
+        id: 'run-123',
+      } as never);
+
       renderWithStore(
         <AIAssistantPanel
           isOpen={true}
@@ -650,7 +639,9 @@ describe('AIAssistantPanel', () => {
         />
       );
 
-      expect(screen.queryByText(/Send code/)).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: /send run logs/i })
+      ).toBeInTheDocument();
     });
   });
 

--- a/assets/test/collaborative-editor/components/AIAssistantPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/AIAssistantPanel.test.tsx
@@ -135,8 +135,6 @@ describe('AIAssistantPanel', () => {
     });
 
     it('should not name which assistant answered', () => {
-      // There is one, so the badge that told Job from Workflow from Global has
-      // nothing left to say.
       renderWithStore(
         <AIAssistantPanel isOpen={true} onClose={mockOnClose} page="job_code" />
       );

--- a/assets/test/collaborative-editor/components/ChatInput.test.tsx
+++ b/assets/test/collaborative-editor/components/ChatInput.test.tsx
@@ -5,15 +5,25 @@
  * - Text input and submission
  * - Keyboard shortcuts
  * - Loading states
- * - Job controls (attach code/logs)
+ * - Run attachment controls (send logs, send data)
  * - LocalStorage persistence
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ChatInput } from '../../../js/collaborative-editor/components/ChatInput';
+
+const toggleContext = async (name: RegExp) => {
+  await userEvent.click(screen.getByRole('checkbox', { name }));
+};
 
 describe('ChatInput', () => {
   let mockSendMessage: ReturnType<typeof vi.fn>;
@@ -40,14 +50,6 @@ describe('ChatInput', () => {
       expect(sendButton).toBeInTheDocument();
     });
 
-    it('should render keyboard hint', () => {
-      render(<ChatInput />);
-
-      expect(screen.getByText(/Press/)).toBeInTheDocument();
-      expect(screen.getByText(/to send/)).toBeInTheDocument();
-      expect(screen.getByText(/for new line/)).toBeInTheDocument();
-    });
-
     it('should show the AI disclaimer footer by default', () => {
       render(<ChatInput />);
 
@@ -60,14 +62,23 @@ describe('ChatInput', () => {
       );
     });
 
-    it('should show job controls when showJobControls is true', () => {
-      render(<ChatInput showJobControls />);
+    it('should offer no attachment controls when there is no run to take them from', () => {
+      render(<ChatInput />);
 
-      expect(screen.getByText(/Send code/)).toBeInTheDocument();
-      expect(screen.getByText(/Send logs/)).toBeInTheDocument();
+      expect(screen.queryByTestId('attached-context')).not.toBeInTheDocument();
+      expect(screen.getByText(/Please use AI responsibly/)).toBeInTheDocument();
+    });
+
+    it('should offer both boxes, unticked, once a run is loaded', () => {
+      render(<ChatInput selectedRunId="run-123" />);
+
+      const controls = screen.getByTestId('attached-context');
       expect(
-        screen.queryByText(/Please use AI responsibly/)
-      ).not.toBeInTheDocument();
+        within(controls).getByRole('checkbox', { name: /send run logs/i })
+      ).not.toBeChecked();
+      expect(
+        within(controls).getByRole('checkbox', { name: /send run data/i })
+      ).not.toBeChecked();
     });
   });
 
@@ -262,500 +273,196 @@ describe('ChatInput', () => {
     });
   });
 
-  describe('Job Controls', () => {
-    it('should include attach_code when job is selected', async () => {
+  describe('Run Attachment Controls', () => {
+    it('should include both flags and the run when a run is selected', async () => {
       render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedJobId="job-123"
-        />
+        <ChatInput onSendMessage={mockSendMessage} selectedRunId="run-123" />
       );
 
       const textarea = screen.getByPlaceholderText('Ask me anything...');
       await userEvent.type(textarea, 'Test{Enter}');
 
+      // Unticked is still an answer, so both ride along as false rather than
+      // being left out.
       expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_code: true, // Default when job selected
+        attach_logs: false,
+        attach_io_data: false,
+        follow_run_id: 'run-123',
       });
     });
 
-    it('should include attach_logs when run is selected', async () => {
+    it('should include attach_logs when run logs are added', async () => {
       render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedRunId="run-123"
-        />
+        <ChatInput onSendMessage={mockSendMessage} selectedRunId="run-123" />
       );
 
-      // Enable logs checkbox
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-      await userEvent.click(logsCheckbox);
+      await toggleContext(/send run logs/i);
 
       const textarea = screen.getByPlaceholderText('Ask me anything...');
       await userEvent.type(textarea, 'Test{Enter}');
 
       expect(mockSendMessage).toHaveBeenCalledWith('Test', {
         attach_logs: true,
+        attach_io_data: false,
         follow_run_id: 'run-123',
       });
     });
 
-    it('should include attach_io_data and step_id when step is selected', async () => {
+    it('should include attach_io_data when run data is added', async () => {
       render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedStepId="step-123"
-        />
+        <ChatInput onSendMessage={mockSendMessage} selectedRunId="run-123" />
       );
 
-      // Enable I/O data checkbox
-      const ioCheckbox = screen.getByRole('checkbox', {
-        name: /send scrubbed i\/o/i,
-      });
-      await userEvent.click(ioCheckbox);
+      await toggleContext(/send run data/i);
 
       const textarea = screen.getByPlaceholderText('Ask me anything...');
       await userEvent.type(textarea, 'Test{Enter}');
 
       expect(mockSendMessage).toHaveBeenCalledWith('Test', {
+        attach_logs: false,
         attach_io_data: true,
-        step_id: 'step-123',
-      });
-    });
-
-    it('should include all options when job, run, and step are selected', async () => {
-      render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedJobId="job-123"
-          selectedRunId="run-123"
-          selectedStepId="step-123"
-        />
-      );
-
-      // Enable logs and I/O data checkboxes
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-      const ioCheckbox = screen.getByRole('checkbox', {
-        name: /send scrubbed i\/o/i,
-      });
-      await userEvent.click(logsCheckbox);
-      await userEvent.click(ioCheckbox);
-
-      const textarea = screen.getByPlaceholderText('Ask me anything...');
-      await userEvent.type(textarea, 'Test{Enter}');
-
-      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_code: true,
-        attach_logs: true,
-        follow_run_id: 'run-123',
-        attach_io_data: true,
-        step_id: 'step-123',
-      });
-    });
-
-    it('should toggle attach_code checkbox when job is selected', async () => {
-      render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedJobId="job-123"
-        />
-      );
-
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-
-      // Default should be checked when job is selected
-      expect(codeCheckbox).toBeChecked();
-
-      // Uncheck
-      await userEvent.click(codeCheckbox);
-      expect(codeCheckbox).not.toBeChecked();
-
-      // Send message
-      const textarea = screen.getByPlaceholderText('Ask me anything...');
-      await userEvent.type(textarea, 'Test{Enter}');
-
-      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_code: false,
-      });
-    });
-
-    it('should toggle attach_logs checkbox when run is selected', async () => {
-      render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedRunId="run-123"
-        />
-      );
-
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-
-      // Default should be unchecked
-      expect(logsCheckbox).not.toBeChecked();
-
-      // Check
-      await userEvent.click(logsCheckbox);
-      expect(logsCheckbox).toBeChecked();
-
-      // Send message
-      const textarea = screen.getByPlaceholderText('Ask me anything...');
-      await userEvent.type(textarea, 'Test{Enter}');
-
-      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_logs: true,
         follow_run_id: 'run-123',
       });
     });
 
-    it('should not include options when showJobControls is false', async () => {
+    it('should send no attachment options when no run is loaded', async () => {
       render(
-        <ChatInput onSendMessage={mockSendMessage} showJobControls={false} />
+        <ChatInput onSendMessage={mockSendMessage} selectedRunId={null} />
       );
 
       const textarea = screen.getByPlaceholderText('Ask me anything...');
       await userEvent.type(textarea, 'Test{Enter}');
 
+      // A step without a run cannot be attached, so nothing goes.
       expect(mockSendMessage).toHaveBeenCalledWith('Test', {});
-    });
-
-    it('should not include attach_code when no job is selected', async () => {
-      render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedJobId={null}
-          selectedRunId="run-123"
-        />
-      );
-
-      // Enable logs
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-      await userEvent.click(logsCheckbox);
-
-      const textarea = screen.getByPlaceholderText('Ask me anything...');
-      await userEvent.type(textarea, 'Test{Enter}');
-
-      // Should only have attach_logs, not attach_code
-      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_logs: true,
-        follow_run_id: 'run-123',
-      });
-    });
-
-    it('should not include attach_logs when no run is selected', async () => {
-      render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedJobId="job-123"
-          selectedRunId={null}
-        />
-      );
-
-      const textarea = screen.getByPlaceholderText('Ask me anything...');
-      await userEvent.type(textarea, 'Test{Enter}');
-
-      // Should only have attach_code, not attach_logs
-      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_code: true,
-      });
-    });
-
-    it('should not include attach_io_data when no step is selected', async () => {
-      render(
-        <ChatInput
-          onSendMessage={mockSendMessage}
-          showJobControls
-          selectedJobId="job-123"
-          selectedStepId={null}
-        />
-      );
-
-      const textarea = screen.getByPlaceholderText('Ask me anything...');
-      await userEvent.type(textarea, 'Test{Enter}');
-
-      // Should only have attach_code, not attach_io_data
-      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
-        attach_code: true,
-      });
     });
   });
 
-  describe('Checkbox Disabled States', () => {
-    it('should disable and uncheck code checkbox when no job is selected', () => {
-      render(<ChatInput showJobControls selectedJobId={null} />);
+  describe('Attached Context', () => {
+    it('should tick only the box that was clicked', async () => {
+      render(<ChatInput selectedRunId="run-123" />);
 
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
+      await toggleContext(/send run logs/i);
 
-      expect(codeCheckbox).toBeDisabled();
-      expect(codeCheckbox).not.toBeChecked();
+      const controls = screen.getByTestId('attached-context');
+      expect(
+        within(controls).getByRole('checkbox', { name: /send run logs/i })
+      ).toBeChecked();
+      expect(
+        within(controls).getByRole('checkbox', { name: /send run data/i })
+      ).not.toBeChecked();
     });
 
-    it('should enable and check code checkbox when job is selected', () => {
-      render(<ChatInput showJobControls selectedJobId="job-123" />);
-
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-
-      expect(codeCheckbox).toBeEnabled();
-      expect(codeCheckbox).toBeChecked(); // Default is true
-    });
-
-    it('should disable and uncheck logs checkbox when no run is selected', () => {
-      render(<ChatInput showJobControls selectedRunId={null} />);
-
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-
-      expect(logsCheckbox).toBeDisabled();
-      expect(logsCheckbox).not.toBeChecked();
-    });
-
-    it('should enable logs checkbox when run is selected', () => {
-      render(<ChatInput showJobControls selectedRunId="run-123" />);
-
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-
-      expect(logsCheckbox).toBeEnabled();
-      // Default is unchecked, but it should be enabled
-      expect(logsCheckbox).not.toBeChecked();
-    });
-
-    it('should disable and uncheck I/O data checkbox when no step is selected', () => {
-      render(<ChatInput showJobControls selectedStepId={null} />);
-
-      const ioCheckbox = screen.getByRole('checkbox', {
-        name: /send scrubbed i\/o/i,
-      });
-
-      expect(ioCheckbox).toBeDisabled();
-      expect(ioCheckbox).not.toBeChecked();
-    });
-
-    it('should enable I/O data checkbox when step is selected', () => {
-      render(<ChatInput showJobControls selectedStepId="step-123" />);
-
-      const ioCheckbox = screen.getByRole('checkbox', {
-        name: /send scrubbed i\/o/i,
-      });
-
-      expect(ioCheckbox).toBeEnabled();
-      // Default is unchecked, but it should be enabled
-      expect(ioCheckbox).not.toBeChecked();
-    });
-
-    it('should show unchecked even if preference is true when disabled', () => {
-      // Set preference to true in localStorage
-      localStorage.setItem('test-key:attach-code', 'true');
-      localStorage.setItem('test-key:attach-logs', 'true');
-      localStorage.setItem('test-key:attach-io-data', 'true');
-
+    it('should untick on a second click', async () => {
       render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedJobId={null}
-          selectedRunId={null}
-          selectedStepId={null}
-        />
+        <ChatInput onSendMessage={mockSendMessage} selectedRunId="run-1" />
       );
 
-      // All checkboxes should be unchecked even though preferences are true
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-      const ioCheckbox = screen.getByRole('checkbox', {
-        name: /send scrubbed i\/o/i,
-      });
+      await toggleContext(/send run logs/i);
+      await toggleContext(/send run logs/i);
 
-      expect(codeCheckbox).not.toBeChecked();
-      expect(logsCheckbox).not.toBeChecked();
-      expect(ioCheckbox).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: /send run logs/i })
+      ).not.toBeChecked();
+
+      const textarea = screen.getByPlaceholderText('Ask me anything...');
+      await userEvent.type(textarea, 'Test{Enter}');
+
+      expect(mockSendMessage).toHaveBeenCalledWith('Test', {
+        attach_logs: false,
+        attach_io_data: false,
+        follow_run_id: 'run-1',
+      });
     });
 
-    it('should restore checked state when selection is provided after being disabled', async () => {
-      localStorage.setItem('test-key:attach-code', 'true');
+    it('should claim nothing when there is no run, whatever was remembered', () => {
+      localStorage.setItem('test-key:attach-logs', 'true');
+      localStorage.setItem('test-key:attach-run-data', 'true');
+
+      // A step on its own is not enough: both attachments are run-scoped.
+      render(<ChatInput storageKey="test-key" selectedRunId={null} />);
+
+      expect(screen.queryByTestId('attached-context')).not.toBeInTheDocument();
+    });
+
+    it('should bring the remembered attachments back when a run arrives', async () => {
+      localStorage.setItem('test-key:attach-logs', 'true');
 
       const { rerender } = render(
-        <ChatInput showJobControls storageKey="test-key" selectedJobId={null} />
+        <ChatInput storageKey="test-key" selectedRunId={null} />
       );
 
-      // Initially disabled and unchecked
-      const disabledCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-      expect(disabledCheckbox).toBeDisabled();
-      expect(disabledCheckbox).not.toBeChecked();
+      expect(screen.queryByTestId('attached-context')).not.toBeInTheDocument();
 
-      // Provide job selection
-      rerender(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedJobId="job-123"
-        />
-      );
+      rerender(<ChatInput storageKey="test-key" selectedRunId="run-123" />);
 
-      // Re-query after rerender - now should be enabled and checked (from preference)
       await waitFor(() => {
-        const enabledCheckbox = screen.getByRole('checkbox', {
-          name: /send code/i,
-        });
-        expect(enabledCheckbox).toBeEnabled();
-        expect(enabledCheckbox).toBeChecked();
+        expect(
+          screen.getByRole('checkbox', { name: /send run logs/i })
+        ).toBeChecked();
       });
     });
   });
 
   describe('LocalStorage Persistence', () => {
-    it('should load attach_code preference from localStorage', () => {
-      localStorage.setItem('test-key:attach-code', 'false');
-
-      render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedJobId="job-123"
-        />
-      );
-
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-      expect(codeCheckbox).not.toBeChecked();
-    });
-
-    it('should load attach_logs preference from localStorage', () => {
+    it('should load remembered attachments from localStorage', () => {
       localStorage.setItem('test-key:attach-logs', 'true');
+      localStorage.setItem('test-key:attach-run-data', 'true');
 
-      render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedRunId="run-123"
-        />
-      );
+      render(<ChatInput storageKey="test-key" selectedRunId="run-123" />);
 
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-      expect(logsCheckbox).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: /send run logs/i })
+      ).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: /send run data/i })
+      ).toBeChecked();
     });
 
-    it('should default to attach_code=true when not in localStorage', () => {
-      render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedJobId="job-123"
-        />
-      );
+    it('should attach nothing by default', () => {
+      render(<ChatInput storageKey="test-key" selectedRunId="run-123" />);
 
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-      expect(codeCheckbox).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: /send run logs/i })
+      ).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: /send run data/i })
+      ).not.toBeChecked();
     });
 
-    it('should default to attach_logs=false when not in localStorage', () => {
-      render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedRunId="run-123"
-        />
-      );
+    it('should save each attachment to localStorage', async () => {
+      render(<ChatInput storageKey="test-key" selectedRunId="run-123" />);
 
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-      expect(logsCheckbox).not.toBeChecked();
-    });
-
-    it('should save attach_code preference to localStorage', async () => {
-      render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedJobId="job-123"
-        />
-      );
-
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-
-      await userEvent.click(codeCheckbox);
-
-      await waitFor(() => {
-        expect(localStorage.getItem('test-key:attach-code')).toBe('false');
-      });
-    });
-
-    it('should save attach_logs preference to localStorage', async () => {
-      render(
-        <ChatInput
-          showJobControls
-          storageKey="test-key"
-          selectedRunId="run-123"
-        />
-      );
-
-      const logsCheckbox = screen.getByRole('checkbox', {
-        name: /send logs/i,
-      });
-
-      await userEvent.click(logsCheckbox);
-
+      await toggleContext(/send run logs/i);
       await waitFor(() => {
         expect(localStorage.getItem('test-key:attach-logs')).toBe('true');
+      });
+
+      await toggleContext(/send run data/i);
+      await waitFor(() => {
+        expect(localStorage.getItem('test-key:attach-run-data')).toBe('true');
       });
     });
 
     it('should update preferences when storageKey changes', async () => {
-      localStorage.setItem('key-1:attach-code', 'false');
-      localStorage.setItem('key-2:attach-code', 'true');
+      localStorage.setItem('key-1:attach-logs', 'false');
+      localStorage.setItem('key-2:attach-logs', 'true');
 
       const { rerender } = render(
-        <ChatInput showJobControls storageKey="key-1" selectedJobId="job-123" />
+        <ChatInput storageKey="key-1" selectedRunId="run-123" />
       );
 
-      const codeCheckbox = screen.getByRole('checkbox', {
-        name: /send code/i,
-      });
-      expect(codeCheckbox).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: /send run logs/i })
+      ).not.toBeChecked();
 
       // Change storageKey
-      rerender(
-        <ChatInput showJobControls storageKey="key-2" selectedJobId="job-123" />
-      );
+      rerender(<ChatInput storageKey="key-2" selectedRunId="run-123" />);
 
       await waitFor(() => {
-        expect(codeCheckbox).toBeChecked();
+        expect(
+          screen.getByRole('checkbox', { name: /send run logs/i })
+        ).toBeChecked();
       });
     });
 
@@ -768,7 +475,7 @@ describe('ChatInput', () => {
 
       // Should not crash
       expect(() => {
-        render(<ChatInput showJobControls storageKey="test-key" />);
+        render(<ChatInput storageKey="test-key" />);
       }).not.toThrow();
 
       // Restore

--- a/assets/test/collaborative-editor/hooks/useAIInitialMessage.test.tsx
+++ b/assets/test/collaborative-editor/hooks/useAIInitialMessage.test.tsx
@@ -60,7 +60,7 @@ describe('useAIInitialMessage', () => {
 
   const jobCodeMode: AIModeResult = {
     mode: 'job_code',
-    context: { job_id: 'job-1', attach_code: false, attach_logs: false },
+    context: { job_id: 'job-1', attach_logs: false },
     storageKey: 'ai-job-job-1',
   };
 

--- a/assets/test/collaborative-editor/hooks/useAIMode.test.tsx
+++ b/assets/test/collaborative-editor/hooks/useAIMode.test.tsx
@@ -108,7 +108,6 @@ describe('useAIMode', () => {
           project_id: 'project-123',
           workflow_id: 'workflow-123',
           job_id: 'job-456',
-          attach_code: false,
           attach_logs: false,
         },
         storageKey: 'ai-workflow-workflow-123',
@@ -137,7 +136,6 @@ describe('useAIMode', () => {
         project_id: 'project-123',
         workflow_id: 'workflow-123',
         job_id: 'job-456',
-        attach_code: false,
         attach_logs: false,
         job_name: 'Test Job',
         job_body: 'fn(state => state);',
@@ -160,7 +158,6 @@ describe('useAIMode', () => {
         project_id: 'project-123',
         workflow_id: 'workflow-123',
         job_id: 'job-456',
-        attach_code: false,
         attach_logs: false,
         // No job_name, job_body, job_adaptor for unsaved job
       });

--- a/assets/test/collaborative-editor/hooks/useAISession.test.tsx
+++ b/assets/test/collaborative-editor/hooks/useAISession.test.tsx
@@ -76,7 +76,6 @@ describe('useAISession', () => {
     it('should update context when job changes', () => {
       const initialContext: JobCodeContext = {
         job_id: 'job-1',
-        attach_code: false,
         attach_logs: false,
       };
 
@@ -118,7 +117,6 @@ describe('useAISession', () => {
       // Set up initial subscription by first render with a session
       const initialContext: JobCodeContext = {
         job_id: 'job-1',
-        attach_code: false,
         attach_logs: false,
       };
 
@@ -153,7 +151,6 @@ describe('useAISession', () => {
     it('should re-initialize context when job changes', () => {
       const initialContext: JobCodeContext = {
         job_id: 'job-1',
-        attach_code: false,
         attach_logs: false,
       };
 
@@ -195,7 +192,6 @@ describe('useAISession', () => {
       // Start with job-1 in context
       mockStore._initializeContext('workflow_template', {
         job_id: 'job-old',
-        attach_code: false,
         attach_logs: false,
       });
 
@@ -208,7 +204,6 @@ describe('useAISession', () => {
               page: 'job_code',
               context: {
                 job_id: props.jobId,
-                attach_code: false,
                 attach_logs: false,
               },
             },
@@ -226,7 +221,6 @@ describe('useAISession', () => {
         'workflow_template',
         {
           job_id: 'job-new',
-          attach_code: false,
           attach_logs: false,
         }
       );
@@ -244,7 +238,7 @@ describe('useAISession', () => {
               page: props.page,
               context:
                 props.page === 'job_code'
-                  ? { job_id: 'job-1', attach_code: false, attach_logs: false }
+                  ? { job_id: 'job-1', attach_logs: false }
                   : { project_id: 'proj-1', workflow_id: 'wf-1' },
             },
             sessionIdFromURL: null,
@@ -281,7 +275,6 @@ describe('useAISession', () => {
               page: 'job_code',
               context: {
                 job_id: 'job-1',
-                attach_code: false,
                 attach_logs: false,
               },
             },
@@ -314,7 +307,6 @@ describe('useAISession', () => {
               page: 'job_code',
               context: {
                 job_id: 'job-1',
-                attach_code: false,
                 attach_logs: false,
               },
             },
@@ -339,7 +331,6 @@ describe('useAISession', () => {
               page: 'job_code',
               context: {
                 job_id: 'job-1',
-                attach_code: false,
                 attach_logs: false,
               },
             },

--- a/assets/test/collaborative-editor/hooks/useAutoPreview.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAutoPreview.test.ts
@@ -27,7 +27,6 @@ describe('useAutoPreview', () => {
       job_id: 'job-1',
       job_body: '',
       job_adaptor: '@openfn/language-common',
-      attach_code: false,
       attach_logs: false,
     },
     storageKey: 'ai-job-job-1',

--- a/assets/test/collaborative-editor/lib/AIChannelRegistry.test.ts
+++ b/assets/test/collaborative-editor/lib/AIChannelRegistry.test.ts
@@ -11,7 +11,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { AIChannelRegistry } from '../../../js/collaborative-editor/lib/AIChannelRegistry';
 import { createAIAssistantStore } from '../../../js/collaborative-editor/stores/createAIAssistantStore';
-import type { AIAssistantStore } from '../../../js/collaborative-editor/types/ai-assistant';
+import type {
+  AIAssistantStore,
+  WorkflowTemplateContext,
+} from '../../../js/collaborative-editor/types/ai-assistant';
 import { createMockJobCodeContext } from '../__helpers__/aiAssistantHelpers';
 import { createMockPhoenixChannel } from '../mocks/phoenixChannel';
 import type { MockPhoenixChannel } from '../mocks/phoenixChannel';
@@ -287,5 +290,81 @@ describe('AIChannelRegistry streaming', () => {
     expect(store.getSnapshot().streamingSegments).toEqual([
       { type: 'text', content: 'New' },
     ]);
+  });
+});
+
+describe('AIChannelRegistry join params', () => {
+  type RegistryArgs = ConstructorParameters<typeof AIChannelRegistry>;
+
+  const joinParamsFor = (context: WorkflowTemplateContext) => {
+    const store = createAIAssistantStore();
+    const channel = createMockPhoenixChannel(
+      'ai_assistant:workflow_template:new'
+    );
+    const channelFn = vi.fn(
+      (_topic: string, _params: Record<string, unknown>) => channel
+    );
+
+    const socket = {
+      channel: channelFn,
+      isConnected: () => true,
+    } as unknown as RegistryArgs[0];
+
+    const registry = new AIChannelRegistry(
+      socket,
+      store as unknown as RegistryArgs[1]
+    );
+
+    registry.subscribe(
+      'ai_assistant:workflow_template:new',
+      'subscriber-1',
+      context
+    );
+    registry.destroy();
+
+    return channelFn.mock.calls[0]?.[1];
+  };
+
+  // The join is the only way a session's first message reaches the server, so
+  // anything the user attached has to ride on it. It used to ride only when a
+  // step was open, which lost the run context for anyone asking from canvas.
+  it('forwards the run attachments without a job in context', () => {
+    const params = joinParamsFor({
+      project_id: 'project-1',
+      workflow_id: 'workflow-1',
+      content: 'what went wrong?',
+      use_global_assistant: true,
+      follow_run_id: 'run-1',
+      attach_logs: true,
+      attach_io_data: true,
+      step_id: 'step-1',
+    });
+
+    expect(params).toMatchObject({
+      follow_run_id: 'run-1',
+      attach_logs: true,
+      attach_io_data: true,
+      step_id: 'step-1',
+    });
+  });
+
+  it('still forwards them with a job in context', () => {
+    const params = joinParamsFor({
+      job_id: 'job-1',
+      project_id: 'project-1',
+      content: 'what went wrong?',
+      follow_run_id: 'run-1',
+      attach_logs: true,
+      attach_io_data: true,
+      step_id: 'step-1',
+    });
+
+    expect(params).toMatchObject({
+      job_id: 'job-1',
+      follow_run_id: 'run-1',
+      attach_logs: true,
+      attach_io_data: true,
+      step_id: 'step-1',
+    });
   });
 });

--- a/assets/test/collaborative-editor/types/sessionContext.test.ts
+++ b/assets/test/collaborative-editor/types/sessionContext.test.ts
@@ -354,7 +354,6 @@ describe.concurrent('SessionContextResponseSchema', () => {
       project_repo_connection: null,
       webhook_auth_methods: [],
       workflow_template: null,
-      experimental_features_enabled: false,
     };
 
     const result = SessionContextResponseSchema.safeParse(validResponse);

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -852,9 +852,6 @@ defmodule Lightning.AiAssistant do
   defp build_context(context, opts) do
     Enum.reduce(opts, context, fn opt, acc ->
       case opt do
-        {:code, false} ->
-          Map.drop(acc, [:expression])
-
         {:log, false} ->
           Map.drop(acc, [:log])
 
@@ -1254,11 +1251,11 @@ defmodule Lightning.AiAssistant do
     control =
       case details do
         %{"largest_attachment" => %{"type" => "log"}} ->
-          "“Send logs”"
+          "“Send run logs”"
 
         %{"largest_attachment" => %{"type" => dataclip}}
         when dataclip in ["input_dataclip", "output_dataclip"] ->
-          "“Send scrubbed I/O”"
+          "“Send run data”"
 
         _ ->
           nil

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -179,7 +179,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     log_attachments(opts["log"] == true, run_id, session.project_id) ++
       io_attachments(
         opts["attach_io_data"] == true,
-        opts["step_id"],
+        run_id,
         session.project_id
       )
   end
@@ -202,30 +202,53 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
   defp log_attachments(_attach, _run_id, _project_id), do: []
 
-  defp io_attachments(true, step_id, project_id) when is_binary(step_id) do
-    case Ecto.UUID.cast(step_id) do
-      {:ok, uuid} ->
-        {input, output} = fetch_and_scrub_io_data(uuid, project_id)
-
-        if is_nil(input) and is_nil(output) do
-          warn_unresolved("I/O data", step: step_id, project: project_id)
-        end
-
-        attachment("input_dataclip", input) ++
-          attachment("output_dataclip", output)
-
-      :error ->
-        warn_unresolved("I/O data", step: step_id)
+  # The whole run, to match the logs beside it. A user reading a run asks about
+  # the run, and the step they happen to have highlighted is rarely the one the
+  # answer turns on.
+  defp io_attachments(true, run_id, project_id) when is_binary(run_id) do
+    case Invocation.scrubbed_io_for_run(run_id, project_id) do
+      # No steps at all: either the run is not this project's, or it has yet
+      # to start one. Worth a look, unlike the case below.
+      [] ->
+        warn_unresolved("I/O data", run: run_id, project: project_id)
         []
+
+      steps ->
+        # A run with steps can still have nothing to attach, when none of them
+        # kept a dataclip. Ordinary, and worth telling apart from the above.
+        case Enum.flat_map(steps, &step_io_attachments/1) do
+          [] ->
+            warn_no_data(run_id, project_id, length(steps))
+            []
+
+          attachments ->
+            attachments
+        end
     end
   end
 
-  defp io_attachments(true, step_id, _project_id) do
-    warn_unresolved("I/O data", step: step_id)
+  defp io_attachments(true, run_id, _project_id) do
+    warn_unresolved("I/O data", run: run_id)
     []
   end
 
-  defp io_attachments(_attach, _step_id, _project_id), do: []
+  defp io_attachments(_attach, _run_id, _project_id), do: []
+
+  # The step name rides inside the content rather than beside it, because
+  # Apollo prints an attachment as its type and its content and nothing else.
+  # Without it a run of five steps arrives as ten blocks that cannot be told
+  # apart.
+  defp step_io_attachments(step) do
+    attachment("input_dataclip", step.step_name, step.input) ++
+      attachment("output_dataclip", step.step_name, step.output)
+  end
+
+  defp warn_no_data(run_id, project_id, steps) do
+    Logger.warning(
+      "[AI Assistant] I/O data requested but the run's steps kept none " <>
+        "(#{inspect(run: run_id, project: project_id, steps: steps)})"
+    )
+  end
 
   # The assistant answers from context the user believes it has.
   defp warn_unresolved(what, context) do
@@ -235,8 +258,12 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     )
   end
 
-  defp attachment(_type, nil), do: []
-  defp attachment(type, content), do: [%{"type" => type, "content" => content}]
+  defp attachment(_type, _step_name, nil), do: []
+
+  defp attachment(type, step_name, content),
+    do: [
+      %{"type" => type, "content" => %{"step" => step_name, "data" => content}}
+    ]
 
   @spec job_chat?(AiAssistant.ChatSession.t(), ChatMessage.t()) :: boolean()
   defp job_chat?(session, message) do

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -202,20 +202,15 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
   defp log_attachments(_attach, _run_id, _project_id), do: []
 
-  # The whole run, to match the logs beside it. A user reading a run asks about
-  # the run, and the step they happen to have highlighted is rarely the one the
-  # answer turns on.
   defp io_attachments(true, run_id, project_id) when is_binary(run_id) do
     case Invocation.scrubbed_io_for_run(run_id, project_id) do
-      # No steps at all: either the run is not this project's, or it has yet
-      # to start one. Worth a look, unlike the case below.
+      # No steps: the run is not this project's, or has yet to start one.
       [] ->
         warn_unresolved("I/O data", run: run_id, project: project_id)
         []
 
       steps ->
-        # A run with steps can still have nothing to attach, when none of them
-        # kept a dataclip. Ordinary, and worth telling apart from the above.
+        # Steps that kept no dataclip. Ordinary, unlike the case above.
         case Enum.flat_map(steps, &step_io_attachments/1) do
           [] ->
             warn_no_data(run_id, project_id, length(steps))
@@ -234,10 +229,8 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
   defp io_attachments(_attach, _run_id, _project_id), do: []
 
-  # The step name rides inside the content rather than beside it, because
-  # Apollo prints an attachment as its type and its content and nothing else.
-  # Without it a run of five steps arrives as ten blocks that cannot be told
-  # apart.
+  # The name goes inside the content because Apollo renders an attachment as
+  # its type and its content, and nothing else.
   defp step_io_attachments(step) do
     attachment("input_dataclip", step.step_name, step.input) ++
       attachment("output_dataclip", step.step_name, step.output)

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -30,14 +30,10 @@ defmodule Lightning.Invocation do
   @logs_byte_budget 300_000
   @logs_line_overhead 150
 
-  # Scrubbing collapses a dataclip to its shape, so a whole run's worth costs
-  # far less than the rows it came from. The budget is on what comes out, give
-  # or take the step that crosses it, which is read whole before its size is
-  # known.
+  # On the scrubbed output, and the step that crosses it is read whole.
   @io_byte_budget 100_000
 
-  # A body still has to be read before it can be collapsed. Anything past this
-  # is described rather than read: no shape needs a megabyte to state.
+  # Past this a body is described rather than read.
   @io_dataclip_byte_cap 1_000_000
 
   @io_erased "[erased by this project's retention policy]"
@@ -1023,9 +1019,7 @@ defmodule Lightning.Invocation do
       join: w in assoc(wo, :workflow),
       left_join: j in assoc(s, :job),
       where: rs.run_id == ^run_id and w.project_id == ^project_id,
-      # Execution order, so the run reads the way it ran. A step that never
-      # started has no start time, so the row's own age breaks the tie; the id
-      # is last only to make the order total.
+      # A step that never started has no start time, so age breaks the tie.
       order_by: [asc_nulls_last: s.started_at, asc: s.inserted_at, asc: s.id],
       select: %{
         step_name: j.name,
@@ -1036,9 +1030,7 @@ defmodule Lightning.Invocation do
     |> Repo.all()
   end
 
-  # Past the budget the run still reads as a sequence, it just says where it
-  # stopped. Dropping the rest silently would leave a reader summarising three
-  # steps of six as though that were the whole run.
+  # Past the budget a step still appears, saying why it was not read.
   defp take_io_within_budget(step, size) when size > @io_byte_budget do
     entry = %{
       step_name: step.step_name,
@@ -1061,11 +1053,9 @@ defmodule Lightning.Invocation do
 
   defp scrubbed_body(nil), do: nil
 
-  # One body at a time, so a long run never holds more than one in memory, and
-  # the size test runs in Postgres so an oversized one is not sent to the BEAM
-  # at all. It measures the JSON rather than the row: pg_column_size reports
-  # the compressed datum, which on the repetitive data these workflows carry is
-  # smaller than the real body by a factor of tens.
+  # One body at a time, and sized in Postgres so an oversized one never reaches
+  # the BEAM. octet_length measures the JSON; pg_column_size would measure the
+  # compressed datum, which on this data is smaller by a factor of tens.
   defp scrubbed_body(dataclip_id) do
     query =
       from(d in Dataclip,
@@ -1106,8 +1096,7 @@ defmodule Lightning.Invocation do
   defp over_budget(_dataclip_id), do: @io_over_budget
 
   defp io_entry_size(entry) do
-    # Scrubbing leaves only strings, numbers, booleans, nil, lists and maps
-    # with string keys, so this cannot fail on anything it is given.
+    # Scrubbed output is always encodable.
     entry |> Jason.encode!() |> byte_size()
   end
 

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -15,6 +15,8 @@ defmodule Lightning.Invocation do
   alias Lightning.Projects.Project
   alias Lightning.Repo
   alias Lightning.Run
+  alias Lightning.RunStep
+  alias Lightning.Scrubber
   alias Lightning.Workflows.Edge
   alias Lightning.Workflows.Job
   alias Lightning.Workflows.Trigger
@@ -27,6 +29,20 @@ defmodule Lightning.Invocation do
   # payload that would have been accepted is never shortened here.
   @logs_byte_budget 300_000
   @logs_line_overhead 150
+
+  # Scrubbing collapses a dataclip to its shape, so a whole run's worth costs
+  # far less than the rows it came from. The budget is on what comes out, give
+  # or take the step that crosses it, which is read whole before its size is
+  # known.
+  @io_byte_budget 100_000
+
+  # A body still has to be read before it can be collapsed. Anything past this
+  # is described rather than read: no shape needs a megabyte to state.
+  @io_dataclip_byte_cap 1_000_000
+
+  @io_erased "[erased by this project's retention policy]"
+  @io_too_large "[too large to summarise]"
+  @io_over_budget "[not read, the run's data ran past what can be sent]"
 
   @workorders_search_timeout 30_000
   @workorders_count_limit 50
@@ -965,6 +981,134 @@ defmodule Lightning.Invocation do
     else
       {:cont, {lines, size}}
     end
+  end
+
+  @doc """
+  Return the input and output of every step in a run, oldest first, with the
+  values replaced by their types.
+
+  What comes back is the shape of the data rather than the data: every leaf
+  becomes `"string"`, `"number"`, `"boolean"`, `"null"` or `"unknown"`, and
+  long lists keep two samples. Field names survive as they are, capped in
+  number. See `Lightning.Scrubber.scrub_values/2`.
+
+  Every step in the run comes back, in the order it ran. A dataclip that was
+  never set comes back as nil; one that is erased, too large to read, or past
+  the point where the run stopped fitting comes back as a short sentence saying
+  so, because a reader that is told nothing assumes it saw everything.
+  """
+  @spec scrubbed_io_for_run(Ecto.UUID.t() | String.t(), Ecto.UUID.t() | nil) ::
+          [map()]
+  def scrubbed_io_for_run(_run_id, nil), do: []
+
+  def scrubbed_io_for_run(run_id, project_id) do
+    case Ecto.UUID.cast(run_id) do
+      {:ok, uuid} -> scrubbed_io_for_run_id(uuid, project_id)
+      :error -> []
+    end
+  end
+
+  defp scrubbed_io_for_run_id(run_id, project_id) do
+    run_id
+    |> io_steps_for_run(project_id)
+    |> Enum.map_reduce(0, &take_io_within_budget/2)
+    |> elem(0)
+  end
+
+  defp io_steps_for_run(run_id, project_id) do
+    from(rs in RunStep,
+      join: s in assoc(rs, :step),
+      join: r in assoc(rs, :run),
+      join: wo in assoc(r, :work_order),
+      join: w in assoc(wo, :workflow),
+      left_join: j in assoc(s, :job),
+      where: rs.run_id == ^run_id and w.project_id == ^project_id,
+      # Execution order, so the run reads the way it ran. A step that never
+      # started has no start time, so the row's own age breaks the tie; the id
+      # is last only to make the order total.
+      order_by: [asc_nulls_last: s.started_at, asc: s.inserted_at, asc: s.id],
+      select: %{
+        step_name: j.name,
+        input_dataclip_id: s.input_dataclip_id,
+        output_dataclip_id: s.output_dataclip_id
+      }
+    )
+    |> Repo.all()
+  end
+
+  # Past the budget the run still reads as a sequence, it just says where it
+  # stopped. Dropping the rest silently would leave a reader summarising three
+  # steps of six as though that were the whole run.
+  defp take_io_within_budget(step, size) when size > @io_byte_budget do
+    entry = %{
+      step_name: step.step_name,
+      input: over_budget(step.input_dataclip_id),
+      output: over_budget(step.output_dataclip_id)
+    }
+
+    {entry, size + io_entry_size(entry)}
+  end
+
+  defp take_io_within_budget(step, size) do
+    entry = %{
+      step_name: step.step_name,
+      input: scrubbed_body(step.input_dataclip_id),
+      output: scrubbed_body(step.output_dataclip_id)
+    }
+
+    {entry, size + io_entry_size(entry)}
+  end
+
+  defp scrubbed_body(nil), do: nil
+
+  # One body at a time, so a long run never holds more than one in memory, and
+  # the size test runs in Postgres so an oversized one is not sent to the BEAM
+  # at all. It measures the JSON rather than the row: pg_column_size reports
+  # the compressed datum, which on the repetitive data these workflows carry is
+  # smaller than the real body by a factor of tens.
+  defp scrubbed_body(dataclip_id) do
+    query =
+      from(d in Dataclip,
+        where: d.id == ^dataclip_id,
+        select: %{
+          wiped: not is_nil(d.wiped_at),
+          empty: is_nil(d.body),
+          too_large:
+            fragment(
+              "? IS NULL AND octet_length(?::text) > ?",
+              d.wiped_at,
+              d.body,
+              ^@io_dataclip_byte_cap
+            ),
+          body:
+            fragment(
+              "CASE WHEN ? IS NULL AND octet_length(?::text) <= ? THEN ? END",
+              d.wiped_at,
+              d.body,
+              ^@io_dataclip_byte_cap,
+              d.body
+            )
+        }
+      )
+
+    # A body of JSON null decodes to the same nil as an absent one, so which it
+    # was has to be asked of Postgres rather than inferred here.
+    case Repo.one(query) do
+      nil -> nil
+      %{wiped: true} -> @io_erased
+      %{empty: true} -> nil
+      %{too_large: true} -> @io_too_large
+      %{body: body} -> Scrubber.scrub_values(body)
+    end
+  end
+
+  defp over_budget(nil), do: nil
+  defp over_budget(_dataclip_id), do: @io_over_budget
+
+  defp io_entry_size(entry) do
+    # Scrubbing leaves only strings, numbers, booleans, nil, lists and maps
+    # with string keys, so this cannot fail on anything it is given.
+    entry |> Jason.encode!() |> byte_size()
   end
 
   def assemble_logs_for_step(nil), do: nil

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -16,6 +16,18 @@ defmodule Lightning.Scrubber do
   """
   use Agent
 
+  # Wide enough that an ordinary record keeps its shape, narrow enough that a
+  # map keyed by identifier does not carry every identifier out.
+  @map_key_limit 50
+
+  # And a ceiling on the whole structure, since nesting multiplies the limit
+  # above by itself at every level.
+  @key_budget 500
+
+  # The budget counts keys, not their length, and a field name can be as long
+  # as the body. This bounds what a single one carries.
+  @max_key_length 200
+
   defmodule State do
     @moduledoc false
     @typep samples :: [String.t()]
@@ -165,7 +177,12 @@ defmodule Lightning.Scrubber do
 
   @doc """
   Recursively scrubs all values from a data structure, replacing them with type placeholders.
-  Preserves keys and structure while hiding actual values. Arrays are sampled up to `array_limit`
+  Keeps the structure and the field names, and hides the values.
+
+  Field names are not values and survive as they are, so a body keyed by
+  record identifier would carry those identifiers out. Long lists keep two
+  samples and keys are capped across the whole structure, and a map that was
+  truncated says how many it dropped under a `"..."` key. Arrays are sampled up to `array_limit`
   elements with a "...N more" indicator if truncated.
 
   ## Examples
@@ -175,36 +192,78 @@ defmodule Lightning.Scrubber do
 
       iex> scrub_values([1, 2, 3])
       ["number", "number", "...1 more"]
+
   """
   @spec scrub_values(any(), non_neg_integer()) :: any()
-  def scrub_values(value, array_limit \\ 2)
+  def scrub_values(value, array_limit \\ 2) do
+    {scrubbed, _left} = scrub_value(value, array_limit, @key_budget)
+    scrubbed
+  end
 
-  def scrub_values(nil, _array_limit), do: "null"
+  defp scrub_value(nil, _array_limit, budget), do: {"null", budget}
 
-  def scrub_values([], _array_limit), do: []
+  defp scrub_value([], _array_limit, budget), do: {[], budget}
 
-  def scrub_values(list, array_limit) when is_list(list) do
-    samples =
+  defp scrub_value(list, array_limit, budget) when is_list(list) do
+    {samples, budget} =
       list
       |> Enum.take(array_limit)
-      |> Enum.map(&scrub_values(&1, array_limit))
+      |> Enum.map_reduce(budget, &scrub_value(&1, array_limit, &2))
 
     remaining = length(list) - array_limit
 
     if remaining > 0 do
-      samples ++ ["...#{remaining} more"]
+      {samples ++ ["...#{remaining} more"], budget}
     else
-      samples
+      {samples, budget}
     end
   end
 
-  def scrub_values(map, array_limit) when is_map(map) do
-    Map.new(map, fn {key, value} -> {key, scrub_values(value, array_limit)} end)
+  # Keys are not values and survive as they are, so a map keyed by record
+  # identifier carries those identifiers out with it. The budget is spent
+  # across the whole structure rather than per map, because fifty keys at each
+  # of four levels is still millions of them.
+  defp scrub_value(map, array_limit, budget) when is_map(map) do
+    {kept, dropped} =
+      map
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.split(min(budget, @map_key_limit))
+
+    {pairs, budget} =
+      Enum.map_reduce(kept, budget - length(kept), fn {key, value}, left ->
+        {scrubbed, left} = scrub_value(value, array_limit, left)
+        {{truncate_key(key), scrubbed}, left}
+      end)
+
+    scrubbed = Map.new(pairs)
+
+    case length(dropped) do
+      0 -> {scrubbed, budget}
+      remaining -> {Map.put(scrubbed, "...", "#{remaining} more keys"), budget}
+    end
   end
 
-  def scrub_values(value, _array_limit) when is_binary(value), do: "string"
-  def scrub_values(value, _array_limit) when is_integer(value), do: "number"
-  def scrub_values(value, _array_limit) when is_float(value), do: "number"
-  def scrub_values(value, _array_limit) when is_boolean(value), do: "boolean"
-  def scrub_values(_value, _array_limit), do: "unknown"
+  defp scrub_value(value, _array_limit, budget) when is_binary(value),
+    do: {"string", budget}
+
+  defp scrub_value(value, _array_limit, budget) when is_integer(value),
+    do: {"number", budget}
+
+  defp scrub_value(value, _array_limit, budget) when is_float(value),
+    do: {"number", budget}
+
+  defp scrub_value(value, _array_limit, budget) when is_boolean(value),
+    do: {"boolean", budget}
+
+  defp scrub_value(_value, _array_limit, budget), do: {"unknown", budget}
+
+  defp truncate_key(key) when is_binary(key) do
+    if String.length(key) > @max_key_length do
+      String.slice(key, 0, @max_key_length)
+    else
+      key
+    end
+  end
+
+  defp truncate_key(key), do: key
 end

--- a/lib/lightning/scrubber.ex
+++ b/lib/lightning/scrubber.ex
@@ -16,16 +16,13 @@ defmodule Lightning.Scrubber do
   """
   use Agent
 
-  # Wide enough that an ordinary record keeps its shape, narrow enough that a
-  # map keyed by identifier does not carry every identifier out.
+  # Wide enough for an ordinary record, narrow enough for one keyed by id.
   @map_key_limit 50
 
-  # And a ceiling on the whole structure, since nesting multiplies the limit
-  # above by itself at every level.
+  # A ceiling on the whole structure, which nesting would otherwise multiply.
   @key_budget 500
 
-  # The budget counts keys, not their length, and a field name can be as long
-  # as the body. This bounds what a single one carries.
+  # The budget counts keys, not their length.
   @max_key_length 200
 
   defmodule State do
@@ -219,10 +216,8 @@ defmodule Lightning.Scrubber do
     end
   end
 
-  # Keys are not values and survive as they are, so a map keyed by record
-  # identifier carries those identifiers out with it. The budget is spent
-  # across the whole structure rather than per map, because fifty keys at each
-  # of four levels is still millions of them.
+  # Keys survive as they are, so the budget is spent across the whole
+  # structure rather than per map.
   defp scrub_value(map, array_limit, budget) when is_map(map) do
     {kept, dropped} =
       map

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -941,7 +941,7 @@ defmodule LightningWeb.AiAssistantChannel do
 
     # Include message_options for the initial message (attach_io_data, step_id, etc.)
     meta =
-      if params["attach_io_data"] || params["step_id"] || params["attach_code"] ||
+      if params["attach_io_data"] || params["step_id"] ||
            params["attach_logs"] || params["use_global_assistant"] do
         Map.put(meta, "message_options", build_message_options(params))
       else
@@ -1037,7 +1037,6 @@ defmodule LightningWeb.AiAssistantChannel do
 
   defp build_message_options(params) do
     %{
-      "code" => params["attach_code"] == true,
       "log" => params["attach_logs"] == true,
       "attach_io_data" => params["attach_io_data"] == true,
       "step_id" => params["step_id"],

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -140,7 +140,7 @@ defmodule Lightning.AiAssistantTest do
       {:ok, _updated_session} = AiAssistant.query_stream(session, "Ping")
     end
 
-    test "job code can be excluded from the context via options", %{
+    test "job code is always in the context, with no option to leave it out", %{
       user: user,
       workflow: %{jobs: [job_1 | _]}
     } do
@@ -163,13 +163,15 @@ defmodule Lightning.AiAssistantTest do
         :call,
         fn %{method: :post, body: json_body}, _opts ->
           body = Jason.decode!(json_body)
-          refute Map.has_key?(body["context"], "expression")
+          assert body["context"]["expression"] == job_expression
           assert body["context"]["adaptor"] == adaptor
 
           {:ok, %Tesla.Env{status: 200, body: job_chat_stream_reply()}}
         end
       )
 
+      # The old `code: false` came from a tickbox that no longer exists, and a
+      # stale value in an old session's meta must not strip the code now.
       {:ok, _updated_session} =
         AiAssistant.query_stream(session, "Ping", code: false)
     end
@@ -2885,7 +2887,7 @@ defmodule Lightning.AiAssistantTest do
 
       assert_received {:ai_assistant, :streaming_error, %{error: message}}
       assert message =~ "300000 characters against a 250000 limit"
-      assert message =~ "Send logs"
+      assert message =~ "Send run logs"
       refute message =~ "deliberately ignore"
     end
 
@@ -2914,7 +2916,7 @@ defmodule Lightning.AiAssistantTest do
       assert {:error, _} = AiAssistant.query_global_stream(session, "why?")
 
       assert_received {:ai_assistant, :streaming_error, %{error: message}}
-      assert message =~ "Send scrubbed I/O"
+      assert message =~ "Send run data"
     end
 
     # Apollo on main has no ATTACHMENT_TOO_LARGE, so an unrecognised type must

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -999,8 +999,7 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
 
       insert(:run_step, run: run, step: other_step)
 
-      # The step the user happens to have highlighted. The answer rarely turns
-      # on it, so it must not be what decides the attachment.
+      # Highlighted, and not what decides the attachment.
       message =
         global_message(user, project, %{
           "attach_io_data" => true,
@@ -1053,8 +1052,7 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
         global_reply().(env, opts)
       end)
 
-      # The user was promised I/O data, so the silence has to be logged. The
-      # run itself resolves, which is why the warning cannot hang off that.
+      # The run resolves, so the warning cannot hang off that.
       logs =
         ExUnit.CaptureLog.capture_log(fn ->
           assert :ok =

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -4,6 +4,7 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
   @moduletag :capture_log
 
   import Mox
+  import Ecto.Query
   import Lightning.Factories
 
   alias Lightning.AiAssistant
@@ -852,7 +853,13 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
 
       insert(:run_step, run: run, step: step)
 
-      %{workflow: workflow, job: job, run: run, step: step}
+      %{
+        workflow: workflow,
+        job: job,
+        run: run,
+        step: step,
+        snapshot: snapshot
+      }
     end
 
     # A job_code session in `project` requesting IO attachment for `step_id`,
@@ -922,9 +929,24 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
 
         assert [
                  %{"type" => "log", "content" => [line]},
-                 %{"type" => "input_dataclip", "content" => %{"a" => "number"}},
-                 %{"type" => "output_dataclip", "content" => %{"b" => "number"}}
+                 %{
+                   "type" => "input_dataclip",
+                   "content" => %{
+                     "step" => input_step,
+                     "data" => %{"a" => "number"}
+                   }
+                 },
+                 %{
+                   "type" => "output_dataclip",
+                   "content" => %{
+                     "step" => output_step,
+                     "data" => %{"b" => "number"}
+                   }
+                 }
                ] = Jason.decode!(env.body)["attachments"]
+
+        assert input_step == job.name
+        assert output_step == job.name
 
         assert line["message"] == "boom"
         assert line["level"] == "error"
@@ -958,17 +980,102 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       assert :ok = perform_job(MessageProcessor, %{"message_id" => message.id})
     end
 
-    test "skips the I/O attachment when step_id is not a uuid", %{
+    test "sends the I/O of every step in the run, not just the selected one", %{
       user: user,
       project: project
     } do
-      # A step_id that cannot be cast used to raise Ecto.Query.CastError from
+      %{workflow: workflow, job: job, run: run, step: step, snapshot: snapshot} =
+        step_in_run(project)
+
+      other_job = insert(:job, workflow: workflow, name: "Second step")
+
+      other_step =
+        insert(:step,
+          job: other_job,
+          snapshot: snapshot,
+          input_dataclip: build(:dataclip, project: project, body: %{"c" => 3}),
+          output_dataclip: build(:dataclip, project: project, body: %{"d" => 4})
+        )
+
+      insert(:run_step, run: run, step: other_step)
+
+      # The step the user happens to have highlighted. The answer rarely turns
+      # on it, so it must not be what decides the attachment.
+      message =
+        global_message(user, project, %{
+          "attach_io_data" => true,
+          "step_id" => step.id,
+          "follow_run_id" => run.id
+        })
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, opts ->
+        attachments = Jason.decode!(env.body)["attachments"]
+
+        assert attachments |> Enum.map(& &1["content"]["step"]) |> Enum.uniq() ==
+                 [job.name, "Second step"]
+
+        assert Enum.map(attachments, & &1["content"]["data"]) == [
+                 %{"a" => "number"},
+                 %{"b" => "number"},
+                 %{"c" => "number"},
+                 %{"d" => "number"}
+               ]
+
+        global_reply().(env, opts)
+      end)
+
+      assert :ok = perform_job(MessageProcessor, %{"message_id" => message.id})
+    end
+
+    test "warns and sends nothing when the run's steps kept no data", %{
+      user: user,
+      project: project
+    } do
+      %{run: run, step: step} = step_in_run(project)
+
+      # The step exists, so the run resolves; it just has nothing to attach.
+      Lightning.Repo.update_all(
+        from(s in Lightning.Invocation.Step),
+        set: [input_dataclip_id: nil, output_dataclip_id: nil]
+      )
+
+      # A step_id is sent, so a step-scoped lookup would have had something to
+      # go on. What is missing is the data itself.
+      message =
+        global_message(user, project, %{
+          "attach_io_data" => true,
+          "step_id" => step.id,
+          "follow_run_id" => run.id
+        })
+
+      Mox.expect(Lightning.Tesla.Mock, :call, fn env, opts ->
+        assert Jason.decode!(env.body)["attachments"] == []
+        global_reply().(env, opts)
+      end)
+
+      # The user was promised I/O data, so the silence has to be logged. The
+      # run itself resolves, which is why the warning cannot hang off that.
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok =
+                   perform_job(MessageProcessor, %{"message_id" => message.id})
+        end)
+
+      assert logs =~ "the run's steps kept none"
+    end
+
+    test "skips the I/O attachment when the run id is not a uuid", %{
+      user: user,
+      project: project
+    } do
+      # A run id that cannot be cast used to raise Ecto.Query.CastError from
       # inside the Oban job, failing the whole message rather than dropping
       # the one attachment the user asked for.
       message =
         global_message(user, project, %{
           "attach_io_data" => true,
-          "step_id" => "not-a-uuid"
+          "step_id" => Ecto.UUID.generate(),
+          "follow_run_id" => "not-a-uuid"
         })
 
       Mox.expect(Lightning.Tesla.Mock, :call, fn env, opts ->

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -2523,6 +2523,216 @@ defmodule Lightning.InvocationTest do
     end
   end
 
+  describe "scrubbed_io_for_run/2" do
+    setup do
+      project = insert(:project)
+      workflow = insert(:workflow, project: project)
+      snapshot = insert(:snapshot, workflow: workflow)
+
+      work_order =
+        insert(:workorder, workflow: workflow, snapshot: snapshot)
+
+      run =
+        insert(:run,
+          work_order: work_order,
+          snapshot: snapshot,
+          dataclip: build(:dataclip, project: project),
+          starting_job: build(:job, workflow: workflow)
+        )
+
+      %{project: project, workflow: workflow, snapshot: snapshot, run: run}
+    end
+
+    defp add_step(ctx, name, opts \\ []) do
+      step =
+        insert(
+          :step,
+          Keyword.merge(
+            [
+              job: insert(:job, workflow: ctx.workflow, name: name),
+              snapshot: ctx.snapshot
+            ],
+            opts
+          )
+        )
+
+      insert(:run_step, run: ctx.run, step: step)
+      step
+    end
+
+    defp clip(project, body), do: build(:dataclip, project: project, body: body)
+
+    test "replaces values with their types", ctx do
+      add_step(ctx, "one",
+        input_dataclip: clip(ctx.project, %{"n" => 1, "s" => "secret"}),
+        output_dataclip: clip(ctx.project, %{"ok" => true})
+      )
+
+      assert [
+               %{
+                 step_name: "one",
+                 input: %{"n" => "number", "s" => "string"},
+                 output: %{"ok" => "boolean"}
+               }
+             ] = Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+    end
+
+    test "returns every step in the run, in the order it ran", ctx do
+      # Inserted back to front, so row order cannot stand in for run order.
+      add_step(ctx, "second",
+        started_at: ~U[2026-09-01 10:00:05Z],
+        input_dataclip: clip(ctx.project, %{"b" => 2})
+      )
+
+      add_step(ctx, "first",
+        started_at: ~U[2026-09-01 10:00:00Z],
+        input_dataclip: clip(ctx.project, %{"a" => 1})
+      )
+
+      # A step that never started has no time to sort on and belongs last.
+      add_step(ctx, "never ran",
+        started_at: nil,
+        input_dataclip: clip(ctx.project, %{"c" => 3})
+      )
+
+      assert ["first", "second", "never ran"] =
+               ctx.run.id
+               |> Invocation.scrubbed_io_for_run(ctx.project.id)
+               |> Enum.map(& &1.step_name)
+    end
+
+    test "says so rather than lying when a dataclip was erased", ctx do
+      add_step(ctx, "wiped",
+        input_dataclip:
+          clip(ctx.project, nil) |> Map.put(:wiped_at, DateTime.utc_now())
+      )
+
+      assert [%{input: input}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+
+      assert input =~ "erased"
+    end
+
+    test "describes a body too large to read instead of reading it", ctx do
+      # Incompressible, so it is over the cap by the measure Postgres uses.
+      big = for i <- 1..40_000, into: %{}, do: {"k#{i}", Ecto.UUID.generate()}
+
+      add_step(ctx, "huge", input_dataclip: clip(ctx.project, big))
+
+      assert [%{input: input}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+
+      assert input =~ "too large"
+    end
+
+    test "measures the body rather than the compressed row", ctx do
+      # Over the cap as JSON and well under it once Postgres has compressed
+      # it, which is the shape these workflows carry and the case a cap on
+      # pg_column_size lets straight through.
+      compressible =
+        for i <- 1..60_000, into: %{}, do: {"key-#{i}", "the same value"}
+
+      add_step(ctx, "compressible",
+        input_dataclip: clip(ctx.project, compressible)
+      )
+
+      assert [%{input: input}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+
+      assert input =~ "too large"
+    end
+
+    test "calls a null body null rather than too large", ctx do
+      step =
+        add_step(ctx, "null output",
+          output_dataclip: clip(ctx.project, %{"a" => 1})
+        )
+
+      # A body of JSON null, which is a value, not an absent one. Ecto writes
+      # SQL NULL for a nil map, so it has to be set as jsonb directly.
+      Lightning.Repo.query!(
+        "UPDATE dataclips SET body = 'null'::jsonb WHERE id = $1",
+        [Ecto.UUID.dump!(step.output_dataclip_id)]
+      )
+
+      assert [%{output: output}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+
+      assert output == "null"
+    end
+
+    test "says nothing about a step that had no data to read", ctx do
+      add_step(ctx, "no input", input_dataclip: nil)
+
+      assert [%{input: nil}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+    end
+
+    test "keeps the run a sequence once the budget is spent", ctx do
+      # As much as one dataclip can carry once the key budget has had its say,
+      # repeated until the run's own budget runs out.
+      dense =
+        for i <- 1..50,
+            into: %{},
+            do:
+              {"a-long-enough-key-name-#{i}",
+               for(
+                 j <- 1..10,
+                 into: %{},
+                 do: {"another-long-key-name-#{j}", "v"}
+               )}
+
+      for n <- 1..8 do
+        add_step(ctx, "step-#{n}",
+          started_at: DateTime.add(~U[2026-09-01 10:00:00Z], n),
+          input_dataclip: clip(ctx.project, dense),
+          output_dataclip: clip(ctx.project, dense)
+        )
+      end
+
+      entries = Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+
+      # Every step is still named, and the ones past the budget say why they
+      # are not there rather than going missing.
+      assert length(entries) == 8
+      assert Enum.any?(entries, &is_map(&1.input))
+
+      assert Enum.any?(
+               entries,
+               &(is_binary(&1.input) and &1.input =~ "ran past")
+             )
+    end
+
+    test "caps how many keys a wide map carries out", ctx do
+      wide = for i <- 1..500, into: %{}, do: {"patient-#{i}", "name"}
+
+      add_step(ctx, "wide", input_dataclip: clip(ctx.project, wide))
+
+      assert [%{input: input}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+
+      assert map_size(input) < 500
+      assert input["..."] =~ "more keys"
+    end
+
+    test "returns nothing for a run outside the project", ctx do
+      add_step(ctx, "one", input_dataclip: clip(ctx.project, %{"a" => 1}))
+
+      assert Invocation.scrubbed_io_for_run(ctx.run.id, insert(:project).id) ==
+               []
+    end
+
+    test "returns nothing without a project", ctx do
+      add_step(ctx, "one", input_dataclip: clip(ctx.project, %{"a" => 1}))
+
+      assert Invocation.scrubbed_io_for_run(ctx.run.id, nil) == []
+    end
+
+    test "returns nothing for a run id that is not a uuid", ctx do
+      assert Invocation.scrubbed_io_for_run("not-a-uuid", ctx.project.id) == []
+    end
+  end
+
   defp assert_dataclips_list(expected, returned) do
     assert expected
            |> Enum.map(&format_listed/1)

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -2642,6 +2642,20 @@ defmodule Lightning.InvocationTest do
       assert input =~ "too large"
     end
 
+    test "says nothing about a dataclip whose body was removed", ctx do
+      step =
+        add_step(ctx, "emptied", input_dataclip: clip(ctx.project, %{"a" => 1}))
+
+      # Not wiped, just no body: what Invocation.delete_dataclip/1 leaves.
+      Lightning.Repo.query!(
+        "UPDATE dataclips SET body = NULL WHERE id = $1",
+        [Ecto.UUID.dump!(step.input_dataclip_id)]
+      )
+
+      assert [%{input: nil}] =
+               Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
+    end
+
     test "calls a null body null rather than too large", ctx do
       step =
         add_step(ctx, "null output",
@@ -2690,11 +2704,24 @@ defmodule Lightning.InvocationTest do
         )
       end
 
+      # Past the budget and with nothing to read either way.
+      add_step(ctx, "nothing to read",
+        started_at: ~U[2026-09-01 10:00:59Z],
+        input_dataclip: nil
+      )
+
       entries = Invocation.scrubbed_io_for_run(ctx.run.id, ctx.project.id)
 
       # Every step is still named, and the ones past the budget say why they
       # are not there rather than going missing.
-      assert length(entries) == 8
+      assert length(entries) == 9
+
+      assert List.last(entries) == %{
+               step_name: "nothing to read",
+               input: nil,
+               output: nil
+             }
+
       assert Enum.any?(entries, &is_map(&1.input))
 
       assert Enum.any?(

--- a/test/lightning/scrubber_test.exs
+++ b/test/lightning/scrubber_test.exs
@@ -245,6 +245,66 @@ defmodule Lightning.ScrubberTest do
   end
 
   describe "scrub_values/1" do
+    test "caps how many keys a wide map carries, since keys are not scrubbed" do
+      # A job that keys state by record identifier puts those identifiers in
+      # key position, where nothing replaces them.
+      wide = for i <- 1..500, into: %{}, do: {"patient-#{i}", "Jane Doe"}
+
+      scrubbed = Scrubber.scrub_values(wide)
+
+      assert map_size(scrubbed) < 500
+      assert scrubbed["..."] =~ "more keys"
+
+      assert Enum.all?(Map.delete(scrubbed, "..."), fn {_k, v} ->
+               v == "string"
+             end)
+    end
+
+    test "spends the key budget across the whole structure, not per map" do
+      # Fifty keys at each of three levels is 125,000 of them, so a per-map
+      # cap alone would let nesting carry out everything it stopped flat.
+      nested =
+        for i <- 1..50,
+            into: %{},
+            do:
+              {"month-#{i}",
+               for(
+                 j <- 1..50,
+                 into: %{},
+                 do: {"patient-#{i}-#{j}", %{"nin" => "123"}}
+               )}
+
+      scrubbed = Scrubber.scrub_values(nested)
+
+      keys =
+        scrubbed
+        |> Jason.encode!()
+        |> then(&Regex.scan(~r/patient-/, &1))
+        |> length()
+
+      assert keys < 600
+    end
+
+    test "truncates a key long enough to be a record in itself" do
+      long = String.duplicate("patient-jane-doe-1984-02-11-", 40)
+
+      assert %{} = scrubbed = Scrubber.scrub_values(%{long => 1})
+      [key] = Map.keys(scrubbed)
+
+      assert String.length(key) < String.length(long)
+      assert String.length(key) == 200
+    end
+
+    test "leaves an ordinary record's keys alone" do
+      record = %{"name" => "Jane", "age" => 30, "active" => true}
+
+      assert Scrubber.scrub_values(record) == %{
+               "name" => "string",
+               "age" => "number",
+               "active" => "boolean"
+             }
+    end
+
     test "scrubs primitive values" do
       assert Scrubber.scrub_values("hello") == "string"
       assert Scrubber.scrub_values(42) == "number"

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -744,32 +744,6 @@ defmodule LightningWeb.AiAssistantChannelTest do
       assert errors.base == ["Message cannot be empty"]
     end
 
-    test "includes code when attach_code is true", %{
-      socket: socket,
-      job: job,
-      user: user
-    } do
-      {:ok, session} =
-        AiAssistant.create_session(job, user, "Initial message", [])
-
-      {:ok, _, socket} =
-        subscribe_and_join(
-          socket,
-          AiAssistantChannel,
-          "ai_assistant:job_code:#{session.id}",
-          %{}
-        )
-
-      ref =
-        push(socket, "new_message", %{
-          "content" => "Explain this code",
-          "attach_code" => true
-        })
-
-      assert_reply ref, :ok, %{message: message}
-      assert message.content == "Explain this code"
-    end
-
     test "returns limit error when quota is exceeded", %{
       socket: socket,
       job: job,
@@ -887,7 +861,7 @@ defmodule LightningWeb.AiAssistantChannelTest do
           %{}
         )
 
-      # Simulate user selecting a run and checking "Send logs"
+      # Simulate user selecting a run and checking "Send run logs"
       ref =
         push(socket, "new_message", %{
           "content" => "Help me debug these logs",
@@ -3004,65 +2978,6 @@ defmodule LightningWeb.AiAssistantChannelTest do
     end
   end
 
-  describe "extract_message_options edge cases" do
-    test "handles attach_code and attach_logs for job_code", %{
-      socket: socket,
-      job: job,
-      user: user
-    } do
-      # Use manual mode to prevent AI response from being generated inline
-      {:ok, session} =
-        AiAssistant.create_session(job, user, "Initial message", [])
-
-      {:ok, _, socket} =
-        subscribe_and_join(
-          socket,
-          AiAssistantChannel,
-          "ai_assistant:job_code:#{session.id}",
-          %{}
-        )
-
-      # Test with both attach_code and attach_logs true
-      ref =
-        push(socket, "new_message", %{
-          "content" => "Help with logs",
-          "attach_code" => true,
-          "attach_logs" => true
-        })
-
-      assert_reply ref, :ok, %{message: message}
-      assert message.role == "user"
-    end
-
-    test "handles attach_code false for job_code", %{
-      socket: socket,
-      job: job,
-      user: user
-    } do
-      # Use manual mode to prevent AI response from being generated inline
-      {:ok, session} =
-        AiAssistant.create_session(job, user, "Initial message", [])
-
-      {:ok, _, socket} =
-        subscribe_and_join(
-          socket,
-          AiAssistantChannel,
-          "ai_assistant:job_code:#{session.id}",
-          %{}
-        )
-
-      # Test with attach_code explicitly false
-      ref =
-        push(socket, "new_message", %{
-          "content" => "Help without code",
-          "attach_code" => false
-        })
-
-      assert_reply ref, :ok, %{message: message}
-      assert message.role == "user"
-    end
-  end
-
   describe "extract_session_options edge cases" do
     test "creates workflow_template session without follow_run_id", %{
       socket: socket,
@@ -3150,7 +3065,7 @@ defmodule LightningWeb.AiAssistantChannelTest do
       assert message_options["step_id"] == step.id
     end
 
-    test "includes attach_code and attach_logs when creating new session", %{
+    test "includes attach_logs when creating new session", %{
       socket: socket,
       job: job,
       project: project
@@ -3159,7 +3074,6 @@ defmodule LightningWeb.AiAssistantChannelTest do
         "job_id" => job.id,
         "project_id" => project.id,
         "content" => "Help me with logs",
-        "attach_code" => true,
         "attach_logs" => true
       }
 
@@ -3174,8 +3088,8 @@ defmodule LightningWeb.AiAssistantChannelTest do
       session = AiAssistant.get_session!(response.session_id)
       message_options = session.meta["message_options"]
 
-      assert message_options["code"] == true
       assert message_options["log"] == true
+      refute Map.has_key?(message_options, "code")
     end
 
     test "excludes message_options when not opted in", %{


### PR DESCRIPTION
## Description

This PR changes what the assistant's attachment tickboxes mean, and makes the global assistant the only one the UI reaches.

1. "Send code" is gone. The assistant sends the whole workflow on every message regardless of that box, so it did nothing.
2. "Send run logs" and "Send run data" now sit above the message box on any page and appear once a run is loaded. "Send run data" covers the whole run rather than one highlighted step. Values are replaced by their types, but field names go as they are, so a job that keys state by patient name or national id sends those. Their number and length are capped.
3. The experimental gate, the opt-in tickbox and the assistant badge are gone. The older paths stay and still serve existing sessions; removing them is #5042.
4. "Build with AI" went to workflow chat, which leaves every step empty. It goes to the global assistant now.
5. A session's first message lost its attachments when asked from the canvas: `buildJoinParams` forwarded the flags only when a job was in context. Same bug `code` had, fixed the same way in #4888.


Closes #5037
Closes #5040

## Validation steps

1. Open a workflow and open the assistant with no run selected. There are no attachment tickboxes, and no "Send code" box, global assistant toggle or assistant badge anywhere.
6. Select a run in the history panel. "Send run logs" and "Send run data" appear above the message box, both on the canvas and with a step open in the editor.
7. Tick both, start a **new** conversation, and ask "Summarize the log and data you received". The reply describes the run's log lines and the input and output of every step in the run, not just the highlighted one.
8. Read the data it quotes back. Every value is its type, so a name reads `"string"` and a count reads `"number"`.
9. Untick both and ask again in a new conversation. The assistant answers that nothing was attached.
10. Go to a project's new workflow screen and use "Build with AI". The prompt opens the assistant as the first message of a new session, the workflow appears on the canvas, and there are no attachment tickboxes, since a new workflow has no run.

## Additional notes for the reviewer

Step 3 asks for a new conversation on purpose. Every message after the first goes through a path that always carried the flags, so a follow-up passes even with the join bug in place.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR