### PR TITLE
Fix Safari CSS for trigger icons and docs COPY/ADD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Safari: give workflow trigger icons explicit size so Heroicons fill their
+  node slot, and raise adaptor-docs COPY/ADD controls above the example block.
+  [#2960](https://github.com/OpenFn/lightning/issues/2960)
+
 ### Changed
 
 - The AI assistant is the global assistant for everyone. It was behind the

--- a/assets/js/adaptor-docs/components/render/Function.tsx
+++ b/assets/js/adaptor-docs/components/render/Function.tsx
@@ -70,8 +70,11 @@ const Example = ({ eg, onInsert }: ExampleProps) => {
       <label className="block text-sm text-secondary-700 mt-2">
         Example{caption && `: ${caption}`}
       </label>
-      <div style={{ marginTop: '-6px' }}>
-        <div className="w-full px-5 text-right" style={{ height: '13px' }}>
+      <div style={{ marginTop: '-6px', position: 'relative' }}>
+        <div
+          className="w-full px-5 text-right relative z-10"
+          style={{ height: '13px' }}
+        >
           <PreButton
             label="COPY"
             onClick={() => doCopy(code)}
@@ -85,7 +88,7 @@ const Example = ({ eg, onInsert }: ExampleProps) => {
             />
           )}
         </div>
-        <pre className="rounded-md pl-4 pr-30 py-2 mx-4 my-0 font-mono bg-slate-100 border-2 border-slate-200 text-slate-800 min-h-full text-xs overflow-x-auto">
+        <pre className="rounded-md pl-4 pr-30 py-2 mx-4 my-0 font-mono bg-slate-100 border-2 border-slate-200 text-slate-800 min-h-full text-xs overflow-x-auto relative z-0">
           {code}
         </pre>
       </div>

--- a/assets/js/workflow-diagram/nodes/Trigger.tsx
+++ b/assets/js/workflow-diagram/nodes/Trigger.tsx
@@ -58,7 +58,7 @@ function getTriggerMeta(trigger: Lightning.TriggerNode): TriggerMeta {
         label: 'Webhook trigger',
         sublabel: `On each request received`,
         tooltip: 'Click to copy webhook URL',
-        primaryIcon: <GlobeAltIcon />,
+        primaryIcon: <GlobeAltIcon className="h-full w-full" />,
         secondaryIcon: trigger.has_auth_method ? lockClosedIcon : null,
       };
     case 'cron':
@@ -73,7 +73,7 @@ function getTriggerMeta(trigger: Lightning.TriggerNode): TriggerMeta {
       return {
         label: 'Cron trigger',
         sublabel,
-        primaryIcon: <ClockIcon />,
+        primaryIcon: <ClockIcon className="h-full w-full" />,
         secondaryIcon: null,
       };
   }


### PR DESCRIPTION
## Description

This PR fixes Safari UI issues on the workflow canvas and adaptor docs panel.

Closes #2960

- Trigger node icons (`GlobeAltIcon` / `ClockIcon`) now use `h-full w-full`, matching MiniMap, so Safari sizes the SVG inside the absolutely positioned slot
- Adaptor docs COPY/ADD controls get an explicit stacking context above the example `<pre>`

## Validation steps

1. On Safari 18, open a workflow with webhook and cron triggers — icons visible inside the circular nodes
2. Open the adaptor docs panel for a job — COPY/ADD remain clickable above example snippets

## AI Usage

- [x] I have used another model
- [ ] I have used Claude Code
- [ ] I have not used AI

## Pre-submission checklist

- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR