### PR TITLE
Test in a sandbox: start with the data that broke it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ adaptor_registry_cache.json
 
 # Ignore credential schemas.
 /priv/schemas/
+/priv/schemas
 
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ adaptor_registry_cache.json
 
 # Ignore credential schemas.
 /priv/schemas/
+# Without the trailing slash too: the pattern above matches a directory, not a
+# symlink of the same name, and a symlink is what a worktree gets.
 /priv/schemas
 
 # In case you use Node.js/npm, you want to ignore these.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to
 
 ### Added
 
+- Edit in sandbox now asks what the sandbox should start with: nothing, the
+  input from the run you are looking at, or one of the project's named inputs.
+  The run's input is shown before it travels so you can remove anything that
+  should not leave production, and what you see is what lands, because the
+  reviewed body is created in the sandbox rather than the original row being
+  copied. The sandbox opens with that input already selected, and says which
+  version it forked when the run used an older one.
+  [#5052](https://github.com/OpenFn/lightning/issues/5052)
+- A named dataclip is now selectable on any job in its project, not only where
+  it has already run.
+  [#5052](https://github.com/OpenFn/lightning/issues/5052)
+
 - Promoting from a sandbox now warns first when the parent project has changed
   that workflow since the sandbox was created. Promote rebuilds the parent
   workflow from the sandbox, so anything the parent gained in the meantime is

--- a/assets/js/collaborative-editor/api/dataclips.ts
+++ b/assets/js/collaborative-editor/api/dataclips.ts
@@ -170,3 +170,17 @@ export async function submitManualRun(
 
   return response.json() as Promise<ManualRunResponse>;
 }
+
+/**
+ * Fetch a dataclip's body as text. The endpoint scrubs step results and http
+ * requests, so this is what a person may safely be shown.
+ */
+export async function getDataclipBody(dataclipId: string): Promise<string> {
+  const response = await fetch(`/dataclip/body/${dataclipId}`);
+
+  if (!response.ok) {
+    throw new Error(`Could not load dataclip ${dataclipId}`);
+  }
+
+  return await response.text();
+}

--- a/assets/js/collaborative-editor/api/dataclips.ts
+++ b/assets/js/collaborative-editor/api/dataclips.ts
@@ -8,6 +8,8 @@ export interface DataclipFilters {
   before?: string;
   after?: string;
   named_only?: boolean;
+  /** Rows to return. Defaults to 10, which suits the run panel's short list. */
+  limit?: number;
 }
 
 export interface SearchDataclipsResponse {
@@ -50,7 +52,7 @@ export async function searchDataclips(
     ...(filters?.named_only !== undefined && {
       named_only: String(filters.named_only),
     }),
-    limit: '10',
+    limit: String(filters?.limit ?? 10),
   });
 
   const response = await fetch(

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -572,16 +572,28 @@ export function EditInSandboxPicker({
   // A reply may only land if it is still the reply this dialog is waiting for:
   // the same request, the same run, and the same choice. Read from refs because
   // all three can have changed since the request went out.
-  const stillWanted = useCallback((runId: string) => {
+  const stillLoading = useCallback((runId: string) => {
     const current = reviewRef.current;
 
-    return (
-      current.status === 'loading' &&
-      current.runId === runId &&
-      startWithRef.current === 'run' &&
-      activeRunIdRef.current === runId
-    );
+    return current.status === 'loading' && current.runId === runId;
   }, []);
+
+  // Landing the result is safe whatever the person has since chosen, because a
+  // review is only ever read back through `activeReview`. Moving them to the
+  // review screen is not: they may have picked something else while it loaded.
+  const shouldShowReview = useCallback(
+    (runId: string) =>
+      startWithRef.current === 'run' && activeRunIdRef.current === runId,
+    []
+  );
+
+  useEffect(() => {
+    if (step === 'review' && !activeReview) {
+      // Whatever the review belonged to has moved on, so the screen showing it
+      // cannot be typed into or sent. Go back rather than sit there dead.
+      setStep('choose');
+    }
+  }, [step, activeReview]);
 
   const handleCreate = useCallback(
     (start: EditInSandboxStart) => {
@@ -653,19 +665,20 @@ export function EditInSandboxPicker({
     void getRunDataclip(project.id, runId, runStepJobId)
       .then(async ({ dataclip }) => {
         if (!dataclip || dataclip.wiped_at) {
-          if (stillWanted(runId)) setReview({ status: 'missing', runId });
+          if (stillLoading(runId)) setReview({ status: 'missing', runId });
           return;
         }
 
         const body = await getDataclipBody(dataclip.id);
 
-        if (!stillWanted(runId)) return;
+        if (!stillLoading(runId)) return;
 
         setReview({ status: 'ready', runId, body });
-        setStep('review');
+
+        if (shouldShowReview(runId)) setStep('review');
       })
       .catch(() => {
-        if (!stillWanted(runId)) return;
+        if (!stillLoading(runId)) return;
 
         setReview({ status: 'idle' });
         notifications.alert({
@@ -679,7 +692,8 @@ export function EditInSandboxPicker({
     canStartFromRun,
     handleCreate,
     hasLoadedBody,
-    stillWanted,
+    stillLoading,
+    shouldShowReview,
     project?.id,
     activeRun,
     runStepJobId,

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -15,7 +15,11 @@ import { Tooltip } from '../../components/Tooltip';
 import type { Dataclip } from '../api/dataclips';
 import { getDataclipBody, searchDataclips } from '../api/dataclips';
 import { useActiveRun } from '../hooks/useHistory';
-import { useProject } from '../hooks/useSessionContext';
+import {
+  useProject,
+  useRequestVersions,
+  useVersions,
+} from '../hooks/useSessionContext';
 import { useWorkflowActions, useWorkflowState } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
 import {
@@ -307,8 +311,18 @@ function describeBodyProblem(body: string): string | null {
   }
 }
 
-const navigateToSandbox = (projectId: string, workflowId: string) => {
-  window.location.href = `/projects/${projectId}/w/${workflowId}`;
+// The dataclip id rides along so the sandbox opens with it already selected
+// rather than merely holding it somewhere.
+const navigateToSandbox = (
+  projectId: string,
+  workflowId: string,
+  dataclipId?: string | null
+) => {
+  const base = `/projects/${projectId}/w/${workflowId}`;
+
+  window.location.href = dataclipId
+    ? `${base}?dataclip=${encodeURIComponent(dataclipId)}`
+    : base;
 };
 
 export function EditInSandboxPicker({
@@ -344,6 +358,8 @@ export function EditInSandboxPicker({
   const activeRun = useActiveRun();
   const project = useProject();
   const jobs = useWorkflowState(state => state.jobs);
+  const versions = useVersions();
+  const requestVersions = useRequestVersions();
 
   // Any job in the project resolves the same set of named dataclips, so the
   // first one is enough to ask for them.
@@ -418,6 +434,23 @@ export function EditInSandboxPicker({
     };
   }, [isOpen, startWith, project?.id, anyJobId]);
 
+  useEffect(() => {
+    if (!isOpen || !activeRun || versions.length > 0) return;
+
+    void requestVersions();
+  }, [isOpen, activeRun, versions.length, requestVersions]);
+
+  // A sandbox always forks the current version, because promote rebuilds the
+  // parent from the sandbox and an older fork would delete the newer work. When
+  // the run came from an older version, say so rather than let it surprise.
+  const runVersionNumber = activeRun?.version_number ?? null;
+  const latestVersionNumber = versions[0]?.version_number ?? null;
+  const startsFromNewerVersion =
+    startWith === 'run' &&
+    runVersionNumber !== null &&
+    latestVersionNumber !== null &&
+    runVersionNumber !== latestVersionNumber;
+
   const handleCreate = useCallback(
     (start: EditInSandboxStart) => {
       setIsCreating(true);
@@ -426,11 +459,11 @@ export function EditInSandboxPicker({
 
       const create = async () => {
         try {
-          const { project_id, workflow_id } = await editInSandbox(
+          const { project_id, workflow_id, dataclip_id } = await editInSandbox(
             trimmed,
             start
           );
-          navigateToSandbox(project_id, workflow_id);
+          navigateToSandbox(project_id, workflow_id, dataclip_id);
         } catch (error) {
           // A rejected name (duplicate, invalid) belongs under the input as an
           // inline field error; only genuinely unexpected/system errors toast.
@@ -586,6 +619,16 @@ export function EditInSandboxPicker({
                     ring-gray-300 focus:ring-2 focus:ring-inset
                     focus:ring-primary-600"
                 />
+
+                {startsFromNewerVersion && (
+                  <p
+                    className="mt-3 text-xs text-gray-500"
+                    data-testid="review-version-note"
+                  >
+                    This run used v{runVersionNumber}. The sandbox starts from v
+                    {latestVersionNumber}, the version live now.
+                  </p>
+                )}
 
                 <div className="mt-1 min-h-[1rem]">
                   {reviewError && (
@@ -764,6 +807,18 @@ export function EditInSandboxPicker({
                           hint="One of this project's named inputs."
                         />
                       </div>
+
+                      {startsFromNewerVersion && (
+                        <p
+                          className="mt-3 text-xs text-gray-500"
+                          data-testid="version-note"
+                        >
+                          This run used v{runVersionNumber}. The sandbox starts
+                          from v{latestVersionNumber}, the version live now,
+                          because promoting an older one would remove the newer
+                          work.
+                        </p>
+                      )}
 
                       {startWith === 'saved' && (
                         <SavedInputList

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from '@headlessui/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { cn } from '#/utils/cn';
 
@@ -400,6 +400,7 @@ export function EditInSandboxPicker({
   const [isLoadingBody, setIsLoadingBody] = useState(false);
   const [runInputMissing, setRunInputMissing] = useState(false);
   const [hasLoadedBody, setHasLoadedBody] = useState(false);
+  const runFetchTokenRef = useRef<string | null>(null);
   const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
 
   const activeRun = useActiveRun();
@@ -442,7 +443,9 @@ export function EditInSandboxPicker({
     setReviewBody('');
     setReviewError(null);
     setRunInputMissing(false);
+    setHasLoadedBody(false);
     setSavedDataclipId(null);
+    runFetchTokenRef.current = null;
 
     const load = async () => {
       try {
@@ -538,6 +541,7 @@ export function EditInSandboxPicker({
     setReviewBody('');
     setHasLoadedBody(false);
     setRunInputMissing(false);
+    runFetchTokenRef.current = null;
   }, [canStartFromRun, startWith]);
 
   const handleCreate = useCallback(
@@ -595,36 +599,52 @@ export function EditInSandboxPicker({
     // Already reviewed: keep what the person has, or Back then Continue would
     // quietly restore the production body they had just redacted. Checked
     // before the loading flag is set, since this path never clears it.
+    setReviewError(null);
+
     if (hasLoadedBody) {
       setStep('review');
       return;
     }
 
     setIsLoadingBody(true);
-    setReviewError(null);
 
     // Whether the input was kept is the dataclip's own answer. Inferring it from
     // the body does not work: a wiped http_request still serves a JSON object,
     // `{"data": null, "request": null}`, which reads as perfectly good data.
+    // Guarded like the other fetches here: closing the dialog, or losing the
+    // run, must not be undone by a reply that was already in flight.
+    const requestedRunId = activeRun.id;
+    runFetchTokenRef.current = requestedRunId;
+
     void getRunDataclip(project.id, activeRun.id, runStepJobId)
       .then(async ({ dataclip }) => {
+        if (runFetchTokenRef.current !== requestedRunId) return;
+
         if (!dataclip || dataclip.wiped_at) {
           setRunInputMissing(true);
           return;
         }
 
-        setReviewBody(await getDataclipBody(dataclip.id));
+        const body = await getDataclipBody(dataclip.id);
+
+        if (runFetchTokenRef.current !== requestedRunId) return;
+
+        setReviewBody(body);
         setHasLoadedBody(true);
         setStep('review');
       })
       .catch(() => {
+        if (runFetchTokenRef.current !== requestedRunId) return;
+
         notifications.alert({
           title: "Could not load this run's input",
           description: 'Please try again.',
         });
       })
       .finally(() => {
-        setIsLoadingBody(false);
+        if (runFetchTokenRef.current === requestedRunId) {
+          setIsLoadingBody(false);
+        }
       });
   }, [
     startWith,

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -202,6 +202,7 @@ function SavedInputList({
   isLoading,
   canAsk,
   anyFound,
+  failed,
   selectedId,
   onSelect,
 }: {
@@ -209,6 +210,7 @@ function SavedInputList({
   isLoading: boolean;
   canAsk: boolean;
   anyFound: boolean;
+  failed: boolean;
   selectedId: string | null;
   onSelect: (id: string) => void;
 }) {
@@ -219,6 +221,17 @@ function SavedInputList({
         data-testid="saved-inputs-unavailable"
       >
         Add a step to this workflow to pick a saved input.
+      </p>
+    );
+  }
+
+  if (failed) {
+    return (
+      <p
+        className="mt-3 text-xs text-gray-500"
+        data-testid="saved-inputs-failed"
+      >
+        Could not load this project's saved inputs.
       </p>
     );
   }
@@ -350,8 +363,10 @@ const navigateToSandbox = (
 ) => {
   const base = `/projects/${projectId}/w/${workflowId}`;
 
+  // The run panel has to be asked for, or the sandbox opens on a bare canvas
+  // and the input we carried is selected somewhere nobody can see.
   window.location.href = dataclipId
-    ? `${base}?dataclip=${encodeURIComponent(dataclipId)}`
+    ? `${base}?panel=run&dataclip=${encodeURIComponent(dataclipId)}`
     : base;
 };
 
@@ -399,6 +414,7 @@ export function EditInSandboxPicker({
   const [savedDataclips, setSavedDataclips] = useState<Dataclip[]>([]);
   const [isLoadingSaved, setIsLoadingSaved] = useState(false);
   const [savedInputsFiltered, setSavedInputsFiltered] = useState(false);
+  const [savedInputsFailed, setSavedInputsFailed] = useState(false);
 
   // A run's own input is its first step's input. Anything deeper is a step
   // result, which is a different thing to offer.
@@ -455,6 +471,7 @@ export function EditInSandboxPicker({
 
     let cancelled = false;
     setIsLoadingSaved(true);
+    setSavedInputsFailed(false);
 
     void searchDataclips(project.id, anyJobId, '', {
       named_only: true,
@@ -467,10 +484,10 @@ export function EditInSandboxPicker({
 
         setSavedDataclips(data.filter(isCopyableDataclip));
         setSavedInputsFiltered(data.length > 0);
-        setSavedInputsFiltered(data.length > 0);
       })
       .catch(() => {
         if (!cancelled) {
+          setSavedInputsFailed(true);
           notifications.alert({
             title: 'Could not load saved inputs',
             description: 'Please try again.',
@@ -509,6 +526,12 @@ export function EditInSandboxPicker({
     runVersionNumber !== null &&
     latestVersionNumber !== null &&
     runVersionNumber !== latestVersionNumber;
+
+  useEffect(() => {
+    if (!canStartFromRun && startWith === 'run') {
+      setStartWith('nothing');
+    }
+  }, [canStartFromRun, startWith]);
 
   const handleCreate = useCallback(
     (start: EditInSandboxStart) => {
@@ -565,6 +588,13 @@ export function EditInSandboxPicker({
     setIsLoadingBody(true);
     setReviewError(null);
 
+    // Already reviewed: keep what the person has, or Back then Continue would
+    // quietly restore the production body they had just redacted.
+    if (reviewBody !== '') {
+      setStep('review');
+      return;
+    }
+
     // Whether the input was kept is the dataclip's own answer. Inferring it from
     // the body does not work: a wiped http_request still serves a JSON object,
     // `{"data": null, "request": null}`, which reads as perfectly good data.
@@ -592,6 +622,7 @@ export function EditInSandboxPicker({
     savedDataclipId,
     canStartFromRun,
     handleCreate,
+    reviewBody,
     project?.id,
     activeRun,
     runStepJobId,
@@ -928,6 +959,7 @@ export function EditInSandboxPicker({
                           isLoading={isLoadingSaved}
                           canAsk={anyJobId !== null}
                           anyFound={savedInputsFiltered}
+                          failed={savedInputsFailed}
                           selectedId={savedDataclipId}
                           onSelect={setSavedDataclipId}
                         />

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -399,6 +399,7 @@ export function EditInSandboxPicker({
   const [reviewError, setReviewError] = useState<string | null>(null);
   const [isLoadingBody, setIsLoadingBody] = useState(false);
   const [runInputMissing, setRunInputMissing] = useState(false);
+  const [hasLoadedBody, setHasLoadedBody] = useState(false);
   const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
 
   const activeRun = useActiveRun();
@@ -528,9 +529,15 @@ export function EditInSandboxPicker({
     runVersionNumber !== latestVersionNumber;
 
   useEffect(() => {
-    if (!canStartFromRun && startWith === 'run') {
-      setStartWith('nothing');
-    }
+    if (canStartFromRun || startWith !== 'run') return;
+
+    // The run went away. Leaving the review step behind would strand a redacted
+    // body somewhere the person cannot reach or send.
+    setStartWith('nothing');
+    setStep('choose');
+    setReviewBody('');
+    setHasLoadedBody(false);
+    setRunInputMissing(false);
   }, [canStartFromRun, startWith]);
 
   const handleCreate = useCallback(
@@ -585,15 +592,16 @@ export function EditInSandboxPicker({
       return;
     }
 
-    setIsLoadingBody(true);
-    setReviewError(null);
-
     // Already reviewed: keep what the person has, or Back then Continue would
-    // quietly restore the production body they had just redacted.
-    if (reviewBody !== '') {
+    // quietly restore the production body they had just redacted. Checked
+    // before the loading flag is set, since this path never clears it.
+    if (hasLoadedBody) {
       setStep('review');
       return;
     }
+
+    setIsLoadingBody(true);
+    setReviewError(null);
 
     // Whether the input was kept is the dataclip's own answer. Inferring it from
     // the body does not work: a wiped http_request still serves a JSON object,
@@ -606,6 +614,7 @@ export function EditInSandboxPicker({
         }
 
         setReviewBody(await getDataclipBody(dataclip.id));
+        setHasLoadedBody(true);
         setStep('review');
       })
       .catch(() => {
@@ -622,7 +631,7 @@ export function EditInSandboxPicker({
     savedDataclipId,
     canStartFromRun,
     handleCreate,
-    reviewBody,
+    hasLoadedBody,
     project?.id,
     activeRun,
     runStepJobId,

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -13,8 +13,12 @@ import { cn } from '#/utils/cn';
 
 import { Tooltip } from '../../components/Tooltip';
 import type { Dataclip } from '../api/dataclips';
-import { getDataclipBody, searchDataclips } from '../api/dataclips';
-import { useActiveRun } from '../hooks/useHistory';
+import {
+  getDataclipBody,
+  getRunDataclip,
+  searchDataclips,
+} from '../api/dataclips';
+import { useActiveRun, useHistory } from '../hooks/useHistory';
 import {
   useProject,
   useRequestVersions,
@@ -196,14 +200,27 @@ function StartOption({
 function SavedInputList({
   dataclips,
   isLoading,
+  canAsk,
   selectedId,
   onSelect,
 }: {
   dataclips: Dataclip[];
   isLoading: boolean;
+  canAsk: boolean;
   selectedId: string | null;
   onSelect: (id: string) => void;
 }) {
+  if (!canAsk) {
+    return (
+      <p
+        className="mt-3 text-xs text-gray-500"
+        data-testid="saved-inputs-unavailable"
+      >
+        Add a step to this workflow to pick a saved input.
+      </p>
+    );
+  }
+
   if (isLoading) {
     return (
       <p
@@ -291,6 +308,14 @@ function createButtonLabel({
   return needsReview ? 'Continue' : 'Create sandbox';
 }
 
+// A sandbox copy is restricted to these: a step result carries whatever the
+// previous step emitted, which is the data we are trying not to move.
+const COPYABLE_DATACLIP_TYPES = ['global', 'saved_input', 'http_request'];
+
+function isCopyableDataclip(dataclip: Dataclip): boolean {
+  return COPYABLE_DATACLIP_TYPES.includes(dataclip.type);
+}
+
 // Shape only, and checked here as well as on the server so the person is told
 // before the sandbox is attempted. Size is the server's to judge, since the
 // limit is configured there.
@@ -358,13 +383,11 @@ export function EditInSandboxPicker({
   const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
 
   const activeRun = useActiveRun();
+  const history = useHistory();
   const project = useProject();
   const jobs = useWorkflowState(state => state.jobs);
   const versions = useVersions();
   const requestVersions = useRequestVersions();
-  const openLockVersion = useWorkflowState(
-    state => state.workflow?.lock_version
-  );
 
   // Any job in the project resolves the same set of named dataclips, so the
   // first one is enough to ask for them.
@@ -375,6 +398,7 @@ export function EditInSandboxPicker({
   // A run's own input is its first step's input. Anything deeper is a step
   // result, which is a different thing to offer.
   const runInputDataclipId = activeRun?.steps?.[0]?.input_dataclip_id ?? null;
+  const runStepJobId = activeRun?.steps?.[0]?.job_id ?? null;
   const runLabel = activeRun ? activeRun.id.slice(0, 6) : null;
 
   useEffect(() => {
@@ -419,9 +443,14 @@ export function EditInSandboxPicker({
     let cancelled = false;
     setIsLoadingSaved(true);
 
-    void searchDataclips(project.id, anyJobId, '', { named_only: true })
+    void searchDataclips(project.id, anyJobId, '', {
+      named_only: true,
+      limit: 100,
+    })
       .then(({ data }) => {
-        if (!cancelled) setSavedDataclips(data);
+        // Only what a sandbox can actually copy. Naming is not type-restricted,
+        // so a named step result can appear here and would be refused on create.
+        if (!cancelled) setSavedDataclips(data.filter(isCopyableDataclip));
       })
       .catch(() => {
         if (!cancelled) {
@@ -449,18 +478,20 @@ export function EditInSandboxPicker({
   // A sandbox always forks the version live now, because promote rebuilds the
   // parent from the sandbox and an older fork would delete the newer work.
   //
-  // What is on screen is the comparison that matters, whether a run pinned it
-  // or the version dropdown did, so the loaded document's snapshot is matched
-  // against the releases rather than anything read off the run.
-  const openVersionNumber =
-    versions.find(version => version.lock_version === openLockVersion)
-      ?.version_number ?? null;
+  // The run's version comes from the history summaries, the same place the
+  // history panel reads it. Opening a run does not load its snapshot, so the
+  // document on screen says nothing about which version the run used.
+  const runVersionNumber =
+    history
+      .flatMap(workOrder => workOrder.runs)
+      .find(run => run.id === activeRun?.id)?.version_number ?? null;
   const latestVersionNumber =
     versions.find(version => version.is_latest)?.version_number ?? null;
   const startsFromNewerVersion =
-    openVersionNumber !== null &&
+    startWith === 'run' &&
+    runVersionNumber !== null &&
     latestVersionNumber !== null &&
-    openVersionNumber !== latestVersionNumber;
+    runVersionNumber !== latestVersionNumber;
 
   const handleCreate = useCallback(
     (start: EditInSandboxStart) => {
@@ -505,7 +536,13 @@ export function EditInSandboxPicker({
       return;
     }
 
-    if (startWith !== 'run' || !runInputDataclipId) {
+    if (
+      startWith !== 'run' ||
+      !runInputDataclipId ||
+      !project?.id ||
+      !activeRun ||
+      !runStepJobId
+    ) {
       handleCreate({});
       return;
     }
@@ -513,17 +550,17 @@ export function EditInSandboxPicker({
     setIsLoadingBody(true);
     setReviewError(null);
 
-    void getDataclipBody(runInputDataclipId)
-      .then(body => {
-        // Zero-persistence projects never keep run data, and retention wipes it
-        // later elsewhere. Either way there is nothing to review, and an empty
-        // editor followed by a validation error explains none of that.
-        if (describeBodyProblem(body)) {
+    // Whether the input was kept is the dataclip's own answer. Inferring it from
+    // the body does not work: a wiped http_request still serves a JSON object,
+    // `{"data": null, "request": null}`, which reads as perfectly good data.
+    void getRunDataclip(project.id, activeRun.id, runStepJobId)
+      .then(async ({ dataclip }) => {
+        if (!dataclip || dataclip.wiped_at) {
           setRunInputMissing(true);
           return;
         }
 
-        setReviewBody(body);
+        setReviewBody(await getDataclipBody(dataclip.id));
         setStep('review');
       })
       .catch(() => {
@@ -535,7 +572,15 @@ export function EditInSandboxPicker({
       .finally(() => {
         setIsLoadingBody(false);
       });
-  }, [startWith, savedDataclipId, runInputDataclipId, handleCreate]);
+  }, [
+    startWith,
+    savedDataclipId,
+    runInputDataclipId,
+    handleCreate,
+    project?.id,
+    activeRun,
+    runStepJobId,
+  ]);
 
   const handleCreateFromReview = useCallback(() => {
     const problem = describeBodyProblem(reviewBody);
@@ -645,8 +690,8 @@ export function EditInSandboxPicker({
                     className="mt-3 text-xs text-gray-500"
                     data-testid="review-version-note"
                   >
-                    This run used v{openVersionNumber}. The sandbox starts from
-                    v{latestVersionNumber}, the version live now.
+                    This run used v{runVersionNumber}. The sandbox starts from v
+                    {latestVersionNumber}, the version live now.
                   </p>
                 )}
 
@@ -657,6 +702,17 @@ export function EditInSandboxPicker({
                       className="text-xs text-red-600"
                     >
                       {reviewError}
+                    </p>
+                  )}
+                  {/* A rejected name is decided a step back, so say it here
+                      rather than leave the button flicking with nothing on
+                      screen changing. */}
+                  {nameError && (
+                    <p
+                      data-testid="review-name-error"
+                      className="text-xs text-red-600"
+                    >
+                      {nameError} Go back to change it.
                     </p>
                   )}
                 </div>
@@ -828,7 +884,7 @@ export function EditInSandboxPicker({
                         />
                       </div>
 
-                      {runInputMissing && (
+                      {startWith === 'run' && runInputMissing && (
                         <p
                           className="mt-3 text-xs text-gray-500"
                           data-testid="run-input-missing"
@@ -844,7 +900,7 @@ export function EditInSandboxPicker({
                           className="mt-3 text-xs text-gray-500"
                           data-testid="version-note"
                         >
-                          This run used v{openVersionNumber}. The sandbox starts
+                          This run used v{runVersionNumber}. The sandbox starts
                           from v{latestVersionNumber}, the version live now,
                           because promoting an older one would remove the newer
                           work.
@@ -855,6 +911,7 @@ export function EditInSandboxPicker({
                         <SavedInputList
                           dataclips={savedDataclips}
                           isLoading={isLoadingSaved}
+                          canAsk={anyJobId !== null}
                           selectedId={savedDataclipId}
                           onSelect={setSavedDataclipId}
                         />

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -7,19 +7,27 @@ import {
   DialogTitle,
 } from '@headlessui/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { cn } from '#/utils/cn';
 
 import { Tooltip } from '../../components/Tooltip';
-import { useWorkflowActions } from '../hooks/useWorkflow';
+import type { Dataclip } from '../api/dataclips';
+import { getDataclipBody, searchDataclips } from '../api/dataclips';
+import { useActiveRun } from '../hooks/useHistory';
+import { useProject } from '../hooks/useSessionContext';
+import { useWorkflowActions, useWorkflowState } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
 import {
   formatChannelErrorMessage,
   isChannelRequestError,
 } from '../lib/errors';
 import { notifications } from '../lib/notifications';
+import type { EditInSandboxStart } from '../stores/createWorkflowStore';
 import type { Sandbox } from '../types/workflow';
+
+type StartChoice = 'nothing' | 'run' | 'saved';
+type Step = 'choose' | 'review';
 
 interface EditInSandboxPickerProps {
   isOpen: boolean;
@@ -147,6 +155,104 @@ function SandboxRow({
 
 // Three placeholder rows shown while the sandbox list loads. Mirrors the shape
 // of a real row (colour tile + two text lines) so the layout doesn't jump.
+function StartOption({
+  value,
+  checked,
+  onChange,
+  label,
+  hint,
+}: {
+  value: StartChoice;
+  checked: boolean;
+  onChange: (value: StartChoice) => void;
+  label: string;
+  hint: string;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-2.5">
+      <input
+        type="radio"
+        name="start-with"
+        value={value}
+        checked={checked}
+        onChange={() => {
+          onChange(value);
+        }}
+        className="mt-0.5 h-4 w-4 shrink-0 border-gray-300 text-primary-600
+          focus:ring-primary-600"
+      />
+      <span className="min-w-0">
+        <span className="block text-sm text-gray-900">{label}</span>
+        <span className="block text-xs text-gray-500">{hint}</span>
+      </span>
+    </label>
+  );
+}
+
+function SavedInputList({
+  dataclips,
+  isLoading,
+  selectedId,
+  onSelect,
+}: {
+  dataclips: Dataclip[];
+  isLoading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  if (isLoading) {
+    return (
+      <p
+        className="mt-3 text-xs text-gray-500"
+        data-testid="saved-inputs-loading"
+      >
+        Loading saved inputs...
+      </p>
+    );
+  }
+
+  if (dataclips.length === 0) {
+    return (
+      <p
+        className="mt-3 text-xs text-gray-500"
+        data-testid="saved-inputs-empty"
+      >
+        This project has no named inputs yet. Name a dataclip to reuse it here.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      className="mt-3 max-h-48 space-y-1 overflow-y-auto"
+      data-testid="saved-inputs"
+    >
+      {dataclips.map(dataclip => (
+        <li key={dataclip.id}>
+          <label
+            className="flex cursor-pointer items-center gap-2.5 rounded-md
+            px-2 py-1.5 hover:bg-gray-50"
+          >
+            <input
+              type="radio"
+              name="saved-input"
+              checked={selectedId === dataclip.id}
+              onChange={() => {
+                onSelect(dataclip.id);
+              }}
+              className="h-4 w-4 shrink-0 border-gray-300 text-primary-600
+                focus:ring-primary-600"
+            />
+            <span className="min-w-0 truncate text-sm text-gray-900">
+              {dataclip.name}
+            </span>
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function SandboxListSkeleton() {
   return (
     <ul className="mt-3 space-y-1" data-testid="sandbox-list-loading">
@@ -165,6 +271,40 @@ function SandboxListSkeleton() {
       ))}
     </ul>
   );
+}
+
+function createButtonLabel({
+  isCreating,
+  isLoadingBody,
+  needsReview,
+}: {
+  isCreating: boolean;
+  isLoadingBody: boolean;
+  needsReview: boolean;
+}) {
+  if (isCreating) return 'Creating...';
+  if (isLoadingBody) return 'Loading...';
+  return needsReview ? 'Continue' : 'Create sandbox';
+}
+
+// Checked here as well as on the server so the person is told before the
+// sandbox is attempted, not after it is refused.
+function describeBodyProblem(body: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(body);
+
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return 'This needs to be a JSON object.';
+    }
+
+    return null;
+  } catch {
+    return "This isn't valid JSON.";
+  }
 }
 
 const navigateToSandbox = (projectId: string, workflowId: string) => {
@@ -194,6 +334,27 @@ export function EditInSandboxPicker({
   const [isCreating, setIsCreating] = useState(false);
   const [isLoadingList, setIsLoadingList] = useState(false);
   const [sandboxes, setSandboxes] = useState<Sandbox[]>([]);
+  const [startWith, setStartWith] = useState<StartChoice>('nothing');
+  const [step, setStep] = useState<Step>('choose');
+  const [reviewBody, setReviewBody] = useState('');
+  const [reviewError, setReviewError] = useState<string | null>(null);
+  const [isLoadingBody, setIsLoadingBody] = useState(false);
+  const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
+
+  const activeRun = useActiveRun();
+  const project = useProject();
+  const jobs = useWorkflowState(state => state.jobs);
+
+  // Any job in the project resolves the same set of named dataclips, so the
+  // first one is enough to ask for them.
+  const anyJobId = jobs[0]?.id ?? null;
+  const [savedDataclips, setSavedDataclips] = useState<Dataclip[]>([]);
+  const [isLoadingSaved, setIsLoadingSaved] = useState(false);
+
+  // A run's own input is its first step's input. Anything deeper is a step
+  // result, which is a different thing to offer.
+  const runInputDataclipId = activeRun?.steps?.[0]?.input_dataclip_id ?? null;
+  const runLabel = activeRun ? activeRun.id.slice(0, 6) : null;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -201,6 +362,11 @@ export function EditInSandboxPicker({
     let cancelled = false;
     setIsLoadingList(true);
     setSandboxes([]);
+    setStartWith('nothing');
+    setStep('choose');
+    setReviewBody('');
+    setReviewError(null);
+    setSavedDataclipId(null);
 
     const load = async () => {
       try {
@@ -225,33 +391,114 @@ export function EditInSandboxPicker({
     };
   }, [isOpen, listSandboxes]);
 
-  const handleCreate = useCallback(() => {
-    setIsCreating(true);
-    setNameError(null);
-    const trimmed = name.trim();
+  useEffect(() => {
+    if (!isOpen || startWith !== 'saved' || !project?.id || !anyJobId) return;
 
-    const create = async () => {
-      try {
-        const { project_id, workflow_id } = await editInSandbox(trimmed);
-        navigateToSandbox(project_id, workflow_id);
-      } catch (error) {
-        // A rejected name (duplicate, invalid) belongs under the input as an
-        // inline field error; only genuinely unexpected/system errors toast.
-        const fieldError = extractNameFieldError(error);
-        if (fieldError) {
-          setNameError(fieldError);
-        } else {
+    let cancelled = false;
+    setIsLoadingSaved(true);
+
+    void searchDataclips(project.id, anyJobId, { named_only: true })
+      .then(({ data }) => {
+        if (!cancelled) setSavedDataclips(data);
+      })
+      .catch(() => {
+        if (!cancelled) {
           notifications.alert({
-            title: 'Could not create a sandbox',
-            description: describeSandboxError(error),
+            title: 'Could not load saved inputs',
+            description: 'Please try again.',
           });
         }
-        setIsCreating(false);
-      }
-    };
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingSaved(false);
+      });
 
-    void create();
-  }, [name, editInSandbox]);
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, startWith, project?.id, anyJobId]);
+
+  const handleCreate = useCallback(
+    (start: EditInSandboxStart) => {
+      setIsCreating(true);
+      setNameError(null);
+      const trimmed = name.trim();
+
+      const create = async () => {
+        try {
+          const { project_id, workflow_id } = await editInSandbox(
+            trimmed,
+            start
+          );
+          navigateToSandbox(project_id, workflow_id);
+        } catch (error) {
+          // A rejected name (duplicate, invalid) belongs under the input as an
+          // inline field error; only genuinely unexpected/system errors toast.
+          const fieldError = extractNameFieldError(error);
+          if (fieldError) {
+            setNameError(fieldError);
+          } else {
+            notifications.alert({
+              title: 'Could not create a sandbox',
+              description: describeSandboxError(error),
+            });
+          }
+          setIsCreating(false);
+        }
+      };
+
+      void create();
+    },
+    [name, editInSandbox]
+  );
+
+  // The run's input is checked before it travels, so that choice takes a review
+  // step first. The other two create straight away.
+  const handleContinue = useCallback(() => {
+    if (startWith === 'saved') {
+      if (!savedDataclipId) return;
+      handleCreate({ dataclipId: savedDataclipId });
+      return;
+    }
+
+    if (startWith !== 'run' || !runInputDataclipId) {
+      handleCreate({});
+      return;
+    }
+
+    setIsLoadingBody(true);
+    setReviewError(null);
+
+    void getDataclipBody(runInputDataclipId)
+      .then(body => {
+        setReviewBody(body);
+        setStep('review');
+      })
+      .catch(() => {
+        notifications.alert({
+          title: "Could not load this run's input",
+          description: 'Please try again.',
+        });
+      })
+      .finally(() => {
+        setIsLoadingBody(false);
+      });
+  }, [startWith, savedDataclipId, runInputDataclipId, handleCreate]);
+
+  const handleCreateFromReview = useCallback(() => {
+    const problem = describeBodyProblem(reviewBody);
+
+    if (problem) {
+      setReviewError(problem);
+      return;
+    }
+
+    setReviewError(null);
+    handleCreate({
+      body: reviewBody,
+      bodyName: runLabel ? `Input from run ${runLabel}` : 'Reviewed input',
+    });
+  }, [reviewBody, runLabel, handleCreate]);
 
   const handleJoin = useCallback((sandbox: Sandbox) => {
     if (!sandbox.workflow_id) return;
@@ -261,7 +508,9 @@ export function EditInSandboxPicker({
   // A name is required to create. The server already returns only joinable
   // sandboxes (each holding a clone of this workflow), so the list is rendered
   // as-is.
-  const canCreate = name.trim().length > 0;
+  const canCreate =
+    name.trim().length > 0 &&
+    (startWith !== 'saved' || savedDataclipId !== null);
 
   return (
     <Dialog
@@ -306,144 +555,270 @@ export function EditInSandboxPicker({
               />
             </button>
 
-            <DialogTitle
-              as="h3"
-              className="text-base font-semibold text-gray-900"
-            >
-              Edit in sandbox
-            </DialogTitle>
-            <p className="mt-1 text-sm text-gray-600">
-              Make changes safely in a sandbox without affecting this live
-              workflow.
-            </p>
+            {step === 'review' ? (
+              <>
+                <DialogTitle
+                  as="h3"
+                  className="text-base font-semibold text-gray-900"
+                >
+                  Check the data before it leaves production
+                </DialogTitle>
+                <p className="mt-1 text-sm text-gray-600">
+                  This is a copy of what the run received. Remove anything that
+                  shouldn't leave this project. The original is untouched.
+                </p>
 
-            {/* Create a new sandbox. Eyebrow title + subtitle mirror the
+                <label htmlFor="review-body" className="sr-only">
+                  Run input
+                </label>
+                <textarea
+                  id="review-body"
+                  data-testid="review-body"
+                  value={reviewBody}
+                  onChange={event => {
+                    setReviewBody(event.target.value);
+                    setReviewError(null);
+                  }}
+                  spellCheck={false}
+                  rows={14}
+                  className="mt-4 block w-full rounded-md border-0 px-3 py-2
+                    font-mono text-xs text-gray-900 shadow-sm ring-1 ring-inset
+                    ring-gray-300 focus:ring-2 focus:ring-inset
+                    focus:ring-primary-600"
+                />
+
+                <div className="mt-1 min-h-[1rem]">
+                  {reviewError && (
+                    <p
+                      data-testid="review-body-error"
+                      className="text-xs text-red-600"
+                    >
+                      {reviewError}
+                    </p>
+                  )}
+                </div>
+
+                <div className="mt-4 flex justify-end gap-3">
+                  <button
+                    type="button"
+                    disabled={isCreating}
+                    onClick={() => {
+                      setStep('choose');
+                    }}
+                    className="inline-flex items-center rounded-md bg-white
+                      px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm
+                      ring-1 ring-inset ring-gray-300 hover:bg-gray-50
+                      disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Back
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="create-from-review-button"
+                    disabled={isCreating}
+                    onClick={handleCreateFromReview}
+                    className="inline-flex items-center rounded-md
+                      bg-primary-600 px-3 py-2 text-sm font-semibold text-white
+                      shadow-sm hover:bg-primary-500
+                      disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isCreating ? 'Creating...' : 'Create sandbox'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <DialogTitle
+                  as="h3"
+                  className="text-base font-semibold text-gray-900"
+                >
+                  Edit in sandbox
+                </DialogTitle>
+                <p className="mt-1 text-sm text-gray-600">
+                  Make changes safely in a sandbox without affecting this live
+                  workflow.
+                </p>
+
+                {/* Create a new sandbox. Eyebrow title + subtitle mirror the
                 "Join an active sandbox" section below so the two read as
                 visual siblings; the title/subtitle/placeholder identify the
                 field, so no separate visible label is needed. */}
-            <div className="mt-6">
-              <p
-                className="text-xs font-semibold uppercase tracking-wide
+                <div className="mt-6">
+                  <p
+                    className="text-xs font-semibold uppercase tracking-wide
                   text-gray-500"
-              >
-                Create a new sandbox
-              </p>
-              <p className="mt-1 text-xs text-gray-500">
-                Branch from the current live version to make changes safely.
-              </p>
-              <form
-                className="mt-3"
-                onSubmit={event => {
-                  event.preventDefault();
-                  // Enter can submit even while the button is disabled; honour
-                  // the same guards (non-empty name, no create in flight).
-                  if (isCreating || !canCreate) return;
-                  handleCreate();
-                }}
-              >
-                <div className="flex gap-2">
-                  <div className="min-w-0 flex-1">
-                    <label htmlFor="sandbox-name" className="sr-only">
-                      Sandbox name
-                    </label>
-                    <input
-                      id="sandbox-name"
-                      type="text"
-                      value={name}
-                      onChange={event => {
-                        setName(event.target.value);
-                        // Editing the name dismisses a stale field error.
-                        setNameError(null);
-                      }}
-                      placeholder="e.g. Test new changes"
-                      disabled={isCreating}
-                      aria-invalid={nameError ? true : undefined}
-                      aria-describedby={
-                        nameError ? 'sandbox-name-error' : undefined
-                      }
-                      className={cn(
-                        `block w-full rounded-md border-0 px-3 py-2 text-sm
+                  >
+                    Create a new sandbox
+                  </p>
+                  <p className="mt-1 text-xs text-gray-500">
+                    Branch from the current live version to make changes safely.
+                  </p>
+                  <form
+                    className="mt-3"
+                    onSubmit={event => {
+                      event.preventDefault();
+                      // Enter can submit even while the button is disabled; honour
+                      // the same guards (non-empty name, no create in flight).
+                      if (isCreating || isLoadingBody || !canCreate) return;
+                      handleContinue();
+                    }}
+                  >
+                    <div className="flex gap-2">
+                      <div className="min-w-0 flex-1">
+                        <label htmlFor="sandbox-name" className="sr-only">
+                          Sandbox name
+                        </label>
+                        <input
+                          id="sandbox-name"
+                          type="text"
+                          value={name}
+                          onChange={event => {
+                            setName(event.target.value);
+                            // Editing the name dismisses a stale field error.
+                            setNameError(null);
+                          }}
+                          placeholder="e.g. Test new changes"
+                          disabled={isCreating}
+                          aria-invalid={nameError ? true : undefined}
+                          aria-describedby={
+                            nameError ? 'sandbox-name-error' : undefined
+                          }
+                          className={cn(
+                            `block w-full rounded-md border-0 px-3 py-2 text-sm
                           shadow-sm ring-1 ring-inset placeholder:text-gray-400
                           focus:ring-2 focus:ring-inset
                           disabled:cursor-not-allowed disabled:opacity-50`,
-                        nameError
-                          ? 'text-red-900 ring-red-300 focus:ring-red-500'
-                          : 'text-gray-900 ring-gray-300 focus:ring-primary-600'
-                      )}
-                    />
-                  </div>
-                  <button
-                    type="submit"
-                    data-testid="create-sandbox-button"
-                    disabled={isCreating || !canCreate}
-                    className="inline-flex shrink-0 items-center self-start
+                            nameError
+                              ? 'text-red-900 ring-red-300 focus:ring-red-500'
+                              : 'text-gray-900 ring-gray-300 focus:ring-primary-600'
+                          )}
+                        />
+                      </div>
+                      <button
+                        type="submit"
+                        data-testid="create-sandbox-button"
+                        disabled={isCreating || isLoadingBody || !canCreate}
+                        className="inline-flex shrink-0 items-center self-start
                       rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold
                       text-white shadow-sm shadow-primary-600/20
                       hover:bg-primary-500 focus-visible:outline-2
                       focus-visible:outline-offset-2
                       focus-visible:outline-primary-600
                       disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {isCreating ? 'Creating...' : 'Create sandbox'}
-                  </button>
-                </div>
-                {/* Always-rendered slot sized for one line of error text, so
+                      >
+                        {createButtonLabel({
+                          isCreating,
+                          isLoadingBody,
+                          needsReview: startWith === 'run',
+                        })}
+                      </button>
+                    </div>
+                    {/* Always-rendered slot sized for one line of error text, so
                     showing/hiding the message never shifts the OR divider or
                     Join section below it. The message itself stays conditional
                     so the field only exposes an error when there is one. */}
-                <div className="mt-1 min-h-[1rem]">
-                  {nameError && (
-                    <p
-                      id="sandbox-name-error"
-                      data-testid="sandbox-name-error"
-                      className="text-xs text-red-600"
-                    >
-                      {nameError}
-                    </p>
-                  )}
-                </div>
-              </form>
-            </div>
+                    <div className="mt-1 min-h-[1rem]">
+                      {nameError && (
+                        <p
+                          id="sandbox-name-error"
+                          data-testid="sandbox-name-error"
+                          className="text-xs text-red-600"
+                        >
+                          {nameError}
+                        </p>
+                      )}
+                    </div>
 
-            {/* Join an existing sandbox. The server returns only sandboxes that
+                    <fieldset className="mt-4" data-testid="start-with">
+                      <legend
+                        className="text-xs font-semibold uppercase tracking-wide
+                      text-gray-500"
+                      >
+                        Start with
+                      </legend>
+
+                      <div className="mt-2 space-y-2">
+                        <StartOption
+                          value="nothing"
+                          checked={startWith === 'nothing'}
+                          onChange={setStartWith}
+                          label="Nothing"
+                          hint="An empty sandbox. Pick input when you run."
+                        />
+
+                        {runInputDataclipId && (
+                          <StartOption
+                            value="run"
+                            checked={startWith === 'run'}
+                            onChange={setStartWith}
+                            label="This run's input"
+                            hint="A copy of the data this run received. You check it first."
+                          />
+                        )}
+
+                        <StartOption
+                          value="saved"
+                          checked={startWith === 'saved'}
+                          onChange={setStartWith}
+                          label="A saved input"
+                          hint="One of this project's named inputs."
+                        />
+                      </div>
+
+                      {startWith === 'saved' && (
+                        <SavedInputList
+                          dataclips={savedDataclips}
+                          isLoading={isLoadingSaved}
+                          selectedId={savedDataclipId}
+                          onSelect={setSavedDataclipId}
+                        />
+                      )}
+                    </fieldset>
+                  </form>
+                </div>
+
+                {/* Join an existing sandbox. The server returns only sandboxes that
                 hold a clone of this workflow; hidden entirely when there are
                 none. */}
-            {(isLoadingList || sandboxes.length > 0) && (
-              <div className="mt-6">
-                <p
-                  className="text-xs font-semibold uppercase tracking-wide
+                {(isLoadingList || sandboxes.length > 0) && (
+                  <div className="mt-6">
+                    <p
+                      className="text-xs font-semibold uppercase tracking-wide
                     text-gray-500"
-                >
-                  Join an active sandbox
-                </p>
-                <p className="mt-1 text-xs text-gray-500">
-                  Continue in a sandbox that's already active for this workflow.
-                </p>
+                    >
+                      Join an active sandbox
+                    </p>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Continue in a sandbox that's already active for this
+                      workflow.
+                    </p>
 
-                {isLoadingList ? (
-                  <SandboxListSkeleton />
-                ) : (
-                  // Cap the list at roughly 5-6 rows so a user with many
-                  // sandboxes scrolls the list rather than the whole modal. The
-                  // scroll container carries the row's -mx-3 bleed itself
-                  // (-mx-3 px-3), so the rows fit exactly inside it: no
-                  // horizontal scrollbar, the hover bleed is kept, and the px-3
-                  // keeps the vertical scrollbar clear of the "Join" text.
-                  <ul
-                    className="mt-3 -mx-3 max-h-80 space-y-1 overflow-y-auto
+                    {isLoadingList ? (
+                      <SandboxListSkeleton />
+                    ) : (
+                      // Cap the list at roughly 5-6 rows so a user with many
+                      // sandboxes scrolls the list rather than the whole modal. The
+                      // scroll container carries the row's -mx-3 bleed itself
+                      // (-mx-3 px-3), so the rows fit exactly inside it: no
+                      // horizontal scrollbar, the hover bleed is kept, and the px-3
+                      // keeps the vertical scrollbar clear of the "Join" text.
+                      <ul
+                        className="mt-3 -mx-3 max-h-80 space-y-1 overflow-y-auto
                       overflow-x-hidden px-3"
-                    data-testid="sandbox-list"
-                  >
-                    {sandboxes.map(sandbox => (
-                      <SandboxRow
-                        key={sandbox.id}
-                        sandbox={sandbox}
-                        onJoin={handleJoin}
-                      />
-                    ))}
-                  </ul>
+                        data-testid="sandbox-list"
+                      >
+                        {sandboxes.map(sandbox => (
+                          <SandboxRow
+                            key={sandbox.id}
+                            sandbox={sandbox}
+                            onJoin={handleJoin}
+                          />
+                        ))}
+                      </ul>
+                    )}
+                  </div>
                 )}
-              </div>
+              </>
             )}
           </DialogPanel>
         </div>

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from '@headlessui/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { cn } from '#/utils/cn';
 
@@ -36,6 +36,14 @@ import type { Sandbox } from '../types/workflow';
 
 type StartChoice = 'nothing' | 'run' | 'saved';
 type Step = 'choose' | 'review';
+
+// The run's input, and which run it came from. A body that belongs to another
+// run is not this run's body, so it can never be shown or sent as one.
+type RunReview =
+  | { status: 'idle' }
+  | { status: 'loading'; runId: string }
+  | { status: 'ready'; runId: string; body: string }
+  | { status: 'missing'; runId: string };
 
 interface EditInSandboxPickerProps {
   isOpen: boolean;
@@ -161,8 +169,7 @@ function SandboxRow({
   );
 }
 
-// Three placeholder rows shown while the sandbox list loads. Mirrors the shape
-// of a real row (colour tile + two text lines) so the layout doesn't jump.
+// A single "start with" choice: radio, label, and a line saying what it means.
 function StartOption({
   value,
   checked,
@@ -291,6 +298,7 @@ function SavedInputList({
   );
 }
 
+// Three placeholder rows shown while the sandbox list loads.
 function SandboxListSkeleton() {
   return (
     <ul className="mt-3 space-y-1" data-testid="sandbox-list-loading">
@@ -309,6 +317,11 @@ function SandboxListSkeleton() {
       ))}
     </ul>
   );
+}
+
+// A reply is only allowed to land on the request that asked for it.
+function stillLoading(current: RunReview, runId: string): boolean {
+  return current.status === 'loading' && current.runId === runId;
 }
 
 function createButtonLabel({
@@ -395,12 +408,12 @@ export function EditInSandboxPicker({
   const [sandboxes, setSandboxes] = useState<Sandbox[]>([]);
   const [startWith, setStartWith] = useState<StartChoice>('nothing');
   const [step, setStep] = useState<Step>('choose');
-  const [reviewBody, setReviewBody] = useState('');
   const [reviewError, setReviewError] = useState<string | null>(null);
-  const [isLoadingBody, setIsLoadingBody] = useState(false);
-  const [runInputMissing, setRunInputMissing] = useState(false);
-  const [hasLoadedBody, setHasLoadedBody] = useState(false);
-  const runFetchTokenRef = useRef<string | null>(null);
+  // One value rather than four booleans and a token. Each state carries the run
+  // it belongs to, so a run swap invalidates it by construction and there is
+  // nothing to remember to reset. Four rounds of review found bugs in the
+  // previous shape, every one of them a flag left out of a reset.
+  const [review, setReview] = useState<RunReview>({ status: 'idle' });
   const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
 
   const activeRun = useActiveRun();
@@ -423,6 +436,12 @@ export function EditInSandboxPicker({
   const runInputDataclipId = activeRun?.steps?.[0]?.input_dataclip_id ?? null;
   const runStepJobId = activeRun?.steps?.[0]?.job_id ?? null;
 
+  const reviewBody = review.status === 'ready' ? review.body : '';
+  const isLoadingBody = review.status === 'loading';
+  const forThisRun = review.status !== 'idle' && review.runId === activeRun?.id;
+  const hasLoadedBody = review.status === 'ready' && forThisRun;
+  const runInputMissing = review.status === 'missing' && forThisRun;
+
   // Everything the fetch needs. Without all of it the choice could only create
   // an empty sandbox while reporting success.
   const canStartFromRun =
@@ -440,12 +459,9 @@ export function EditInSandboxPicker({
     setSandboxes([]);
     setStartWith('nothing');
     setStep('choose');
-    setReviewBody('');
     setReviewError(null);
-    setRunInputMissing(false);
-    setHasLoadedBody(false);
+    setReview({ status: 'idle' });
     setSavedDataclipId(null);
-    runFetchTokenRef.current = null;
 
     const load = async () => {
       try {
@@ -538,10 +554,6 @@ export function EditInSandboxPicker({
     // body somewhere the person cannot reach or send.
     setStartWith('nothing');
     setStep('choose');
-    setReviewBody('');
-    setHasLoadedBody(false);
-    setRunInputMissing(false);
-    runFetchTokenRef.current = null;
   }, [canStartFromRun, startWith]);
 
   const handleCreate = useCallback(
@@ -601,50 +613,49 @@ export function EditInSandboxPicker({
     // before the loading flag is set, since this path never clears it.
     setReviewError(null);
 
+    // Already reviewed this run: keep it, or Back then Continue would restore
+    // the production body the person had just redacted.
     if (hasLoadedBody) {
       setStep('review');
       return;
     }
 
-    setIsLoadingBody(true);
+    const runId = activeRun.id;
+    setReview({ status: 'loading', runId });
 
     // Whether the input was kept is the dataclip's own answer. Inferring it from
     // the body does not work: a wiped http_request still serves a JSON object,
     // `{"data": null, "request": null}`, which reads as perfectly good data.
-    // Guarded like the other fetches here: closing the dialog, or losing the
-    // run, must not be undone by a reply that was already in flight.
-    const requestedRunId = activeRun.id;
-    runFetchTokenRef.current = requestedRunId;
-
-    void getRunDataclip(project.id, activeRun.id, runStepJobId)
+    void getRunDataclip(project.id, runId, runStepJobId)
       .then(async ({ dataclip }) => {
-        if (runFetchTokenRef.current !== requestedRunId) return;
-
         if (!dataclip || dataclip.wiped_at) {
-          setRunInputMissing(true);
+          setReview(current =>
+            stillLoading(current, runId)
+              ? { status: 'missing', runId }
+              : current
+          );
           return;
         }
 
         const body = await getDataclipBody(dataclip.id);
 
-        if (runFetchTokenRef.current !== requestedRunId) return;
-
-        setReviewBody(body);
-        setHasLoadedBody(true);
-        setStep('review');
-      })
-      .catch(() => {
-        if (runFetchTokenRef.current !== requestedRunId) return;
-
-        notifications.alert({
-          title: "Could not load this run's input",
-          description: 'Please try again.',
+        setReview(current => {
+          if (!stillLoading(current, runId)) return current;
+          setStep('review');
+          return { status: 'ready', runId, body };
         });
       })
-      .finally(() => {
-        if (runFetchTokenRef.current === requestedRunId) {
-          setIsLoadingBody(false);
-        }
+      .catch(() => {
+        setReview(current => {
+          if (!stillLoading(current, runId)) return current;
+
+          notifications.alert({
+            title: "Could not load this run's input",
+            description: 'Please try again.',
+          });
+
+          return { status: 'idle' };
+        });
       });
   }, [
     startWith,
@@ -749,7 +760,13 @@ export function EditInSandboxPicker({
                   data-testid="review-body"
                   value={reviewBody}
                   onChange={event => {
-                    setReviewBody(event.target.value);
+                    const { value } = event.target;
+
+                    setReview(current =>
+                      current.status === 'ready'
+                        ? { ...current, body: value }
+                        : current
+                    );
                     setReviewError(null);
                   }}
                   spellCheck={false}

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -201,12 +201,14 @@ function SavedInputList({
   dataclips,
   isLoading,
   canAsk,
+  anyFound,
   selectedId,
   onSelect,
 }: {
   dataclips: Dataclip[];
   isLoading: boolean;
   canAsk: boolean;
+  anyFound: boolean;
   selectedId: string | null;
   onSelect: (id: string) => void;
 }) {
@@ -238,7 +240,9 @@ function SavedInputList({
         className="mt-3 text-xs text-gray-500"
         data-testid="saved-inputs-empty"
       >
-        This project has no named inputs yet. Name a dataclip to reuse it here.
+        {anyFound
+          ? "None of this project's named inputs can be copied into a sandbox. A step result cannot travel."
+          : 'This project has no named inputs yet. Name a dataclip to reuse it here.'}
       </p>
     );
   }
@@ -394,11 +398,20 @@ export function EditInSandboxPicker({
   const anyJobId = jobs[0]?.id ?? null;
   const [savedDataclips, setSavedDataclips] = useState<Dataclip[]>([]);
   const [isLoadingSaved, setIsLoadingSaved] = useState(false);
+  const [savedInputsFiltered, setSavedInputsFiltered] = useState(false);
 
   // A run's own input is its first step's input. Anything deeper is a step
   // result, which is a different thing to offer.
   const runInputDataclipId = activeRun?.steps?.[0]?.input_dataclip_id ?? null;
   const runStepJobId = activeRun?.steps?.[0]?.job_id ?? null;
+
+  // Everything the fetch needs. Without all of it the choice could only create
+  // an empty sandbox while reporting success.
+  const canStartFromRun =
+    runInputDataclipId !== null &&
+    runStepJobId !== null &&
+    activeRun !== null &&
+    Boolean(project?.id);
   const runLabel = activeRun ? activeRun.id.slice(0, 6) : null;
 
   useEffect(() => {
@@ -450,7 +463,11 @@ export function EditInSandboxPicker({
       .then(({ data }) => {
         // Only what a sandbox can actually copy. Naming is not type-restricted,
         // so a named step result can appear here and would be refused on create.
-        if (!cancelled) setSavedDataclips(data.filter(isCopyableDataclip));
+        if (cancelled) return;
+
+        setSavedDataclips(data.filter(isCopyableDataclip));
+        setSavedInputsFiltered(data.length > 0);
+        setSavedInputsFiltered(data.length > 0);
       })
       .catch(() => {
         if (!cancelled) {
@@ -536,14 +553,12 @@ export function EditInSandboxPicker({
       return;
     }
 
-    if (
-      startWith !== 'run' ||
-      !runInputDataclipId ||
-      !project?.id ||
-      !activeRun ||
-      !runStepJobId
-    ) {
+    if (startWith !== 'run') {
       handleCreate({});
+      return;
+    }
+
+    if (!canStartFromRun || !project?.id || !activeRun || !runStepJobId) {
       return;
     }
 
@@ -575,7 +590,7 @@ export function EditInSandboxPicker({
   }, [
     startWith,
     savedDataclipId,
-    runInputDataclipId,
+    canStartFromRun,
     handleCreate,
     project?.id,
     activeRun,
@@ -865,7 +880,7 @@ export function EditInSandboxPicker({
                           hint="An empty sandbox. Pick input when you run."
                         />
 
-                        {runInputDataclipId && (
+                        {canStartFromRun && (
                           <StartOption
                             value="run"
                             checked={startWith === 'run'}
@@ -912,6 +927,7 @@ export function EditInSandboxPicker({
                           dataclips={savedDataclips}
                           isLoading={isLoadingSaved}
                           canAsk={anyJobId !== null}
+                          anyFound={savedInputsFiltered}
                           selectedId={savedDataclipId}
                           onSelect={setSavedDataclipId}
                         />

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from '@headlessui/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { cn } from '#/utils/cn';
 
@@ -319,11 +319,6 @@ function SandboxListSkeleton() {
   );
 }
 
-// A reply is only allowed to land on the request that asked for it.
-function stillLoading(current: RunReview, runId: string): boolean {
-  return current.status === 'loading' && current.runId === runId;
-}
-
 function createButtonLabel({
   isCreating,
   isLoadingBody,
@@ -414,6 +409,11 @@ export function EditInSandboxPicker({
   // nothing to remember to reset. Four rounds of review found bugs in the
   // previous shape, every one of them a flag left out of a reset.
   const [review, setReview] = useState<RunReview>({ status: 'idle' });
+  // A reply lands after a render, so what the person now wants has to be read
+  // live rather than out of the closure that started the request.
+  const startWithRef = useRef<StartChoice>('nothing');
+  const activeRunIdRef = useRef<string | null>(null);
+  const reviewRef = useRef<RunReview>({ status: 'idle' });
   const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
 
   const activeRun = useActiveRun();
@@ -436,11 +436,23 @@ export function EditInSandboxPicker({
   const runInputDataclipId = activeRun?.steps?.[0]?.input_dataclip_id ?? null;
   const runStepJobId = activeRun?.steps?.[0]?.job_id ?? null;
 
-  const reviewBody = review.status === 'ready' ? review.body : '';
-  const isLoadingBody = review.status === 'loading';
-  const forThisRun = review.status !== 'idle' && review.runId === activeRun?.id;
-  const hasLoadedBody = review.status === 'ready' && forThisRun;
-  const runInputMissing = review.status === 'missing' && forThisRun;
+  // Gated once, here, so no read can forget to ask. A review belongs to one run
+  // and to the run choice: it is not this dialog's state if either has moved on.
+  const activeReview =
+    review.status !== 'idle' &&
+    review.runId === activeRun?.id &&
+    startWith === 'run'
+      ? review
+      : null;
+
+  startWithRef.current = startWith;
+  activeRunIdRef.current = activeRun?.id ?? null;
+  reviewRef.current = review;
+
+  const reviewBody = activeReview?.status === 'ready' ? activeReview.body : '';
+  const isLoadingBody = activeReview?.status === 'loading';
+  const hasLoadedBody = activeReview?.status === 'ready';
+  const runInputMissing = activeReview?.status === 'missing';
 
   // Everything the fetch needs. Without all of it the choice could only create
   // an empty sandbox while reporting success.
@@ -554,7 +566,22 @@ export function EditInSandboxPicker({
     // body somewhere the person cannot reach or send.
     setStartWith('nothing');
     setStep('choose');
+    setReview({ status: 'idle' });
   }, [canStartFromRun, startWith]);
+
+  // A reply may only land if it is still the reply this dialog is waiting for:
+  // the same request, the same run, and the same choice. Read from refs because
+  // all three can have changed since the request went out.
+  const stillWanted = useCallback((runId: string) => {
+    const current = reviewRef.current;
+
+    return (
+      current.status === 'loading' &&
+      current.runId === runId &&
+      startWithRef.current === 'run' &&
+      activeRunIdRef.current === runId
+    );
+  }, []);
 
   const handleCreate = useCallback(
     (start: EditInSandboxStart) => {
@@ -608,9 +635,6 @@ export function EditInSandboxPicker({
       return;
     }
 
-    // Already reviewed: keep what the person has, or Back then Continue would
-    // quietly restore the production body they had just redacted. Checked
-    // before the loading flag is set, since this path never clears it.
     setReviewError(null);
 
     // Already reviewed this run: keep it, or Back then Continue would restore
@@ -629,32 +653,24 @@ export function EditInSandboxPicker({
     void getRunDataclip(project.id, runId, runStepJobId)
       .then(async ({ dataclip }) => {
         if (!dataclip || dataclip.wiped_at) {
-          setReview(current =>
-            stillLoading(current, runId)
-              ? { status: 'missing', runId }
-              : current
-          );
+          if (stillWanted(runId)) setReview({ status: 'missing', runId });
           return;
         }
 
         const body = await getDataclipBody(dataclip.id);
 
-        setReview(current => {
-          if (!stillLoading(current, runId)) return current;
-          setStep('review');
-          return { status: 'ready', runId, body };
-        });
+        if (!stillWanted(runId)) return;
+
+        setReview({ status: 'ready', runId, body });
+        setStep('review');
       })
       .catch(() => {
-        setReview(current => {
-          if (!stillLoading(current, runId)) return current;
+        if (!stillWanted(runId)) return;
 
-          notifications.alert({
-            title: "Could not load this run's input",
-            description: 'Please try again.',
-          });
-
-          return { status: 'idle' };
+        setReview({ status: 'idle' });
+        notifications.alert({
+          title: "Could not load this run's input",
+          description: 'Please try again.',
         });
       });
   }, [
@@ -663,6 +679,7 @@ export function EditInSandboxPicker({
     canStartFromRun,
     handleCreate,
     hasLoadedBody,
+    stillWanted,
     project?.id,
     activeRun,
     runStepJobId,

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from '@headlessui/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { cn } from '#/utils/cn';
 
@@ -291,8 +291,9 @@ function createButtonLabel({
   return needsReview ? 'Continue' : 'Create sandbox';
 }
 
-// Checked here as well as on the server so the person is told before the
-// sandbox is attempted, not after it is refused.
+// Shape only, and checked here as well as on the server so the person is told
+// before the sandbox is attempted. Size is the server's to judge, since the
+// limit is configured there.
 function describeBodyProblem(body: string): string | null {
   try {
     const parsed: unknown = JSON.parse(body);
@@ -353,6 +354,7 @@ export function EditInSandboxPicker({
   const [reviewBody, setReviewBody] = useState('');
   const [reviewError, setReviewError] = useState<string | null>(null);
   const [isLoadingBody, setIsLoadingBody] = useState(false);
+  const [runInputMissing, setRunInputMissing] = useState(false);
   const [savedDataclipId, setSavedDataclipId] = useState<string | null>(null);
 
   const activeRun = useActiveRun();
@@ -360,6 +362,9 @@ export function EditInSandboxPicker({
   const jobs = useWorkflowState(state => state.jobs);
   const versions = useVersions();
   const requestVersions = useRequestVersions();
+  const openLockVersion = useWorkflowState(
+    state => state.workflow?.lock_version
+  );
 
   // Any job in the project resolves the same set of named dataclips, so the
   // first one is enough to ask for them.
@@ -382,6 +387,7 @@ export function EditInSandboxPicker({
     setStep('choose');
     setReviewBody('');
     setReviewError(null);
+    setRunInputMissing(false);
     setSavedDataclipId(null);
 
     const load = async () => {
@@ -413,7 +419,7 @@ export function EditInSandboxPicker({
     let cancelled = false;
     setIsLoadingSaved(true);
 
-    void searchDataclips(project.id, anyJobId, { named_only: true })
+    void searchDataclips(project.id, anyJobId, '', { named_only: true })
       .then(({ data }) => {
         if (!cancelled) setSavedDataclips(data);
       })
@@ -435,21 +441,26 @@ export function EditInSandboxPicker({
   }, [isOpen, startWith, project?.id, anyJobId]);
 
   useEffect(() => {
-    if (!isOpen || !activeRun || versions.length > 0) return;
+    if (!isOpen || versions.length > 0) return;
 
     void requestVersions();
-  }, [isOpen, activeRun, versions.length, requestVersions]);
+  }, [isOpen, versions.length, requestVersions]);
 
-  // A sandbox always forks the current version, because promote rebuilds the
-  // parent from the sandbox and an older fork would delete the newer work. When
-  // the run came from an older version, say so rather than let it surprise.
-  const runVersionNumber = activeRun?.version_number ?? null;
-  const latestVersionNumber = versions[0]?.version_number ?? null;
+  // A sandbox always forks the version live now, because promote rebuilds the
+  // parent from the sandbox and an older fork would delete the newer work.
+  //
+  // What is on screen is the comparison that matters, whether a run pinned it
+  // or the version dropdown did, so the loaded document's snapshot is matched
+  // against the releases rather than anything read off the run.
+  const openVersionNumber =
+    versions.find(version => version.lock_version === openLockVersion)
+      ?.version_number ?? null;
+  const latestVersionNumber =
+    versions.find(version => version.is_latest)?.version_number ?? null;
   const startsFromNewerVersion =
-    startWith === 'run' &&
-    runVersionNumber !== null &&
+    openVersionNumber !== null &&
     latestVersionNumber !== null &&
-    runVersionNumber !== latestVersionNumber;
+    openVersionNumber !== latestVersionNumber;
 
   const handleCreate = useCallback(
     (start: EditInSandboxStart) => {
@@ -504,6 +515,14 @@ export function EditInSandboxPicker({
 
     void getDataclipBody(runInputDataclipId)
       .then(body => {
+        // Zero-persistence projects never keep run data, and retention wipes it
+        // later elsewhere. Either way there is nothing to review, and an empty
+        // editor followed by a validation error explains none of that.
+        if (describeBodyProblem(body)) {
+          setRunInputMissing(true);
+          return;
+        }
+
         setReviewBody(body);
         setStep('review');
       })
@@ -543,7 +562,8 @@ export function EditInSandboxPicker({
   // as-is.
   const canCreate =
     name.trim().length > 0 &&
-    (startWith !== 'saved' || savedDataclipId !== null);
+    (startWith !== 'saved' || savedDataclipId !== null) &&
+    !(startWith === 'run' && runInputMissing);
 
   return (
     <Dialog
@@ -625,8 +645,8 @@ export function EditInSandboxPicker({
                     className="mt-3 text-xs text-gray-500"
                     data-testid="review-version-note"
                   >
-                    This run used v{runVersionNumber}. The sandbox starts from v
-                    {latestVersionNumber}, the version live now.
+                    This run used v{openVersionNumber}. The sandbox starts from
+                    v{latestVersionNumber}, the version live now.
                   </p>
                 )}
 
@@ -808,12 +828,23 @@ export function EditInSandboxPicker({
                         />
                       </div>
 
+                      {runInputMissing && (
+                        <p
+                          className="mt-3 text-xs text-gray-500"
+                          data-testid="run-input-missing"
+                        >
+                          This run's input was not kept, so there is nothing to
+                          copy. Projects that never retain input and output data
+                          have none to start from.
+                        </p>
+                      )}
+
                       {startsFromNewerVersion && (
                         <p
                           className="mt-3 text-xs text-gray-500"
                           data-testid="version-note"
                         >
-                          This run used v{runVersionNumber}. The sandbox starts
+                          This run used v{openVersionNumber}. The sandbox starts
                           from v{latestVersionNumber}, the version live now,
                           because promoting an older one would remove the newer
                           work.

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -108,6 +108,7 @@ export function ManualRunPanel({
   const [manuallyUnselected, setManuallyUnselected] = useState(false);
 
   // Ref to avoid stale closure in async fetch callback
+  const honouredDataclipRef = useRef(false);
   const selectedDataclipRef = useRef(selectedDataclip);
   selectedDataclipRef.current = selectedDataclip;
 
@@ -152,7 +153,7 @@ export function ManualRunPanel({
   const { canRun: canRunWorkflow, tooltipMessage: workflowRunTooltipMessage } =
     useCanRun();
 
-  const { params, updateSearchParams, replaceSearchParams } = useURLState();
+  const { params, updateSearchParams } = useURLState();
   const followedRunId = params.run ?? null;
 
   // Connect to run channel when following a run in standalone mode
@@ -306,25 +307,30 @@ export function ManualRunPanel({
 
         // A sandbox started from a run's data arrives with that dataclip named
         // in the URL, so it opens ready to run rather than merely holding it.
-        // Honoured once: the param is dropped afterwards, or every refetch
+        //
+        // Honoured once per mount, tracked here rather than by clearing the
+        // param: rewriting the URL to record it would either drop the other
+        // params or add a history entry, and re-honouring it on every refetch
         // would undo a deliberate deselection.
         const requestedId = params['dataclip'];
 
         if (
           requestedId &&
+          !honouredDataclipRef.current &&
           !selectedDataclipRef.current &&
           !manuallyUnselected
         ) {
+          honouredDataclipRef.current = true;
+
           const requested = response.data.find(d => d.id === requestedId);
 
           if (requested) {
             setSelectedDataclip(requested);
             setSelectedTab('existing');
+            // Returned before the cron block below, which reads a ref that is
+            // only refreshed on render and would still see nothing selected.
+            return;
           }
-
-          // Replaced, not pushed: a new entry would make Back re-select the
-          // dataclip instead of leaving the sandbox.
-          replaceSearchParams({ dataclip: null });
         }
 
         // Auto-select next cron run dataclip only if:

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -317,14 +317,16 @@ export function ManualRunPanel({
         if (
           requestedId &&
           !honouredDataclipRef.current &&
+          !disableAutoSelection &&
           !selectedDataclipRef.current &&
           !manuallyUnselected
         ) {
-          honouredDataclipRef.current = true;
-
           const requested = response.data.find(d => d.id === requestedId);
 
           if (requested) {
+            // Flagged only on a hit, so a dataclip that has dropped off this
+            // page can still be picked up by a later fetch.
+            honouredDataclipRef.current = true;
             setSelectedDataclip(requested);
             setSelectedTab('existing');
             // Returned before the cron block below, which reads a ref that is

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -293,6 +293,8 @@ export function ManualRunPanel({
   useEffect(() => {
     if (!dataclipJobId) return;
 
+    let cancelled = false;
+
     const fetchDataclips = async () => {
       try {
         const response = await dataclipApi.searchDataclips(
@@ -301,6 +303,8 @@ export function ManualRunPanel({
           '',
           {}
         );
+        if (cancelled) return;
+
         setDataclips(response.data);
         setNextCronRunDataclipId(response.next_cron_run_dataclip_id);
         setCanEditDataclip(response.can_edit_dataclip);
@@ -308,10 +312,9 @@ export function ManualRunPanel({
         // A sandbox started from a run's data arrives with that dataclip named
         // in the URL, so it opens ready to run rather than merely holding it.
         //
-        // Honoured once per mount, tracked here rather than by clearing the
-        // param: rewriting the URL to record it would either drop the other
-        // params or add a history entry, and re-honouring it on every refetch
-        // would undo a deliberate deselection.
+        // Honoured once per mount, then dropped from the URL so reopening the
+        // panel on another job cannot silently select it again. Clearing costs
+        // one history entry, which is the lesser of the two.
         const requestedId = params['dataclip'];
 
         if (
@@ -365,6 +368,10 @@ export function ManualRunPanel({
     };
 
     void fetchDataclips();
+
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, dataclipJobId, followedRunId, params['dataclip']]);
 

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -321,12 +321,14 @@ export function ManualRunPanel({
           !selectedDataclipRef.current &&
           !manuallyUnselected
         ) {
+          // Spent on the attempt, not on the hit. Retrying on a later fetch
+          // would yank the panel onto this dataclip after the person had moved
+          // to a custom body, mid-run.
+          honouredDataclipRef.current = true;
+
           const requested = response.data.find(d => d.id === requestedId);
 
           if (requested) {
-            // Flagged only on a hit, so a dataclip that has dropped off this
-            // page can still be picked up by a later fetch.
-            honouredDataclipRef.current = true;
             setSelectedDataclip(requested);
             setSelectedTab('existing');
             // Returned before the cron block below, which reads a ref that is
@@ -363,7 +365,13 @@ export function ManualRunPanel({
 
     void fetchDataclips();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId, dataclipJobId, followedRunId, params['dataclip']]);
+  }, [
+    projectId,
+    dataclipJobId,
+    followedRunId,
+    params['dataclip'],
+    disableAutoSelection,
+  ]);
 
   const buildFilters = useCallback(() => {
     const filters: Record<string, string> = {};

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -152,7 +152,7 @@ export function ManualRunPanel({
   const { canRun: canRunWorkflow, tooltipMessage: workflowRunTooltipMessage } =
     useCanRun();
 
-  const { params, updateSearchParams } = useURLState();
+  const { params, updateSearchParams, replaceSearchParams } = useURLState();
   const followedRunId = params.run ?? null;
 
   // Connect to run channel when following a run in standalone mode
@@ -322,7 +322,9 @@ export function ManualRunPanel({
             setSelectedTab('existing');
           }
 
-          updateSearchParams({ dataclip: null });
+          // Replaced, not pushed: a new entry would make Back re-select the
+          // dataclip instead of leaving the sandbox.
+          replaceSearchParams({ dataclip: null });
         }
 
         // Auto-select next cron run dataclip only if:

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -306,15 +306,23 @@ export function ManualRunPanel({
 
         // A sandbox started from a run's data arrives with that dataclip named
         // in the URL, so it opens ready to run rather than merely holding it.
+        // Honoured once: the param is dropped afterwards, or every refetch
+        // would undo a deliberate deselection.
         const requestedId = params['dataclip'];
 
-        if (requestedId && !selectedDataclipRef.current) {
+        if (
+          requestedId &&
+          !selectedDataclipRef.current &&
+          !manuallyUnselected
+        ) {
           const requested = response.data.find(d => d.id === requestedId);
 
           if (requested) {
             setSelectedDataclip(requested);
             setSelectedTab('existing');
           }
+
+          updateSearchParams({ dataclip: null });
         }
 
         // Auto-select next cron run dataclip only if:

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -329,12 +329,16 @@ export function ManualRunPanel({
           // to a custom body, mid-run.
           honouredDataclipRef.current = true;
 
+          // Dropped on the attempt, not the hit: left in place after a miss,
+          // a later mount on another job would try again and, now that every
+          // named dataclip is selectable everywhere, succeed.
+          updateSearchParams({ dataclip: null });
+
           const requested = response.data.find(d => d.id === requestedId);
 
           if (requested) {
             setSelectedDataclip(requested);
             setSelectedTab('existing');
-            updateSearchParams({ dataclip: null });
             // Returned before the cron block below, which reads a ref that is
             // only refreshed on render and would still see nothing selected.
             return;

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -331,6 +331,7 @@ export function ManualRunPanel({
           if (requested) {
             setSelectedDataclip(requested);
             setSelectedTab('existing');
+            updateSearchParams({ dataclip: null });
             // Returned before the cron block below, which reads a ref that is
             // only refreshed on render and would still see nothing selected.
             return;
@@ -365,13 +366,7 @@ export function ManualRunPanel({
 
     void fetchDataclips();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    projectId,
-    dataclipJobId,
-    followedRunId,
-    params['dataclip'],
-    disableAutoSelection,
-  ]);
+  }, [projectId, dataclipJobId, followedRunId, params['dataclip']]);
 
   const buildFilters = useCallback(() => {
     const filters: Record<string, string> = {};

--- a/assets/js/collaborative-editor/components/ManualRunPanel.tsx
+++ b/assets/js/collaborative-editor/components/ManualRunPanel.tsx
@@ -304,6 +304,19 @@ export function ManualRunPanel({
         setNextCronRunDataclipId(response.next_cron_run_dataclip_id);
         setCanEditDataclip(response.can_edit_dataclip);
 
+        // A sandbox started from a run's data arrives with that dataclip named
+        // in the URL, so it opens ready to run rather than merely holding it.
+        const requestedId = params['dataclip'];
+
+        if (requestedId && !selectedDataclipRef.current) {
+          const requested = response.data.find(d => d.id === requestedId);
+
+          if (requested) {
+            setSelectedDataclip(requested);
+            setSelectedTab('existing');
+          }
+        }
+
         // Auto-select next cron run dataclip only if:
         // - Auto-selection is not disabled by parent
         // - Not following a run
@@ -331,7 +344,8 @@ export function ManualRunPanel({
     };
 
     void fetchDataclips();
-  }, [projectId, dataclipJobId, followedRunId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, dataclipJobId, followedRunId, params['dataclip']]);
 
   const buildFilters = useCallback(() => {
     const filters: Record<string, string> = {};

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -236,6 +236,35 @@ export interface CreateWorkflowStoreOptions {
   getCanEdit?: () => boolean;
 }
 
+export interface EditInSandboxStart {
+  /** A reviewed body, sent by value so what was checked is what lands. */
+  body?: string;
+  /** The name to give that reviewed body in the sandbox. */
+  bodyName?: string | null;
+  /** An existing named dataclip in the parent, copied by id instead. */
+  dataclipId?: string;
+}
+
+export interface EditInSandboxResult {
+  project_id: string;
+  workflow_id: string;
+  dataclip_id: string | null;
+}
+
+function startingDataPayload(start?: EditInSandboxStart) {
+  if (start?.body !== undefined) {
+    return {
+      starting_dataclip: { body: start.body, name: start.bodyName ?? null },
+    };
+  }
+
+  if (start?.dataclipId) {
+    return { dataclip_id: start.dataclipId };
+  }
+
+  return {};
+}
+
 export const createWorkflowStore = (
   options: CreateWorkflowStoreOptions = {}
 ) => {
@@ -1617,14 +1646,18 @@ export const createWorkflowStore = (
   };
 
   const editInSandbox = async (
-    name?: string
-  ): Promise<{ project_id: string; workflow_id: string }> => {
+    name?: string,
+    start?: EditInSandboxStart
+  ): Promise<EditInSandboxResult> => {
     const { provider } = ensureConnected();
 
-    const payload = name ? { name } : {};
+    const payload = {
+      ...(name ? { name } : {}),
+      ...startingDataPayload(start),
+    };
 
     try {
-      return await channelRequest<{ project_id: string; workflow_id: string }>(
+      return await channelRequest<EditInSandboxResult>(
         provider.channel,
         'edit_in_sandbox',
         payload

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -29,11 +29,12 @@ const editInSandbox = vi.fn<
 >();
 
 let jobs: { id: string }[] = [];
+let openLockVersion: number | undefined;
 
 vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
   useWorkflowActions: () => ({ listSandboxes, editInSandbox }),
   useWorkflowState: (selector: (state: unknown) => unknown) =>
-    selector({ jobs }),
+    selector({ jobs, workflow: { lock_version: openLockVersion } }),
 }));
 
 let activeRun: {
@@ -45,7 +46,11 @@ vi.mock('../../../js/collaborative-editor/hooks/useHistory', () => ({
   useActiveRun: () => activeRun,
 }));
 
-let versions: { version_number: number }[] = [];
+let versions: {
+  version_number: number;
+  lock_version: number;
+  is_latest: boolean;
+}[] = [];
 const requestVersionsMock = vi.fn();
 
 vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
@@ -139,6 +144,7 @@ describe('EditInSandboxPicker', () => {
     activeRun = null;
     jobs = [{ id: 'job-1' }];
     versions = [];
+    openLockVersion = undefined;
     requestVersionsMock.mockReset();
     requestVersionsMock.mockResolvedValue(undefined);
   });
@@ -192,21 +198,53 @@ describe('EditInSandboxPicker', () => {
       });
     });
 
-    test('refuses to create when the reviewed body is not an object', async () => {
+    test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {
         id: 'abcdef123456',
         steps: [{ input_dataclip_id: 'dc-1' }],
       };
-      getDataclipBodyMock.mockResolvedValue('[1,2,3]');
+      // What a zero-persistence project, or an expired retention window, leaves
+      // behind.
+      getDataclipBodyMock.mockResolvedValue('null');
 
       renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
-      await typeName(user);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
 
       await user.click(screen.getByLabelText(/this run's input/i));
       await user.click(screen.getByTestId('create-sandbox-button'));
 
-      await screen.findByTestId('review-body');
+      expect(
+        await screen.findByTestId('run-input-missing')
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('review-body')).toBeNull();
+      expect(screen.getByTestId('create-sandbox-button')).toBeDisabled();
+      expect(editInSandbox).not.toHaveBeenCalled();
+    });
+
+    test('refuses to create when the person edits the body into something invalid', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"a":1}');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      const body = await screen.findByTestId('review-body');
+      await user.clear(body);
+      await user.type(body, '[[1,2,3]');
       await user.click(screen.getByTestId('create-from-review-button'));
 
       expect(screen.getByTestId('review-body-error')).toHaveTextContent(
@@ -215,63 +253,21 @@ describe('EditInSandboxPicker', () => {
       expect(editInSandbox).not.toHaveBeenCalled();
     });
 
-    test('says which version the sandbox will start from when the run is older', async () => {
+    test('asks for named inputs only, scoped to the project', async () => {
       const user = userEvent.setup();
-      activeRun = {
-        id: 'abcdef123456',
-        steps: [{ input_dataclip_id: 'dc-1' }],
-        version_number: 3,
-      };
-      versions = [{ version_number: 7 }];
 
       renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
-      await user.click(screen.getByLabelText(/this run's input/i));
-
-      expect(screen.getByTestId('version-note')).toHaveTextContent(
-        /This run used v3\./
-      );
-      expect(screen.getByTestId('version-note')).toHaveTextContent(/v7/);
-    });
-
-    test('stays quiet when the run already used the version now live', async () => {
-      const user = userEvent.setup();
-      activeRun = {
-        id: 'abcdef123456',
-        steps: [{ input_dataclip_id: 'dc-1' }],
-        version_number: 7,
-      };
-      versions = [{ version_number: 7 }];
-
-      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
-      await user.click(screen.getByLabelText(/this run's input/i));
-
-      expect(screen.queryByTestId('version-note')).toBeNull();
-    });
-
-    test('sends the chosen saved input by id', async () => {
-      const user = userEvent.setup();
-      searchDataclipsMock.mockResolvedValue({
-        data: [{ id: 'dc-saved', name: 'known good' }],
-      });
-      editInSandbox.mockResolvedValue({
-        project_id: 'p2',
-        workflow_id: 'w2',
-        dataclip_id: null,
-      });
-
-      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
-      await typeName(user);
-
       await user.click(screen.getByLabelText(/a saved input/i));
 
-      const saved = await screen.findByTestId('saved-inputs');
-      await user.click(within(saved).getByRole('radio'));
-      await user.click(screen.getByTestId('create-sandbox-button'));
-
       await waitFor(() => {
-        expect(editInSandbox).toHaveBeenCalledWith('My SB', {
-          dataclipId: 'dc-saved',
-        });
+        expect(searchDataclipsMock).toHaveBeenCalledWith(
+          'project-1',
+          'job-1',
+          '',
+          {
+            named_only: true,
+          }
+        );
       });
     });
 
@@ -512,6 +508,7 @@ describe('EditInSandboxPicker', () => {
     editInSandbox.mockResolvedValue({
       project_id: 'new-project',
       workflow_id: 'new-workflow',
+      dataclip_id: null,
     });
 
     const nav = stubNavigation();
@@ -633,6 +630,7 @@ describe('EditInSandboxPicker', () => {
     editInSandbox.mockResolvedValue({
       project_id: 'new-project',
       workflow_id: 'new-workflow',
+      dataclip_id: null,
     });
 
     const nav = stubNavigation();
@@ -700,6 +698,7 @@ describe('EditInSandboxPicker', () => {
     editInSandbox.mockResolvedValue({
       project_id: 'p',
       workflow_id: 'w',
+      dataclip_id: null,
     });
 
     const nav = stubNavigation();

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -466,6 +466,79 @@ describe('EditInSandboxPicker', () => {
       expect(screen.queryByTestId('review-body')).toBeNull();
     });
 
+    test('recovers when the choice is switched back after a dropped reply', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+
+      let release: (v: {
+        dataclip: { id: string; wiped_at: null };
+      }) => void = () => {};
+      getRunDataclipMock.mockReturnValue(
+        new Promise(resolve => {
+          release = resolve;
+        })
+      );
+      getDataclipBodyMock.mockResolvedValue('{"a":1}');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      await user.click(screen.getByLabelText(/an empty sandbox/i));
+
+      release({ dataclip: { id: 'dc-1', wiped_at: null } });
+      await waitFor(() => {
+        expect(screen.getByTestId('create-sandbox-button')).toBeEnabled();
+      });
+
+      // Switching back must not find a load still marked in flight with no
+      // request behind it, which would latch the button off for good.
+      await user.click(screen.getByLabelText(/this run's input/i));
+
+      const submit = screen.getByTestId('create-sandbox-button');
+      expect(submit).toBeEnabled();
+      expect(submit).not.toHaveTextContent('Loading');
+    });
+
+    test('leaves a review screen whose run has been swapped out', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'aaaaaa000000',
+        steps: [{ input_dataclip_id: 'dc-a', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"from":"run-a"}');
+
+      const { rerender } = renderPicker(
+        <EditInSandboxPicker isOpen onClose={() => {}} />
+      );
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      await screen.findByTestId('review-body');
+
+      activeRun = {
+        id: 'bbbbbb000000',
+        steps: [{ input_dataclip_id: 'dc-b', job_id: 'job-1' }],
+      };
+      rerender(<EditInSandboxPicker isOpen onClose={() => {}} />);
+
+      // Staying would leave a textarea that cannot be typed into and a button
+      // that only ever answers "This isn't valid JSON."
+      await waitFor(() => {
+        expect(screen.queryByTestId('review-body')).toBeNull();
+      });
+    });
+
     test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -427,6 +427,45 @@ describe('EditInSandboxPicker', () => {
       );
     });
 
+    test('does not force the review screen on someone who changed their mind', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+
+      let release: (v: {
+        dataclip: { id: string; wiped_at: null };
+      }) => void = () => {};
+      getRunDataclipMock.mockReturnValue(
+        new Promise(resolve => {
+          release = resolve;
+        })
+      );
+      getDataclipBodyMock.mockResolvedValue('{"email":"real@example.com"}');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      // Mind changed while the load was in flight.
+      await user.click(screen.getByLabelText(/an empty sandbox/i));
+
+      release({ dataclip: { id: 'dc-1', wiped_at: null } });
+
+      // Landing them on a screen holding production data would be the worst
+      // possible answer to "actually, nothing".
+      await waitFor(() => {
+        expect(screen.getByTestId('create-sandbox-button')).toBeEnabled();
+      });
+      expect(screen.queryByTestId('review-body')).toBeNull();
+    });
+
     test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -221,6 +221,37 @@ describe('EditInSandboxPicker', () => {
       });
     });
 
+    test('keeps a redaction across Back and Continue', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"email":"real@example.com"}');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      const body = await screen.findByTestId('review-body');
+      await user.clear(body);
+      await user.type(body, '{{"email":"redacted"}');
+
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      // Refetching here would put the production email back in front of them,
+      // which is the one thing this screen exists to prevent.
+      expect(await screen.findByTestId('review-body')).toHaveValue(
+        '{"email":"redacted"}'
+      );
+    });
+
     test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {
@@ -407,6 +438,69 @@ describe('EditInSandboxPicker', () => {
       expect(
         screen.getByTestId('saved-inputs-unavailable')
       ).toBeInTheDocument();
+    });
+
+    test('sends the chosen saved input by id', async () => {
+      const user = userEvent.setup();
+      searchDataclipsMock.mockResolvedValue({
+        data: [{ id: 'dc-saved', name: 'known good', type: 'saved_input' }],
+      });
+      editInSandbox.mockResolvedValue({
+        project_id: 'p2',
+        workflow_id: 'w2',
+        dataclip_id: 'dc-copy',
+      });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/a saved input/i));
+      const saved = await screen.findByTestId('saved-inputs');
+      await user.click(within(saved).getByRole('radio'));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      await waitFor(() => {
+        expect(editInSandbox).toHaveBeenCalledWith('My SB', {
+          dataclipId: 'dc-saved',
+        });
+      });
+    });
+
+    test('lands on the run panel so the carried input is visible', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"a":1}');
+      editInSandbox.mockResolvedValue({
+        project_id: 'p2',
+        workflow_id: 'w2',
+        dataclip_id: 'dc-new',
+      });
+      const nav = stubNavigation();
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      await screen.findByTestId('review-body');
+      await user.click(screen.getByTestId('create-from-review-button'));
+
+      // Without panel=run the sandbox opens on a bare canvas and the input we
+      // carried is selected where nobody can see it.
+      await waitFor(() => {
+        expect(nav.hrefSetter).toHaveBeenCalledWith(
+          '/projects/p2/w/w2?panel=run&dataclip=dc-new'
+        );
+      });
     });
 
     test('will not create until a saved input is picked', async () => {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -17,13 +17,44 @@ const renderPicker = (ui: ReactElement) =>
   render(ui, { wrapper: KeyboardProvider });
 
 const listSandboxes = vi.fn<() => Promise<Sandbox[]>>();
-const editInSandbox =
-  vi.fn<
-    (name?: string) => Promise<{ project_id: string; workflow_id: string }>
-  >();
+const editInSandbox = vi.fn<
+  (
+    name?: string,
+    start?: unknown
+  ) => Promise<{
+    project_id: string;
+    workflow_id: string;
+    dataclip_id: string | null;
+  }>
+>();
+
+let jobs: { id: string }[] = [];
 
 vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
   useWorkflowActions: () => ({ listSandboxes, editInSandbox }),
+  useWorkflowState: (selector: (state: unknown) => unknown) =>
+    selector({ jobs }),
+}));
+
+let activeRun: {
+  id: string;
+  steps: { input_dataclip_id: string | null }[];
+} | null = null;
+
+vi.mock('../../../js/collaborative-editor/hooks/useHistory', () => ({
+  useActiveRun: () => activeRun,
+}));
+
+vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
+  useProject: () => ({ id: 'project-1' }),
+}));
+
+const searchDataclipsMock = vi.fn();
+const getDataclipBodyMock = vi.fn();
+
+vi.mock('../../../js/collaborative-editor/api/dataclips', () => ({
+  searchDataclips: (...args: unknown[]) => searchDataclipsMock(...args),
+  getDataclipBody: (...args: unknown[]) => getDataclipBodyMock(...args),
 }));
 
 const notifyAlert =
@@ -95,7 +126,140 @@ describe('EditInSandboxPicker', () => {
     listSandboxes.mockReset();
     editInSandbox.mockReset();
     notifyAlert.mockReset();
+    searchDataclipsMock.mockReset();
+    getDataclipBodyMock.mockReset();
     listSandboxes.mockResolvedValue([]);
+    searchDataclipsMock.mockResolvedValue({ data: [] });
+    getDataclipBodyMock.mockResolvedValue('{}');
+    activeRun = null;
+    jobs = [{ id: 'job-1' }];
+  });
+
+  describe('choosing what to start with', () => {
+    const typeName = async (user: ReturnType<typeof userEvent.setup>) => {
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+    };
+
+    test("offers this run's input only while a run is open", async () => {
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+
+      expect(screen.queryByLabelText(/this run's input/i)).toBeNull();
+    });
+
+    test("carries the reviewed body through when the run's input is chosen", async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"email":"real@example.com"}');
+      editInSandbox.mockResolvedValue({
+        project_id: 'p2',
+        workflow_id: 'w2',
+        dataclip_id: 'dc-new',
+      });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await typeName(user);
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      // The body is shown before it travels, and can be edited.
+      const body = await screen.findByTestId('review-body');
+      expect(body).toHaveValue('{"email":"real@example.com"}');
+
+      await user.clear(body);
+      await user.type(body, '{{"email":"redacted"}');
+      await user.click(screen.getByTestId('create-from-review-button'));
+
+      await waitFor(() => {
+        expect(editInSandbox).toHaveBeenCalledWith('My SB', {
+          body: '{"email":"redacted"}',
+          bodyName: 'Input from run abcdef',
+        });
+      });
+    });
+
+    test('refuses to create when the reviewed body is not an object', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('[1,2,3]');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await typeName(user);
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      await screen.findByTestId('review-body');
+      await user.click(screen.getByTestId('create-from-review-button'));
+
+      expect(screen.getByTestId('review-body-error')).toHaveTextContent(
+        'This needs to be a JSON object.'
+      );
+      expect(editInSandbox).not.toHaveBeenCalled();
+    });
+
+    test('sends the chosen saved input by id', async () => {
+      const user = userEvent.setup();
+      searchDataclipsMock.mockResolvedValue({
+        data: [{ id: 'dc-saved', name: 'known good' }],
+      });
+      editInSandbox.mockResolvedValue({
+        project_id: 'p2',
+        workflow_id: 'w2',
+        dataclip_id: null,
+      });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await typeName(user);
+
+      await user.click(screen.getByLabelText(/a saved input/i));
+
+      const saved = await screen.findByTestId('saved-inputs');
+      await user.click(within(saved).getByRole('radio'));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      await waitFor(() => {
+        expect(editInSandbox).toHaveBeenCalledWith('My SB', {
+          dataclipId: 'dc-saved',
+        });
+      });
+    });
+
+    test('will not create until a saved input is picked', async () => {
+      const user = userEvent.setup();
+      searchDataclipsMock.mockResolvedValue({
+        data: [{ id: 'dc-saved', name: 'known good' }],
+      });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await typeName(user);
+
+      await user.click(screen.getByLabelText(/a saved input/i));
+      await screen.findByTestId('saved-inputs');
+
+      expect(screen.getByTestId('create-sandbox-button')).toBeDisabled();
+    });
+
+    test('says so when the project has no named inputs', async () => {
+      const user = userEvent.setup();
+      searchDataclipsMock.mockResolvedValue({ data: [] });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/a saved input/i));
+
+      expect(
+        await screen.findByTestId('saved-inputs-empty')
+      ).toBeInTheDocument();
+    });
   });
 
   test('renders the create option and fetches sandboxes on open', async () => {
@@ -442,7 +606,7 @@ describe('EditInSandboxPicker', () => {
       );
 
       await waitFor(() => {
-        expect(editInSandbox).toHaveBeenCalledWith('My SB');
+        expect(editInSandbox).toHaveBeenCalledWith('My SB', {});
       });
       await waitFor(() => {
         expect(nav.hrefSetter).toHaveBeenCalledWith(
@@ -508,7 +672,7 @@ describe('EditInSandboxPicker', () => {
       );
       await user.click(screen.getByTestId('create-sandbox-button'));
       await waitFor(() => {
-        expect(editInSandbox).toHaveBeenCalledWith('My SB');
+        expect(editInSandbox).toHaveBeenCalledWith('My SB', {});
       });
     } finally {
       nav.restore();

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -45,8 +45,13 @@ vi.mock('../../../js/collaborative-editor/hooks/useHistory', () => ({
   useActiveRun: () => activeRun,
 }));
 
+let versions: { version_number: number }[] = [];
+const requestVersionsMock = vi.fn();
+
 vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
   useProject: () => ({ id: 'project-1' }),
+  useVersions: () => versions,
+  useRequestVersions: () => requestVersionsMock,
 }));
 
 const searchDataclipsMock = vi.fn();
@@ -133,6 +138,9 @@ describe('EditInSandboxPicker', () => {
     getDataclipBodyMock.mockResolvedValue('{}');
     activeRun = null;
     jobs = [{ id: 'job-1' }];
+    versions = [];
+    requestVersionsMock.mockReset();
+    requestVersionsMock.mockResolvedValue(undefined);
   });
 
   describe('choosing what to start with', () => {
@@ -205,6 +213,39 @@ describe('EditInSandboxPicker', () => {
         'This needs to be a JSON object.'
       );
       expect(editInSandbox).not.toHaveBeenCalled();
+    });
+
+    test('says which version the sandbox will start from when the run is older', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1' }],
+        version_number: 3,
+      };
+      versions = [{ version_number: 7 }];
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/this run's input/i));
+
+      expect(screen.getByTestId('version-note')).toHaveTextContent(
+        /This run used v3\./
+      );
+      expect(screen.getByTestId('version-note')).toHaveTextContent(/v7/);
+    });
+
+    test('stays quiet when the run already used the version now live', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1' }],
+        version_number: 7,
+      };
+      versions = [{ version_number: 7 }];
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/this run's input/i));
+
+      expect(screen.queryByTestId('version-note')).toBeNull();
     });
 
     test('sends the chosen saved input by id', async () => {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -308,6 +308,41 @@ describe('EditInSandboxPicker', () => {
       expect(await screen.findByTestId('review-body')).toHaveValue('');
     });
 
+    test('loads the body again after the dialog is closed and reopened', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"a":1}');
+
+      const { rerender } = renderPicker(
+        <EditInSandboxPicker isOpen onClose={() => {}} />
+      );
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      expect(await screen.findByTestId('review-body')).toHaveValue('{"a":1}');
+
+      rerender(<EditInSandboxPicker isOpen={false} onClose={() => {}} />);
+      rerender(<EditInSandboxPicker isOpen onClose={() => {}} />);
+
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      // A flag left set across a reopen skips the fetch and shows an empty
+      // review step that can never recover.
+      expect(await screen.findByTestId('review-body')).toHaveValue('{"a":1}');
+    });
+
     test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -252,6 +252,62 @@ describe('EditInSandboxPicker', () => {
       );
     });
 
+    test('stays usable after Back and Continue', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"a":1}');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      await screen.findByTestId('review-body');
+
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      await screen.findByTestId('review-body');
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+
+      // Back is what a rejected name tells the person to do, so the button has
+      // to survive the round trip rather than stick on "Loading...".
+      const submit = screen.getByTestId('create-sandbox-button');
+      expect(submit).toBeEnabled();
+      expect(submit).not.toHaveTextContent('Loading');
+    });
+
+    test('keeps an emptied body across Back and Continue', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"email":"real@example.com"}');
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      // Clearing it is a redaction. Treating an empty box as "not loaded yet"
+      // hands the production body straight back.
+      await user.clear(await screen.findByTestId('review-body'));
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      expect(await screen.findByTestId('review-body')).toHaveValue('');
+    });
+
     test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -29,21 +29,26 @@ const editInSandbox = vi.fn<
 >();
 
 let jobs: { id: string }[] = [];
-let openLockVersion: number | undefined;
 
 vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
   useWorkflowActions: () => ({ listSandboxes, editInSandbox }),
   useWorkflowState: (selector: (state: unknown) => unknown) =>
-    selector({ jobs, workflow: { lock_version: openLockVersion } }),
+    selector({ jobs }),
 }));
 
 let activeRun: {
   id: string;
-  steps: { input_dataclip_id: string | null }[];
+  steps: { input_dataclip_id: string | null; job_id: string | null }[];
 } | null = null;
+
+let runHistory: {
+  id: string;
+  runs: { id: string; version_number: number | null }[];
+}[] = [];
 
 vi.mock('../../../js/collaborative-editor/hooks/useHistory', () => ({
   useActiveRun: () => activeRun,
+  useHistory: () => runHistory,
 }));
 
 let versions: {
@@ -61,10 +66,12 @@ vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
 
 const searchDataclipsMock = vi.fn();
 const getDataclipBodyMock = vi.fn();
+const getRunDataclipMock = vi.fn();
 
 vi.mock('../../../js/collaborative-editor/api/dataclips', () => ({
   searchDataclips: (...args: unknown[]) => searchDataclipsMock(...args),
   getDataclipBody: (...args: unknown[]) => getDataclipBodyMock(...args),
+  getRunDataclip: (...args: unknown[]) => getRunDataclipMock(...args),
 }));
 
 const notifyAlert =
@@ -138,13 +145,17 @@ describe('EditInSandboxPicker', () => {
     notifyAlert.mockReset();
     searchDataclipsMock.mockReset();
     getDataclipBodyMock.mockReset();
+    getRunDataclipMock.mockReset();
+    getRunDataclipMock.mockResolvedValue({
+      dataclip: { id: 'dc-1', wiped_at: null },
+    });
+    runHistory = [];
     listSandboxes.mockResolvedValue([]);
     searchDataclipsMock.mockResolvedValue({ data: [] });
     getDataclipBodyMock.mockResolvedValue('{}');
     activeRun = null;
     jobs = [{ id: 'job-1' }];
     versions = [];
-    openLockVersion = undefined;
     requestVersionsMock.mockReset();
     requestVersionsMock.mockResolvedValue(undefined);
   });
@@ -167,7 +178,7 @@ describe('EditInSandboxPicker', () => {
       const user = userEvent.setup();
       activeRun = {
         id: 'abcdef123456',
-        steps: [{ input_dataclip_id: 'dc-1' }],
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
       };
       getDataclipBodyMock.mockResolvedValue('{"email":"real@example.com"}');
       editInSandbox.mockResolvedValue({
@@ -202,11 +213,17 @@ describe('EditInSandboxPicker', () => {
       const user = userEvent.setup();
       activeRun = {
         id: 'abcdef123456',
-        steps: [{ input_dataclip_id: 'dc-1' }],
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
       };
-      // What a zero-persistence project, or an expired retention window, leaves
-      // behind.
-      getDataclipBodyMock.mockResolvedValue('null');
+      // A wiped http_request still serves a JSON object, so the guard has to
+      // read wiped_at rather than judge the body.
+      getRunDataclipMock.mockResolvedValue({
+        dataclip: {
+          id: 'dc-1',
+          wiped_at: '2026-09-01T00:00:00Z',
+        },
+      });
+      getDataclipBodyMock.mockResolvedValue('{"data": null, "request": null}');
 
       renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
       await user.type(
@@ -229,7 +246,7 @@ describe('EditInSandboxPicker', () => {
       const user = userEvent.setup();
       activeRun = {
         id: 'abcdef123456',
-        steps: [{ input_dataclip_id: 'dc-1' }],
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
       };
       getDataclipBodyMock.mockResolvedValue('{"a":1}');
 
@@ -253,6 +270,71 @@ describe('EditInSandboxPicker', () => {
       expect(editInSandbox).not.toHaveBeenCalled();
     });
 
+    test('says which version the sandbox will fork when the run used an older one', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      // The run's version comes from the history summaries, not from whatever
+      // the editor happens to have open.
+      runHistory = [
+        { id: 'wo-1', runs: [{ id: 'abcdef123456', version_number: 3 }] },
+      ];
+      // Deliberately not newest-first, so the note has to read is_latest rather
+      // than trust the order.
+      versions = [
+        { version_number: 3, lock_version: 4, is_latest: false },
+        { version_number: 7, lock_version: 9, is_latest: true },
+      ];
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/this run's input/i));
+
+      const note = screen.getByTestId('version-note');
+      expect(note).toHaveTextContent(/This run used v3\./);
+      expect(note).toHaveTextContent(/v7/);
+    });
+
+    test('stays quiet when the run already used the version live now', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      runHistory = [
+        { id: 'wo-1', runs: [{ id: 'abcdef123456', version_number: 7 }] },
+      ];
+      versions = [{ version_number: 7, lock_version: 9, is_latest: true }];
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/this run's input/i));
+
+      expect(screen.queryByTestId('version-note')).toBeNull();
+    });
+
+    test('does not mention the run when starting from something else', async () => {
+      const user = userEvent.setup();
+      // A run is open and it did use an older version, but the sandbox is being
+      // started from a saved input, so the run has nothing to do with it.
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+      runHistory = [
+        { id: 'wo-1', runs: [{ id: 'abcdef123456', version_number: 3 }] },
+      ];
+      versions = [
+        { version_number: 3, lock_version: 4, is_latest: false },
+        { version_number: 7, lock_version: 9, is_latest: true },
+      ];
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/a saved input/i));
+
+      expect(screen.queryByTestId('version-note')).toBeNull();
+    });
+
     test('asks for named inputs only, scoped to the project', async () => {
       const user = userEvent.setup();
 
@@ -264,17 +346,47 @@ describe('EditInSandboxPicker', () => {
           'project-1',
           'job-1',
           '',
-          {
-            named_only: true,
-          }
+          { named_only: true, limit: 100 }
         );
       });
+    });
+
+    test('does not offer a named dataclip a sandbox cannot copy', async () => {
+      const user = userEvent.setup();
+      searchDataclipsMock.mockResolvedValue({
+        data: [
+          { id: 'dc-step', name: 'from a step', type: 'step_result' },
+          { id: 'dc-ok', name: 'known good', type: 'saved_input' },
+        ],
+      });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/a saved input/i));
+
+      const saved = await screen.findByTestId('saved-inputs');
+
+      // A step result carries whatever the previous step emitted, which is the
+      // data we are trying not to move, so create would refuse it anyway.
+      expect(within(saved).getByText('known good')).toBeInTheDocument();
+      expect(within(saved).queryByText('from a step')).toBeNull();
+    });
+
+    test('says a step is needed before a saved input can be picked', async () => {
+      const user = userEvent.setup();
+      jobs = [];
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/a saved input/i));
+
+      expect(
+        screen.getByTestId('saved-inputs-unavailable')
+      ).toBeInTheDocument();
     });
 
     test('will not create until a saved input is picked', async () => {
       const user = userEvent.setup();
       searchDataclipsMock.mockResolvedValue({
-        data: [{ id: 'dc-saved', name: 'known good' }],
+        data: [{ id: 'dc-saved', name: 'known good', type: 'saved_input' }],
       });
 
       renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -343,6 +343,90 @@ describe('EditInSandboxPicker', () => {
       expect(await screen.findByTestId('review-body')).toHaveValue('{"a":1}');
     });
 
+    test('does not strand the button when the dialog closes mid-fetch', async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: 'job-1' }],
+      };
+
+      let release: (v: {
+        dataclip: { id: string; wiped_at: null };
+      }) => void = () => {};
+      getRunDataclipMock.mockReturnValue(
+        new Promise(resolve => {
+          release = resolve;
+        })
+      );
+
+      const { rerender } = renderPicker(
+        <EditInSandboxPicker isOpen onClose={() => {}} />
+      );
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      rerender(<EditInSandboxPicker isOpen={false} onClose={() => {}} />);
+      rerender(<EditInSandboxPicker isOpen onClose={() => {}} />);
+
+      release({ dataclip: { id: 'dc-1', wiped_at: null } });
+
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+
+      // A reply that lost its race must not leave the button latched on
+      // "Loading..." for the rest of the page's life.
+      await waitFor(() => {
+        expect(screen.getByTestId('create-sandbox-button')).toBeEnabled();
+      });
+      expect(screen.getByTestId('create-sandbox-button')).not.toHaveTextContent(
+        'Loading'
+      );
+    });
+
+    test("never shows one run's body for another run", async () => {
+      const user = userEvent.setup();
+      activeRun = {
+        id: 'aaaaaa000000',
+        steps: [{ input_dataclip_id: 'dc-a', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"from":"run-a"}');
+
+      const { rerender } = renderPicker(
+        <EditInSandboxPicker isOpen onClose={() => {}} />
+      );
+      await user.type(
+        screen.getByPlaceholderText('e.g. Test new changes'),
+        'My SB'
+      );
+      await user.click(screen.getByLabelText(/this run's input/i));
+      await user.click(screen.getByTestId('create-sandbox-button'));
+      expect(await screen.findByTestId('review-body')).toHaveValue(
+        '{"from":"run-a"}'
+      );
+
+      // The run changes under the open dialog, which Back/Forward does.
+      await user.click(screen.getByRole('button', { name: 'Back' }));
+      activeRun = {
+        id: 'bbbbbb000000',
+        steps: [{ input_dataclip_id: 'dc-b', job_id: 'job-1' }],
+      };
+      getDataclipBodyMock.mockResolvedValue('{"from":"run-b"}');
+      rerender(<EditInSandboxPicker isOpen onClose={() => {}} />);
+
+      await user.click(screen.getByTestId('create-sandbox-button'));
+
+      // Run A's body belongs to run A. Showing it here would ship it as B's.
+      expect(await screen.findByTestId('review-body')).toHaveValue(
+        '{"from":"run-b"}'
+      );
+    });
+
     test('says nothing was kept when the run has no input to copy', async () => {
       const user = userEvent.setup();
       activeRun = {

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -174,6 +174,18 @@ describe('EditInSandboxPicker', () => {
       expect(screen.queryByLabelText(/this run's input/i)).toBeNull();
     });
 
+    test("does not offer the run's input when its step has no job", async () => {
+      activeRun = {
+        id: 'abcdef123456',
+        steps: [{ input_dataclip_id: 'dc-1', job_id: null }],
+      };
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+
+      // Offering it could only create an empty sandbox while reporting success.
+      expect(screen.queryByLabelText(/this run's input/i)).toBeNull();
+    });
+
     test("carries the reviewed body through when the run's input is chosen", async () => {
       const user = userEvent.setup();
       activeRun = {
@@ -369,6 +381,20 @@ describe('EditInSandboxPicker', () => {
       // data we are trying not to move, so create would refuse it anyway.
       expect(within(saved).getByText('known good')).toBeInTheDocument();
       expect(within(saved).queryByText('from a step')).toBeNull();
+    });
+
+    test('distinguishes nothing named from nothing copyable', async () => {
+      const user = userEvent.setup();
+      searchDataclipsMock.mockResolvedValue({
+        data: [{ id: 'dc-step', name: 'from a step', type: 'step_result' }],
+      });
+
+      renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
+      await user.click(screen.getByLabelText(/a saved input/i));
+
+      expect(await screen.findByTestId('saved-inputs-empty')).toHaveTextContent(
+        /can be copied into a sandbox/i
+      );
     });
 
     test('says a step is needed before a saved input can be picked', async () => {

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -431,6 +431,14 @@ describe('ManualRunPanel', () => {
     expect(
       await screen.findByText('Input from run abcdef')
     ).toBeInTheDocument();
+
+    // Honoured once: left in place, every refetch would undo a deliberate
+    // deselection.
+    await waitFor(() => {
+      expect(urlState.mockFns.updateSearchParams).toHaveBeenCalledWith({
+        dataclip: null,
+      });
+    });
   });
 
   test('leaves the selection alone when the URL names a dataclip it does not have', async () => {

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -403,6 +403,60 @@ describe('ManualRunPanel', () => {
     });
   });
 
+  test('preselects the dataclip named in the URL', async () => {
+    urlState.setParam('dataclip', 'dc-from-run');
+
+    vi.mocked(dataclipApi.searchDataclips).mockResolvedValue({
+      data: [
+        {
+          id: 'dc-from-run',
+          name: 'Input from run abcdef',
+          type: 'saved_input',
+        },
+        { id: 'dc-other', name: 'something else', type: 'saved_input' },
+      ],
+      next_cron_run_dataclip_id: null,
+      can_edit_dataclip: true,
+    } as never);
+
+    renderManualRunPanel({
+      workflow: mockWorkflow,
+      projectId: 'project-1',
+      workflowId: 'workflow-1',
+      jobId: 'job-1',
+      onClose: () => {},
+    });
+
+    // A sandbox started from a run's data opens ready to run.
+    expect(
+      await screen.findByText('Input from run abcdef')
+    ).toBeInTheDocument();
+  });
+
+  test('leaves the selection alone when the URL names a dataclip it does not have', async () => {
+    urlState.setParam('dataclip', 'dc-missing');
+
+    vi.mocked(dataclipApi.searchDataclips).mockResolvedValue({
+      data: [{ id: 'dc-other', name: 'something else', type: 'saved_input' }],
+      next_cron_run_dataclip_id: null,
+      can_edit_dataclip: true,
+    } as never);
+
+    renderManualRunPanel({
+      workflow: mockWorkflow,
+      projectId: 'project-1',
+      workflowId: 'workflow-1',
+      jobId: 'job-1',
+      onClose: () => {},
+    });
+
+    await waitFor(() => {
+      expect(dataclipApi.searchDataclips).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText('dc-missing')).toBeNull();
+  });
+
   test('fetches dataclips on mount with trigger context', async () => {
     renderManualRunPanel({
       workflow: mockWorkflow,

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -432,13 +432,12 @@ describe('ManualRunPanel', () => {
       await screen.findByText('Input from run abcdef')
     ).toBeInTheDocument();
 
-    // Honoured once: left in place, every refetch would undo a deliberate
-    // deselection.
-    await waitFor(() => {
-      expect(urlState.mockFns.replaceSearchParams).toHaveBeenCalledWith({
-        dataclip: null,
-      });
+    // The URL is left alone: rewriting it would drop the other params or add a
+    // history entry, and neither is worth it to record something a ref holds.
+    expect(urlState.mockFns.updateSearchParams).not.toHaveBeenCalledWith({
+      dataclip: null,
     });
+    expect(urlState.mockFns.replaceSearchParams).not.toHaveBeenCalled();
   });
 
   test('leaves the selection alone when the URL names a dataclip it does not have', async () => {

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -432,10 +432,13 @@ describe('ManualRunPanel', () => {
       await screen.findByText('Input from run abcdef')
     ).toBeInTheDocument();
 
-    // The URL is left alone: rewriting it would drop the other params or add a
-    // history entry, and neither is worth it to record something a ref holds.
-    expect(urlState.mockFns.updateSearchParams).not.toHaveBeenCalledWith({
-      dataclip: null,
+    // Cleared once honoured, with the merging helper so the other params
+    // survive. Left in place, reopening the panel on another job would select
+    // this dataclip again.
+    await waitFor(() => {
+      expect(urlState.mockFns.updateSearchParams).toHaveBeenCalledWith({
+        dataclip: null,
+      });
     });
     expect(urlState.mockFns.replaceSearchParams).not.toHaveBeenCalled();
   });

--- a/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
+++ b/assets/test/collaborative-editor/components/ManualRunPanel.test.tsx
@@ -435,7 +435,7 @@ describe('ManualRunPanel', () => {
     // Honoured once: left in place, every refetch would undo a deliberate
     // deselection.
     await waitFor(() => {
-      expect(urlState.mockFns.updateSearchParams).toHaveBeenCalledWith({
+      expect(urlState.mockFns.replaceSearchParams).toHaveBeenCalledWith({
         dataclip: null,
       });
     });

--- a/assets/test/collaborative-editor/stores/createWorkflowStore.editInSandbox.test.ts
+++ b/assets/test/collaborative-editor/stores/createWorkflowStore.editInSandbox.test.ts
@@ -1,0 +1,106 @@
+/**
+ * WorkflowStore - what edit_in_sandbox puts on the wire.
+ *
+ * A reviewed body travels by value so the person's edits are what land; a saved
+ * dataclip travels by id and is copied server-side.
+ */
+
+import type { Channel } from 'phoenix';
+import type { PhoenixChannelProvider } from 'y-phoenix-channel';
+import * as Y from 'yjs';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createWorkflowStore } from '../../../js/collaborative-editor/stores/createWorkflowStore';
+import type { WorkflowStoreInstance } from '../../../js/collaborative-editor/stores/createWorkflowStore';
+import type { Session } from '../../../js/collaborative-editor/types/session';
+import { createMockChannelPushWithHandler } from '../__helpers__/channelMocks';
+
+describe('WorkflowStore - editInSandbox', () => {
+  let store: WorkflowStoreInstance;
+  let sent: { event: string; payload: unknown }[];
+
+  beforeEach(() => {
+    store = createWorkflowStore();
+    const ydoc = new Y.Doc() as Session.WorkflowDoc;
+    sent = [];
+
+    const mockChannel = {
+      push: createMockChannelPushWithHandler((event, payload) => {
+        sent.push({ event, payload });
+        return {
+          okResponse: {
+            project_id: 'p1',
+            workflow_id: 'w1',
+            dataclip_id: 'dc1',
+          },
+        };
+      }),
+      on: () => {},
+    } as unknown as Channel;
+
+    const provider = {
+      channel: mockChannel,
+      synced: true,
+      awareness: null,
+      doc: ydoc,
+    } as unknown as PhoenixChannelProvider & { channel: Channel };
+
+    ydoc.getMap('workflow').set('id', 'workflow-123');
+    ydoc.getArray('jobs');
+    ydoc.getArray('triggers');
+    ydoc.getArray('edges');
+    ydoc.getMap('positions');
+
+    store.connect(ydoc, provider);
+  });
+
+  const lastPayload = () => sent[sent.length - 1]?.payload;
+
+  test('sends nothing extra when no starting data is chosen', async () => {
+    await store.editInSandbox('My SB');
+
+    expect(lastPayload()).toEqual({ name: 'My SB' });
+  });
+
+  test('sends a reviewed body by value, with the name it should carry', async () => {
+    await store.editInSandbox('My SB', {
+      body: '{"email":"redacted"}',
+      bodyName: 'Input from run abcdef',
+    });
+
+    expect(lastPayload()).toEqual({
+      name: 'My SB',
+      starting_dataclip: {
+        body: '{"email":"redacted"}',
+        name: 'Input from run abcdef',
+      },
+    });
+  });
+
+  test('sends a saved dataclip by id instead', async () => {
+    await store.editInSandbox('My SB', { dataclipId: 'dc-saved' });
+
+    expect(lastPayload()).toEqual({
+      name: 'My SB',
+      dataclip_id: 'dc-saved',
+    });
+  });
+
+  test('prefers the reviewed body when both are somehow given', async () => {
+    await store.editInSandbox('My SB', {
+      body: '{}',
+      dataclipId: 'dc-saved',
+    });
+
+    expect(lastPayload()).toEqual({
+      name: 'My SB',
+      starting_dataclip: { body: '{}', name: null },
+    });
+  });
+
+  test('returns where the reviewed body landed', async () => {
+    const result = await store.editInSandbox('My SB', { body: '{}' });
+
+    expect(result.dataclip_id).toBe('dc1');
+  });
+});

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -79,7 +79,7 @@ defmodule Lightning.Invocation do
     Query.selectable_for_job(job_id, project_id_for_job(job_id, opts), limit)
     |> where([d], is_nil(d.wiped_at))
     |> where([d], ^dataclip_where_filter(user_filters))
-    |> then(fn query -> if offset, do: query, else: offset(query, ^offset) end)
+    |> then(fn query -> if offset, do: offset(query, ^offset), else: query end)
     |> Repo.all()
     |> maybe_filter_uuid_prefix(user_filters)
   end

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -76,12 +76,30 @@ defmodule Lightning.Invocation do
     limit = Keyword.fetch!(opts, :limit)
     offset = Keyword.get(opts, :offset)
 
-    Query.selectable_for_job(job_id, limit)
+    Query.selectable_for_job(job_id, project_id_for_job(job_id, opts), limit)
     |> where([d], is_nil(d.wiped_at))
     |> where([d], ^dataclip_where_filter(user_filters))
     |> then(fn query -> if offset, do: query, else: offset(query, ^offset) end)
     |> Repo.all()
     |> maybe_filter_uuid_prefix(user_filters)
+  end
+
+  # The project anchors the dataclip query, so callers that already know it pass
+  # it rather than making this look it up on every search keystroke.
+  defp project_id_for_job(job_id, opts) do
+    case Keyword.get(opts, :project_id) do
+      nil ->
+        from(j in Lightning.Workflows.Job,
+          join: w in Lightning.Workflows.Workflow,
+          on: w.id == j.workflow_id,
+          where: j.id == ^job_id,
+          select: w.project_id
+        )
+        |> Repo.one()
+
+      project_id ->
+        project_id
+    end
   end
 
   @spec get_dataclip_with_body!(id :: Ecto.UUID.t()) :: %{

--- a/lib/lightning/invocation.ex
+++ b/lib/lightning/invocation.ex
@@ -76,7 +76,7 @@ defmodule Lightning.Invocation do
     limit = Keyword.fetch!(opts, :limit)
     offset = Keyword.get(opts, :offset)
 
-    Query.last_n_for_job(job_id, limit)
+    Query.selectable_for_job(job_id, limit)
     |> where([d], is_nil(d.wiped_at))
     |> where([d], ^dataclip_where_filter(user_filters))
     |> then(fn query -> if offset, do: query, else: offset(query, ^offset) end)

--- a/lib/lightning/invocation/query.ex
+++ b/lib/lightning/invocation/query.ex
@@ -268,18 +268,26 @@ defmodule Lightning.Invocation.Query do
   the driving relation on every keystroke of the picker's search.
   """
   def selectable_for_job(job_id, project_id, limit) do
+    consumed = job_input_dataclip_ids(job_id)
+
     # No resolvable project means no project to draw named inputs from, which is
     # what an unknown job looks like.
     selectable =
       if project_id do
-        union(job_input_dataclip_ids(job_id), ^named_dataclip_ids(project_id))
+        union(consumed, ^named_dataclip_ids(project_id))
       else
-        job_input_dataclip_ids(job_id)
+        consumed
       end
 
+    # The job's own inputs sort first, so a project with many named dataclips
+    # cannot crowd them off a fixed page. The run panel resolves a followed
+    # run's input out of this list, and losing it there shows no input at all.
     from(d in Dataclip,
       where: d.id in subquery(selectable),
-      order_by: [desc: d.inserted_at],
+      order_by: [
+        desc: d.id in subquery(consumed),
+        desc: d.inserted_at
+      ],
       limit: ^limit
     )
   end

--- a/lib/lightning/invocation/query.ex
+++ b/lib/lightning/invocation/query.ex
@@ -10,7 +10,6 @@ defmodule Lightning.Invocation.Query do
   alias Lightning.Projects.Project
   alias Lightning.Run
   alias Lightning.Workflows.Job
-  alias Lightning.Workflows.Workflow
   alias Lightning.WorkOrder
 
   @doc """
@@ -259,16 +258,27 @@ defmodule Lightning.Invocation.Query do
   every named dataclip in its project.
 
   A named dataclip is a curated input rather than a trace of a past run, so it
-  belongs to the project and is selectable on any job in it. Without that, a
-  dataclip created for a job it has never run against is invisible to the
-  picker.
+  belongs to the project and is selectable on any job in it. Note that the
+  result is therefore no longer bounded by the job: callers who want only what
+  this job has run should not use this.
+
+  The two sources are unioned rather than ORed, so each side keeps its own index
+  (`steps.job_id` and `dataclips.project_id`) and the outer query is a primary
+  key probe. An OR across them makes dataclips, the largest table in the schema,
+  the driving relation on every keystroke of the picker's search.
   """
-  def selectable_for_job(job_id, limit) do
+  def selectable_for_job(job_id, project_id, limit) do
+    # No resolvable project means no project to draw named inputs from, which is
+    # what an unknown job looks like.
+    selectable =
+      if project_id do
+        union(job_input_dataclip_ids(job_id), ^named_dataclip_ids(project_id))
+      else
+        job_input_dataclip_ids(job_id)
+      end
+
     from(d in Dataclip,
-      where:
-        d.id in subquery(job_input_dataclip_ids(job_id)) or
-          (not is_nil(d.name) and
-             d.project_id in subquery(project_id_for_job(job_id))),
+      where: d.id in subquery(selectable),
       order_by: [desc: d.inserted_at],
       limit: ^limit
     )
@@ -281,12 +291,10 @@ defmodule Lightning.Invocation.Query do
     )
   end
 
-  defp project_id_for_job(job_id) do
-    from(j in Job,
-      join: w in Workflow,
-      on: w.id == j.workflow_id,
-      where: j.id == ^job_id,
-      select: w.project_id
+  defp named_dataclip_ids(project_id) do
+    from(d in Dataclip,
+      where: d.project_id == ^project_id and not is_nil(d.name),
+      select: d.id
     )
   end
 

--- a/lib/lightning/invocation/query.ex
+++ b/lib/lightning/invocation/query.ex
@@ -263,9 +263,10 @@ defmodule Lightning.Invocation.Query do
   this job has run should not use this.
 
   The two sources are unioned rather than ORed, so each side keeps its own index
-  (`steps.job_id` and `dataclips.project_id`) and the outer query is a primary
-  key probe. An OR across them makes dataclips, the largest table in the schema,
-  the driving relation on every keystroke of the picker's search.
+  (`steps.job_id` and `dataclips.project_id`) instead of making dataclips, the
+  largest table in the schema, the driving relation on every keystroke of the
+  picker's search. The outer query still sorts the matched set, as the query it
+  replaced did.
   """
   def selectable_for_job(job_id, project_id, limit) do
     consumed = job_input_dataclip_ids(job_id)

--- a/lib/lightning/invocation/query.ex
+++ b/lib/lightning/invocation/query.ex
@@ -10,6 +10,7 @@ defmodule Lightning.Invocation.Query do
   alias Lightning.Projects.Project
   alias Lightning.Run
   alias Lightning.Workflows.Job
+  alias Lightning.Workflows.Workflow
   alias Lightning.WorkOrder
 
   @doc """
@@ -251,6 +252,42 @@ defmodule Lightning.Invocation.Query do
   def last_successful_step_for_job(%Job{id: id}) do
     last_step_for_job(%Job{id: id})
     |> steps_with_reason("success")
+  end
+
+  @doc """
+  Dataclips a job can be run against: the ones it has already consumed, plus
+  every named dataclip in its project.
+
+  A named dataclip is a curated input rather than a trace of a past run, so it
+  belongs to the project and is selectable on any job in it. Without that, a
+  dataclip created for a job it has never run against is invisible to the
+  picker.
+  """
+  def selectable_for_job(job_id, limit) do
+    from(d in Dataclip,
+      where:
+        d.id in subquery(job_input_dataclip_ids(job_id)) or
+          (not is_nil(d.name) and
+             d.project_id in subquery(project_id_for_job(job_id))),
+      order_by: [desc: d.inserted_at],
+      limit: ^limit
+    )
+  end
+
+  defp job_input_dataclip_ids(job_id) do
+    from(s in Step,
+      where: s.job_id == ^job_id and not is_nil(s.input_dataclip_id),
+      select: s.input_dataclip_id
+    )
+  end
+
+  defp project_id_for_job(job_id) do
+    from(j in Job,
+      join: w in Workflow,
+      on: w.id == j.workflow_id,
+      where: j.id == ^job_id,
+      select: w.project_id
+    )
   end
 
   @doc """

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -2351,7 +2351,12 @@ defmodule Lightning.Projects do
   to test connections against dev systems.
   """
   @spec provision_editing_sandbox(Project.t(), User.t(), String.t(), map()) ::
-          {:ok, %{sandbox: Project.t(), workflow: Workflow.t()}}
+          {:ok,
+           %{
+             sandbox: Project.t(),
+             workflow: Workflow.t(),
+             starting_dataclip_id: Ecto.UUID.t() | nil
+           }}
           | {:error, term()}
   def provision_editing_sandbox(parent, actor, workflow_name, attrs) do
     with {:ok, sandbox} <- provision_sandbox(parent, actor, attrs) do

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -2366,7 +2366,7 @@ defmodule Lightning.Projects do
            %{
              sandbox: sandbox,
              workflow: workflow,
-             starting_dataclip_id: Map.get(sandbox, :starting_dataclip_id)
+             starting_dataclip_id: sandbox.starting_dataclip_id
            }}
 
         nil ->

--- a/lib/lightning/projects.ex
+++ b/lib/lightning/projects.ex
@@ -2357,7 +2357,12 @@ defmodule Lightning.Projects do
     with {:ok, sandbox} <- provision_sandbox(parent, actor, attrs) do
       case Lightning.Workflows.get_workflow_by_name(sandbox.id, workflow_name) do
         %Workflow{} = workflow ->
-          {:ok, %{sandbox: sandbox, workflow: workflow}}
+          {:ok,
+           %{
+             sandbox: sandbox,
+             workflow: workflow,
+             starting_dataclip_id: Map.get(sandbox, :starting_dataclip_id)
+           }}
 
         nil ->
           # The clone of `workflow_name` is expected to exist after a

--- a/lib/lightning/projects/project.ex
+++ b/lib/lightning/projects/project.ex
@@ -37,6 +37,10 @@ defmodule Lightning.Projects.Project do
 
     field :raw_name, :string, virtual: true
 
+    # Set by sandbox provisioning to report the dataclip it created in the new
+    # sandbox, so the caller can open it with that input selected.
+    field :starting_dataclip_id, :binary_id, virtual: true
+
     belongs_to :parent, __MODULE__, type: :binary_id
 
     has_many :project_users, ProjectUser

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -160,24 +160,79 @@ defmodule Lightning.Projects.Sandboxes do
     end
   end
 
+  @doc """
+  Whether every id names a dataclip this parent can copy into a sandbox.
+
+  `provision/3` drops ineligible ids silently, which suits a bulk selection but
+  not a caller offering one deliberate choice: that caller wants to say why
+  nothing arrived.
+  """
+  @spec copyable_dataclips?(Project.t(), [Ecto.UUID.t()]) :: boolean()
+  def copyable_dataclips?(%Project{} = parent, ids) when is_list(ids) do
+    Enum.all?(ids, &valid_uuid?/1) and
+      eligible_dataclip_count(parent.id, ids) == length(Enum.uniq(ids))
+  end
+
+  defp valid_uuid?(value) when is_binary(value) do
+    match?({:ok, _}, Ecto.UUID.cast(value))
+  end
+
+  defp valid_uuid?(_value), do: false
+
+  defp eligible_dataclip_count(parent_id, ids) do
+    from(dataclip in Dataclip,
+      where:
+        dataclip.project_id == ^parent_id and dataclip.id in ^ids and
+          dataclip.type in ^@allowed_dataclip_types and
+          not is_nil(dataclip.name) and is_nil(dataclip.wiped_at)
+    )
+    |> Repo.aggregate(:count)
+  end
+
   defp cast_starting_dataclip(attrs) do
     case Map.get(attrs, :starting_dataclip) do
       nil ->
         {:ok, attrs}
 
       %{} = starting ->
-        with {:ok, body} <- decode_dataclip_body(Map.get(starting, :body)) do
-          {:ok,
-           Map.put(attrs, :starting_dataclip, %{
-             body: body,
-             name: Map.get(starting, :name)
-           })}
+        with {:ok, body} <-
+               decode_dataclip_body(get_either(starting, :body)),
+             {:ok, name} <- cast_dataclip_name(get_either(starting, :name)) do
+          {:ok, Map.put(attrs, :starting_dataclip, %{body: body, name: name})}
         end
 
       _other ->
         {:error, :invalid_starting_dataclip}
     end
   end
+
+  # Accepts either key style, because this arrives from a channel as strings and
+  # from Elixir callers as atoms.
+  defp get_either(map, key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  # Never nameless. Retention only wipes unnamed dataclips, and the input picker
+  # only offers named ones project-wide, so an unnamed one would be invisible
+  # and short-lived: the feature would appear to do nothing.
+  @starting_dataclip_fallback_name "Reviewed input"
+
+  defp cast_dataclip_name(nil), do: {:ok, @starting_dataclip_fallback_name}
+
+  defp cast_dataclip_name(name) when is_binary(name) do
+    case String.trim(name) do
+      "" ->
+        {:ok, @starting_dataclip_fallback_name}
+
+      trimmed when byte_size(trimmed) > 255 ->
+        {:error, :invalid_starting_dataclip}
+
+      trimmed ->
+        {:ok, trimmed}
+    end
+  end
+
+  defp cast_dataclip_name(_name), do: {:error, :invalid_starting_dataclip}
 
   defp decode_dataclip_body(body) when is_binary(body) do
     if byte_size(body) > Lightning.Config.max_dataclip_size_bytes() do
@@ -1513,7 +1568,7 @@ defmodule Lightning.Projects.Sandboxes do
           dataclip.project_id == ^parent_id and
             dataclip.id in ^dataclip_ids and
             dataclip.type in ^@allowed_dataclip_types and
-            not is_nil(dataclip.name),
+            not is_nil(dataclip.name) and is_nil(dataclip.wiped_at),
         select: %{
           name: dataclip.name,
           body: type(dataclip.body, :map),

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -47,6 +47,7 @@ defmodule Lightning.Projects.Sandboxes do
   alias Lightning.Collections.Collection
   alias Lightning.Credentials.KeychainCredential
   alias Lightning.Credentials.Scoping
+  alias Lightning.Invocation.Dataclip
   alias Lightning.Policies.Permissions
   alias Lightning.Projects.Events
   alias Lightning.Projects.MergeProjects
@@ -78,6 +79,9 @@ defmodule Lightning.Projects.Sandboxes do
   * `:env` - Environment identifier (e.g. `"staging"`, `"dev"`)
   * `:dataclip_ids` - UUIDs of dataclips to copy (only copies named dataclips
     of types `:global`, `:saved_input`, or `:http_request`)
+  * `:starting_dataclip` - a `%{body: json_string, name: string | nil}` map. The
+    body is created in the sandbox as a `:saved_input` dataclip rather than
+    copied from the parent, so what the caller reviewed is what lands.
 
   The sandbox's `project_users` are derived from the parent project: every
   parent user is copied across with their role preserved, except the parent
@@ -91,7 +95,11 @@ defmodule Lightning.Projects.Sandboxes do
           required(:name) => String.t(),
           optional(:color) => String.t() | nil,
           optional(:env) => String.t() | nil,
-          optional(:dataclip_ids) => [Ecto.UUID.t()]
+          optional(:dataclip_ids) => [Ecto.UUID.t()],
+          optional(:starting_dataclip) => %{
+            required(:body) => String.t(),
+            optional(:name) => String.t() | nil
+          }
         }
 
   @cloned_project_fields ~w(
@@ -143,12 +151,47 @@ defmodule Lightning.Projects.Sandboxes do
              | Ecto.Changeset.t()
              | term()}
   def provision(%Project{} = parent, %User{} = actor, attrs) do
-    if Permissions.can?(:sandboxes, :provision_sandbox, actor, parent) do
+    with true <- Permissions.can?(:sandboxes, :provision_sandbox, actor, parent),
+         {:ok, attrs} <- cast_starting_dataclip(attrs) do
       create_sandbox_from_parent(parent, actor, attrs)
     else
-      {:error, :unauthorized}
+      false -> {:error, :unauthorized}
+      {:error, _reason} = error -> error
     end
   end
+
+  defp cast_starting_dataclip(attrs) do
+    case Map.get(attrs, :starting_dataclip) do
+      nil ->
+        {:ok, attrs}
+
+      %{} = starting ->
+        with {:ok, body} <- decode_dataclip_body(Map.get(starting, :body)) do
+          {:ok,
+           Map.put(attrs, :starting_dataclip, %{
+             body: body,
+             name: Map.get(starting, :name)
+           })}
+        end
+
+      _other ->
+        {:error, :invalid_starting_dataclip}
+    end
+  end
+
+  defp decode_dataclip_body(body) when is_binary(body) do
+    if byte_size(body) > Lightning.Config.max_dataclip_size_bytes() do
+      {:error, :starting_dataclip_too_large}
+    else
+      case Jason.decode(body) do
+        {:ok, %{} = decoded} -> {:ok, decoded}
+        {:ok, _not_an_object} -> {:error, :starting_dataclip_not_an_object}
+        {:error, _} -> {:error, :starting_dataclip_invalid_json}
+      end
+    end
+  end
+
+  defp decode_dataclip_body(_body), do: {:error, :invalid_starting_dataclip}
 
   defp nesting_depth_exceeded?(%Project{id: parent_id}) do
     Lightning.Projects.depth_of(parent_id) >=
@@ -1318,6 +1361,7 @@ defmodule Lightning.Projects.Sandboxes do
     |> copy_workflow_version_history(sandbox.workflow_id_mapping)
     |> create_initial_workflow_snapshots()
     |> copy_selected_dataclips(parent.id, Map.get(original_attrs, :dataclip_ids))
+    |> create_starting_dataclip(Map.get(original_attrs, :starting_dataclip))
     |> clone_collections_from_parent(parent)
   end
 
@@ -1464,7 +1508,7 @@ defmodule Lightning.Projects.Sandboxes do
   defp copy_selected_dataclips(sandbox, parent_id, dataclip_ids)
        when is_list(dataclip_ids) do
     selected_dataclips =
-      from(dataclip in Lightning.Invocation.Dataclip,
+      from(dataclip in Dataclip,
         where:
           dataclip.project_id == ^parent_id and
             dataclip.id in ^dataclip_ids and
@@ -1481,9 +1525,19 @@ defmodule Lightning.Projects.Sandboxes do
     Enum.each(selected_dataclips, fn dataclip_attrs ->
       dataclip_attrs
       |> Map.put(:project_id, sandbox.id)
-      |> Lightning.Invocation.Dataclip.new()
+      |> Dataclip.new()
       |> Repo.insert!()
     end)
+
+    sandbox
+  end
+
+  defp create_starting_dataclip(sandbox, nil), do: sandbox
+
+  defp create_starting_dataclip(sandbox, %{body: body, name: name}) do
+    %{project_id: sandbox.id, body: body, name: name, type: :saved_input}
+    |> Dataclip.new()
+    |> Repo.insert!()
 
     sandbox
   end

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -1572,7 +1572,12 @@ defmodule Lightning.Projects.Sandboxes do
         select: %{
           name: dataclip.name,
           body: type(dataclip.body, :map),
-          request: type(dataclip.request, :map),
+          request:
+            fragment(
+              "case when ? = 'http_request' then ? else null end",
+              dataclip.type,
+              dataclip.request
+            ),
           type: dataclip.type
         }
       )

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -239,14 +239,37 @@ defmodule Lightning.Projects.Sandboxes do
       {:error, :starting_dataclip_too_large}
     else
       case Jason.decode(body) do
-        {:ok, %{} = decoded} -> {:ok, decoded}
-        {:ok, _not_an_object} -> {:error, :starting_dataclip_not_an_object}
-        {:error, _} -> {:error, :starting_dataclip_invalid_json}
+        {:ok, %{} = decoded} ->
+          # Postgres refuses a NUL byte in jsonb, and the insert raising here
+          # would take the channel with it rather than saying what was wrong.
+          if contains_null_byte?(decoded),
+            do: {:error, :starting_dataclip_invalid_json},
+            else: {:ok, decoded}
+
+        {:ok, _not_an_object} ->
+          {:error, :starting_dataclip_not_an_object}
+
+        {:error, _} ->
+          {:error, :starting_dataclip_invalid_json}
       end
     end
   end
 
   defp decode_dataclip_body(_body), do: {:error, :invalid_starting_dataclip}
+
+  defp contains_null_byte?(value) when is_binary(value),
+    do: String.contains?(value, <<0>>)
+
+  defp contains_null_byte?(value) when is_map(value) do
+    Enum.any?(value, fn {key, nested} ->
+      contains_null_byte?(key) or contains_null_byte?(nested)
+    end)
+  end
+
+  defp contains_null_byte?(value) when is_list(value),
+    do: Enum.any?(value, &contains_null_byte?/1)
+
+  defp contains_null_byte?(_value), do: false
 
   defp nesting_depth_exceeded?(%Project{id: parent_id}) do
     Lightning.Projects.depth_of(parent_id) >=

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -1577,14 +1577,21 @@ defmodule Lightning.Projects.Sandboxes do
       )
       |> Repo.all()
 
-    Enum.each(selected_dataclips, fn dataclip_attrs ->
-      dataclip_attrs
-      |> Map.put(:project_id, sandbox.id)
-      |> Dataclip.new()
-      |> Repo.insert!()
-    end)
+    copied =
+      Enum.map(selected_dataclips, fn dataclip_attrs ->
+        dataclip_attrs
+        |> Map.put(:project_id, sandbox.id)
+        |> Dataclip.new()
+        |> Repo.insert!()
+      end)
 
-    sandbox
+    # Reported only when the caller asked for exactly one, which is the editor
+    # offering a single deliberate choice. A bulk selection has no "the" input
+    # to open with.
+    case copied do
+      [%Dataclip{id: id}] -> %{sandbox | starting_dataclip_id: id}
+      _ -> sandbox
+    end
   end
 
   defp create_starting_dataclip(sandbox, nil), do: sandbox
@@ -1595,7 +1602,7 @@ defmodule Lightning.Projects.Sandboxes do
       |> Dataclip.new()
       |> Repo.insert!()
 
-    Map.put(sandbox, :starting_dataclip_id, dataclip.id)
+    %{sandbox | starting_dataclip_id: dataclip.id}
   end
 
   defp get_sandbox_keychain_id(

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -228,7 +228,11 @@ defmodule Lightning.Projects.Sandboxes do
         {:error, :invalid_starting_dataclip}
 
       trimmed ->
-        {:ok, trimmed}
+        # Postgres refuses a NUL in varchar as it does in jsonb, and this name
+        # comes from the same untrusted payload as the body.
+        if contains_null_byte?(trimmed),
+          do: {:error, :invalid_starting_dataclip},
+          else: {:ok, trimmed}
     end
   end
 

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -1572,6 +1572,7 @@ defmodule Lightning.Projects.Sandboxes do
         select: %{
           name: dataclip.name,
           body: type(dataclip.body, :map),
+          request: type(dataclip.request, :map),
           type: dataclip.type
         }
       )

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -1535,11 +1535,12 @@ defmodule Lightning.Projects.Sandboxes do
   defp create_starting_dataclip(sandbox, nil), do: sandbox
 
   defp create_starting_dataclip(sandbox, %{body: body, name: name}) do
-    %{project_id: sandbox.id, body: body, name: name, type: :saved_input}
-    |> Dataclip.new()
-    |> Repo.insert!()
+    dataclip =
+      %{project_id: sandbox.id, body: body, name: name, type: :saved_input}
+      |> Dataclip.new()
+      |> Repo.insert!()
 
-    sandbox
+    Map.put(sandbox, :starting_dataclip_id, dataclip.id)
   end
 
   defp get_sandbox_keychain_id(

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -484,23 +484,35 @@ defmodule LightningWeb.WorkflowChannel do
     workflow = socket.assigns.workflow
     user = socket.assigns.current_user
 
-    attrs = %{
-      name: sandbox_name(params, workflow, parent),
-      env: "dev",
-      color: LightningWeb.SandboxLive.Components.random_color()
-    }
+    attrs =
+      %{
+        name: sandbox_name(params, workflow, parent),
+        env: "dev",
+        color: LightningWeb.SandboxLive.Components.random_color()
+      }
+      |> put_starting_data(params)
 
     with :ok <- authorize_provision_sandbox(user, parent),
          :ok <- limit_new_sandbox(parent),
-         {:ok, %{sandbox: sandbox, workflow: cloned_workflow}} <-
+         {:ok,
+          %{
+            sandbox: sandbox,
+            workflow: cloned_workflow,
+            starting_dataclip_id: starting_dataclip_id
+          }} <-
            Projects.provision_editing_sandbox(
              parent,
              user,
              workflow.name,
              attrs
            ) do
-      {:reply, {:ok, %{project_id: sandbox.id, workflow_id: cloned_workflow.id}},
-       socket}
+      {:reply,
+       {:ok,
+        %{
+          project_id: sandbox.id,
+          workflow_id: cloned_workflow.id,
+          dataclip_id: starting_dataclip_id
+        }}, socket}
     else
       error -> workflow_error_reply(socket, error)
     end
@@ -1738,6 +1750,26 @@ defmodule LightningWeb.WorkflowChannel do
     case ProjectLimiter.limit_new_sandbox(parent.id) do
       :ok -> :ok
       {:error, _reason, message} -> {:error, message}
+    end
+  end
+
+  # The reviewed body travels by value, so what the person saw is what lands.
+  # A saved dataclip travels by id, and the copy is restricted to the parent's
+  # own named dataclips.
+  defp put_starting_data(attrs, params) do
+    case params do
+      %{"starting_dataclip" => %{"body" => body} = starting}
+      when is_binary(body) ->
+        Map.put(attrs, :starting_dataclip, %{
+          body: body,
+          name: Map.get(starting, "name")
+        })
+
+      %{"dataclip_id" => dataclip_id} when is_binary(dataclip_id) ->
+        Map.put(attrs, :dataclip_ids, [dataclip_id])
+
+      _ ->
+        attrs
     end
   end
 

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -494,6 +494,7 @@ defmodule LightningWeb.WorkflowChannel do
 
     with :ok <- authorize_provision_sandbox(user, parent),
          :ok <- limit_new_sandbox(parent),
+         :ok <- check_chosen_dataclip(parent, attrs),
          {:ok,
           %{
             sandbox: sandbox,
@@ -1411,6 +1412,38 @@ defmodule LightningWeb.WorkflowChannel do
       }}, socket}
   end
 
+  defp workflow_error_reply(socket, {:error, :starting_dataclip_invalid_json}) do
+    starting_dataclip_error(socket, "The input you reviewed is not valid JSON.")
+  end
+
+  defp workflow_error_reply(
+         socket,
+         {:error, :starting_dataclip_not_an_object}
+       ) do
+    starting_dataclip_error(
+      socket,
+      "The input you reviewed must be a JSON object."
+    )
+  end
+
+  defp workflow_error_reply(socket, {:error, :starting_dataclip_too_large}) do
+    starting_dataclip_error(
+      socket,
+      "The input you reviewed is too large to copy into a sandbox."
+    )
+  end
+
+  defp workflow_error_reply(socket, {:error, :invalid_starting_dataclip}) do
+    starting_dataclip_error(socket, "The input you reviewed could not be read.")
+  end
+
+  defp workflow_error_reply(socket, {:error, :starting_dataclip_not_found}) do
+    starting_dataclip_error(
+      socket,
+      "That saved input is no longer available in this project."
+    )
+  end
+
   defp workflow_error_reply(socket, {:error, :workflow_deleted}) do
     {:reply,
      {:error,
@@ -1510,6 +1543,11 @@ defmodule LightningWeb.WorkflowChannel do
         errors: %{base: ["An internal error occurred"]},
         type: "internal_error"
       }}, socket}
+  end
+
+  defp starting_dataclip_error(socket, message) do
+    {:reply, {:error, %{errors: %{base: [message]}, type: "validation_error"}},
+     socket}
   end
 
   defp format_changeset_errors(changeset) do
@@ -1756,16 +1794,25 @@ defmodule LightningWeb.WorkflowChannel do
   # The reviewed body travels by value, so what the person saw is what lands.
   # A saved dataclip travels by id, and the copy is restricted to the parent's
   # own named dataclips.
+  # The editor offers one deliberate choice, so a dataclip the parent cannot
+  # copy is refused rather than dropped into an empty sandbox unexplained.
+  defp check_chosen_dataclip(parent, %{dataclip_ids: ids}) do
+    if Sandboxes.copyable_dataclips?(parent, ids),
+      do: :ok,
+      else: {:error, :starting_dataclip_not_found}
+  end
+
+  defp check_chosen_dataclip(_parent, _attrs), do: :ok
+
+  # Matched on presence, not on shape: a malformed body must be refused rather
+  # than fall through to the copy path and report success for data that never
+  # travelled.
   defp put_starting_data(attrs, params) do
     case params do
-      %{"starting_dataclip" => %{"body" => body} = starting}
-      when is_binary(body) ->
-        Map.put(attrs, :starting_dataclip, %{
-          body: body,
-          name: Map.get(starting, "name")
-        })
+      %{"starting_dataclip" => starting} ->
+        Map.put(attrs, :starting_dataclip, starting)
 
-      %{"dataclip_id" => dataclip_id} when is_binary(dataclip_id) ->
+      %{"dataclip_id" => dataclip_id} ->
         Map.put(attrs, :dataclip_ids, [dataclip_id])
 
       _ ->

--- a/lib/lightning_web/live/workflow_live/new_manual_run.ex
+++ b/lib/lightning_web/live/workflow_live/new_manual_run.ex
@@ -33,7 +33,8 @@ defmodule LightningWeb.WorkflowLive.NewManualRun do
             %Job{id: job_id},
             filters,
             limit: limit,
-            offset: offset
+            offset: offset,
+            project_id: project.id
           )
 
         {:ok,

--- a/priv/schemas
+++ b/priv/schemas
@@ -1,0 +1,1 @@
+/Users/elias/Lab/openfn/lightning/priv/schemas

--- a/priv/schemas
+++ b/priv/schemas
@@ -1,1 +1,0 @@
-/Users/elias/Lab/openfn/lightning/priv/schemas

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -321,6 +321,53 @@ defmodule Lightning.InvocationTest do
       assert id == named.id
     end
 
+    test "honours an offset" do
+      %{project: project, jobs: [job | _]} = insert(:complex_workflow)
+
+      for n <- 1..3 do
+        insert(:dataclip,
+          project: project,
+          name: "named #{n}",
+          type: :saved_input,
+          inserted_at: DateTime.utc_now() |> DateTime.add(n, :second)
+        )
+      end
+
+      first = Invocation.list_dataclips_for_job(job, %{}, limit: 1)
+
+      second =
+        Invocation.list_dataclips_for_job(job, %{}, limit: 1, offset: 1)
+
+      assert [%{id: first_id}] = first
+      assert [%{id: second_id}] = second
+      refute first_id == second_id
+    end
+
+    test "keeps the job's own inputs ahead of the project's named ones" do
+      %{project: project, jobs: [job | _]} = insert(:complex_workflow)
+
+      consumed =
+        insert(:dataclip, project: project, name: nil, type: :http_request)
+
+      insert(:step, input_dataclip: consumed, job: job)
+
+      # Plenty of named inputs, all newer, so a plain date sort would bury the
+      # one the job actually ran against.
+      for n <- 1..3 do
+        insert(:dataclip,
+          project: project,
+          name: "named #{n}",
+          type: :saved_input,
+          inserted_at: DateTime.utc_now() |> DateTime.add(n, :second)
+        )
+      end
+
+      assert [%{id: first_id} | _] =
+               Invocation.list_dataclips_for_job(job, %{}, limit: 2)
+
+      assert first_id == consumed.id
+    end
+
     test "leaves an unnamed dataclip out unless the job has consumed it" do
       %{project: project, jobs: [job | _]} = insert(:complex_workflow)
 

--- a/test/lightning/invocation_test.exs
+++ b/test/lightning/invocation_test.exs
@@ -302,6 +302,33 @@ defmodule Lightning.InvocationTest do
                )
     end
 
+    test "offers a named project dataclip the job has never run against" do
+      %{project: project, jobs: [job | _]} = insert(:complex_workflow)
+
+      named =
+        insert(:dataclip,
+          project: project,
+          name: "known good input",
+          type: :saved_input,
+          body: %{"a" => 1}
+        )
+
+      # A curated input belongs to the project, so it is selectable on a job
+      # that has never consumed it.
+      assert [%{id: id}] =
+               Invocation.list_dataclips_for_job(job, %{}, limit: 5)
+
+      assert id == named.id
+    end
+
+    test "leaves an unnamed dataclip out unless the job has consumed it" do
+      %{project: project, jobs: [job | _]} = insert(:complex_workflow)
+
+      insert(:dataclip, project: project, name: nil, type: :saved_input)
+
+      assert [] = Invocation.list_dataclips_for_job(job, %{}, limit: 5)
+    end
+
     test "returns dataclips without the body" do
       %{jobs: [job1, job2 | _rest]} = insert(:complex_workflow)
 

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -497,6 +497,74 @@ defmodule Lightning.Projects.SandboxesTest do
                ])
     end
 
+    test "creates the reviewed body in the sandbox rather than copying a row" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      {:ok, sandbox} =
+        Sandboxes.provision(parent, actor, %{
+          name: "sb-start",
+          starting_dataclip: %{
+            body: ~s({"name":"redacted","id":7}),
+            name: "from run 1234"
+          }
+        })
+
+      assert [
+               {"from run 1234", :saved_input,
+                %{"name" => "redacted", "id" => 7}}
+             ] =
+               from(d in Dataclip,
+                 where: d.project_id == ^sandbox.id,
+                 select: {d.name, d.type, d.body}
+               )
+               |> Repo.all()
+
+      # The parent keeps whatever it had; nothing moved.
+      assert from(d in Dataclip, where: d.project_id == ^parent.id)
+             |> Repo.aggregate(:count) > 0
+    end
+
+    test "leaves no sandbox behind when the reviewed body is not valid JSON" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      assert {:error, :starting_dataclip_invalid_json} =
+               Sandboxes.provision(parent, actor, %{
+                 name: "sb-bad",
+                 starting_dataclip: %{body: "{not json", name: nil}
+               })
+
+      refute Repo.get_by(Project, name: "sb-bad")
+    end
+
+    test "refuses a reviewed body that is not an object" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      assert {:error, :starting_dataclip_not_an_object} =
+               Sandboxes.provision(parent, actor, %{
+                 name: "sb-array",
+                 starting_dataclip: %{body: "[1,2,3]", name: nil}
+               })
+
+      refute Repo.get_by(Project, name: "sb-array")
+    end
+
+    test "refuses a reviewed body over the dataclip size limit" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      Mox.stub(Lightning.MockConfig, :max_dataclip_size_bytes, fn -> 10 end)
+
+      assert {:error, :starting_dataclip_too_large} =
+               Sandboxes.provision(parent, actor, %{
+                 name: "sb-big",
+                 starting_dataclip: %{
+                   body: ~s({"padding":"aaaaaaaaaaaaaaaaaaaa"}),
+                   name: nil
+                 }
+               })
+
+      refute Repo.get_by(Project, name: "sb-big")
+    end
+
     test "copies trigger webhook auth methods when present" do
       %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
 

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -599,6 +599,20 @@ defmodule Lightning.Projects.SandboxesTest do
       refute Repo.get_by(Project, name: "sb-bad")
     end
 
+    test "refuses a reviewed body carrying a NUL byte" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      # Valid JSON, an object, under the limit, and Postgres will not take it.
+      # Left to the insert this raises and kills the channel.
+      assert {:error, :starting_dataclip_invalid_json} =
+               Sandboxes.provision(parent, actor, %{
+                 name: "sb-nul",
+                 starting_dataclip: %{body: ~S({"a":"\u0000"}), name: nil}
+               })
+
+      refute Repo.get_by(Project, name: "sb-nul")
+    end
+
     test "refuses a reviewed body that is not an object" do
       %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
 

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -599,6 +599,21 @@ defmodule Lightning.Projects.SandboxesTest do
       refute Repo.get_by(Project, name: "sb-bad")
     end
 
+    test "refuses a dataclip name carrying a NUL byte" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      assert {:error, :invalid_starting_dataclip} =
+               Sandboxes.provision(parent, actor, %{
+                 name: "sb-nul-name",
+                 starting_dataclip: %{
+                   body: ~s({"a":1}),
+                   name: <<"x", 0, "y">>
+                 }
+               })
+
+      refute Repo.get_by(Project, name: "sb-nul-name")
+    end
+
     test "refuses a reviewed body carrying a NUL byte" do
       %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
 

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -497,6 +497,34 @@ defmodule Lightning.Projects.SandboxesTest do
                ])
     end
 
+    test "carries an http request's metadata onto the copy" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      original =
+        insert(:dataclip,
+          project: parent,
+          name: "a webhook call",
+          type: :http_request,
+          body: %{"a" => 1},
+          request: %{"headers" => %{"x-thing" => "1"}}
+        )
+
+      {:ok, sandbox} =
+        Sandboxes.provision(parent, actor, %{
+          name: "sb-req",
+          dataclip_ids: [original.id]
+        })
+
+      # Without the request, a job reading state.request sees a different input
+      # in the sandbox than the one that ran in production.
+      assert [%{"headers" => %{"x-thing" => "1"}}] =
+               from(d in Dataclip,
+                 where: d.project_id == ^sandbox.id,
+                 select: d.request
+               )
+               |> Repo.all()
+    end
+
     test "creates the reviewed body in the sandbox rather than copying a row" do
       %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
 

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -525,6 +525,41 @@ defmodule Lightning.Projects.SandboxesTest do
                |> Repo.all()
     end
 
+    test "leaves a request off a type that must not carry one" do
+      %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
+
+      # A row like this cannot be written through the app today, but legacy data
+      # can look like it, and the changeset refuses a request on this type.
+      {1, _} =
+        Repo.insert_all(Dataclip, [
+          %{
+            id: Ecto.UUID.generate(),
+            project_id: parent.id,
+            name: "legacy",
+            type: :saved_input,
+            body: %{"a" => 1},
+            request: %{"headers" => %{}},
+            inserted_at: DateTime.utc_now(),
+            updated_at: DateTime.utc_now()
+          }
+        ])
+
+      legacy = Repo.get_by!(Dataclip, name: "legacy")
+
+      assert {:ok, sandbox} =
+               Sandboxes.provision(parent, actor, %{
+                 name: "sb-legacy",
+                 dataclip_ids: [legacy.id]
+               })
+
+      assert [nil] =
+               from(d in Dataclip,
+                 where: d.project_id == ^sandbox.id,
+                 select: d.request
+               )
+               |> Repo.all()
+    end
+
     test "creates the reviewed body in the sandbox rather than copying a row" do
       %{actor: actor, parent: parent} = build_parent_fixture!(:admin)
 

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -601,6 +601,80 @@ defmodule LightningWeb.WorkflowChannelTest do
                |> Enum.map(& &1.name)
     end
 
+    test "refuses a saved dataclip this project cannot copy", %{
+      socket: socket
+    } do
+      elsewhere = insert(:project)
+
+      foreign =
+        insert(:dataclip,
+          project: elsewhere,
+          name: "not yours",
+          type: :saved_input,
+          body: %{"a" => 1}
+        )
+
+      ref = push(socket, "edit_in_sandbox", %{"dataclip_id" => foreign.id})
+      assert_reply ref, :error, %{type: "validation_error"}
+
+      refute Lightning.Repo.get_by(Lightning.Projects.Project, name: "not yours")
+    end
+
+    test "refuses an unnamed dataclip, which retention would wipe", %{
+      socket: socket,
+      project: project
+    } do
+      unnamed =
+        insert(:dataclip, project: project, name: nil, type: :saved_input)
+
+      ref = push(socket, "edit_in_sandbox", %{"dataclip_id" => unnamed.id})
+      assert_reply ref, :error, %{type: "validation_error"}
+    end
+
+    test "refuses a dataclip id that is not a uuid", %{socket: socket} do
+      ref = push(socket, "edit_in_sandbox", %{"dataclip_id" => "not-a-uuid"})
+      assert_reply ref, :error, %{type: "validation_error"}
+    end
+
+    test "names a reviewed body that arrives without one", %{socket: socket} do
+      ref =
+        push(socket, "edit_in_sandbox", %{
+          "starting_dataclip" => %{"body" => ~s({"a":1}), "name" => nil}
+        })
+
+      assert_reply ref, :ok, %{dataclip_id: dataclip_id}
+
+      # Retention wipes unnamed dataclips, and the picker only offers named ones,
+      # so an unnamed one would vanish and never be selectable.
+      dataclip = Lightning.Repo.get!(Lightning.Invocation.Dataclip, dataclip_id)
+      assert dataclip.name == "Reviewed input"
+    end
+
+    test "says what is wrong when the reviewed body is not an object", %{
+      socket: socket
+    } do
+      ref =
+        push(socket, "edit_in_sandbox", %{
+          "starting_dataclip" => %{"body" => "[1,2]", "name" => nil}
+        })
+
+      assert_reply ref, :error, %{
+        type: "validation_error",
+        errors: %{base: [message]}
+      }
+
+      assert message =~ "JSON object"
+    end
+
+    test "refuses a reviewed body that is not a string", %{socket: socket} do
+      ref =
+        push(socket, "edit_in_sandbox", %{
+          "starting_dataclip" => %{"body" => %{"a" => 1}}
+        })
+
+      assert_reply ref, :error, %{type: "validation_error"}
+    end
+
     test "refuses a reviewed body that is not valid JSON", %{socket: socket} do
       ref =
         push(socket, "edit_in_sandbox", %{

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -592,7 +592,12 @@ defmodule LightningWeb.WorkflowChannelTest do
         )
 
       ref = push(socket, "edit_in_sandbox", %{"dataclip_id" => saved.id})
-      assert_reply ref, :ok, %{project_id: sandbox_id, dataclip_id: nil}
+      assert_reply ref, :ok, %{project_id: sandbox_id, dataclip_id: copied_id}
+
+      # The copy is a new row, and the sandbox opens with it selected just as
+      # the reviewed path does.
+      assert is_binary(copied_id)
+      refute copied_id == saved.id
 
       assert ["known good"] =
                Lightning.Invocation.Dataclip

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -556,6 +556,60 @@ defmodule LightningWeb.WorkflowChannelTest do
       %{trigger: trigger, other_workflow: other_workflow}
     end
 
+    test "starts the sandbox holding the reviewed body and says where it landed",
+         %{socket: socket} do
+      ref =
+        push(socket, "edit_in_sandbox", %{
+          "starting_dataclip" => %{
+            "body" => ~s({"email":"redacted"}),
+            "name" => "from run 42"
+          }
+        })
+
+      assert_reply ref, :ok, %{
+        project_id: sandbox_id,
+        dataclip_id: dataclip_id
+      }
+
+      assert is_binary(dataclip_id)
+
+      dataclip = Lightning.Repo.get!(Lightning.Invocation.Dataclip, dataclip_id)
+      assert dataclip.project_id == sandbox_id
+      assert dataclip.name == "from run 42"
+      assert dataclip.type == :saved_input
+    end
+
+    test "copies a chosen saved dataclip instead when one is named", %{
+      socket: socket,
+      project: project
+    } do
+      saved =
+        insert(:dataclip,
+          project: project,
+          name: "known good",
+          type: :saved_input,
+          body: %{"ok" => true}
+        )
+
+      ref = push(socket, "edit_in_sandbox", %{"dataclip_id" => saved.id})
+      assert_reply ref, :ok, %{project_id: sandbox_id, dataclip_id: nil}
+
+      assert ["known good"] =
+               Lightning.Invocation.Dataclip
+               |> Lightning.Repo.all()
+               |> Enum.filter(&(&1.project_id == sandbox_id))
+               |> Enum.map(& &1.name)
+    end
+
+    test "refuses a reviewed body that is not valid JSON", %{socket: socket} do
+      ref =
+        push(socket, "edit_in_sandbox", %{
+          "starting_dataclip" => %{"body" => "{nope", "name" => nil}
+        })
+
+      assert_reply ref, :error, _reason
+    end
+
     test "provisions a sandbox with the edited clone as a disabled draft, like the others",
          %{
            socket: socket,

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -622,7 +622,12 @@ defmodule LightningWeb.WorkflowChannelTest do
       ref = push(socket, "edit_in_sandbox", %{"dataclip_id" => foreign.id})
       assert_reply ref, :error, %{type: "validation_error"}
 
-      refute Lightning.Repo.get_by(Lightning.Projects.Project, name: "not yours")
+      # Refused outright, so no sandbox exists to have copied it into.
+      assert [] =
+               Lightning.Invocation.Dataclip
+               |> Lightning.Repo.all()
+               |> Enum.filter(&(&1.name == "not yours"))
+               |> Enum.reject(&(&1.id == foreign.id))
     end
 
     test "refuses an unnamed dataclip, which retention would wipe", %{


### PR DESCRIPTION
## Description

A developer fixing a workflow that failed in production needs the input that broke it, which is the data they are least allowed to copy. Until now a new sandbox started empty, so people either invented input that did not reproduce the bug or moved a production dataclip by hand into a project with a different membership list. This makes the safe path the fast one.

Edit in sandbox now asks what to start with: nothing, the input from the run you are looking at, or one of the project's named inputs. The run's input goes through a review step, because that is the data that matters: it is shown as it will land, you can remove anything that should not leave production, and it is checked before the sandbox is attempted. Two steps, not a wizard, so there is no step count to get wrong.

The reviewed body is created in the sandbox rather than the original row being copied. That is the difference between reviewing something and reviewing something else: the existing carry-over copies a parent row by id, which cannot carry an edit, and would have shown one thing while another travelled. The original is never touched.

Three things that had to change for it to be usable at all. A named dataclip is now selectable on any job in its project, because the input picker only offered dataclips a job had already consumed, so the one we had just created was invisible. The sandbox opens with that input already selected, so there is nothing to hunt for even once. And a sandbox always forks the version live now rather than the one the run used, because promote rebuilds the parent from the sandbox and an older fork would delete the newer work, so it says which version it forked when those differ.

Two cases that would otherwise fail quietly. A run whose input was never kept, which is every run in a zero-persistence project, says so rather than opening an empty editor. And a reviewed body is never stored nameless, because retention wipes unnamed dataclips and the picker only offers named ones, so an unnamed one would both vanish and never be selectable.

Closes #5052

## Validation steps

1. Open a live workflow with a failed run, click the run in the history panel, then Edit in sandbox.
2. Under the name field, pick "This run's input" and continue. The data appears for review; edit it and create.
3. The sandbox opens with that input already selected in the run panel. Run it.
4. Check the parent project's dataclip is unchanged.
5. Pick "A saved input" instead. Only named dataclips are listed, and create is refused until one is chosen.
6. In the review step, edit the body into an array and try to create. It says it needs a JSON object and does not create.
7. On a project set to never retain input/output data, "This run's input" says nothing was kept.
8. On a run that used an older version than the one live, both the choice and the review say which version the sandbox will fork.

## Additional notes for the reviewer

`Query.selectable_for_job/3` widens the manual-run input picker for every project, not only sandboxes: a named dataclip is a curated input and is now offered on any job in its project. It unions two indexed sources rather than ORing them, so dataclips does not become the driving relation on every keystroke of the picker's search.

Automatic detection of personal data is deliberately out of scope, as the issue says. The review step is manual, and #5132 is the curated-inputs answer that makes this the exception rather than the routine.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
