### PR TITLE
Move the editor's sandbox and lifecycle buttons onto the shared Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,9 @@ adaptor_registry_cache.json
 /priv/static/cache_manifest.json
 
 # Ignore credential schemas.
-/priv/schemas/
+# No trailing slash: it is often a symlink to a shared checkout, and a trailing
+# slash matches only directories.
+/priv/schemas
 
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to
 
 ### Changed
 
+- The sandbox and lifecycle buttons in the editor use the shared button
+  component rather than six hand-rolled copies of the same classes, and the
+  Edit-in-sandbox dialog says what a sandbox is once instead of three times.
+  [#4991](https://github.com/OpenFn/lightning/issues/4991),
+  [#4992](https://github.com/OpenFn/lightning/issues/4992)
+
 - Runs on Erlang/OTP 28 and Elixir 1.18.4. OTP 27 only finishes normalising
   the first character of a string, which breaks names in many languages.
   Lightning does not normalise anything today, but #4577 adds it on every name,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to
 ### Changed
 
 - The sandbox and lifecycle buttons in the editor use the shared button
-  component rather than seven hand-rolled copies of the same classes, and the
-  Edit-in-sandbox dialog says what a sandbox is once instead of three times.
+  component rather than seven hand-rolled copies of the same classes, the
+  version dropdown uses the shared text size rather than an arbitrary one, and
+  the Edit-in-sandbox dialog says what a sandbox is once instead of three times.
+  Tooltips explaining why Save, Go live and Edit in sandbox are greyed out now
+  open, which they never did before.
   [#4991](https://github.com/OpenFn/lightning/issues/4991),
   [#4992](https://github.com/OpenFn/lightning/issues/4992)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,15 @@ and this project adheres to
 ### Changed
 
 - The sandbox and lifecycle buttons in the editor use the shared button
-  component rather than six hand-rolled copies of the same classes, and the
+  component rather than seven hand-rolled copies of the same classes, and the
   Edit-in-sandbox dialog says what a sandbox is once instead of three times.
   [#4991](https://github.com/OpenFn/lightning/issues/4991),
   [#4992](https://github.com/OpenFn/lightning/issues/4992)
 
-- Runs on Erlang/OTP 28 and Elixir 1.18.4. OTP 27 only finishes normalising
-  the first character of a string, which breaks names in many languages.
-  Lightning does not normalise anything today, but #4577 adds it on every name,
-  so the runtime moves first.
+- Runs on Erlang/OTP 28 and Elixir 1.18.4. OTP 27 only finishes normalising the
+  first character of a string, which breaks names in many languages. Lightning
+  does not normalise anything today, but #4577 adds it on every name, so the
+  runtime moves first.
 
 ### Added
 
@@ -76,8 +76,7 @@ and this project adheres to
   place, with add, edit, delete and copy on the row itself. A path already used
   by another workflow in the project is reported while you type, not after you
   save. A path the server would reject shows what is wrong and is left as you
-  typed it.
-  [#4952](https://github.com/OpenFn/lightning/issues/4952)
+  typed it. [#4952](https://github.com/OpenFn/lightning/issues/4952)
 
 ### Fixed
 
@@ -106,17 +105,17 @@ and this project adheres to
 - AI assistant code blocks share the surface the workflow diffs use, so a reply
   and the diff below it no longer read as two different products.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
-- A global assistant reply whose changes could not be applied now says so on
-  the reply itself, beside the diffs that did not land, and offers to try
-  again. It used to fall back to a raw YAML panel.
+- A global assistant reply whose changes could not be applied now says so on the
+  reply itself, beside the diffs that did not land, and offers to try again. It
+  used to fall back to a raw YAML panel.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
-- A failed apply is now remembered, so reloading no longer turns it back into
-  a success. The reply kept its diff blocks and offered to undo changes that
-  had never landed. A retry that works clears the record.
+- A failed apply is now remembered, so reloading no longer turns it back into a
+  success. The reply kept its diff blocks and offered to undo changes that had
+  never landed. A retry that works clears the record.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
 - Editing an open step with the global assistant no longer puts a diff in the
-  code editor. The change is already applied, so the diff read as a proposal
-  to accept or reject when the only control was a close button, and reloading
+  code editor. The change is already applied, so the diff read as a proposal to
+  accept or reject when the only control was a close button, and reloading
   revealed the change had been written all along.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
 
@@ -714,8 +713,7 @@ Migrations in this release, all in `priv/repo/migrations/`:
   archive the sandbox or keep it to promote more related workflows first. A
   non-live workflow can have a trigger turned on for testing behind a warning,
   and live (read-only) workflows no longer show run or edit actions that cannot
-  be used there.
-  [#5005](https://github.com/OpenFn/lightning/pull/5005)
+  be used there. [#5005](https://github.com/OpenFn/lightning/pull/5005)
 - Record a version each time a workflow goes live or is promoted. Every publish
   now writes a release row carrying a sequential version number, the snapshot it
   published, who published it and, for a promote, the sandbox it came from.

--- a/assets/js/collaborative-editor/components/Button.tsx
+++ b/assets/js/collaborative-editor/components/Button.tsx
@@ -1,110 +1,120 @@
-import type { ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
 
-interface ButtonProps {
+interface ButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
   children?: ReactNode;
   variant?: 'primary' | 'danger' | 'secondary' | 'ghost' | 'nakedClose';
   disabled?: boolean;
   loading?: boolean;
-  onClick?: () => void;
   type?: 'button' | 'submit';
   className?: string;
-  'aria-label'?: string;
 }
 
 /**
  * Reusable button component with consistent styling
  * across the collaborative editor.
  *
+ * Forwards its ref and any remaining props to the element, so it can be used
+ * as a Radix trigger. Without that, a wrapper's `data-state` and handlers are
+ * silently dropped and the tooltip never wires up.
+ *
  * @example
  * <Button variant="danger" onClick={handleDelete}>
  *   Delete
  * </Button>
  */
-export function Button({
-  children,
-  variant = 'primary',
-  disabled = false,
-  loading = false,
-  onClick,
-  type = 'button',
-  className = '',
-  'aria-label': ariaLabel,
-}: ButtonProps) {
-  const isDisabled = disabled || loading;
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      children,
+      variant = 'primary',
+      disabled = false,
+      loading = false,
+      type = 'button',
+      className = '',
+      ...rest
+    },
+    ref
+  ) {
+    const isDisabled = disabled || loading;
 
-  // Base classes for standard buttons (not nakedClose). Shadow is opt-in per
-  // variant so the flat `ghost` button has no raised/outlined appearance.
-  const baseClasses = `
+    // Base classes for standard buttons (not nakedClose). Shadow is opt-in per
+    // variant so the flat `ghost` button has no raised/outlined appearance.
+    const baseClasses = `
     rounded-md px-3 py-2 text-sm font-semibold
     focus-visible:outline-2 focus-visible:outline-offset-2
     disabled:cursor-not-allowed
   `;
 
-  // nakedClose button has different base classes (no padding/shadow)
-  const nakedCloseBaseClasses = `
+    // nakedClose button has different base classes (no padding/shadow)
+    const nakedCloseBaseClasses = `
     relative rounded-md
     focus-visible:outline-2 focus-visible:outline-offset-2
     focus-visible:outline-indigo-600
     disabled:opacity-50 disabled:cursor-not-allowed
   `;
 
-  // Variant-specific classes
-  const variantClasses = {
-    primary: `
+    // Variant-specific classes
+    const variantClasses = {
+      primary: `
       bg-primary-600 hover:bg-primary-500 text-white shadow-xs
       focus-visible:outline-primary-600
       disabled:bg-primary-300 disabled:hover:bg-primary-300
     `,
-    danger: `
+      danger: `
       bg-red-600 hover:bg-red-500 text-white shadow-xs
       focus-visible:outline-red-600
       disabled:bg-red-300 disabled:hover:bg-red-300
     `,
-    secondary: `
+      secondary: `
       bg-white text-gray-900 shadow-xs
       inset-ring inset-ring-gray-300
       hover:inset-ring-gray-400
       disabled:bg-gray-50 disabled:text-gray-400
     `,
-    ghost: `
+      ghost: `
       bg-transparent text-gray-700
       hover:bg-gray-100 hover:text-gray-900
       focus-visible:outline-gray-400
       disabled:bg-transparent disabled:text-gray-400
       disabled:hover:bg-transparent disabled:hover:text-gray-400
     `,
-    nakedClose: `
+      nakedClose: `
       text-gray-400 hover:text-gray-500
       disabled:opacity-50
     `,
-  };
+    };
 
-  const buttonClasses =
-    variant === 'nakedClose' ? nakedCloseBaseClasses : baseClasses;
+    const buttonClasses =
+      variant === 'nakedClose' ? nakedCloseBaseClasses : baseClasses;
 
-  return (
-    <button
-      type={type}
-      onClick={onClick}
-      disabled={isDisabled}
-      aria-label={ariaLabel}
-      className={`
+    return (
+      <button
+        {...rest}
+        ref={ref}
+        type={type}
+        disabled={isDisabled}
+        className={`
         ${buttonClasses}
         ${variantClasses[variant]}
         ${className}
       `
-        .replace(/\s+/g, ' ')
-        .trim()}
-    >
-      {variant === 'nakedClose' ? (
-        <>
-          <span className="absolute -inset-2.5" />
-          <span className="sr-only">{ariaLabel || 'Close panel'}</span>
-          <div className="hero-x-mark size-6" />
-        </>
-      ) : (
-        children
-      )}
-    </button>
-  );
-}
+          .replace(/\s+/g, ' ')
+          .trim()}
+      >
+        {variant === 'nakedClose' ? (
+          <>
+            <span className="absolute -inset-2.5" />
+            <span className="sr-only">
+              {rest['aria-label'] || 'Close panel'}
+            </span>
+            <div className="hero-x-mark size-6" />
+          </>
+        ) : (
+          children
+        )}
+      </button>
+    );
+  }
+);

--- a/assets/js/collaborative-editor/components/Button.tsx
+++ b/assets/js/collaborative-editor/components/Button.tsx
@@ -17,7 +17,8 @@ interface ButtonProps
  *
  * Forwards its ref and any remaining props to the element, so it can be used
  * as a Radix trigger. Without that, a wrapper's `data-state` and handlers are
- * silently dropped and the tooltip never wires up.
+ * silently dropped. A tooltip on a button that can be disabled still needs a
+ * wrapping element to listen on, because a disabled button dispatches nothing.
  *
  * @example
  * <Button variant="danger" onClick={handleDelete}>

--- a/assets/js/collaborative-editor/components/Button.tsx
+++ b/assets/js/collaborative-editor/components/Button.tsx
@@ -17,8 +17,7 @@ interface ButtonProps
  *
  * Forwards its ref and any remaining props to the element, so it can be used
  * as a Radix trigger. Without that, a wrapper's `data-state` and handlers are
- * silently dropped. A tooltip on a button that can be disabled still needs a
- * wrapping element to listen on, because a disabled button dispatches nothing.
+ * silently dropped and the tooltip never wires up.
  *
  * @example
  * <Button variant="danger" onClick={handleDelete}>

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -12,7 +12,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { cn } from '#/utils/cn';
 
 import { Tooltip } from '../../components/Tooltip';
-import { Button } from './Button';
 import { useWorkflowActions } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
 import {
@@ -21,6 +20,8 @@ import {
 } from '../lib/errors';
 import { notifications } from '../lib/notifications';
 import type { Sandbox } from '../types/workflow';
+
+import { Button } from './Button';
 
 interface EditInSandboxPickerProps {
   isOpen: boolean;

--- a/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
+++ b/assets/js/collaborative-editor/components/EditInSandboxPicker.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { cn } from '#/utils/cn';
 
 import { Tooltip } from '../../components/Tooltip';
+import { Button } from './Button';
 import { useWorkflowActions } from '../hooks/useWorkflow';
 import { useKeyboardShortcut } from '../keyboard';
 import {
@@ -313,14 +314,12 @@ export function EditInSandboxPicker({
               Edit in sandbox
             </DialogTitle>
             <p className="mt-1 text-sm text-gray-600">
-              Make changes safely in a sandbox without affecting this live
-              workflow.
+              A sandbox is a copy of this project. Nothing you do in it touches
+              the live workflow until you promote it back.
             </p>
 
-            {/* Create a new sandbox. Eyebrow title + subtitle mirror the
-                "Join an active sandbox" section below so the two read as
-                visual siblings; the title/subtitle/placeholder identify the
-                field, so no separate visible label is needed. */}
+            {/* The title, subtitle and placeholder identify the field, so it
+                needs no separate visible label. */}
             <div className="mt-6">
               <p
                 className="text-xs font-semibold uppercase tracking-wide
@@ -329,7 +328,7 @@ export function EditInSandboxPicker({
                 Create a new sandbox
               </p>
               <p className="mt-1 text-xs text-gray-500">
-                Branch from the current live version to make changes safely.
+                Starts from the version live now.
               </p>
               <form
                 className="mt-3"
@@ -355,7 +354,7 @@ export function EditInSandboxPicker({
                         // Editing the name dismisses a stale field error.
                         setNameError(null);
                       }}
-                      placeholder="e.g. Test new changes"
+                      placeholder="What are you trying out?"
                       disabled={isCreating}
                       aria-invalid={nameError ? true : undefined}
                       aria-describedby={
@@ -372,20 +371,14 @@ export function EditInSandboxPicker({
                       )}
                     />
                   </div>
-                  <button
+                  <Button
                     type="submit"
                     data-testid="create-sandbox-button"
                     disabled={isCreating || !canCreate}
-                    className="inline-flex shrink-0 items-center self-start
-                      rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold
-                      text-white shadow-sm shadow-primary-600/20
-                      hover:bg-primary-500 focus-visible:outline-2
-                      focus-visible:outline-offset-2
-                      focus-visible:outline-primary-600
-                      disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex shrink-0 items-center self-start"
                   >
                     {isCreating ? 'Creating...' : 'Create sandbox'}
-                  </button>
+                  </Button>
                 </div>
                 {/* Always-rendered slot sized for one line of error text, so
                     showing/hiding the message never shifts the OR divider or
@@ -417,7 +410,8 @@ export function EditInSandboxPicker({
                   Join an active sandbox
                 </p>
                 <p className="mt-1 text-xs text-gray-500">
-                  Continue in a sandbox that's already active for this workflow.
+                  Pick up where someone left off, in a sandbox already open for
+                  this workflow.
                 </p>
 
                 {isLoadingList ? (

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -659,7 +659,7 @@ export function Header({
                     variant="secondary"
                     data-testid="switch-to-draft-button"
                     className="inline-flex items-center hover:bg-gray-50
-                      disabled:hover:bg-white disabled:hover:inset-ring-gray-300"
+                      disabled:hover:inset-ring-gray-300"
                     disabled={isTransitioning}
                     onClick={() => {
                       setShowSwitchToDraftDialog(true);

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -36,6 +36,7 @@ import { isFinalState } from '../types/history';
 
 import { ActiveCollaborators } from './ActiveCollaborators';
 import { AIButton } from './AIButton';
+import { Button } from './Button';
 import { AlertDialog } from './AlertDialog';
 import { Breadcrumbs } from './Breadcrumbs';
 import { EditInSandboxPicker } from './EditInSandboxPicker';
@@ -84,21 +85,15 @@ export function SaveButton({
             }
             side="bottom"
           >
-            <button
-              type="button"
+            <Button
               data-testid="save-workflow-button"
-              className="rounded-md text-sm font-semibold shadow-xs
-            phx-submit-loading:opacity-75 cursor-pointer
-            disabled:cursor-not-allowed disabled:bg-primary-300 px-3 py-2
-            bg-primary-600 hover:bg-primary-500
-            disabled:hover:bg-primary-300 text-white
-            focus-visible:outline-2 focus-visible:outline-offset-2
-            focus-visible:outline-primary-600 focus:ring-transparent"
+              className="phx-submit-loading:opacity-75 cursor-pointer
+                focus:ring-transparent"
               onClick={onClick}
               disabled={!canSave}
             >
               {label}
-            </button>
+            </Button>
           </Tooltip>
         </div>
         {hasChanges ? (
@@ -120,21 +115,15 @@ export function SaveButton({
           }
           side="bottom"
         >
-          <button
-            type="button"
+          <Button
             data-testid="save-workflow-button"
-            className="rounded-l-md text-sm font-semibold shadow-xs
-            phx-submit-loading:opacity-75 cursor-pointer
-            disabled:cursor-not-allowed disabled:bg-primary-300 px-3 py-2
-            bg-primary-600 hover:bg-primary-500
-            disabled:hover:bg-primary-300 text-white
-            focus-visible:outline-2 focus-visible:outline-offset-2
-            focus-visible:outline-primary-600 focus:ring-transparent"
+            className="rounded-r-none phx-submit-loading:opacity-75
+              cursor-pointer focus:ring-transparent"
             onClick={onClick}
             disabled={!canSave}
           >
             {label}
-          </button>
+          </Button>
         </Tooltip>
         <Menu as="div" className="relative -ml-px block">
           <MenuButton
@@ -634,9 +623,9 @@ export function Header({
                     }
                     side="bottom"
                   >
-                    <button
-                      type="button"
+                    <Button
                       data-testid="go-live-button"
+                      className="inline-flex items-center"
                       disabled={isReadOnly || isTransitioning}
                       onClick={() => {
                         setIsTransitioning(true);
@@ -651,39 +640,37 @@ export function Header({
                             setIsTransitioning(false);
                           });
                       }}
-                      className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300"
                     >
                       Go live
-                    </button>
+                    </Button>
                   </Tooltip>
                 )}
               {!isNewWorkflow &&
                 !isSandbox &&
                 !isViewingNonCurrentVersion &&
                 lifecycleState === 'live' && (
-                  <button
-                    type="button"
+                  <Button
+                    variant="secondary"
                     data-testid="switch-to-draft-button"
+                    className="inline-flex items-center"
                     disabled={isTransitioning}
                     onClick={() => {
                       setShowSwitchToDraftDialog(true);
                     }}
-                    className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 disabled:hover:bg-gray-50"
                   >
                     Switch to draft
-                  </button>
+                  </Button>
                 )}
               {!isNewWorkflow && isSandbox && !isViewingNonCurrentVersion && (
-                <button
-                  type="button"
+                <Button
                   data-testid="promote-sandbox-button"
+                  className="inline-flex items-center gap-1"
                   onClick={() => {
                     setShowPromoteDialog(true);
                   }}
-                  className="inline-flex items-center gap-1 rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300"
                 >
                   Promote
-                </button>
+                </Button>
               )}
               {lifecycleState === 'live' &&
                 !isSandbox &&
@@ -697,18 +684,17 @@ export function Header({
                     }
                     side="bottom"
                   >
-                    <button
-                      type="button"
+                    <Button
                       data-testid="edit-in-sandbox-button"
+                      className="inline-flex items-center"
                       disabled={!canProvisionSandbox}
                       onClick={() => {
                         if (!canProvisionSandbox) return;
                         setShowEditInSandboxPicker(true);
                       }}
-                      className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-primary-500 disabled:cursor-not-allowed disabled:bg-primary-300 disabled:hover:bg-primary-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
                     >
                       Edit in sandbox
-                    </button>
+                    </Button>
                   </Tooltip>
                 )}
               {projectId && workflowId && firstTriggerId && !isReadOnly && (

--- a/assets/js/collaborative-editor/components/Header.tsx
+++ b/assets/js/collaborative-editor/components/Header.tsx
@@ -36,9 +36,9 @@ import { isFinalState } from '../types/history';
 
 import { ActiveCollaborators } from './ActiveCollaborators';
 import { AIButton } from './AIButton';
-import { Button } from './Button';
 import { AlertDialog } from './AlertDialog';
 import { Breadcrumbs } from './Breadcrumbs';
+import { Button } from './Button';
 import { EditInSandboxPicker } from './EditInSandboxPicker';
 import { EmailVerificationBanner } from './EmailVerificationBanner';
 import { GitHubSyncModal } from './GitHubSyncModal';
@@ -85,15 +85,17 @@ export function SaveButton({
             }
             side="bottom"
           >
-            <Button
-              data-testid="save-workflow-button"
-              className="phx-submit-loading:opacity-75 cursor-pointer
-                focus:ring-transparent"
-              onClick={onClick}
-              disabled={!canSave}
-            >
-              {label}
-            </Button>
+            <span className="inline-block">
+              <Button
+                data-testid="save-workflow-button"
+                className="phx-submit-loading:opacity-75 cursor-pointer
+                  focus:ring-transparent"
+                onClick={onClick}
+                disabled={!canSave}
+              >
+                {label}
+              </Button>
+            </span>
           </Tooltip>
         </div>
         {hasChanges ? (
@@ -115,15 +117,17 @@ export function SaveButton({
           }
           side="bottom"
         >
-          <Button
-            data-testid="save-workflow-button"
-            className="rounded-r-none phx-submit-loading:opacity-75
-              cursor-pointer focus:ring-transparent"
-            onClick={onClick}
-            disabled={!canSave}
-          >
-            {label}
-          </Button>
+          <span className="inline-block">
+            <Button
+              data-testid="save-workflow-button"
+              className="rounded-r-none phx-submit-loading:opacity-75
+                cursor-pointer focus:ring-transparent"
+              onClick={onClick}
+              disabled={!canSave}
+            >
+              {label}
+            </Button>
+          </span>
         </Tooltip>
         <Menu as="div" className="relative -ml-px block">
           <MenuButton
@@ -623,26 +627,28 @@ export function Header({
                     }
                     side="bottom"
                   >
-                    <Button
-                      data-testid="go-live-button"
-                      className="inline-flex items-center"
-                      disabled={isReadOnly || isTransitioning}
-                      onClick={() => {
-                        setIsTransitioning(true);
-                        void goLive()
-                          .catch(() =>
-                            notifications.alert({
-                              title: 'Could not go live',
-                              description: 'Please try again.',
-                            })
-                          )
-                          .finally(() => {
-                            setIsTransitioning(false);
-                          });
-                      }}
-                    >
-                      Go live
-                    </Button>
+                    <span className="inline-block">
+                      <Button
+                        data-testid="go-live-button"
+                        className="inline-flex items-center"
+                        disabled={isReadOnly || isTransitioning}
+                        onClick={() => {
+                          setIsTransitioning(true);
+                          void goLive()
+                            .catch(() =>
+                              notifications.alert({
+                                title: 'Could not go live',
+                                description: 'Please try again.',
+                              })
+                            )
+                            .finally(() => {
+                              setIsTransitioning(false);
+                            });
+                        }}
+                      >
+                        Go live
+                      </Button>
+                    </span>
                   </Tooltip>
                 )}
               {!isNewWorkflow &&
@@ -652,7 +658,8 @@ export function Header({
                   <Button
                     variant="secondary"
                     data-testid="switch-to-draft-button"
-                    className="inline-flex items-center"
+                    className="inline-flex items-center hover:bg-gray-50
+                      disabled:hover:bg-white disabled:hover:inset-ring-gray-300"
                     disabled={isTransitioning}
                     onClick={() => {
                       setShowSwitchToDraftDialog(true);
@@ -684,17 +691,19 @@ export function Header({
                     }
                     side="bottom"
                   >
-                    <Button
-                      data-testid="edit-in-sandbox-button"
-                      className="inline-flex items-center"
-                      disabled={!canProvisionSandbox}
-                      onClick={() => {
-                        if (!canProvisionSandbox) return;
-                        setShowEditInSandboxPicker(true);
-                      }}
-                    >
-                      Edit in sandbox
-                    </Button>
+                    <span className="inline-block">
+                      <Button
+                        data-testid="edit-in-sandbox-button"
+                        className="inline-flex items-center"
+                        disabled={!canProvisionSandbox}
+                        onClick={() => {
+                          if (!canProvisionSandbox) return;
+                          setShowEditInSandboxPicker(true);
+                        }}
+                      >
+                        Edit in sandbox
+                      </Button>
+                    </span>
                   </Tooltip>
                 )}
               {projectId && workflowId && firstTriggerId && !isReadOnly && (

--- a/assets/js/collaborative-editor/components/VersionDropdown.tsx
+++ b/assets/js/collaborative-editor/components/VersionDropdown.tsx
@@ -162,7 +162,7 @@ export function VersionDropdown({
               </div>
             ) : (
               <>
-                <p className="px-4 pt-1 pb-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+                <p className="px-4 pt-1 pb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">
                   Version history
                 </p>
 
@@ -196,7 +196,7 @@ export function VersionDropdown({
                     >
                       <span
                         className={cn(
-                          'mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ring-1 ring-inset',
+                          'mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ring-1 ring-inset',
                           version.is_latest
                             ? 'bg-green-100 text-green-800 ring-green-600/20'
                             : 'bg-gray-100 text-gray-600 ring-gray-500/10'

--- a/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
+++ b/assets/test/collaborative-editor/components/EditInSandboxPicker.test.tsx
@@ -105,7 +105,7 @@ describe('EditInSandboxPicker', () => {
 
     expect(screen.getByText('Create a new sandbox')).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText('e.g. Test new changes')
+      screen.getByPlaceholderText('What are you trying out?')
     ).toBeInTheDocument();
     expect(screen.getByTestId('create-sandbox-button')).toBeInTheDocument();
 
@@ -283,7 +283,7 @@ describe('EditInSandboxPicker', () => {
     renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
     const button = screen.getByTestId('create-sandbox-button');
-    const input = screen.getByPlaceholderText('e.g. Test new changes');
+    const input = screen.getByPlaceholderText('What are you trying out?');
 
     // Blank -> disabled.
     expect(button).toBeDisabled();
@@ -315,7 +315,7 @@ describe('EditInSandboxPicker', () => {
       renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
       await user.type(
-        screen.getByPlaceholderText('e.g. Test new changes'),
+        screen.getByPlaceholderText('What are you trying out?'),
         'My SB'
       );
       await user.click(screen.getByTestId('create-sandbox-button'));
@@ -358,7 +358,7 @@ describe('EditInSandboxPicker', () => {
 
     renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
-    const input = screen.getByPlaceholderText('e.g. Test new changes');
+    const input = screen.getByPlaceholderText('What are you trying out?');
     await user.type(input, 'My SB');
     await user.click(screen.getByTestId('create-sandbox-button'));
 
@@ -408,7 +408,7 @@ describe('EditInSandboxPicker', () => {
 
     renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
-    const input = screen.getByPlaceholderText('e.g. Test new changes');
+    const input = screen.getByPlaceholderText('What are you trying out?');
     await user.type(input, 'My SB');
     await user.click(screen.getByTestId('create-sandbox-button'));
 
@@ -437,7 +437,7 @@ describe('EditInSandboxPicker', () => {
 
       // Focus the input and press Enter; no click on "Create sandbox".
       await user.type(
-        screen.getByPlaceholderText('e.g. Test new changes'),
+        screen.getByPlaceholderText('What are you trying out?'),
         'My SB{Enter}'
       );
 
@@ -460,7 +460,7 @@ describe('EditInSandboxPicker', () => {
 
     renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
-    const input = screen.getByPlaceholderText('e.g. Test new changes');
+    const input = screen.getByPlaceholderText('What are you trying out?');
     input.focus();
     await user.keyboard('{Enter}');
 
@@ -476,7 +476,7 @@ describe('EditInSandboxPicker', () => {
     renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
     await user.type(
-      screen.getByPlaceholderText('e.g. Test new changes'),
+      screen.getByPlaceholderText('What are you trying out?'),
       'My SB'
     );
     await user.click(screen.getByTestId('create-sandbox-button'));
@@ -486,7 +486,9 @@ describe('EditInSandboxPicker', () => {
       expect(button).toHaveTextContent('Creating...');
     });
     expect(button).toBeDisabled();
-    expect(screen.getByPlaceholderText('e.g. Test new changes')).toBeDisabled();
+    expect(
+      screen.getByPlaceholderText('What are you trying out?')
+    ).toBeDisabled();
   });
 
   test('forwards the trimmed name to the create action', async () => {
@@ -503,7 +505,7 @@ describe('EditInSandboxPicker', () => {
       renderPicker(<EditInSandboxPicker isOpen onClose={() => {}} />);
 
       await user.type(
-        screen.getByPlaceholderText('e.g. Test new changes'),
+        screen.getByPlaceholderText('What are you trying out?'),
         '  My SB  '
       );
       await user.click(screen.getByTestId('create-sandbox-button'));

--- a/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
+++ b/assets/test/collaborative-editor/components/Header.sandbox.test.tsx
@@ -209,9 +209,10 @@ describe('Header - Edit in sandbox button gating', () => {
     renderHeader({ isSandbox: false });
     const button = screen.getByTestId('edit-in-sandbox-button');
     expect(button).toBeEnabled();
-    // No tooltip wrapper: the Tooltip renders bare children when content is null,
-    // so the Radix trigger attribute is absent when provisioning is allowed.
+    // The Tooltip renders bare children when content is null, so nothing here
+    // is a Radix trigger when provisioning is allowed.
     expect(button).not.toHaveAttribute('data-state');
+    expect(button.parentElement).not.toHaveAttribute('data-state');
   });
 
   test('renders the button disabled and tooltip-wrapped when provisioning is not allowed', () => {
@@ -220,9 +221,9 @@ describe('Header - Edit in sandbox button gating', () => {
 
     const button = screen.getByTestId('edit-in-sandbox-button');
     expect(button).toBeDisabled();
-    // The disabled button is wrapped in the shared Tooltip, so Radix marks it as
-    // a trigger with a data-state attribute.
-    expect(button).toHaveAttribute('data-state');
+    // A disabled button dispatches no pointer events, so the Radix trigger has
+    // to be the wrapper around it rather than the button itself.
+    expect(button.parentElement).toHaveAttribute('data-state');
   });
 
   test('hides the button when the workflow is in draft', () => {

--- a/priv/schemas
+++ b/priv/schemas
@@ -1,0 +1,1 @@
+/Users/elias/Lab/openfn/lightning/.claude/worktrees/read-path/priv/schemas

--- a/priv/schemas
+++ b/priv/schemas
@@ -1,1 +1,0 @@
-/Users/elias/Lab/openfn/lightning/.claude/worktrees/read-path/priv/schemas


### PR DESCRIPTION
### Validation steps

Closes https://github.com/OpenFn/lightning/issues/4991
Closes https://github.com/OpenFn/lightning/issues/4992

Seven buttons in the editor header and the Edit-in-sandbox dialog each carried their own copy of the same Tailwind classes. This moves them onto `Button.tsx`, which meant teaching that component to forward its ref and any remaining props. Without that, a wrapper's `data-state` and handlers were silently dropped, so a `Button` could not be a tooltip trigger at all. TypeScript waves hyphenated attributes like `data-testid` through unchecked, which is why nothing complained.

While doing it I found the tooltips that explain why Save, Go live and Edit in sandbox are greyed out could never open. A disabled button dispatches no pointer events, so Radix never hears the hover. They now hang off a wrapping element, the way the rest of the editor already does it. That bug predates this PR but it lives on the lines this PR rewrote.

The dialog also said what a sandbox is three times over. It says it once now.

1. Open a live workflow as someone who cannot create sandboxes. Hover the greyed "Edit in sandbox" button and check the explanation appears.
2. Hover Save with nothing to save, and Go live on a pinned version. Same.
3. Check the buttons look unchanged otherwise, including the split save button's square right edge and the dirty dot.
4. Open the Edit-in-sandbox dialog and check the explanation reads once.

### AI usage

Refactor and PR body drafted with Claude Code, reviewed and corrected by me.