### PR TITLE
Resolve the merge target from the projects the screen would offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,10 @@ and this project adheres to
 
 ### Fixed
 
-- Opening the merge dialog no longer crashes in a workspace with a branch more
-  than two levels below the project you are in. Working out whether a candidate
-  target sits under the sandbox climbed a chain of parents that was only loaded
-  one level deep.
+- Opening the merge dialog, and deleting a sandbox, no longer crash in a
+  workspace with a branch more than two levels below the project you are in.
+  Working out whether one project sits under another climbed a chain of parents
+  that was only loaded one level deep.
   [#5141](https://github.com/OpenFn/lightning/issues/5141)
 
 - Reading an older version of a workflow no longer offers actions that change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to
 
 ### Fixed
 
+- Opening the merge dialog no longer crashes in a workspace with a branch more
+  than two levels below the project you are in. Working out whether a candidate
+  target sits under the sandbox climbed a chain of parents that was only loaded
+  one level deep.
+  [#5141](https://github.com/OpenFn/lightning/issues/5141)
+
 - Reading an older version of a workflow no longer offers actions that change
   the current one. Switch to draft, Go live, Promote and Edit in sandbox are
   hidden while a version or a run's view is pinned, so clicking one cannot take

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -358,10 +358,14 @@ defmodule LightningWeb.SandboxLive.Index do
       ) do
     merge_changeset = merge_changeset(%{target_id: target_id})
 
+    # Same gate as the confirm path, so the preview cannot show a merge that
+    # confirming would then refuse.
     target_project =
-      Enum.find(socket.assigns.workspace_projects, fn project ->
-        project.id == target_id
-      end)
+      find_target_project(
+        socket.assigns.workspace_projects,
+        target_id,
+        socket.assigns.merge_source_sandbox
+      )
 
     {sandbox, target_project} =
       preload_merge_projects(socket.assigns.merge_source_sandbox, target_project)
@@ -451,7 +455,7 @@ defmodule LightningWeb.SandboxLive.Index do
 
       true ->
         socket.assigns.workspace_projects
-        |> find_target_project(target_id, source, root_project)
+        |> find_target_project(target_id, source)
         |> case do
           nil ->
             socket
@@ -815,11 +819,11 @@ defmodule LightningWeb.SandboxLive.Index do
 
   defp get_merge_target_options(socket, source_sandbox) do
     current_user = socket.assigns.current_user
-    root_project = socket.assigns.root_project
+    descendant_ids = sandbox_descendant_ids(source_sandbox)
 
     socket.assigns.workspace_projects
     |> Enum.filter(fn project ->
-      mergeable_target?(project, source_sandbox, root_project) and
+      mergeable_target?(project, source_sandbox, descendant_ids) and
         user_role_on_project(project, current_user) in [:owner, :admin, :editor]
     end)
     |> Enum.map(fn project ->
@@ -841,19 +845,34 @@ defmodule LightningWeb.SandboxLive.Index do
   # sandbox itself, its descendants and anything scheduled for deletion, and
   # searching the whole workspace would let a hand-made event name one of those
   # anyway.
-  # A target the screen would never have offered is not a target. The role check
-  # belongs to the caller, which has its own message for it; this only enforces
-  # the structural exclusions, which nothing downstream re-checks.
-  defp find_target_project(workspace_projects, target_id, source, root_project) do
+  # No source means no merge, so no target either.
+  defp find_target_project(_workspace_projects, _target_id, nil), do: nil
+
+  defp find_target_project(workspace_projects, target_id, source) do
+    descendant_ids = sandbox_descendant_ids(source)
+
     Enum.find(workspace_projects, fn project ->
       project.id == target_id and
-        mergeable_target?(project, source, root_project)
+        mergeable_target?(project, source, descendant_ids)
     end)
   end
 
-  defp mergeable_target?(project, source_sandbox, root_project) do
+  # A merge into the sandbox itself or into anything under it retires what it
+  # just wrote, because archiving the source schedules its whole subtree for
+  # deletion. Nothing downstream refuses either, so the confirm path enforces it
+  # rather than trusting the dropdown to have been the only way in. Whether the
+  # user may merge into the target is the caller's question and has its own
+  # message.
+  defp mergeable_target?(project, source_sandbox, descendant_ids) do
     is_nil(project.scheduled_deletion) and project.id != source_sandbox.id and
-      not Projects.descendant_of?(project, source_sandbox, root_project)
+      not MapSet.member?(descendant_ids, project.id)
+  end
+
+  # Read rather than walked. `Projects.descendant_of?/3` climbs `parent` and
+  # needs the whole chain preloaded, which the workspace list does not do beyond
+  # one level, so it raised on any branch deeper than that.
+  defp sandbox_descendant_ids(sandbox) do
+    MapSet.new(Projects.descendant_ids([sandbox.id]))
   end
 
   defp build_merge_workflow_list(

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -215,7 +215,10 @@ defmodule LightningWeb.SandboxLive.Index do
 
       sandbox ->
         if sandbox.can_merge do
-          target_options = get_merge_target_options(socket, sandbox)
+          descendant_ids = sandbox_descendant_ids(sandbox)
+
+          target_options =
+            get_merge_target_options(socket, sandbox, descendant_ids)
 
           default_target =
             Enum.find(target_options, &(&1.value == sandbox.parent_id))
@@ -230,9 +233,11 @@ defmodule LightningWeb.SandboxLive.Index do
           target_id = default_target && default_target.value
 
           target_project =
-            Enum.find(
+            find_target_project(
               socket.assigns.workspace_projects,
-              fn project -> project.id == target_id end
+              target_id,
+              sandbox,
+              descendant_ids
             )
 
           {sandbox, target_project} =
@@ -263,6 +268,7 @@ defmodule LightningWeb.SandboxLive.Index do
            |> assign(:merge_modal_open?, true)
            |> assign(:merge_source_sandbox, sandbox)
            |> assign(:merge_target_options, target_options)
+           |> assign(:merge_descendant_ids, descendant_ids)
            |> assign(:merge_changeset, merge_changeset)
            |> assign(:merge_descendants, descendants)
            |> assign(:merge_diverged_workflows, diverged_workflows)
@@ -356,16 +362,20 @@ defmodule LightningWeb.SandboxLive.Index do
         %{"merge" => %{"target_id" => target_id}},
         socket
       ) do
-    merge_changeset = merge_changeset(%{target_id: target_id})
-
     # Same gate as the confirm path, so the preview cannot show a merge that
     # confirming would then refuse.
     target_project =
       find_target_project(
         socket.assigns.workspace_projects,
         target_id,
-        socket.assigns.merge_source_sandbox
+        socket.assigns.merge_source_sandbox,
+        socket.assigns.merge_descendant_ids
       )
+
+    # A rejected target is not left showing as the selection, or the form would
+    # describe a merge the confirm step refuses.
+    merge_changeset =
+      merge_changeset(%{target_id: target_project && target_project.id})
 
     {sandbox, target_project} =
       preload_merge_projects(socket.assigns.merge_source_sandbox, target_project)
@@ -455,7 +465,11 @@ defmodule LightningWeb.SandboxLive.Index do
 
       true ->
         socket.assigns.workspace_projects
-        |> find_target_project(target_id, source)
+        |> find_target_project(
+          target_id,
+          source,
+          socket.assigns.merge_descendant_ids
+        )
         |> case do
           nil ->
             socket
@@ -703,6 +717,7 @@ defmodule LightningWeb.SandboxLive.Index do
     |> assign(:merge_source_sandbox, nil)
     |> assign(:merge_changeset, merge_changeset())
     |> assign(:merge_target_options, [])
+    |> assign(:merge_descendant_ids, nil)
     |> assign(:merge_descendants, [])
     |> assign(:merge_diverged_workflows, [])
     |> assign(:merge_source_workflows, [])
@@ -739,15 +754,13 @@ defmodule LightningWeb.SandboxLive.Index do
   defp handle_sandbox_delete_result(
          {:ok, _project},
          deleted_sandbox,
-         %{assigns: %{project: current_project, root_project: root_project}} =
-           socket
+         %{assigns: %{project: current_project}} = socket
        ) do
     should_redirect =
       current_project.id == deleted_sandbox.id or
-        Projects.descendant_of?(
-          current_project,
-          deleted_sandbox,
-          root_project
+        MapSet.member?(
+          sandbox_descendant_ids(deleted_sandbox),
+          current_project.id
         )
 
     socket_to_return =
@@ -817,9 +830,8 @@ defmodule LightningWeb.SandboxLive.Index do
     put_flash(socket, :error, text)
   end
 
-  defp get_merge_target_options(socket, source_sandbox) do
+  defp get_merge_target_options(socket, source_sandbox, descendant_ids) do
     current_user = socket.assigns.current_user
-    descendant_ids = sandbox_descendant_ids(source_sandbox)
 
     socket.assigns.workspace_projects
     |> Enum.filter(fn project ->
@@ -846,10 +858,13 @@ defmodule LightningWeb.SandboxLive.Index do
   # searching the whole workspace would let a hand-made event name one of those
   # anyway.
   # No source means no merge, so no target either.
-  defp find_target_project(_workspace_projects, _target_id, nil), do: nil
+  defp find_target_project(_workspace_projects, _target_id, nil, _descendants),
+    do: nil
 
-  defp find_target_project(workspace_projects, target_id, source) do
-    descendant_ids = sandbox_descendant_ids(source)
+  defp find_target_project(workspace_projects, target_id, source, descendants) do
+    # Read once when the dialog opens and carried on the socket, because the
+    # form re-runs this on every change inside it, including credential ticks.
+    descendant_ids = descendants || sandbox_descendant_ids(source)
 
     Enum.find(workspace_projects, fn project ->
       project.id == target_id and

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -362,8 +362,6 @@ defmodule LightningWeb.SandboxLive.Index do
         %{"merge" => %{"target_id" => target_id}},
         socket
       ) do
-    # Same gate as the confirm path, so the preview cannot show a merge that
-    # confirming would then refuse.
     target_project =
       find_target_project(
         socket.assigns.workspace_projects,
@@ -372,8 +370,6 @@ defmodule LightningWeb.SandboxLive.Index do
         socket.assigns.merge_descendant_ids
       )
 
-    # A rejected target is not left showing as the selection, or the form would
-    # describe a merge the confirm step refuses.
     merge_changeset =
       merge_changeset(%{target_id: target_project && target_project.id})
 
@@ -853,17 +849,11 @@ defmodule LightningWeb.SandboxLive.Index do
     end
   end
 
-  # Only a project the screen actually offered. The option list leaves out the
-  # sandbox itself, its descendants and anything scheduled for deletion, and
-  # searching the whole workspace would let a hand-made event name one of those
-  # anyway.
-  # No source means no merge, so no target either.
   defp find_target_project(_workspace_projects, _target_id, nil, _descendants),
     do: nil
 
   defp find_target_project(workspace_projects, target_id, source, descendants) do
-    # Read once when the dialog opens and carried on the socket, because the
-    # form re-runs this on every change inside it, including credential ticks.
+    # The form re-runs this on every change inside it, credential ticks included.
     descendant_ids = descendants || sandbox_descendant_ids(source)
 
     Enum.find(workspace_projects, fn project ->
@@ -872,20 +862,16 @@ defmodule LightningWeb.SandboxLive.Index do
     end)
   end
 
-  # A merge into the sandbox itself or into anything under it retires what it
-  # just wrote, because archiving the source schedules its whole subtree for
-  # deletion. Nothing downstream refuses either, so the confirm path enforces it
-  # rather than trusting the dropdown to have been the only way in. Whether the
-  # user may merge into the target is the caller's question and has its own
-  # message.
+  # Merging into the sandbox or into anything under it retires what it just
+  # wrote, since archiving the source schedules its whole subtree for deletion.
+  # Nothing downstream refuses that. Role is the caller's question.
   defp mergeable_target?(project, source_sandbox, descendant_ids) do
     is_nil(project.scheduled_deletion) and project.id != source_sandbox.id and
       not MapSet.member?(descendant_ids, project.id)
   end
 
-  # Read rather than walked. `Projects.descendant_of?/3` climbs `parent` and
-  # needs the whole chain preloaded, which the workspace list does not do beyond
-  # one level, so it raised on any branch deeper than that.
+  # Read rather than walked: `Projects.descendant_of?/3` needs the whole parent
+  # chain preloaded, and the workspace list only loads one level.
   defp sandbox_descendant_ids(sandbox) do
     MapSet.new(Projects.descendant_ids([sandbox.id]))
   end

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -215,7 +215,8 @@ defmodule LightningWeb.SandboxLive.Index do
 
       sandbox ->
         if sandbox.can_merge do
-          descendant_ids = sandbox_descendant_ids(sandbox)
+          subtree = Projects.list_descendants(sandbox.id)
+          descendant_ids = MapSet.new(subtree, & &1.id)
 
           target_options =
             get_merge_target_options(socket, sandbox, descendant_ids)
@@ -223,7 +224,7 @@ defmodule LightningWeb.SandboxLive.Index do
           default_target =
             Enum.find(target_options, &(&1.value == sandbox.parent_id))
 
-          descendants = active_descendants(sandbox.id)
+          descendants = Enum.filter(subtree, &is_nil(&1.scheduled_deletion))
 
           merge_changeset =
             merge_changeset(%{
@@ -852,10 +853,9 @@ defmodule LightningWeb.SandboxLive.Index do
   defp find_target_project(_workspace_projects, _target_id, nil, _descendants),
     do: nil
 
-  defp find_target_project(workspace_projects, target_id, source, descendants) do
-    # The form re-runs this on every change inside it, credential ticks included.
-    descendant_ids = descendants || sandbox_descendant_ids(source)
-
+  # `descendant_ids` is read once when the dialog opens and carried on the
+  # socket, because the form re-runs this on every change inside it.
+  defp find_target_project(workspace_projects, target_id, source, descendant_ids) do
     Enum.find(workspace_projects, fn project ->
       project.id == target_id and
         mergeable_target?(project, source, descendant_ids)

--- a/lib/lightning_web/live/sandbox_live/index.ex
+++ b/lib/lightning_web/live/sandbox_live/index.ex
@@ -451,7 +451,7 @@ defmodule LightningWeb.SandboxLive.Index do
 
       true ->
         socket.assigns.workspace_projects
-        |> find_target_project(target_id)
+        |> find_target_project(target_id, source, root_project)
         |> case do
           nil ->
             socket
@@ -818,13 +818,9 @@ defmodule LightningWeb.SandboxLive.Index do
     root_project = socket.assigns.root_project
 
     socket.assigns.workspace_projects
-    |> Enum.reject(fn potential_target ->
-      not is_nil(potential_target.scheduled_deletion) or
-        potential_target.id == source_sandbox.id or
-        Projects.descendant_of?(potential_target, source_sandbox, root_project)
-    end)
     |> Enum.filter(fn project ->
-      user_role_on_project(project, current_user) in [:owner, :admin, :editor]
+      mergeable_target?(project, source_sandbox, root_project) and
+        user_role_on_project(project, current_user) in [:owner, :admin, :editor]
     end)
     |> Enum.map(fn project ->
       %{
@@ -841,8 +837,23 @@ defmodule LightningWeb.SandboxLive.Index do
     end
   end
 
-  defp find_target_project(workspace_projects, target_id) do
-    Enum.find(workspace_projects, fn project -> project.id == target_id end)
+  # Only a project the screen actually offered. The option list leaves out the
+  # sandbox itself, its descendants and anything scheduled for deletion, and
+  # searching the whole workspace would let a hand-made event name one of those
+  # anyway.
+  # A target the screen would never have offered is not a target. The role check
+  # belongs to the caller, which has its own message for it; this only enforces
+  # the structural exclusions, which nothing downstream re-checks.
+  defp find_target_project(workspace_projects, target_id, source, root_project) do
+    Enum.find(workspace_projects, fn project ->
+      project.id == target_id and
+        mergeable_target?(project, source, root_project)
+    end)
+  end
+
+  defp mergeable_target?(project, source_sandbox, root_project) do
+    is_nil(project.scheduled_deletion) and project.id != source_sandbox.id and
+      not Projects.descendant_of?(project, source_sandbox, root_project)
   end
 
   defp build_merge_workflow_list(

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1044,16 +1044,9 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         end
       )
 
-      Mimic.expect(Lightning.Projects, :descendant_of?, fn current,
-                                                           deleted,
-                                                           root ->
-        assert current.id == grandchild_sandbox.id
-        assert deleted.id == child_sandbox.id
-        assert root.id == parent.id
-        true
-      end)
-
-      Mimic.allow(Lightning.Projects, self(), view.pid)
+      # Whether the project you are standing in sits under the one being deleted
+      # is read from the tree rather than stubbed, so this covers the walk as
+      # well as the redirect.
       Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
@@ -1067,6 +1060,49 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       |> render_submit()
 
       assert_redirect(view, ~p"/projects/#{parent.id}/sandboxes")
+    end
+
+    test "deleting a sandbox from three levels down does not crash", %{
+      conn: conn,
+      parent: parent,
+      grandchild_sandbox: grandchild_sandbox,
+      user: user
+    } do
+      # Standing this deep means the redirect check has more parents to climb
+      # than the project assign preloads, which used to raise after the delete
+      # had already committed.
+      great_grandchild =
+        insert(:project,
+          name: "great-grandchild",
+          parent: grandchild_sandbox,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      sibling =
+        insert(:project,
+          name: "sibling",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      {:ok, view, _} =
+        live(conn, ~p"/projects/#{great_grandchild.id}/sandboxes")
+
+      Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
+
+      view
+      |> element("#delete-sandbox-#{sibling.id} button")
+      |> render_click()
+
+      html =
+        view
+        |> form("#confirm-delete-sandbox form",
+          confirm: %{"name" => sibling.name}
+        )
+        |> render_submit()
+
+      # Deleting something we are not under leaves us where we are.
+      assert html =~ "scheduled for deletion"
     end
 
     test "deleting sandbox does not redirect when current project is not descendant",
@@ -3728,6 +3764,32 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         |> render_click()
 
       assert html =~ "Merge"
+    end
+
+    test "drops a rejected target from the form rather than leaving it selected",
+         %{conn: conn, parent: parent, sandbox: sandbox, user: user} do
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      child =
+        insert(:project,
+          name: "child-of-sandbox",
+          parent: sandbox,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      render_click(view, "select-merge-target", %{
+        "merge" => %{"target_id" => child.id}
+      })
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      refute assigns.merge_changeset.changes[:target_id] == child.id
     end
 
     test "does not preview a merge into a target the confirm path would refuse",

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -1044,9 +1044,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         end
       )
 
-      # Whether the project you are standing in sits under the one being deleted
-      # is read from the tree rather than stubbed, so this covers the walk as
-      # well as the redirect.
       Mimic.allow(Lightning.Projects.Sandboxes, self(), view.pid)
 
       view
@@ -1068,9 +1065,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       grandchild_sandbox: grandchild_sandbox,
       user: user
     } do
-      # Standing this deep means the redirect check has more parents to climb
-      # than the project assign preloads, which used to raise after the delete
-      # had already committed.
       great_grandchild =
         insert(:project,
           name: "great-grandchild",
@@ -1101,7 +1095,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
         )
         |> render_submit()
 
-      # Deleting something we are not under leaves us where we are.
       assert html =~ "scheduled for deletion"
     end
 
@@ -3730,9 +3723,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       sandbox: sandbox,
       user: user
     } do
-      # The workspace list preloads one level of parent, so working out whether
-      # a candidate sits under the sandbox by climbing that chain ran out of
-      # struct on the second hop and raised.
       a =
         insert(:project,
           name: "a",
@@ -3822,8 +3812,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       assigns = :sys.get_state(view.pid).socket.assigns
 
-      # Previewing a merge the confirm step will refuse only teaches the user
-      # something untrue, and it is the target's side of the diff that says so.
       refute Enum.any?(
                assigns.merge_source_workflows,
                &(&1.name == "Only In Child")
@@ -3854,8 +3842,6 @@ defmodule LightningWeb.SandboxLive.IndexTest do
 
       assigns = :sys.get_state(view.pid).socket.assigns
 
-      # The dropdown leaves out a project on its way to deletion, so naming it
-      # by hand must not get past that.
       refute Enum.any?(assigns.merge_target_options, &(&1.value == retiring.id))
 
       html =

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -3688,6 +3688,86 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute html =~ "Added Later"
     end
 
+    test "opens the merge modal in a workspace deeper than two levels", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      user: user
+    } do
+      # The workspace list preloads one level of parent, so working out whether
+      # a candidate sits under the sandbox by climbing that chain ran out of
+      # struct on the second hop and raised.
+      a =
+        insert(:project,
+          name: "a",
+          parent: parent,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      b =
+        insert(:project,
+          name: "b",
+          parent: a,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      _c =
+        insert(:project,
+          name: "c",
+          parent: b,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      html =
+        view
+        |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+        |> render_click()
+
+      assert html =~ "Merge"
+    end
+
+    test "does not preview a merge into a target the confirm path would refuse",
+         %{
+           conn: conn,
+           parent: parent,
+           sandbox: sandbox,
+           user: user
+         } do
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      child =
+        insert(:project,
+          name: "child-of-sandbox",
+          parent: sandbox,
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      insert(:workflow, project: child, name: "Only In Child")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      render_click(view, "select-merge-target", %{
+        "merge" => %{"target_id" => child.id}
+      })
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      # Previewing a merge the confirm step will refuse only teaches the user
+      # something untrue, and it is the target's side of the diff that says so.
+      refute Enum.any?(
+               assigns.merge_source_workflows,
+               &(&1.name == "Only In Child")
+             )
+    end
+
     test "refuses a target the merge screen never offered", %{
       conn: conn,
       parent: parent,

--- a/test/lightning_web/live/sandbox_live/index_test.exs
+++ b/test/lightning_web/live/sandbox_live/index_test.exs
@@ -3688,6 +3688,64 @@ defmodule LightningWeb.SandboxLive.IndexTest do
       refute html =~ "Added Later"
     end
 
+    test "refuses a target the merge screen never offered", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox,
+      user: user
+    } do
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      retiring =
+        insert(:project,
+          name: "retiring",
+          parent: parent,
+          scheduled_deletion: DateTime.utc_now() |> DateTime.truncate(:second),
+          project_users: [%{user: user, role: :owner}]
+        )
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      # The dropdown leaves out a project on its way to deletion, so naming it
+      # by hand must not get past that.
+      refute Enum.any?(assigns.merge_target_options, &(&1.value == retiring.id))
+
+      html =
+        render_click(view, "confirm-merge", %{
+          "merge" => %{"target_id" => retiring.id}
+        })
+
+      assert html =~ "Target project not found"
+      assert Lightning.Repo.all(Lightning.Workflows.Workflow) |> length() == 1
+    end
+
+    test "refuses the sandbox itself as a merge target", %{
+      conn: conn,
+      parent: parent,
+      sandbox: sandbox
+    } do
+      _sandbox_alpha = insert(:workflow, project: sandbox, name: "Alpha")
+
+      {:ok, view, _} = live(conn, ~p"/projects/#{parent.id}/sandboxes")
+
+      view
+      |> element("#branch-rewire-sandbox-#{sandbox.id} button")
+      |> render_click()
+
+      html =
+        render_click(view, "confirm-merge", %{
+          "merge" => %{"target_id" => sandbox.id}
+        })
+
+      assert html =~ "Target project not found"
+    end
+
     test "explicitly checking a target-only workflow deletes it on merge",
          %{conn: conn, parent: parent, sandbox: sandbox} do
       parent_alpha = insert(:workflow, project: parent, name: "Alpha")


### PR DESCRIPTION
## Description

Two fixes on the sandbox management screen, both in how one project is tested against another.

The merge target came from the client and was resolved against every project in the workspace, while the dropdown was built by leaving out the sandbox itself, its descendants and anything scheduled for deletion. So a hand-made confirm event could name one of those. It is not an escalation, since the merge is still authorised against whatever project is named, but merging into the sandbox or into something under it retires what it just wrote: archiving the source schedules its whole subtree for deletion. Those exclusions now live in one predicate that the dropdown, the preview and the confirm path share. Role stays a separate check, so merging into a project you only read still says that rather than claiming it does not exist.

Working out whether one project sits under another walked up a chain of parents that is only loaded one level deep, so any branch more than two levels below the project you are in raised. That crashed opening the merge dialog, and crashed deleting a sandbox after the delete had already committed. Default nesting allows five levels. Both read the descendants now instead.

Closes #5141

## Validation steps

1. In a workspace, nest sandboxes three deep.
2. From the top project, open the merge dialog on any sandbox. Before this it raises.
3. From three levels down, delete an unrelated sandbox. Before this it raises after the delete has committed.
4. Merge normally from the dropdown. Unchanged.
5. Send a `confirm-merge` naming the sandbox itself, a descendant, or a project scheduled for deletion. Each is refused with "Target project not found".
6. Send one naming a project you are only a viewer on. Still "You are not authorized to merge into this project".

## Additional notes for the reviewer

Swapping the parent walk for a descendant read changes how the same question is answered, so the existing descendant-exclusion tests are the ones that matter. They fail if the descendant set is emptied. The delete-path test previously stubbed the check out, so it now reads the tree.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
