### PR TITLE
Hide lifecycle actions while reading an older version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
+/_build
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
 # The directory Mix downloads your dependencies sources to.
 /deps/
+/deps
 
 # Where 3rd-party dependencies like ExDoc output generated docs.
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to
 
 ### Fixed
 
+- Reading an older version of a workflow no longer offers actions that change
+  the current one. Switch to draft, Go live, Promote and Edit in sandbox are
+  hidden while a version or a run's view is pinned, so clicking one cannot take
+  production offline while you are looking at history.
+  [#5136](https://github.com/OpenFn/lightning/pull/5136)
+
 - The global assistant no longer offers to paste a reply's code block into
   whichever job you have open. It applies its own changes and shows them as
   diffs, so those blocks are data it quoted back or work it has already done.

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -268,6 +268,9 @@ export function Header({
   // The Live badge describes the workflow's current state, which would be a lie
   // on these views, so it is suppressed and the version badge carries the
   // context instead.
+  // A view of the past is for reading. The lifecycle and sandbox actions all act
+  // on the current workflow, so offering them here reaches past what is on
+  // screen: Switch to draft would take production offline while you read history.
   const isViewingNonCurrentVersion = isPinnedVersion || isViewingAsExecuted;
 
   // Determine AI button disabled message based on priority
@@ -615,50 +618,56 @@ export function Header({
               </div>
             </div>
             <div className="relative flex gap-2">
-              {!isNewWorkflow && !isSandbox && lifecycleState === 'draft' && (
-                <Tooltip
-                  content={
-                    isReadOnly ? 'You cannot go live on this version' : null
-                  }
-                  side="bottom"
-                >
+              {!isNewWorkflow &&
+                !isSandbox &&
+                !isViewingNonCurrentVersion &&
+                lifecycleState === 'draft' && (
+                  <Tooltip
+                    content={
+                      isReadOnly ? 'You cannot go live on this version' : null
+                    }
+                    side="bottom"
+                  >
+                    <button
+                      type="button"
+                      data-testid="go-live-button"
+                      disabled={isReadOnly || isTransitioning}
+                      onClick={() => {
+                        setIsTransitioning(true);
+                        void goLive()
+                          .catch(() =>
+                            notifications.alert({
+                              title: 'Could not go live',
+                              description: 'Please try again.',
+                            })
+                          )
+                          .finally(() => {
+                            setIsTransitioning(false);
+                          });
+                      }}
+                      className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300"
+                    >
+                      Go live
+                    </button>
+                  </Tooltip>
+                )}
+              {!isNewWorkflow &&
+                !isSandbox &&
+                !isViewingNonCurrentVersion &&
+                lifecycleState === 'live' && (
                   <button
                     type="button"
-                    data-testid="go-live-button"
-                    disabled={isReadOnly || isTransitioning}
+                    data-testid="switch-to-draft-button"
+                    disabled={isTransitioning}
                     onClick={() => {
-                      setIsTransitioning(true);
-                      void goLive()
-                        .catch(() =>
-                          notifications.alert({
-                            title: 'Could not go live',
-                            description: 'Please try again.',
-                          })
-                        )
-                        .finally(() => {
-                          setIsTransitioning(false);
-                        });
+                      setShowSwitchToDraftDialog(true);
                     }}
-                    className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300"
+                    className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 disabled:hover:bg-gray-50"
                   >
-                    Go live
+                    Switch to draft
                   </button>
-                </Tooltip>
-              )}
-              {!isNewWorkflow && !isSandbox && lifecycleState === 'live' && (
-                <button
-                  type="button"
-                  data-testid="switch-to-draft-button"
-                  disabled={isTransitioning}
-                  onClick={() => {
-                    setShowSwitchToDraftDialog(true);
-                  }}
-                  className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 disabled:hover:bg-gray-50"
-                >
-                  Switch to draft
-                </button>
-              )}
-              {!isNewWorkflow && isSandbox && (
+                )}
+              {!isNewWorkflow && isSandbox && !isViewingNonCurrentVersion && (
                 <button
                   type="button"
                   data-testid="promote-sandbox-button"
@@ -670,29 +679,32 @@ export function Header({
                   Promote
                 </button>
               )}
-              {lifecycleState === 'live' && !isSandbox && !isNewWorkflow && (
-                <Tooltip
-                  content={
-                    canProvisionSandbox
-                      ? null
-                      : 'You do not have permission to create a sandbox in this project.'
-                  }
-                  side="bottom"
-                >
-                  <button
-                    type="button"
-                    data-testid="edit-in-sandbox-button"
-                    disabled={!canProvisionSandbox}
-                    onClick={() => {
-                      if (!canProvisionSandbox) return;
-                      setShowEditInSandboxPicker(true);
-                    }}
-                    className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+              {lifecycleState === 'live' &&
+                !isSandbox &&
+                !isNewWorkflow &&
+                !isViewingNonCurrentVersion && (
+                  <Tooltip
+                    content={
+                      canProvisionSandbox
+                        ? null
+                        : 'You do not have permission to create a sandbox in this project.'
+                    }
+                    side="bottom"
                   >
-                    Edit in sandbox
-                  </button>
-                </Tooltip>
-              )}
+                    <button
+                      type="button"
+                      data-testid="edit-in-sandbox-button"
+                      disabled={!canProvisionSandbox}
+                      onClick={() => {
+                        if (!canProvisionSandbox) return;
+                        setShowEditInSandboxPicker(true);
+                      }}
+                      className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+                    >
+                      Edit in sandbox
+                    </button>
+                  </Tooltip>
+                )}
               {projectId && workflowId && firstTriggerId && !isReadOnly && (
                 <NewRunButton
                   onClick={() => {

--- a/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
@@ -296,6 +296,55 @@ describe('Header - lifecycle actions', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('hides the lifecycle and sandbox actions on a pinned older version', () => {
+    // They all act on the current workflow, so offering them here would reach
+    // past what is on screen.
+    lifecycleState = 'live';
+    urlParams = { v: '2' };
+
+    renderHeader();
+
+    expect(
+      screen.queryByTestId('switch-to-draft-button')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('edit-in-sandbox-button')
+    ).not.toBeInTheDocument();
+  });
+
+  test('hides Go live on a pinned older version of a draft workflow', () => {
+    lifecycleState = 'draft';
+    urlParams = { v: '1' };
+
+    renderHeader();
+
+    expect(screen.queryByTestId('go-live-button')).not.toBeInTheDocument();
+  });
+
+  test('hides the lifecycle and sandbox actions in an as-executed run view', () => {
+    lifecycleState = 'live';
+    urlParams = { as_run: 'run-123' };
+
+    renderHeader();
+
+    expect(
+      screen.queryByTestId('switch-to-draft-button')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('edit-in-sandbox-button')
+    ).not.toBeInTheDocument();
+  });
+
+  test('offers the actions again on the current version', () => {
+    lifecycleState = 'live';
+    urlParams = {};
+
+    renderHeader();
+
+    expect(screen.getByTestId('switch-to-draft-button')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-in-sandbox-button')).toBeInTheDocument();
+  });
+
   test('hides the Live badge in an as-executed run view', () => {
     lifecycleState = 'live';
     urlParams = { as_run: 'run-123' };


### PR DESCRIPTION
## Description

This PR fixes a bug where the actions on screen reached past what you were looking at.

Pinning an older version, or opening a run that used one, makes the document read-only. But Switch to draft, Go live, Promote and Edit in sandbox all stayed on screen and enabled, and they act on the *current* workflow, not the version in front of you.

Switch to draft is the one that mattered. You open v2 to work out what went wrong, click it, and the live workflow goes out of production with its triggers turned off. Nothing on screen suggested that button reached past what you were reading, because the Live badge is deliberately hidden on these views.

That suppression is the precedent: we already decided the Live badge would be a lie on a pinned view. The actions have the same problem and did not get the same treatment. This applies the existing condition to them.

Closes #5131

## Validation steps

1. Open a live workflow with more than one published version. Confirm Switch to draft and Edit in sandbox are offered.
2. Pin an older version from the version dropdown. Both should disappear, and the Read-only pill stays.
3. Return to the latest version. Both come back.
4. From Recent History, open a run that executed against an older version. Same again: no lifecycle actions while you are looking at that run.
5. Take the workflow to draft and pin an old version. Go live should not be offered either.
6. In a sandbox, Promote should not be offered while a version is pinned.

## Additional notes for the reviewer

The condition already existed and was already used to hide the Live badge, so this is applying it in four more places rather than inventing a rule.

I checked the reverse case too: on the current version nothing changes, which is the last of the four tests.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR