### PR TITLE
Warn before a promote overwrites newer parent work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,6 @@ and this project adheres to
   Lightning does not normalise anything today, but #4577 adds it on every name,
   so the runtime moves first.
 
-### Fixed
-
-- Merging a sandbox no longer reports its own merge as the parent having moved
-  on. A merge records a new version on the target computed from the merged
-  content, and nothing wrote that back to the sandbox, so every merge after the
-  first showed the sandbox as diverged from work it had just done itself.
-  [#4863](https://github.com/OpenFn/lightning/issues/4863)
-
 ### Added
 
 - Promoting from a sandbox now warns first when the parent project has changed
@@ -82,6 +74,12 @@ and this project adheres to
   [#4952](https://github.com/OpenFn/lightning/issues/4952)
 
 ### Fixed
+
+- Merging a sandbox no longer reports its own merge as the parent having moved
+  on. A merge records a new version on the target computed from the merged
+  content, and nothing wrote that back to the sandbox, so every merge after the
+  first showed the sandbox as diverged from work it had just done itself.
+  [#4863](https://github.com/OpenFn/lightning/issues/4863)
 
 - Reading an older version of a workflow no longer offers actions that change
   the current one. Switch to draft, Go live, Promote and Edit in sandbox are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,22 @@ and this project adheres to
   Lightning does not normalise anything today, but #4577 adds it on every name,
   so the runtime moves first.
 
+### Fixed
+
+- Merging a sandbox no longer reports its own merge as the parent having moved
+  on. A merge records a new version on the target computed from the merged
+  content, and nothing wrote that back to the sandbox, so every merge after the
+  first showed the sandbox as diverged from work it had just done itself.
+  [#4863](https://github.com/OpenFn/lightning/issues/4863)
+
 ### Added
 
+- Promoting from a sandbox now warns first when the parent project has changed
+  that workflow since the sandbox was created. Promote rebuilds the parent
+  workflow from the sandbox, so anything the parent gained in the meantime is
+  removed rather than merged, and the confirm step names the parent and says so
+  before you commit to it.
+  [#4863](https://github.com/OpenFn/lightning/issues/4863)
 - The editor's version list now shows published versions rather than every
   intermediate save, each with who published it, when, and whether it came from
   going live or a promote. Picking one opens it read-only, and Recent History

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -216,8 +216,14 @@ export function Header({
   // IMPORTANT: All hooks must be called unconditionally before any early returns or conditional logic
   const { params, updateSearchParams } = useURLState();
   const { selectNode } = useNodeSelection();
-  const { saveWorkflow, goLive, switchToDraft, promote, archiveSandbox } =
-    useWorkflowActions();
+  const {
+    saveWorkflow,
+    goLive,
+    switchToDraft,
+    promote,
+    checkPromote,
+    archiveSandbox,
+  } = useWorkflowActions();
   const { canSave, tooltipMessage } = useCanSave();
   const triggers = useWorkflowState(state => state.triggers);
   const { canRun } = useCanRun();
@@ -772,6 +778,7 @@ export function Header({
             onArchive={handleArchiveSandbox}
             onKeep={handleKeepSandbox}
             onCancel={handleCancelPromote}
+            onCheckDivergence={checkPromote}
           />
 
           <EditInSandboxPicker

--- a/assets/js/collaborative-editor/components/PromoteDialog.tsx
+++ b/assets/js/collaborative-editor/components/PromoteDialog.tsx
@@ -74,11 +74,12 @@ export function PromoteDialog({
   const [phase, setPhase] = useState<Phase>('confirm');
   const [isPromoting, setIsPromoting] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);
-  // Non-null once the server says the parent has moved on; the name inside it
-  // can still be null, so absence and anonymity stay distinguishable.
-  const [divergence, setDivergence] = useState<{
-    parentName: string | null;
-  } | null>(null);
+  // The parent's name once the server says it has moved on, null while it has
+  // not. The server only names the parent on the diverged reply.
+  const [divergedParentName, setDivergedParentName] = useState<string | null>(
+    null
+  );
+  const [checkFailed, setCheckFailed] = useState(false);
 
   const isBusy = isPromoting || isArchiving;
 
@@ -89,7 +90,8 @@ export function PromoteDialog({
       setPhase('confirm');
       setIsPromoting(false);
       setIsArchiving(false);
-      setDivergence(null);
+      setDivergedParentName(null);
+      setCheckFailed(false);
     }
   }, [isOpen]);
 
@@ -100,12 +102,15 @@ export function PromoteDialog({
 
     void onCheckDivergence()
       .then(({ diverged, parent_name }) => {
-        if (!cancelled && diverged) {
-          setDivergence({ parentName: parent_name });
+        if (!cancelled && diverged && parent_name) {
+          setDivergedParentName(parent_name);
         }
       })
       .catch(() => {
-        // Deliberately silent. The dialog still works without the warning.
+        // Say so rather than reading a failed check as "nothing has changed".
+        if (!cancelled) {
+          setCheckFailed(true);
+        }
       });
 
     return () => {
@@ -190,7 +195,14 @@ export function PromoteDialog({
                   and starts processing data with these changes.
                 </p>
 
-                {divergence && (
+                {checkFailed && (
+                  <p className="mt-4 text-sm text-gray-500">
+                    We could not check whether the parent has changed since this
+                    sandbox was created.
+                  </p>
+                )}
+
+                {divergedParentName !== null && (
                   <div
                     className="mt-4 flex gap-2.5 rounded-md bg-amber-50 p-3
                       text-sm text-amber-800"
@@ -203,7 +215,7 @@ export function PromoteDialog({
                     <p>
                       This workflow has changed in{' '}
                       <span className="font-semibold">
-                        {divergence.parentName ?? 'the parent project'}
+                        {divergedParentName}
                       </span>{' '}
                       since this sandbox was created. Promoting replaces that
                       version with yours, and anything added there is removed.

--- a/assets/js/collaborative-editor/components/PromoteDialog.tsx
+++ b/assets/js/collaborative-editor/components/PromoteDialog.tsx
@@ -39,8 +39,8 @@ interface PromoteDialogProps {
   onCancel: () => void;
   /**
    * Asks the server whether the parent has changed this workflow since the
-   * sandbox forked. Called when the dialog opens; a failure is treated as no
-   * divergence, because a missing warning must not block a valid promote.
+   * sandbox forked. Called when the dialog opens. A rejection is shown as a
+   * failed check rather than as no divergence, and never blocks the promote.
    */
   onCheckDivergence: () => Promise<{
     diverged: boolean;

--- a/assets/js/collaborative-editor/components/PromoteDialog.tsx
+++ b/assets/js/collaborative-editor/components/PromoteDialog.tsx
@@ -80,6 +80,7 @@ export function PromoteDialog({
     null
   );
   const [checkFailed, setCheckFailed] = useState(false);
+  const [checking, setChecking] = useState(false);
 
   const isBusy = isPromoting || isArchiving;
 
@@ -92,6 +93,7 @@ export function PromoteDialog({
       setIsArchiving(false);
       setDivergedParentName(null);
       setCheckFailed(false);
+      setChecking(true);
     }
   }, [isOpen]);
 
@@ -110,6 +112,11 @@ export function PromoteDialog({
         // Say so rather than reading a failed check as "nothing has changed".
         if (!cancelled) {
           setCheckFailed(true);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setChecking(false);
         }
       });
 
@@ -195,6 +202,13 @@ export function PromoteDialog({
                   and starts processing data with these changes.
                 </p>
 
+                {checking && (
+                  <p className="mt-4 text-sm text-gray-500">
+                    Checking whether the parent has changed since this sandbox
+                    was created...
+                  </p>
+                )}
+
                 {checkFailed && (
                   <p className="mt-4 text-sm text-gray-500">
                     We could not check whether the parent has changed since this
@@ -234,6 +248,7 @@ export function PromoteDialog({
                   <Button
                     variant="primary"
                     loading={isPromoting}
+                    disabled={checking}
                     onClick={() => void handleConfirm()}
                   >
                     {isPromoting ? (

--- a/assets/js/collaborative-editor/components/PromoteDialog.tsx
+++ b/assets/js/collaborative-editor/components/PromoteDialog.tsx
@@ -73,13 +73,16 @@ export function PromoteDialog({
     null
   );
   const [checkFailed, setCheckFailed] = useState(false);
-  const [checking, setChecking] = useState(false);
+  const [checking, setChecking] = useState(true);
+  const [wasOpen, setWasOpen] = useState(isOpen);
 
   const isBusy = isPromoting || isArchiving;
 
-  // Reset to the confirm step each time the dialog is (re)opened so a second
-  // promote never starts on the previous run's success step.
-  useEffect(() => {
+  // Reset during render rather than in an effect: an effect lands a frame late,
+  // and that frame shows the previous run's warning over an enabled button.
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+
     if (isOpen) {
       setPhase('confirm');
       setIsPromoting(false);
@@ -88,7 +91,7 @@ export function PromoteDialog({
       setCheckFailed(false);
       setChecking(true);
     }
-  }, [isOpen]);
+  }
 
   useEffect(() => {
     if (!isOpen) return;

--- a/assets/js/collaborative-editor/components/PromoteDialog.tsx
+++ b/assets/js/collaborative-editor/components/PromoteDialog.tsx
@@ -37,11 +37,6 @@ interface PromoteDialogProps {
   onKeep: () => void;
   /** Phase one dismissal. Close without saving or promoting. */
   onCancel: () => void;
-  /**
-   * Asks the server whether the parent has changed this workflow since the
-   * sandbox forked. Called when the dialog opens. A rejection is shown as a
-   * failed check rather than as no divergence, and never blocks the promote.
-   */
   onCheckDivergence: () => Promise<{
     diverged: boolean;
     parent_name: string | null;
@@ -74,8 +69,6 @@ export function PromoteDialog({
   const [phase, setPhase] = useState<Phase>('confirm');
   const [isPromoting, setIsPromoting] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);
-  // The parent's name once the server says it has moved on, null while it has
-  // not. The server only names the parent on the diverged reply.
   const [divergedParentName, setDivergedParentName] = useState<string | null>(
     null
   );
@@ -109,7 +102,6 @@ export function PromoteDialog({
         }
       })
       .catch(() => {
-        // Say so rather than reading a failed check as "nothing has changed".
         if (!cancelled) {
           setCheckFailed(true);
         }

--- a/assets/js/collaborative-editor/components/PromoteDialog.tsx
+++ b/assets/js/collaborative-editor/components/PromoteDialog.tsx
@@ -37,6 +37,15 @@ interface PromoteDialogProps {
   onKeep: () => void;
   /** Phase one dismissal. Close without saving or promoting. */
   onCancel: () => void;
+  /**
+   * Asks the server whether the parent has changed this workflow since the
+   * sandbox forked. Called when the dialog opens; a failure is treated as no
+   * divergence, because a missing warning must not block a valid promote.
+   */
+  onCheckDivergence: () => Promise<{
+    diverged: boolean;
+    parent_name: string | null;
+  }>;
 }
 
 type Phase = 'confirm' | 'success';
@@ -60,10 +69,16 @@ export function PromoteDialog({
   onArchive,
   onKeep,
   onCancel,
+  onCheckDivergence,
 }: PromoteDialogProps) {
   const [phase, setPhase] = useState<Phase>('confirm');
   const [isPromoting, setIsPromoting] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);
+  // Non-null once the server says the parent has moved on; the name inside it
+  // can still be null, so absence and anonymity stay distinguishable.
+  const [divergence, setDivergence] = useState<{
+    parentName: string | null;
+  } | null>(null);
 
   const isBusy = isPromoting || isArchiving;
 
@@ -74,8 +89,29 @@ export function PromoteDialog({
       setPhase('confirm');
       setIsPromoting(false);
       setIsArchiving(false);
+      setDivergence(null);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+
+    void onCheckDivergence()
+      .then(({ diverged, parent_name }) => {
+        if (!cancelled && diverged) {
+          setDivergence({ parentName: parent_name });
+        }
+      })
+      .catch(() => {
+        // Deliberately silent. The dialog still works without the warning.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, onCheckDivergence]);
 
   // Dismissing means different things per phase: cancel on confirm, keep on
   // success. Never dismiss mid-flight so a save/merge/archive can't be orphaned.
@@ -153,6 +189,27 @@ export function PromoteDialog({
                   into the parent project's live workflow. The parent stays live
                   and starts processing data with these changes.
                 </p>
+
+                {divergence && (
+                  <div
+                    className="mt-4 flex gap-2.5 rounded-md bg-amber-50 p-3
+                      text-sm text-amber-800"
+                  >
+                    <span
+                      className="hero-exclamation-triangle mt-0.5 h-4 w-4
+                        shrink-0 text-amber-500"
+                      aria-hidden="true"
+                    />
+                    <p>
+                      This workflow has changed in{' '}
+                      <span className="font-semibold">
+                        {divergence.parentName ?? 'the parent project'}
+                      </span>{' '}
+                      since this sandbox was created. Promoting replaces that
+                      version with yours, and anything added there is removed.
+                    </p>
+                  </div>
+                )}
 
                 <div className="mt-6 flex justify-end gap-3">
                   <Button

--- a/assets/js/collaborative-editor/hooks/useWorkflow.tsx
+++ b/assets/js/collaborative-editor/hooks/useWorkflow.tsx
@@ -1100,7 +1100,8 @@ export const useWorkflowReadOnly = (): {
   if (isViewingAsExecuted) {
     return {
       isReadOnly: true,
-      tooltipMessage: 'You are viewing this workflow as a past run executed it',
+      tooltipMessage:
+        'You are viewing this workflow as a past run executed it',
       reason: 'as_run',
     };
   }

--- a/assets/js/collaborative-editor/hooks/useWorkflow.tsx
+++ b/assets/js/collaborative-editor/hooks/useWorkflow.tsx
@@ -728,6 +728,7 @@ export const useWorkflowActions = () => {
     // Promote merges only; archiving the sandbox is the separate archiveSandbox
     // command below, offered as an optional second step after a successful merge.
     promote: store.promote,
+    checkPromote: store.checkPromote,
     archiveSandbox: store.archiveSandbox,
 
     resetWorkflow: store.resetWorkflow,
@@ -1099,8 +1100,7 @@ export const useWorkflowReadOnly = (): {
   if (isViewingAsExecuted) {
     return {
       isReadOnly: true,
-      tooltipMessage:
-        'You are viewing this workflow as a past run executed it',
+      tooltipMessage: 'You are viewing this workflow as a past run executed it',
       reason: 'as_run',
     };
   }

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -1315,7 +1315,8 @@ export const createWorkflowStore = (
         // Type assertion needed because Y.Map.get returns unknown
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         const typedEntityErrors = entityErrors as
-          Record<string, Record<string, string[]>> | undefined;
+          | Record<string, Record<string, string[]>>
+          | undefined;
 
         const updatedEntityErrors = {
           ...(typedEntityErrors ?? {}),
@@ -1416,7 +1417,8 @@ export const createWorkflowStore = (
           // Type assertion needed because Y.Map.get returns unknown
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
           const typedEntityErrors = entityErrors as
-            Record<string, Record<string, string[]>> | undefined;
+            | Record<string, Record<string, string[]>>
+            | undefined;
 
           return typedEntityErrors?.[entityId] ?? {};
         }
@@ -1663,12 +1665,17 @@ export const createWorkflowStore = (
     diverged: boolean;
     parent_name: string | null;
   }> => {
-    const { provider } = ensureConnected();
+    const { ydoc, provider } = ensureConnected();
+
+    // The merge matches workflows across projects by name, and promote saves
+    // before merging, so the name it will act on is the working one, not the
+    // last saved one.
+    const { name } = ydoc.getMap('workflow').toJSON() as { name?: string };
 
     return await channelRequest<{
       diverged: boolean;
       parent_name: string | null;
-    }>(provider.channel, 'request_promote_check', {});
+    }>(provider.channel, 'request_promote_check', { workflow_name: name });
   };
 
   // Archive this sandbox after promoting. Archiving turns off the sandbox's

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -1658,18 +1658,13 @@ export const createWorkflowStore = (
     }
   };
 
-  // Whether the parent has changed this workflow since the sandbox forked. The
-  // merge rebuilds the parent from the sandbox, so anything the parent gained
-  // in the meantime is removed rather than kept.
   const checkPromote = async (): Promise<{
     diverged: boolean;
     parent_name: string | null;
   }> => {
     const { ydoc, provider } = ensureConnected();
 
-    // The merge matches workflows across projects by name, and promote saves
-    // before merging, so the name it will act on is the working one, not the
-    // last saved one.
+    // Promote saves before merging, so the name it acts on is the working one.
     const { name } = ydoc.getMap('workflow').toJSON() as { name?: string };
 
     return await channelRequest<{

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -1315,8 +1315,7 @@ export const createWorkflowStore = (
         // Type assertion needed because Y.Map.get returns unknown
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         const typedEntityErrors = entityErrors as
-          | Record<string, Record<string, string[]>>
-          | undefined;
+          Record<string, Record<string, string[]>> | undefined;
 
         const updatedEntityErrors = {
           ...(typedEntityErrors ?? {}),
@@ -1417,8 +1416,7 @@ export const createWorkflowStore = (
           // Type assertion needed because Y.Map.get returns unknown
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
           const typedEntityErrors = entityErrors as
-            | Record<string, Record<string, string[]>>
-            | undefined;
+            Record<string, Record<string, string[]>> | undefined;
 
           return typedEntityErrors?.[entityId] ?? {};
         }
@@ -1656,6 +1654,21 @@ export const createWorkflowStore = (
       logger.error('Failed to promote workflow', error);
       throw error;
     }
+  };
+
+  // Whether the parent has changed this workflow since the sandbox forked. The
+  // merge rebuilds the parent from the sandbox, so anything the parent gained
+  // in the meantime is removed rather than kept.
+  const checkPromote = async (): Promise<{
+    diverged: boolean;
+    parent_name: string | null;
+  }> => {
+    const { provider } = ensureConnected();
+
+    return await channelRequest<{
+      diverged: boolean;
+      parent_name: string | null;
+    }>(provider.channel, 'request_promote_check', {});
   };
 
   // Archive this sandbox after promoting. Archiving turns off the sandbox's
@@ -2188,6 +2201,7 @@ export const createWorkflowStore = (
     editInSandbox,
     promote,
     archiveSandbox,
+    checkPromote,
     saveAndSyncWorkflow,
     resetWorkflow,
     validateWorkflowName,

--- a/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
@@ -467,6 +467,39 @@ describe('Header - lifecycle actions', () => {
     expect(promote).not.toHaveBeenCalled();
   });
 
+  test('holds the promote until the divergence check has answered', async () => {
+    const user = userEvent.setup();
+    let resolveCheck: (value: {
+      diverged: boolean;
+      parent_name: string | null;
+    }) => void = () => {};
+    checkPromote.mockReturnValue(
+      new Promise(resolve => {
+        resolveCheck = resolve;
+      })
+    );
+    renderHeader({ isSandbox: true });
+
+    await user.click(screen.getByTestId('promote-sandbox-button'));
+
+    const dialog = screen.getByRole('dialog');
+    // Silence while the answer is in flight would read as "nothing changed".
+    expect(
+      within(dialog).getByRole('button', { name: 'Save and promote' })
+    ).toBeDisabled();
+    expect(
+      within(dialog).getByText(/checking whether the parent has changed/i)
+    ).toBeInTheDocument();
+
+    resolveCheck({ diverged: false, parent_name: null });
+
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole('button', { name: 'Save and promote' })
+      ).toBeEnabled();
+    });
+  });
+
   test('warns on the confirm step when the parent has changed since the fork', async () => {
     const user = userEvent.setup();
     checkPromote.mockResolvedValue({

--- a/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
@@ -483,7 +483,6 @@ describe('Header - lifecycle actions', () => {
     await user.click(screen.getByTestId('promote-sandbox-button'));
 
     const dialog = screen.getByRole('dialog');
-    // Silence while the answer is in flight would read as "nothing changed".
     expect(
       within(dialog).getByRole('button', { name: 'Save and promote' })
     ).toBeDisabled();
@@ -515,7 +514,6 @@ describe('Header - lifecycle actions', () => {
       await within(dialog).findByText(/has changed in/i)
     ).toBeInTheDocument();
     expect(within(dialog).getByText('Production')).toBeInTheDocument();
-    // Informational only: the promote stays available.
     expect(
       within(dialog).getByRole('button', { name: 'Save and promote' })
     ).toBeEnabled();
@@ -551,7 +549,6 @@ describe('Header - lifecycle actions', () => {
     expect(
       within(dialog).queryByText(/has changed in/i)
     ).not.toBeInTheDocument();
-    // Silence would read as "nothing has changed", which we do not know.
     expect(
       within(dialog).getByText(
         /could not check whether the parent has changed/i
@@ -576,8 +573,6 @@ describe('Header - lifecycle actions', () => {
       within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' })
     );
 
-    // The parent has since been promoted into, so the second open must not
-    // inherit the first open's warning.
     checkPromote.mockResolvedValue({ diverged: false, parent_name: null });
     await user.click(screen.getByTestId('promote-sandbox-button'));
 

--- a/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
@@ -38,6 +38,8 @@ const promote = vi.fn<
   }>
 >();
 const archiveSandbox = vi.fn<() => Promise<{ parent_project_id: string }>>();
+const checkPromote =
+  vi.fn<() => Promise<{ diverged: boolean; parent_name: string | null }>>();
 
 let urlParams: Record<string, string> = {};
 
@@ -89,6 +91,7 @@ vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
     listSandboxes: vi.fn(),
     editInSandbox: vi.fn(),
     promote,
+    checkPromote,
     archiveSandbox,
   }),
   useWorkflowReadOnly: () => readOnly,
@@ -259,6 +262,8 @@ describe('Header - lifecycle actions', () => {
     saveWorkflow.mockReset();
     promote.mockReset();
     archiveSandbox.mockReset();
+    checkPromote.mockReset();
+    checkPromote.mockResolvedValue({ diverged: false, parent_name: null });
     notifySuccess.mockReset();
     notifyInfo.mockReset();
     notifyAlert.mockReset();
@@ -460,6 +465,55 @@ describe('Header - lifecycle actions', () => {
     // Neither the save nor the promote fires until the user confirms.
     expect(saveWorkflow).not.toHaveBeenCalled();
     expect(promote).not.toHaveBeenCalled();
+  });
+
+  test('warns on the confirm step when the parent has changed since the fork', async () => {
+    const user = userEvent.setup();
+    checkPromote.mockResolvedValue({
+      diverged: true,
+      parent_name: 'Production',
+    });
+    renderHeader({ isSandbox: true });
+
+    await user.click(screen.getByTestId('promote-sandbox-button'));
+
+    const dialog = screen.getByRole('dialog');
+    expect(
+      await within(dialog).findByText(/has changed in/i)
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('Production')).toBeInTheDocument();
+    // Informational only: the promote stays available.
+    expect(
+      within(dialog).getByRole('button', { name: 'Save and promote' })
+    ).toBeEnabled();
+  });
+
+  test('shows no divergence warning when the parent has not moved on', async () => {
+    const user = userEvent.setup();
+    renderHeader({ isSandbox: true });
+
+    await user.click(screen.getByTestId('promote-sandbox-button'));
+
+    await waitFor(() => {
+      expect(checkPromote).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(/has changed in/i)).not.toBeInTheDocument();
+  });
+
+  test('a failed divergence check leaves the dialog usable', async () => {
+    const user = userEvent.setup();
+    checkPromote.mockRejectedValue(new Error('channel down'));
+    renderHeader({ isSandbox: true });
+
+    await user.click(screen.getByTestId('promote-sandbox-button'));
+
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByRole('button', { name: 'Save and promote' })
+    ).toBeEnabled();
+    expect(
+      within(dialog).queryByText(/has changed in/i)
+    ).not.toBeInTheDocument();
   });
 
   test('confirming saves before merging, then shows the success step without navigating', async () => {

--- a/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
@@ -507,6 +507,10 @@ describe('Header - lifecycle actions', () => {
 
     await user.click(screen.getByTestId('promote-sandbox-button'));
 
+    await waitFor(() => {
+      expect(checkPromote).toHaveBeenCalledTimes(1);
+    });
+
     const dialog = screen.getByRole('dialog');
     expect(
       within(dialog).getByRole('button', { name: 'Save and promote' })
@@ -514,6 +518,40 @@ describe('Header - lifecycle actions', () => {
     expect(
       within(dialog).queryByText(/has changed in/i)
     ).not.toBeInTheDocument();
+    // Silence would read as "nothing has changed", which we do not know.
+    expect(
+      within(dialog).getByText(
+        /could not check whether the parent has changed/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('reopening the dialog re-runs the check and clears a stale warning', async () => {
+    const user = userEvent.setup();
+    checkPromote.mockResolvedValue({
+      diverged: true,
+      parent_name: 'Production',
+    });
+    renderHeader({ isSandbox: true });
+
+    await user.click(screen.getByTestId('promote-sandbox-button'));
+    expect(
+      await within(screen.getByRole('dialog')).findByText(/has changed in/i)
+    ).toBeInTheDocument();
+
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' })
+    );
+
+    // The parent has since been promoted into, so the second open must not
+    // inherit the first open's warning.
+    checkPromote.mockResolvedValue({ diverged: false, parent_name: null });
+    await user.click(screen.getByTestId('promote-sandbox-button'));
+
+    await waitFor(() => {
+      expect(checkPromote).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByText(/has changed in/i)).not.toBeInTheDocument();
   });
 
   test('confirming saves before merging, then shows the success step without navigating', async () => {

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -2427,9 +2427,9 @@ defmodule Lightning.Projects do
                  selected_workflow_ids: [sandbox_workflow.id],
                  record_release: :promote
                }) do
-          # Reloaded because the caller's struct predates the save that promote
-          # performs, so a rename in the same session would look up the wrong
-          # name here.
+          # Reloaded because the caller's struct is captured at channel join and
+          # the client saves before promoting, so a rename in the same session
+          # would look this up under the old name.
           parent_workflow_id =
             with %Workflow{name: name} <- Repo.reload(sandbox_workflow),
                  %Workflow{id: id} <-

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -2427,13 +2427,16 @@ defmodule Lightning.Projects do
                  selected_workflow_ids: [sandbox_workflow.id],
                  record_release: :promote
                }) do
+          # Reloaded because the caller's struct predates the save that promote
+          # performs, so a rename in the same session would look up the wrong
+          # name here.
           parent_workflow_id =
-            case Lightning.Workflows.get_workflow_by_name(
-                   parent.id,
-                   sandbox_workflow.name
-                 ) do
-              %Workflow{id: id} -> id
-              nil -> nil
+            with %Workflow{name: name} <- Repo.reload(sandbox_workflow),
+                 %Workflow{id: id} <-
+                   Lightning.Workflows.get_workflow_by_name(parent.id, name) do
+              id
+            else
+              _ -> nil
             end
 
           {:ok,

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -1111,8 +1111,9 @@ defmodule Lightning.Projects.MergeProjects do
   never seen that target workflow at all, and merging it overwrites the lot.
   Here an unknown name on the source side is divergence, not silence.
 
-  A name the target does not hold is not divergence, because the merge creates
-  it rather than replacing anything.
+  A name with no recorded version on the target is not divergence: either the
+  target does not hold the workflow, in which case the merge creates it, or it
+  holds nothing this could overwrite.
   """
   @spec workflow_diverged?(Project.t(), Project.t(), String.t()) :: boolean()
   def workflow_diverged?(

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -1102,18 +1102,12 @@ defmodule Lightning.Projects.MergeProjects do
   end
 
   @doc """
-  Whether merging one named workflow from `source_project` into `target_project`
+  Whether merging `workflow_name` from `source_project` into `target_project`
   would overwrite work the target has done since the source forked.
 
-  Narrower than `diverged_workflows/2`, and deliberately not the same question.
-  That function only reports names it finds on both sides, which reads a rename
-  as safe: a source workflow renamed onto a name the target already holds has
-  never seen that target workflow at all, and merging it overwrites the lot.
-  Here an unknown name on the source side is divergence, not silence.
-
-  A name with no recorded version on the target is not divergence: either the
-  target does not hold the workflow, in which case the merge creates it, or it
-  holds nothing this could overwrite.
+  Unlike `diverged_workflows/2`, a name the source has no history for counts as
+  divergence rather than being skipped, because a source workflow renamed onto a
+  name the target already holds has never seen that target workflow.
   """
   @spec workflow_diverged?(Project.t(), Project.t(), String.t()) :: boolean()
   def workflow_diverged?(

--- a/lib/lightning/projects/merge_projects.ex
+++ b/lib/lightning/projects/merge_projects.ex
@@ -1101,6 +1101,48 @@ defmodule Lightning.Projects.MergeProjects do
     )
   end
 
+  @doc """
+  Whether merging one named workflow from `source_project` into `target_project`
+  would overwrite work the target has done since the source forked.
+
+  Narrower than `diverged_workflows/2`, and deliberately not the same question.
+  That function only reports names it finds on both sides, which reads a rename
+  as safe: a source workflow renamed onto a name the target already holds has
+  never seen that target workflow at all, and merging it overwrites the lot.
+  Here an unknown name on the source side is divergence, not silence.
+
+  A name the target does not hold is not divergence, because the merge creates
+  it rather than replacing anything.
+  """
+  @spec workflow_diverged?(Project.t(), Project.t(), String.t()) :: boolean()
+  def workflow_diverged?(
+        %Project{} = source_project,
+        %Project{} = target_project,
+        workflow_name
+      )
+      when is_binary(workflow_name) do
+    case version_hashes(target_project.id, workflow_name) do
+      [] ->
+        false
+
+      [target_head | _] ->
+        target_head not in version_hashes(source_project.id, workflow_name)
+    end
+  end
+
+  defp version_hashes(project_id, workflow_name) do
+    from(version in WorkflowVersion,
+      join: workflow in Workflow,
+      on: workflow.id == version.workflow_id,
+      where:
+        workflow.project_id == ^project_id and workflow.name == ^workflow_name and
+          is_nil(workflow.deleted_at),
+      order_by: [desc: version.inserted_at, desc: version.id],
+      select: version.hash
+    )
+    |> Repo.all()
+  end
+
   defp get_workflow_version_hashes_by_name(workflows) do
     workflow_ids = Enum.map(workflows, & &1.id)
     workflow_name_map = Map.new(workflows, fn w -> {w.id, w.name} end)

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -255,7 +255,8 @@ defmodule Lightning.Projects.Sandboxes do
            {:ok, _} <-
              sync_collections(source, target,
                allow_deletions: allow_collection_deletions?
-             ) do
+             ),
+           :ok <- record_merge_sync_points(source, merge_doc, opts) do
         {:ok, {updated_target, merge_doc}}
       end
     end)
@@ -291,6 +292,96 @@ defmodule Lightning.Projects.Sandboxes do
     else
       _ -> []
     end
+  end
+
+  # A merge leaves the target holding a state this source produced, so the source
+  # has now seen that state. Recording it on the source is what stops
+  # `MergeProjects.diverged_workflows/2` reading the source's own merge as the
+  # target having moved on, which would warn on every promote after the first.
+  # The mirror of `copy_workflow_version_history/2`, which seeds a new sandbox
+  # with the parent's head.
+  defp record_merge_sync_points(source, merge_doc, opts) do
+    merged = merged_workflow_pairs(source, merge_doc, opts)
+    source_hashes = existing_hashes(Map.values(merged))
+
+    merged
+    |> Map.keys()
+    |> latest_versions_by_workflow()
+    |> Enum.each(fn %{workflow_id: target_id, hash: hash, source: version_source} ->
+      source_id = Map.fetch!(merged, target_id)
+
+      unless hash in Map.get(source_hashes, source_id, []) do
+        Repo.insert!(%WorkflowVersion{
+          workflow_id: source_id,
+          hash: hash,
+          source: version_source
+        })
+      end
+    end)
+
+    :ok
+  end
+
+  # Target workflow id => source workflow id, for the workflows this merge wrote.
+  # A promote scopes to its selection; a whole-project merge carries everything
+  # the document did not mark deleted.
+  defp merged_workflow_pairs(source, merge_doc, opts) do
+    entries =
+      merge_doc
+      |> Map.get("workflows", [])
+      |> Enum.reject(&(&1["delete"] == true))
+
+    entries =
+      case Map.get(opts, :selected_workflow_ids) do
+        [_ | _] = selected_ids ->
+          target_ids = promoted_target_ids(selected_ids, merge_doc)
+          Enum.filter(entries, &MapSet.member?(target_ids, &1["id"]))
+
+        _ ->
+          entries
+      end
+
+    source_ids_by_name = Map.new(source.workflows, &{&1.name, &1.id})
+
+    entries
+    |> Enum.flat_map(fn entry ->
+      case Map.fetch(source_ids_by_name, entry["name"]) do
+        {:ok, source_id} -> [{entry["id"], source_id}]
+        :error -> []
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp latest_versions_by_workflow([]), do: []
+
+  defp latest_versions_by_workflow(workflow_ids) do
+    from(version in WorkflowVersion,
+      where: version.workflow_id in ^workflow_ids,
+      distinct: version.workflow_id,
+      order_by: [
+        asc: version.workflow_id,
+        desc: version.inserted_at,
+        desc: version.id
+      ],
+      select: %{
+        workflow_id: version.workflow_id,
+        hash: version.hash,
+        source: version.source
+      }
+    )
+    |> Repo.all()
+  end
+
+  defp existing_hashes([]), do: %{}
+
+  defp existing_hashes(workflow_ids) do
+    from(version in WorkflowVersion,
+      where: version.workflow_id in ^workflow_ids,
+      select: {version.workflow_id, version.hash}
+    )
+    |> Repo.all()
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
   end
 
   defp promoted_target_ids(selected_source_ids, merge_doc) do

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -162,6 +162,10 @@ defmodule Lightning.Projects.Sandboxes do
   provisioner and synchronises collection names. Runs inside a single
   transaction. Collection data is never copied.
 
+  Also writes to the source: each workflow this merge carried gains the target's
+  resulting head in its version history, so a later merge can tell the target
+  moving on from this merge's own work.
+
   Callers must authorise the merge before calling (e.g. `:merge_sandbox`).
 
   ## Parameters
@@ -307,19 +311,36 @@ defmodule Lightning.Projects.Sandboxes do
     merged
     |> Map.keys()
     |> latest_versions_by_workflow()
-    |> Enum.each(fn %{workflow_id: target_id, hash: hash, source: version_source} ->
+    |> Enum.reduce_while(:ok, fn %{
+                                   workflow_id: target_id,
+                                   hash: hash,
+                                   source: version_source
+                                 },
+                                 :ok ->
       source_id = Map.fetch!(merged, target_id)
 
-      unless hash in Map.get(source_hashes, source_id, []) do
-        Repo.insert!(%WorkflowVersion{
+      if hash in Map.get(source_hashes, source_id, []) do
+        {:cont, :ok}
+      else
+        # The target's own source is carried over rather than chosen. It is
+        # normally "cli", and `WorkflowVersions.record_version/3` squashes a
+        # write that repeats the latest row's source, so a later CLI deploy into
+        # this sandbox can delete the sync point and bring the false warning
+        # back. Writing "app" instead would lose it to the next editor save,
+        # which happens far more often.
+        %WorkflowVersion{}
+        |> Ecto.Changeset.change(%{
           workflow_id: source_id,
           hash: hash,
           source: version_source
         })
+        |> Repo.insert()
+        |> case do
+          {:ok, _} -> {:cont, :ok}
+          {:error, changeset} -> {:halt, {:error, changeset}}
+        end
       end
     end)
-
-    :ok
   end
 
   # Target workflow id => source workflow id, for the workflows this merge wrote.
@@ -331,14 +352,19 @@ defmodule Lightning.Projects.Sandboxes do
       |> Map.get("workflows", [])
       |> Enum.reject(&(&1["delete"] == true))
 
+    # An empty selection is a selection, not the absence of one: a merge that
+    # carries only deletions writes no workflow content, so nothing has been
+    # brought into step. Reading it as "everything" would stamp the parent's
+    # head onto workflows the merge never touched and silence their divergence
+    # for good.
     entries =
       case Map.get(opts, :selected_workflow_ids) do
-        [_ | _] = selected_ids ->
+        nil ->
+          entries
+
+        selected_ids ->
           target_ids = promoted_target_ids(selected_ids, merge_doc)
           Enum.filter(entries, &MapSet.member?(target_ids, &1["id"]))
-
-        _ ->
-          entries
       end
 
     source_ids_by_name = Map.new(source.workflows, &{&1.name, &1.id})

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -311,28 +311,23 @@ defmodule Lightning.Projects.Sandboxes do
     merged
     |> Map.keys()
     |> latest_versions_by_workflow()
-    |> Enum.reduce_while(:ok, fn %{
-                                   workflow_id: target_id,
-                                   hash: hash,
-                                   source: version_source
-                                 },
-                                 :ok ->
+    |> Enum.reduce_while(:ok, fn %{workflow_id: target_id, hash: hash}, :ok ->
       source_id = Map.fetch!(merged, target_id)
 
       if hash in Map.get(source_hashes, source_id, []) do
         {:cont, :ok}
       else
-        # The target's own source is carried over rather than chosen. It is
-        # normally "cli", and `WorkflowVersions.record_version/3` squashes a
-        # write that repeats the latest row's source, so a later CLI deploy into
-        # this sandbox can delete the sync point and bring the false warning
-        # back. Writing "app" instead would lose it to the next editor save,
-        # which happens far more often.
+        # "cli" because the provisioner wrote the row this mirrors, and stating
+        # it beats inheriting whatever the target happens to hold.
+        # `WorkflowVersions.record_version/3` squashes a write repeating the
+        # latest row's source, so a later CLI deploy into this sandbox can
+        # delete the sync point and bring the false warning back. "app" would be
+        # worse: the next editor save would take it, and those are constant.
         %WorkflowVersion{}
         |> WorkflowVersion.changeset(%{
           workflow_id: source_id,
           hash: hash,
-          source: version_source
+          source: "cli"
         })
         |> Repo.insert()
         |> case do

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -290,7 +290,7 @@ defmodule Lightning.Projects.Sandboxes do
         release: %{
           kind: :promote,
           source_project_id: source.id,
-          workflow_ids: promoted_target_ids(selected_ids, merge_doc)
+          workflow_ids: promoted_target_ids(source, selected_ids, merge_doc)
         }
       ]
     else
@@ -329,7 +329,7 @@ defmodule Lightning.Projects.Sandboxes do
         # back. Writing "app" instead would lose it to the next editor save,
         # which happens far more often.
         %WorkflowVersion{}
-        |> Ecto.Changeset.change(%{
+        |> WorkflowVersion.changeset(%{
           workflow_id: source_id,
           hash: hash,
           source: version_source
@@ -363,7 +363,7 @@ defmodule Lightning.Projects.Sandboxes do
           entries
 
         selected_ids ->
-          target_ids = promoted_target_ids(selected_ids, merge_doc)
+          target_ids = promoted_target_ids(source, selected_ids, merge_doc)
           Enum.filter(entries, &MapSet.member?(target_ids, &1["id"]))
       end
 
@@ -410,10 +410,15 @@ defmodule Lightning.Projects.Sandboxes do
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
   end
 
-  defp promoted_target_ids(selected_source_ids, merge_doc) do
+  defp promoted_target_ids(source, selected_source_ids, merge_doc) do
+    # Scoped to the source project: these ids decide both what a release records
+    # and which workflows are brought into step, so an id from elsewhere must
+    # not resolve to a name here.
     selected_names =
       from(w in Workflow,
-        where: w.id in ^selected_source_ids,
+        where:
+          w.id in ^selected_source_ids and w.project_id == ^source.id and
+            is_nil(w.deleted_at),
         select: w.name
       )
       |> Repo.all()

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -243,6 +243,7 @@ defmodule Lightning.Projects.Sandboxes do
                force: true
              ),
            merge_doc = MergeProjects.merge_project(source, target, opts),
+           selected_target_ids = selected_target_ids(source, opts, merge_doc),
            # Defer the collaboration reconcile: the import runs inside this outer
            # transaction, so we broadcast below only once it has committed —
            # otherwise the subscriber would reload pre-commit state on its own
@@ -253,14 +254,20 @@ defmodule Lightning.Projects.Sandboxes do
                actor,
                merge_doc,
                [allow_stale: true, reconcile_collaboration: false] ++
-                 release_import_opts(source, opts, merge_doc)
+                 release_import_opts(source, opts, selected_target_ids)
              ),
            :ok <- reject_out_of_project_credentials(target),
            {:ok, _} <-
              sync_collections(source, target,
                allow_deletions: allow_collection_deletions?
              ),
-           :ok <- record_merge_sync_points(source, merge_doc, opts) do
+           :ok <-
+             record_merge_sync_points(
+               source,
+               merge_doc,
+               opts,
+               selected_target_ids
+             ) do
         {:ok, {updated_target, merge_doc}}
       end
     end)
@@ -283,14 +290,14 @@ defmodule Lightning.Projects.Sandboxes do
   # workflows land on the target under the target's ids, so we map the selected
   # source workflows to their merged-document ids by name (workflow names are
   # unique within a project) and hand the provisioner exactly those ids.
-  defp release_import_opts(source, opts, merge_doc) do
+  defp release_import_opts(source, opts, selected_target_ids) do
     with :promote <- Map.get(opts, :record_release),
-         [_ | _] = selected_ids <- Map.get(opts, :selected_workflow_ids) do
+         [_ | _] <- Map.get(opts, :selected_workflow_ids) do
       [
         release: %{
           kind: :promote,
           source_project_id: source.id,
-          workflow_ids: promoted_target_ids(source, selected_ids, merge_doc)
+          workflow_ids: selected_target_ids
         }
       ]
     else
@@ -298,10 +305,18 @@ defmodule Lightning.Projects.Sandboxes do
     end
   end
 
+  # nil means the merge carries everything; a list, even an empty one, scopes it.
+  defp selected_target_ids(source, opts, merge_doc) do
+    case Map.get(opts, :selected_workflow_ids) do
+      nil -> nil
+      selected_ids -> promoted_target_ids(source, selected_ids, merge_doc)
+    end
+  end
+
   # Without this the source's own merge reads as the target having moved on, and
   # every merge after the first warns. Mirrors `copy_workflow_version_history/2`.
-  defp record_merge_sync_points(source, merge_doc, opts) do
-    merged = merged_workflow_pairs(source, merge_doc, opts)
+  defp record_merge_sync_points(source, merge_doc, opts, selected_target_ids) do
+    merged = merged_workflow_pairs(source, merge_doc, opts, selected_target_ids)
     source_hashes = existing_hashes(Map.values(merged))
 
     merged
@@ -331,7 +346,7 @@ defmodule Lightning.Projects.Sandboxes do
     end)
   end
 
-  defp merged_workflow_pairs(source, merge_doc, opts) do
+  defp merged_workflow_pairs(source, merge_doc, _opts, selected_target_ids) do
     entries =
       merge_doc
       |> Map.get("workflows", [])
@@ -340,13 +355,10 @@ defmodule Lightning.Projects.Sandboxes do
     # An empty selection is a selection. A merge carrying only deletions writes
     # no workflow content, so nothing has been brought into step.
     entries =
-      case Map.get(opts, :selected_workflow_ids) do
-        nil ->
-          entries
-
-        selected_ids ->
-          target_ids = promoted_target_ids(source, selected_ids, merge_doc)
-          Enum.filter(entries, &MapSet.member?(target_ids, &1["id"]))
+      if selected_target_ids do
+        Enum.filter(entries, &MapSet.member?(selected_target_ids, &1["id"]))
+      else
+        entries
       end
 
     source_ids_by_name = Map.new(source.workflows, &{&1.name, &1.id})
@@ -372,11 +384,7 @@ defmodule Lightning.Projects.Sandboxes do
         desc: version.inserted_at,
         desc: version.id
       ],
-      select: %{
-        workflow_id: version.workflow_id,
-        hash: version.hash,
-        source: version.source
-      }
+      select: %{workflow_id: version.workflow_id, hash: version.hash}
     )
     |> Repo.all()
   end

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -262,12 +262,7 @@ defmodule Lightning.Projects.Sandboxes do
                allow_deletions: allow_collection_deletions?
              ),
            :ok <-
-             record_merge_sync_points(
-               source,
-               merge_doc,
-               opts,
-               selected_target_ids
-             ) do
+             record_merge_sync_points(source, merge_doc, selected_target_ids) do
         {:ok, {updated_target, merge_doc}}
       end
     end)
@@ -286,10 +281,7 @@ defmodule Lightning.Projects.Sandboxes do
 
   # Builds the `:release` import option for a promote. A promote asks for it via
   # `opts.record_release` and always scopes to `selected_workflow_ids`; any other
-  # merge (e.g. the full sandbox-management merge) records nothing. The promoted
-  # workflows land on the target under the target's ids, so we map the selected
-  # source workflows to their merged-document ids by name (workflow names are
-  # unique within a project) and hand the provisioner exactly those ids.
+  # merge (e.g. the full sandbox-management merge) records nothing.
   defp release_import_opts(source, opts, selected_target_ids) do
     with :promote <- Map.get(opts, :record_release),
          [_ | _] <- Map.get(opts, :selected_workflow_ids) do
@@ -315,8 +307,8 @@ defmodule Lightning.Projects.Sandboxes do
 
   # Without this the source's own merge reads as the target having moved on, and
   # every merge after the first warns. Mirrors `copy_workflow_version_history/2`.
-  defp record_merge_sync_points(source, merge_doc, opts, selected_target_ids) do
-    merged = merged_workflow_pairs(source, merge_doc, opts, selected_target_ids)
+  defp record_merge_sync_points(source, merge_doc, selected_target_ids) do
+    merged = merged_workflow_pairs(source, merge_doc, selected_target_ids)
     source_hashes = existing_hashes(Map.values(merged))
 
     merged
@@ -346,7 +338,7 @@ defmodule Lightning.Projects.Sandboxes do
     end)
   end
 
-  defp merged_workflow_pairs(source, merge_doc, _opts, selected_target_ids) do
+  defp merged_workflow_pairs(source, merge_doc, selected_target_ids) do
     entries =
       merge_doc
       |> Map.get("workflows", [])

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -298,12 +298,8 @@ defmodule Lightning.Projects.Sandboxes do
     end
   end
 
-  # A merge leaves the target holding a state this source produced, so the source
-  # has now seen that state. Recording it on the source is what stops
-  # `MergeProjects.diverged_workflows/2` reading the source's own merge as the
-  # target having moved on, which would warn on every promote after the first.
-  # The mirror of `copy_workflow_version_history/2`, which seeds a new sandbox
-  # with the parent's head.
+  # Without this the source's own merge reads as the target having moved on, and
+  # every merge after the first warns. Mirrors `copy_workflow_version_history/2`.
   defp record_merge_sync_points(source, merge_doc, opts) do
     merged = merged_workflow_pairs(source, merge_doc, opts)
     source_hashes = existing_hashes(Map.values(merged))
@@ -317,12 +313,9 @@ defmodule Lightning.Projects.Sandboxes do
       if hash in Map.get(source_hashes, source_id, []) do
         {:cont, :ok}
       else
-        # "cli" because the provisioner wrote the row this mirrors, and stating
-        # it beats inheriting whatever the target happens to hold.
-        # `WorkflowVersions.record_version/3` squashes a write repeating the
-        # latest row's source, so a later CLI deploy into this sandbox can
-        # delete the sync point and bring the false warning back. "app" would be
-        # worse: the next editor save would take it, and those are constant.
+        # `record_version/3` squashes a write repeating the latest row's source,
+        # so a later CLI deploy here drops this and the false warning returns.
+        # "app" is worse: the next editor save would take it.
         %WorkflowVersion{}
         |> WorkflowVersion.changeset(%{
           workflow_id: source_id,
@@ -338,20 +331,14 @@ defmodule Lightning.Projects.Sandboxes do
     end)
   end
 
-  # Target workflow id => source workflow id, for the workflows this merge wrote.
-  # A promote scopes to its selection; a whole-project merge carries everything
-  # the document did not mark deleted.
   defp merged_workflow_pairs(source, merge_doc, opts) do
     entries =
       merge_doc
       |> Map.get("workflows", [])
       |> Enum.reject(&(&1["delete"] == true))
 
-    # An empty selection is a selection, not the absence of one: a merge that
-    # carries only deletions writes no workflow content, so nothing has been
-    # brought into step. Reading it as "everything" would stamp the parent's
-    # head onto workflows the merge never touched and silence their divergence
-    # for good.
+    # An empty selection is a selection. A merge carrying only deletions writes
+    # no workflow content, so nothing has been brought into step.
     entries =
       case Map.get(opts, :selected_workflow_ids) do
         nil ->
@@ -406,9 +393,6 @@ defmodule Lightning.Projects.Sandboxes do
   end
 
   defp promoted_target_ids(source, selected_source_ids, merge_doc) do
-    # Scoped to the source project: these ids decide both what a release records
-    # and which workflows are brought into step, so an id from elsewhere must
-    # not resolve to a name here.
     selected_names =
       from(w in Workflow,
         where:

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -528,7 +528,7 @@ defmodule LightningWeb.WorkflowChannel do
            :ok <- authorize_merge_sandbox(user, parent) do
         %{
           diverged:
-            workflow_name in MergeProjects.diverged_workflows(sandbox, parent),
+            MergeProjects.workflow_diverged?(sandbox, parent, workflow_name),
           parent_name: parent.name
         }
       else

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -517,7 +517,8 @@ defmodule LightningWeb.WorkflowChannel do
 
     # The merge matches workflows across projects by name, and promote saves
     # before merging, so the answer has to be about the working name. The client
-    # sends it; the last saved name is the fallback.
+    # sends it. The fallback is the name this socket joined on, which a rename
+    # since then has already made wrong, so it is a floor rather than an answer.
     workflow_name =
       case params do
         %{"workflow_name" => name} when is_binary(name) and name != "" -> name

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -507,8 +507,9 @@ defmodule LightningWeb.WorkflowChannel do
   end
 
   # Whether promoting would overwrite work the parent has done since this
-  # sandbox forked. `diverged_workflows/2` answers for every workflow in the
-  # project, so it is narrowed to the one being promoted.
+  # sandbox forked. Not a filtered `diverged_workflows/2`: that one only reports
+  # names it finds on both sides, so it reads a rename onto a name the parent
+  # already holds as safe when it is the case that destroys the most.
   @impl true
   def handle_in("request_promote_check", params, socket) do
     sandbox = socket.assigns.project

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -506,19 +506,14 @@ defmodule LightningWeb.WorkflowChannel do
     end
   end
 
-  # Whether promoting would overwrite work the parent has done since this
-  # sandbox forked. Not a filtered `diverged_workflows/2`: that one only reports
-  # names it finds on both sides, so it reads a rename onto a name the parent
-  # already holds as safe when it is the case that destroys the most.
   @impl true
   def handle_in("request_promote_check", params, socket) do
     sandbox = socket.assigns.project
     user = socket.assigns.current_user
 
-    # The merge matches workflows across projects by name, and promote saves
-    # before merging, so the answer has to be about the working name. The client
-    # sends it. The fallback is the name this socket joined on, which a rename
-    # since then has already made wrong, so it is a floor rather than an answer.
+    # Promote saves before merging, so the answer must be about the working name.
+    # The fallback is the name this socket joined on, already stale after a
+    # rename.
     workflow_name =
       case params do
         %{"workflow_name" => name} when is_binary(name) and name != "" -> name

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -510,17 +510,25 @@ defmodule LightningWeb.WorkflowChannel do
   # sandbox forked. `diverged_workflows/2` answers for every workflow in the
   # project, so it is narrowed to the one being promoted.
   @impl true
-  def handle_in("request_promote_check", _params, socket) do
+  def handle_in("request_promote_check", params, socket) do
     sandbox = socket.assigns.project
-    workflow = socket.assigns.workflow
     user = socket.assigns.current_user
+
+    # The merge matches workflows across projects by name, and promote saves
+    # before merging, so the answer has to be about the working name. The client
+    # sends it; the last saved name is the fallback.
+    workflow_name =
+      case params do
+        %{"workflow_name" => name} when is_binary(name) and name != "" -> name
+        _ -> socket.assigns.workflow.name
+      end
 
     async_task(socket, "request_promote_check", fn ->
       with %_{} = parent <- fetch_parent_project(sandbox),
            :ok <- authorize_merge_sandbox(user, parent) do
         %{
           diverged:
-            workflow.name in MergeProjects.diverged_workflows(sandbox, parent),
+            workflow_name in MergeProjects.diverged_workflows(sandbox, parent),
           parent_name: parent.name
         }
       else

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -23,6 +23,7 @@ defmodule LightningWeb.WorkflowChannel do
   alias Lightning.Projects.Events.ProjectUserRoleChanged
   alias Lightning.Projects.Events.SupportAccessUpdated
   alias Lightning.Projects.Events.WorkflowDeleted
+  alias Lightning.Projects.MergeProjects
   alias Lightning.Projects.ProjectLimiter
   alias Lightning.Projects.Sandboxes
   alias Lightning.Projects.Scope
@@ -503,6 +504,29 @@ defmodule LightningWeb.WorkflowChannel do
     else
       error -> workflow_error_reply(socket, error)
     end
+  end
+
+  # Whether promoting would overwrite work the parent has done since this
+  # sandbox forked. `diverged_workflows/2` answers for every workflow in the
+  # project, so it is narrowed to the one being promoted.
+  @impl true
+  def handle_in("request_promote_check", _params, socket) do
+    sandbox = socket.assigns.project
+    workflow = socket.assigns.workflow
+    user = socket.assigns.current_user
+
+    async_task(socket, "request_promote_check", fn ->
+      with %_{} = parent <- fetch_parent_project(sandbox),
+           :ok <- authorize_merge_sandbox(user, parent) do
+        %{
+          diverged:
+            workflow.name in MergeProjects.diverged_workflows(sandbox, parent),
+          parent_name: parent.name
+        }
+      else
+        _ -> %{diverged: false, parent_name: nil}
+      end
+    end)
   end
 
   @impl true
@@ -1134,6 +1158,7 @@ defmodule LightningWeb.WorkflowChannel do
               "get_context",
               "request_history",
               "request_versions",
+              "request_promote_check",
               "request_trigger_auth_methods",
               "get_limits"
             ] do

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -950,6 +950,131 @@ defmodule Lightning.Projects.SandboxesTest do
   # project-level Local or Inherited fields from sandbox to parent. They
   # guard against future changes to MergeProjects or Provisioner that
   # could accidentally start syncing these fields.
+  describe "merge/4 divergence sync points" do
+    setup do
+      actor = insert(:user)
+      parent = insert(:project, project_users: [%{user: actor, role: :owner}])
+
+      alpha = insert(:simple_workflow, project: parent, name: "alpha")
+      beta = insert(:simple_workflow, project: parent, name: "beta")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(alpha, "aaa111aaa111", "app")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(beta, "bbb111bbb111", "app")
+
+      {:ok, sandbox} =
+        Lightning.Projects.provision_sandbox(parent, actor, %{name: "sb"})
+
+      %{
+        actor: actor,
+        parent: parent,
+        parent_alpha: alpha,
+        parent_beta: beta,
+        sandbox: sandbox
+      }
+    end
+
+    test "leaves the source in step with the target it just wrote", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      sandbox_alpha =
+        Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
+
+      [job | _] =
+        Lightning.Workflows.get_workflow(sandbox_alpha.id, include: [:jobs]).jobs
+
+      Repo.update!(Ecto.Changeset.change(job, body: "console.log('merged');"))
+
+      assert {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
+
+      # Without a sync point the merge's own new version on the parent reads as
+      # the parent having moved on, and every later merge warns.
+      assert [] =
+               Lightning.Projects.MergeProjects.diverged_workflows(
+                 sandbox,
+                 parent
+               )
+    end
+
+    test "does not silence a real divergence when only a deletion is merged", %{
+      actor: actor,
+      parent: parent,
+      parent_alpha: parent_alpha,
+      sandbox: sandbox
+    } do
+      # Someone else moves the parent's alpha on after the fork.
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          parent_alpha,
+          "ccc111ccc111",
+          "app"
+        )
+
+      assert "alpha" in Lightning.Projects.MergeProjects.diverged_workflows(
+               sandbox,
+               parent
+             )
+
+      sandbox_beta = Lightning.Workflows.get_workflow_by_name(sandbox.id, "beta")
+
+      parent_beta_id =
+        Lightning.Workflows.get_workflow_by_name(parent.id, "beta").id
+
+      Repo.update!(
+        Ecto.Changeset.change(sandbox_beta,
+          deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+      )
+
+      # Merging only beta's deletion writes nothing to alpha, so alpha's
+      # divergence must survive it.
+      assert {:ok, _} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_workflow_ids: [],
+                 deleted_target_workflow_ids: [parent_beta_id]
+               })
+
+      assert "alpha" in Lightning.Projects.MergeProjects.diverged_workflows(
+               sandbox,
+               parent
+             )
+    end
+
+    test "does not silence a divergence outside the workflows a promote selected",
+         %{
+           actor: actor,
+           parent: parent,
+           parent_beta: parent_beta,
+           sandbox: sandbox
+         } do
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          parent_beta,
+          "ccc111ccc111",
+          "app"
+        )
+
+      sandbox_alpha =
+        Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
+
+      assert {:ok, _} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_workflow_ids: [sandbox_alpha.id],
+                 record_release: :promote
+               })
+
+      # Promoting alpha says nothing about beta.
+      assert "beta" in Lightning.Projects.MergeProjects.diverged_workflows(
+               sandbox,
+               parent
+             )
+    end
+  end
+
   describe "merge/4 does not propagate Local/Inherited fields" do
     setup do
       actor = insert(:user)

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -991,8 +991,6 @@ defmodule Lightning.Projects.SandboxesTest do
 
       assert {:ok, _} = Sandboxes.merge(sandbox, parent, actor)
 
-      # Without a sync point the merge's own new version on the parent reads as
-      # the parent having moved on, and every later merge warns.
       assert [] =
                Lightning.Projects.MergeProjects.diverged_workflows(
                  sandbox,
@@ -1006,7 +1004,6 @@ defmodule Lightning.Projects.SandboxesTest do
       parent_alpha: parent_alpha,
       sandbox: sandbox
     } do
-      # Someone else moves the parent's alpha on after the fork.
       {:ok, _} =
         Lightning.WorkflowVersions.record_version(
           parent_alpha,
@@ -1030,8 +1027,6 @@ defmodule Lightning.Projects.SandboxesTest do
         )
       )
 
-      # Merging only beta's deletion writes nothing to alpha, so alpha's
-      # divergence must survive it.
       assert {:ok, _} =
                Sandboxes.merge(sandbox, parent, actor, %{
                  selected_workflow_ids: [],
@@ -1054,10 +1049,6 @@ defmodule Lightning.Projects.SandboxesTest do
 
       Repo.update!(Ecto.Changeset.change(sandbox_alpha, name: "gamma"))
 
-      # The parent has no gamma, so the merge creates it under a fresh id rather
-      # than matching one. The sync point has to follow that id back to the
-      # sandbox workflow, or the next promote warns about a workflow this
-      # sandbox just created.
       assert {:ok, _} =
                Sandboxes.merge(sandbox, parent, actor, %{
                  selected_workflow_ids: [sandbox_alpha.id],
@@ -1084,8 +1075,6 @@ defmodule Lightning.Projects.SandboxesTest do
           "app"
         )
 
-      # A workflow of the same name somewhere else must not stand in for this
-      # project's alpha and bring it into step with the parent.
       elsewhere = insert(:project)
       foreign_alpha = insert(:simple_workflow, project: elsewhere, name: "alpha")
 
@@ -1123,7 +1112,6 @@ defmodule Lightning.Projects.SandboxesTest do
                  record_release: :promote
                })
 
-      # Promoting alpha says nothing about beta.
       assert "beta" in Lightning.Projects.MergeProjects.diverged_workflows(
                sandbox,
                parent

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1044,6 +1044,62 @@ defmodule Lightning.Projects.SandboxesTest do
              )
     end
 
+    test "brings a workflow the merge created on the target into step", %{
+      actor: actor,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      sandbox_alpha =
+        Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
+
+      Repo.update!(Ecto.Changeset.change(sandbox_alpha, name: "gamma"))
+
+      # The parent has no gamma, so the merge creates it under a fresh id rather
+      # than matching one. The sync point has to follow that id back to the
+      # sandbox workflow, or the next promote warns about a workflow this
+      # sandbox just created.
+      assert {:ok, _} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_workflow_ids: [sandbox_alpha.id],
+                 record_release: :promote
+               })
+
+      refute Lightning.Projects.MergeProjects.workflow_diverged?(
+               sandbox,
+               parent,
+               "gamma"
+             )
+    end
+
+    test "ignores a selected id that belongs to another project", %{
+      actor: actor,
+      parent: parent,
+      parent_alpha: parent_alpha,
+      sandbox: sandbox
+    } do
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          parent_alpha,
+          "ccc111ccc111",
+          "app"
+        )
+
+      # A workflow of the same name somewhere else must not stand in for this
+      # project's alpha and bring it into step with the parent.
+      elsewhere = insert(:project)
+      foreign_alpha = insert(:simple_workflow, project: elsewhere, name: "alpha")
+
+      assert {:ok, _} =
+               Sandboxes.merge(sandbox, parent, actor, %{
+                 selected_workflow_ids: [foreign_alpha.id]
+               })
+
+      assert "alpha" in Lightning.Projects.MergeProjects.diverged_workflows(
+               sandbox,
+               parent
+             )
+    end
+
     test "does not silence a divergence outside the workflows a promote selected",
          %{
            actor: actor,

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -969,8 +969,6 @@ defmodule LightningWeb.WorkflowChannelTest do
           "app"
         )
 
-      # beta exists in both projects and has diverged, but alpha is the workflow
-      # being promoted, so this socket must stay quiet.
       ref = push(socket, "request_promote_check", %{})
       assert_reply ref, :ok, %{diverged: false}
     end
@@ -981,9 +979,6 @@ defmodule LightningWeb.WorkflowChannelTest do
       parent: parent,
       user: user
     } do
-      # The parent gained gamma after the fork, so the sandbox has no history
-      # under that name at all. Promoting an unsaved rename onto it overwrites
-      # gamma wholesale, which is the case a both-sides comparison reads as safe.
       gamma = insert(:workflow, project: parent, name: "gamma")
 
       {:ok, _} =
@@ -992,7 +987,6 @@ defmodule LightningWeb.WorkflowChannelTest do
       ref = push(socket, "request_promote_check", %{"workflow_name" => "gamma"})
       assert_reply ref, :ok, %{diverged: true}
 
-      # And it stops warning once the promote has actually happened.
       sandbox_alpha =
         Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
 
@@ -1011,8 +1005,6 @@ defmodule LightningWeb.WorkflowChannelTest do
     test "stays quiet when the working name is one the parent does not hold", %{
       sandbox_socket: socket
     } do
-      # A rename onto a fresh name creates a workflow on the parent rather than
-      # replacing one, so there is nothing to warn about.
       ref = push(socket, "request_promote_check", %{"workflow_name" => "delta"})
       assert_reply ref, :ok, %{diverged: false}
     end
@@ -1041,7 +1033,6 @@ defmodule LightningWeb.WorkflowChannelTest do
           %{"project_id" => sandbox.id, "action" => "edit"}
         )
 
-      # A viewer has no rights on the parent, so it is never named to them.
       ref = push(viewer_socket, "request_promote_check", %{})
       assert_reply ref, :ok, %{diverged: false, parent_name: nil}
     end
@@ -1058,9 +1049,6 @@ defmodule LightningWeb.WorkflowChannelTest do
 
       {:ok, _} = Lightning.Projects.promote_workflow(sandbox_alpha, user)
 
-      # The promote records a new version on the parent, computed from the
-      # merged content, so without a sync point the parent's head is a hash this
-      # sandbox has never held and every promote after the first warns.
       ref = push(socket, "request_promote_check", %{})
       assert_reply ref, :ok, %{diverged: false, parent_name: "parent-project"}
     end

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -897,18 +897,27 @@ defmodule LightningWeb.WorkflowChannelTest do
       {:ok, _} =
         Lightning.WorkflowVersions.record_version(alpha, "aaa111aaa111", "app")
 
+      # Beta is a sibling carried into the sandbox by the fork, so it can be
+      # made to diverge independently of alpha.
+      beta = insert(:workflow, project: parent, name: "beta")
+      beta_trigger = insert(:trigger, workflow: beta, type: :webhook)
+      beta_job = insert(:job, workflow: beta, name: "B1")
+
+      insert(:edge,
+        workflow: beta,
+        source_trigger: beta_trigger,
+        target_job: beta_job,
+        condition_type: :always
+      )
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(beta, "bbb000bbb000", "app")
+
       {:ok, sandbox} =
         Lightning.Projects.provision_sandbox(parent, user, %{name: "sb"})
 
       sandbox_alpha =
         Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
-
-      {:ok, _} =
-        Lightning.WorkflowVersions.record_version(
-          sandbox_alpha,
-          "aaa111aaa111",
-          "app"
-        )
 
       {:ok, _, sandbox_socket} =
         LightningWeb.UserSocket
@@ -924,6 +933,9 @@ defmodule LightningWeb.WorkflowChannelTest do
       %{
         parent: parent,
         parent_alpha: alpha,
+        parent_beta: beta,
+        sandbox: sandbox,
+        sandbox_alpha_id: sandbox_alpha.id,
         sandbox_socket: sandbox_socket
       }
     end
@@ -948,17 +960,82 @@ defmodule LightningWeb.WorkflowChannelTest do
       assert_reply ref, :ok, %{diverged: true, parent_name: "parent-project"}
     end
 
-    test "reports no divergence for a sibling workflow that moved on", %{
-      sandbox_socket: socket,
-      parent: parent
-    } do
-      beta = insert(:workflow, project: parent, name: "beta")
-
+    test "reports no divergence when a sibling workflow is the one that moved on",
+         %{sandbox_socket: socket, parent_beta: parent_beta} do
       {:ok, _} =
-        Lightning.WorkflowVersions.record_version(beta, "ccc333ccc333", "app")
+        Lightning.WorkflowVersions.record_version(
+          parent_beta,
+          "ccc333ccc333",
+          "app"
+        )
 
+      # beta exists in both projects and has diverged, but alpha is the workflow
+      # being promoted, so this socket must stay quiet.
       ref = push(socket, "request_promote_check", %{})
       assert_reply ref, :ok, %{diverged: false}
+    end
+
+    test "answers for the working name when the workflow has been renamed but not saved",
+         %{sandbox_socket: socket, parent_beta: parent_beta} do
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          parent_beta,
+          "ccc333ccc333",
+          "app"
+        )
+
+      # The editor holds an unsaved rename of alpha to beta. Promote saves first,
+      # so the merge will match the parent's diverged beta, not alpha.
+      ref = push(socket, "request_promote_check", %{"workflow_name" => "beta"})
+      assert_reply ref, :ok, %{diverged: true}
+    end
+
+    test "stays quiet for a user who cannot merge into the parent", %{
+      sandbox: sandbox,
+      parent_alpha: parent_alpha,
+      sandbox_alpha_id: sandbox_alpha_id
+    } do
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          parent_alpha,
+          "bbb222bbb222",
+          "app"
+        )
+
+      viewer = insert(:user)
+      insert(:project_user, project: sandbox, user: viewer, role: :viewer)
+
+      {:ok, _, viewer_socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{viewer.id}", %{current_user: viewer})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          "workflow:collaborate:#{sandbox_alpha_id}",
+          %{"project_id" => sandbox.id, "action" => "edit"}
+        )
+
+      # A viewer has no rights on the parent, so it is never named to them.
+      ref = push(viewer_socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: false, parent_name: nil}
+    end
+
+    test "does not warn about this sandbox's own promote", %{
+      sandbox_socket: socket,
+      sandbox: sandbox,
+      user: user
+    } do
+      sandbox_alpha =
+        Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
+
+      edit_single_job_body!(sandbox_alpha.id, "console.log('promoted');")
+
+      {:ok, _} = Lightning.Projects.promote_workflow(sandbox_alpha, user)
+
+      # The promote records a new version on the parent, computed from the
+      # merged content, so without a sync point the parent's head is a hash this
+      # sandbox has never held and every promote after the first warns.
+      ref = push(socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: false, parent_name: "parent-project"}
     end
 
     test "reports no divergence outside a sandbox", %{socket: socket} do

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -975,19 +975,29 @@ defmodule LightningWeb.WorkflowChannelTest do
       assert_reply ref, :ok, %{diverged: false}
     end
 
-    test "answers for the working name when the workflow has been renamed but not saved",
-         %{sandbox_socket: socket, parent_beta: parent_beta} do
-      {:ok, _} =
-        Lightning.WorkflowVersions.record_version(
-          parent_beta,
-          "ccc333ccc333",
-          "app"
-        )
+    test "warns when the working name lands on a workflow the parent gained", %{
+      sandbox_socket: socket,
+      parent: parent
+    } do
+      # The parent gained gamma after the fork, so the sandbox has no history
+      # under that name at all. Promoting an unsaved rename onto it overwrites
+      # gamma wholesale, which is the case a both-sides comparison reads as safe.
+      gamma = insert(:workflow, project: parent, name: "gamma")
 
-      # The editor holds an unsaved rename of alpha to beta. Promote saves first,
-      # so the merge will match the parent's diverged beta, not alpha.
-      ref = push(socket, "request_promote_check", %{"workflow_name" => "beta"})
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(gamma, "ddd111ddd111", "app")
+
+      ref = push(socket, "request_promote_check", %{"workflow_name" => "gamma"})
       assert_reply ref, :ok, %{diverged: true}
+    end
+
+    test "stays quiet when the working name is one the parent does not hold", %{
+      sandbox_socket: socket
+    } do
+      # A rename onto a fresh name creates a workflow on the parent rather than
+      # replacing one, so there is nothing to warn about.
+      ref = push(socket, "request_promote_check", %{"workflow_name" => "delta"})
+      assert_reply ref, :ok, %{diverged: false}
     end
 
     test "stays quiet for a user who cannot merge into the parent", %{

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -870,6 +870,103 @@ defmodule LightningWeb.WorkflowChannelTest do
     end
   end
 
+  describe "request_promote_check" do
+    setup %{user: user} do
+      Mox.stub_with(
+        Lightning.Extensions.MockProjectHook,
+        Lightning.Extensions.ProjectHook
+      )
+
+      parent =
+        insert(:project,
+          name: "parent-project",
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      alpha = insert(:workflow, project: parent, name: "alpha")
+      trigger = insert(:trigger, workflow: alpha, type: :webhook)
+      job = insert(:job, workflow: alpha, name: "A1")
+
+      insert(:edge,
+        workflow: alpha,
+        source_trigger: trigger,
+        target_job: job,
+        condition_type: :always
+      )
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(alpha, "aaa111aaa111", "app")
+
+      {:ok, sandbox} =
+        Lightning.Projects.provision_sandbox(parent, user, %{name: "sb"})
+
+      sandbox_alpha =
+        Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          sandbox_alpha,
+          "aaa111aaa111",
+          "app"
+        )
+
+      {:ok, _, sandbox_socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{user.id}", %{current_user: user})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          "workflow:collaborate:#{sandbox_alpha.id}",
+          %{"project_id" => sandbox.id, "action" => "edit"}
+        )
+
+      on_exit(fn -> ensure_doc_supervisor_stopped(sandbox_alpha.id) end)
+
+      %{
+        parent: parent,
+        parent_alpha: alpha,
+        sandbox_socket: sandbox_socket
+      }
+    end
+
+    test "reports no divergence while the parent has not moved on", %{
+      sandbox_socket: socket
+    } do
+      ref = push(socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: false, parent_name: "parent-project"}
+    end
+
+    test "reports divergence once the parent gains a version the sandbox never saw",
+         %{sandbox_socket: socket, parent_alpha: parent_alpha} do
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(
+          parent_alpha,
+          "bbb222bbb222",
+          "app"
+        )
+
+      ref = push(socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: true, parent_name: "parent-project"}
+    end
+
+    test "reports no divergence for a sibling workflow that moved on", %{
+      sandbox_socket: socket,
+      parent: parent
+    } do
+      beta = insert(:workflow, project: parent, name: "beta")
+
+      {:ok, _} =
+        Lightning.WorkflowVersions.record_version(beta, "ccc333ccc333", "app")
+
+      ref = push(socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: false}
+    end
+
+    test "reports no divergence outside a sandbox", %{socket: socket} do
+      ref = push(socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: false, parent_name: nil}
+    end
+  end
+
   describe "archive_sandbox" do
     setup %{user: user} do
       Mox.stub_with(

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -1009,6 +1009,27 @@ defmodule LightningWeb.WorkflowChannelTest do
       assert_reply ref, :ok, %{diverged: false}
     end
 
+    test "answers for a workflow that has not been saved yet", %{
+      sandbox: sandbox,
+      user: user
+    } do
+      new_workflow_id = Ecto.UUID.generate()
+
+      {:ok, _, new_socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{user.id}", %{current_user: user})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          "workflow:collaborate:#{new_workflow_id}",
+          %{"project_id" => sandbox.id, "action" => "new"}
+        )
+
+      on_exit(fn -> ensure_doc_supervisor_stopped(new_workflow_id) end)
+
+      ref = push(new_socket, "request_promote_check", %{})
+      assert_reply ref, :ok, %{diverged: false, parent_name: "parent-project"}
+    end
+
     test "stays quiet for a user who cannot merge into the parent", %{
       sandbox: sandbox,
       parent_alpha: parent_alpha,

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -977,7 +977,9 @@ defmodule LightningWeb.WorkflowChannelTest do
 
     test "warns when the working name lands on a workflow the parent gained", %{
       sandbox_socket: socket,
-      parent: parent
+      sandbox: sandbox,
+      parent: parent,
+      user: user
     } do
       # The parent gained gamma after the fork, so the sandbox has no history
       # under that name at all. Promoting an unsaved rename onto it overwrites
@@ -989,6 +991,21 @@ defmodule LightningWeb.WorkflowChannelTest do
 
       ref = push(socket, "request_promote_check", %{"workflow_name" => "gamma"})
       assert_reply ref, :ok, %{diverged: true}
+
+      # And it stops warning once the promote has actually happened.
+      sandbox_alpha =
+        Lightning.Workflows.get_workflow_by_name(sandbox.id, "alpha")
+
+      Lightning.Repo.update!(Ecto.Changeset.change(sandbox_alpha, name: "gamma"))
+
+      {:ok, _} =
+        Lightning.Projects.promote_workflow(
+          Lightning.Repo.reload!(sandbox_alpha),
+          user
+        )
+
+      ref = push(socket, "request_promote_check", %{"workflow_name" => "gamma"})
+      assert_reply ref, :ok, %{diverged: false}
     end
 
     test "stays quiet when the working name is one the parent does not hold", %{


### PR DESCRIPTION
## Description

Promoting from a sandbox rebuilds the parent's workflow from the sandbox, so anything the parent gained since the fork is deleted rather than merged. The editor gave no sign of that. The confirm step now asks the server when it opens and, if the parent has moved on, names it and says what promoting does. It waits for the answer before enabling the button, warns rather than blocks, and says so when the check itself fails.

Two fixes underneath it.

A merge records a new version on the target computed from the merged content, and nothing wrote that back to the source. So the parent's head was always a hash the sandbox had never held, and every promote after the first would have warned about the user's own promote. A merge now records the target's resulting head on each source workflow it carried. That fixes the sandbox management merge screen too, which has shown the same false Diverged badge since it shipped.

Asking whether a name appears among the workflows that differ on both sides skips a name the sandbox has no history for, which is exactly a rename onto a name the parent already holds. `workflow_diverged?/3` asks about one named workflow instead and treats that case as divergence.

Closes #4863

## Validation steps

1. Create a project with a workflow, go live, create a sandbox from it.
2. Edit and save the workflow in the parent.
3. Edit the same workflow in the sandbox and click Promote. The confirm step names the parent and warns.
4. Confirm, then click Promote again. No warning, because the only change to the parent came from this sandbox.
5. Do step 3 against a parent that has not changed. No warning.
6. On the sandbox management screen, merge a sandbox twice. The second merge no longer shows Diverged for the workflow the first one carried.

## Additional notes for the reviewer

`Sandboxes.merge/4` now writes to the source project as well as the target: one `workflow_versions` row per workflow the merge carried. A merge carrying only a deletion passes an empty selection, which carries nothing, so it records nothing.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
