### PR TITLE
Fix email-update password validation UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Profile email updates no longer show password validation errors while typing;
+  the current password is checked when submitting Update email.
+  [#2546](https://github.com/OpenFn/lightning/issues/2546)
+
 ### Changed
 
 - The AI assistant is the global assistant for everyone. It was behind the

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -718,22 +718,42 @@ defmodule Lightning.Accounts do
 
   An `Ecto.Changeset` containing any validation errors.
 
+  ## Options
+
+    * `:validate_password` - when `true` (default), require and check
+      `current_password`. Set to `false` for live validation while typing so
+      password errors only appear on submit.
+
   ## Examples
 
       iex> validate_change_user_email(user, %{"email" => "new@example.com", "current_password" => "secret"})
       %Ecto.Changeset{...}
 
   """
-  def validate_change_user_email(user, params \\ %{}) do
+  def validate_change_user_email(user, params \\ %{}, opts \\ []) do
+    validate_password? = Keyword.get(opts, :validate_password, true)
+
     data = %{email: nil, current_password: nil}
     types = %{email: :string, current_password: :string}
 
-    {data, types}
-    |> Changeset.cast(params, Map.keys(types))
-    |> Changeset.validate_required([:email, :current_password])
-    |> User.validate_email()
-    |> validate_email_changed(user)
-    |> validate_current_password(user)
+    changeset =
+      {data, types}
+      |> Changeset.cast(params, Map.keys(types))
+      |> then(fn changeset ->
+        if validate_password? do
+          Changeset.validate_required(changeset, [:email, :current_password])
+        else
+          Changeset.validate_required(changeset, [:email])
+        end
+      end)
+      |> User.validate_email()
+      |> validate_email_changed(user)
+
+    if validate_password? do
+      validate_current_password(changeset, user)
+    else
+      changeset
+    end
   end
 
   defp validate_email_changed(changeset, user) do

--- a/lib/lightning/accounts.ex
+++ b/lib/lightning/accounts.ex
@@ -703,16 +703,23 @@ defmodule Lightning.Accounts do
   @doc """
   Validates the changes for updating a user's email address.
 
-  This function ensures that:
+  By default this function ensures that:
   - The `email` and `current_password` fields are present.
   - The new email is in a valid format.
   - The new email is different from the current one.
   - The provided `current_password` matches the user's password.
 
+  Pass `validate_password: false` for live (`phx-change`) validation so only
+  the email is checked; password presence and correctness are still enforced
+  on submit (the default).
+
   ## Parameters
 
   - `user`: The `%User{}` struct representing the current user.
-  - `params`: A map of parameters containing the new email and current password.
+  - `params`: A map of parameters containing the new email and optionally
+    the current password.
+  - `opts`: Keyword options. `:validate_password` (default `true`) controls
+    whether `current_password` is required and verified.
 
   ## Returns
 

--- a/lib/lightning_web/live/profile_live/form_component.ex
+++ b/lib/lightning_web/live/profile_live/form_component.ex
@@ -110,10 +110,16 @@ defmodule LightningWeb.ProfileLive.FormComponent do
   def handle_event("validate_email", %{"user" => user_params}, socket) do
     changeset =
       socket.assigns.user
-      |> Accounts.validate_change_user_email(user_params)
+      |> Accounts.validate_change_user_email(user_params, validate_password: false)
       |> Map.put(:action, :validate_email)
 
     {:noreply, assign(socket, :email_changeset, changeset)}
+  end
+
+  def email_form_submit_disabled?(changeset) do
+    password = Ecto.Changeset.get_field(changeset, :current_password)
+
+    not changeset.valid? or password in [nil, ""]
   end
 
   @impl true

--- a/lib/lightning_web/live/profile_live/form_component.html.heex
+++ b/lib/lightning_web/live/profile_live/form_component.html.heex
@@ -81,7 +81,6 @@
           field={f[:current_password]}
           label="Enter password to confirm"
           required="true"
-          phx-debounce="blur"
           autocomplete="current-password"
         />
       </div>
@@ -92,7 +91,7 @@
     <.button
       type="submit"
       theme="primary"
-      disabled={!@email_changeset.valid?}
+      disabled={email_form_submit_disabled?(@email_changeset)}
       phx-disable-with="Sending confirmation email..."
     >
       Update email

--- a/lib/lightning_web/live/user_confirmation_required_live.ex
+++ b/lib/lightning_web/live/user_confirmation_required_live.ex
@@ -70,10 +70,16 @@ defmodule LightningWeb.UserConfirmationRequiredLive do
   def handle_event("validate_email", %{"user" => user_params}, socket) do
     changeset =
       socket.assigns.current_user
-      |> Accounts.validate_change_user_email(user_params)
+      |> Accounts.validate_change_user_email(user_params, validate_password: false)
       |> Map.put(:action, :validate_email)
 
     {:noreply, assign(socket, :email_changeset, changeset)}
+  end
+
+  def email_form_submit_disabled?(changeset) do
+    password = Ecto.Changeset.get_field(changeset, :current_password)
+
+    not changeset.valid? or password in [nil, ""]
   end
 
   def handle_event("change_email", %{"user" => user_params}, socket) do

--- a/lib/lightning_web/live/user_confirmation_required_live.html.heex
+++ b/lib/lightning_web/live/user_confirmation_required_live.html.heex
@@ -109,13 +109,12 @@
           field={f[:current_password]}
           label="Enter password to confirm"
           required="true"
-          phx-debounce="blur"
           autocomplete="current-password"
         />
         <.button
           type="submit"
           theme="primary"
-          disabled={!@email_changeset.valid?}
+          disabled={email_form_submit_disabled?(@email_changeset)}
           phx-disable-with="Sending confirmation email..."
         >
           Update email

--- a/test/lightning/accounts_test.exs
+++ b/test/lightning/accounts_test.exs
@@ -195,6 +195,20 @@ defmodule Lightning.AccountsTest do
       assert {"can't be blank", _} = errors[:current_password]
     end
 
+    test "skips password checks when validate_password is false" do
+      user = insert(:user)
+
+      changeset =
+        Accounts.validate_change_user_email(
+          user,
+          %{"email" => "new@example.com", "current_password" => ""},
+          validate_password: false
+        )
+
+      assert changeset.valid?
+      refute changeset.errors[:current_password]
+    end
+
     test "gives a password-less account a changeset error rather than raising" do
       # AccountHook is adapter-pluggable, so an SSO-provisioned account can have
       # no hash at all. This form is the one page such an account can reach.

--- a/test/lightning_web/live/profile_live_test.exs
+++ b/test/lightning_web/live/profile_live_test.exs
@@ -43,7 +43,8 @@ defmodule LightningWeb.ProfileLiveTest do
   }
 
   @update_email_attrs %{
-    email: "new@example.com"
+    email: "new@example.com",
+    current_password: "hello world!"
   }
 
   describe "Edit user profile" do
@@ -168,6 +169,52 @@ defmodule LightningWeb.ProfileLiveTest do
       assert profile_live
              |> form("#email-form", user: %{email: user.email})
              |> render_change() =~ "Please change your email"
+    end
+
+    test "does not show password errors while typing a new email", %{
+      conn: conn
+    } do
+      {:ok, profile_live, _html} =
+        live(conn, Routes.profile_edit_path(conn, :edit), on_error: :raise)
+
+      html =
+        profile_live
+        |> form("#email-form",
+          user: %{email: "new_email_123@openfn.org", current_password: ""}
+        )
+        |> render_change()
+
+      refute html =~ "This field can&#39;t be blank."
+      refute html =~ "Your passwords do not match."
+      assert html =~ ~s(disabled="disabled")
+    end
+
+    test "clears a prior password error when the user types again", %{
+      conn: conn
+    } do
+      {:ok, profile_live, _html} =
+        live(conn, Routes.profile_edit_path(conn, :edit), on_error: :raise)
+
+      assert profile_live
+             |> form("#email-form",
+               user: %{
+                 email: "new_email_123@openfn.org",
+                 current_password: "invalid"
+               }
+             )
+             |> render_submit() =~ "Your passwords do not match."
+
+      html =
+        profile_live
+        |> form("#email-form",
+          user: %{
+            email: "new_email_123@openfn.org",
+            current_password: "still typing"
+          }
+        )
+        |> render_change()
+
+      refute html =~ "Your passwords do not match."
     end
 
     test "a user can change their email address", %{conn: conn} do

--- a/test/lightning_web/live/user_confirmation_required_live_test.exs
+++ b/test/lightning_web/live/user_confirmation_required_live_test.exs
@@ -157,6 +157,54 @@ defmodule LightningWeb.UserConfirmationRequiredLiveTest do
       refute_email_sent(subject: "Please confirm your new email")
     end
 
+    test "does not show password errors while typing a new email", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} =
+        conn |> log_in_user(user) |> live(~p"/users/confirm-required")
+
+      html =
+        view
+        |> form("#email-form",
+          user: %{email: "typo-fixed@example.com", current_password: ""}
+        )
+        |> render_change()
+
+      refute html =~ "This field can&#39;t be blank."
+      refute html =~ "Your passwords do not match."
+      assert html =~ ~s(disabled="disabled")
+    end
+
+    test "clears a prior password error when the user types again", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} =
+        conn |> log_in_user(user) |> live(~p"/users/confirm-required")
+
+      assert view
+             |> form("#email-form",
+               user: %{
+                 email: "typo-fixed@example.com",
+                 current_password: "wrong"
+               }
+             )
+             |> render_submit() =~ "Your passwords do not match."
+
+      html =
+        view
+        |> form("#email-form",
+          user: %{
+            email: "typo-fixed@example.com",
+            current_password: "still typing"
+          }
+        )
+        |> render_change()
+
+      refute html =~ "Your passwords do not match."
+    end
+
     test "sends instructions to the new address", %{conn: conn, user: user} do
       {:ok, view, _html} =
         conn |> log_in_user(user) |> live(~p"/users/confirm-required")


### PR DESCRIPTION
## Description

This PR fixes password validation UX on the profile email-update form.

Closes #2546

- Validate email (format / unchanged) on change
- Validate current password only on submit
- Keep Update email disabled until a password is entered (without showing password errors while typing)
- Clear a prior password error as the user continues typing
- Same behavior on the confirmation-required email correction form

## Validation steps

1. Open Profile → Change email
2. Enter a new email with an empty password — no "can't be blank" on the password field; Update stays disabled
3. Submit with a wrong password — see mismatch error
4. Type in the password field again — mismatch error clears while typing
5. Submit with the correct password — confirmation email flow proceeds

## Additional notes for the reviewer

1. `Accounts.validate_change_user_email/3` gains `validate_password:` (default `true`)

## AI Usage

- [x] I have used another model
- [ ] I have used Claude Code
- [ ] I have not used AI

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review` with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**. (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR