### PR TITLE
Restore an earlier version of a workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- You can restore an earlier version of a workflow. It puts that version's
+  content back and publishes it, so production keeps running throughout, and it
+  tells you first which triggers it will delete and which URLs stop answering.
+  The versions in between stay in the history.
+  [#4864](https://github.com/OpenFn/lightning/issues/4864)
+
 ### Changed
 
-- Runs on Erlang/OTP 28 and Elixir 1.18.4. OTP 27 only finishes normalising
-  the first character of a string, which breaks names in many languages.
-  Lightning does not normalise anything today, but #4577 adds it on every name,
-  so the runtime moves first.
-
-### Added
+- Runs on Erlang/OTP 28 and Elixir 1.18.4. OTP 27 only finishes normalising the
+  first character of a string, which breaks names in many languages. Lightning
+  does not normalise anything today, but #4577 adds it on every name, so the
+  runtime moves first.
 
 - Promoting from a sandbox now warns first when the parent project has changed
   that workflow since the sandbox was created. Promote rebuilds the parent
@@ -70,8 +76,7 @@ and this project adheres to
   place, with add, edit, delete and copy on the row itself. A path already used
   by another workflow in the project is reported while you type, not after you
   save. A path the server would reject shows what is wrong and is left as you
-  typed it.
-  [#4952](https://github.com/OpenFn/lightning/issues/4952)
+  typed it. [#4952](https://github.com/OpenFn/lightning/issues/4952)
 
 ### Fixed
 
@@ -100,17 +105,17 @@ and this project adheres to
 - AI assistant code blocks share the surface the workflow diffs use, so a reply
   and the diff below it no longer read as two different products.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
-- A global assistant reply whose changes could not be applied now says so on
-  the reply itself, beside the diffs that did not land, and offers to try
-  again. It used to fall back to a raw YAML panel.
+- A global assistant reply whose changes could not be applied now says so on the
+  reply itself, beside the diffs that did not land, and offers to try again. It
+  used to fall back to a raw YAML panel.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
-- A failed apply is now remembered, so reloading no longer turns it back into
-  a success. The reply kept its diff blocks and offered to undo changes that
-  had never landed. A retry that works clears the record.
+- A failed apply is now remembered, so reloading no longer turns it back into a
+  success. The reply kept its diff blocks and offered to undo changes that had
+  never landed. A retry that works clears the record.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
 - Editing an open step with the global assistant no longer puts a diff in the
-  code editor. The change is already applied, so the diff read as a proposal
-  to accept or reject when the only control was a close button, and reloading
+  code editor. The change is already applied, so the diff read as a proposal to
+  accept or reject when the only control was a close button, and reloading
   revealed the change had been written all along.
   [#5118](https://github.com/OpenFn/lightning/issues/5118)
 
@@ -708,8 +713,7 @@ Migrations in this release, all in `priv/repo/migrations/`:
   archive the sandbox or keep it to promote more related workflows first. A
   non-live workflow can have a trigger turned on for testing behind a warning,
   and live (read-only) workflows no longer show run or edit actions that cannot
-  be used there.
-  [#5005](https://github.com/OpenFn/lightning/pull/5005)
+  be used there. [#5005](https://github.com/OpenFn/lightning/pull/5005)
 - Record a version each time a workflow goes live or is promoted. Every publish
   now writes a release row carrying a sequential version number, the snapshot it
   published, who published it and, for a promote, the sandbox it came from.

--- a/assets/js/collaborative-editor/CollaborativeEditor.tsx
+++ b/assets/js/collaborative-editor/CollaborativeEditor.tsx
@@ -15,7 +15,7 @@ import { LandingScreen } from './components/LandingScreen';
 import { LoadingBoundary } from './components/LoadingBoundary';
 import { PromotedNotice } from './components/PromotedNotice';
 import { RestoreVersionDialog } from './components/RestoreVersionDialog';
-import type { LosingTrigger } from './components/RestoreVersionDialog';
+import type { RestoreCost } from './components/RestoreVersionDialog';
 import { TemplateBrowserModalWrapper } from './components/TemplateBrowserModalWrapper';
 import { Toaster } from './components/ui/Toaster';
 import { VersionDebugLogger } from './components/VersionDebugLogger';
@@ -121,24 +121,33 @@ export function BreadcrumbContent({
   // Held here rather than in the dropdown, which closes as soon as Restore is
   // clicked and would take the dialog with it.
   const [restoring, setRestoring] = useState<number | null>(null);
-  const [losingTriggers, setLosingTriggers] = useState<LosingTrigger[] | null>(
-    null
-  );
+  const [cost, setCost] = useState<RestoreCost | null>(null);
+
+  // Which version the open dialog is about, readable synchronously when a
+  // check replies. A check for a version the user has since cancelled can land
+  // after a later one, and would otherwise replace a real warning with silence.
+  const askingAboutRef = useRef<number | null>(null);
 
   const handleVersionRestore = useCallback(
     (versionNumber: number) => {
+      askingAboutRef.current = versionNumber;
       setRestoring(versionNumber);
-      setLosingTriggers(null);
+      setCost(null);
 
       // Advisory. A failure here must not block the restore, so an unanswered
       // check reads as nothing to lose.
       void checkRestore(versionNumber)
-        .then(({ losing_triggers }) => {
-          setLosingTriggers(losing_triggers);
-          return losing_triggers;
+        .then(({ losing_triggers, returning_triggers, version_number }) => {
+          if (askingAboutRef.current === version_number) {
+            setCost({ losing: losing_triggers, returning: returning_triggers });
+          }
+
+          return version_number;
         })
         .catch(() => {
-          setLosingTriggers([]);
+          if (askingAboutRef.current === versionNumber) {
+            setCost({ losing: [], returning: [] });
+          }
         });
     },
     [checkRestore]
@@ -171,6 +180,7 @@ export function BreadcrumbContent({
       description: 'The workflow is live on that version\u2019s content.',
     });
 
+    askingAboutRef.current = null;
     setRestoring(null);
 
     return true;
@@ -287,9 +297,10 @@ export function BreadcrumbContent({
       <RestoreVersionDialog
         isOpen={restoring !== null}
         versionNumber={restoring}
-        losingTriggers={losingTriggers}
+        cost={cost}
         onConfirm={handleConfirmRestore}
         onCancel={() => {
+          askingAboutRef.current = null;
           setRestoring(null);
         }}
       />

--- a/assets/js/collaborative-editor/CollaborativeEditor.tsx
+++ b/assets/js/collaborative-editor/CollaborativeEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useURLState } from '#/react/lib/use-url-state';
 
@@ -14,6 +14,8 @@ import { Header } from './components/Header';
 import { LandingScreen } from './components/LandingScreen';
 import { LoadingBoundary } from './components/LoadingBoundary';
 import { PromotedNotice } from './components/PromotedNotice';
+import { RestoreVersionDialog } from './components/RestoreVersionDialog';
+import type { LosingTrigger } from './components/RestoreVersionDialog';
 import { TemplateBrowserModalWrapper } from './components/TemplateBrowserModalWrapper';
 import { Toaster } from './components/ui/Toaster';
 import { VersionDebugLogger } from './components/VersionDebugLogger';
@@ -32,6 +34,7 @@ import {
   useIsNewWorkflow,
   useLatestSnapshotLockVersion,
   useLimits,
+  usePermissions,
   useProject,
 } from './hooks/useSessionContext';
 import {
@@ -40,8 +43,14 @@ import {
   useUICommands,
 } from './hooks/useUI';
 import { useVersionSelect } from './hooks/useVersionSelect';
-import { useCreateWorkflowFlow, useWorkflowState } from './hooks/useWorkflow';
+import {
+  useCreateWorkflowFlow,
+  useWorkflowActions,
+  useWorkflowState,
+} from './hooks/useWorkflow';
 import { KeyboardProvider } from './keyboard';
+import { formatChannelErrorMessage, isChannelRequestError } from './lib/errors';
+import { notifications } from './lib/notifications';
 
 export interface CollaborativeEditorDataProps {
   'data-workflow-id': string;
@@ -106,6 +115,66 @@ export function BreadcrumbContent({
   const { params, updateSearchParams } = useURLState();
   const isIDEOpen = params['panel'] === 'editor';
   const handleVersionSelect = useVersionSelect();
+  const canEditWorkflow = usePermissions()?.can_edit_workflow ?? false;
+  const { restoreVersion, checkRestore } = useWorkflowActions();
+
+  // Held here rather than in the dropdown, which closes as soon as Restore is
+  // clicked and would take the dialog with it.
+  const [restoring, setRestoring] = useState<number | null>(null);
+  const [losingTriggers, setLosingTriggers] = useState<LosingTrigger[] | null>(
+    null
+  );
+
+  const handleVersionRestore = useCallback(
+    (versionNumber: number) => {
+      setRestoring(versionNumber);
+      setLosingTriggers(null);
+
+      // Advisory. A failure here must not block the restore, so an unanswered
+      // check reads as nothing to lose.
+      void checkRestore(versionNumber)
+        .then(({ losing_triggers }) => {
+          setLosingTriggers(losing_triggers);
+          return losing_triggers;
+        })
+        .catch(() => {
+          setLosingTriggers([]);
+        });
+    },
+    [checkRestore]
+  );
+
+  const handleConfirmRestore = useCallback(async () => {
+    if (restoring === null) return false;
+
+    try {
+      await restoreVersion(restoring);
+    } catch (error) {
+      notifications.alert({
+        title: `Could not restore v${restoring}`,
+        description: isChannelRequestError(error)
+          ? formatChannelErrorMessage({
+              errors: error.errors as { base?: string[] } & Record<
+                string,
+                string[]
+              >,
+              type: error.type,
+            })
+          : 'Please try again.',
+      });
+
+      return false;
+    }
+
+    notifications.success({
+      title: `Restored v${restoring}`,
+      description: 'The workflow is live on that version\u2019s content.',
+    });
+
+    setRestoring(null);
+
+    return true;
+  }, [restoring, restoreVersion]);
 
   // Clicking the workflow title returns to the root workflow editor view: it
   // closes the full IDE (and any other panel), deselects the current node, and
@@ -164,6 +233,9 @@ export function BreadcrumbContent({
             currentVersion={workflowFromStore?.lock_version ?? null}
             latestVersion={latestSnapshotLockVersion}
             onVersionSelect={handleVersionSelect}
+            {...(canEditWorkflow && {
+              onVersionRestore: handleVersionRestore,
+            })}
           />
           {projectEnv && (
             <div
@@ -193,6 +265,8 @@ export function BreadcrumbContent({
     latestSnapshotLockVersion,
     handleTitleClick,
     handleVersionSelect,
+    handleVersionRestore,
+    canEditWorkflow,
   ]);
 
   // Hide header until the first save clears isNewWorkflow in the store.
@@ -209,6 +283,16 @@ export function BreadcrumbContent({
       aiAssistantEnabled={aiAssistantEnabled}
     >
       {breadcrumbElements}
+      {/* Outside the memo above, which does not depend on the restore state. */}
+      <RestoreVersionDialog
+        isOpen={restoring !== null}
+        versionNumber={restoring}
+        losingTriggers={losingTriggers}
+        onConfirm={handleConfirmRestore}
+        onCancel={() => {
+          setRestoring(null);
+        }}
+      />
     </Header>
   );
 }

--- a/assets/js/collaborative-editor/components/RestoreVersionDialog.tsx
+++ b/assets/js/collaborative-editor/components/RestoreVersionDialog.tsx
@@ -1,0 +1,168 @@
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/react';
+import { useEffect, useState } from 'react';
+
+import { useKeyboardShortcut } from '../keyboard';
+
+import { Button } from './Button';
+
+export interface LosingTrigger {
+  id: string;
+  type: string;
+  custom_path: string | null;
+  enabled: boolean;
+}
+
+interface RestoreVersionDialogProps {
+  isOpen: boolean;
+  versionNumber: number | null;
+  /** Null while the answer is still coming back. */
+  losingTriggers: LosingTrigger[] | null;
+  onConfirm: () => Promise<boolean>;
+  onCancel: () => void;
+}
+
+function describeTrigger(trigger: LosingTrigger) {
+  if (trigger.type === 'cron') return 'a scheduled trigger';
+
+  return trigger.custom_path
+    ? `the webhook at /${trigger.custom_path}`
+    : 'a webhook trigger';
+}
+
+/**
+ * Asked before an earlier version's content replaces what is live.
+ *
+ * Restoring is not a mistake to be warned about, it is a deliberate rollback,
+ * so this says what it costs rather than trying to talk anyone out of it. The
+ * costs worth naming are the ones nobody should discover afterwards: a trigger
+ * added since that version disappears, and the URL built from it stops
+ * answering.
+ */
+export function RestoreVersionDialog({
+  isOpen,
+  versionNumber,
+  losingTriggers,
+  onConfirm,
+  onCancel,
+}: RestoreVersionDialogProps) {
+  const [isRestoring, setIsRestoring] = useState(false);
+
+  // Nothing unmounts this between opens, so it has to clear its own in-flight
+  // state or the next open is a dead button.
+  useEffect(() => {
+    if (!isOpen) setIsRestoring(false);
+  }, [isOpen]);
+
+  const dismiss = () => {
+    if (isRestoring) return;
+    onCancel();
+  };
+
+  useKeyboardShortcut('Escape', dismiss, 100, { enabled: isOpen });
+
+  const handleConfirm = async () => {
+    setIsRestoring(true);
+
+    const restored = await onConfirm();
+
+    if (!restored) setIsRestoring(false);
+  };
+
+  const isChecking = losingTriggers === null;
+
+  return (
+    <Dialog open={isOpen} onClose={dismiss} className="relative z-[60]">
+      <DialogBackdrop
+        transition
+        className="modal-backdrop data-closed:opacity-0 data-enter:duration-300
+          data-enter:ease-out data-leave:duration-200 data-leave:ease-in"
+      />
+
+      <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+        <div
+          className="flex min-h-full items-end justify-center p-4 text-center
+            sm:items-center sm:p-0"
+        >
+          <DialogPanel
+            transition
+            className="relative transform overflow-hidden rounded-lg bg-white
+              px-4 pb-4 pt-5 text-left shadow-xl transition-all
+              data-closed:translate-y-4 data-closed:opacity-0
+              data-enter:duration-300 data-enter:ease-out
+              data-leave:duration-200 data-leave:ease-in sm:my-8 sm:w-full
+              sm:max-w-lg sm:p-6"
+            data-testid="restore-version-dialog"
+          >
+            <DialogTitle
+              as="h3"
+              className="text-base font-semibold text-gray-900"
+            >
+              Restore v{versionNumber}?
+            </DialogTitle>
+
+            <p className="mt-2 text-sm text-gray-600">
+              This puts v{versionNumber}&rsquo;s content back and publishes it.
+              The workflow stays live throughout, and anything it has gained
+              since v{versionNumber} is lost. The versions in between stay in
+              the history.
+            </p>
+
+            {isChecking ? (
+              <p
+                className="mt-3 text-sm text-gray-500"
+                data-testid="restore-checking"
+              >
+                Checking what this will change...
+              </p>
+            ) : losingTriggers.length > 0 ? (
+              <div
+                className="mt-3 rounded-md bg-danger-50 p-3"
+                data-testid="restore-losing-triggers"
+              >
+                <p className="text-sm font-medium text-danger-800">
+                  {losingTriggers.length === 1
+                    ? 'One trigger will be deleted'
+                    : `${losingTriggers.length} triggers will be deleted`}
+                </p>
+                <ul className="mt-1 list-disc pl-5 text-sm text-danger-700">
+                  {losingTriggers.map(trigger => (
+                    <li key={trigger.id}>
+                      {describeTrigger(trigger)}
+                      {trigger.enabled ? ', which is on now' : ''}
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-1 text-sm text-danger-700">
+                  Anything calling those URLs stops working.
+                </p>
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
+              <Button
+                variant="secondary"
+                disabled={isRestoring}
+                onClick={onCancel}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                loading={isRestoring}
+                disabled={isChecking}
+                onClick={() => void handleConfirm()}
+              >
+                {isRestoring ? 'Restoring...' : `Restore v${versionNumber}`}
+              </Button>
+            </div>
+          </DialogPanel>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/assets/js/collaborative-editor/components/RestoreVersionDialog.tsx
+++ b/assets/js/collaborative-editor/components/RestoreVersionDialog.tsx
@@ -17,16 +17,27 @@ export interface LosingTrigger {
   enabled: boolean;
 }
 
+export interface ReturningTrigger {
+  id: string;
+  type: string;
+  custom_path: string | null;
+}
+
+export interface RestoreCost {
+  losing: LosingTrigger[];
+  returning: ReturningTrigger[];
+}
+
 interface RestoreVersionDialogProps {
   isOpen: boolean;
   versionNumber: number | null;
   /** Null while the answer is still coming back. */
-  losingTriggers: LosingTrigger[] | null;
+  cost: RestoreCost | null;
   onConfirm: () => Promise<boolean>;
   onCancel: () => void;
 }
 
-function describeTrigger(trigger: LosingTrigger) {
+function describeTrigger(trigger: LosingTrigger | ReturningTrigger) {
   if (trigger.type === 'cron') return 'a scheduled trigger';
 
   return trigger.custom_path
@@ -46,7 +57,7 @@ function describeTrigger(trigger: LosingTrigger) {
 export function RestoreVersionDialog({
   isOpen,
   versionNumber,
-  losingTriggers,
+  cost,
   onConfirm,
   onCancel,
 }: RestoreVersionDialogProps) {
@@ -73,7 +84,7 @@ export function RestoreVersionDialog({
     if (!restored) setIsRestoring(false);
   };
 
-  const isChecking = losingTriggers === null;
+  const isChecking = cost === null;
 
   return (
     <Dialog open={isOpen} onClose={dismiss} className="relative z-[60]">
@@ -119,29 +130,56 @@ export function RestoreVersionDialog({
               >
                 Checking what this will change...
               </p>
-            ) : losingTriggers.length > 0 ? (
-              <div
-                className="mt-3 rounded-md bg-danger-50 p-3"
-                data-testid="restore-losing-triggers"
-              >
-                <p className="text-sm font-medium text-danger-800">
-                  {losingTriggers.length === 1
-                    ? 'One trigger will be deleted'
-                    : `${losingTriggers.length} triggers will be deleted`}
-                </p>
-                <ul className="mt-1 list-disc pl-5 text-sm text-danger-700">
-                  {losingTriggers.map(trigger => (
-                    <li key={trigger.id}>
-                      {describeTrigger(trigger)}
-                      {trigger.enabled ? ', which is on now' : ''}
-                    </li>
-                  ))}
-                </ul>
-                <p className="mt-1 text-sm text-danger-700">
-                  Anything calling those URLs stops working.
-                </p>
-              </div>
-            ) : null}
+            ) : (
+              <>
+                {cost.losing.length > 0 && (
+                  <div
+                    className="mt-3 rounded-md bg-danger-50 p-3"
+                    data-testid="restore-losing-triggers"
+                  >
+                    <p className="text-sm font-medium text-danger-800">
+                      {cost.losing.length === 1
+                        ? 'One trigger will be deleted'
+                        : `${cost.losing.length} triggers will be deleted`}
+                    </p>
+                    <ul className="mt-1 list-disc pl-5 text-sm text-danger-700">
+                      {cost.losing.map(trigger => (
+                        <li key={trigger.id}>
+                          {describeTrigger(trigger)}
+                          {trigger.enabled ? ', which is on now' : ''}
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="mt-1 text-sm text-danger-700">
+                      Anything calling those URLs stops working.
+                    </p>
+                  </div>
+                )}
+
+                {cost.returning.length > 0 && (
+                  <div
+                    className="mt-3 rounded-md bg-warning-50 p-3"
+                    data-testid="restore-returning-triggers"
+                  >
+                    <p className="text-sm font-medium text-warning-800">
+                      {cost.returning.length === 1
+                        ? 'One trigger comes back switched off'
+                        : `${cost.returning.length} triggers come back switched off`}
+                    </p>
+                    <ul className="mt-1 list-disc pl-5 text-sm text-warning-700">
+                      {cost.returning.map(trigger => (
+                        <li key={trigger.id}>{describeTrigger(trigger)}</li>
+                      ))}
+                    </ul>
+                    <p className="mt-1 text-sm text-warning-700">
+                      A version does not record which authentication was
+                      attached, so switch these on again once you have set that
+                      up.
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
 
             <div className="mt-6 flex flex-wrap justify-end gap-3">
               <Button

--- a/assets/js/collaborative-editor/components/VersionDropdown.tsx
+++ b/assets/js/collaborative-editor/components/VersionDropdown.tsx
@@ -19,12 +19,18 @@ interface VersionDropdownProps {
   currentVersion: number | null;
   latestVersion: number | null;
   onVersionSelect: (version: number | 'latest') => void;
+  /**
+   * Offered per row, because restore is about the version being read rather
+   * than the workflow on screen. Omitted when the viewer cannot edit.
+   */
+  onVersionRestore?: (version: number) => void;
 }
 
 export function VersionDropdown({
   currentVersion,
   latestVersion,
   onVersionSelect,
+  onVersionRestore,
 }: VersionDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -182,54 +188,78 @@ export function VersionDropdown({
                     : '';
 
                   return (
-                    <button
+                    <div
                       key={version.lock_version}
-                      type="button"
-                      onClick={() => handleVersionClick(version)}
                       className={cn(
-                        'w-full text-left px-4 py-2.5 text-sm hover:bg-gray-100 flex items-start gap-3',
-                        isActive
-                          ? 'bg-primary-50 text-primary-900'
-                          : 'text-gray-700'
+                        'group flex items-start hover:bg-gray-100',
+                        isActive ? 'bg-primary-50' : ''
                       )}
-                      role="menuitem"
                     >
-                      <span
+                      <button
+                        type="button"
+                        onClick={() => handleVersionClick(version)}
                         className={cn(
-                          'mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ring-1 ring-inset',
-                          version.is_latest
-                            ? 'bg-green-100 text-green-800 ring-green-600/20'
-                            : 'bg-gray-100 text-gray-600 ring-gray-500/10'
+                          'min-w-0 flex-1 text-left px-4 py-2.5 text-sm flex items-start gap-3',
+                          isActive ? 'text-primary-900' : 'text-gray-700'
                         )}
+                        role="menuitem"
                       >
-                        v{version.version_number}
-                      </span>
-
-                      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                        <span className="truncate">
-                          {releaseActionLabel(version)}
-                        </span>
-                        <span className="flex min-w-0 items-center gap-1 text-xs text-gray-500">
-                          {version.published_by && (
-                            <>
-                              <span className="min-w-0 truncate">
-                                {version.published_by}
-                              </span>
-                              <span aria-hidden="true">·</span>
-                            </>
+                        <span
+                          className={cn(
+                            'mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ring-1 ring-inset',
+                            version.is_latest
+                              ? 'bg-green-100 text-green-800 ring-green-600/20'
+                              : 'bg-gray-100 text-gray-600 ring-gray-500/10'
                           )}
-                          <Tooltip content={exact} side="top">
-                            <span className="whitespace-nowrap">
-                              {absolute}
-                            </span>
-                          </Tooltip>
+                        >
+                          v{version.version_number}
                         </span>
-                      </span>
 
-                      {isActive && (
-                        <span className="hero-check mt-0.5 h-4 w-4 shrink-0 text-primary-600" />
+                        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                          <span className="truncate">
+                            {releaseActionLabel(version)}
+                          </span>
+                          <span className="flex min-w-0 items-center gap-1 text-xs text-gray-500">
+                            {version.published_by && (
+                              <>
+                                <span className="min-w-0 truncate">
+                                  {version.published_by}
+                                </span>
+                                <span aria-hidden="true">·</span>
+                              </>
+                            )}
+                            <Tooltip content={exact} side="top">
+                              <span className="whitespace-nowrap">
+                                {absolute}
+                              </span>
+                            </Tooltip>
+                          </span>
+                        </span>
+
+                        {isActive && (
+                          <span className="hero-check mt-0.5 h-4 w-4 shrink-0 text-primary-600" />
+                        )}
+                      </button>
+
+                      {/* The newest release is what is live, so there is nothing
+                        to put back. */}
+                      {onVersionRestore && !version.is_latest && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onVersionRestore(version.version_number);
+                            setIsOpen(false);
+                          }}
+                          className="shrink-0 self-center px-3 py-2.5 text-xs
+                          font-medium text-primary-700 opacity-0
+                          hover:underline focus:opacity-100
+                          group-hover:opacity-100"
+                          data-testid={`restore-version-${version.version_number}`}
+                        >
+                          Restore
+                        </button>
                       )}
-                    </button>
+                    </div>
                   );
                 })}
               </>

--- a/assets/js/collaborative-editor/hooks/useWorkflow.tsx
+++ b/assets/js/collaborative-editor/hooks/useWorkflow.tsx
@@ -731,6 +731,12 @@ export const useWorkflowActions = () => {
     checkPromote: store.checkPromote,
     archiveSandbox: store.archiveSandbox,
 
+    // Put an earlier version's content back without taking the workflow
+    // offline. checkRestore asks what that will destroy, so the confirmation
+    // can say so before anyone agrees.
+    restoreVersion: store.restoreVersion,
+    checkRestore: store.checkRestore,
+
     resetWorkflow: store.resetWorkflow,
     importWorkflow: store.importWorkflow,
 
@@ -1100,8 +1106,7 @@ export const useWorkflowReadOnly = (): {
   if (isViewingAsExecuted) {
     return {
       isReadOnly: true,
-      tooltipMessage:
-        'You are viewing this workflow as a past run executed it',
+      tooltipMessage: 'You are viewing this workflow as a past run executed it',
       reason: 'as_run',
     };
   }

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -1704,6 +1704,11 @@ export const createWorkflowStore = (
       custom_path: string | null;
       enabled: boolean;
     }[];
+    returning_triggers: {
+      id: string;
+      type: string;
+      custom_path: string | null;
+    }[];
     version_number: number;
   }> => {
     const { provider } = ensureConnected();

--- a/assets/js/collaborative-editor/stores/createWorkflowStore.ts
+++ b/assets/js/collaborative-editor/stores/createWorkflowStore.ts
@@ -1673,6 +1673,46 @@ export const createWorkflowStore = (
     }>(provider.channel, 'request_promote_check', { workflow_name: name });
   };
 
+  // A restore is a publish, not an edit: the server writes the chosen version's
+  // content into the live workflow and leaves it live. It reconciles every open
+  // editor itself, so there is nothing to reload here.
+  const restoreVersion = async (
+    versionNumber: number
+  ): Promise<{ lock_version: number }> => {
+    const { provider } = ensureConnected();
+
+    try {
+      return await channelRequest<{ lock_version: number }>(
+        provider.channel,
+        'restore_version',
+        { version_number: versionNumber }
+      );
+    } catch (error) {
+      logger.error('Failed to restore version', error);
+      throw error;
+    }
+  };
+
+  // Advisory, so the confirmation can name what the restore will destroy before
+  // anyone agrees to it.
+  const checkRestore = async (
+    versionNumber: number
+  ): Promise<{
+    losing_triggers: {
+      id: string;
+      type: string;
+      custom_path: string | null;
+      enabled: boolean;
+    }[];
+    version_number: number;
+  }> => {
+    const { provider } = ensureConnected();
+
+    return await channelRequest(provider.channel, 'request_restore_check', {
+      version_number: versionNumber,
+    });
+  };
+
   // Archive this sandbox after promoting. Archiving turns off the sandbox's
   // triggers and schedules it for deletion (reversible during a grace window);
   // it is not an instant hard delete. Kept separate from promote so a user can
@@ -2204,6 +2244,8 @@ export const createWorkflowStore = (
     promote,
     archiveSandbox,
     checkPromote,
+    restoreVersion,
+    checkRestore,
     saveAndSyncWorkflow,
     resetWorkflow,
     validateWorkflowName,

--- a/assets/js/collaborative-editor/types/sessionContext.ts
+++ b/assets/js/collaborative-editor/types/sessionContext.ts
@@ -69,6 +69,7 @@ export const VersionSchema = z.object({
   published_by: z.string().nullable(),
   source_project: z.string().nullable(),
   lock_version: z.number().int(),
+  restored_from_version_number: z.number().int().nullable(),
   is_latest: z.boolean(),
 });
 

--- a/assets/js/collaborative-editor/types/sessionContext.ts
+++ b/assets/js/collaborative-editor/types/sessionContext.ts
@@ -69,7 +69,9 @@ export const VersionSchema = z.object({
   published_by: z.string().nullable(),
   source_project: z.string().nullable(),
   lock_version: z.number().int(),
-  restored_from_version_number: z.number().int().nullable(),
+  // nullish with a default so a new asset bundle served against an older node
+  // during a rolling deploy does not fail the parse and blank the dropdown.
+  restored_from_version_number: z.number().int().nullish().default(null),
   is_latest: z.boolean(),
 });
 

--- a/assets/js/collaborative-editor/utils/releaseLabel.tsx
+++ b/assets/js/collaborative-editor/utils/releaseLabel.tsx
@@ -4,6 +4,7 @@
  * Used by both the version dropdown and the Recent History markers so the two
  * surfaces read identically. Label set:
  * - promote → "Promoted sandbox {source_project}" (sandbox name emphasised)
+ * - restore → "Restored v{n}", naming the version it put back
  * - first release (v1 go-live) → "Initial go-live"
  * - any later go-live → "Published from draft"
  */
@@ -12,7 +13,7 @@ import type { Version } from '../types/sessionContext';
 
 type ReleaseLike = Pick<
   Version,
-  'kind' | 'source_project' | 'version_number'
+  'kind' | 'source_project' | 'version_number' | 'restored_from_version_number'
 >;
 
 export function releaseActionLabel(version: ReleaseLike): React.ReactNode {
@@ -25,5 +26,18 @@ export function releaseActionLabel(version: ReleaseLike): React.ReactNode {
     );
   }
 
-  return version.version_number === 1 ? 'Initial go-live' : 'Published from draft';
+  if (version.kind === 'restore') {
+    return (
+      <>
+        Restored{' '}
+        <span className="font-medium">
+          v{version.restored_from_version_number}
+        </span>
+      </>
+    );
+  }
+
+  return version.version_number === 1
+    ? 'Initial go-live'
+    : 'Published from draft';
 }

--- a/assets/test/collaborative-editor/components/CollaborativeEditor.breadcrumbTitle.test.tsx
+++ b/assets/test/collaborative-editor/components/CollaborativeEditor.breadcrumbTitle.test.tsx
@@ -19,6 +19,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { BreadcrumbContent } from '../../../js/collaborative-editor/CollaborativeEditor';
+import { KeyboardProvider } from '../../../js/collaborative-editor/keyboard';
 import {
   createMockURLState,
   getURLStateMockValue,
@@ -63,9 +64,15 @@ vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
   useProject: () => ({ id: 'project-1', name: 'Test Project' }),
   useLatestSnapshotLockVersion: () => 1,
   useIsNewWorkflow: () => false,
+  // The breadcrumbs offer Restore per version, which only editors get.
+  usePermissions: () => ({ can_edit_workflow: true }),
 }));
 
 vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
+  useWorkflowActions: () => ({
+    restoreVersion: vi.fn(),
+    checkRestore: vi.fn().mockResolvedValue({ losing_triggers: [] }),
+  }),
   useWorkflowState: (selector: (state: unknown) => unknown) => {
     const state = { workflow: { id: 'workflow-1', lock_version: 1 } };
     return typeof selector === 'function' ? selector(state) : state;
@@ -86,12 +93,17 @@ vi.mock('../../../js/collaborative-editor/hooks/useVersionSelect', () => ({
 }));
 
 function renderBreadcrumbs() {
+  // The breadcrumbs carry the restore confirmation, which registers a
+  // MODAL-priority Escape handler, and in the app they render inside the
+  // editor's KeyboardProvider.
   return render(
-    <BreadcrumbContent
-      workflowId="workflow-1"
-      workflowName="Test Workflow"
-      aiAssistantEnabled={false}
-    />
+    <KeyboardProvider>
+      <BreadcrumbContent
+        workflowId="workflow-1"
+        workflowName="Test Workflow"
+        aiAssistantEnabled={false}
+      />
+    </KeyboardProvider>
   );
 }
 

--- a/assets/test/collaborative-editor/components/CollaborativeEditor.restore.test.tsx
+++ b/assets/test/collaborative-editor/components/CollaborativeEditor.restore.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Restore wiring tests
+ *
+ * The dialog's whole job is to say what a rollback costs. These drive the real
+ * breadcrumbs so that the answer the user sees is the answer for the version
+ * they are actually restoring, which is not free: a check for a version they
+ * have since cancelled can land after a later one.
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { BreadcrumbContent } from '../../../js/collaborative-editor/CollaborativeEditor';
+import { KeyboardProvider } from '../../../js/collaborative-editor/keyboard';
+import {
+  createMockURLState,
+  getURLStateMockValue,
+} from '../__helpers__/urlStateMocks';
+
+const urlState = createMockURLState();
+
+type CheckReply = {
+  losing_triggers: {
+    id: string;
+    type: string;
+    custom_path: string | null;
+    enabled: boolean;
+  }[];
+  returning_triggers: {
+    id: string;
+    type: string;
+    custom_path: string | null;
+  }[];
+  version_number: number;
+};
+
+const checkRestore = vi.fn<(v: number) => Promise<CheckReply>>();
+const restoreVersion = vi.fn<() => Promise<{ lock_version: number }>>();
+
+vi.mock('#/react/lib/use-url-state', () => ({
+  useURLState: () => getURLStateMockValue(urlState),
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  default: () => <div data-testid="monaco-editor" />,
+}));
+
+vi.mock(
+  '../../../js/collaborative-editor/components/CollaborativeMonaco',
+  () => ({
+    CollaborativeMonaco: () => <div data-testid="collaborative-monaco" />,
+  })
+);
+
+vi.mock('../../../js/collaborative-editor/components/WorkflowEditor', () => ({
+  WorkflowEditor: () => <div data-testid="workflow-editor" />,
+}));
+
+vi.mock('../../../js/collaborative-editor/components/Header', () => ({
+  Header: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="header">{children}</div>
+  ),
+}));
+
+// Real triggers for the real handler, so the wiring between them is tested.
+vi.mock('../../../js/collaborative-editor/components/VersionDropdown', () => ({
+  VersionDropdown: ({
+    onVersionRestore,
+  }: {
+    onVersionRestore?: (version: number) => void;
+  }) => (
+    <>
+      <button data-testid="ask-restore-3" onClick={() => onVersionRestore?.(3)}>
+        Restore 3
+      </button>
+      <button data-testid="ask-restore-5" onClick={() => onVersionRestore?.(5)}>
+        Restore 5
+      </button>
+    </>
+  ),
+}));
+
+vi.mock('../../../js/collaborative-editor/hooks/useSessionContext', () => ({
+  useProject: () => ({ id: 'project-1', name: 'Test Project' }),
+  useLatestSnapshotLockVersion: () => 1,
+  useIsNewWorkflow: () => false,
+  usePermissions: () => ({ can_edit_workflow: true }),
+}));
+
+vi.mock('../../../js/collaborative-editor/hooks/useWorkflow', () => ({
+  useWorkflowActions: () => ({ restoreVersion, checkRestore }),
+  useWorkflowState: (selector: (state: unknown) => unknown) => {
+    const state = { workflow: { id: 'workflow-1', lock_version: 1 } };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../../js/collaborative-editor/hooks/useUI', () => ({
+  useIsRunPanelOpen: () => false,
+  useUICommands: () => ({ closeRunPanel: vi.fn() }),
+}));
+
+vi.mock('../../../js/collaborative-editor/hooks/useHistory', () => ({
+  useHistoryCommands: () => ({ closeRunViewer: vi.fn() }),
+}));
+
+vi.mock('../../../js/collaborative-editor/hooks/useVersionSelect', () => ({
+  useVersionSelect: () => vi.fn(),
+}));
+
+const webhook = {
+  id: 'trigger-1',
+  type: 'webhook',
+  custom_path: 'payments',
+  enabled: true,
+};
+
+function renderBreadcrumbs() {
+  return render(
+    <KeyboardProvider>
+      <BreadcrumbContent
+        workflowId="workflow-1"
+        workflowName="Test Workflow"
+        aiAssistantEnabled={false}
+      />
+    </KeyboardProvider>
+  );
+}
+
+describe('restore, wired up', () => {
+  beforeEach(() => {
+    urlState.reset();
+    checkRestore.mockReset();
+    restoreVersion.mockReset();
+    restoreVersion.mockResolvedValue({ lock_version: 2 });
+  });
+
+  test('shows the cost of the version being restored', async () => {
+    checkRestore.mockResolvedValue({
+      losing_triggers: [webhook],
+      returning_triggers: [],
+      version_number: 3,
+    });
+    const user = userEvent.setup();
+    renderBreadcrumbs();
+
+    await user.click(screen.getByTestId('ask-restore-3'));
+
+    expect(
+      await screen.findByTestId('restore-losing-triggers')
+    ).toHaveTextContent('the webhook at /payments');
+  });
+
+  test('a late answer for an abandoned version does not silence a real warning', async () => {
+    // v3's check is slow and empty; v5's is immediate and has a warning. The
+    // user cancels v3 and asks for v5, so the late v3 answer must be ignored.
+    let releaseV3: ((reply: CheckReply) => void) | null = null;
+
+    checkRestore.mockImplementation((version: number) => {
+      if (version === 3) {
+        return new Promise<CheckReply>(resolve => {
+          releaseV3 = resolve;
+        });
+      }
+
+      return Promise.resolve({
+        losing_triggers: [webhook],
+        returning_triggers: [],
+        version_number: 5,
+      });
+    });
+
+    const user = userEvent.setup();
+    renderBreadcrumbs();
+
+    await user.click(screen.getByTestId('ask-restore-3'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByTestId('ask-restore-5'));
+
+    expect(
+      await screen.findByTestId('restore-losing-triggers')
+    ).toBeInTheDocument();
+
+    // Let the late answer land and flush, or the assertion below passes on the
+    // state as it was before it arrived.
+    await act(async () => {
+      releaseV3?.({
+        losing_triggers: [],
+        returning_triggers: [],
+        version_number: 3,
+      });
+
+      await Promise.resolve();
+    });
+
+    // Still warning about v5's trigger, not blanked by v3's empty answer.
+    expect(screen.getByTestId('restore-losing-triggers')).toHaveTextContent(
+      'the webhook at /payments'
+    );
+  });
+
+  test('a failed check does not block the rollback', async () => {
+    checkRestore.mockRejectedValue(new Error('no answer'));
+    const user = userEvent.setup();
+    renderBreadcrumbs();
+
+    await user.click(screen.getByTestId('ask-restore-3'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /^Restore v3$/ })
+      ).toBeEnabled();
+    });
+  });
+});

--- a/assets/test/collaborative-editor/components/RestoreVersionDialog.test.tsx
+++ b/assets/test/collaborative-editor/components/RestoreVersionDialog.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * RestoreVersionDialog Tests
+ *
+ * Restoring is a deliberate rollback, not a mistake to be talked out of, so the
+ * dialog's job is to say what it costs. The cost that matters is the one nobody
+ * should discover afterwards: a trigger added since that version disappears and
+ * the URL built from it stops answering.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { RestoreVersionDialog } from '../../../js/collaborative-editor/components/RestoreVersionDialog';
+import type { LosingTrigger } from '../../../js/collaborative-editor/components/RestoreVersionDialog';
+import { KeyboardProvider } from '../../../js/collaborative-editor/keyboard';
+
+const onConfirm = vi.fn<() => Promise<boolean>>();
+const onCancel = vi.fn();
+
+function renderDialog(losingTriggers: LosingTrigger[] | null, isOpen = true) {
+  return render(
+    <KeyboardProvider>
+      <RestoreVersionDialog
+        isOpen={isOpen}
+        versionNumber={3}
+        losingTriggers={losingTriggers}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    </KeyboardProvider>
+  );
+}
+
+// This branch's Button does not forward data-* attributes yet (that is #4991),
+// so the confirm button is found by its accessible name.
+const confirmButton = () =>
+  screen.getByRole('button', { name: /^Restor(e|ing)/ });
+
+const webhook: LosingTrigger = {
+  id: 'trigger-1',
+  type: 'webhook',
+  custom_path: 'orders-in',
+  enabled: true,
+};
+
+const cron: LosingTrigger = {
+  id: 'trigger-2',
+  type: 'cron',
+  custom_path: null,
+  enabled: false,
+};
+
+describe('RestoreVersionDialog', () => {
+  beforeEach(() => {
+    onConfirm.mockReset();
+    onConfirm.mockResolvedValue(true);
+    onCancel.mockReset();
+  });
+
+  test('names the version being restored', () => {
+    renderDialog([]);
+
+    expect(screen.getByTestId('restore-version-dialog')).toHaveTextContent(
+      'Restore v3?'
+    );
+  });
+
+  test('will not let you confirm until the check has answered', () => {
+    renderDialog(null);
+
+    expect(screen.getByTestId('restore-checking')).toBeInTheDocument();
+    expect(confirmButton()).toBeDisabled();
+  });
+
+  test('names each trigger it will delete, and its URL', async () => {
+    renderDialog([webhook, cron]);
+
+    const warning = await screen.findByTestId('restore-losing-triggers');
+
+    expect(warning).toHaveTextContent('2 triggers will be deleted');
+    expect(warning).toHaveTextContent('the webhook at /orders-in');
+    expect(warning).toHaveTextContent('which is on now');
+    expect(warning).toHaveTextContent('a scheduled trigger');
+  });
+
+  test('says nothing about triggers when none are lost', () => {
+    renderDialog([]);
+
+    expect(
+      screen.queryByTestId('restore-losing-triggers')
+    ).not.toBeInTheDocument();
+    expect(confirmButton()).toBeEnabled();
+  });
+
+  test('confirming restores', async () => {
+    const user = userEvent.setup();
+    renderDialog([]);
+
+    await user.click(confirmButton());
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('a failed restore leaves the dialog usable', async () => {
+    onConfirm.mockResolvedValue(false);
+    const user = userEvent.setup();
+    renderDialog([]);
+
+    await user.click(confirmButton());
+
+    await waitFor(() => {
+      expect(confirmButton()).toBeEnabled();
+    });
+  });
+
+  test('cancelling restores nothing', async () => {
+    const user = userEvent.setup();
+    renderDialog([]);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/assets/test/collaborative-editor/components/RestoreVersionDialog.test.tsx
+++ b/assets/test/collaborative-editor/components/RestoreVersionDialog.test.tsx
@@ -12,25 +12,31 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { RestoreVersionDialog } from '../../../js/collaborative-editor/components/RestoreVersionDialog';
-import type { LosingTrigger } from '../../../js/collaborative-editor/components/RestoreVersionDialog';
+import type {
+  LosingTrigger,
+  RestoreCost,
+  ReturningTrigger,
+} from '../../../js/collaborative-editor/components/RestoreVersionDialog';
 import { KeyboardProvider } from '../../../js/collaborative-editor/keyboard';
 
 const onConfirm = vi.fn<() => Promise<boolean>>();
 const onCancel = vi.fn();
 
-function renderDialog(losingTriggers: LosingTrigger[] | null, isOpen = true) {
+function renderDialog(cost: RestoreCost | null, isOpen = true) {
   return render(
     <KeyboardProvider>
       <RestoreVersionDialog
         isOpen={isOpen}
         versionNumber={3}
-        losingTriggers={losingTriggers}
+        cost={cost}
         onConfirm={onConfirm}
         onCancel={onCancel}
       />
     </KeyboardProvider>
   );
 }
+
+const nothingLost: RestoreCost = { losing: [], returning: [] };
 
 // This branch's Button does not forward data-* attributes yet (that is #4991),
 // so the confirm button is found by its accessible name.
@@ -51,6 +57,12 @@ const cron: LosingTrigger = {
   enabled: false,
 };
 
+const returning: ReturningTrigger = {
+  id: 'trigger-3',
+  type: 'webhook',
+  custom_path: 'payments',
+};
+
 describe('RestoreVersionDialog', () => {
   beforeEach(() => {
     onConfirm.mockReset();
@@ -59,7 +71,7 @@ describe('RestoreVersionDialog', () => {
   });
 
   test('names the version being restored', () => {
-    renderDialog([]);
+    renderDialog(nothingLost);
 
     expect(screen.getByTestId('restore-version-dialog')).toHaveTextContent(
       'Restore v3?'
@@ -74,7 +86,7 @@ describe('RestoreVersionDialog', () => {
   });
 
   test('names each trigger it will delete, and its URL', async () => {
-    renderDialog([webhook, cron]);
+    renderDialog({ losing: [webhook, cron], returning: [] });
 
     const warning = await screen.findByTestId('restore-losing-triggers');
 
@@ -84,18 +96,33 @@ describe('RestoreVersionDialog', () => {
     expect(warning).toHaveTextContent('a scheduled trigger');
   });
 
+  test('names each trigger that comes back switched off, and why', async () => {
+    renderDialog({ losing: [], returning: [returning] });
+
+    const warning = await screen.findByTestId('restore-returning-triggers');
+
+    expect(warning).toHaveTextContent('comes back switched off');
+    expect(warning).toHaveTextContent('the webhook at /payments');
+    // A version never recorded which auth methods were attached, so bringing
+    // the URL back on would put it back without its authentication.
+    expect(warning).toHaveTextContent('authentication');
+  });
+
   test('says nothing about triggers when none are lost', () => {
-    renderDialog([]);
+    renderDialog(nothingLost);
 
     expect(
       screen.queryByTestId('restore-losing-triggers')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('restore-returning-triggers')
     ).not.toBeInTheDocument();
     expect(confirmButton()).toBeEnabled();
   });
 
   test('confirming restores', async () => {
     const user = userEvent.setup();
-    renderDialog([]);
+    renderDialog(nothingLost);
 
     await user.click(confirmButton());
 
@@ -107,7 +134,7 @@ describe('RestoreVersionDialog', () => {
   test('a failed restore leaves the dialog usable', async () => {
     onConfirm.mockResolvedValue(false);
     const user = userEvent.setup();
-    renderDialog([]);
+    renderDialog(nothingLost);
 
     await user.click(confirmButton());
 
@@ -118,7 +145,7 @@ describe('RestoreVersionDialog', () => {
 
   test('cancelling restores nothing', async () => {
     const user = userEvent.setup();
-    renderDialog([]);
+    renderDialog(nothingLost);
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
 

--- a/assets/test/collaborative-editor/components/VersionDropdown.test.tsx
+++ b/assets/test/collaborative-editor/components/VersionDropdown.test.tsx
@@ -58,6 +58,7 @@ const createMockVersion = (overrides?: Partial<Version>): Version => ({
   published_by: 'Test User',
   source_project: null,
   lock_version: 1,
+  restored_from_version_number: null,
   is_latest: false,
   ...overrides,
 });
@@ -299,11 +300,13 @@ describe('VersionDropdown', () => {
       const mockVersions: Version[] = [
         createMockVersion({
           lock_version: 5,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           lock_version: 4,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
@@ -384,18 +387,21 @@ describe('VersionDropdown', () => {
         createMockVersion({
           version_number: 3,
           lock_version: 30,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           version_number: 2,
           lock_version: 20,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
         createMockVersion({
           version_number: 1,
           lock_version: 10,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: false,
         }),
@@ -436,6 +442,7 @@ describe('VersionDropdown', () => {
           published_by: 'Ada Lovelace',
           source_project: 'sandy-sandbox',
           lock_version: 20,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
@@ -445,6 +452,7 @@ describe('VersionDropdown', () => {
           published_by: 'Grace Hopper',
           source_project: null,
           lock_version: 10,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
@@ -496,6 +504,7 @@ describe('VersionDropdown', () => {
           kind: 'go_live',
           published_by: 'Alan Turing',
           lock_version: 30,
+          restored_from_version_number: null,
           inserted_at: '2024-01-16T10:30:00Z',
           is_latest: true,
         }),
@@ -526,6 +535,7 @@ describe('VersionDropdown', () => {
           kind: 'go_live',
           published_by: null,
           lock_version: 10,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: true,
         }),
@@ -579,6 +589,7 @@ describe('VersionDropdown', () => {
         createMockVersion({
           version_number: 1,
           lock_version: 20,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
@@ -613,12 +624,14 @@ describe('VersionDropdown', () => {
         createMockVersion({
           version_number: 3,
           lock_version: 30,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           version_number: 1,
           lock_version: 22,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
@@ -649,14 +662,19 @@ describe('VersionDropdown', () => {
       const selectedButton = screen
         .getAllByRole('menuitem')
         .find(btn => btn.textContent?.includes('v1'));
-      expect(selectedButton).toHaveClass('bg-primary-50', 'text-primary-900');
+      // The row highlight sits on the wrapper, which also holds the per-row
+      // Restore action; the text colour stays on the pinning button.
+      expect(selectedButton).toHaveClass('text-primary-900');
+      expect(selectedButton?.parentElement).toHaveClass('bg-primary-50');
       expect(selectedButton?.querySelector('.hero-check')).toBeInTheDocument();
 
       // The newest row is NOT active while pinned to an older version
       const newestButton = screen
         .getAllByRole('menuitem')
         .find(btn => btn.textContent?.includes('v3'));
-      expect(newestButton?.querySelector('.hero-check')).not.toBeInTheDocument();
+      expect(
+        newestButton?.querySelector('.hero-check')
+      ).not.toBeInTheDocument();
     });
 
     test('marks the newest row when unpinned (following live)', async () => {
@@ -666,12 +684,14 @@ describe('VersionDropdown', () => {
         createMockVersion({
           version_number: 3,
           lock_version: 30,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           version_number: 2,
           lock_version: 20,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
@@ -693,7 +713,8 @@ describe('VersionDropdown', () => {
       const newestButton = screen
         .getAllByRole('menuitem')
         .find(btn => btn.textContent?.includes('v3'));
-      expect(newestButton).toHaveClass('bg-primary-50', 'text-primary-900');
+      expect(newestButton).toHaveClass('text-primary-900');
+      expect(newestButton?.parentElement).toHaveClass('bg-primary-50');
       expect(newestButton?.querySelector('.hero-check')).toBeInTheDocument();
 
       const olderButton = screen
@@ -709,12 +730,14 @@ describe('VersionDropdown', () => {
         createMockVersion({
           version_number: 5,
           lock_version: 50,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           version_number: 4,
           lock_version: 40,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
@@ -756,6 +779,7 @@ describe('VersionDropdown', () => {
       const mockVersions: Version[] = [
         createMockVersion({
           lock_version: 5,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
@@ -792,12 +816,14 @@ describe('VersionDropdown', () => {
         createMockVersion({
           version_number: 2,
           lock_version: 50,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           version_number: 1,
           lock_version: 30,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: false,
         }),
@@ -834,6 +860,7 @@ describe('VersionDropdown', () => {
       const mockVersions: Version[] = [
         createMockVersion({
           lock_version: 5,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
@@ -936,6 +963,80 @@ describe('VersionDropdown', () => {
     });
   });
 
+  describe('restoring a version', () => {
+    // Three releases, newest first, matching what the channel sends.
+    const threeVersions = () => {
+      mockUseVersions.mockReturnValue([
+        createMockVersion({
+          version_number: 3,
+          is_latest: true,
+          lock_version: 3,
+        }),
+        createMockVersion({ version_number: 2, lock_version: 2 }),
+        createMockVersion({ version_number: 1, lock_version: 1 }),
+      ]);
+    };
+
+    const renderWithRestore = (onVersionRestore?: (v: number) => void) =>
+      render(
+        <VersionDropdown
+          currentVersion={3}
+          latestVersion={3}
+          onVersionSelect={mockOnVersionSelect}
+          {...(onVersionRestore && { onVersionRestore })}
+        />
+      );
+
+    test('offers Restore on every version but the newest', async () => {
+      const onVersionRestore = vi.fn();
+      const user = userEvent.setup();
+      threeVersions();
+
+      renderWithRestore(onVersionRestore);
+      await user.click(screen.getByRole('button'));
+
+      // The newest release is what is live, so there is nothing to put back.
+      expect(screen.queryByTestId('restore-version-3')).not.toBeInTheDocument();
+      expect(screen.getByTestId('restore-version-2')).toBeInTheDocument();
+      expect(screen.getByTestId('restore-version-1')).toBeInTheDocument();
+    });
+
+    test('asks to restore the version whose row was clicked', async () => {
+      const onVersionRestore = vi.fn();
+      const user = userEvent.setup();
+      threeVersions();
+
+      renderWithRestore(onVersionRestore);
+      await user.click(screen.getByRole('button'));
+      await user.click(screen.getByTestId('restore-version-2'));
+
+      expect(onVersionRestore).toHaveBeenCalledWith(2);
+    });
+
+    test('restoring does not also pin the version', async () => {
+      const onVersionRestore = vi.fn();
+      const user = userEvent.setup();
+      threeVersions();
+
+      renderWithRestore(onVersionRestore);
+      await user.click(screen.getByRole('button'));
+      await user.click(screen.getByTestId('restore-version-2'));
+
+      // Two separate actions on one row: reading it and putting it back.
+      expect(mockOnVersionSelect).not.toHaveBeenCalled();
+    });
+
+    test('offers no Restore when the viewer cannot edit', async () => {
+      const user = userEvent.setup();
+      threeVersions();
+
+      renderWithRestore();
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.queryByTestId('restore-version-2')).not.toBeInTheDocument();
+    });
+  });
+
   describe('accessibility', () => {
     test('button has correct ARIA attributes', () => {
       render(
@@ -982,6 +1083,7 @@ describe('VersionDropdown', () => {
       mockUseVersions.mockReturnValue([
         createMockVersion({
           lock_version: 1,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -1011,11 +1113,13 @@ describe('VersionDropdown', () => {
       mockUseVersions.mockReturnValue([
         createMockVersion({
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: true,
         }),
         createMockVersion({
           lock_version: 1,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: false,
         }),

--- a/assets/test/collaborative-editor/stores/createSessionContextStore.versions.test.ts
+++ b/assets/test/collaborative-editor/stores/createSessionContextStore.versions.test.ts
@@ -33,6 +33,7 @@ const makeVersion = (overrides: Partial<Version> = {}): Version => ({
   published_by: 'Test User',
   source_project: null,
   lock_version: 1,
+  restored_from_version_number: null,
   is_latest: false,
   ...overrides,
 });
@@ -48,18 +49,21 @@ describe('createSessionContextStore - Version Management', () => {
           kind: 'promote',
           source_project: 'staging',
           lock_version: 5,
+          restored_from_version_number: null,
           inserted_at: '2024-01-15T10:30:00Z',
           is_latest: true,
         }),
         makeVersion({
           version_number: 2,
           lock_version: 4,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: false,
         }),
         makeVersion({
           version_number: 1,
           lock_version: 3,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: false,
         }),
@@ -93,6 +97,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 3,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -177,6 +182,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -233,6 +239,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -242,12 +249,14 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 2,
           lock_version: 3,
+          restored_from_version_number: null,
           inserted_at: '2024-01-14T10:30:00Z',
           is_latest: true,
         }),
         makeVersion({
           version_number: 1,
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: false,
         }),
@@ -303,6 +312,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 1,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -363,6 +373,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 1,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -401,6 +412,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 1,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -449,12 +461,14 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 2,
           lock_version: 3,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
         makeVersion({
           version_number: 1,
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-12T10:30:00Z',
           is_latest: false,
         }),
@@ -498,6 +512,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),
@@ -544,6 +559,7 @@ describe('createSessionContextStore - Version Management', () => {
         makeVersion({
           version_number: 1,
           lock_version: 2,
+          restored_from_version_number: null,
           inserted_at: '2024-01-13T10:30:00Z',
           is_latest: true,
         }),

--- a/assets/test/collaborative-editor/utils/releaseLabel.test.tsx
+++ b/assets/test/collaborative-editor/utils/releaseLabel.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * releaseActionLabel Tests
+ *
+ * One label set shared by the version dropdown and the Recent History markers,
+ * so the two surfaces read identically.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { releaseActionLabel } from '../../../js/collaborative-editor/utils/releaseLabel';
+
+function renderLabel(version: Parameters<typeof releaseActionLabel>[0]) {
+  render(<span data-testid="label">{releaseActionLabel(version)}</span>);
+
+  return screen.getByTestId('label');
+}
+
+describe('releaseActionLabel', () => {
+  test('a restore names the version it put back', () => {
+    const label = renderLabel({
+      kind: 'restore',
+      version_number: 4,
+      source_project: null,
+      restored_from_version_number: 2,
+    });
+
+    expect(label).toHaveTextContent('Restored v2');
+  });
+
+  test('a promote names the sandbox it came from', () => {
+    const label = renderLabel({
+      kind: 'promote',
+      version_number: 3,
+      source_project: 'fixing-the-mapping',
+      restored_from_version_number: null,
+    });
+
+    expect(label).toHaveTextContent('Promoted sandbox fixing-the-mapping');
+  });
+
+  test('the first release is the initial go-live', () => {
+    const label = renderLabel({
+      kind: 'go_live',
+      version_number: 1,
+      source_project: null,
+      restored_from_version_number: null,
+    });
+
+    expect(label).toHaveTextContent('Initial go-live');
+  });
+
+  test('a later go-live is published from draft', () => {
+    const label = renderLabel({
+      kind: 'go_live',
+      version_number: 2,
+      source_project: null,
+      restored_from_version_number: null,
+    });
+
+    expect(label).toHaveTextContent('Published from draft');
+  });
+});

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -23,6 +23,7 @@ defmodule Lightning.Workflows do
   alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Trigger
   alias Lightning.Workflows.Workflow
+  alias Lightning.Workflows.WorkflowRelease
   alias Lightning.Workflows.WorkflowReleases
   alias Lightning.WorkflowVersions
   alias Lightning.WorkOrder
@@ -364,27 +365,32 @@ defmodule Lightning.Workflows do
   # updated the workflow row, so two concurrent publishes cannot read the same
   # max(version_number).
   defp maybe_record_go_live_release(multi, opts) do
-    if Keyword.get(opts, :record_release) == :go_live do
-      Multi.run(multi, :workflow_release, fn repo, changes ->
-        %{workflow: workflow, actor: actor} = changes
-
-        case changes[:snapshot] do
-          nil ->
-            {:ok, nil}
-
-          snapshot ->
-            WorkflowReleases.insert_release(repo, %{
-              workflow_id: workflow.id,
-              kind: :go_live,
-              snapshot_id: snapshot.id,
-              published_by_id: actor_id(actor),
-              source_project_id: nil
-            })
-        end
-      end)
-    else
-      multi
+    case Keyword.get(opts, :record_release) do
+      nil -> multi
+      :go_live -> record_release(multi, :go_live, nil)
+      {:restore, from} -> record_release(multi, :restore, from)
     end
+  end
+
+  defp record_release(multi, kind, restored_from) do
+    Multi.run(multi, :workflow_release, fn repo, changes ->
+      %{workflow: workflow, actor: actor} = changes
+
+      case changes[:snapshot] do
+        nil ->
+          {:ok, nil}
+
+        snapshot ->
+          WorkflowReleases.insert_release(repo, %{
+            workflow_id: workflow.id,
+            kind: kind,
+            snapshot_id: snapshot.id,
+            published_by_id: actor_id(actor),
+            source_project_id: nil,
+            restored_from_version_number: restored_from
+          })
+      end
+    end)
   end
 
   defp actor_id(%Lightning.Accounts.User{id: id}), do: id
@@ -1388,6 +1394,40 @@ defmodule Lightning.Workflows do
     |> update_triggers_enabled_state(true)
     |> Ecto.Changeset.put_change(:state, :live)
     |> save_workflow(actor, record_release: :go_live)
+  end
+
+  @doc """
+  Puts an earlier version's content back, without taking the workflow offline.
+
+  A restore is a publish, not an edit. It writes the chosen release's snapshot
+  in as the workflow's content, leaves the lifecycle state and every surviving
+  trigger's enabled flag alone, and records the result as the next version
+  labelled with the version it came from. The bad version stays in the history
+  rather than being erased, so the trail reads forward.
+
+  Anything the snapshot does not hold is deleted, which is what makes this a
+  revert rather than a merge. A trigger added since that version goes, and the
+  URL built from it stops answering.
+
+  The caller must authorise this and must reconcile any open editor afterwards,
+  the way a promote does. `save_workflow/3` is asked to skip its own reconcile
+  because a wholesale replacement produces changes the incremental reconciler
+  cannot express.
+  """
+  @spec restore_version(Workflow.t(), WorkflowRelease.t(), struct()) ::
+          {:ok, Workflow.t()} | {:error, Ecto.Changeset.t(Workflow.t())}
+  def restore_version(
+        %Workflow{} = workflow,
+        %WorkflowRelease{snapshot: %Snapshot{} = snapshot} = release,
+        actor
+      ) do
+    workflow
+    |> Repo.preload([:triggers, :jobs, :edges])
+    |> change_workflow(Snapshot.to_workflow_attrs(snapshot))
+    |> save_workflow(actor,
+      skip_reconcile: true,
+      record_release: {:restore, release.version_number}
+    )
   end
 
   @doc """

--- a/lib/lightning/workflows.ex
+++ b/lib/lightning/workflows.ex
@@ -1421,8 +1421,12 @@ defmodule Lightning.Workflows do
         %WorkflowRelease{snapshot: %Snapshot{} = snapshot} = release,
         actor
       ) do
-    workflow
-    |> Repo.preload([:triggers, :jobs, :edges])
+    # Read the row again rather than trusting the caller's struct, which is
+    # usually the one a channel joined on. The replacement is computed against
+    # these children, so stale ones leave rows behind that the snapshot does not
+    # hold, and a stale lock_version turns the write into a StaleEntryError.
+    workflow.id
+    |> get_workflow(include: [:triggers, :jobs, :edges])
     |> change_workflow(Snapshot.to_workflow_attrs(snapshot))
     |> save_workflow(actor,
       skip_reconcile: true,

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -321,19 +321,44 @@ defmodule Lightning.Workflows.Snapshot do
   Trigger `enabled` is deliberately left out. A restore is a publish into a live
   workflow, and putting an old enabled flag back would take production offline
   in the middle of a rollback. It is also what a promote does, which is the
-  behaviour this mirrors.
+  behaviour this mirrors. A trigger the restore has to re-create has no current
+  state to keep, and it arrives off, because a snapshot does not record which
+  webhook auth methods were attached to it: bringing the URL back on without
+  its authentication would be worse than bringing it back off.
+
+  `positions` is only written when the snapshot holds them. An older snapshot
+  predating the column, or one published while the canvas was on auto-layout,
+  holds none, and writing that nil would wipe a hand-arranged canvas.
   """
   @spec to_workflow_attrs(t()) :: map()
   def to_workflow_attrs(%__MODULE__{} = snapshot) do
     %{
       name: snapshot.name,
-      positions: snapshot.positions,
       jobs: Enum.map(snapshot.jobs, &child_attrs(&1, @job_write_fields)),
-      triggers:
-        Enum.map(snapshot.triggers, &child_attrs(&1, @trigger_write_fields)),
+      triggers: Enum.map(snapshot.triggers, &trigger_attrs/1),
       edges: Enum.map(snapshot.edges, &child_attrs(&1, @edge_write_fields))
     }
+    |> maybe_put_positions(snapshot.positions)
   end
+
+  defp maybe_put_positions(attrs, nil), do: attrs
+
+  defp maybe_put_positions(attrs, positions),
+    do: Map.put(attrs, :positions, positions)
+
+  # The response config is an embed, so it has to be written as one or the
+  # trigger keeps the codes from the version being rolled away from.
+  defp trigger_attrs(trigger) do
+    trigger
+    |> child_attrs(@trigger_write_fields)
+    |> Map.put(
+      :webhook_response_config,
+      embed_attrs(trigger.webhook_response_config)
+    )
+  end
+
+  defp embed_attrs(nil), do: nil
+  defp embed_attrs(embed), do: Map.from_struct(embed)
 
   defp child_attrs(child, fields) do
     child |> Map.from_struct() |> Map.take(fields)

--- a/lib/lightning/workflows/snapshot.ex
+++ b/lib/lightning/workflows/snapshot.ex
@@ -277,4 +277,65 @@ defmodule Lightning.Workflows.Snapshot do
       {:ok, get_current_query(workflow) |> repo.one()}
     end)
   end
+
+  # Everything a restore writes back. Timestamps are left to the live rows, and
+  # trigger `enabled` is deliberately absent: see `to_workflow_attrs/1`.
+  @job_write_fields [
+    :id,
+    :name,
+    :body,
+    :adaptor,
+    :project_credential_id,
+    :keychain_credential_id
+  ]
+
+  @trigger_write_fields [
+    :id,
+    :comment,
+    :custom_path,
+    :cron_expression,
+    :cron_cursor_job_id,
+    :type,
+    :webhook_reply
+  ]
+
+  @edge_write_fields [
+    :id,
+    :source_job_id,
+    :source_trigger_id,
+    :target_job_id,
+    :condition_type,
+    :condition_expression,
+    :condition_label,
+    :enabled
+  ]
+
+  @doc """
+  Turns a snapshot into attributes that can be written back as a workflow's
+  current content.
+
+  The write-side twin of the reader that loads a pinned version. Collections are
+  complete, so `on_replace` deletes anything the snapshot does not hold: that is
+  what makes a restore a revert rather than a merge.
+
+  Trigger `enabled` is deliberately left out. A restore is a publish into a live
+  workflow, and putting an old enabled flag back would take production offline
+  in the middle of a rollback. It is also what a promote does, which is the
+  behaviour this mirrors.
+  """
+  @spec to_workflow_attrs(t()) :: map()
+  def to_workflow_attrs(%__MODULE__{} = snapshot) do
+    %{
+      name: snapshot.name,
+      positions: snapshot.positions,
+      jobs: Enum.map(snapshot.jobs, &child_attrs(&1, @job_write_fields)),
+      triggers:
+        Enum.map(snapshot.triggers, &child_attrs(&1, @trigger_write_fields)),
+      edges: Enum.map(snapshot.edges, &child_attrs(&1, @edge_write_fields))
+    }
+  end
+
+  defp child_attrs(child, fields) do
+    child |> Map.from_struct() |> Map.take(fields)
+  end
 end

--- a/lib/lightning/workflows/workflow_release.ex
+++ b/lib/lightning/workflows/workflow_release.ex
@@ -28,11 +28,14 @@ defmodule Lightning.Workflows.WorkflowRelease do
           inserted_at: DateTime.t() | nil
         }
 
-  @kinds [:go_live, :promote]
+  @kinds [:go_live, :promote, :restore]
 
   schema "workflow_releases" do
     field :version_number, :integer
     field :kind, Ecto.Enum, values: @kinds
+
+    # Set only by a :restore, naming the version it put back.
+    field :restored_from_version_number, :integer
 
     belongs_to :workflow, Workflow
     belongs_to :snapshot, Snapshot
@@ -51,7 +54,8 @@ defmodule Lightning.Workflows.WorkflowRelease do
       :workflow_id,
       :snapshot_id,
       :published_by_id,
-      :source_project_id
+      :source_project_id,
+      :restored_from_version_number
     ])
     |> validate_required([:version_number, :kind, :workflow_id, :snapshot_id])
     |> validate_number(:version_number, greater_than: 0)

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -12,6 +12,7 @@ defmodule LightningWeb.WorkflowChannel do
   alias Lightning.Collaborate
   alias Lightning.Collaboration.Session
   alias Lightning.Collaboration.Utils
+  alias Lightning.Collaboration.WorkflowReconciler
   alias Lightning.Collaboration.WorkflowResolver
   alias Lightning.Policies.Permissions
   alias Lightning.Policies.ProjectUsers
@@ -532,6 +533,60 @@ defmodule LightningWeb.WorkflowChannel do
         _ -> %{diverged: false, parent_name: nil}
       end
     end)
+  end
+
+  # Advisory, so the confirmation can name what a restore is about to destroy
+  # before anyone agrees to it. Answers about the workflow as it stands, not the
+  # row this socket joined on.
+  @impl true
+  def handle_in("request_restore_check", %{"version_number" => number}, socket)
+      when is_integer(number) do
+    workflow = socket.assigns.workflow
+
+    async_task(socket, "request_restore_check", fn ->
+      with :ok <- authorize_edit_workflow(socket),
+           %WorkflowRelease{snapshot: %_{} = snapshot} <-
+             WorkflowReleases.get_by_version_number(workflow.id, number) do
+        %{
+          losing_triggers: render_losing_triggers(workflow, snapshot),
+          version_number: number
+        }
+      else
+        _ -> %{losing_triggers: [], version_number: number}
+      end
+    end)
+  end
+
+  # A restore is a publish, not an edit: it writes an earlier version's content
+  # into the live workflow and leaves it live. Gated on :edit_workflow rather
+  # than authorize_content_edit/1, which refuses a live workflow outside a
+  # sandbox and would refuse the only case that matters. go_live and promote
+  # answer the same question the same way.
+  @impl true
+  def handle_in("restore_version", %{"version_number" => number}, socket)
+      when is_integer(number) do
+    workflow = socket.assigns.workflow
+    user = socket.assigns.current_user
+
+    with :ok <- authorize_edit_workflow(socket),
+         %WorkflowRelease{snapshot: %_{}} = release <-
+           WorkflowReleases.get_by_version_number(workflow.id, number),
+         {:ok, restored} <- Workflows.restore_version(workflow, release, user) do
+      # The content was replaced wholesale, which the incremental reconciler
+      # cannot express, so ask every open editor to reload from the database.
+      WorkflowReconciler.request_reconciliation(workflow.id)
+
+      broadcast_from!(socket, "workflow_saved", %{
+        latest_snapshot_lock_version: restored.lock_version,
+        workflow: restored
+      })
+
+      {:reply, {:ok, %{lock_version: restored.lock_version}},
+       assign(socket, :workflow, restored)}
+    else
+      nil -> workflow_error_reply(socket, {:error, :version_not_found})
+      error -> workflow_error_reply(socket, error)
+    end
   end
 
   @impl true
@@ -1164,6 +1219,7 @@ defmodule LightningWeb.WorkflowChannel do
               "request_history",
               "request_versions",
               "request_promote_check",
+              "request_restore_check",
               "request_trigger_auth_methods",
               "get_limits"
             ] do
@@ -1289,6 +1345,27 @@ defmodule LightningWeb.WorkflowChannel do
     }
   end
 
+  # A trigger the snapshot does not hold is deleted by the restore, and the URL
+  # built from it stops answering. Nobody should discover that afterwards.
+  defp render_losing_triggers(workflow, snapshot) do
+    kept = MapSet.new(snapshot.triggers, & &1.id)
+
+    # `force` because the assign is the workflow as it was at join, and this
+    # answers about the workflow as it stands.
+    workflow
+    |> Lightning.Repo.preload(:triggers, force: true)
+    |> Map.fetch!(:triggers)
+    |> Enum.reject(&MapSet.member?(kept, &1.id))
+    |> Enum.map(
+      &%{
+        id: &1.id,
+        type: &1.type,
+        custom_path: &1.custom_path,
+        enabled: &1.enabled
+      }
+    )
+  end
+
   defp render_release(release, is_latest) do
     %{
       version_number: release.version_number,
@@ -1299,6 +1376,7 @@ defmodule LightningWeb.WorkflowChannel do
       # The client pins a version via `?v=<version_number>`; lock_version is kept
       # here only as informational snapshot metadata.
       lock_version: release.snapshot && release.snapshot.lock_version,
+      restored_from_version_number: release.restored_from_version_number,
       is_latest: is_latest
     }
   end
@@ -1484,6 +1562,15 @@ defmodule LightningWeb.WorkflowChannel do
       %{
         errors: format_changeset_errors(changeset),
         type: determine_error_type(changeset)
+      }}, socket}
+  end
+
+  defp workflow_error_reply(socket, {:error, :version_not_found}) do
+    {:reply,
+     {:error,
+      %{
+        errors: %{base: ["That version no longer exists"]},
+        type: "version_not_found"
       }}, socket}
   end
 

--- a/lib/lightning_web/channels/workflow_channel.ex
+++ b/lib/lightning_web/channels/workflow_channel.ex
@@ -549,10 +549,12 @@ defmodule LightningWeb.WorkflowChannel do
              WorkflowReleases.get_by_version_number(workflow.id, number) do
         %{
           losing_triggers: render_losing_triggers(workflow, snapshot),
+          returning_triggers: render_returning_triggers(workflow, snapshot),
           version_number: number
         }
       else
-        _ -> %{losing_triggers: [], version_number: number}
+        _ ->
+          %{losing_triggers: [], returning_triggers: [], version_number: number}
       end
     end)
   end
@@ -571,7 +573,7 @@ defmodule LightningWeb.WorkflowChannel do
     with :ok <- authorize_edit_workflow(socket),
          %WorkflowRelease{snapshot: %_{}} = release <-
            WorkflowReleases.get_by_version_number(workflow.id, number),
-         {:ok, restored} <- Workflows.restore_version(workflow, release, user) do
+         {:ok, restored} <- restore_or_conflict(workflow, release, user) do
       # The content was replaced wholesale, which the incremental reconciler
       # cannot express, so ask every open editor to reload from the database.
       WorkflowReconciler.request_reconciliation(workflow.id)
@@ -581,8 +583,15 @@ defmodule LightningWeb.WorkflowChannel do
         workflow: restored
       })
 
-      {:reply, {:ok, %{lock_version: restored.lock_version}},
-       assign(socket, :workflow, restored)}
+      socket = assign(socket, :workflow, restored)
+
+      # The restoring client is excluded from the broadcast, and without this
+      # its idea of the latest version stays behind: the version chip would
+      # read as "you are on an old version" straight after a rollback, and the
+      # dropdown would still offer Restore on the version now live.
+      push(socket, "session_context_updated", build_session_context(socket))
+
+      {:reply, {:ok, %{lock_version: restored.lock_version}}, socket}
     else
       nil -> workflow_error_reply(socket, {:error, :version_not_found})
       error -> workflow_error_reply(socket, error)
@@ -1345,6 +1354,16 @@ defmodule LightningWeb.WorkflowChannel do
     }
   end
 
+  # save_workflow deliberately lets Ecto.StaleEntryError through, and the
+  # collaborative editor saves on a debounce, so a second person typing is
+  # enough to collide with a restore. Unrescued it kills the channel and the
+  # client waits out its timeout for a reply that never comes.
+  defp restore_or_conflict(workflow, release, user) do
+    Workflows.restore_version(workflow, release, user)
+  rescue
+    Ecto.StaleEntryError -> {:error, :workflow_moved_on}
+  end
+
   # A trigger the snapshot does not hold is deleted by the restore, and the URL
   # built from it stops answering. Nobody should discover that afterwards.
   defp render_losing_triggers(workflow, snapshot) do
@@ -1364,6 +1383,23 @@ defmodule LightningWeb.WorkflowChannel do
         enabled: &1.enabled
       }
     )
+  end
+
+  # A trigger the snapshot holds and the workflow no longer does is re-created
+  # by the restore, and it arrives off, without whatever webhook auth methods
+  # were once attached to it: a snapshot never recorded those. So the URL comes
+  # back inert and has to be switched on deliberately once its authentication
+  # is back.
+  defp render_returning_triggers(workflow, snapshot) do
+    live =
+      workflow
+      |> Lightning.Repo.preload(:triggers, force: true)
+      |> Map.fetch!(:triggers)
+      |> MapSet.new(& &1.id)
+
+    snapshot.triggers
+    |> Enum.reject(&MapSet.member?(live, &1.id))
+    |> Enum.map(&%{id: &1.id, type: &1.type, custom_path: &1.custom_path})
   end
 
   defp render_release(release, is_latest) do
@@ -1562,6 +1598,17 @@ defmodule LightningWeb.WorkflowChannel do
       %{
         errors: format_changeset_errors(changeset),
         type: determine_error_type(changeset)
+      }}, socket}
+  end
+
+  defp workflow_error_reply(socket, {:error, :workflow_moved_on}) do
+    {:reply,
+     {:error,
+      %{
+        errors: %{
+          base: ["Someone else saved this workflow. Try the restore again."]
+        },
+        type: "workflow_moved_on"
       }}, socket}
   end
 

--- a/priv/repo/migrations/20260908170138_add_restored_from_to_workflow_releases.exs
+++ b/priv/repo/migrations/20260908170138_add_restored_from_to_workflow_releases.exs
@@ -1,0 +1,11 @@
+defmodule Lightning.Repo.Migrations.AddRestoredFromToWorkflowReleases do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workflow_releases) do
+      # Which version this one put back. Only a :restore release sets it, so the
+      # trail reads forward and the version it came from stays in the history.
+      add :restored_from_version_number, :integer
+    end
+  end
+end

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -128,6 +128,101 @@ defmodule Lightning.WorkflowsTest do
              |> Enum.any?(&(&1.type == :cron))
     end
 
+    test "a re-created trigger comes back off, because its auth is not restored",
+         %{user: user} do
+      workflow = insert(:simple_workflow)
+      [original] = Repo.preload(workflow, :triggers).triggers
+      {live, v1} = publish(workflow, user)
+
+      # Delete the trigger v1 held, and add another in its place.
+      {:ok, replaced} =
+        live
+        |> Repo.preload([:triggers, :jobs, :edges])
+        |> Workflows.change_workflow(%{
+          triggers: [%{type: :cron, cron_expression: "0 * * * *"}]
+        })
+        |> Workflows.save_workflow(user)
+
+      refute Repo.reload(original)
+
+      {:ok, restored} = Workflows.restore_version(replaced, v1, user)
+
+      back = Repo.preload(restored, :triggers, force: true).triggers
+      assert [%{id: id, enabled: false}] = back
+      assert id == original.id
+
+      # A snapshot never recorded which webhook auth methods were attached, so
+      # switching this on for the user would put the URL back without its
+      # authentication. It comes back inert and the dialog says so.
+      assert restored.state == :live
+    end
+
+    test "does not wipe the canvas when the restored version has no positions",
+         %{user: user} do
+      workflow = insert(:simple_workflow)
+      {live, v1} = publish(workflow, user)
+
+      snapshot = Repo.preload(v1, :snapshot).snapshot
+      assert is_nil(snapshot.positions)
+
+      {:ok, arranged} =
+        live
+        |> Repo.preload([:triggers, :jobs, :edges])
+        |> Workflows.change_workflow(%{
+          positions: %{"node-a" => %{"x" => 10, "y" => 20}}
+        })
+        |> Workflows.save_workflow(user)
+
+      {:ok, restored} = Workflows.restore_version(arranged, v1, user)
+
+      # Writing the snapshot's nil would drop the layout back to auto, with no
+      # way back.
+      assert restored.positions == %{"node-a" => %{"x" => 10, "y" => 20}}
+    end
+
+    test "puts the webhook response config back", %{user: user} do
+      workflow = insert(:simple_workflow)
+      [trigger] = Repo.preload(workflow, :triggers).triggers
+
+      {:ok, configured} =
+        workflow
+        |> Repo.preload([:triggers, :jobs, :edges])
+        |> Workflows.change_workflow(%{
+          triggers: [
+            %{
+              id: trigger.id,
+              webhook_reply: :after_completion,
+              webhook_response_config: %{success_code: 202, error_code: 422}
+            }
+          ]
+        })
+        |> Workflows.save_workflow(user)
+
+      {live, v1} = publish(configured, user)
+
+      {:ok, changed} =
+        live
+        |> Repo.preload([:triggers, :jobs, :edges])
+        |> Workflows.change_workflow(%{
+          triggers: [
+            %{
+              id: trigger.id,
+              webhook_reply: :after_completion,
+              webhook_response_config: %{success_code: 500, error_code: 599}
+            }
+          ]
+        })
+        |> Workflows.save_workflow(user)
+
+      {:ok, restored} = Workflows.restore_version(changed, v1, user)
+
+      # An embed is left alone when its key is absent, so omitting it left the
+      # trigger replying with the codes from the version being rolled away from.
+      [back] = Repo.preload(restored, :triggers, force: true).triggers
+      assert back.webhook_response_config.success_code == 202
+      assert back.webhook_response_config.error_code == 422
+    end
+
     test "records the restore as the next version, naming the one it came from",
          %{user: user} do
       {live, v1} = publish(insert(:simple_workflow), user)

--- a/test/lightning/workflows_test.exs
+++ b/test/lightning/workflows_test.exs
@@ -19,6 +19,143 @@ defmodule Lightning.WorkflowsTest do
   alias Lightning.Workflows.WorkflowReleases
   alias Lightning.WorkOrder
 
+  describe "restore_version/3" do
+    setup do
+      %{user: insert(:user)}
+    end
+
+    # Publishes the workflow as it stands and hands back the release, so a test
+    # can restore to it later.
+    defp publish(workflow, user) do
+      {:ok, live} = Workflows.go_live(workflow, user)
+      [release] = WorkflowReleases.list_for_workflow(live)
+      {live, release}
+    end
+
+    test "puts the old content back without taking the workflow offline", %{
+      user: user
+    } do
+      {live, v1} = publish(insert(:simple_workflow), user)
+      [job] = Repo.preload(live, :jobs).jobs
+
+      {:ok, changed} =
+        live
+        |> Workflows.change_workflow(%{
+          jobs: [%{id: job.id, body: "// broken by a bad go-live"}]
+        })
+        |> Workflows.save_workflow(user)
+
+      {:ok, restored} = Workflows.restore_version(changed, v1, user)
+
+      assert [%{body: body}] = Repo.preload(restored, :jobs, force: true).jobs
+      assert body == job.body
+      refute body =~ "broken"
+
+      # The whole point: a rollback must not take production offline.
+      assert restored.state == :live
+
+      assert Repo.preload(restored, :triggers, force: true).triggers
+             |> Enum.all?(& &1.enabled)
+    end
+
+    test "leaves a trigger that was off in the restored version switched on", %{
+      user: user
+    } do
+      workflow = insert(:simple_workflow)
+      [trigger] = Repo.preload(workflow, :triggers).triggers
+
+      # The version being restored has to have captured a DISABLED trigger, and
+      # go_live always enables, so publish the snapshot the draft save took. A
+      # promote of a sandbox whose triggers were off lands in exactly this state.
+      {:ok, off} =
+        workflow
+        |> Workflows.update_triggers_enabled_state(false)
+        |> Ecto.Changeset.put_change(:state, :draft)
+        |> Workflows.save_workflow(user)
+
+      draft_snapshot = Snapshot.get_current_for(off)
+      refute draft_snapshot.triggers |> Enum.any?(& &1.enabled)
+
+      {:ok, v1} =
+        WorkflowReleases.insert_release(Repo, %{
+          workflow_id: off.id,
+          kind: :promote,
+          snapshot_id: draft_snapshot.id,
+          published_by_id: user.id
+        })
+
+      {:ok, live} = Workflows.go_live(off, user)
+      assert Repo.reload!(trigger).enabled
+
+      {:ok, restored} =
+        Workflows.restore_version(live, Repo.preload(v1, :snapshot), user)
+
+      # Restoring an old enabled flag would stop production receiving in the
+      # middle of a rollback, so the surviving trigger keeps the state it has.
+      assert Repo.reload!(trigger).enabled
+      assert restored.state == :live
+    end
+
+    test "deletes a trigger added after the restored version", %{user: user} do
+      {live, v1} = publish(insert(:simple_workflow), user)
+
+      {:ok, with_cron} =
+        live
+        |> Workflows.change_workflow(%{
+          triggers: [
+            %{
+              type: :cron,
+              cron_expression: "0 * * * *",
+              custom_path: "added-later"
+            }
+          ]
+        })
+        |> Workflows.save_workflow(user)
+
+      added =
+        Repo.preload(with_cron, :triggers, force: true).triggers
+        |> Enum.find(&(&1.type == :cron))
+
+      assert added
+
+      {:ok, restored} = Workflows.restore_version(with_cron, v1, user)
+
+      # Correct behaviour for a revert, and the reason the UI has to say so
+      # before it happens: the URL built from this trigger stops answering.
+      refute Repo.reload(added)
+
+      refute Repo.preload(restored, :triggers, force: true).triggers
+             |> Enum.any?(&(&1.type == :cron))
+    end
+
+    test "records the restore as the next version, naming the one it came from",
+         %{user: user} do
+      {live, v1} = publish(insert(:simple_workflow), user)
+      [job] = Repo.preload(live, :jobs).jobs
+
+      {:ok, changed} =
+        live
+        |> Workflows.change_workflow(%{jobs: [%{id: job.id, body: "// bad"}]})
+        |> Workflows.save_workflow(user)
+
+      {:ok, restored} = Workflows.restore_version(changed, v1, user)
+
+      releases = WorkflowReleases.list_for_workflow(restored)
+
+      assert %WorkflowRelease{
+               version_number: 2,
+               kind: :restore,
+               restored_from_version_number: 1,
+               published_by_id: published_by_id
+             } = hd(releases)
+
+      assert published_by_id == user.id
+
+      # The trail reads forward: v1 is still there.
+      assert Enum.any?(releases, &(&1.version_number == 1))
+    end
+  end
+
   describe "go_live/2 and switch_to_draft/2" do
     setup do
       %{user: insert(:user)}

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -1979,6 +1979,169 @@ defmodule LightningWeb.WorkflowChannelTest do
     end
   end
 
+  describe "restore_version" do
+    setup %{user: user, project: project} do
+      workflow = insert(:simple_workflow, project: project)
+      {:ok, live} = Lightning.Workflows.go_live(workflow, user)
+      [v1] = Lightning.Workflows.WorkflowReleases.list_for_workflow(live)
+
+      [job] = Lightning.Repo.preload(live, :jobs).jobs
+
+      {:ok, changed} =
+        live
+        |> Lightning.Workflows.change_workflow(%{
+          jobs: [%{id: job.id, body: "// broken by a bad go-live"}]
+        })
+        |> Lightning.Workflows.save_workflow(user)
+
+      {:ok, _, socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{user.id}", %{current_user: user})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          "workflow:collaborate:#{changed.id}",
+          %{"project_id" => project.id, "action" => "edit"}
+        )
+
+      on_exit(fn -> ensure_doc_supervisor_stopped(changed.id) end)
+
+      %{
+        restore_socket: socket,
+        workflow: changed,
+        v1: v1,
+        original_body: job.body
+      }
+    end
+
+    test "puts the version's content back and leaves the workflow live", %{
+      restore_socket: socket,
+      workflow: workflow,
+      original_body: original_body
+    } do
+      ref = push(socket, "restore_version", %{"version_number" => 1})
+
+      assert_reply ref, :ok, %{lock_version: _}
+
+      reloaded = Lightning.Repo.reload!(workflow)
+      assert reloaded.state == :live
+
+      assert [%{body: ^original_body}] =
+               Lightning.Repo.preload(reloaded, :jobs, force: true).jobs
+    end
+
+    test "records the restore as the next version, naming the one it restored",
+         %{restore_socket: socket, workflow: workflow} do
+      ref = push(socket, "restore_version", %{"version_number" => 1})
+      assert_reply ref, :ok, _reply
+
+      releases =
+        Lightning.Workflows.WorkflowReleases.list_for_workflow(workflow.id)
+
+      assert %{kind: :restore, restored_from_version_number: 1} = hd(releases)
+    end
+
+    test "refuses a version that does not exist", %{restore_socket: socket} do
+      ref = push(socket, "restore_version", %{"version_number" => 99})
+
+      assert_reply ref, :error, %{type: "version_not_found"}
+    end
+
+    test "refuses someone who cannot edit the workflow", %{
+      project: project,
+      workflow: workflow
+    } do
+      viewer = insert(:user)
+      insert(:project_user, project: project, user: viewer, role: :viewer)
+
+      {:ok, _, socket} =
+        LightningWeb.UserSocket
+        |> socket("user_#{viewer.id}", %{current_user: viewer})
+        |> subscribe_and_join(
+          LightningWeb.WorkflowChannel,
+          "workflow:collaborate:#{workflow.id}",
+          %{"project_id" => project.id, "action" => "edit"}
+        )
+
+      ref = push(socket, "restore_version", %{"version_number" => 1})
+
+      assert_reply ref, :error, %{errors: %{base: [message]}}
+      assert message =~ "permission"
+    end
+
+    test "deletes a trigger added after this socket joined", %{
+      restore_socket: socket,
+      workflow: workflow,
+      user: user
+    } do
+      # Added after the join, so it is absent from socket.assigns.workflow. A
+      # restore computed against that stale struct would leave it behind.
+      {:ok, with_cron} =
+        workflow
+        |> Lightning.Repo.preload([:triggers, :jobs, :edges])
+        |> Lightning.Workflows.change_workflow(%{
+          triggers: [
+            %{
+              type: :cron,
+              cron_expression: "0 * * * *",
+              custom_path: "added-after-join"
+            }
+          ]
+        })
+        |> Lightning.Workflows.save_workflow(user)
+
+      added =
+        Lightning.Repo.preload(with_cron, :triggers, force: true).triggers
+        |> Enum.find(&(&1.type == :cron))
+
+      assert added
+
+      ref = push(socket, "restore_version", %{"version_number" => 1})
+      assert_reply ref, :ok, _reply
+
+      refute Lightning.Repo.reload(added)
+    end
+
+    test "the check names the triggers a restore would delete", %{
+      restore_socket: socket,
+      workflow: workflow,
+      user: user
+    } do
+      {:ok, with_cron} =
+        workflow
+        |> Lightning.Repo.preload([:triggers, :jobs, :edges])
+        |> Lightning.Workflows.change_workflow(%{
+          triggers: [
+            %{
+              type: :cron,
+              cron_expression: "0 * * * *",
+              custom_path: "added-after-v1"
+            }
+          ]
+        })
+        |> Lightning.Workflows.save_workflow(user)
+
+      added =
+        Lightning.Repo.preload(with_cron, :triggers, force: true).triggers
+        |> Enum.find(&(&1.type == :cron))
+
+      ref = push(socket, "request_restore_check", %{"version_number" => 1})
+
+      assert_reply ref, :ok, %{losing_triggers: losing, version_number: 1}
+
+      # The URL built from this trigger stops answering, so the confirmation has
+      # to be able to say which one.
+      assert Enum.any?(losing, &(&1.id == added.id))
+    end
+
+    test "the check reports nothing to lose when the triggers are unchanged", %{
+      restore_socket: socket
+    } do
+      ref = push(socket, "request_restore_check", %{"version_number" => 1})
+
+      assert_reply ref, :ok, %{losing_triggers: []}
+    end
+  end
+
   describe "version-pinned join (?v=version_number)" do
     test "loads the snapshot belonging to the release with that version_number",
          %{project: project, workflow: workflow, user: user} do

--- a/test/lightning_web/channels/workflow_channel_test.exs
+++ b/test/lightning_web/channels/workflow_channel_test.exs
@@ -2040,6 +2040,24 @@ defmodule LightningWeb.WorkflowChannelTest do
       assert %{kind: :restore, restored_from_version_number: 1} = hd(releases)
     end
 
+    test "tells the restoring client the workflow moved on", %{
+      restore_socket: socket
+    } do
+      ref = push(socket, "restore_version", %{"version_number" => 1})
+      assert_reply ref, :ok, _reply
+
+      # The broadcast excludes the sender, so without this push the restoring
+      # client's idea of the latest version stays behind: the version chip
+      # would read as an old version straight after a rollback, and the
+      # dropdown would still offer Restore on the version now live.
+      assert_push "session_context_updated", %{
+        latest_snapshot_lock_version: lock_version
+      }
+
+      assert lock_version ==
+               Lightning.Repo.reload!(socket.assigns.workflow).lock_version
+    end
+
     test "refuses a version that does not exist", %{restore_socket: socket} do
       ref = push(socket, "restore_version", %{"version_number" => 99})
 
@@ -2133,12 +2151,58 @@ defmodule LightningWeb.WorkflowChannelTest do
       assert Enum.any?(losing, &(&1.id == added.id))
     end
 
+    test "the check names the triggers a restore will bring back off", %{
+      restore_socket: socket,
+      workflow: workflow,
+      user: user
+    } do
+      [original] = Lightning.Repo.preload(workflow, :triggers).triggers
+
+      {:ok, _replaced} =
+        workflow
+        |> Lightning.Repo.preload([:triggers, :jobs, :edges])
+        |> Lightning.Workflows.change_workflow(%{
+          triggers: [%{type: :cron, cron_expression: "0 * * * *"}]
+        })
+        |> Lightning.Workflows.save_workflow(user)
+
+      ref = push(socket, "request_restore_check", %{"version_number" => 1})
+
+      assert_reply ref, :ok, %{returning_triggers: returning}
+
+      # It comes back off and without its auth methods, which a snapshot never
+      # recorded, so the confirmation has to say so.
+      assert Enum.any?(returning, &(&1.id == original.id))
+    end
+
+    test "a concurrent save is refused, not a dropped channel", %{
+      restore_socket: socket,
+      workflow: workflow,
+      user: user
+    } do
+      # Someone else saves between the join and the restore, so the socket's
+      # lock_version is behind. Unrescued this killed the channel and the client
+      # waited out its timeout for a reply that never came.
+      Mimic.copy(Lightning.Workflows)
+
+      Mimic.stub(Lightning.Workflows, :restore_version, fn _wf, _rel, _actor ->
+        raise Ecto.StaleEntryError, action: :update, changeset: %Ecto.Changeset{}
+      end)
+
+      ref = push(socket, "restore_version", %{"version_number" => 1})
+
+      assert_reply ref, :error, %{type: "workflow_moved_on"}
+      assert Process.alive?(socket.channel_pid)
+
+      _ = {workflow, user}
+    end
+
     test "the check reports nothing to lose when the triggers are unchanged", %{
       restore_socket: socket
     } do
       ref = push(socket, "request_restore_check", %{"version_number" => 1})
 
-      assert_reply ref, :ok, %{losing_triggers: []}
+      assert_reply ref, :ok, %{losing_triggers: [], returning_triggers: []}
     end
   end
 


### PR DESCRIPTION
### Validation steps

Closes https://github.com/OpenFn/lightning/issues/4864

Everything else in this epic gives people new ways to change production. This is the only way back. Without it a bad go-live or promote leaves someone rebuilding a workflow by hand.

A restore is a publish, not an edit. It writes the chosen version's snapshot in as the workflow's content and leaves it live, so production keeps running through the rollback. That is guaranteed rather than checked: the workflow changeset cannot express the lifecycle state at all, which is the same reason a promote cannot draft the workflow it promotes into.

Surviving triggers keep the on/off state they have now. Putting an old one back would stop production receiving in the middle of a rollback, which is the worst possible moment, and it is what promote already does. So the restore is faithful in content but not in enablement, deliberately.

Anything the snapshot does not hold is deleted, which is what makes this a revert rather than a merge. A trigger added since that version disappears and the URL built from it stops answering. The dialog says which ones before you agree, because nobody should discover that afterwards. The result is recorded as the next version, labelled with the version it came from, so the trail reads forward and the bad version stays in the history.

The action sits on the version's own row rather than in the header button group. Those buttons all act on the workflow on screen and are hidden on a pinned view; restore is the one action that is about the version being read.

Two things the issue got wrong, which I found while building it. It says promote's tests already assert that a merge never drafts or disables its target; they do not, the guarantee is tested a layer down on the provisioner, so this PR adds the assertion where it belongs. And it says to reuse the reconciler, which is ambiguous in a way that fails silently: the incremental one has no case for a wholesale replacement and would leave deleted jobs on screen in every open editor. This asks for a full reconcile after commit, the way a merge does.

Also worth knowing: restoring past a job's creation deletes the AI chat sessions attached to that job, because they cascade. Run history and "view as executed" survive intact.

1. Publish a workflow, break a job, then restore the earlier version. Check the content comes back, the workflow stays live, and its triggers stay on.
2. Add a webhook trigger, then restore to before it existed. Check the dialog names that trigger and its URL, and that the trigger is gone afterwards.
3. Restore to a version captured while a trigger was off. Check the trigger stays on.
4. Check the dropdown shows "Restored v2" on the new version, and that v2 is still listed.
5. As a viewer, check no Restore action appears. On the newest version, check the same.
6. Have a second editor open on the canvas during a restore and check it updates without a reload.

### AI usage

Implementation and PR body drafted with Claude Code, reviewed and corrected by me.