### PR TITLE
Global Assistant: Say revert changes, not revert this reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 ### Changed
 
+- The AI assistant's reply footer now reads "Revert changes" and "Restore
+  changes" rather than "Revert this reply", and its confirmation matches.
+  [#5161](https://github.com/OpenFn/lightning/pull/5161)
+
 - The AI assistant is the global assistant for everyone. It was behind the
   experimental features setting and an opt-in tickbox on the chat input, and
   both are gone: every message goes to it, and the badge naming which assistant

--- a/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
+++ b/assets/js/collaborative-editor/components/AIAssistantPanelWrapper.tsx
@@ -617,6 +617,7 @@ export function AIAssistantPanelWrapper({
     undoneMessageId,
     requestUndoChanges,
     isConfirmOpen,
+    isRestoring,
     confirmUndoChanges,
     cancelUndoChanges,
   } = useAIWorkflowUndo({
@@ -874,13 +875,22 @@ export function AIAssistantPanelWrapper({
         isOpen={isConfirmOpen}
         onClose={cancelUndoChanges}
         onConfirm={confirmUndoChanges}
-        title="Undo replaces the whole workflow"
-        // States what undo does rather than claiming edits exist. The check
-        // behind this dialog also fires when it simply cannot tell, after a
-        // reload has lost the record of how the canvas was left, so copy that
-        // asserts the workflow has changed is wrong about half the time.
-        description="It goes back to how it was before this reply, so anything changed since will be lost."
-        confirmLabel="Undo anyway"
+        title={
+          isRestoring
+            ? 'Restoring replaces the whole workflow'
+            : 'Reverting replaces the whole workflow'
+        }
+        // States what the action does rather than claiming edits exist. The
+        // check behind this dialog also fires when it simply cannot tell,
+        // after a reload has lost the record of how the canvas was left, so
+        // copy that asserts the workflow has changed is wrong about half the
+        // time.
+        description={
+          isRestoring
+            ? "It goes back to how it was with these changes applied, so anything you've edited since will be lost."
+            : "It goes back to how it was before these changes, so anything you've edited since will be lost."
+        }
+        confirmLabel={isRestoring ? 'Restore anyway' : 'Revert anyway'}
         variant="danger"
       />
     </div>

--- a/assets/js/collaborative-editor/components/MessageList.tsx
+++ b/assets/js/collaborative-editor/components/MessageList.tsx
@@ -494,7 +494,7 @@ const RevertReplyButton = ({
         undone ? 'hero-arrow-uturn-right' : 'hero-arrow-uturn-left'
       )}
     />
-    <span>{undone ? 'Restore this reply' : 'Revert this reply'}</span>
+    <span>{undone ? 'Restore changes' : 'Revert changes'}</span>
   </button>
 );
 
@@ -763,7 +763,7 @@ interface MessageListProps {
   onUndoChanges?: (
     messageId: string,
     yaml: string,
-    options?: { fromModel?: boolean }
+    options?: { restoring?: boolean }
   ) => void;
   /** Reply whose changes are currently undone, so its control offers Redo */
   undoneMessageId?: string | null;
@@ -868,8 +868,8 @@ export function MessageList({
   const lastMessage = messages.at(-1);
   const viewerJustSent = Boolean(
     lastMessage?.role === 'user' &&
-    currentUserId &&
-    lastMessage.user?.id === currentUserId
+      currentUserId &&
+      lastMessage.user?.id === currentUserId
   );
 
   useEffect(() => {
@@ -1013,12 +1013,12 @@ export function MessageList({
       ? isGlobalAssistantActive
       : Boolean(
           message.from_global &&
-          // Only a successful reply was auto-applied. An errored or
-          // cancelled one can still carry code, and rendering its blocks
-          // would present changes that never reached the canvas as a
-          // record of what happened.
-          message.status === 'success' &&
-          (message.code || snapshotsByMessageId[message.id]?.length)
+            // Only a successful reply was auto-applied. An errored or
+            // cancelled one can still carry code, and rendering its blocks
+            // would present changes that never reached the canvas as a
+            // record of what happened.
+            message.status === 'success' &&
+            (message.code || snapshotsByMessageId[message.id]?.length)
         );
 
   /**
@@ -1029,18 +1029,18 @@ export function MessageList({
   const canUndoChanges = (message: Message): boolean =>
     Boolean(
       onUndoChanges &&
-      !isApplyInFlight &&
-      !isWriteDisabled &&
-      !isStreaming(message) &&
-      displayMessages.at(-1)?.id === message.id &&
-      message.from_global &&
-      // Only a successful reply was auto-applied; an error or cancelled one
-      // can still carry code, and undoing it would offer to "redo" changes
-      // that never landed.
-      message.status === 'success' &&
-      message.code &&
-      !failedApplyMessageIds?.has(message.id) &&
-      beforeYamlByMessageId.get(message.id)
+        !isApplyInFlight &&
+        !isWriteDisabled &&
+        !isStreaming(message) &&
+        displayMessages.at(-1)?.id === message.id &&
+        message.from_global &&
+        // Only a successful reply was auto-applied; an error or cancelled one
+        // can still carry code, and undoing it would offer to "redo" changes
+        // that never landed.
+        message.status === 'success' &&
+        message.code &&
+        !failedApplyMessageIds?.has(message.id) &&
+        beforeYamlByMessageId.get(message.id)
     );
 
   const snapshotsFor = (message: Message): WorkflowSnapshot[] =>
@@ -1470,10 +1470,7 @@ export function MessageList({
                                 redoing
                                   ? message.code!
                                   : beforeYamlByMessageId.get(message.id)!,
-                                // Redo restores the reply's own YAML, which
-                                // the model wrote; undo restores our own
-                                // serializer's.
-                                { fromModel: redoing }
+                                { restoring: redoing }
                               );
                             }}
                           />

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowUndo.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowUndo.ts
@@ -67,6 +67,9 @@ export function useAIWorkflowUndo({
     yaml: string;
     restoring: boolean;
   } | null>(null);
+  // Held past close, because the dialog fades out over 200ms. Reading the
+  // direction off `pending` flipped its copy to the other one on the way out.
+  const [restoringPending, setRestoringPending] = useState(false);
 
   const { run: restore } = useActionLock(
     async (messageId: string, yaml: string, fromModel: boolean) => {
@@ -104,6 +107,7 @@ export function useAIWorkflowUndo({
   const requestUndoChanges = useCallback(
     (messageId: string, yaml: string, options?: { restoring?: boolean }) => {
       const restoring = options?.restoring ?? false;
+      setRestoringPending(restoring);
       if (appliedCanvas.hasChangedSinceApply()) {
         setPending({ messageId, yaml, restoring });
         return;
@@ -128,7 +132,7 @@ export function useAIWorkflowUndo({
     undoneMessageId,
     requestUndoChanges,
     isConfirmOpen: pending !== null,
-    isRestoring: pending?.restoring ?? false,
+    isRestoring: restoringPending,
     confirmUndoChanges,
     cancelUndoChanges,
   };

--- a/assets/js/collaborative-editor/hooks/useAIWorkflowUndo.ts
+++ b/assets/js/collaborative-editor/hooks/useAIWorkflowUndo.ts
@@ -31,9 +31,11 @@ interface UseAIWorkflowUndoReturn {
   requestUndoChanges: (
     messageId: string,
     yaml: string,
-    options?: { fromModel?: boolean }
+    options?: { restoring?: boolean }
   ) => void;
   isConfirmOpen: boolean;
+  /** Whether the pending confirmation is a redo, so its copy can say so */
+  isRestoring: boolean;
   confirmUndoChanges: () => void;
   cancelUndoChanges: () => void;
 }
@@ -63,7 +65,7 @@ export function useAIWorkflowUndo({
   const [pending, setPending] = useState<{
     messageId: string;
     yaml: string;
-    fromModel: boolean;
+    restoring: boolean;
   } | null>(null);
 
   const { run: restore } = useActionLock(
@@ -100,20 +102,21 @@ export function useAIWorkflowUndo({
   );
 
   const requestUndoChanges = useCallback(
-    (messageId: string, yaml: string, options?: { fromModel?: boolean }) => {
-      const fromModel = options?.fromModel ?? false;
+    (messageId: string, yaml: string, options?: { restoring?: boolean }) => {
+      const restoring = options?.restoring ?? false;
       if (appliedCanvas.hasChangedSinceApply()) {
-        setPending({ messageId, yaml, fromModel });
+        setPending({ messageId, yaml, restoring });
         return;
       }
-      void restore(messageId, yaml, fromModel);
+      // Only a redo restores the reply's own YAML, so it alone is model-written.
+      void restore(messageId, yaml, restoring);
     },
     [appliedCanvas, restore]
   );
 
   const confirmUndoChanges = useCallback(() => {
     if (pending)
-      void restore(pending.messageId, pending.yaml, pending.fromModel);
+      void restore(pending.messageId, pending.yaml, pending.restoring);
     setPending(null);
   }, [pending, restore]);
 
@@ -125,6 +128,7 @@ export function useAIWorkflowUndo({
     undoneMessageId,
     requestUndoChanges,
     isConfirmOpen: pending !== null,
+    isRestoring: pending?.restoring ?? false,
     confirmUndoChanges,
     cancelUndoChanges,
   };

--- a/assets/node_modules
+++ b/assets/node_modules
@@ -1,0 +1,1 @@
+/Users/elias/Lab/openfn/lightning/.claude/worktrees/custom-path-diff/assets/node_modules

--- a/assets/node_modules
+++ b/assets/node_modules
@@ -1,1 +1,0 @@
-/Users/elias/Lab/openfn/lightning/.claude/worktrees/custom-path-diff/assets/node_modules

--- a/assets/test/collaborative-editor/components/MessageList.undoChanges.test.tsx
+++ b/assets/test/collaborative-editor/components/MessageList.undoChanges.test.tsx
@@ -73,9 +73,8 @@ describe('MessageList - undo applied changes', () => {
 
     await userEvent.click(screen.getByTestId('undo-changes-button'));
 
-    // Undo restores YAML this app serialized, so it needs no id validation
     expect(onUndoChanges).toHaveBeenCalledWith('reply-1', BASELINE_YAML, {
-      fromModel: false,
+      restoring: false,
     });
   });
 
@@ -90,12 +89,11 @@ describe('MessageList - undo applied changes', () => {
     );
 
     const button = screen.getByTestId('undo-changes-button');
-    expect(button).toHaveTextContent('Restore this reply');
+    expect(button).toHaveTextContent('Restore changes');
 
     await userEvent.click(button);
-    // Redo restores the reply's own YAML, which the model wrote
     expect(onUndoChanges).toHaveBeenCalledWith('reply-1', APPLIED_YAML, {
-      fromModel: true,
+      restoring: true,
     });
   });
 

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowUndo.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowUndo.test.ts
@@ -122,7 +122,7 @@ describe('useAIWorkflowUndo', () => {
 
     act(() => {
       result.current.requestUndoChanges(MESSAGE_ID, modelYaml, {
-        fromModel: true,
+        restoring: true,
       });
     });
 
@@ -160,6 +160,25 @@ describe('useAIWorkflowUndo', () => {
     await waitFor(() => {
       expect(importWorkflow).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('tells the confirmation which direction it is confirming', () => {
+    const { result } = setup({ hasChanged: true });
+
+    act(() => {
+      result.current.requestUndoChanges(MESSAGE_ID, BASELINE_YAML);
+    });
+    expect(result.current.isRestoring).toBe(false);
+
+    act(() => {
+      result.current.cancelUndoChanges();
+    });
+    act(() => {
+      result.current.requestUndoChanges(MESSAGE_ID, BASELINE_YAML, {
+        restoring: true,
+      });
+    });
+    expect(result.current.isRestoring).toBe(true);
   });
 
   it('drops the pending restore when the confirmation is cancelled', () => {

--- a/assets/test/collaborative-editor/hooks/useAIWorkflowUndo.test.ts
+++ b/assets/test/collaborative-editor/hooks/useAIWorkflowUndo.test.ts
@@ -181,6 +181,27 @@ describe('useAIWorkflowUndo', () => {
     expect(result.current.isRestoring).toBe(true);
   });
 
+  it('keeps the direction while the confirmation fades out', () => {
+    // The dialog leaves over 200ms, so it is still on screen after a confirm.
+    // Reading the direction off the pending restore flipped its copy to the
+    // other one on the way out.
+    const { result } = setup({ hasChanged: true });
+
+    act(() => {
+      result.current.requestUndoChanges(MESSAGE_ID, BASELINE_YAML, {
+        restoring: true,
+      });
+    });
+    expect(result.current.isRestoring).toBe(true);
+
+    act(() => {
+      result.current.confirmUndoChanges();
+    });
+
+    expect(result.current.isConfirmOpen).toBe(false);
+    expect(result.current.isRestoring).toBe(true);
+  });
+
   it('drops the pending restore when the confirmation is cancelled', () => {
     const { result, importWorkflow } = setup({ hasChanged: true });
 


### PR DESCRIPTION
Renames the AI assistant's reply footer control from "Revert/Restore this reply" to "Revert/Restore changes".

<img width="434" height="190" alt="Renamed the Gmail step to straße - the internal key and" src="https://github.com/user-attachments/assets/d802b4c5-cae5-4f58-a12e-246b1a9956e6" />

The confirmation dialog behind it is also changed to add two different versions depending on whether the user has clicked "revert" or "restore".

<img width="561" height="247" alt="Reverting replaces the whole workflow" src="https://github.com/user-attachments/assets/64f2e65f-ee27-44d2-9d8f-1cbda3e6c3e3" />
<img width="575" height="238" alt="Restoring replaces the whole workflow" src="https://github.com/user-attachments/assets/ea23874b-ce81-4ed6-a367-8dbbd69d5c7e" />

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [ ] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`) — n/a, copy and client
      state only, no new data access
- [x] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
