### PR TITLE
Say something when the assistant silently did nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@ and this project adheres to
 
 ### Fixed
 
+- The assistant says when it tried to change your code and could not. Apollo
+  reports how many of its edits landed, and none landing used to arrive as a
+  reply with nothing to apply and no explanation, which read as the assistant
+  declining to help. There is now a line saying so, with a way to try again.
+  [#5133](https://github.com/OpenFn/lightning/issues/5133)
 - Starting an AI chat with a message over the 10,000 character limit no longer
   kills the connection. The reply carried a raw changeset, which cannot be
   encoded, so the socket died before answering and the assistant appeared to do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@ and this project adheres to
 
 ### Fixed
 
+- Starting an AI chat with a message over the 10,000 character limit no longer
+  kills the connection. The reply carried a raw changeset, which cannot be
+  encoded, so the socket died before answering and the assistant appeared to do
+  nothing. The limit is also shown in the box now, once you are near it.
+  [#4883](https://github.com/OpenFn/lightning/issues/4883)
 - AI chat messages no longer sit in "processing" forever when the job running
   them is interrupted. Oban's job-stop event now has a handler, the shutdown
   grace period is longer than the longest an AI job can run, and a cron sweep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to
   reports how many of its edits landed, and none landing used to arrive as a
   reply with nothing to apply and no explanation, which read as the assistant
   declining to help. There is now a line saying so, with a way to try again.
+  Needs Apollo v3.1.2 or later, which reports that on the direct single-step
+  route as well as through the planner.
   [#5133](https://github.com/OpenFn/lightning/issues/5133)
 - Starting an AI chat with a message over the 10,000 character limit no longer
   kills the connection. The reply carried a raw changeset, which cannot be

--- a/assets/js/collaborative-editor/components/ChatInput.tsx
+++ b/assets/js/collaborative-editor/components/ChatInput.tsx
@@ -8,8 +8,7 @@ import { AIDisclaimerFooter } from './AIDisclaimerFooter';
 
 interface ChatInputProps {
   onSendMessage?:
-    | ((content: string, options?: MessageOptions) => void)
-    | undefined;
+    ((content: string, options?: MessageOptions) => void) | undefined;
   isLoading?: boolean | undefined;
   /** Disabled state (separate from loading, e.g., due to limits) */
   isDisabled?: boolean | undefined;
@@ -56,13 +55,10 @@ type AttachmentKey = (typeof ATTACHMENTS)[number]['key'];
 const MIN_TEXTAREA_HEIGHT = 52;
 const MAX_TEXTAREA_HEIGHT = 200;
 
-// Mirrors ChatMessage.max_content_length/0. Without this the server rejects the
-// message on a path that cannot report it, so the assistant appears to do
-// nothing.
+// Mirrors ChatMessage.max_content_length/0.
 const MAX_MESSAGE_LENGTH = 10_000;
 
-// Nothing is said until you are close: a counter that is always there reads as
-// a warning about a limit almost nobody meets.
+// An always-on counter reads as a warning about a limit almost nobody meets.
 const COUNT_FROM = MAX_MESSAGE_LENGTH - 500;
 
 export function ChatInput({

--- a/assets/js/collaborative-editor/components/ChatInput.tsx
+++ b/assets/js/collaborative-editor/components/ChatInput.tsx
@@ -8,7 +8,8 @@ import { AIDisclaimerFooter } from './AIDisclaimerFooter';
 
 interface ChatInputProps {
   onSendMessage?:
-    ((content: string, options?: MessageOptions) => void) | undefined;
+    | ((content: string, options?: MessageOptions) => void)
+    | undefined;
   isLoading?: boolean | undefined;
   /** Disabled state (separate from loading, e.g., due to limits) */
   isDisabled?: boolean | undefined;
@@ -312,21 +313,22 @@ export function ChatInput({
 
                 <div className="flex items-center justify-between gap-3 px-3 pb-2">
                   <div className="min-w-0">
-                    {showCount ? (
-                      <span
-                        data-testid="chat-input-length"
-                        className={cn(
-                          'text-xs',
-                          tooLong ? 'text-red-600' : 'text-gray-400'
-                        )}
-                      >
-                        {input.length.toLocaleString()} /{' '}
-                        {MAX_MESSAGE_LENGTH.toLocaleString()}
-                        {tooLong ? ' — too long to send' : null}
-                      </span>
-                    ) : (
+                    <div className="flex items-center gap-3 min-w-0">
                       <AIDisclaimerFooter />
-                    )}
+                      {showCount && (
+                        <span
+                          data-testid="chat-input-length"
+                          className={cn(
+                            'text-xs whitespace-nowrap',
+                            tooLong ? 'text-red-600' : 'text-gray-400'
+                          )}
+                        >
+                          {input.length.toLocaleString()} /{' '}
+                          {MAX_MESSAGE_LENGTH.toLocaleString()}
+                          {tooLong ? ' — too long to send' : null}
+                        </span>
+                      )}
+                    </div>
                   </div>
 
                   <button

--- a/assets/js/collaborative-editor/components/ChatInput.tsx
+++ b/assets/js/collaborative-editor/components/ChatInput.tsx
@@ -8,8 +8,7 @@ import { AIDisclaimerFooter } from './AIDisclaimerFooter';
 
 interface ChatInputProps {
   onSendMessage?:
-    | ((content: string, options?: MessageOptions) => void)
-    | undefined;
+    ((content: string, options?: MessageOptions) => void) | undefined;
   isLoading?: boolean | undefined;
   /** Disabled state (separate from loading, e.g., due to limits) */
   isDisabled?: boolean | undefined;
@@ -56,6 +55,15 @@ type AttachmentKey = (typeof ATTACHMENTS)[number]['key'];
 const MIN_TEXTAREA_HEIGHT = 52;
 const MAX_TEXTAREA_HEIGHT = 200;
 
+// Mirrors ChatMessage.max_content_length/0. Without this the server rejects the
+// message on a path that cannot report it, so the assistant appears to do
+// nothing.
+const MAX_MESSAGE_LENGTH = 10_000;
+
+// Nothing is said until you are close: a counter that is always there reads as
+// a warning about a limit almost nobody meets.
+const COUNT_FROM = MAX_MESSAGE_LENGTH - 500;
+
 export function ChatInput({
   onSendMessage,
   isLoading = false,
@@ -68,6 +76,8 @@ export function ChatInput({
   selectedRunId,
 }: ChatInputProps) {
   const [input, setInput] = useState('');
+  const tooLong = input.length > MAX_MESSAGE_LENGTH;
+  const showCount = input.length >= COUNT_FROM;
 
   const [attachLogs, setAttachLogs] = useState(() => {
     if (!storageKey) {
@@ -196,7 +206,7 @@ export function ChatInput({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!input.trim() || isLoading || isDisabled) return;
+    if (!input.trim() || isLoading || isDisabled || tooLong) return;
 
     const options: MessageOptions = {};
     // The run rides along so what we promise to attach and what the backend
@@ -302,19 +312,35 @@ export function ChatInput({
 
                 <div className="flex items-center justify-between gap-3 px-3 pb-2">
                   <div className="min-w-0">
-                    <AIDisclaimerFooter />
+                    {showCount ? (
+                      <span
+                        data-testid="chat-input-length"
+                        className={cn(
+                          'text-xs',
+                          tooLong ? 'text-red-600' : 'text-gray-400'
+                        )}
+                      >
+                        {input.length.toLocaleString()} /{' '}
+                        {MAX_MESSAGE_LENGTH.toLocaleString()}
+                        {tooLong ? ' — too long to send' : null}
+                      </span>
+                    ) : (
+                      <AIDisclaimerFooter />
+                    )}
                   </div>
 
                   <button
                     type="submit"
                     data-testid="send-message-button"
-                    disabled={!input.trim() || isLoading || isDisabled}
+                    disabled={
+                      !input.trim() || isLoading || isDisabled || tooLong
+                    }
                     className={cn(
                       'inline-flex items-center justify-center',
                       'h-7 w-7 rounded-lg',
                       'transition-all duration-200',
                       'focus:outline-none focus:ring-2 focus:ring-offset-2',
-                      input.trim() && !isLoading && !isDisabled
+                      input.trim() && !isLoading && !isDisabled && !tooLong
                         ? 'bg-primary-600 hover:bg-primary-700 text-white focus:ring-primary-500'
                         : 'bg-gray-100 text-gray-400 cursor-not-allowed'
                     )}

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -868,8 +868,8 @@ export function MessageList({
   const lastMessage = messages.at(-1);
   const viewerJustSent = Boolean(
     lastMessage?.role === 'user' &&
-    currentUserId &&
-    lastMessage.user?.id === currentUserId
+      currentUserId &&
+      lastMessage.user?.id === currentUserId
   );
 
   useEffect(() => {
@@ -1013,12 +1013,12 @@ export function MessageList({
       ? isGlobalAssistantActive
       : Boolean(
           message.from_global &&
-          // Only a successful reply was auto-applied. An errored or
-          // cancelled one can still carry code, and rendering its blocks
-          // would present changes that never reached the canvas as a
-          // record of what happened.
-          message.status === 'success' &&
-          (message.code || snapshotsByMessageId[message.id]?.length)
+            // Only a successful reply was auto-applied. An errored or
+            // cancelled one can still carry code, and rendering its blocks
+            // would present changes that never reached the canvas as a
+            // record of what happened.
+            message.status === 'success' &&
+            (message.code || snapshotsByMessageId[message.id]?.length)
         );
 
   /**
@@ -1029,18 +1029,18 @@ export function MessageList({
   const canUndoChanges = (message: Message): boolean =>
     Boolean(
       onUndoChanges &&
-      !isApplyInFlight &&
-      !isWriteDisabled &&
-      !isStreaming(message) &&
-      displayMessages.at(-1)?.id === message.id &&
-      message.from_global &&
-      // Only a successful reply was auto-applied; an error or cancelled one
-      // can still carry code, and undoing it would offer to "redo" changes
-      // that never landed.
-      message.status === 'success' &&
-      message.code &&
-      !failedApplyMessageIds?.has(message.id) &&
-      beforeYamlByMessageId.get(message.id)
+        !isApplyInFlight &&
+        !isWriteDisabled &&
+        !isStreaming(message) &&
+        displayMessages.at(-1)?.id === message.id &&
+        message.from_global &&
+        // Only a successful reply was auto-applied; an error or cancelled one
+        // can still carry code, and undoing it would offer to "redo" changes
+        // that never landed.
+        message.status === 'success' &&
+        message.code &&
+        !failedApplyMessageIds?.has(message.id) &&
+        beforeYamlByMessageId.get(message.id)
     );
 
   const snapshotsFor = (message: Message): WorkflowSnapshot[] =>
@@ -1165,8 +1165,12 @@ export function MessageList({
         // pairing to lean on. Offered only on the newest exchange: a retry
         // appends a new reply and leaves this one saying the same thing for
         // good, so an older one would keep a button that starts a fresh job.
+        // Only on the last message. A retry appends a reply and leaves this
+        // one flagged for good, so anything looser hands an old notice a live
+        // button that starts a fresh job on every click.
         const editedPrompt =
-          message.code_change_failed && index >= displayMessages.length - 2
+          message.code_change_failed &&
+          displayMessages.at(-1)?.id === message.id
             ? displayMessages.slice(0, index).findLast(m => m.role === 'user')
             : undefined;
 

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -1161,6 +1161,22 @@ export function MessageList({
         const promptCarriesNotice =
           message.status === 'error' && !failedPairs.claimed.has(message.id);
 
+        // A reply whose edit failed succeeded in every other way, so it has no
+        // pairing to lean on. Offered only on the newest exchange: a retry
+        // appends a new reply and leaves this one saying the same thing for
+        // good, so an older one would keep a button that starts a fresh job.
+        const editedPrompt =
+          message.code_change_failed && index >= displayMessages.length - 2
+            ? displayMessages.slice(0, index).findLast(m => m.role === 'user')
+            : undefined;
+
+        const retryEditedPrompt =
+          onRetryMessage && editedPrompt
+            ? () => {
+                onRetryMessage(editedPrompt.id);
+              }
+            : undefined;
+
         const showMessageAddButtons =
           !isStreaming(message) &&
           message.status !== 'error' &&
@@ -1377,6 +1393,17 @@ export function MessageList({
                         onRetry={retry}
                       />
                     )}
+
+                    {/* The reply itself succeeded; the edit inside it did not,
+                        so there is nothing to apply and nothing saying why. */}
+                    {!isStreaming(message) &&
+                      message.status !== 'error' &&
+                      message.code_change_failed && (
+                        <FailureNotice
+                          reason="I tried to update the code but couldn't apply the change."
+                          onRetry={retryEditedPrompt}
+                        />
+                      )}
 
                     {!isStreaming(message) &&
                       message.status === 'processing' && (

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -868,8 +868,8 @@ export function MessageList({
   const lastMessage = messages.at(-1);
   const viewerJustSent = Boolean(
     lastMessage?.role === 'user' &&
-      currentUserId &&
-      lastMessage.user?.id === currentUserId
+    currentUserId &&
+    lastMessage.user?.id === currentUserId
   );
 
   useEffect(() => {
@@ -1013,12 +1013,12 @@ export function MessageList({
       ? isGlobalAssistantActive
       : Boolean(
           message.from_global &&
-            // Only a successful reply was auto-applied. An errored or
-            // cancelled one can still carry code, and rendering its blocks
-            // would present changes that never reached the canvas as a
-            // record of what happened.
-            message.status === 'success' &&
-            (message.code || snapshotsByMessageId[message.id]?.length)
+          // Only a successful reply was auto-applied. An errored or
+          // cancelled one can still carry code, and rendering its blocks
+          // would present changes that never reached the canvas as a
+          // record of what happened.
+          message.status === 'success' &&
+          (message.code || snapshotsByMessageId[message.id]?.length)
         );
 
   /**
@@ -1029,18 +1029,18 @@ export function MessageList({
   const canUndoChanges = (message: Message): boolean =>
     Boolean(
       onUndoChanges &&
-        !isApplyInFlight &&
-        !isWriteDisabled &&
-        !isStreaming(message) &&
-        displayMessages.at(-1)?.id === message.id &&
-        message.from_global &&
-        // Only a successful reply was auto-applied; an error or cancelled one
-        // can still carry code, and undoing it would offer to "redo" changes
-        // that never landed.
-        message.status === 'success' &&
-        message.code &&
-        !failedApplyMessageIds?.has(message.id) &&
-        beforeYamlByMessageId.get(message.id)
+      !isApplyInFlight &&
+      !isWriteDisabled &&
+      !isStreaming(message) &&
+      displayMessages.at(-1)?.id === message.id &&
+      message.from_global &&
+      // Only a successful reply was auto-applied; an error or cancelled one
+      // can still carry code, and undoing it would offer to "redo" changes
+      // that never landed.
+      message.status === 'success' &&
+      message.code &&
+      !failedApplyMessageIds?.has(message.id) &&
+      beforeYamlByMessageId.get(message.id)
     );
 
   const snapshotsFor = (message: Message): WorkflowSnapshot[] =>
@@ -1161,13 +1161,8 @@ export function MessageList({
         const promptCarriesNotice =
           message.status === 'error' && !failedPairs.claimed.has(message.id);
 
-        // A reply whose edit failed succeeded in every other way, so it has no
-        // pairing to lean on. Offered only on the newest exchange: a retry
-        // appends a new reply and leaves this one saying the same thing for
-        // good, so an older one would keep a button that starts a fresh job.
-        // Only on the last message. A retry appends a reply and leaves this
-        // one flagged for good, so anything looser hands an old notice a live
-        // button that starts a fresh job on every click.
+        // Last message only: a retry appends a reply and leaves this one
+        // flagged for good, so anything looser leaves a live button behind.
         const editedPrompt =
           message.code_change_failed &&
           displayMessages.at(-1)?.id === message.id

--- a/assets/js/collaborative-editor/types/ai-assistant.ts
+++ b/assets/js/collaborative-editor/types/ai-assistant.ts
@@ -95,6 +95,11 @@ export interface Message {
   /** Recorded server-side when this reply's changes never reached the canvas. */
   apply_failed?: boolean;
   /**
+   * Recorded server-side when Apollo attempted a code edit and none of its
+   * patches applied, so the reply arrives with nothing to apply.
+   */
+  code_change_failed?: boolean;
+  /**
    * Why this message failed, in words meant for the person reading it. Set by
    * the server on the message that failed; absent on anything that did not.
    */

--- a/assets/test/collaborative-editor/components/ChatInput.test.tsx
+++ b/assets/test/collaborative-editor/components/ChatInput.test.tsx
@@ -273,6 +273,49 @@ describe('ChatInput', () => {
     });
   });
 
+  describe('Message Length', () => {
+    const type = async (text: string) => {
+      const textarea = screen.getByPlaceholderText('Ask me anything...');
+      // fireEvent, not userEvent: typing ten thousand characters one keystroke
+      // at a time takes minutes.
+      fireEvent.change(textarea, { target: { value: text } });
+    };
+
+    it('says nothing until you are close to the limit', async () => {
+      render(<ChatInput />);
+      await type('x'.repeat(9000));
+
+      expect(screen.queryByTestId('chat-input-length')).not.toBeInTheDocument();
+    });
+
+    it('counts down once you are within five hundred', async () => {
+      render(<ChatInput />);
+      await type('x'.repeat(9600));
+
+      expect(screen.getByTestId('chat-input-length')).toHaveTextContent(
+        '9,600 / 10,000'
+      );
+    });
+
+    // The server rejects this on the channel join, a path that cannot report
+    // back, so the assistant would appear to do nothing at all.
+    it('refuses to send once over it', async () => {
+      const onSendMessage = vi.fn();
+      render(<ChatInput onSendMessage={onSendMessage} />);
+      await type('x'.repeat(10001));
+
+      const counter = screen.getByTestId('chat-input-length');
+      expect(counter).toHaveTextContent('too long to send');
+
+      const sendButton = screen.getByRole('button', { name: /send message/i });
+      expect(sendButton).toBeDisabled();
+
+      const textarea = screen.getByPlaceholderText('Ask me anything...');
+      await userEvent.type(textarea, '{Enter}');
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Run Attachment Controls', () => {
     it('should include both flags and the run when a run is selected', async () => {
       render(

--- a/assets/test/collaborative-editor/components/ChatInput.test.tsx
+++ b/assets/test/collaborative-editor/components/ChatInput.test.tsx
@@ -299,6 +299,25 @@ describe('ChatInput', () => {
 
     // The server rejects this on the channel join, a path that cannot report
     // back, so the assistant would appear to do nothing at all.
+    it('still sends at exactly the limit', async () => {
+      const onSendMessage = vi.fn();
+      render(<ChatInput onSendMessage={onSendMessage} />);
+      await type('x'.repeat(10000));
+
+      const sendButton = screen.getByRole('button', { name: /send message/i });
+      expect(sendButton).toBeEnabled();
+      await userEvent.click(sendButton);
+      expect(onSendMessage).toHaveBeenCalled();
+    });
+
+    it('keeps the AI disclaimer alongside the counter', async () => {
+      render(<ChatInput />);
+      await type('x'.repeat(9600));
+
+      expect(screen.getByTestId('chat-input-length')).toBeInTheDocument();
+      expect(screen.getByText(/use AI responsibly/i)).toBeInTheDocument();
+    });
+
     it('refuses to send once over it', async () => {
       const onSendMessage = vi.fn();
       render(<ChatInput onSendMessage={onSendMessage} />);

--- a/assets/test/collaborative-editor/components/ChatInput.test.tsx
+++ b/assets/test/collaborative-editor/components/ChatInput.test.tsx
@@ -297,8 +297,6 @@ describe('ChatInput', () => {
       );
     });
 
-    // The server rejects this on the channel join, a path that cannot report
-    // back, so the assistant would appear to do nothing at all.
     it('still sends at exactly the limit', async () => {
       const onSendMessage = vi.fn();
       render(<ChatInput onSendMessage={onSendMessage} />);

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -563,6 +563,85 @@ describe('MessageList', () => {
     });
   });
 
+  describe('Failed code edit', () => {
+    const exchange = (extra = {}) => [
+      createMockAIMessage({
+        id: 'prompt-1',
+        role: 'user',
+        content: 'fix the mapping',
+        status: 'success',
+      }),
+      createMockAIMessage({
+        id: 'reply-1',
+        role: 'assistant',
+        content: 'Here is what I changed.',
+        status: 'success',
+        code_change_failed: true,
+        ...extra,
+      }),
+    ];
+
+    // The reply succeeded, so nothing else on screen says the edit did not.
+    it('says so when the edit did not apply', () => {
+      render(<MessageList messages={exchange()} onRetryMessage={vi.fn()} />);
+
+      expect(screen.getByTestId('ai-failure-notice')).toHaveTextContent(
+        "I tried to update the code but couldn't apply the change"
+      );
+    });
+
+    // Every way a patch fails comes from what the model produced that turn, and
+    // Apollo has already tried once to correct itself, so another go can work.
+    it('offers to try again, re-running the prompt', async () => {
+      const onRetryMessage = vi.fn();
+      render(
+        <MessageList messages={exchange()} onRetryMessage={onRetryMessage} />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      expect(onRetryMessage).toHaveBeenCalledWith('prompt-1');
+    });
+
+    // A retry appends a new reply and leaves the old one saying the same thing
+    // for good, so an older exchange must not keep a live button.
+    it('does not offer it on an older exchange', () => {
+      const messages = [
+        ...exchange(),
+        createMockAIMessage({
+          id: 'prompt-2',
+          role: 'user',
+          content: 'another question',
+          status: 'success',
+        }),
+        createMockAIMessage({
+          id: 'reply-2',
+          role: 'assistant',
+          content: 'a clean answer',
+          status: 'success',
+        }),
+      ];
+
+      render(<MessageList messages={messages} onRetryMessage={vi.fn()} />);
+
+      expect(screen.getByTestId('ai-failure-notice')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /try again/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('says nothing when the edit applied', () => {
+      render(
+        <MessageList
+          messages={exchange({ code_change_failed: false })}
+          onRetryMessage={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('ai-failure-notice')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Code Blocks', () => {
     it('should render code block when message has code property', () => {
       const messages = [

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -581,7 +581,6 @@ describe('MessageList', () => {
       }),
     ];
 
-    // The reply succeeded, so nothing else on screen says the edit did not.
     it('says so when the edit did not apply', () => {
       render(<MessageList messages={exchange()} onRetryMessage={vi.fn()} />);
 
@@ -590,8 +589,6 @@ describe('MessageList', () => {
       );
     });
 
-    // Every way a patch fails comes from what the model produced that turn, and
-    // Apollo has already tried once to correct itself, so another go can work.
     it('offers to try again, re-running the prompt', async () => {
       const onRetryMessage = vi.fn();
       render(

--- a/assets/test/collaborative-editor/components/MessageList.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.test.tsx
@@ -603,6 +603,25 @@ describe('MessageList', () => {
       expect(onRetryMessage).toHaveBeenCalledWith('prompt-1');
     });
 
+    it('drops the button once a retry has appended a reply', () => {
+      const messages = [
+        ...exchange(),
+        createMockAIMessage({
+          id: 'reply-2',
+          role: 'assistant',
+          content: 'this time it worked',
+          status: 'success',
+        }),
+      ];
+
+      render(<MessageList messages={messages} onRetryMessage={vi.fn()} />);
+
+      expect(screen.getByTestId('ai-failure-notice')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /try again/i })
+      ).not.toBeInTheDocument();
+    });
+
     // A retry appends a new reply and leaves the old one saying the same thing
     // for good, so an older exchange must not keep a live button.
     it('does not offer it on an older exchange', () => {

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1698,11 +1698,16 @@ defmodule Lightning.AiAssistant do
   defp build_global_message(body) do
     code = extract_global_workflow_yaml(body["attachments"])
 
+    meta =
+      if code_change_failed?(body),
+        do: %{"from_global" => true, "code_change_failed" => true},
+        else: %{"from_global" => true}
+
     message_attrs =
       %{
         role: :assistant,
         content: body["response"],
-        meta: %{"from_global" => true}
+        meta: meta
       }
       |> put_response_segments(
         normalize_response_segments(body["response_segments"])
@@ -1710,6 +1715,29 @@ defmodule Lightning.AiAssistant do
 
     opts = [usage: body["usage"] || %{}, meta: body["meta"], code: code]
     {message_attrs, opts}
+  end
+
+  # Apollo's job-code subagent reports how many of its edits landed. Zero means
+  # it tried and could not, which reaches the user as a reply with nothing to
+  # apply and no reason given. Its `warning` is built partly from `str(e)`, so
+  # that goes to the log and the panel gets a sentence of ours.
+  defp code_change_failed?(body) do
+    failed =
+      body
+      |> get_in(["meta", "subagent_calls"])
+      |> List.wrap()
+      |> Enum.filter(&match?(%{"diff" => %{"patches_applied" => 0}}, &1))
+
+    Enum.each(failed, fn call ->
+      if warning = get_in(call, ["diff", "warning"]) do
+        Logger.warning(
+          "[AI Assistant] Apollo applied no code edits: " <>
+            inspect(warning, printable_limit: 128)
+        )
+      end
+    end)
+
+    failed != []
   end
 
   # Flat replies omit the key entirely: casting nil into embeds_many is an

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1698,8 +1698,12 @@ defmodule Lightning.AiAssistant do
   defp build_global_message(body) do
     code = extract_global_workflow_yaml(body["attachments"])
 
+    # Only when nothing came back to apply. The planner can call the job agent
+    # more than once in a turn, so one failed edit alongside one that landed
+    # would otherwise put "couldn't apply the change" on a reply carrying the
+    # change.
     meta =
-      if code_change_failed?(body),
+      if is_nil(code) and code_change_failed?(body),
         do: %{"from_global" => true, "code_change_failed" => true},
         else: %{"from_global" => true}
 

--- a/lib/lightning/ai_assistant/ai_assistant.ex
+++ b/lib/lightning/ai_assistant/ai_assistant.ex
@@ -1698,10 +1698,8 @@ defmodule Lightning.AiAssistant do
   defp build_global_message(body) do
     code = extract_global_workflow_yaml(body["attachments"])
 
-    # Only when nothing came back to apply. The planner can call the job agent
-    # more than once in a turn, so one failed edit alongside one that landed
-    # would otherwise put "couldn't apply the change" on a reply carrying the
-    # change.
+    # The planner can call the job agent more than once, so one failed edit
+    # beside one that landed must not mark a reply that carries the change.
     meta =
       if is_nil(code) and code_change_failed?(body),
         do: %{"from_global" => true, "code_change_failed" => true},
@@ -1721,10 +1719,8 @@ defmodule Lightning.AiAssistant do
     {message_attrs, opts}
   end
 
-  # Apollo's job-code subagent reports how many of its edits landed. Zero means
-  # it tried and could not, which reaches the user as a reply with nothing to
-  # apply and no reason given. Its `warning` is built partly from `str(e)`, so
-  # that goes to the log and the panel gets a sentence of ours.
+  # Zero means the subagent tried to edit and could not. Its `warning` is built
+  # partly from `str(e)`, so that stays in the log.
   defp code_change_failed?(body) do
     failed =
       body

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -1097,7 +1097,8 @@ defmodule LightningWeb.AiAssistantChannel do
       user: format_user(message.user),
       job_id: job_id,
       from_global: from_global,
-      apply_failed: match?(%{"apply_failed" => true}, message.meta)
+      apply_failed: match?(%{"apply_failed" => true}, message.meta),
+      code_change_failed: match?(%{"code_change_failed" => true}, message.meta)
     }
     |> put_failure(message)
   end

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -76,13 +76,10 @@ defmodule LightningWeb.AiAssistantChannel do
 
       # A changeset here has no Jason encoder, so putting it in the reply kills
       # the socket before any reply goes out and the assistant just does
-      # nothing. Same shape new_message already replies with.
+      # nothing.
       {:session, {:error, %Ecto.Changeset{} = changeset}} ->
-        {:error,
-         %{
-           reason: "validation_error",
-           errors: format_changeset_errors(changeset)
-         }}
+        errors = format_changeset_errors(changeset)
+        {:error, %{reason: validation_sentence(errors), errors: errors}}
 
       {:session, {:error, reason}} ->
         {:error, %{reason: reason}}
@@ -1146,6 +1143,20 @@ defmodule LightningWeb.AiAssistantChannel do
       failure_category: to_string(message.failure_category),
       failure_message: message.failure_message
     })
+  end
+
+  # A join reply's `reason` is shown to the reader as it stands, unlike the
+  # `type`/`errors` pair the message handlers reply with, so the field errors
+  # become a sentence rather than a code.
+  defp validation_sentence(errors) do
+    errors
+    |> Enum.flat_map(fn {field, messages} ->
+      Enum.map(messages, &"#{field} #{&1}")
+    end)
+    |> case do
+      [] -> "the session could not be started"
+      sentences -> Enum.join(sentences, ", ")
+    end
   end
 
   defp format_user(nil), do: nil

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -74,6 +74,16 @@ defmodule LightningWeb.AiAssistantChannel do
       {:parse_topic, {:error, :invalid_topic}} ->
         {:error, %{reason: "invalid topic format"}}
 
+      # A changeset here has no Jason encoder, so putting it in the reply kills
+      # the socket before any reply goes out and the assistant just does
+      # nothing. Same shape new_message already replies with.
+      {:session, {:error, %Ecto.Changeset{} = changeset}} ->
+        {:error,
+         %{
+           reason: "validation_error",
+           errors: format_changeset_errors(changeset)
+         }}
+
       {:session, {:error, reason}} ->
         {:error, %{reason: reason}}
 

--- a/lib/lightning_web/channels/ai_assistant_channel.ex
+++ b/lib/lightning_web/channels/ai_assistant_channel.ex
@@ -74,9 +74,8 @@ defmodule LightningWeb.AiAssistantChannel do
       {:parse_topic, {:error, :invalid_topic}} ->
         {:error, %{reason: "invalid topic format"}}
 
-      # A changeset here has no Jason encoder, so putting it in the reply kills
-      # the socket before any reply goes out and the assistant just does
-      # nothing.
+      # A changeset has no Jason encoder, so putting one in the reply kills the
+      # socket before anything is sent.
       {:session, {:error, %Ecto.Changeset{} = changeset}} ->
         errors = format_changeset_errors(changeset)
         {:error, %{reason: validation_sentence(errors), errors: errors}}
@@ -1145,9 +1144,8 @@ defmodule LightningWeb.AiAssistantChannel do
     })
   end
 
-  # A join reply's `reason` is shown to the reader as it stands, unlike the
-  # `type`/`errors` pair the message handlers reply with, so the field errors
-  # become a sentence rather than a code.
+  # A join reply's `reason` is shown as it stands, unlike the `type`/`errors`
+  # pair the message handlers use, so it has to read as a sentence.
   defp validation_sentence(errors) do
     errors
     |> Enum.flat_map(fn {field, messages} ->

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -433,9 +433,6 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       refute retried.failure_message
     end
 
-    # Apollo's job-code subagent says how many edits landed. Zero is a reply
-    # with nothing to apply, which otherwise reads as the assistant declining
-    # to help. Its warning is built partly from str(e), so it stays in the log.
     test "marks a reply whose code edits all failed to apply", %{
       user: user,
       project: project
@@ -500,9 +497,6 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       refute assistant.content =~ "job_chat.py"
     end
 
-    # The planner can call the job agent more than once, so one failed edit
-    # beside one that landed must not put "couldn't apply" on a reply that
-    # carries the change.
     test "does not mark a reply that still produced a workflow", %{
       user: user,
       project: project

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -433,6 +433,73 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       refute retried.failure_message
     end
 
+    # Apollo's job-code subagent says how many edits landed. Zero is a reply
+    # with nothing to apply, which otherwise reads as the assistant declining
+    # to help. Its warning is built partly from str(e), so it stays in the log.
+    test "marks a reply whose code edits all failed to apply", %{
+      user: user,
+      project: project
+    } do
+      workflow = insert(:workflow, project: project)
+
+      session =
+        insert(:chat_session,
+          user: user,
+          session_type: "workflow_template",
+          project: project,
+          workflow: workflow,
+          job_id: nil,
+          meta: %{"message_options" => %{"use_global_assistant" => true}}
+        )
+
+      {:ok, updated_session} =
+        AiAssistant.save_message(session, %{
+          role: :user,
+          content: "fix the mapping",
+          user: user
+        })
+
+      user_message = Enum.find(updated_session.messages, &(&1.role == :user))
+
+      Mox.stub(
+        Lightning.Tesla.Mock,
+        :call,
+        Lightning.AiAssistantHelpers.streaming_or_sync_response(%{
+          "response" => "Here is what I changed.",
+          "usage" => %{},
+          "meta" => %{
+            "subagent_calls" => [
+              %{
+                "_call_metadata" => %{"subagent" => "job_agent"},
+                "diff" => %{
+                  "patches_applied" => 0,
+                  "warning" =>
+                    "Failed to apply edit: KeyError at /app/services/job_chat.py"
+                }
+              }
+            ]
+          }
+        })
+      )
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok =
+                   perform_job(MessageProcessor, %{
+                     "message_id" => user_message.id
+                   })
+        end)
+
+      reloaded = AiAssistant.get_session!(session.id)
+      assistant = Enum.find(reloaded.messages, &(&1.role == :assistant))
+
+      assert assistant.meta["code_change_failed"] == true
+
+      # Apollo's warning carries a container path, so it stays out of the row.
+      assert log =~ "Apollo applied no code edits"
+      refute assistant.content =~ "job_chat.py"
+    end
+
     test "persists the segments timeline alongside the flat response",
          %{user: user, project: project} do
       workflow = insert(:workflow, project: project)

--- a/test/lightning/ai_assistant/message_processor_test.exs
+++ b/test/lightning/ai_assistant/message_processor_test.exs
@@ -500,6 +500,61 @@ defmodule Lightning.AiAssistant.MessageProcessorTest do
       refute assistant.content =~ "job_chat.py"
     end
 
+    # The planner can call the job agent more than once, so one failed edit
+    # beside one that landed must not put "couldn't apply" on a reply that
+    # carries the change.
+    test "does not mark a reply that still produced a workflow", %{
+      user: user,
+      project: project
+    } do
+      workflow = insert(:workflow, project: project)
+
+      session =
+        insert(:chat_session,
+          user: user,
+          session_type: "workflow_template",
+          project: project,
+          workflow: workflow,
+          job_id: nil,
+          meta: %{"message_options" => %{"use_global_assistant" => true}}
+        )
+
+      {:ok, updated_session} =
+        AiAssistant.save_message(session, %{
+          role: :user,
+          content: "fix both steps",
+          user: user
+        })
+
+      user_message = Enum.find(updated_session.messages, &(&1.role == :user))
+
+      Mox.stub(
+        Lightning.Tesla.Mock,
+        :call,
+        Lightning.AiAssistantHelpers.streaming_or_sync_response(%{
+          "response" => "Changed one of them.",
+          "usage" => %{},
+          "attachments" => [
+            %{"type" => "workflow_yaml", "content" => "workflow:\n  name: new"}
+          ],
+          "meta" => %{
+            "subagent_calls" => [
+              %{"diff" => %{"patches_applied" => 0}},
+              %{"diff" => %{"patches_applied" => 1}}
+            ]
+          }
+        })
+      )
+
+      assert :ok =
+               perform_job(MessageProcessor, %{"message_id" => user_message.id})
+
+      reloaded = AiAssistant.get_session!(session.id)
+      assistant = Enum.find(reloaded.messages, &(&1.role == :assistant))
+
+      refute assistant.meta["code_change_failed"]
+    end
+
     test "persists the segments timeline alongside the flat response",
          %{user: user, project: project} do
       workflow = insert(:workflow, project: project)

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -318,6 +318,43 @@ defmodule LightningWeb.AiAssistantChannelTest do
     end
   end
 
+  describe "join with an invalid first message" do
+    # The reply is JSON-encoded before it reaches the client, and a changeset
+    # has no encoder, so a raw one kills the socket before any reply goes out
+    # and the assistant simply does nothing.
+    test "returns a clean error rather than crashing the socket", %{
+      socket: socket,
+      project: project,
+      workflow: workflow
+    } do
+      too_long =
+        String.duplicate(
+          "x",
+          Lightning.AiAssistant.ChatMessage.max_content_length() + 1
+        )
+
+      params = %{
+        "project_id" => project.id,
+        "workflow_id" => workflow.id,
+        "content" => too_long
+      }
+
+      assert {:error, reply} =
+               subscribe_and_join(
+                 socket,
+                 AiAssistantChannel,
+                 "ai_assistant:workflow_template:new",
+                 params
+               )
+
+      assert {:ok, _json} = Jason.encode(reply)
+
+      assert %{reason: "validation_error", errors: errors} = reply
+      assert %{"content" => [message]} = errors
+      assert message =~ "should be at most 10000 character(s)"
+    end
+  end
+
   describe "message serialization" do
     test "serializes from_global marker with nil job_id", %{
       socket: socket,

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -349,9 +349,12 @@ defmodule LightningWeb.AiAssistantChannelTest do
 
       assert {:ok, _json} = Jason.encode(reply)
 
-      assert %{reason: "validation_error", errors: errors} = reply
+      assert %{reason: reason, errors: errors} = reply
       assert %{"content" => [message]} = errors
       assert message =~ "should be at most 10000 character(s)"
+
+      # Shown to the reader as it stands, so it cannot be a code.
+      assert reason =~ "should be at most 10000 character(s)"
     end
   end
 
@@ -399,6 +402,37 @@ defmodule LightningWeb.AiAssistantChannelTest do
                },
                %{from_global: false}
              ] = messages
+    end
+
+    test "serializes the flag for a reply whose code edit did not apply", %{
+      socket: socket,
+      job: job,
+      user: user
+    } do
+      session =
+        insert(:chat_session,
+          job: job,
+          user: user,
+          session_type: "job_code",
+          messages: [
+            %{
+              role: :assistant,
+              content: "Here is what I changed.",
+              status: :success,
+              meta: %{"from_global" => true, "code_change_failed" => true}
+            }
+          ]
+        )
+
+      assert {:ok, %{messages: [message]}, _socket} =
+               subscribe_and_join(
+                 socket,
+                 AiAssistantChannel,
+                 "ai_assistant:job_code:#{session.id}",
+                 %{}
+               )
+
+      assert message.code_change_failed == true
     end
 
     # Everyone in the session sees a failure, not just whoever sent the message.

--- a/test/lightning_web/channels/ai_assistant_channel_test.exs
+++ b/test/lightning_web/channels/ai_assistant_channel_test.exs
@@ -319,9 +319,6 @@ defmodule LightningWeb.AiAssistantChannelTest do
   end
 
   describe "join with an invalid first message" do
-    # The reply is JSON-encoded before it reaches the client, and a changeset
-    # has no encoder, so a raw one kills the socket before any reply goes out
-    # and the assistant simply does nothing.
     test "returns a clean error rather than crashing the socket", %{
       socket: socket,
       project: project,


### PR DESCRIPTION
## Description

Two ways the assistant did something and told you nothing.

1. Starting a chat with a message over the 10,000 character limit put a raw changeset in the join reply. It has no JSON encoder, so the socket died before answering and the panel just sat there. It now returns a readable error, and the box shows the limit once you are within 500 characters.
2. Asking for a code change could produce a reply with nothing to apply and no explanation. Apollo reports how many of its edits landed and we were ignoring it. Zero now gets a line saying so, with a Try again.

Needs Apollo v3.1.2, which reports that on the single-step route as well as through the planner (OpenFn/apollo#676).

Closes #4883
Closes #5133

## Validation steps

1. Paste more than 10,000 characters into a new chat and send. You get an error rather than silence, and a counter warns you first.
3. Ask for a code change Apollo cannot apply. The reply says it tried and could not.

## Additional notes for the reviewer

Refusing a long paste is the wrong answer; taking it as an attachment is #5138.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [x] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR