### PR TITLE
Close the IDE with Cmd/Ctrl+E while the code editor has focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to
 
 ### Fixed
 
+- Cmd/Ctrl+E now closes the IDE while the code editor has focus. Monaco claimed
+  the combination for "Use Selection for Find", so the shortcut that opened the
+  IDE could not close it again. Cmd/Ctrl+F still opens Monaco's find widget.
+  [#4959](https://github.com/OpenFn/lightning/issues/4959)
 - The global assistant no longer offers to paste a reply's code block into
   whichever job you have open. It applies its own changes and shows them as
   diffs, so those blocks are data it quoted back or work it has already done.

--- a/assets/js/collaborative-editor/components/ide/FullScreenIDE.tsx
+++ b/assets/js/collaborative-editor/components/ide/FullScreenIDE.tsx
@@ -701,8 +701,12 @@ export function FullScreenIDE({
     });
   }, [onCredentialSaved, currentJob, updateJob, requestCredentials]);
 
+  const isShortcutEnabled =
+    !isConfigureModalOpen && !isAdaptorPickerOpen && !isCredentialModalOpen;
+
+  // Escape steps out of the editor before it closes the IDE.
   useKeyboardShortcut(
-    'Escape, Control+e, Meta+e',
+    'Escape',
     () => {
       const activeElement = document.activeElement;
       const isMonacoFocused = activeElement?.closest('.monaco-editor');
@@ -714,10 +718,18 @@ export function FullScreenIDE({
       }
     },
     50, // IDE priority
-    {
-      enabled:
-        !isConfigureModalOpen && !isAdaptorPickerOpen && !isCredentialModalOpen,
-    }
+    { enabled: isShortcutEnabled }
+  );
+
+  // Mod+E always closes the IDE, including from inside Monaco, so that it
+  // mirrors the Mod+E that opened it.
+  useKeyboardShortcut(
+    'Control+e, Meta+e',
+    () => {
+      onClose();
+    },
+    50, // IDE priority
+    { enabled: isShortcutEnabled }
   );
 
   // Save docs panel collapsed state to localStorage

--- a/assets/js/monaco/keyboard-overrides.ts
+++ b/assets/js/monaco/keyboard-overrides.ts
@@ -15,6 +15,7 @@ import type { Monaco } from './index';
  * - Cmd/Ctrl+Enter: Dispatches to window for run/retry actions
  * - Cmd/Ctrl+Shift+Enter: Dispatches to window for force-run actions
  * - Cmd/Ctrl+K: Dispatches to window for AI chat shortcut
+ * - Cmd/Ctrl+E: Dispatches to window for the IDE open/close shortcut
  *
  * Usage:
  * ```typescript
@@ -70,6 +71,21 @@ export function addKeyboardShortcutOverrides(
     const event = new KeyboardEvent('keydown', {
       key: 'k',
       code: 'KeyK',
+      metaKey: isMac,
+      ctrlKey: !isMac,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+  });
+
+  // Override Monaco's Cmd/Ctrl+E ("Use Selection for Find") so the IDE toggle
+  // still works while the editor has focus. Cmd/Ctrl+F is left alone, so the
+  // find widget remains reachable.
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyE, () => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'e',
+      code: 'KeyE',
       metaKey: isMac,
       ctrlKey: !isMac,
       bubbles: true,

--- a/assets/test/collaborative-editor/components/ide/FullScreenIDE.keyboard.test.tsx
+++ b/assets/test/collaborative-editor/components/ide/FullScreenIDE.keyboard.test.tsx
@@ -3,6 +3,7 @@
  *
  * Tests keyboard shortcuts for the FullScreenIDE component:
  * - Escape: Smart behavior (blur Monaco first, then close IDE)
+ * - Mod+E: Close the IDE, including while Monaco has focus
  * - Mod+Enter: Run or retry (prioritizes retry when available)
  * - Mod+Shift+Enter: Force new run (ignores retry)
  *
@@ -592,6 +593,57 @@ describe('FullScreenIDE Keyboard Shortcuts', () => {
       await waitFor(() => expect(onClose).toHaveBeenCalled());
 
       document.body.removeChild(input);
+    });
+  });
+
+  describe('Mod+E - Close IDE', () => {
+    test('closes IDE when Monaco is not focused (Mac)', async () => {
+      const user = userEvent.setup();
+      setupMockUseRunRetry();
+      const onClose = vi.fn();
+      renderFullScreenIDE({ onClose });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('collaborative-monaco')).toBeInTheDocument()
+      );
+
+      await user.keyboard('{Meta>}e{/Meta}');
+
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    test('closes IDE while Monaco has focus (Mac)', async () => {
+      const user = userEvent.setup();
+      setupMockUseRunRetry();
+      const onClose = vi.fn();
+      renderFullScreenIDE({ onClose });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('collaborative-monaco')).toBeInTheDocument()
+      );
+
+      focusElement(screen.getByTestId('monaco-contenteditable'));
+
+      await user.keyboard('{Meta>}e{/Meta}');
+
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    test('closes IDE while Monaco has focus (Windows)', async () => {
+      const user = userEvent.setup();
+      setupMockUseRunRetry();
+      const onClose = vi.fn();
+      renderFullScreenIDE({ onClose });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('collaborative-monaco')).toBeInTheDocument()
+      );
+
+      focusElement(screen.getByTestId('monaco-contenteditable'));
+
+      await user.keyboard('{Control>}e{/Control}');
+
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
     });
   });
 

--- a/assets/test/monaco/keyboard-overrides.test.ts
+++ b/assets/test/monaco/keyboard-overrides.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Monaco keyboard override tests
+ *
+ * Monaco claims a handful of Cmd/Ctrl combos for its own commands. These
+ * overrides re-dispatch them on `window` so the application's keyboard system
+ * can handle them instead.
+ */
+
+import type { editor } from 'monaco-editor';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { Monaco } from '../../js/monaco';
+import { addKeyboardShortcutOverrides } from '../../js/monaco/keyboard-overrides';
+
+// Arbitrary but distinct values; only their combination matters here.
+const KeyMod = { CtrlCmd: 2048, Shift: 1024 } as const;
+const KeyCode = { Enter: 3, KeyE: 35, KeyF: 36, KeyK: 41 } as const;
+
+function setupEditor() {
+  const commands = new Map<number, () => void>();
+
+  const editorStub = {
+    addCommand: (keybinding: number, handler: () => void) => {
+      commands.set(keybinding, handler);
+    },
+  } as unknown as editor.IStandaloneCodeEditor;
+
+  const monacoStub = { KeyMod, KeyCode } as unknown as Monaco;
+
+  addKeyboardShortcutOverrides(editorStub, monacoStub);
+
+  return commands;
+}
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  });
+}
+
+const originalUserAgent = navigator.userAgent;
+
+describe('addKeyboardShortcutOverrides', () => {
+  let dispatched: KeyboardEvent[];
+  let listener: (event: Event) => void;
+
+  beforeEach(() => {
+    dispatched = [];
+    listener = event => {
+      dispatched.push(event as KeyboardEvent);
+    };
+    window.addEventListener('keydown', listener);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('keydown', listener);
+    setUserAgent(originalUserAgent);
+    vi.restoreAllMocks();
+  });
+
+  test('registers an override for Mod+E', () => {
+    const commands = setupEditor();
+
+    expect(commands.has(KeyMod.CtrlCmd | KeyCode.KeyE)).toBe(true);
+  });
+
+  test('Mod+E dispatches a Cmd+E keydown on Mac', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    const commands = setupEditor();
+
+    commands.get(KeyMod.CtrlCmd | KeyCode.KeyE)?.();
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]).toMatchObject({
+      key: 'e',
+      code: 'KeyE',
+      metaKey: true,
+      ctrlKey: false,
+    });
+  });
+
+  test('Mod+E dispatches a Ctrl+E keydown off Mac', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    const commands = setupEditor();
+
+    commands.get(KeyMod.CtrlCmd | KeyCode.KeyE)?.();
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]).toMatchObject({
+      key: 'e',
+      code: 'KeyE',
+      metaKey: false,
+      ctrlKey: true,
+    });
+  });
+
+  test('leaves Mod+F to Monaco so the find widget still opens', () => {
+    const commands = setupEditor();
+
+    expect(commands.has(KeyMod.CtrlCmd | KeyCode.KeyF)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

This PR fixes Cmd/Ctrl+E so it closes the IDE while the Monaco editor has focus.

Two things were in the way:

1. Monaco owns Cmd+E for its `actions.findWithSelection` ("Use Selection for
   Find") command, so the keydown never reached the app's keyboard system.
   `addKeyboardShortcutOverrides` already re-dispatches Cmd/Ctrl+Enter,
   Cmd/Ctrl+Shift+Enter and Cmd/Ctrl+K on `window`; Cmd/Ctrl+E now joins them.
   Cmd/Ctrl+F is deliberately left to Monaco, so the find widget is still one
   keystroke away.
2. `FullScreenIDE` registered `Escape, Control+e, Meta+e` on a single handler
   that blurs Monaco when the editor has focus and only closes otherwise. Even
   with the key delivered, Cmd+E would have blurred instead of closing. The
   handler is now split: Escape keeps its step-out-then-close behaviour, and
   Mod+E always closes, mirroring the Mod+E that opened the IDE.

Closes #4959

## Validation steps

1. Open a job in the IDE (Cmd+E from a selected job, or click the step).
2. Click into the code editor so Monaco has focus.
3. Press Cmd+E (Ctrl+E on Windows/Linux). The IDE closes.
4. Press Cmd+F with Monaco focused. Monaco's find widget still opens.
5. Press Escape with Monaco focused. Focus leaves the editor; a second Escape
   closes the IDE, as before.

## Additional notes for the reviewer

1. New tests: `assets/test/monaco/keyboard-overrides.test.ts` covers the
   override registration and the dispatched event on both platforms, plus a
   guard that Mod+F is not claimed. `FullScreenIDE.keyboard.test.tsx` gains a
   "Mod+E - Close IDE" block. Five of these fail on `main` and pass here (I
   verified by reverting the two source files and re-running).
2. `assets` checks run locally: the new and changed files are Prettier-clean and
   add no new ESLint or `tsc --project tsconfig.browser.json` errors (both files
   already carry pre-existing errors; the counts are identical before and
   after). I could not run `mix` checks: there is no Elixir toolchain on this
   machine, and nothing in this change touches Elixir.
3. `addKeyboardShortcutOverrides` is also used by the manual run panel's custom
   dataclip editor, so Mod+E closes the IDE from there too. That seemed right;
   say the word if you'd rather scope it to the job editor.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) — n/a, client-side
      keyboard handling only
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
