### PR TITLE
Stop anyone changing a project's environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ adaptor_registry_cache.json
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json
 
-# Ignore credential schemas.
-/priv/schemas/
+# Ignore credential schemas. No trailing slash: it is often a symlink to a
+# shared checkout, and a trailing slash matches only directories.
+/priv/schemas
 
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Security
+
+- A project's environment can no longer be changed once the project exists. It
+  decides which of a credential's value sets the project reads, so anyone who
+  could type it could read any set on any credential shared with that project.
+  A sandbox holds a reference to every credential its parent holds, and creating
+  a sandbox makes you its owner, so a sandbox admin could name their environment
+  after the parent's and read the parent's production values. The field stays on
+  the project settings page, because it tells you which values resolve there, but
+  it is read-only and no longer accepted from a form or from the sandbox update.
+
 ### Changed
 
 - The AI assistant is the global assistant for everyone. It was behind the

--- a/lib/lightning/projects/sandboxes.ex
+++ b/lib/lightning/projects/sandboxes.ex
@@ -511,7 +511,9 @@ defmodule Lightning.Projects.Sandboxes do
       sandbox
     )
     |> if do
-      allowed_attrs = Map.take(attrs, [:name, :color, :env])
+      # Without `:env`. See the note on @project_settings_fields: a sandbox
+      # owner who could set it could read the parent's production values.
+      allowed_attrs = Map.take(attrs, [:name, :color])
       Lightning.Projects.update_project(sandbox, allowed_attrs, actor)
     else
       {:error, :unauthorized}

--- a/lib/lightning_web/live/project_live/settings.ex
+++ b/lib/lightning_web/live/project_live/settings.ex
@@ -342,7 +342,11 @@ defmodule LightningWeb.ProjectLive.Settings do
   # `can_edit_project`. Privileged fields (requires_mfa, scheduled_deletion,
   # retention, allow_support_access, parent_id) are deliberately excluded so a
   # crafted payload cannot set them past their own dedicated gates.
-  @project_settings_fields ~w(raw_name name description concurrency color env)
+  # Deliberately without `env`. It decides which of a credential's value sets
+  # this project reads, and a project admin who could type it could read any set
+  # of any credential the project holds. It stays readable on the form and is
+  # set when a project or sandbox is created.
+  @project_settings_fields ~w(raw_name name description concurrency color)
 
   # Retention fields, gated by `can_edit_data_retention`.
   @retention_fields ~w(retention_policy history_retention_period

--- a/lib/lightning_web/live/project_live/settings.html.heex
+++ b/lib/lightning_web/live/project_live/settings.html.heex
@@ -133,7 +133,7 @@
                   <.input
                     type="text"
                     field={f[:env]}
-                    disabled={!@can_edit_project}
+                    disabled={true}
                     label="Project environment"
                   />
                   <small class="mt-2 block text-xs text-gray-600">
@@ -1081,7 +1081,7 @@
             <% else %>
               <.button
                 id={"download-export-file-#{file.id}-button"}
-                disabled={true}
+                disabled={!@can_edit_project}
                 class="table-action disabled:bg-gray-50"
                 tooltip="Export is not yet ready for download"
               >

--- a/test/lightning/sandboxes_test.exs
+++ b/test/lightning/sandboxes_test.exs
@@ -1926,6 +1926,21 @@ defmodule Lightning.Projects.SandboxesTest do
       assert updated.name == "updated"
     end
 
+    test "ignores env, whoever asks", %{actor: actor, sandbox: sb} do
+      ensure_member!(sb, actor, :owner)
+      original_env = sb.env
+
+      {:ok, updated} =
+        Sandboxes.update_sandbox(sb, actor, %{name: "updated", env: "main"})
+
+      # The environment decides which of a credential's value sets this project
+      # reads. A sandbox holds a reference to every credential its parent holds,
+      # so an owner who could name it after the parent's would read the parent's
+      # production values.
+      assert updated.name == "updated"
+      assert updated.env == original_env
+    end
+
     test "uuid not found returns not_found", %{actor: actor} do
       bad_id = Ecto.UUID.generate()
 

--- a/test/lightning_web/live/project_live_test.exs
+++ b/test/lightning_web/live/project_live_test.exs
@@ -1791,6 +1791,43 @@ defmodule LightningWeb.ProjectLiveTest do
              } = Repo.get!(Project, project.id)
     end
 
+    test "project settings form cannot change the environment", %{
+      conn: conn,
+      user: user
+    } do
+      project =
+        insert(:project,
+          name: "project-1",
+          env: "staging",
+          project_users: [%{user_id: user.id, role: :admin}]
+        )
+
+      {:ok, view, html} = live(conn, ~p"/projects/#{project}/settings")
+
+      # It stays on the page, because it tells you which values a credential
+      # resolves here, but nobody can type in it.
+      assert html =~ "Project environment"
+
+      # The form helper refuses a field it cannot fill, which is the assertion
+      # that the input is disabled rather than merely styled to look it.
+      assert_raise ArgumentError, ~r/could not find non-disabled input/, fn ->
+        view
+        |> form("#project-settings-form", project: %{env: "main"})
+        |> render_submit()
+      end
+
+      # The field is disabled, so the form helper refuses to fill it. Push the
+      # event as a crafted submit would, which is the case that matters.
+      assert render_submit(view, "save", %{
+               "project" => %{"raw_name" => "project-1", "env" => "main"}
+             }) =~ "Project updated successfully"
+
+      # Submitting it anyway changes nothing. A project admin who could type
+      # this could read any set of values on any credential the project holds,
+      # and a sandbox admin could read the parent's production values.
+      assert %{env: "staging"} = Repo.get!(Project, project.id)
+    end
+
     test "project settings form converts uppercase name to url-safe format",
          %{
            conn: conn,


### PR DESCRIPTION
## Description

This PR stops anyone changing a project's environment after the project exists.

The environment decides which of a credential's value sets the project reads, and
it is a text field on project settings that any project admin can type. So an
admin of a project a credential is shared with can read any set of values on that
credential. It is worse in a sandbox. A sandbox holds a reference to every
credential its parent holds, and creating a sandbox makes you its owner, so a
sandbox admin can name the environment after the parent's and read the parent's
production values. Nobody approves it and nothing records it.

The field stays on the page, because it tells you which values resolve there, but
it is read-only, and `env` comes out of both places that took it from a user: the
settings form's allowlist, so a crafted submit is ignored as well, and
`update_sandbox`. Our own code still sets it, so a new root project gets `main`
and a new sandbox gets `dev`.

## Validation steps

1. As a project admin, open project settings. The environment is shown and cannot
   be typed in.
2. Submit the settings form with an `env` value anyway, by hand. The project
   saves and the environment does not change.
3. Create a sandbox, become its owner, and try the same on its settings. Same
   result.
4. Check a credential still resolves as before on a project whose environment
   already matches one of its value sets.

## Additional notes for the reviewer

1. This does not undo access anyone already has. Sandboxes whose environment was
   changed before this keep reading the parent's values until those are reset,
   which is a data fix. 27 sandboxes across 13 projects are in that state.
2. Nobody can set an environment now, including support. If a customer needs a
   project mapped to a credential's non-default value set, that has to go through
   a console or a follow-up that gives someone the ability deliberately.
3. This is the stopgap. It defends a name rather than recording which values a
   project may read, so the rule has to hold at every future write path. The
   fuller fix records the grant on the share itself.
4. Also in here: the `.gitignore` pattern for `priv/schemas` loses its trailing
   slash, so the symlink a worktree gets is ignored rather than committed by
   accident.

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [x] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
