### PR TITLE
Say a failure once, and stop the kept reply retyping itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,12 +83,12 @@ and this project adheres to
   typed it. [#4952](https://github.com/OpenFn/lightning/issues/4952)
 - **Breaking:** `APOLLO_TIMEOUT` is renamed `APOLLO_IDLE_TIMEOUT_MS` and joined
   by `APOLLO_CONNECT_TIMEOUT_MS` and `APOLLO_REQUEST_TIMEOUT_MS`. The old name
-  is no longer read and logs a warning at boot if it is still set. It only ever
-  measured silence, so put its value on `APOLLO_IDLE_TIMEOUT_MS` if you were
-  setting it. All three have defaults, so a deployment need not set any of them.
-  The idle default is 30s, which assumes Apollo v3.1.1 or later and its 15s
-  keepalive; on an older Apollo a working stream can go quiet for longer than
-  that, so raise it or upgrade Apollo.
+  is no longer read and logs a warning at boot if it is still set. On the wire
+  it only ever measured silence, so put its value on `APOLLO_IDLE_TIMEOUT_MS` if
+  you were setting it. All three have defaults, so a deployment need not set any
+  of them. The idle default is 30s, which assumes Apollo v3.1.1 or later and its
+  15s keepalive; on an older Apollo a working stream can go quiet for longer
+  than that, so raise it or upgrade Apollo.
   [#4882](https://github.com/OpenFn/lightning/issues/4882)
 
 ### Fixed
@@ -101,11 +101,12 @@ and this project adheres to
   sweep is what recovers the message when that happens.
   [#4260](https://github.com/OpenFn/lightning/issues/4260)
   [#5124](https://github.com/OpenFn/lightning/issues/5124)
-- Why an AI chat failed is now recorded on the message and sent to the client: a
-  hung Apollo, a lost connection and a rate limit are no longer the same event
-  to us. The panel still renders one generic error, so this is the groundwork
-  for telling them apart rather than the change a user will see.
-  [#5125](https://github.com/OpenFn/lightning/issues/5125)
+- Why an AI chat failed is now recorded on the message and shown on the reply it
+  belongs to, rather than as one generic banner: a hung Apollo, a lost
+  connection and a rate limit each read differently. A failed reply keeps its
+  text as an answer, with the reason and a Try again beneath it, and the
+  question you asked is no longer marked "Failed to send" when it was sent and
+  half answered. [#5125](https://github.com/OpenFn/lightning/issues/5125)
 - An AI answer that is cut off partway through is kept rather than discarded.
   The text and any workflow YAML the user already watched appear are saved,
   along with the status updates, in the order they were shown.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -268,16 +268,16 @@ The idle default assumes Apollo v3.1.1 or later, which sends a keepalive every
 is thinking, and 30 seconds will cut it off, so raise `APOLLO_IDLE_TIMEOUT_MS`
 or upgrade Apollo.
 
-The three added together bound how long one AI job may run, and that has to stay
-under Oban's shutdown grace period, which is six minutes. Raising them past it
-means a deploy landing on a running answer kills it with nothing left to report
-the failure, so Lightning warns at boot if the sum gets too close. Note that the
-longer grace period also makes rolling restarts slower, since Oban now waits up
-to six minutes for a running job rather than two.
+The three added together, plus a ten-second buffer, bound how long one AI job
+may run, and that has to stay under Oban's shutdown grace period of six minutes.
+Raising them past it means a deploy landing on a running answer kills it with
+nothing left to report the failure, so Lightning warns at boot if the sum gets
+too close. Note that the longer grace period also makes rolling restarts slower,
+since Oban now waits up to six minutes for a running job rather than two.
 
-`APOLLO_TIMEOUT` is the old name for `APOLLO_IDLE_TIMEOUT_MS`. It only ever
-covered the silence, never the other two. It is no longer read, and Lightning
-logs a warning at boot if it is still set.
+`APOLLO_TIMEOUT` is the old name for `APOLLO_IDLE_TIMEOUT_MS`. On the wire it
+only ever covered the silence, never the other two. It is no longer read, and
+Lightning logs a warning at boot if it is still set.
 
 ### OAuth credential connections (Google, Salesforce, etc.)
 

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -1064,19 +1064,37 @@ export function MessageList({
     return null;
   };
 
-  // The user message a reply answers; a session can hold prompts with no reply.
-  const promptFor = (message: Message, index: number): Message | undefined => {
-    if (message.role === 'user') return message;
+  // Pairs each failed reply with the prompt it answers, once, rather than each
+  // message peeking at its neighbours. Timestamps are stored to the second, so
+  // a reply that dies in the same second as its prompt sorts either side of it
+  // and neighbours cannot be trusted. The server marks a prompt failed whenever
+  // its reply failed, so a failed prompt is what a failed reply is looking for:
+  // the nearest one before it, or after it when it sorted ahead of its own.
+  const failedPairs = useMemo(() => {
+    const owners = new Map<string, Message>();
+    const claimed = new Set<string>();
+    const unclaimedPrompt = (m: Message | undefined) =>
+      m?.role === 'user' && m.status === 'error' && !claimed.has(m.id);
 
-    for (let i = index - 1; i >= 0; i--) {
-      const candidate = displayMessages[i];
-      if (candidate?.role === 'user') return candidate;
-    }
+    displayMessages.forEach((reply, index) => {
+      if (reply.role !== 'assistant' || reply.status !== 'error') return;
 
-    // A reply that arrived before its own prompt, which the second-precision
-    // ordering allows when both land in the same second.
-    return displayMessages.find(m => m.role === 'user');
-  };
+      let owner: Message | undefined;
+      for (let i = index - 1; i >= 0 && !owner; i--) {
+        if (unclaimedPrompt(displayMessages[i])) owner = displayMessages[i];
+      }
+      for (let i = index + 1; i < displayMessages.length && !owner; i++) {
+        if (unclaimedPrompt(displayMessages[i])) owner = displayMessages[i];
+      }
+
+      if (owner) {
+        owners.set(reply.id, owner);
+        claimed.add(owner.id);
+      }
+    });
+
+    return { owners, claimed };
+  }, [displayMessages]);
 
   // Only the global endpoint emits status segments today.
   const timelineSegments = (message: Message): ResponseSegment[] | null => {
@@ -1122,7 +1140,11 @@ export function MessageList({
     >
       {displayMessages.map((message, index) => {
         const segments = timelineSegments(message);
-        const prompt = promptFor(message, index);
+
+        const prompt =
+          message.role === 'user'
+            ? message
+            : failedPairs.owners.get(message.id);
 
         // Gated on the prompt, not on the reply: a reply keeps :error for good,
         // so reading its status would leave the button live for the session and
@@ -1134,21 +1156,10 @@ export function MessageList({
               }
             : undefined;
 
-        const failedReply = (m: Message | undefined) =>
-          m?.role === 'assistant' && m.status === 'error';
-
-        // A failed reply carries the notice; the prompt carries it only when no
-        // reply arrived. The reply before a prompt counts as its own only when
-        // nothing precedes it, since a reply that dies in the same second as
-        // its prompt sorts either way round. Otherwise it belongs to an earlier
-        // exchange, and this prompt's failure would go unmentioned.
-        const ownFailedReply =
-          failedReply(displayMessages[index + 1]) ||
-          (failedReply(displayMessages[index - 1]) &&
-            !displayMessages.slice(0, index - 1).some(m => m.role === 'user'));
-
+        // A failed reply carries the notice; the prompt carries it only when
+        // no reply claimed it.
         const promptCarriesNotice =
-          message.status === 'error' && !ownFailedReply;
+          message.status === 'error' && !failedPairs.claimed.has(message.id);
 
         const showMessageAddButtons =
           !isStreaming(message) &&

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -1064,8 +1064,7 @@ export function MessageList({
     return null;
   };
 
-  // The user message a reply answers. Walks back rather than pairing by index,
-  // since a session can hold prompts with no reply at all.
+  // The user message a reply answers; a session can hold prompts with no reply.
   const promptFor = (message: Message, index: number): Message | undefined => {
     if (message.role === 'user') return message;
 
@@ -1125,11 +1124,9 @@ export function MessageList({
         const segments = timelineSegments(message);
         const prompt = promptFor(message, index);
 
-        // Retry re-runs the prompt, and only while that prompt is still the
-        // failed one. The server flips it to :pending and broadcasts that, so
-        // this is what stops a second click firing a second job: the reply it
-        // sits under keeps :error for good and would otherwise stay clickable
-        // for the life of the session.
+        // Gated on the prompt, not on the reply: a reply keeps :error for good,
+        // so reading its status would leave the button live for the session and
+        // every click would start another job.
         const retry =
           onRetryMessage && prompt?.status === 'error'
             ? () => {
@@ -1137,22 +1134,21 @@ export function MessageList({
               }
             : undefined;
 
-        // A failed reply carries the notice; the prompt carries it only when
-        // no reply arrived at all. Both neighbours are checked because a reply
-        // that dies in the same second as its prompt can come back either way
-        // round, timestamps being stored to the second.
-        const adjacentFailedReply = [index - 1, index + 1].some(i => {
-          const neighbour = displayMessages[i];
-          return (
-            neighbour?.role === 'assistant' && neighbour.status === 'error'
-          );
-        });
+        const failedReply = (m: Message | undefined) =>
+          m?.role === 'assistant' && m.status === 'error';
 
-        // Nothing has failed yet while a reply is still arriving. The prompt is
-        // marked failed before the partial reply reaches the client, so without
-        // this the notice appears above text that is still typing itself out.
+        // A failed reply carries the notice; the prompt carries it only when no
+        // reply arrived. The reply before a prompt counts as its own only when
+        // nothing precedes it, since a reply that dies in the same second as
+        // its prompt sorts either way round. Otherwise it belongs to an earlier
+        // exchange, and this prompt's failure would go unmentioned.
+        const ownFailedReply =
+          failedReply(displayMessages[index + 1]) ||
+          (failedReply(displayMessages[index - 1]) &&
+            !displayMessages.slice(0, index - 1).some(m => m.role === 'user'));
+
         const promptCarriesNotice =
-          message.status === 'error' && !adjacentFailedReply && !isLoading;
+          message.status === 'error' && !ownFailedReply;
 
         const showMessageAddButtons =
           !isStreaming(message) &&

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -283,15 +283,6 @@ export class AIChannelRegistry {
     this.stopDraining();
   }
 
-  /**
-   * Stop drip-feeding and run whatever was waiting on the drain.
-   *
-   * A dead stream leaves the saved partial queued behind the remaining buffer,
-   * which drains a letter at a time and far slower than Apollo fills it. The
-   * error that follows clears the buffer, so the reply the user just watched
-   * appear would restart from the middle and type itself out again before the
-   * saved message arrived.
-   */
   private finishDrainNow(): void {
     this.streamingDrainPos = this.streamingBuffer.length;
     this.flushDueStatusMarkers();
@@ -793,8 +784,11 @@ export class AIChannelRegistry {
         failure_message?: string;
       };
 
-      // Land the partial before clearing the buffer it is queued behind.
-      this.finishDrainNow();
+      // Get the saved partial into the store before the error clears the
+      // buffer it is queued behind. Only when something is actually waiting:
+      // message_error names any message, and the reaper reports on ones
+      // several exchanges back while a newer reply may still be streaming.
+      if (this.streamingDrainCallback) this.finishDrainNow();
 
       this.store._updateMessageStatus(
         typedPayload.message_id,

--- a/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
+++ b/assets/js/collaborative-editor/lib/AIChannelRegistry.ts
@@ -284,6 +284,25 @@ export class AIChannelRegistry {
   }
 
   /**
+   * Stop drip-feeding and run whatever was waiting on the drain.
+   *
+   * A dead stream leaves the saved partial queued behind the remaining buffer,
+   * which drains a letter at a time and far slower than Apollo fills it. The
+   * error that follows clears the buffer, so the reply the user just watched
+   * appear would restart from the middle and type itself out again before the
+   * saved message arrived.
+   */
+  private finishDrainNow(): void {
+    this.streamingDrainPos = this.streamingBuffer.length;
+    this.flushDueStatusMarkers();
+    this.stopDraining();
+
+    const callback = this.streamingDrainCallback;
+    this.streamingDrainCallback = null;
+    if (callback) callback();
+  }
+
+  /**
    * Subscribe to a channel topic
    *
    * - Creates and joins channel if it doesn't exist
@@ -773,6 +792,10 @@ export class AIChannelRegistry {
         status: MessageStatus;
         failure_message?: string;
       };
+
+      // Land the partial before clearing the buffer it is queued behind.
+      this.finishDrainNow();
+
       this.store._updateMessageStatus(
         typedPayload.message_id,
         'error',

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -364,11 +364,89 @@ describe('MessageList', () => {
       render(<MessageList messages={messages} onRetryMessage={vi.fn()} />);
 
       const notice = screen.getByTestId('ai-failure-notice');
-      // Under the reply, not under the prompt.
       expect(notice.closest('[data-role]')).toHaveAttribute(
         'data-role',
         'assistant-message'
       );
+    });
+
+    // Timestamps are stored to the second, so a reply that dies in the same
+    // second as its prompt can load ahead of it. Pairing has to survive that
+    // wherever it happens, not only on the session's first exchange.
+    it('shows one notice when a later reply loads before its prompt', () => {
+      const messages = [
+        createMockAIMessage({
+          id: 'prompt-1',
+          role: 'user',
+          content: 'first question',
+          status: 'success',
+        }),
+        createMockAIMessage({
+          id: 'reply-1',
+          role: 'assistant',
+          content: 'a clean answer',
+          status: 'success',
+        }),
+        createMockAIMessage({
+          id: 'reply-2',
+          role: 'assistant',
+          content: 'half an answer',
+          status: 'error',
+          failure_message: 'The connection to the assistant was lost.',
+        }),
+        createMockAIMessage({
+          id: 'prompt-2',
+          role: 'user',
+          content: 'second question',
+          status: 'error',
+          failure_message: 'The connection to the assistant was lost.',
+        }),
+      ];
+
+      render(<MessageList messages={messages} onRetryMessage={vi.fn()} />);
+
+      expect(screen.getAllByTestId('ai-failure-notice')).toHaveLength(1);
+    });
+
+    // The reply above belongs to the prompt it sorted ahead of, not to the one
+    // two exchanges back that already succeeded.
+    it('retries the question the failed reply actually answers', async () => {
+      const onRetryMessage = vi.fn();
+      const messages = [
+        createMockAIMessage({
+          id: 'prompt-1',
+          role: 'user',
+          content: 'first question',
+          status: 'success',
+        }),
+        createMockAIMessage({
+          id: 'reply-1',
+          role: 'assistant',
+          content: 'a clean answer',
+          status: 'success',
+        }),
+        createMockAIMessage({
+          id: 'reply-2',
+          role: 'assistant',
+          content: 'half an answer',
+          status: 'error',
+          failure_message: 'The connection to the assistant was lost.',
+        }),
+        createMockAIMessage({
+          id: 'prompt-2',
+          role: 'user',
+          content: 'second question',
+          status: 'error',
+        }),
+      ];
+
+      render(
+        <MessageList messages={messages} onRetryMessage={onRetryMessage} />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      expect(onRetryMessage).toHaveBeenCalledWith('prompt-2');
     });
 
     // Two failures in a row: the first left a reply behind, the second did not.

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -343,9 +343,8 @@ describe('MessageList', () => {
       ).toBeInTheDocument();
     });
 
-    // The prompt is marked failed before the partial reply reaches the client,
-    // so the notice would otherwise sit above text still typing itself out.
-    it('holds the notice back while a reply is still arriving', () => {
+    // A failed reply speaks for its prompt, so the prompt stays quiet.
+    it('leaves the notice to the reply when there is one', () => {
       const messages = [
         createMockAIMessage({
           id: 'prompt-1',
@@ -353,18 +352,59 @@ describe('MessageList', () => {
           content: 'My message',
           status: 'error',
         }),
+        createMockAIMessage({
+          id: 'reply-1',
+          role: 'assistant',
+          content: 'half an answer',
+          status: 'error',
+          failure_message: 'The assistant stopped responding partway through.',
+        }),
       ];
 
-      render(
-        <MessageList
-          messages={messages}
-          isLoading={true}
-          streamingContent="half an answ"
-          onRetryMessage={vi.fn()}
-        />
-      );
+      render(<MessageList messages={messages} onRetryMessage={vi.fn()} />);
 
-      expect(screen.queryByTestId('ai-failure-notice')).not.toBeInTheDocument();
+      const notice = screen.getByTestId('ai-failure-notice');
+      // Under the reply, not under the prompt.
+      expect(notice.closest('[data-role]')).toHaveAttribute(
+        'data-role',
+        'assistant-message'
+      );
+    });
+
+    // Two failures in a row: the first left a reply behind, the second did not.
+    // Reading only the neighbour above would let the older reply speak for the
+    // newer prompt, and the question just asked would fail in silence.
+    it('still speaks for a prompt whose own reply never arrived', () => {
+      const messages = [
+        createMockAIMessage({
+          id: 'prompt-1',
+          role: 'user',
+          content: 'first question',
+          status: 'error',
+        }),
+        createMockAIMessage({
+          id: 'reply-1',
+          role: 'assistant',
+          content: 'half an answer',
+          status: 'error',
+          failure_message: 'The assistant stopped responding partway through.',
+        }),
+        createMockAIMessage({
+          id: 'prompt-2',
+          role: 'user',
+          content: 'second question',
+          status: 'error',
+          failure_message: 'The connection to the assistant was lost.',
+        }),
+      ];
+
+      render(<MessageList messages={messages} onRetryMessage={vi.fn()} />);
+
+      const notices = screen.getAllByTestId('ai-failure-notice');
+      expect(notices).toHaveLength(2);
+      expect(notices[1]).toHaveTextContent(
+        'The connection to the assistant was lost'
+      );
     });
 
     it('falls back to a plain sentence when the server sent no reason', () => {

--- a/assets/test/collaborative-editor/lib/AIChannelRegistry.test.ts
+++ b/assets/test/collaborative-editor/lib/AIChannelRegistry.test.ts
@@ -164,6 +164,41 @@ describe('AIChannelRegistry streaming', () => {
     });
   });
 
+  // The server sends the saved partial and then the error, and the partial is
+  // queued behind a drain that runs far slower than Apollo fills it. The error
+  // clears the buffer, so unless the drain is finished first the reply the user
+  // watched appear never reaches the store.
+  it('lands a partial reply before the error that follows it', () => {
+    channel._test.emit('streaming_chunk', {
+      content: 'a long answer that is still draining',
+    });
+
+    channel._test.emit('new_message', {
+      message: {
+        id: 'reply-1',
+        role: 'assistant',
+        content: 'a long answer that is still draining',
+        status: 'error',
+        inserted_at: new Date().toISOString(),
+      },
+    });
+
+    // Mid-drain: the partial is still waiting on the buffer.
+    vi.advanceTimersByTime(30);
+    expect(store.getSnapshot().messages).toHaveLength(0);
+
+    channel._test.emit('message_error', {
+      message_id: 'prompt-1',
+      status: 'error',
+      failure_message: 'The connection to the assistant was lost.',
+    });
+
+    const saved = store.getSnapshot().messages;
+    expect(saved).toHaveLength(1);
+    expect(saved[0]?.content).toBe('a long answer that is still draining');
+    expect(store.getSnapshot().streamingContent).toBeNull();
+  });
+
   it('clears an active status when a text chunk arrives over the wire', () => {
     // A status is showing (e.g. "Writing code...") when text starts streaming.
     channel._test.emit('streaming_status', { text: 'Writing code...' });

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,7 +27,7 @@ ignore:
   # Mix tasks — one-shot CLI utilities, not exercised by the suite
   - "lib/mix/tasks/**"
 
-  # A copy of Tesla's Finch adapter, carried until we bump past 1.21.1, which
-  # carries the fix (tesla#912). Upstream owns and tests these branches; the
+  # A copy of Tesla's Finch adapter, carried until we bump to 1.21.1 or later,
+  # which carries the fix (tesla#912). Upstream owns and tests these branches; the
   # deviations we made have tests of our own.
   - "lib/lightning/tesla/adapter/finch.ex"

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,7 +27,7 @@ ignore:
   # Mix tasks — one-shot CLI utilities, not exercised by the suite
   - "lib/mix/tasks/**"
 
-  # A copy of Tesla's Finch adapter, carried only until the upstream fix is
-  # released (tesla#912) and then deleted. Upstream owns and tests these
-  # branches; the deviations we made have tests of our own.
+  # A copy of Tesla's Finch adapter, carried until we bump past 1.21.1, which
+  # carries the fix (tesla#912). Upstream owns and tests these branches; the
+  # deviations we made have tests of our own.
   - "lib/lightning/tesla/adapter/finch.ex"

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -32,17 +32,13 @@ defmodule Lightning.AiAssistant do
   @title_max_length 40
   @success_status_range 200..299
 
-  # What a user sees when the reason is ours and not fit to show them.
   @internal_failure "Something went wrong. Please try again."
 
-  # Apollo names every error it raises, but a name is not a promise that the
-  # text is safe to show. It wraps unhandled exceptions as `str(e)` under
-  # INTERNAL_ERROR, UNKNOWN_ERROR, BAD_REQUEST, INVALID_REQUEST, DATABASE_ERROR,
-  # FETCH_ERROR and ADAPTOR_API_ERROR, and `str(e)` carries internal hostnames,
-  # upstream URLs and container paths. These are the ones whose message Apollo
-  # writes for a person instead, read off apollo at v3.1.1. A type not on the
-  # list is treated the same as no type at all: logged, not shown. Revisit when
-  # Apollo adds error types.
+  # A name is not a promise the text is safe: apollo's entry.py rewraps any
+  # unhandled exception as `str(e)` under a type of its own, and `str(e)`
+  # carries hostnames and container paths. These are the types whose message
+  # apollo writes for a person, read off v3.1.1. Anything else is logged, not
+  # shown.
   @apollo_readable_errors ~w(
     AUTH_ERROR
     CONNECTION_ERROR
@@ -1191,7 +1187,7 @@ defmodule Lightning.AiAssistant do
 
       broadcast_streaming_error(session.id, message)
 
-      Logger.error(
+      Logger.warning(
         "[AI Assistant] Stream exited for session #{session.id}: #{inspect(reason)}"
       )
 
@@ -1214,11 +1210,9 @@ defmodule Lightning.AiAssistant do
     save_partial_response(session, content, code, acc)
   end
 
-  # Nothing arrived that a reader could use, so there is nothing to keep. Status
-  # updates alone are not worth a message: they describe work that did not
-  # produce anything. Decided on the trimmed text rather than on whether any
-  # chunks arrived at all, because a reply that sent only whitespace before
-  # dying would otherwise be saved as a message reading "(no response)".
+  # Status updates alone are not worth keeping: they describe work that
+  # produced nothing. Decided on the trimmed text, so a reply that sent only
+  # whitespace saves nothing rather than a message reading "(no response)".
   defp save_partial_response(_session, "", nil, acc) do
     {:error, acc.apollo_error || stream_failure_message()}
   end
@@ -1230,9 +1224,8 @@ defmodule Lightning.AiAssistant do
     attrs =
       %{
         role: :assistant,
-        # Only reachable with code and no text, since no text and no code is
-        # handled above. `content` is required, and yaml on its own is still
-        # worth keeping.
+        # Reachable only with code and no text; content is required and yaml
+        # alone is still worth keeping.
         content: if(content == "", do: "(no response)", else: content),
         status: :error,
         failure_category: :incomplete_response,
@@ -1257,10 +1250,8 @@ defmodule Lightning.AiAssistant do
     end
   end
 
-  # A global chat's reply carries workflow YAML and never a job, and the flag
-  # is what says so. Without it the partial is treated as job code and has the
-  # session's job attached, so the YAML the user watched appear comes back
-  # rendered as a code suggestion.
+  # Without the flag the partial is filed as job code with the session's job
+  # attached, and the YAML comes back rendered as a code suggestion.
   defp partial_meta(session) do
     if get_in(session.meta, ["message_options", "use_global_assistant"]) do
       %{meta: %{"from_global" => true}}
@@ -1290,13 +1281,9 @@ defmodule Lightning.AiAssistant do
   defp append_segment(acc, segment),
     do: %{acc | segments: [segment | acc.segments]}
 
-  # Only worth persisting when the reply actually had a shape to it. A stream
-  # of plain text renders the same from `content` alone, and writing a
-  # one-segment timeline for it would change how every job chat failure looks.
-  #
-  # Bounded the way the complete path bounds Apollo's own segments: an
-  # over-long, empty or over-numerous timeline would make the changeset
-  # invalid, and a partial save that fails saves nothing at all.
+  # Only when the reply had a shape to it: plain text renders the same from
+  # `content` alone. Bounded like the complete path, since an invalid timeline
+  # fails the changeset and a partial save that fails saves nothing at all.
   defp put_partial_segments(attrs, acc) do
     segments =
       acc
@@ -1304,12 +1291,8 @@ defmodule Lightning.AiAssistant do
       |> Map.fetch!(:segments)
       |> Enum.reverse()
       |> Enum.map(&clamp_segment/1)
-      # Dropped rather than carried, matching what the complete path does with
-      # Apollo's own segments: an empty content fails the embed's
-      # validate_required, which would invalidate the whole changeset and lose
-      # the text as well - the loss this function exists to prevent. Trimmed,
-      # because validate_required trims before it checks, so whitespace alone
-      # fails it too.
+      # An empty segment fails validate_required and takes the whole changeset
+      # with it. Trimmed, because validate_required trims before it checks.
       |> Enum.reject(&(String.trim(&1.content) == ""))
       |> Enum.take(ChatMessage.max_response_segments())
 
@@ -1340,9 +1323,8 @@ defmodule Lightning.AiAssistant do
       :timeout ->
         transport_failure_message(:timeout)
 
-      # Anything Finch reports. It wraps Mint's error in a struct of its own,
-      # and both carry :reason, so the reason is taken out before it is matched
-      # on rather than matching one struct and missing the other.
+      # Binds the struct module so one clause covers both: Finch wraps Mint's
+      # error in its own, and matching only Mint's missed every real failure.
       %s{reason: reason}
       when s in [Finch.TransportError, Mint.TransportError] ->
         transport_failure_message(reason)
@@ -1358,11 +1340,9 @@ defmodule Lightning.AiAssistant do
 
   # A silence long enough to give up on reaches us two ways, from our own
   # adapter and from Finch, and both have to read the same to the user.
-  # APOLLO_REQUEST_TIMEOUT_MS lands here too: Finch reports the whole-request
-  # cap as the same :timeout, so an answer arriving steadily and cut off for
-  # running long is, at this layer, the same value as one that went quiet. The
-  # two settings are logged so that whoever reads an incident can tell which
-  # ceiling was hit from how long the request lasted.
+  # APOLLO_REQUEST_TIMEOUT_MS lands here too, as the same :timeout, so an
+  # answer cut off for running long is indistinguishable from one that went
+  # quiet. Both ceilings are logged; how long it ran is what tells them apart.
   defp transport_failure_message(:timeout) do
     Logger.warning(
       "[AI Assistant] Stream timed out. Either it went quiet for " <>
@@ -1403,9 +1383,7 @@ defmodule Lightning.AiAssistant do
     message =
       case Jason.decode(data) do
         # On /stream the HTTP status is already 200 by the time this arrives,
-        # so the type in the payload is the only thing that identifies it. This
-        # sentence is built from `details` rather than Apollo's prose, so it is
-        # ours to show.
+        # so the type in the payload is the only thing that identifies it.
         {:ok, %{"type" => "ATTACHMENT_TOO_LARGE", "details" => details}} ->
           attachment_too_large_message(details)
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -34,11 +34,12 @@ defmodule Lightning.AiAssistant do
 
   @internal_failure "Something went wrong. Please try again."
 
-  # A name is not a promise the text is safe: apollo's entry.py rewraps any
-  # unhandled exception as `str(e)` under a type of its own, and `str(e)`
-  # carries hostnames and container paths. These are the types whose message
-  # apollo writes for a person, read off v3.1.1. Anything else is logged, not
-  # shown.
+  # A name is not a promise the text is safe: most apollo services catch broadly
+  # and rewrap as `str(e)` under a type of their own - BAD_REQUEST,
+  # INVALID_REQUEST, UNKNOWN_ERROR, DATABASE_ERROR, FETCH_ERROR,
+  # ADAPTOR_API_ERROR - and `str(e)` carries hostnames and container paths.
+  # These are the types whose message apollo writes for a person, read off
+  # v3.1.1. Anything else is logged, not shown.
   @apollo_readable_errors ~w(
     AUTH_ERROR
     CONNECTION_ERROR

--- a/lib/lightning/ai_assistant/chat_message.ex
+++ b/lib/lightning/ai_assistant/chat_message.ex
@@ -172,11 +172,9 @@ defmodule Lightning.AiAssistant.ChatMessage do
     field :status, Ecto.Enum,
       values: [:pending, :processing, :success, :error, :cancelled]
 
-    # Why a message failed, kept alongside the status rather than broadcast.
-    # The failure people care about most is a deploy interrupting a run, and
-    # that is exactly when the browser reconnects to a different node - a
-    # PubSub-only signal is gone by then. It is also often written by a
-    # different process than the one that failed.
+    # Kept on the row as well as broadcast: the failure that matters most is a
+    # deploy interrupting a run, which is exactly when the browser reconnects
+    # to a different node and a PubSub-only signal is already gone.
     field :failure_category, Ecto.Enum,
       values: [
         :upstream_error,

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -65,12 +65,10 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   """
   @spec job_timeout() :: pos_integer()
   def job_timeout do
-    # Sits just outside the transport's own worst case, so the HTTP layer gets
-    # to fail first and say why. request_timeout is only checked between reads,
-    # so it can overrun by up to one idle_timeout - hence adding both rather
-    # than a flat margin. Must stay below Oban's shutdown_grace_period: if it
-    # doesn't, an interrupted job is killed after its producer has stopped and
-    # no telemetry fires at all.
+    # Just outside the transport's worst case, so the HTTP layer fails first and
+    # says why. request_timeout is only checked between reads, so it can overrun
+    # by one idle_timeout; hence both, not a flat margin. Must stay under Oban's
+    # shutdown_grace_period.
     Lightning.Config.apollo(:connect_timeout) +
       Lightning.Config.apollo(:request_timeout) +
       Lightning.Config.apollo(:idle_timeout) + 10_000
@@ -302,10 +300,9 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
         {:error, "Failed to save assistant response"}
 
-      # Something raised on our side. The text describes our internals, so the
-      # user gets the generic sentence instead. It is not logged again here:
-      # whoever raised it already logged the exception, and each extra
-      # Logger.error is a second Sentry event for one failure.
+      # Raised on our side, so the text describes our internals. Not logged
+      # again: whoever raised it already did, and a second Logger.error is a
+      # second Sentry event for one failure.
       {:error, {:internal, raw}} ->
         {:ok, _updated_session, _updated_message} =
           update_message_status(
@@ -317,9 +314,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
         {:error, raw}
 
       {:error, error_message} ->
-        # Every string reaching here is already written for a person to read,
-        # whether it came from handle_error_response or from the partial-save
-        # path.
+        # Every string reaching here is already written for a person to read.
         {:ok, _updated_session, _updated_message} =
           update_message_status(
             message,
@@ -405,10 +400,9 @@ defmodule Lightning.AiAssistant.MessageProcessor do
           atom() | {atom(), AiAssistant.ChatSession.t()},
           Ecto.UUID.t() | nil
         ) :: :ok
-  # message_id is carried so a listener does not have to guess which message
-  # this is about. It guessed by taking the newest, which is wrong the moment
-  # anything reports on an older one - the reaper clearing a message stranded
-  # several exchanges back would have marked the newest as failed instead.
+  # Carries message_id so a listener need not guess. It guessed by taking the
+  # newest, which marks the wrong one the moment the reaper reports on a message
+  # stranded several exchanges back.
   defp broadcast_status(session_id, status, message_id) do
     Lightning.broadcast(
       "ai_session:#{session_id}",
@@ -430,10 +424,8 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   """
   @spec broadcast_message_error(Ecto.UUID.t(), Ecto.UUID.t()) :: :ok
   def broadcast_message_error(session_id, message_id) do
-    # get/1 rather than get!/1: the reaper calls this per message inside an
-    # Enum.each, so a session deleted since it selected its candidates would
-    # raise and abandon the rest of the sweep. Nobody is listening to a
-    # deleted session anyway.
+    # get/1, not get!/1: the reaper calls this per message, so a session deleted
+    # since it selected its candidates would abandon the rest of the sweep.
     case AiAssistant.get_session(session_id) do
       {:ok, session} ->
         broadcast_status(session_id, {:error, session}, message_id)
@@ -517,10 +509,8 @@ defmodule Lightning.AiAssistant.MessageProcessor do
 
   defp put_failure(changes, nil), do: changes
 
-  # Clamped here rather than in the changeset, because this writes through
-  # Ecto.Changeset.change/2, which applies no validation at all. The column is
-  # read back and re-sent on every channel join, so an unbounded string would
-  # be paid for on each one.
+  # Clamped here, not in the changeset: this writes through change/2, which
+  # validates nothing, and the column is re-sent on every channel join.
   defp put_failure(changes, {category, message}) do
     Map.merge(changes, %{
       failure_category: category,
@@ -553,10 +543,8 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     error = meta.error
     timeout? = is_map(error) and Map.get(error, :reason) == :timeout
 
-    # A timeout is an upstream condition, not a fault of ours, and the Sentry
-    # capture below already treats it as a warning. Logging it at :error would
-    # raise a second, louder Sentry event for the same thing - see
-    # .claude/rules/logging.md.
+    # An upstream condition, not our fault, and the capture below is already a
+    # warning. See .claude/rules/logging.md.
     Logger.log(if(timeout?, do: :warning, else: :error), ~s"""
     AI Assistant exception:
     Worker: #{job.worker}
@@ -566,9 +554,8 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     Duration: #{measure.duration / 1_000_000}ms
     """)
 
-    # get/2 rather than get!/2: a session deleted while its job was running would
-    # raise here, and a raise in a telemetry handler detaches it, silently ending
-    # Oban error reporting for the rest of the node's life.
+    # get/2, not get!/2: a raise in a telemetry handler detaches it, silently
+    # ending Oban error reporting for the life of the node.
     ChatMessage
     |> Repo.get(job.args["message_id"])
     |> case do
@@ -651,9 +638,7 @@ defmodule Lightning.AiAssistant.MessageProcessor do
         :ok
 
       other ->
-        # Cancelled or discarded, most often because a deploy interrupted the
-        # job. Expected rather than faulty, and the Sentry capture below is
-        # already a warning.
+        # Cancelled or discarded, usually a deploy. Expected, not faulty.
         Logger.warning("""
         AI Assistant stop (non-success):
         Worker: #{meta.job.worker}

--- a/lib/lightning/ai_assistant/message_processor.ex
+++ b/lib/lightning/ai_assistant/message_processor.ex
@@ -74,7 +74,6 @@ defmodule Lightning.AiAssistant.MessageProcessor do
       Lightning.Config.apollo(:idle_timeout) + 10_000
   end
 
-  @doc false
   @spec process_message(String.t()) ::
           {:ok, AiAssistant.ChatSession.t()} | {:error, String.t()}
   defp process_message(message_id) do
@@ -482,7 +481,6 @@ defmodule Lightning.AiAssistant.MessageProcessor do
   # :processing clears the last attempt's failure. A retry writes only :pending,
   # so without that a message which failed and then succeeded keeps the old
   # category and sentence, and the channel attaches both to a :success message.
-  @doc false
   @spec build_status_changes(atom()) :: map()
   defp build_status_changes(:processing) do
     %{
@@ -519,7 +517,6 @@ defmodule Lightning.AiAssistant.MessageProcessor do
     })
   end
 
-  @doc false
   @spec workflow_code_from_session(AiAssistant.ChatSession.t()) ::
           String.t() | nil
   defp workflow_code_from_session(session) do

--- a/lib/lightning/ai_assistant/stuck_message_reaper.ex
+++ b/lib/lightning/ai_assistant/stuck_message_reaper.ex
@@ -26,7 +26,7 @@ defmodule Lightning.AiAssistant.StuckMessageReaper do
 
   require Logger
 
-  @worker "Lightning.AiAssistant.MessageProcessor"
+  @worker inspect(MessageProcessor)
   @live_states ~w(available scheduled executing retryable)
   @message "The assistant was interrupted before it finished. Please try again."
   @batch_size 200
@@ -56,10 +56,8 @@ defmodule Lightning.AiAssistant.StuckMessageReaper do
       where: m.status == :processing,
       where: m.processing_started_at < ^cutoff,
       order_by: [asc: m.processing_started_at],
-      # Bounded because each one reaped loads its whole session to tell the
-      # panel. The backlog this worker exists for is exactly when that would
-      # be largest, and it runs on a single-slot queue; the oldest go first
-      # and the rest wait five minutes.
+      # Each one reaped loads its whole session to tell the panel, and this runs
+      # on a single-slot queue. Oldest first; the rest wait five minutes.
       limit: @batch_size,
       select: %{id: m.id, chat_session_id: m.chat_session_id}
     )
@@ -73,12 +71,10 @@ defmodule Lightning.AiAssistant.StuckMessageReaper do
   defp live_message_ids(cutoff) do
     from(j in Oban.Job,
       where: j.worker == ^@worker and j.state in ^@live_states,
-      # An executing row only means the job is alive while it is fresh. Oban
-      # leaves the row executing when a node dies mid-job, and nothing here
-      # moves it out again: Cron is the only plugin configured, and Lifeline
-      # is what would rescue it. Counting a stale one as live would let an
-      # orphaned row shield its message from every future sweep, which is the
-      # exact case this worker exists to catch.
+      # An executing row means the job is alive only while it is fresh: Oban
+      # leaves it executing when a node dies mid-job and nothing moves it out,
+      # since Lifeline is not configured. Counting a stale one as live would let
+      # it shield its message from every future sweep.
       where: j.state != "executing" or j.attempted_at >= ^cutoff,
       select: fragment("?->>'message_id'", j.args)
     )

--- a/lib/lightning/ai_assistant/stuck_message_reaper.ex
+++ b/lib/lightning/ai_assistant/stuck_message_reaper.ex
@@ -57,7 +57,7 @@ defmodule Lightning.AiAssistant.StuckMessageReaper do
       where: m.processing_started_at < ^cutoff,
       order_by: [asc: m.processing_started_at],
       # Each one reaped loads its whole session to tell the panel, and this runs
-      # on a single-slot queue. Oldest first; the rest wait five minutes.
+      # on a single-slot queue; the rest wait five minutes.
       limit: @batch_size,
       select: %{id: m.id, chat_session_id: m.chat_session_id}
     )

--- a/lib/lightning/application.ex
+++ b/lib/lightning/application.ex
@@ -181,18 +181,11 @@ defmodule Lightning.Application do
     Supervisor.start_link(children, opts)
   end
 
-  # Finch already keys pools by {scheme, host, port}, so Apollo has its own
-  # either way, and size and count restate Finch's own defaults. Under the
-  # shipped configuration this changes nothing; it exists so that setting
-  # APOLLO_CONNECT_TIMEOUT_MS has somewhere to take effect, and so a change to
-  # Finch's defaults cannot quietly shrink a pool whose streams hold their
-  # connection for as long as an answer takes.
-  #
-  # http1 is Finch's default too, and is written out because this pool depends
-  # on it: :request_timeout is HTTP/1-only, and on http2 receive_timeout
-  # becomes a deadline for the whole request rather than the gap between
-  # chunks, which would silently cap the length of an answer. Pinned so a
-  # change to that default cannot quietly take both settings with it.
+  # Size, count and protocol restate Finch's own defaults, so this changes
+  # nothing as shipped. It exists to give APOLLO_CONNECT_TIMEOUT_MS somewhere to
+  # take effect, and to pin http1: :request_timeout is HTTP/1-only, and on http2
+  # receive_timeout becomes a whole-request deadline instead of the gap between
+  # chunks, which would silently cap how long an answer may be.
   @doc false
   def apollo_pools do
     base = %{default: [size: 50, count: 1]}
@@ -229,10 +222,8 @@ defmodule Lightning.Application do
 
   defp poolable_url?(_endpoint), do: false
 
-  # Reaching Apollo happens inside the adapter's wait for the first byte, which
-  # the idle timeout bounds, so a connect timeout above it can never expire.
-  # Silently, and on the setting an operator most expects to control a slow or
-  # unreachable host.
+  # Reaching Apollo happens inside the adapter's wait for the first byte, so a
+  # connect timeout above the idle one can never expire.
   @doc false
   def warn_if_connect_timeout_is_unreachable do
     connect = Lightning.Config.apollo(:connect_timeout)
@@ -261,10 +252,9 @@ defmodule Lightning.Application do
     end
   end
 
-  # Oban stops its producer once the grace period expires and only then kills
-  # whatever is still running, so a job that outlives the window is killed with
-  # nothing left to report it. Its AI message would stay :processing until the
-  # reaper picks it up, and no telemetry would fire.
+  # Oban stops its producer before killing what is still running, so a job that
+  # outlives the window dies with nothing left to report it and its message sits
+  # :processing until the reaper finds it.
   @doc false
   def warn_if_ai_jobs_outlive_the_drain_window do
     grace = Application.get_env(:lightning, Oban)[:shutdown_grace_period]

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -138,7 +138,6 @@ defmodule Lightning.Config.Bootstrap do
            :apollo_timeout_env_still_set,
            env!("APOLLO_TIMEOUT", :string, nil) != nil
 
-    # How long to wait to reach Apollo at all.
     apollo_connect_timeout =
       env!(
         "APOLLO_CONNECT_TIMEOUT_MS",
@@ -146,11 +145,9 @@ defmodule Lightning.Config.Bootstrap do
         Utils.get_env([:lightning, :apollo, :connect_timeout])
       )
 
-    # Longest acceptable silence, both before the first byte of an answer and
-    # between the chunks after it. Apollo sends a keepalive every 15s from
-    # v3.1.1, so half a minute of nothing means the path is broken rather than
-    # that a model is thinking. Raise it if you run an older Apollo that has no
-    # keepalive.
+    # Covers the wait for the first byte as well as the gaps after it. Apollo
+    # sends a keepalive every 15s from v3.1.1, so half a minute of silence means
+    # the path is broken rather than a model thinking. Raise it on an older one.
     apollo_idle_timeout =
       env!(
         "APOLLO_IDLE_TIMEOUT_MS",
@@ -158,7 +155,6 @@ defmodule Lightning.Config.Bootstrap do
         Utils.get_env([:lightning, :apollo, :idle_timeout])
       )
 
-    # Longest one whole request may take, however steadily it is streaming.
     apollo_request_timeout =
       env!(
         "APOLLO_REQUEST_TIMEOUT_MS",
@@ -333,19 +329,13 @@ defmodule Lightning.Config.Bootstrap do
       plugins: [
         {Oban.Plugins.Cron, crontab: all_cron}
       ],
-      # Should exceed MessageProcessor.timeout/1: below it, an AI job interrupted
-      # by a deploy is killed after Oban's producer has stopped, so no telemetry
-      # fires and nothing reports the failure. Application start warns if that
-      # inverts.
-      #
-      # It only has that effect if the platform lets the node live that long.
-      # Kubernetes force-kills after terminationGracePeriodSeconds, which is
-      # set in the deployment manifests rather than here, and defaults to 30s if
-      # left out - well short of this.
-      # Until that is raised a deploy landing on a running AI job still severs
-      # it, and StuckMessageReaper is what recovers the message rather than the
-      # :stop handler. Raising it trades slower rolling restarts for users
-      # keeping an in-flight answer.
+      # Must exceed MessageProcessor.job_timeout/0, or an interrupted AI job is
+      # killed after Oban's producer has stopped and nothing reports it; boot
+      # warns if that inverts. This only holds if the platform lets the node
+      # live that long: Kubernetes force-kills after
+      # terminationGracePeriodSeconds, set in the deployment manifests and 30s
+      # if left out, so until that is raised the reaper is what recovers a
+      # severed message.
       shutdown_grace_period: :timer.minutes(6),
       dispatch_cooldown: 100,
       queues: [

--- a/lib/lightning/config/bootstrap.ex
+++ b/lib/lightning/config/bootstrap.ex
@@ -155,6 +155,7 @@ defmodule Lightning.Config.Bootstrap do
         Utils.get_env([:lightning, :apollo, :idle_timeout])
       )
 
+    # The whole request, however steadily it is streaming.
     apollo_request_timeout =
       env!(
         "APOLLO_REQUEST_TIMEOUT_MS",

--- a/lib/lightning/tesla/adapter/finch.ex
+++ b/lib/lightning/tesla/adapter/finch.ex
@@ -20,22 +20,22 @@ defmodule Lightning.Tesla.Adapter.Finch do
   that process's dictionary and read back with `take_stream_error/0` once the
   stream has been consumed.
 
-  Also passes `:request_timeout` through to Finch, which the 1.18.3 we are
-  pinned to drops. That one is already fixed upstream, in 1.19.0 and later, so
-  a Tesla upgrade would cover it without this module.
+  Also passes `:request_timeout` through to Finch, which the 1.18.3 we pin
+  drops.
 
-  Reported upstream as
-  [tesla#912](https://github.com/elixir-tesla/tesla/issues/912). Delete this
-  module once a release carries the fix; the reason will arrive as a raised
-  `Tesla.Error` rather than through `take_stream_error/0`, so the callers in
-  `Lightning.AiAssistant` change with it.
+  Both are fixed upstream, in
+  [tesla#912](https://github.com/elixir-tesla/tesla/issues/912), released in
+  1.21.1. This module exists only because we pin `~> 1.18.2`; bumping deletes
+  it, and the reason then arrives as a raised `Tesla.Error` rather than through
+  `take_stream_error/0`, so the two callers in `Lightning.AiAssistant` change
+  with it. Tracked in
+  [#5080](https://github.com/OpenFn/lightning/issues/5080).
   """
 
   @behaviour Tesla.Adapter
 
-  # receive_timeout covers two waits, not one: the wait for status and headers
-  # in stream/3, and each gap between chunks in body_stream/3. Whichever
-  # elapses first ends the request.
+  # receive_timeout covers two waits: for status and headers in stream/3, and
+  # each gap between chunks in body_stream/3.
   @defaults [receive_timeout: 15_000]
   @stream_error_key {__MODULE__, :stream_error}
 
@@ -86,10 +86,9 @@ defmodule Lightning.Tesla.Adapter.Finch do
     owner = self()
     ref = make_ref()
 
-    # Upstream's callback carries two `{:error, _}` clauses. `Finch.stream/5`
-    # only ever passes `:status`, `:headers`, `:data` and `:trailers` to it and
-    # reports a failure through its return value, which handle_stream_response/3
-    # below reads. Those clauses cannot fire, so they are left out.
+    # Upstream's two `{:error, _}` clauses are left out: Finch.stream/5 passes
+    # only :status, :headers, :data and :trailers here and reports failures
+    # through its return value, which handle_stream_response/3 reads.
     fun = fn
       {:status, status}, _acc ->
         status
@@ -140,9 +139,8 @@ defmodule Lightning.Tesla.Adapter.Finch do
           Task.await(task)
           nil
 
-        # The two clauses upstream discards. Both still halt the stream, so a
-        # consumer sees what it would on upstream; the difference is that the
-        # reason survives.
+        # The two clauses upstream discards. Both still halt the stream; the
+        # difference is that the reason survives.
         {^ref, {:error, error}} ->
           Process.put(@stream_error_key, error)
           Task.shutdown(task, :brutal_kill)
@@ -156,10 +154,8 @@ defmodule Lightning.Tesla.Adapter.Finch do
     end)
   end
 
-  # Upstream keeps a bare `{:error, reason}` clause behind a version check, for
-  # Finch below 0.20. We pin 0.23, where `Finch.stream/5` returns only
-  # `{:ok, acc}` or `{:error, exception, acc}`, so upstream compiles the same two
-  # clauses this does. Restore it if the pin ever moves below 0.20.
+  # Upstream's third clause is gated on Finch below 0.20. We pin 0.23, where
+  # Finch.stream/5 returns only {:ok, acc} or {:error, exception, acc}.
   defp handle_stream_response({:ok, _acc}, ref, owner) do
     send(owner, {ref, :eof})
   end

--- a/lib/lightning/tesla/adapter/finch.ex
+++ b/lib/lightning/tesla/adapter/finch.ex
@@ -23,13 +23,14 @@ defmodule Lightning.Tesla.Adapter.Finch do
   Also passes `:request_timeout` through to Finch, which the 1.18.3 we pin
   drops.
 
-  Both are fixed upstream, in
-  [tesla#912](https://github.com/elixir-tesla/tesla/issues/912), released in
-  1.21.1. This module exists only because we pin `~> 1.18.2`; bumping deletes
-  it, and the reason then arrives as a raised `Tesla.Error` rather than through
-  `take_stream_error/0`, so the two callers in `Lightning.AiAssistant` change
-  with it. Tracked in
-  [#5080](https://github.com/OpenFn/lightning/issues/5080).
+  Both are fixed upstream, in separate releases: the option pass-through in
+  1.19.0 ([tesla#879](https://github.com/elixir-tesla/tesla/pull/879)), the
+  stream reason in 1.21.1
+  ([tesla#912](https://github.com/elixir-tesla/tesla/issues/912)). This module
+  exists only because we pin `~> 1.18.2`; bumping to 1.21.1 deletes it, and the
+  reason then arrives as a raised `Tesla.Error` rather than through
+  `take_stream_error/0`, so the caller in `Lightning.AiAssistant` changes with
+  it. Tracked in [#5080](https://github.com/OpenFn/lightning/issues/5080).
   """
 
   @behaviour Tesla.Adapter

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -1096,16 +1096,9 @@ defmodule LightningWeb.AiAssistantChannel do
   # is already on screen, and a session whose newest assistant reply succeeded
   # has nothing partial to send.
   defp broadcast_partial_answer(socket, session) do
-    # Picked by role rather than by taking the last message. Messages are
-    # ordered by inserted_at and that is stored to the second, so a turn that
-    # dies quickly ties with the question that started it and can come back
-    # either way round. Taking the last one then finds the question, matches
-    # nothing here, and the answer the user watched appear is never sent - the
-    # loss this whole path exists to prevent.
-    #
-    # Re-sending is the safe direction: the client keys messages by id and
-    # ignores one it already has, so a partial kept from an earlier turn is
-    # dropped there rather than shown twice.
+    # By role, not by taking the last: inserted_at is stored to the second, so a
+    # turn that dies quickly ties with its own question and can sort either way
+    # round. Re-sending is safe, since the client dedupes by id.
     partial =
       session.messages
       |> Enum.filter(&(&1.role == :assistant))
@@ -1120,10 +1113,8 @@ defmodule LightningWeb.AiAssistantChannel do
     end
   end
 
-  # The broadcaster says which message it is reporting on. Falling back to the
-  # newest user message is only right when nothing said - anything reporting on
-  # an older one, like the reaper clearing something stranded several exchanges
-  # back, would otherwise mark the wrong message failed.
+  # Falling back to the newest is only right when the broadcaster named nothing;
+  # the reaper reports on messages several exchanges back.
   defp failed_message(session, nil) do
     session.messages
     |> Enum.reverse()

--- a/test/lightning/ai_assistant/ai_assistant_test.exs
+++ b/test/lightning/ai_assistant/ai_assistant_test.exs
@@ -3207,9 +3207,8 @@ defmodule Lightning.AiAssistantTest do
       assert message =~ "paste the part you need into the chat"
     end
 
-    # Anything the clauses above did not name reaches the reader as ours, and
-    # goes to the log as itself.
-    test "falls back to a sentence of ours for a shape it cannot read", %{
+    # A transport error no clause names: the reader gets ours, the log gets it.
+    test "logs an unrecognised transport error before generalising it", %{
       user: user,
       project: project,
       workflow: workflow
@@ -3287,9 +3286,9 @@ defmodule Lightning.AiAssistantTest do
                Lightning.AiAssistant.ChatMessage.max_failure_message_length()
     end
 
-    # Apollo on main has no ATTACHMENT_TOO_LARGE, so an unrecognised type must
-    # keep falling through to its own message rather than being swallowed.
-    test "passes through an error type it does not recognise", %{
+    # PROMPT_TOO_LONG is on the allowlist, so Apollo's own sentence reaches the
+    # reader. Anything off it is swallowed; see the INTERNAL_ERROR test above.
+    test "passes through an error type on the allowlist", %{
       user: user,
       project: project,
       workflow: workflow


### PR DESCRIPTION
## Description

Fixes two bugs that shipped in #5074, and cuts the commentary that PR added.

A failed exchange showed its notice twice, or not at all, depending on how the messages happened to load. Timestamps are stored to the second, so a reply that dies in the same second as its prompt sorts either side of it, and the code was reading neighbours. Each failed reply now claims the prompt it answers, once, across the whole list. That also fixes Try again re-running the question from two exchanges back.

A long partial re-typed itself from the middle after failing, because the saved reply was queued behind the letter-by-letter drain that the error then cleared.

The rest is prose that had drifted: the tesla note folded two upstream releases into one, and the allowlist comment named the wrong Apollo module. 186 comment lines out, 107 back.

## Validation steps

1. Point `APOLLO_ENDPOINT` at something that goes quiet, set `APOLLO_IDLE_TIMEOUT_MS=5000`, send a message and let it fail. Send a second and let that one fail too. Each failure is reported once, under the reply it belongs to.
2. Let a long answer stream a while before killing it. The text stays put rather than restarting from the middle.
3. Reload. Still one notice per failure, and Try again re-runs the right question.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**
- [x] I have ticked a box in "AI usage" in this PR
