### PR TITLE
Show a webhook's changes in the assistant's change summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to
 
 ### Added
 
+- The assistant's change summary now reports a webhook trigger's settings. A
+  custom path being set, changed or cleared shows as its own row, as do the
+  reply timing and the response codes, all of which used to land with nothing
+  said about them.
+  [#5149](https://github.com/OpenFn/lightning/issues/5149)
+
 - The AI assistant now shows what changed as a global reply edits your workflow.
   Each change renders under the status that made it, while the reply is still
   streaming, as a per-step code diff with syntax highlighting, old and new line

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -369,6 +369,12 @@ const pathOf = (trigger: StateWebhookTrigger): string | null | undefined => {
     : trigger.custom_path;
 };
 
+// A path with surrounding space is one the server would refuse and the panel
+// shows no URL for, and it renders as an arrow pointing at nothing. Quoted, so
+// the row reads as a value rather than a truncated sentence.
+const showPath = (path: string): string =>
+  path.trim() === path ? path : `'${path}'`;
+
 const codeOf = (code: number | null | undefined): string =>
   code == null ? 'default' : String(code);
 
@@ -384,7 +390,9 @@ const bareWebhook = (trigger: { id: string }): StateWebhookTrigger => ({
 
 const webhookDetails = (
   before: StateWebhookTrigger,
-  after: StateWebhookTrigger
+  after: StateWebhookTrigger,
+  /** The trigger is new, so a setting was chosen rather than changed. */
+  asNew = false
 ): string[] => {
   const details: string[] = [];
 
@@ -397,14 +405,16 @@ const webhookDetails = (
       afterPath === null
         ? 'path removed'
         : beforePath === null
-          ? `path: ${afterPath}`
-          : `path: ${beforePath} → ${afterPath}`
+          ? `path: ${showPath(afterPath)}`
+          : `path: ${showPath(beforePath)} → ${showPath(afterPath)}`
     );
   }
 
   if (replyOf(before) !== replyOf(after)) {
     details.push(
-      `reply: ${REPLY_LABEL[replyOf(before)]} → ${REPLY_LABEL[replyOf(after)]}`
+      asNew
+        ? `reply: ${REPLY_LABEL[replyOf(after)]}`
+        : `reply: ${REPLY_LABEL[replyOf(before)]} → ${REPLY_LABEL[replyOf(after)]}`
     );
   }
 
@@ -417,7 +427,9 @@ const webhookDetails = (
     const afterCode = after.webhook_response_config?.[field] ?? null;
     if (beforeCode !== afterCode) {
       details.push(
-        `${name} code: ${codeOf(beforeCode)} → ${codeOf(afterCode)}`
+        asNew
+          ? `${name} code: ${codeOf(afterCode)}`
+          : `${name} code: ${codeOf(beforeCode)} → ${codeOf(afterCode)}`
       );
     }
   }
@@ -450,7 +462,7 @@ const deriveTriggerChanges = (
     // only that a trigger appeared.
     const details =
       trigger.type === 'webhook'
-        ? webhookDetails(bareWebhook(trigger), trigger)
+        ? webhookDetails(bareWebhook(trigger), trigger, true)
         : [];
     changes.push({
       kind: 'trigger',
@@ -488,11 +500,11 @@ const deriveTriggerChanges = (
       // A cron trigger becoming a webhook mints a public URL, so report the
       // settings rather than only the type change. Diffing against a bare
       // webhook reads them all as newly set, which is what they are.
-      const baseline: StateWebhookTrigger =
-        beforeTrigger.type === 'webhook'
-          ? beforeTrigger
-          : bareWebhook(beforeTrigger);
-      details.push(...webhookDetails(baseline, afterTrigger));
+      const becameWebhook = beforeTrigger.type !== 'webhook';
+      const baseline: StateWebhookTrigger = becameWebhook
+        ? bareWebhook(beforeTrigger)
+        : beforeTrigger;
+      details.push(...webhookDetails(baseline, afterTrigger, becameWebhook));
     }
 
     if (details.length > 0) {
@@ -772,20 +784,37 @@ export const clearWorkflowDiffCaches = (): void => {
  * Copies rather than mutates: these states are cached by the YAML that
  * produced them and are handed out again.
  */
+// Keyed on type rather than id: a snapshot without ids is parsed with a fresh
+// uuid each time, which would change the salt on every re-parse and fill the
+// pair cache with entries nothing can reach again.
 const heldPaths = (state: DiffState): string =>
   state.triggers
     .filter(
       (trigger): trigger is StateWebhookTrigger =>
         trigger.type === 'webhook' && trigger.custom_path !== undefined
     )
-    .map(trigger => `${trigger.id}=${trigger.custom_path ?? ''}`)
+    .map(trigger => `${trigger.type}=${trigger.custom_path ?? ''}`)
+    .sort()
     .join(',');
 
 const carryWebhookPaths = (previous: DiffState, next: DiffState): DiffState => {
+  // Paired the way the diff pairs them. A snapshot that omits trigger ids is
+  // parsed with an invented uuid per trigger, so matching on the raw id would
+  // carry nothing on exactly the replies where Apollo drops them.
+  const { pairs } = matchEntities(
+    previous.triggers,
+    next.triggers,
+    trigger => `type:${trigger.type}`
+  );
+
   const held = new Map<string, string | null>();
-  for (const trigger of previous.triggers) {
-    if (trigger.type === 'webhook' && trigger.custom_path !== undefined) {
-      held.set(trigger.id, trigger.custom_path);
+  for (const [previousTrigger, nextTrigger] of pairs) {
+    if (
+      previousTrigger.type === 'webhook' &&
+      nextTrigger.type === 'webhook' &&
+      previousTrigger.custom_path !== undefined
+    ) {
+      held.set(nextTrigger.id, previousTrigger.custom_path);
     }
   }
   if (held.size === 0) return next;

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -127,9 +127,7 @@ const matchEntities = <T extends { id: string }>(
   for (const pick of [(entity: T) => entity.id, fallbackKey] as Array<
     (entity: T) => string
   >) {
-    // Forward, so two entities sharing a fallback key pair in document order.
-    // Walking backwards paired them in reverse, which cancels out over a whole
-    // chain but crosses their fields when both sides state one.
+    // Forward, or two entities sharing a fallback key pair in reverse.
     for (let i = 0; i < remainingBefore.length; ) {
       const b = remainingBefore[i]!;
       const j = remainingAfter.findIndex(a => pick(a) === pick(b));
@@ -356,17 +354,13 @@ const REPLY_LABEL: Record<WebhookReply, string> = {
   after_completion: 'On Complete',
 };
 
-// An absent reply means before_start, so normalise before comparing or a
-// trigger that only ever had the default reports a change it never made.
+// An absent reply is before_start, so normalise or the default reads as a change.
 const replyOf = (trigger: StateWebhookTrigger): WebhookReply =>
   trigger.webhook_reply ?? 'before_start';
 
-// `undefined` (the answer never mentioned a path) and `null` (the answer
-// cleared it) mean opposite things here: applying a workflow that omits the key
-// keeps whatever the trigger holds, so only an explicit value is a change.
-// Blank counts as cleared, which is how the server and the panel read it.
-// Only exactly blank: the panel rejects a whitespace path rather than
-// treating it as none, so calling it a removal here would disagree.
+// Absent and null mean opposite things: applying a workflow that omits the key
+// keeps the path the trigger holds, so only an explicit value is a change.
+// Exactly blank is a clear; the panel rejects whitespace rather than ignoring it.
 const pathOf = (trigger: StateWebhookTrigger): string | null | undefined => {
   if (trigger.custom_path === undefined) return undefined;
   return trigger.custom_path === null || trigger.custom_path === ''
@@ -374,17 +368,13 @@ const pathOf = (trigger: StateWebhookTrigger): string | null | undefined => {
     : trigger.custom_path;
 };
 
-// A path with surrounding space is one the server would refuse and the panel
-// shows no URL for, and it renders as an arrow pointing at nothing. Quoted, so
-// the row reads as a value rather than a truncated sentence.
+// Quoted, or a padded path renders as an arrow pointing at blank.
 const showPath = (path: string): string =>
   path.trim() === path ? path : `'${path}'`;
 
 const codeOf = (code: number | null | undefined): string =>
   code == null ? 'default' : String(code);
 
-// A webhook with nothing configured, so a trigger that has just appeared can
-// be diffed against it and read as having set what it carries.
 const bareWebhook = (trigger: { id: string }): StateWebhookTrigger => ({
   id: trigger.id,
   type: 'webhook',
@@ -401,8 +391,7 @@ const webhookDetails = (
 ): string[] => {
   const details: string[] = [];
 
-  // A path the before never stated is a trigger with no path, since the
-  // baseline we diff against writes the key whenever there is one.
+  // The baseline writes the key whenever there is one, so unstated means none.
   const beforePath = pathOf(before) ?? null;
   const afterPath = pathOf(after);
   if (afterPath !== undefined && afterPath !== beforePath) {
@@ -463,8 +452,7 @@ const deriveTriggerChanges = (
   const changes: StructuralChange[] = [];
 
   for (const trigger of added) {
-    // A new webhook mints a public URL, so say what it answers on rather than
-    // only that a trigger appeared.
+    // A new webhook mints a public URL, so name it.
     const details =
       trigger.type === 'webhook'
         ? webhookDetails(bareWebhook(trigger), trigger, true)
@@ -477,8 +465,6 @@ const deriveTriggerChanges = (
     });
   }
   for (const trigger of removed) {
-    // Retiring a webhook stops a public URL answering, so name it for the same
-    // reason a new one is named.
     const path =
       trigger.type === 'webhook' && trigger.custom_path
         ? showPath(trigger.custom_path)
@@ -509,9 +495,8 @@ const deriveTriggerChanges = (
       );
     }
     if (afterTrigger.type === 'webhook') {
-      // A cron trigger becoming a webhook mints a public URL, so report the
-      // settings rather than only the type change. Diffing against a bare
-      // webhook reads them all as newly set, which is what they are.
+      // Becoming a webhook mints a URL too, and against a bare one its
+      // settings read as newly set, which they are.
       const becameWebhook = beforeTrigger.type !== 'webhook';
       const baseline: StateWebhookTrigger = becameWebhook
         ? bareWebhook(beforeTrigger)
@@ -752,8 +737,7 @@ const cachedDiff = (
   // Keyed on short ids rather than the documents themselves. A workflow can
   // be hundreds of KB, and pairing two of them per entry meant this cache
   // retained more text than the parse cache it sits beside.
-  // Salted, because a carried webhook path is in neither document, so the pair
-  // alone no longer says what was compared.
+  // A carried path is in neither document, so the pair alone underspecifies it.
   const key = `${documentId(beforeYaml)}:${documentId(afterYaml)}:${salt}`;
   if (diffedPairs.has(key)) {
     const cached = diffedPairs.get(key) ?? null;
@@ -784,11 +768,7 @@ export const clearWorkflowDiffCaches = (): void => {
   documentIds.clear();
 };
 
-// Positional, not by id: a snapshot without ids is parsed with a fresh uuid
-// each time, which would change the salt on every re-parse and fill the pair
-// cache with entries nothing can reach. Position comes from the YAML mapping,
-// so it is stable, and unlike the type it stays distinct when a workflow holds
-// more than one webhook.
+// Positional: ids are invented per parse, and the type is shared by two webhooks.
 const heldPaths = (state: DiffState): string =>
   state.triggers
     .map((trigger, index) =>
@@ -800,21 +780,15 @@ const heldPaths = (state: DiffState): string =>
     .join(',');
 
 /**
- * `next`, with each webhook path the snapshot left unstated filled in from the
- * state before it.
+ * `next`, with each webhook path it left unstated filled in from `previous`.
  *
- * Applying a workflow that omits a webhook's path keeps the one the trigger
- * holds, so the document does not lose it. Carrying it forward keeps the next
- * snapshot diffed against what the document actually holds, or a later
- * snapshot that clears the path is compared against nothing and says nothing.
- *
- * Copies rather than mutates: these states are cached by the YAML that
- * produced them and are handed out again.
+ * The apply keeps an unstated path, so without this a later snapshot that
+ * clears a live one is compared against nothing and reports nothing. Copies
+ * rather than mutates: these states are cached and handed out again.
  */
 const carryWebhookPaths = (previous: DiffState, next: DiffState): DiffState => {
-  // Paired the way the diff pairs them. A snapshot that omits trigger ids is
-  // parsed with an invented uuid per trigger, so matching on the raw id would
-  // carry nothing on exactly the replies where Apollo drops them.
+  // Paired as the diff pairs them: Apollo drops trigger ids on some replies,
+  // and parsing invents one per trigger, so a raw id match would carry nothing.
   const { pairs } = matchEntities(
     previous.triggers,
     next.triggers,

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -127,14 +127,19 @@ const matchEntities = <T extends { id: string }>(
   for (const pick of [(entity: T) => entity.id, fallbackKey] as Array<
     (entity: T) => string
   >) {
-    for (let i = remainingBefore.length - 1; i >= 0; i--) {
+    // Forward, so two entities sharing a fallback key pair in document order.
+    // Walking backwards paired them in reverse, which cancels out over a whole
+    // chain but crosses their fields when both sides state one.
+    for (let i = 0; i < remainingBefore.length; ) {
       const b = remainingBefore[i]!;
       const j = remainingAfter.findIndex(a => pick(a) === pick(b));
-      if (j !== -1) {
-        pairs.push([b, remainingAfter[j]!]);
-        remainingBefore.splice(i, 1);
-        remainingAfter.splice(j, 1);
+      if (j === -1) {
+        i++;
+        continue;
       }
+      pairs.push([b, remainingAfter[j]!]);
+      remainingBefore.splice(i, 1);
+      remainingAfter.splice(j, 1);
     }
   }
 

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -354,13 +354,12 @@ const REPLY_LABEL: Record<WebhookReply, string> = {
   after_completion: 'On Complete',
 };
 
-// An absent reply is before_start, so normalise or the default reads as a change.
 const replyOf = (trigger: StateWebhookTrigger): WebhookReply =>
   trigger.webhook_reply ?? 'before_start';
 
-// Absent and null mean opposite things: applying a workflow that omits the key
-// keeps the path the trigger holds, so only an explicit value is a change.
-// Exactly blank is a clear; the panel rejects whitespace rather than ignoring it.
+// Absent and null mean opposite things: the apply keeps a path the answer
+// omits, so only an explicit value is a change. Blank is a clear, but only
+// exactly blank, since the panel rejects whitespace rather than ignoring it.
 const pathOf = (trigger: StateWebhookTrigger): string | null | undefined => {
   if (trigger.custom_path === undefined) return undefined;
   return trigger.custom_path === null || trigger.custom_path === ''
@@ -386,7 +385,6 @@ const bareWebhook = (trigger: { id: string }): StateWebhookTrigger => ({
 const webhookDetails = (
   before: StateWebhookTrigger,
   after: StateWebhookTrigger,
-  /** The trigger is new, so a setting was chosen rather than changed. */
   asNew = false
 ): string[] => {
   const details: string[] = [];
@@ -452,7 +450,6 @@ const deriveTriggerChanges = (
   const changes: StructuralChange[] = [];
 
   for (const trigger of added) {
-    // A new webhook mints a public URL, so name it.
     const details =
       trigger.type === 'webhook'
         ? webhookDetails(bareWebhook(trigger), trigger, true)
@@ -495,8 +492,6 @@ const deriveTriggerChanges = (
       );
     }
     if (afterTrigger.type === 'webhook') {
-      // Becoming a webhook mints a URL too, and against a bare one its
-      // settings read as newly set, which they are.
       const becameWebhook = beforeTrigger.type !== 'webhook';
       const baseline: StateWebhookTrigger = becameWebhook
         ? bareWebhook(beforeTrigger)
@@ -780,11 +775,9 @@ const heldPaths = (state: DiffState): string =>
     .join(',');
 
 /**
- * `next`, with each webhook path it left unstated filled in from `previous`.
- *
- * The apply keeps an unstated path, so without this a later snapshot that
- * clears a live one is compared against nothing and reports nothing. Copies
- * rather than mutates: these states are cached and handed out again.
+ * The apply keeps a path a snapshot leaves unstated, so without carrying it a
+ * later snapshot that clears a live one is compared against nothing and reports
+ * nothing. Copies rather than mutates: these states are cached and reused.
  */
 const carryWebhookPaths = (previous: DiffState, next: DiffState): DiffState => {
   // Paired as the diff pairs them: Apollo drops trigger ids on some replies,

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -343,16 +343,29 @@ const deriveEdgeChanges = (
   return changes;
 };
 
+type WebhookReply = NonNullable<StateWebhookTrigger['webhook_reply']>;
+
 /** Wording taken from the response type picker, so a row reads like the panel. */
-const REPLY_LABEL: Record<string, string> = {
+const REPLY_LABEL: Record<WebhookReply, string> = {
   before_start: 'Immediately',
   after_completion: 'On Complete',
 };
 
 // An absent reply means before_start, so normalise before comparing or a
 // trigger that only ever had the default reports a change it never made.
-const replyOf = (trigger: StateWebhookTrigger): string =>
+const replyOf = (trigger: StateWebhookTrigger): WebhookReply =>
   trigger.webhook_reply ?? 'before_start';
+
+// `undefined` (the answer never mentioned a path) and `null` (the answer
+// cleared it) mean opposite things here: applying a workflow that omits the key
+// keeps whatever the trigger holds, so only an explicit value is a change.
+// Blank counts as cleared, which is how the server and the panel read it.
+const pathOf = (trigger: StateWebhookTrigger): string | null | undefined => {
+  if (trigger.custom_path === undefined) return undefined;
+  return trigger.custom_path === null || trigger.custom_path.trim() === ''
+    ? null
+    : trigger.custom_path;
+};
 
 const codeOf = (code: number | null | undefined): string =>
   code == null ? 'default' : String(code);
@@ -363,9 +376,11 @@ const webhookDetails = (
 ): string[] => {
   const details: string[] = [];
 
-  const beforePath = before.custom_path ?? null;
-  const afterPath = after.custom_path ?? null;
-  if (beforePath !== afterPath) {
+  // A path the before never stated is a trigger with no path, since the
+  // baseline we diff against writes the key whenever there is one.
+  const beforePath = pathOf(before) ?? null;
+  const afterPath = pathOf(after);
+  if (afterPath !== undefined && afterPath !== beforePath) {
     details.push(
       afterPath === null
         ? 'path removed'
@@ -450,8 +465,20 @@ const deriveTriggerChanges = (
         `schedule: ${beforeTrigger.cron_expression} → ${afterTrigger.cron_expression}`
       );
     }
-    if (beforeTrigger.type === 'webhook' && afterTrigger.type === 'webhook') {
-      details.push(...webhookDetails(beforeTrigger, afterTrigger));
+    if (afterTrigger.type === 'webhook') {
+      // A cron trigger becoming a webhook mints a public URL, so report the
+      // settings rather than only the type change. Diffing against a bare
+      // webhook reads them all as newly set, which is what they are.
+      const baseline: StateWebhookTrigger =
+        beforeTrigger.type === 'webhook'
+          ? beforeTrigger
+          : {
+              id: beforeTrigger.id,
+              type: 'webhook',
+              enabled: beforeTrigger.enabled,
+              webhook_reply: null,
+            };
+      details.push(...webhookDetails(baseline, afterTrigger));
     }
 
     if (details.length > 0) {

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -11,7 +11,12 @@
 
 import { structuredPatch } from 'diff';
 
-import type { StateEdge, StateJob, WorkflowState } from '../../yaml/types';
+import type {
+  StateEdge,
+  StateJob,
+  StateWebhookTrigger,
+  WorkflowState,
+} from '../../yaml/types';
 import { convertWorkflowSpecToState, parseWorkflowYAML } from '../../yaml/util';
 import type { WorkflowSnapshot } from '../types/ai-assistant';
 
@@ -338,6 +343,61 @@ const deriveEdgeChanges = (
   return changes;
 };
 
+/** Wording taken from the response type picker, so a row reads like the panel. */
+const REPLY_LABEL: Record<string, string> = {
+  before_start: 'Immediately',
+  after_completion: 'On Complete',
+};
+
+// An absent reply means before_start, so normalise before comparing or a
+// trigger that only ever had the default reports a change it never made.
+const replyOf = (trigger: StateWebhookTrigger): string =>
+  trigger.webhook_reply ?? 'before_start';
+
+const codeOf = (code: number | null | undefined): string =>
+  code == null ? 'default' : String(code);
+
+const webhookDetails = (
+  before: StateWebhookTrigger,
+  after: StateWebhookTrigger
+): string[] => {
+  const details: string[] = [];
+
+  const beforePath = before.custom_path ?? null;
+  const afterPath = after.custom_path ?? null;
+  if (beforePath !== afterPath) {
+    details.push(
+      afterPath === null
+        ? 'path removed'
+        : beforePath === null
+          ? `path: ${afterPath}`
+          : `path: ${beforePath} → ${afterPath}`
+    );
+  }
+
+  if (replyOf(before) !== replyOf(after)) {
+    details.push(
+      `reply: ${REPLY_LABEL[replyOf(before)]} → ${REPLY_LABEL[replyOf(after)]}`
+    );
+  }
+
+  const codes = [
+    ['success', 'success_code'],
+    ['error', 'error_code'],
+  ] as const;
+  for (const [name, field] of codes) {
+    const beforeCode = before.webhook_response_config?.[field] ?? null;
+    const afterCode = after.webhook_response_config?.[field] ?? null;
+    if (beforeCode !== afterCode) {
+      details.push(
+        `${name} code: ${codeOf(beforeCode)} → ${codeOf(afterCode)}`
+      );
+    }
+  }
+
+  return details;
+};
+
 const deriveTriggerChanges = (
   before: DiffState,
   after: DiffState
@@ -389,6 +449,9 @@ const deriveTriggerChanges = (
       details.push(
         `schedule: ${beforeTrigger.cron_expression} → ${afterTrigger.cron_expression}`
       );
+    }
+    if (beforeTrigger.type === 'webhook' && afterTrigger.type === 'webhook') {
+      details.push(...webhookDetails(beforeTrigger, afterTrigger));
     }
 
     if (details.length > 0) {

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -472,10 +472,17 @@ const deriveTriggerChanges = (
     });
   }
   for (const trigger of removed) {
+    // Retiring a webhook stops a public URL answering, so name it for the same
+    // reason a new one is named.
+    const path =
+      trigger.type === 'webhook' && trigger.custom_path
+        ? showPath(trigger.custom_path)
+        : null;
     changes.push({
       kind: 'trigger',
       change: 'remove',
       description: `${trigger.type} trigger`,
+      ...(path !== null && { detail: `path: ${path}` }),
     });
   }
 
@@ -772,6 +779,21 @@ export const clearWorkflowDiffCaches = (): void => {
   documentIds.clear();
 };
 
+// Positional, not by id: a snapshot without ids is parsed with a fresh uuid
+// each time, which would change the salt on every re-parse and fill the pair
+// cache with entries nothing can reach. Position comes from the YAML mapping,
+// so it is stable, and unlike the type it stays distinct when a workflow holds
+// more than one webhook.
+const heldPaths = (state: DiffState): string =>
+  state.triggers
+    .map((trigger, index) =>
+      trigger.type === 'webhook' && trigger.custom_path !== undefined
+        ? `${index}=${trigger.custom_path ?? ''}`
+        : null
+    )
+    .filter(entry => entry !== null)
+    .join(',');
+
 /**
  * `next`, with each webhook path the snapshot left unstated filled in from the
  * state before it.
@@ -784,19 +806,6 @@ export const clearWorkflowDiffCaches = (): void => {
  * Copies rather than mutates: these states are cached by the YAML that
  * produced them and are handed out again.
  */
-// Keyed on type rather than id: a snapshot without ids is parsed with a fresh
-// uuid each time, which would change the salt on every re-parse and fill the
-// pair cache with entries nothing can reach again.
-const heldPaths = (state: DiffState): string =>
-  state.triggers
-    .filter(
-      (trigger): trigger is StateWebhookTrigger =>
-        trigger.type === 'webhook' && trigger.custom_path !== undefined
-    )
-    .map(trigger => `${trigger.type}=${trigger.custom_path ?? ''}`)
-    .sort()
-    .join(',');
-
 const carryWebhookPaths = (previous: DiffState, next: DiffState): DiffState => {
   // Paired the way the diff pairs them. A snapshot that omits trigger ids is
   // parsed with an invented uuid per trigger, so matching on the raw id would

--- a/assets/js/collaborative-editor/utils/workflowDiff.ts
+++ b/assets/js/collaborative-editor/utils/workflowDiff.ts
@@ -360,15 +360,27 @@ const replyOf = (trigger: StateWebhookTrigger): WebhookReply =>
 // cleared it) mean opposite things here: applying a workflow that omits the key
 // keeps whatever the trigger holds, so only an explicit value is a change.
 // Blank counts as cleared, which is how the server and the panel read it.
+// Only exactly blank: the panel rejects a whitespace path rather than
+// treating it as none, so calling it a removal here would disagree.
 const pathOf = (trigger: StateWebhookTrigger): string | null | undefined => {
   if (trigger.custom_path === undefined) return undefined;
-  return trigger.custom_path === null || trigger.custom_path.trim() === ''
+  return trigger.custom_path === null || trigger.custom_path === ''
     ? null
     : trigger.custom_path;
 };
 
 const codeOf = (code: number | null | undefined): string =>
   code == null ? 'default' : String(code);
+
+// A webhook with nothing configured, so a trigger that has just appeared can
+// be diffed against it and read as having set what it carries.
+const bareWebhook = (trigger: { id: string }): StateWebhookTrigger => ({
+  id: trigger.id,
+  type: 'webhook',
+  enabled: false,
+  webhook_reply: null,
+  custom_path: null,
+});
 
 const webhookDetails = (
   before: StateWebhookTrigger,
@@ -434,10 +446,17 @@ const deriveTriggerChanges = (
   const changes: StructuralChange[] = [];
 
   for (const trigger of added) {
+    // A new webhook mints a public URL, so say what it answers on rather than
+    // only that a trigger appeared.
+    const details =
+      trigger.type === 'webhook'
+        ? webhookDetails(bareWebhook(trigger), trigger)
+        : [];
     changes.push({
       kind: 'trigger',
       change: 'add',
       description: `${trigger.type} trigger`,
+      ...(details.length > 0 && { detail: details.join('; ') }),
     });
   }
   for (const trigger of removed) {
@@ -472,12 +491,7 @@ const deriveTriggerChanges = (
       const baseline: StateWebhookTrigger =
         beforeTrigger.type === 'webhook'
           ? beforeTrigger
-          : {
-              id: beforeTrigger.id,
-              type: 'webhook',
-              enabled: beforeTrigger.enabled,
-              webhook_reply: null,
-            };
+          : bareWebhook(beforeTrigger);
       details.push(...webhookDetails(baseline, afterTrigger));
     }
 
@@ -708,12 +722,15 @@ const cachedDiff = (
   beforeYaml: string,
   afterYaml: string,
   before: DiffState,
-  after: DiffState
+  after: DiffState,
+  salt: string
 ): WorkflowChangeSet | null => {
   // Keyed on short ids rather than the documents themselves. A workflow can
   // be hundreds of KB, and pairing two of them per entry meant this cache
   // retained more text than the parse cache it sits beside.
-  const key = `${documentId(beforeYaml)}:${documentId(afterYaml)}`;
+  // Salted, because a carried webhook path is in neither document, so the pair
+  // alone no longer says what was compared.
+  const key = `${documentId(beforeYaml)}:${documentId(afterYaml)}:${salt}`;
   if (diffedPairs.has(key)) {
     const cached = diffedPairs.get(key) ?? null;
     diffedPairs.delete(key);
@@ -743,6 +760,48 @@ export const clearWorkflowDiffCaches = (): void => {
   documentIds.clear();
 };
 
+/**
+ * `next`, with each webhook path the snapshot left unstated filled in from the
+ * state before it.
+ *
+ * Applying a workflow that omits a webhook's path keeps the one the trigger
+ * holds, so the document does not lose it. Carrying it forward keeps the next
+ * snapshot diffed against what the document actually holds, or a later
+ * snapshot that clears the path is compared against nothing and says nothing.
+ *
+ * Copies rather than mutates: these states are cached by the YAML that
+ * produced them and are handed out again.
+ */
+const heldPaths = (state: DiffState): string =>
+  state.triggers
+    .filter(
+      (trigger): trigger is StateWebhookTrigger =>
+        trigger.type === 'webhook' && trigger.custom_path !== undefined
+    )
+    .map(trigger => `${trigger.id}=${trigger.custom_path ?? ''}`)
+    .join(',');
+
+const carryWebhookPaths = (previous: DiffState, next: DiffState): DiffState => {
+  const held = new Map<string, string | null>();
+  for (const trigger of previous.triggers) {
+    if (trigger.type === 'webhook' && trigger.custom_path !== undefined) {
+      held.set(trigger.id, trigger.custom_path);
+    }
+  }
+  if (held.size === 0) return next;
+
+  return {
+    ...next,
+    triggers: next.triggers.map(trigger =>
+      trigger.type === 'webhook' &&
+      trigger.custom_path === undefined &&
+      held.has(trigger.id)
+        ? { ...trigger, custom_path: held.get(trigger.id) ?? null }
+        : trigger
+    ),
+  };
+};
+
 export const deriveSnapshotChanges = (
   baselineYaml: string | null | undefined,
   snapshots: WorkflowSnapshot[]
@@ -768,11 +827,17 @@ export const deriveSnapshotChanges = (
     // costs its own block instead of poisoning every snapshot after it.
     if (!after) continue;
 
-    const changes = cachedDiff(beforeYaml, snapshot.yaml, before, after);
+    const changes = cachedDiff(
+      beforeYaml,
+      snapshot.yaml,
+      before,
+      after,
+      heldPaths(before)
+    );
     if (changes) {
       out.push({ segmentIndex: snapshot.segmentIndex, changes });
     }
-    before = after;
+    before = carryWebhookPaths(before, after);
     beforeYaml = snapshot.yaml;
   }
 

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -492,6 +492,22 @@ describe('deriveWorkflowChanges', () => {
       expect(triggerDetail(blank, blankToNamed)).toBe('path: staff-intake');
     });
 
+    it('does not call a whitespace path a removal, since the panel rejects it', () => {
+      const intake = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+      const spaces = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: '   ',
+      });
+
+      // The answer set a path the panel will flag as invalid. Saying it was
+      // removed would send the reader looking for a change that never happened.
+      expect(triggerDetail(intake, spaces)).not.toBe('path removed');
+      expect(triggerDetail(intake, spaces)).toContain('intake-form');
+    });
+
     it('reports the path on a webhook trigger that has just appeared', () => {
       const none = buildYaml({
         jobs: [transformJob('fn(state => state);')],
@@ -974,6 +990,42 @@ describe('deriveSnapshotChanges', () => {
     expect(rows.map(row => row.detail)).toEqual([
       'path: intake-form → staff-intake',
     ]);
+  });
+
+  it("does not let one reply's carried path answer another reply's identical pair", () => {
+    // The carried path is in neither document, so the pair alone cannot key
+    // the cache. Both chains share the same two snapshots on purpose.
+    const withPath = (path: string | null | undefined, body: string) =>
+      buildYaml({
+        jobs: [transformJob(body)],
+        triggers: [
+          {
+            ...webhookTrigger,
+            ...(path !== undefined && { custom_path: path }),
+          },
+        ],
+        edges: [webhookToTransformEdge],
+      });
+
+    const unstated = snapshot(withPath(undefined, 'fn(s => ({ ...s }));'), 0);
+    const cleared = snapshot(withPath(null, 'fn(s => ({ ...s }));'), 1);
+
+    const hadPath = deriveSnapshotChanges(
+      withPath('intake-form', 'fn(s => s);'),
+      [unstated, cleared]
+    );
+    const neverHadPath = deriveSnapshotChanges(
+      withPath(undefined, 'fn(s => s);'),
+      [unstated, cleared]
+    );
+
+    const rows = (result: ReturnType<typeof deriveSnapshotChanges>) =>
+      result.flatMap(entry =>
+        entry.changes.structure.filter(row => row.kind === 'trigger')
+      );
+
+    expect(rows(hadPath).map(row => row.detail)).toEqual(['path removed']);
+    expect(rows(neverHadPath)).toEqual([]);
   });
 
   it('pins each change set to the segment index its snapshot carried', () => {

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import {
   assignStepDiffsToStatuses,
+  clearWorkflowDiffCaches,
   deriveSnapshotChanges,
   deriveWorkflowChanges,
 } from '../../../js/collaborative-editor/utils/workflowDiff';
@@ -143,6 +144,9 @@ const baseWorkflow = (body: string) =>
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // The parse and pair caches are module state, so a test that reuses a
+  // document another test already diffed would otherwise read its answer.
+  clearWorkflowDiffCaches();
 });
 
 describe('deriveWorkflowChanges', () => {
@@ -486,6 +490,24 @@ describe('deriveWorkflowChanges', () => {
 
       expect(triggerDetail(intake, blank)).toBe('path removed');
       expect(triggerDetail(blank, blankToNamed)).toBe('path: staff-intake');
+    });
+
+    it('reports the path on a webhook trigger that has just appeared', () => {
+      const none = buildYaml({
+        jobs: [transformJob('fn(state => state);')],
+        triggers: [],
+        edges: [],
+      });
+      const named = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+
+      const row = deriveWorkflowChanges(none, named)!.structure.find(
+        entry => entry.kind === 'trigger'
+      );
+      expect(row?.change).toBe('add');
+      expect(row?.detail).toBe('path: intake-form');
     });
 
     it('reports the settings when a cron trigger becomes a webhook', () => {
@@ -894,6 +916,64 @@ describe('deriveSnapshotChanges', () => {
     // whole point: a cumulative diff would report 1 then 2.
     expect(result[0]!.changes.steps[0]!.addedLines).toBe(1);
     expect(result[1]!.changes.steps[0]!.addedLines).toBe(1);
+  });
+
+  it('carries a webhook path a snapshot left unstated, so a later clear is reported', () => {
+    // Applying a snapshot that omits the path keeps it, so the document still
+    // holds one when the next snapshot clears it.
+    const withPath = (path: string | null | undefined, body: string) =>
+      buildYaml({
+        jobs: [transformJob(body)],
+        triggers: [
+          {
+            ...webhookTrigger,
+            ...(path !== undefined && { custom_path: path }),
+          },
+        ],
+        edges: [webhookToTransformEdge],
+      });
+
+    const result = deriveSnapshotChanges(
+      withPath('intake-form', 'fn(s => s);'),
+      [
+        snapshot(withPath(undefined, 'fn(s => ({ ...s }));'), 0),
+        snapshot(withPath(null, 'fn(s => ({ ...s }));'), 1),
+      ]
+    );
+
+    const rows = result.flatMap(entry =>
+      entry.changes.structure.filter(row => row.kind === 'trigger')
+    );
+    expect(rows.map(row => row.detail)).toEqual(['path removed']);
+  });
+
+  it('reports a replacement against the carried path, not as a first set', () => {
+    const withPath = (path: string | undefined, body: string) =>
+      buildYaml({
+        jobs: [transformJob(body)],
+        triggers: [
+          {
+            ...webhookTrigger,
+            ...(path !== undefined && { custom_path: path }),
+          },
+        ],
+        edges: [webhookToTransformEdge],
+      });
+
+    const result = deriveSnapshotChanges(
+      withPath('intake-form', 'fn(s => s);'),
+      [
+        snapshot(withPath(undefined, 'fn(s => ({ ...s }));'), 0),
+        snapshot(withPath('staff-intake', 'fn(s => ({ ...s }));'), 1),
+      ]
+    );
+
+    const rows = result.flatMap(entry =>
+      entry.changes.structure.filter(row => row.kind === 'trigger')
+    );
+    expect(rows.map(row => row.detail)).toEqual([
+      'path: intake-form → staff-intake',
+    ]);
   });
 
   it('pins each change set to the segment index its snapshot carried', () => {

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -1093,6 +1093,61 @@ describe('deriveSnapshotChanges', () => {
     expect(rows.map(row => row.detail)).toEqual(['path removed']);
   });
 
+  it('keeps two webhooks apart in the cache salt', () => {
+    // buildYaml keys triggers by type, so this one is written out: the spec
+    // allows any key, and two webhooks are what make a type-keyed salt
+    // ambiguous. Both chains stream the same two snapshots on purpose.
+    const twoHooks = (a: string, b: string, body: string) => `id: wf-1
+name: Test Workflow
+jobs:
+  transform-data:
+    id: job-1
+    name: Transform data
+    adaptor: '@openfn/language-common@latest'
+    body: |
+      ${body}
+triggers:
+  hook-a:
+    id: trigger-a
+    type: webhook
+    enabled: true
+${a}  hook-b:
+    id: trigger-b
+    type: webhook
+    enabled: true
+${b}edges: {}
+`;
+    const path = (value: string) => `    custom_path: '${value}'\n`;
+    const unstated = '';
+
+    const first = snapshot(
+      twoHooks(unstated, unstated, 'fn(s => ({ ...s }));'),
+      0
+    );
+    const second = snapshot(
+      twoHooks(path('alpha'), unstated, 'fn(s => ({ ...s }));'),
+      1
+    );
+
+    const rows = (baselineA: string, baselineB: string) =>
+      deriveSnapshotChanges(twoHooks(baselineA, baselineB, 'fn(s => s);'), [
+        first,
+        second,
+      ]).flatMap(entry =>
+        entry.changes.structure
+          .filter(row => row.kind === 'trigger')
+          .map(row => row.detail)
+      );
+
+    // hook-a already held alpha, so the second snapshot changes nothing.
+    expect(rows(path('alpha'), path('beta'))).toEqual([]);
+    // Swapped, hook-a moves from beta to alpha. A salt that only counted the
+    // paths would read the answer above instead.
+    expect(rows(path('beta'), path('alpha'))).toEqual([
+      'path: beta \u2192 alpha',
+    ]);
+  });
+
   it('pins each change set to the segment index its snapshot carried', () => {
     const baseline = baseWorkflow('fn(s => s);');
     const edited = baseWorkflow('fn(s => s);\nconsole.log(1);');

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -527,6 +527,24 @@ describe('deriveWorkflowChanges', () => {
       expect(row?.detail).toBe('path: intake-form');
     });
 
+    it('names the path of a webhook trigger that was removed', () => {
+      const named = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+      const none = buildYaml({
+        jobs: [transformJob('fn(state => state);')],
+        triggers: [],
+        edges: [],
+      });
+
+      const row = deriveWorkflowChanges(named, none)!.structure.find(
+        entry => entry.kind === 'trigger'
+      );
+      expect(row?.change).toBe('remove');
+      expect(row?.detail).toBe('path: intake-form');
+    });
+
     it("states a new trigger's settings rather than implying a previous value", () => {
       const none = buildYaml({
         jobs: [transformJob('fn(state => state);')],

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -504,8 +504,9 @@ describe('deriveWorkflowChanges', () => {
 
       // The answer set a path the panel will flag as invalid. Saying it was
       // removed would send the reader looking for a change that never happened.
-      expect(triggerDetail(intake, spaces)).not.toBe('path removed');
-      expect(triggerDetail(intake, spaces)).toContain('intake-form');
+      expect(triggerDetail(intake, spaces)).toBe(
+        "path: intake-form \u2192 '   '"
+      );
     });
 
     it('reports the path on a webhook trigger that has just appeared', () => {
@@ -524,6 +525,24 @@ describe('deriveWorkflowChanges', () => {
       );
       expect(row?.change).toBe('add');
       expect(row?.detail).toBe('path: intake-form');
+    });
+
+    it("states a new trigger's settings rather than implying a previous value", () => {
+      const none = buildYaml({
+        jobs: [transformJob('fn(state => state);')],
+        triggers: [],
+        edges: [],
+      });
+      const configured = webhookWorkflow({
+        ...webhookTrigger,
+        webhook_reply: 'after_completion',
+        webhook_response_config: { success_code: 202 },
+      });
+
+      const row = deriveWorkflowChanges(none, configured)!.structure.find(
+        entry => entry.kind === 'trigger'
+      );
+      expect(row?.detail).toBe('reply: On Complete; success code: 202');
     });
 
     it('reports the settings when a cron trigger becomes a webhook', () => {
@@ -1026,6 +1045,34 @@ describe('deriveSnapshotChanges', () => {
 
     expect(rows(hadPath).map(row => row.detail)).toEqual(['path removed']);
     expect(rows(neverHadPath)).toEqual([]);
+  });
+
+  it('carries the path even when the snapshots omit trigger ids', () => {
+    // Apollo drops trigger ids on some replies, and parsing mints a fresh one
+    // per trigger, so carrying by raw id would carry nothing on those replies.
+    const idless = (path: string | null | undefined, body: string) => {
+      const yaml = buildYaml({
+        jobs: [transformJob(body)],
+        triggers: [
+          {
+            ...webhookTrigger,
+            ...(path !== undefined && { custom_path: path }),
+          },
+        ],
+        edges: [webhookToTransformEdge],
+      });
+      return yaml.replace(/^ {4}id: trigger-1\n/m, '');
+    };
+
+    const result = deriveSnapshotChanges(idless('intake-form', 'fn(s => s);'), [
+      snapshot(idless(undefined, 'fn(s => ({ ...s }));'), 0),
+      snapshot(idless(null, 'fn(s => ({ ...s }));'), 1),
+    ]);
+
+    const rows = result.flatMap(entry =>
+      entry.changes.structure.filter(row => row.kind === 'trigger')
+    );
+    expect(rows.map(row => row.detail)).toEqual(['path removed']);
   });
 
   it('pins each change set to the segment index its snapshot carried', () => {

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -79,7 +79,11 @@ const buildYaml = ({
       `    enabled: ${trigger.enabled ?? true}`
     );
     if (trigger.custom_path !== undefined) {
-      lines.push(`    custom_path: ${trigger.custom_path ?? 'null'}`);
+      // Quoted, so an empty path stays an empty string. Bare `custom_path:`
+      // is read back as null, which is a different case entirely.
+      const path =
+        trigger.custom_path === null ? 'null' : `'${trigger.custom_path}'`;
+      lines.push(`    custom_path: ${path}`);
     }
     if (trigger.webhook_reply) {
       lines.push(`    webhook_reply: ${trigger.webhook_reply}`);

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -28,6 +28,9 @@ interface YamlTrigger {
   type?: 'webhook' | 'cron';
   enabled?: boolean;
   cron_expression?: string;
+  custom_path?: string | null;
+  webhook_reply?: 'before_start' | 'after_completion';
+  webhook_response_config?: { success_code?: number; error_code?: number };
 }
 
 interface YamlEdge {
@@ -75,6 +78,20 @@ const buildYaml = ({
       `    type: ${type}`,
       `    enabled: ${trigger.enabled ?? true}`
     );
+    if (trigger.custom_path !== undefined) {
+      lines.push(`    custom_path: ${trigger.custom_path ?? 'null'}`);
+    }
+    if (trigger.webhook_reply) {
+      lines.push(`    webhook_reply: ${trigger.webhook_reply}`);
+    }
+    if (trigger.webhook_response_config) {
+      lines.push('    webhook_response_config:');
+      for (const [key, value] of Object.entries(
+        trigger.webhook_response_config
+      )) {
+        lines.push(`      ${key}: ${value}`);
+      }
+    }
     if (trigger.cron_expression) {
       lines.push(`    cron_expression: '${trigger.cron_expression}'`);
     }
@@ -404,6 +421,88 @@ describe('deriveWorkflowChanges', () => {
       );
       expect(triggerRow?.change).toBe('modify');
       expect(triggerRow?.detail).toContain('type: webhook → cron');
+    });
+
+    const webhookWorkflow = (trigger: YamlTrigger) =>
+      buildYaml({
+        jobs: [transformJob('fn(state => state);')],
+        triggers: [trigger],
+        edges: [webhookToTransformEdge],
+      });
+
+    const triggerDetail = (before: string, after: string) =>
+      deriveWorkflowChanges(before, after)!.structure.find(
+        row => row.kind === 'trigger'
+      )?.detail;
+
+    it('reports a custom path that was set, changed and cleared', () => {
+      const none = webhookWorkflow(webhookTrigger);
+      const intake = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+      const staff = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'staff-intake',
+      });
+      const cleared = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: null,
+      });
+
+      expect(triggerDetail(none, intake)).toBe('path: intake-form');
+      expect(triggerDetail(intake, staff)).toBe(
+        'path: intake-form → staff-intake'
+      );
+      expect(triggerDetail(intake, cleared)).toBe('path removed');
+    });
+
+    it('says nothing about a path that did not move', () => {
+      const intake = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+      const disabled = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+        enabled: false,
+      });
+
+      expect(triggerDetail(intake, disabled)).toBe('disabled');
+    });
+
+    it('reports a reply change in the words the trigger panel uses', () => {
+      const immediately = webhookWorkflow(webhookTrigger);
+      const onComplete = webhookWorkflow({
+        ...webhookTrigger,
+        webhook_reply: 'after_completion',
+      });
+
+      expect(triggerDetail(immediately, onComplete)).toBe(
+        'reply: Immediately → On Complete'
+      );
+    });
+
+    it('treats an absent reply as the default rather than a change', () => {
+      const absent = webhookWorkflow(webhookTrigger);
+      const explicit = webhookWorkflow({
+        ...webhookTrigger,
+        webhook_reply: 'before_start',
+      });
+
+      expect(deriveWorkflowChanges(absent, explicit)).toBeNull();
+    });
+
+    it('reports response codes, naming an absent one as the default', () => {
+      const none = webhookWorkflow(webhookTrigger);
+      const configured = webhookWorkflow({
+        ...webhookTrigger,
+        webhook_response_config: { success_code: 202, error_code: 500 },
+      });
+
+      expect(triggerDetail(none, configured)).toBe(
+        'success code: default → 202; error code: default → 500'
+      );
     });
   });
 

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -1093,6 +1093,38 @@ describe('deriveSnapshotChanges', () => {
     expect(rows.map(row => row.detail)).toEqual(['path removed']);
   });
 
+  it('pairs two id-less webhooks in document order, not in reverse', () => {
+    // Both sides are identical apart from a job body. Pairing the leftovers
+    // from the end crossed the two triggers and invented a path move on each.
+    const twoHooks = (body: string) => `id: wf-1
+name: Test Workflow
+jobs:
+  transform-data:
+    id: job-1
+    name: Transform data
+    adaptor: '@openfn/language-common@latest'
+    body: |
+      ${body}
+triggers:
+  hook-a:
+    type: webhook
+    enabled: true
+    custom_path: 'alpha'
+  hook-b:
+    type: webhook
+    enabled: true
+    custom_path: 'beta'
+edges: {}
+`;
+
+    const changes = deriveWorkflowChanges(
+      twoHooks('fn(s => s);'),
+      twoHooks('fn(s => ({ ...s }));')
+    )!;
+
+    expect(changes.structure.filter(row => row.kind === 'trigger')).toEqual([]);
+  });
+
   it('keeps two webhooks apart in the cache salt', () => {
     // buildYaml keys triggers by type, so this one is written out: the spec
     // allows any key, and two webhooks are what make a type-keyed salt

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -457,6 +457,57 @@ describe('deriveWorkflowChanges', () => {
       expect(triggerDetail(intake, cleared)).toBe('path removed');
     });
 
+    it('says nothing when the answer never mentions the path', () => {
+      // Applying a workflow that omits the key keeps the path the trigger
+      // holds, so claiming a removal here would be a lie about a live URL.
+      const intake = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+      const silent = webhookWorkflow({ ...webhookTrigger, enabled: false });
+
+      expect(triggerDetail(intake, silent)).toBe('disabled');
+    });
+
+    it('treats a blank path the way the server does, as no path', () => {
+      const intake = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+      const blank = webhookWorkflow({ ...webhookTrigger, custom_path: '' });
+      const blankToNamed = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'staff-intake',
+      });
+
+      expect(triggerDetail(intake, blank)).toBe('path removed');
+      expect(triggerDetail(blank, blankToNamed)).toBe('path: staff-intake');
+    });
+
+    it('reports the settings when a cron trigger becomes a webhook', () => {
+      const cron = buildYaml({
+        jobs: [transformJob('fn(state => state);')],
+        triggers: [
+          { id: 'trigger-1', type: 'cron', cron_expression: '0 * * * *' },
+        ],
+        edges: [
+          {
+            ...webhookToTransformEdge,
+            key: 'cron->transform-data',
+            source_trigger: 'cron',
+          },
+        ],
+      });
+      const named = webhookWorkflow({
+        ...webhookTrigger,
+        custom_path: 'intake-form',
+      });
+
+      const detail = triggerDetail(cron, named);
+      expect(detail).toContain('type: cron → webhook');
+      expect(detail).toContain('path: intake-form');
+    });
+
     it('says nothing about a path that did not move', () => {
       const intake = webhookWorkflow({
         ...webhookTrigger,

--- a/assets/test/collaborative-editor/utils/workflowDiff.test.ts
+++ b/assets/test/collaborative-editor/utils/workflowDiff.test.ts
@@ -466,8 +466,6 @@ describe('deriveWorkflowChanges', () => {
     });
 
     it('says nothing when the answer never mentions the path', () => {
-      // Applying a workflow that omits the key keeps the path the trigger
-      // holds, so claiming a removal here would be a lie about a live URL.
       const intake = webhookWorkflow({
         ...webhookTrigger,
         custom_path: 'intake-form',
@@ -972,8 +970,6 @@ describe('deriveSnapshotChanges', () => {
   });
 
   it('carries a webhook path a snapshot left unstated, so a later clear is reported', () => {
-    // Applying a snapshot that omits the path keeps it, so the document still
-    // holds one when the next snapshot clears it.
     const withPath = (path: string | null | undefined, body: string) =>
       buildYaml({
         jobs: [transformJob(body)],


### PR DESCRIPTION
## Description

The assistant's change summary compared a trigger's type, whether it was enabled, and its cron schedule. So a webhook's custom path could be set, changed or cleared and the summary said nothing, even though that path names the URL the webhook answers on. The reply timing and the response codes had the same gap. They all get a row now.

Closes #5149

## Validation steps

1. Give a webhook trigger a custom path in the trigger panel.
2. Ask the assistant to change it. The summary shows `Trigger: webhook trigger (path: old → new)`.
3. Ask it to remove the path. The row reads `(path removed)`.
4. Ask it to set a path again. The row reads `(path: your-new-path)`, with no arrow.
5. Ask for something that only edits a job. No trigger row.

## Additional notes for the reviewer

1. Needs OpenFn/apollo#670 for Apollo to change a path at all. I tested the three cases against a local Apollo on that branch.
2. `matchEntities` is also changed: it pairs same-key leftovers in document order now, because walking backwards crossed two id-less triggers.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our [Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR