### PR TITLE
Workflow health: bucketed run counts behind the window

### DIFF
--- a/assets/js/health/WorkflowHealth.tsx
+++ b/assets/js/health/WorkflowHealth.tsx
@@ -71,12 +71,9 @@ export const HealthContent = ({
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900">
-            {workflowName}
-          </h1>
-          <Subtitle outcomes={outcomes.data} error={outcomes.error} />
-        </div>
+        <h1 className="min-w-0 text-2xl font-semibold break-words text-gray-900">
+          {workflowName}
+        </h1>
         {/* The picker and the freshness stamp both belong to the whole page,
             so they stack in the header rather than sitting on any one card. */}
         <div className="flex shrink-0 flex-col items-end gap-1">
@@ -201,7 +198,7 @@ const Panel = <T,>({
   children: (data: T) => ReactNode;
 }) => {
   // `alert` is the assertive live region: a failure is read out at once,
-  // where the polite subtitle would only fall silent.
+  // where the polite stamp above would only fall silent.
   if (error) {
     return (
       <p role="alert" className="text-sm text-red-700">
@@ -216,8 +213,7 @@ const Panel = <T,>({
 
 // Reached on a first load and again after a failure, so it holds the chart's
 // frame either way and the card doesn't jump when the data lands. Not a live
-// region: the subtitle announces loading once for the page, this text is only
-// for a reader who lands inside the card.
+// region: this text is only for a reader who lands inside the card.
 const ChartLoading = () => (
   <div className={FRAME}>
     <span className="sr-only">Loading…</span>
@@ -226,39 +222,16 @@ const ChartLoading = () => (
 
 // The stamp is the server's compute time, not the moment the browser asked —
 // `window.to` is when the numbers were true, however long the round trip took.
-const UpdatedAt = ({ at }: { at: string | null }) => {
-  if (!at) return null;
-
-  return (
-    <span className="text-xs text-gray-500">
-      Last Updated {new Date(at).toLocaleTimeString()}
-    </span>
-  );
-};
-
-// Holds its line while empty (`min-h-5` is one `text-sm` line). It names the
-// window the numbers beside it came from, and goes back to "Loading…" on a
-// range switch rather than naming a window no panel is showing yet. The page's
-// one polite live region: a first load and a range switch are each read out
-// here once, rather than by every card in turn. Falls silent on a failure
-// rather than announcing a load that isn't happening — the cards raise that as
-// an alert, which is read out at once where this region would have to wait.
-const Subtitle = ({
-  outcomes,
-  error,
-}: {
-  outcomes: Outcomes | null;
-  error: string | null;
-}) => (
-  <p role="status" className="min-h-5 text-sm text-gray-500">
-    {outcomes
-      ? `Last ${windowLabel(outcomes.window)} · ${workOrders(outcomes.counts)}`
-      : !error && 'Loading…'}
+//
+// Holds its line while empty (`min-h-4` is one `text-xs` line) so the picker
+// above it doesn't move.
+const UpdatedAt = ({ at }: { at: string | null }) => (
+  <p className="min-h-4 text-xs text-gray-500">
+    {at && `Last Updated ${new Date(at).toLocaleTimeString()}`}
   </p>
 );
 
-// "1 work order", "1,287 work orders": the subtitle and the Outcomes card both
-// say it, so it is spelled once.
+// "1 work order", "1,287 work orders".
 const workOrders = (counts: Outcomes['counts']) => {
   const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
 

--- a/assets/js/health/WorkflowHealth.tsx
+++ b/assets/js/health/WorkflowHealth.tsx
@@ -83,8 +83,8 @@ export const HealthContent = ({
       </div>
 
       {/* Four columns: a narrow donut beside a wide time axis, then an even
-          split. Stacks in source order below `md`. */}
-      <div className="grid gap-6 md:grid-cols-4">
+          split. Stacks in source order below `lg`. */}
+      <div className="grid gap-6 lg:grid-cols-4">
         <Card
           title="Outcomes"
           meta={outcomes.data && workOrders(outcomes.data.counts)}
@@ -103,7 +103,7 @@ export const HealthContent = ({
             names the bucket size rather than a total that won't reconcile. */}
         <Card
           title="Volume over time"
-          className="md:col-span-3"
+          className="lg:col-span-3"
           meta={volume.data && bucketMeta(volume.data.buckets)}
         >
           <Panel data={volume.data} error={volume.error}>
@@ -121,7 +121,7 @@ export const HealthContent = ({
             fix. */}
         <Card
           title="Triage"
-          className="md:col-span-2"
+          className="lg:col-span-2"
           meta="grouped by failure type · counted once per failed branch"
         >
           <Panel data={signatures.data} error={signatures.error}>
@@ -141,7 +141,7 @@ export const HealthContent = ({
             the slices here and the red wedge there cannot disagree. */}
         <Card
           title="Failure breakdown"
-          className="md:col-span-2"
+          className="lg:col-span-2"
           meta={
             outcomes.data &&
             `${failures(outcomes.data.counts)} · by work order state`

--- a/assets/js/health/WorkflowHealth.tsx
+++ b/assets/js/health/WorkflowHealth.tsx
@@ -1,10 +1,14 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
+import { cn } from '#/utils/cn';
+
 import { FRAME } from './charts/Donut';
 import { FailureBreakdownDonut } from './charts/FailureBreakdownDonut';
 import { OutcomesDonut } from './charts/OutcomesDonut';
 import { TriageTable } from './charts/TriageTable';
+import type { RunVolume } from './charts/VolumeBars';
+import { bucketMeta, VolumeBars } from './charts/VolumeBars';
 import { DEFAULT_DAYS, RangePicker } from './RangePicker';
 import type { ErrorSignatures, Outcomes } from './types';
 import { FAILURE_STATES } from './types';
@@ -60,6 +64,9 @@ export const HealthContent = ({
   const signatures = useHealthQuery<ErrorSignatures>(
     `${base}/failures?days=${days}`
   );
+  // Counts runs where the rest of the page counts work orders, so there is
+  // nothing to share with the other two queries.
+  const volume = useHealthQuery<RunVolume>(`${base}/runs?days=${days}`);
 
   return (
     <div className="flex flex-col gap-6">
@@ -78,7 +85,9 @@ export const HealthContent = ({
         </div>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2">
+      {/* Four columns: a narrow donut beside a wide time axis, then an even
+          split. Stacks in source order below `md`. */}
+      <div className="grid gap-6 md:grid-cols-4">
         <Card
           title="Outcomes"
           meta={outcomes.data && workOrders(outcomes.data.counts)}
@@ -93,10 +102,49 @@ export const HealthContent = ({
           </Panel>
         </Card>
 
-        {/* Same reply as the panel beside it — one aggregate read two ways, so
-            the wedge here and the red wedge there cannot disagree. */}
+        {/* Runs, where the donut beside it counts work orders — so the meta
+            names the bucket size rather than a total that won't reconcile. */}
+        <Card
+          title="Volume over time"
+          className="md:col-span-3"
+          meta={volume.data && bucketMeta(volume.data.buckets)}
+        >
+          <Panel data={volume.data} error={volume.error}>
+            {({ buckets, window }) => (
+              <VolumeBars
+                buckets={buckets}
+                emptyMessage={emptyMessage(window, 'runs')}
+              />
+            )}
+          </Panel>
+        </Card>
+
+        {/* Counts are per failed step, so the rows can sum past the failure
+            total the donuts draw: a second broken branch is its own thing to
+            fix. */}
+        <Card
+          title="Triage"
+          className="md:col-span-2"
+          meta="grouped by failure type · counted once per failed branch"
+        >
+          <Panel data={signatures.data} error={signatures.error}>
+            {({ signatures, window }) => (
+              <TriageTable
+                signatures={signatures}
+                emptyMessage={emptyMessage(window, 'failures')}
+                projectId={projectId}
+                workflowId={workflowId}
+                from={window.from}
+              />
+            )}
+          </Panel>
+        </Card>
+
+        {/* Same reply as the Outcomes panel — one aggregate read two ways, so
+            the slices here and the red wedge there cannot disagree. */}
         <Card
           title="Failure breakdown"
+          className="md:col-span-2"
           meta={
             outcomes.data &&
             `${failures(outcomes.data.counts)} · by work order state`
@@ -112,25 +160,6 @@ export const HealthContent = ({
           </Panel>
         </Card>
       </div>
-
-      {/* Counts are per failed step, so the rows can sum past the failure total
-          the donuts draw: a second broken branch is its own thing to fix. */}
-      <Card
-        title="Triage"
-        meta="grouped by failure type · counted once per failed branch"
-      >
-        <Panel data={signatures.data} error={signatures.error}>
-          {({ signatures, window }) => (
-            <TriageTable
-              signatures={signatures}
-              emptyMessage={emptyMessage(window, 'failures')}
-              projectId={projectId}
-              workflowId={workflowId}
-              from={window.from}
-            />
-          )}
-        </Panel>
-      </Card>
     </div>
   );
 };
@@ -138,13 +167,19 @@ export const HealthContent = ({
 const Card = ({
   title,
   meta,
+  className,
   children,
 }: {
   title: string;
   meta: ReactNode;
+  className?: string;
   children: ReactNode;
 }) => (
-  <div className="rounded-lg bg-white p-6 shadow">
+  // A column, so a panel that wants the room can take the height the grid row
+  // stretches this card to instead of leaving it blank.
+  <div
+    className={cn('flex flex-col rounded-lg bg-white p-6 shadow', className)}
+  >
     <div className="mb-4 flex items-baseline justify-between gap-4">
       <h2 className="text-sm font-medium text-gray-900">{title}</h2>
       {meta && <span className="text-xs text-gray-500">{meta}</span>}

--- a/assets/js/health/WorkflowHealth.tsx
+++ b/assets/js/health/WorkflowHealth.tsx
@@ -225,7 +225,7 @@ const ChartLoading = () => (
 // Holds its line while empty (`min-h-4` is one `text-xs` line) so the picker
 // above it doesn't move.
 const UpdatedAt = ({ at }: { at: string | null }) => (
-  <p className="min-h-4 text-xs text-gray-500">
+  <p role="status" className="min-h-4 text-xs text-gray-500">
     {at && `Last Updated ${new Date(at).toLocaleTimeString()}`}
   </p>
 );
@@ -250,9 +250,7 @@ const failures = (counts: Outcomes['counts']) => {
   return `${total.toLocaleString()} failed work order${total === 1 ? '' : 's'}`;
 };
 
-// A work order with two broken branches lands in two triage rows, so the
-// column can sum past the failure total the donut draws. Only worth a word
-// when it actually happened — most windows reconcile and need no footnote.
+// Rows count failed branches, so they can sum past the failure total.
 const overCounts = (signatures: ErrorSignature[], counts: Outcomes['counts']) =>
   signatures.reduce((sum, signature) => sum + signature.count, 0) >
   failureCount(counts);
@@ -262,8 +260,10 @@ const emptyMessage = (
   noun = 'finished work orders'
 ) => `No ${noun} in the last ${windowLabel(window)}`;
 
+// The runs window ends with the bucket `now` sits in, so it is `days` plus a
+// part-bucket. Floor it, or a 30-day view reads as "31 days" after midday.
 const windowDays = ({ from, to }: { from: string; to: string }) =>
-  Math.round((Date.parse(to) - Date.parse(from)) / 86_400_000);
+  Math.floor((Date.parse(to) - Date.parse(from)) / 86_400_000);
 
 // Matches the picker's own wording — "24 hours", not "1 day".
 const windowLabel = (window: Outcomes['window']) => {

--- a/assets/js/health/WorkflowHealth.tsx
+++ b/assets/js/health/WorkflowHealth.tsx
@@ -10,7 +10,7 @@ import { TriageTable } from './charts/TriageTable';
 import type { RunVolume } from './charts/VolumeBars';
 import { bucketMeta, VolumeBars } from './charts/VolumeBars';
 import { DEFAULT_DAYS, RangePicker } from './RangePicker';
-import type { ErrorSignatures, Outcomes } from './types';
+import type { ErrorSignature, ErrorSignatures, Outcomes } from './types';
 import { FAILURE_STATES } from './types';
 import { healthBase, useHealthQuery } from './useHealthQuery';
 
@@ -102,7 +102,7 @@ export const HealthContent = ({
         {/* Runs, where the donut beside it counts work orders — so the meta
             names the bucket size rather than a total that won't reconcile. */}
         <Card
-          title="Volume over time"
+          title="Runs over time"
           className="lg:col-span-3"
           meta={volume.data && bucketMeta(volume.data.buckets)}
         >
@@ -116,23 +116,25 @@ export const HealthContent = ({
           </Panel>
         </Card>
 
-        {/* Counts are per failed step, so the rows can sum past the failure
-            total the donuts draw: a second broken branch is its own thing to
-            fix. */}
-        <Card
-          title="Triage"
-          className="lg:col-span-2"
-          meta="grouped by failure type · counted once per failed branch"
-        >
+        <Card title="Triage" className="lg:col-span-2">
           <Panel data={signatures.data} error={signatures.error}>
             {({ signatures, window }) => (
-              <TriageTable
-                signatures={signatures}
-                emptyMessage={emptyMessage(window, 'failures')}
-                projectId={projectId}
-                workflowId={workflowId}
-                from={window.from}
-              />
+              <>
+                <TriageTable
+                  signatures={signatures}
+                  emptyMessage={emptyMessage(window, 'failures')}
+                  projectId={projectId}
+                  workflowId={workflowId}
+                  from={window.from}
+                />
+                {outcomes.data &&
+                  overCounts(signatures, outcomes.data.counts) && (
+                    <p className="mt-3 text-xs text-gray-500">
+                      Some work orders failed on more than one branch, so they
+                      appear in more than one row.
+                    </p>
+                  )}
+              </>
             )}
           </Panel>
         </Card>
@@ -142,10 +144,7 @@ export const HealthContent = ({
         <Card
           title="Failure breakdown"
           className="lg:col-span-2"
-          meta={
-            outcomes.data &&
-            `${failures(outcomes.data.counts)} · by work order state`
-          }
+          meta={outcomes.data && failures(outcomes.data.counts)}
         >
           <Panel data={outcomes.data} error={outcomes.error}>
             {({ counts, window }) => (
@@ -168,7 +167,7 @@ const Card = ({
   children,
 }: {
   title: string;
-  meta: ReactNode;
+  meta?: ReactNode;
   className?: string;
   children: ReactNode;
 }) => (
@@ -238,15 +237,25 @@ const workOrders = (counts: Outcomes['counts']) => {
   return `${total.toLocaleString()} work order${total === 1 ? '' : 's'}`;
 };
 
+const failureCount = (counts: Outcomes['counts']) =>
+  FAILURE_STATES.reduce((sum, state) => sum + counts[state], 0);
+
 // The donut's centre total sits inside the `aria-hidden` frame and the legend
 // below lists slices but never their sum, so this is the only place a screen
 // reader can reach the number of failures. Summed from `FAILURE_STATES` rather
 // than the drawn slices, which drop the states that never happened.
 const failures = (counts: Outcomes['counts']) => {
-  const total = FAILURE_STATES.reduce((sum, state) => sum + counts[state], 0);
+  const total = failureCount(counts);
 
-  return `${total.toLocaleString()} failure${total === 1 ? '' : 's'}`;
+  return `${total.toLocaleString()} failed work order${total === 1 ? '' : 's'}`;
 };
+
+// A work order with two broken branches lands in two triage rows, so the
+// column can sum past the failure total the donut draws. Only worth a word
+// when it actually happened — most windows reconcile and need no footnote.
+const overCounts = (signatures: ErrorSignature[], counts: Outcomes['counts']) =>
+  signatures.reduce((sum, signature) => sum + signature.count, 0) >
+  failureCount(counts);
 
 const emptyMessage = (
   window: Outcomes['window'],

--- a/assets/js/health/charts/ChartTooltip.tsx
+++ b/assets/js/health/charts/ChartTooltip.tsx
@@ -1,0 +1,72 @@
+import type { TooltipContentProps } from 'recharts';
+
+import { cn } from '#/utils/cn';
+
+/**
+ * Hover panel for the health charts, in the page's own card chrome.
+ *
+ * Recharts' default panel is a square-cornered box of coloured text, which
+ * matches nothing else here. This one borrows the card it floats over
+ * (`WorkflowHealth.tsx:178` — white, `rounded-lg`, a shadow) and lays its rows
+ * out like the legends under the charts: swatch, name, count. The swatch is
+ * what carries the series colour, so the counts stay readable rather than
+ * trading contrast for identity.
+ */
+
+interface ChartTooltipProps
+  extends Partial<TooltipContentProps<number, string>> {
+  /** Renders the axis label — the bar's slot, say, rather than its start. */
+  formatLabel?: (label: string) => string;
+  /** Renders one row's count, for panels that add a share to it. */
+  formatValue?: (value: number) => string;
+  /** Flips the rows, for a stack whose bars are declared bottom-up. */
+  reverse?: boolean;
+}
+
+export const ChartTooltip = ({
+  active,
+  payload,
+  label,
+  reverse,
+  formatLabel,
+  formatValue = value => value.toLocaleString(),
+}: ChartTooltipProps) => {
+  if (!active || !payload?.length) return null;
+
+  const rows = reverse ? [...payload].reverse() : payload;
+
+  // A lone row has no column to line up against and nothing to stand out
+  // from, so the treatment that reads a column — counts pushed right, and
+  // weighted — is only earned once there are several. The donut shows one
+  // slice at a time.
+  const column = rows.length > 1;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white text-xs shadow-lg">
+      {label != null && (
+        <p className="border-b border-gray-100 px-3 py-2 font-medium text-gray-900">
+          {formatLabel ? formatLabel(String(label)) : String(label)}
+        </p>
+      )}
+      <ul className="flex flex-col gap-1.5 px-3 py-2 text-gray-700">
+        {rows.map(({ dataKey, name, value, color }) => (
+          <li key={String(name ?? dataKey)} className="flex items-center gap-2">
+            <span
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <span className={column ? 'grow pr-4' : ''}>{name}</span>
+            <span
+              className={cn(
+                'tabular-nums text-gray-900',
+                column && 'font-medium'
+              )}
+            >
+              {formatValue(Number(value))}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/assets/js/health/charts/Donut.tsx
+++ b/assets/js/health/charts/Donut.tsx
@@ -7,8 +7,6 @@ import {
   Tooltip,
 } from 'recharts';
 
-import { cn } from '#/utils/cn';
-
 /**
  * A part-to-whole donut with the total in the middle and an always-on legend.
  *
@@ -35,22 +33,17 @@ interface DonutProps {
 // switch. Only the legend below it follows the data.
 export const FRAME = 'h-55';
 
+// An empty panel fills the card and centres its one line in it.
+export const EMPTY =
+  'flex min-h-55 flex-1 items-center justify-center text-center text-sm text-gray-500';
+
 export const Donut = ({ slices, emptyMessage }: DonutProps) => {
   const total = slices.reduce((sum, { value }) => sum + value, 0);
 
   // A pie of zeroes renders as an empty box in Recharts, which reads as
   // broken rather than empty.
   if (total === 0) {
-    return (
-      <p
-        className={cn(
-          FRAME,
-          'flex items-center justify-center text-sm text-gray-500'
-        )}
-      >
-        {emptyMessage}
-      </p>
-    );
+    return <p className={EMPTY}>{emptyMessage}</p>;
   }
 
   const share = (value: number) => `${((value / total) * 100).toFixed(1)}%`;

--- a/assets/js/health/charts/Donut.tsx
+++ b/assets/js/health/charts/Donut.tsx
@@ -7,6 +7,8 @@ import {
   Tooltip,
 } from 'recharts';
 
+import { ChartTooltip } from './ChartTooltip';
+
 /**
  * A part-to-whole donut with the total in the middle and an always-on legend.
  *
@@ -53,11 +55,18 @@ export const Donut = ({ slices, emptyMessage }: DonutProps) => {
       <div className={FRAME} aria-hidden="true">
         <ResponsiveContainer width="100%" height={220}>
           <PieChart accessibilityLayer={false}>
+            {/* Recharts transitions the panel's transform, so it slides
+                diagonally across the plot as the pointer moves between
+                slices. */}
             <Tooltip
-              formatter={(value, name) => [
-                `${Number(value).toLocaleString()} (${share(Number(value))})`,
-                name,
-              ]}
+              isAnimationActive={false}
+              content={
+                <ChartTooltip
+                  formatValue={value =>
+                    `${value.toLocaleString()} (${share(value)})`
+                  }
+                />
+              }
             />
             {/* `accessibilityLayer` only governs the svg; the pie's own root
                 group is a tab stop by default (`rootTabIndex` 0), and

--- a/assets/js/health/charts/FailureBreakdownDonut.tsx
+++ b/assets/js/health/charts/FailureBreakdownDonut.tsx
@@ -5,6 +5,7 @@ import {
 } from '../types';
 
 import { Donut } from './Donut';
+import { FAILED } from './OutcomesDonut';
 
 /**
  * Failed work orders split by the state they finished in, as a donut.
@@ -26,7 +27,7 @@ import { Donut } from './Donut';
 // A `Record` keyed by `FailureState`, so adding a state without choosing a
 // colour for it is a compile error rather than a silently missing slice.
 const COLORS: Record<FailureState, string> = {
-  failed: '#d03b3b',
+  failed: FAILED,
   crashed: '#e87ba4',
   killed: '#4a3aa7',
   exception: '#2a78d6',

--- a/assets/js/health/charts/OutcomesDonut.tsx
+++ b/assets/js/health/charts/OutcomesDonut.tsx
@@ -16,9 +16,12 @@ import { Donut } from './Donut';
 // are reserved so they never impersonate a series. Grey for cancelled is the
 // convention the rest of the app already uses (`dashboard_components.ex` gives
 // it `bg-gray-500`), and it reads as "stopped, not broken" beside the red.
-const SUCCESS = '#0ca30c';
-const FAILED = '#d03b3b';
-const CANCELLED = '#6b7280';
+//
+// Exported because the volume chart shares this row: a green bar and a green
+// wedge on one screen have to mean the same thing.
+export const SUCCESS = '#0ca30c';
+export const FAILED = '#d03b3b';
+export const CANCELLED = '#6b7280';
 
 interface OutcomesDonutProps {
   counts: WorkOrderStateCounts;

--- a/assets/js/health/charts/TriageTable.tsx
+++ b/assets/js/health/charts/TriageTable.tsx
@@ -156,7 +156,7 @@ const ViewButton = ({ href }: { href: string }) => (
     href={href}
     target="_blank"
     rel="noopener noreferrer"
-    className="inline-flex items-center gap-x-1 whitespace-nowrap rounded-full bg-primary-50 px-2.5 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-100"
+    className="inline-flex items-center gap-x-1 whitespace-nowrap rounded-full bg-primary-50 px-2.5 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
   >
     View
     <span className="hero-arrow-right-micro h-3 w-3" />

--- a/assets/js/health/charts/TriageTable.tsx
+++ b/assets/js/health/charts/TriageTable.tsx
@@ -1,5 +1,7 @@
 import type { ErrorSignature } from '../types';
 
+import { EMPTY } from './Donut';
+
 /**
  * Failed work orders grouped by error signature, heaviest first. Each row
  * links to the history page filtered to the work orders it counts, where the
@@ -76,7 +78,7 @@ export const TriageTable = ({
   from,
 }: TriageTableProps) => {
   if (signatures.length === 0) {
-    return <p className="text-sm text-gray-500">{emptyMessage}</p>;
+    return <p className={EMPTY}>{emptyMessage}</p>;
   }
 
   return (

--- a/assets/js/health/charts/TriageTable.tsx
+++ b/assets/js/health/charts/TriageTable.tsx
@@ -179,9 +179,14 @@ const historyUrl = (
   from: string,
   signature: ErrorSignature
 ) => {
+  // History only applies its own defaults to a visit that names no filters at
+  // all, and this link names several. Without `log`, arriving here drops the
+  // one search field a normal history visit starts with, and the first search
+  // term typed into the box matches nothing with every toggle visibly off.
   const params = new URLSearchParams({
     'filters[workflow_id]': workflowId,
     'filters[date_after]': from,
+    'filters[log]': 'true',
   });
 
   if (signature.exit_reason === 'rejected') {

--- a/assets/js/health/charts/TriageTable.tsx
+++ b/assets/js/health/charts/TriageTable.tsx
@@ -97,7 +97,7 @@ export const TriageTable = ({
               Work orders
             </th>
             <th scope="col" className="py-2 font-medium">
-              Signature
+              Failure type
             </th>
             <th scope="col" className="w-24 py-2 pl-4 font-medium">
               <span className="sr-only">Actions</span>

--- a/assets/js/health/charts/VolumeBars.tsx
+++ b/assets/js/health/charts/VolumeBars.tsx
@@ -1,0 +1,257 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { cn } from '#/utils/cn';
+
+import type { FailureState } from '../types';
+import { FAILURE_STATES } from '../types';
+
+import { CANCELLED, FAILED, SUCCESS } from './OutcomesDonut';
+
+/**
+ * Run volume over the window, stacked by outcome.
+ *
+ * Counts runs where the donuts beside it count work orders, so the two differ
+ * on purpose and the card carries no total. Buckets arrive already counted and
+ * zero-filled from `Stats.runs/2` — one row per bar, one key per run state,
+ * which is the shape Recharts takes as `data`.
+ */
+
+// A run has no `rejected` state — a work order rejected on arrival never
+// produced one. Narrowed off the donut's list so a state added there reaches
+// both.
+type RunFailureState = Exclude<FailureState, 'rejected'>;
+
+const RUN_FAILURE_STATES = FAILURE_STATES.filter(
+  (state): state is RunFailureState => state !== 'rejected'
+);
+
+/** One bar: when its slot starts, and the run counts that landed in it. */
+export interface RunBucket {
+  at: string;
+  success: number;
+  cancelled: number;
+  failed: number;
+  crashed: number;
+  killed: number;
+  exception: number;
+  lost: number;
+}
+
+export interface RunVolume {
+  window: { from: string; to: string };
+  buckets: RunBucket[];
+}
+
+// Top to bottom, as the legend and the spoken totals read. The bars draw from
+// the reverse of it, since Recharts puts the first `Bar` on the axis.
+const SERIES = [
+  { key: 'success', label: 'Success', color: SUCCESS },
+  { key: 'cancelled', label: 'Cancelled', color: CANCELLED },
+  { key: 'failed', label: 'Failed', color: FAILED },
+] as const;
+
+// The donut's `FRAME` is a fixed box and gains nothing from extra room; the
+// bars have a time axis to spread along. `flex-1` takes the height the grid
+// row stretches the card to, floored at the donut's own height so a short row
+// still lines the two up.
+const CHART = 'min-h-55 flex-1';
+
+interface VolumeBarsProps {
+  buckets: RunBucket[];
+  emptyMessage: string;
+}
+
+export const VolumeBars = ({ buckets, emptyMessage }: VolumeBarsProps) => {
+  const rows = buckets.map(bucket => ({
+    at: bucket.at,
+    success: bucket.success,
+    cancelled: bucket.cancelled,
+    failed: RUN_FAILURE_STATES.reduce((sum, state) => sum + bucket[state], 0),
+  }));
+
+  // Cancelled is drawn only when it happened — a "Cancelled 0" row on every
+  // healthy workflow is noise. Success and Failed stay put at zero.
+  const totals = SERIES.map(series => ({
+    ...series,
+    value: rows.reduce((sum, row) => sum + row[series.key], 0),
+  })).filter(({ key, value }) => key !== 'cancelled' || value > 0);
+
+  // Recharts draws a bare axis for an all-zero window, which reads as broken
+  // rather than empty.
+  if (totals.every(({ value }) => value === 0)) {
+    return (
+      <p
+        className={cn(
+          CHART,
+          'flex items-center justify-center text-sm text-gray-500'
+        )}
+      >
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  const hours = bucketHours(buckets);
+
+  return (
+    <>
+      <div className={CHART} aria-hidden="true">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={rows}
+            accessibilityLayer={false}
+            margin={{ top: 4, right: 4, bottom: 0, left: -20 }}
+          >
+            <CartesianGrid vertical={false} stroke="#f3f4f6" />
+            {/* The blank afternoon labels count against the gap rule, so left
+                to thin the axis itself Recharts drops named bars too. */}
+            <XAxis
+              dataKey="at"
+              tickFormatter={at => tickLabel(at as string, hours)}
+              tickLine={false}
+              axisLine={false}
+              interval={hours >= 12 && hours < 24 ? 0 : 'preserveEnd'}
+              minTickGap={16}
+              tick={{ fontSize: 11, fill: TICK_FILL }}
+            />
+            {/* Recharts ends the axis at the tallest bar, so that bar finishes
+                flush against the top gridline and reads as clipped. A tenth of
+                headroom puts the ceiling above the data. */}
+            <YAxis
+              allowDecimals={false}
+              domain={[0, (max: number) => Math.ceil(max * 1.1)]}
+              tickLine={false}
+              axisLine={false}
+              width={44}
+              tick={{ fontSize: 11, fill: TICK_FILL }}
+            />
+            {/* Recharts lists rows in `Bar` declaration order, the reverse of
+                the stack, so they are sorted back into `SERIES` order. */}
+            <Tooltip
+              cursor={{ fill: '#f9fafb' }}
+              itemSorter={({ dataKey }) =>
+                SERIES.findIndex(({ key }) => key === dataKey)
+              }
+              labelFormatter={at => rangeLabel(at as string, hours)}
+              formatter={(value, name) => [
+                Number(value).toLocaleString(),
+                name,
+              ]}
+            />
+            {/* Reversed, so failures land on the axis and can be read against
+                a fixed baseline day to day rather than judged by thickness. */}
+            {[...totals].reverse().map(({ key, label: name, color }) => (
+              <Bar
+                key={key}
+                dataKey={key}
+                name={name}
+                stackId="runs"
+                maxBarSize={64}
+                fill={color}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* The chart is hidden from assistive tech and these totals are its
+          accessible representation, named as totals because a sum says nothing
+          about when anything happened. Per-bucket would be ninety-odd cells.
+          The legend below repeats the labels, so it is hidden there. */}
+      <p className="sr-only">
+        {`Window totals: ${totals
+          .map(({ label: name, value }) => `${name} ${value.toLocaleString()}`)
+          .join(', ')}.`}
+      </p>
+
+      {/* A key, no counts — those are on the y-axis and in the tooltip. It
+          stays a key because cancelled is a thin grey band between the green
+          and the red, and nothing about that stripe says what it is. */}
+      <ul
+        aria-hidden="true"
+        className="mt-2 flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm text-gray-700"
+      >
+        {totals.map(({ key, label: name, color }) => (
+          <li key={key} className="flex items-center gap-2">
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <span>{name}</span>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+// Read off the data rather than passed in, so nothing naming the bucket width
+// can disagree with the bars under it. A window too short to measure reads as
+// daily, which only ever costs a coarser label.
+const bucketHours = (buckets: RunBucket[]) => {
+  const [first, second] = buckets;
+
+  return first && second
+    ? (Date.parse(second.at) - Date.parse(first.at)) / 3_600_000
+    : 24;
+};
+
+/** The card's meta line, measured off the same buckets the chart draws. */
+export const bucketMeta = (buckets: RunBucket[]) => {
+  const hours = bucketHours(buckets);
+
+  return hours >= 24
+    ? 'daily buckets (runs) · UTC'
+    : `${hours}-hour bucket (runs) · UTC`;
+};
+
+const TICK_FILL = '#6b7280';
+
+// Rendered in UTC because that is where the buckets are: the server lays the
+// grid on the raw epoch, so a day starts at UTC midnight — 03:00 in Nairobi,
+// 05:30 in Delhi. The card's meta says UTC for the same reason.
+const dayLabel = (date: Date) =>
+  date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+
+const hourLabel = (date: Date) => `${date.getUTCHours()}:00`;
+
+export const tickLabel = (at: string, hours: number) => {
+  const date = new Date(at);
+
+  if (hours >= 24) return dayLabel(date);
+
+  // Two bars to a day at this width, so the date goes on the morning bar,
+  // where the day starts, and the afternoon is left blank. A window opening
+  // mid-day leaves that first bar unlabelled, which is honest — its morning
+  // is outside the window — and keeps every date two bars from the last.
+  if (hours >= 12) return date.getUTCHours() < 12 ? dayLabel(date) : '';
+
+  return hourLabel(date);
+};
+
+// The axis is thinned and its labels name only where a bucket starts, so the
+// tooltip names the whole slot rather than leaving the reader to add the width
+// to the start.
+export const rangeLabel = (at: string, hours: number) => {
+  const start = new Date(at);
+
+  // A daily bar is a whole UTC day, and `00:00 – 00:00` invites the question
+  // of whether the closing midnight is inside the bar or the next one.
+  if (hours >= 24) return `${dayLabel(start)} UTC`;
+
+  const end = new Date(start.getTime() + hours * 3_600_000);
+
+  return `${dayLabel(start)}, ${hourLabel(start)} – ${hourLabel(end)} UTC`;
+};

--- a/assets/js/health/charts/VolumeBars.tsx
+++ b/assets/js/health/charts/VolumeBars.tsx
@@ -194,11 +194,17 @@ const bucketHours = (buckets: RunBucket[]) => {
     : 24;
 };
 
-/** The card's meta line, measured off the same buckets the chart draws. */
+/**
+ * The card's meta line, measured off the same buckets the chart draws.
+ *
+ * Names the zone as well as the width: the axis and the tooltip are in UTC,
+ * while the page's freshness stamp is in the reader's own clock, so a bar can
+ * sit hours behind a "Last Updated" that looks current.
+ */
 export const bucketMeta = (buckets: RunBucket[]) => {
   const hours = bucketHours(buckets);
 
-  return hours >= 24 ? 'daily buckets' : `${hours}-hour buckets`;
+  return `${hours >= 24 ? 'daily' : `${hours}-hour`} buckets · UTC`;
 };
 
 const TICK_FILL = '#6b7280';

--- a/assets/js/health/charts/VolumeBars.tsx
+++ b/assets/js/health/charts/VolumeBars.tsx
@@ -8,11 +8,10 @@ import {
   YAxis,
 } from 'recharts';
 
-import { cn } from '#/utils/cn';
-
 import type { FailureState } from '../types';
 import { FAILURE_STATES } from '../types';
 
+import { EMPTY } from './Donut';
 import { CANCELLED, FAILED, SUCCESS } from './OutcomesDonut';
 
 /**
@@ -58,12 +57,6 @@ const SERIES = [
   { key: 'failed', label: 'Failed', color: FAILED },
 ] as const;
 
-// The donut's `FRAME` is a fixed box and gains nothing from extra room; the
-// bars have a time axis to spread along. `flex-1` takes the height the grid
-// row stretches the card to, floored at the donut's own height so a short row
-// still lines the two up.
-const CHART = 'min-h-55 flex-1';
-
 interface VolumeBarsProps {
   buckets: RunBucket[];
   emptyMessage: string;
@@ -87,23 +80,18 @@ export const VolumeBars = ({ buckets, emptyMessage }: VolumeBarsProps) => {
   // Recharts draws a bare axis for an all-zero window, which reads as broken
   // rather than empty.
   if (totals.every(({ value }) => value === 0)) {
-    return (
-      <p
-        className={cn(
-          CHART,
-          'flex items-center justify-center text-sm text-gray-500'
-        )}
-      >
-        {emptyMessage}
-      </p>
-    );
+    return <p className={EMPTY}>{emptyMessage}</p>;
   }
 
   const hours = bucketHours(buckets);
 
   return (
     <>
-      <div className={CHART} aria-hidden="true">
+      {/* The donut's `FRAME` is a fixed box and gains nothing from extra
+          room; the bars have a time axis to spread along. `flex-1` takes the
+          height the grid row stretches the card to, floored at the donut's
+          own height so a short row still lines the two up. */}
+      <div className="min-h-55 flex-1" aria-hidden="true">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={rows}

--- a/assets/js/health/charts/VolumeBars.tsx
+++ b/assets/js/health/charts/VolumeBars.tsx
@@ -11,6 +11,7 @@ import {
 import type { FailureState } from '../types';
 import { FAILURE_STATES } from '../types';
 
+import { ChartTooltip } from './ChartTooltip';
 import { EMPTY } from './Donut';
 import { CANCELLED, FAILED, SUCCESS } from './OutcomesDonut';
 
@@ -121,18 +122,19 @@ export const VolumeBars = ({ buckets, emptyMessage }: VolumeBarsProps) => {
               width={44}
               tick={{ fontSize: 11, fill: TICK_FILL }}
             />
-            {/* Recharts lists rows in `Bar` declaration order, the reverse of
-                the stack, so they are sorted back into `SERIES` order. */}
+            {/* Recharts transitions the panel's transform, so it slides
+                diagonally across the plot as the pointer moves between bars.
+                Its rows arrive in `Bar` declaration order, the reverse of the
+                stack, so the panel is flipped back into `SERIES` order. */}
             <Tooltip
+              isAnimationActive={false}
               cursor={{ fill: '#f9fafb' }}
-              itemSorter={({ dataKey }) =>
-                SERIES.findIndex(({ key }) => key === dataKey)
+              content={
+                <ChartTooltip
+                  reverse
+                  formatLabel={at => rangeLabel(at, hours)}
+                />
               }
-              labelFormatter={at => rangeLabel(at as string, hours)}
-              formatter={(value, name) => [
-                Number(value).toLocaleString(),
-                name,
-              ]}
             />
             {/* Reversed, so failures land on the axis and can be read against
                 a fixed baseline day to day rather than judged by thickness. */}

--- a/assets/js/health/charts/VolumeBars.tsx
+++ b/assets/js/health/charts/VolumeBars.tsx
@@ -198,16 +198,14 @@ const bucketHours = (buckets: RunBucket[]) => {
 export const bucketMeta = (buckets: RunBucket[]) => {
   const hours = bucketHours(buckets);
 
-  return hours >= 24
-    ? 'daily buckets (runs) · UTC'
-    : `${hours}-hour bucket (runs) · UTC`;
+  return hours >= 24 ? 'daily buckets' : `${hours}-hour buckets`;
 };
 
 const TICK_FILL = '#6b7280';
 
 // Rendered in UTC because that is where the buckets are: the server lays the
 // grid on the raw epoch, so a day starts at UTC midnight — 03:00 in Nairobi,
-// 05:30 in Delhi. The card's meta says UTC for the same reason.
+// 05:30 in Delhi. The tooltip says UTC for the same reason.
 const dayLabel = (date: Date) =>
   date.toLocaleDateString(undefined, {
     month: 'short',

--- a/assets/test/health/WorkflowHealth.test.tsx
+++ b/assets/test/health/WorkflowHealth.test.tsx
@@ -356,6 +356,27 @@ describe('WorkflowHealth', () => {
     ).toBeVisible();
   });
 
+  // The rows count a work order once per failed branch, so they can sum past
+  // the failure total the donut draws. Say so only when it happened.
+  test('footnotes the triage rows only when they outrun the failures', async () => {
+    const { unmount } = mount(both);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Triage' })
+    ).toBeVisible();
+    expect(screen.queryByText(/more than one branch/)).toBeNull();
+    unmount();
+
+    const doubled = {
+      ...errorSignatures,
+      signatures: [{ ...errorSignatures.signatures[0], count: 200 }],
+    };
+
+    mount({ ...both, failures: doubled });
+
+    expect(await screen.findByText(/more than one branch/)).toBeVisible();
+  });
+
   test('reports a refused request without echoing the server', async () => {
     mount({ outcomes: 404, failures: 404, runs: 404 });
 
@@ -391,7 +412,7 @@ describe('WorkflowHealth', () => {
     ).toBeVisible();
     expect(screen.getByRole('heading', { name: 'Outcomes' })).toBeVisible();
     expect(
-      screen.getByRole('heading', { name: 'Volume over time' })
+      screen.getByRole('heading', { name: 'Runs over time' })
     ).toBeVisible();
     expect(
       screen.getByRole('heading', { name: 'Failure breakdown' })

--- a/assets/test/health/WorkflowHealth.test.tsx
+++ b/assets/test/health/WorkflowHealth.test.tsx
@@ -147,7 +147,7 @@ describe('WorkflowHealth', () => {
 
     const { fetchMock } = mount(responses);
 
-    await screen.findByText('Last 30 days · 1,287 work orders');
+    await screen.findByText('1,287 work orders');
     expect(fetchMock).toHaveBeenCalledTimes(3);
 
     responses.outcomes = {
@@ -160,9 +160,7 @@ describe('WorkflowHealth', () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(6);
 
-    expect(
-      await screen.findByText('Last 30 days · 2,287 work orders')
-    ).toBeVisible();
+    expect(await screen.findByText('2,287 work orders')).toBeVisible();
 
     // The interval still fires; the bump is gated on visibility.
     vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
@@ -179,7 +177,7 @@ describe('WorkflowHealth', () => {
 
     const { fetchMock } = mount({ ...both });
 
-    await screen.findByText('Last 30 days · 1,287 work orders');
+    await screen.findByText('1,287 work orders');
     expect(fetchMock).toHaveBeenCalledTimes(3);
 
     const hidden = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
@@ -229,9 +227,7 @@ describe('WorkflowHealth', () => {
 
     land(outcomes);
 
-    expect(
-      await screen.findByText('Last 30 days · 1,287 work orders')
-    ).toBeVisible();
+    expect(await screen.findByText('1,287 work orders')).toBeVisible();
 
     // And the gap that follows is a whole interval measured from the answer.
     // On a grid measured from the request, a read this slow would be due again
@@ -254,7 +250,7 @@ describe('WorkflowHealth', () => {
 
     mount(responses);
 
-    await screen.findByText('Last 30 days · 1,287 work orders');
+    await screen.findByText('1,287 work orders');
 
     responses['outcomes'] = 502;
     responses['failures'] = 502;
@@ -264,7 +260,7 @@ describe('WorkflowHealth', () => {
     });
 
     expect(screen.queryByRole('alert')).toBeNull();
-    expect(screen.getByText('Last 30 days · 1,287 work orders')).toBeVisible();
+    expect(screen.getByText('1,287 work orders')).toBeVisible();
     expect(screen.getAllByText('Success')[0]).toBeVisible();
 
     // And recovers on the tick after, with no reload.
@@ -277,18 +273,16 @@ describe('WorkflowHealth', () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
 
-    expect(
-      await screen.findByText('Last 30 days · 2,287 work orders')
-    ).toBeVisible();
+    expect(await screen.findByText('2,287 work orders')).toBeVisible();
   });
 
-  test('renders the header, deriving the day count from the window', async () => {
+  test('names the workflow and totals its work orders', async () => {
     mount(both);
 
     expect(
       await screen.findByRole('heading', { name: 'Sync patients' })
     ).toBeInTheDocument();
-    expect(screen.getByText('Last 30 days · 1,287 work orders')).toBeVisible();
+    expect(screen.getByText('1,287 work orders')).toBeVisible();
   });
 
   test('refetches every slice at the selected range', async () => {
@@ -312,16 +306,18 @@ describe('WorkflowHealth', () => {
     );
   });
 
-  test('calls a one-day window "Last 24 hours", not "Last 1 day"', async () => {
-    const dayWide = {
-      ...outcomes,
+  test('calls a one-day window "24 hours", not "1 day"', async () => {
+    const quietDay = {
       window: { from: '2026-08-30T10:00:00Z', to: '2026-08-31T10:00:00Z' },
+      counts: Object.fromEntries(
+        Object.keys(outcomes.counts).map(state => [state, 0])
+      ),
     };
 
-    mount({ outcomes: dayWide, failures: errorSignatures });
+    mount({ outcomes: quietDay, failures: errorSignatures });
 
     expect(
-      await screen.findByText('Last 24 hours · 1,287 work orders')
+      await screen.findByText('No finished work orders in the last 24 hours')
     ).toBeVisible();
   });
 
@@ -434,13 +430,15 @@ describe('WorkflowHealth', () => {
     await userEvent.click(screen.getByRole('radio', { name: 'Last 7 days' }));
 
     expect(screen.queryAllByText('Success')).toHaveLength(0);
-    expect(screen.getByRole('status')).toHaveTextContent('Loading…');
+    // Each panel holds a placeholder, but only for a reader who lands inside
+    // it. jsdom does no layout, so the reserved height needs a browser.
+    expect(screen.getAllByText('Loading…')).toHaveLength(4);
   });
 
   // Why the panels drop together rather than each keeping its own last answer:
   // `outcomes` is a group-by and `failures` a three-way join, so the cheap one
-  // lands first. Keeping stale data would put the new window in the subtitle
-  // while the Triage card below still named the old one.
+  // lands first. Keeping stale data would leave the Triage card naming the old
+  // window under the new window's numbers.
   test('never names two windows at once during a range switch', async () => {
     const quiet = { window: outcomes.window, signatures: [] };
     const responses: Record<string, unknown> = { outcomes, failures: quiet };
@@ -460,7 +458,7 @@ describe('WorkflowHealth', () => {
 
     await userEvent.click(screen.getByRole('radio', { name: 'Last 7 days' }));
 
-    await screen.findByText('Last 7 days · 1,287 work orders');
+    await screen.findByText('1,287 work orders');
 
     expect(screen.queryByText('No failures in the last 30 days')).toBeNull();
   });
@@ -480,7 +478,7 @@ describe('WorkflowHealth', () => {
 
     await userEvent.click(screen.getByRole('radio', { name: 'Last 7 days' }));
 
-    // An `alert`, so the failure is read out where the subtitle falls silent.
+    // An `alert`, so the failure is read out at once.
     const alerts = await screen.findAllByRole('alert');
     expect(alerts.map(alert => alert.textContent)).toEqual([
       ERROR,
@@ -488,15 +486,5 @@ describe('WorkflowHealth', () => {
       ERROR,
     ]);
     expect(screen.queryAllByText('Success')).toHaveLength(0);
-  });
-
-  // One announcement for the page, from the subtitle; the cards say it too,
-  // but only to a reader who lands inside them. jsdom does no layout, so the
-  // reserved height itself can only be checked in a browser.
-  test('announces loading once, not once per panel', () => {
-    mount(both);
-
-    expect(screen.getByRole('status')).toHaveTextContent('Loading…');
-    expect(screen.getAllByText('Loading…')).toHaveLength(5);
   });
 });

--- a/assets/test/health/WorkflowHealth.test.tsx
+++ b/assets/test/health/WorkflowHealth.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { HealthContent } from '#/health/WorkflowHealth';
 
+import { bucket } from './charts/counts';
+
 const outcomes = {
   window: { from: '2026-08-01T10:00:00Z', to: '2026-08-31T10:00:00Z' },
   counts: {
@@ -32,7 +34,17 @@ const errorSignatures = {
   ],
 };
 
-const both = { outcomes, failures: errorSignatures };
+// Two buckets is the least the chart can measure its own width from. What the
+// bars look like is `VolumeBars`'s own test; the page only hands them through.
+const runVolume = {
+  window: outcomes.window,
+  buckets: [
+    bucket('2026-08-30T00:00:00Z', { success: 40, failed: 3 }),
+    bucket('2026-08-31T00:00:00Z', { success: 60, failed: 1 }),
+  ],
+};
+
+const both = { outcomes, failures: errorSignatures, runs: runVolume };
 
 const ERROR = 'Could not load workflow stats. Refresh to try again.';
 
@@ -99,7 +111,7 @@ describe('WorkflowHealth', () => {
   test('requests each slice from the project-scoped health path', async () => {
     const { fetchMock } = mount(both);
 
-    await screen.findByText('Success');
+    await screen.findAllByText('Success');
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects/proj-1/workflows/wf-1/health/outcomes?days=30',
@@ -107,6 +119,10 @@ describe('WorkflowHealth', () => {
     );
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects/proj-1/workflows/wf-1/health/failures?days=30',
+      expect.objectContaining({ credentials: 'same-origin' })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/proj-1/workflows/wf-1/health/runs?days=30',
       expect.objectContaining({ credentials: 'same-origin' })
     );
   });
@@ -132,7 +148,7 @@ describe('WorkflowHealth', () => {
     const { fetchMock } = mount(responses);
 
     await screen.findByText('Last 30 days · 1,287 work orders');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     responses.outcomes = {
       ...outcomes,
@@ -142,7 +158,7 @@ describe('WorkflowHealth', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
 
     expect(
       await screen.findByText('Last 30 days · 2,287 work orders')
@@ -155,7 +171,7 @@ describe('WorkflowHealth', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
   test('reads again on returning to the tab, without waiting for the tick', async () => {
@@ -164,7 +180,7 @@ describe('WorkflowHealth', () => {
     const { fetchMock } = mount({ ...both });
 
     await screen.findByText('Last 30 days · 1,287 work orders');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     const hidden = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
 
@@ -181,7 +197,7 @@ describe('WorkflowHealth', () => {
     visibility(true);
     visibility(false);
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
   test('lets a read slower than the interval finish', async () => {
@@ -249,7 +265,7 @@ describe('WorkflowHealth', () => {
 
     expect(screen.queryByRole('alert')).toBeNull();
     expect(screen.getByText('Last 30 days · 1,287 work orders')).toBeVisible();
-    expect(screen.getByText('Success')).toBeVisible();
+    expect(screen.getAllByText('Success')[0]).toBeVisible();
 
     // And recovers on the tick after, with no reload.
     responses['outcomes'] = {
@@ -275,10 +291,10 @@ describe('WorkflowHealth', () => {
     expect(screen.getByText('Last 30 days · 1,287 work orders')).toBeVisible();
   });
 
-  test('refetches both slices at the selected range', async () => {
+  test('refetches every slice at the selected range', async () => {
     const { fetchMock } = mount(both);
 
-    await screen.findByText('Success');
+    await screen.findAllByText('Success');
 
     await userEvent.click(screen.getByRole('radio', { name: 'Last 7 days' }));
 
@@ -288,6 +304,10 @@ describe('WorkflowHealth', () => {
     );
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects/proj-1/workflows/wf-1/health/failures?days=7',
+      expect.objectContaining({ credentials: 'same-origin' })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/proj-1/workflows/wf-1/health/runs?days=7',
       expect.objectContaining({ credentials: 'same-origin' })
     );
   });
@@ -310,9 +330,9 @@ describe('WorkflowHealth', () => {
 
     // 98 + 24 + 12 + 7 — one response feeds both donuts, so the two panels can
     // only disagree if this fold drifts from the breakdown's own total.
-    expect(await screen.findByText('Failed')).toBeVisible();
+    expect((await screen.findAllByText('Failed'))[0]).toBeVisible();
     expect(screen.getByText('141')).toBeVisible();
-    expect(screen.getByText('Success')).toBeVisible();
+    expect(screen.getAllByText('Success')[0]).toBeVisible();
   });
 
   test('breaks the same failures down by work order state', async () => {
@@ -341,38 +361,42 @@ describe('WorkflowHealth', () => {
   });
 
   test('reports a refused request without echoing the server', async () => {
-    mount({ outcomes: 404, failures: 404 });
+    mount({ outcomes: 404, failures: 404, runs: 404 });
 
-    // Both slices refused takes every panel with it.
-    expect(await screen.findAllByText(ERROR)).toHaveLength(3);
+    // Every slice refused takes every panel with it.
+    expect(await screen.findAllByText(ERROR)).toHaveLength(4);
     expect(screen.queryByText(/404|Not Found/)).toBeNull();
   });
 
   test('degrades both donuts when the outcomes request fails', async () => {
-    mount({ outcomes: 500, failures: errorSignatures });
+    mount({ ...both, outcomes: 500 });
 
-    // Both donuts read the same response, so both degrade.
+    // Both donuts read the same response, so both degrade — and only those
+    // two: the volume chart asked its own question and still has an answer.
     expect(await screen.findAllByText(ERROR)).toHaveLength(2);
   });
 
   // The whole point of requesting each slice separately: one failing query
   // must not blank the panels that answered.
   test('keeps the donuts when only the triage query fails', async () => {
-    mount({ outcomes, failures: 500 });
+    mount({ ...both, failures: 500 });
 
     expect(await screen.findByText(ERROR)).toBeVisible();
-    expect(screen.getByText('Success')).toBeVisible();
+    expect(screen.getAllByText('Success')[0]).toBeVisible();
     expect(screen.getByText('69.5%')).toBeVisible();
   });
 
   test('keeps the page around a failed chart', async () => {
-    mount({ outcomes: 500, failures: 500 });
+    mount({ outcomes: 500, failures: 500, runs: 500 });
 
     await screen.findAllByText(ERROR);
     expect(
       screen.getByRole('heading', { name: 'Sync patients' })
     ).toBeVisible();
     expect(screen.getByRole('heading', { name: 'Outcomes' })).toBeVisible();
+    expect(
+      screen.getByRole('heading', { name: 'Volume over time' })
+    ).toBeVisible();
     expect(
       screen.getByRole('heading', { name: 'Failure breakdown' })
     ).toBeVisible();
@@ -382,9 +406,9 @@ describe('WorkflowHealth', () => {
   test('aborts in-flight requests on unmount', async () => {
     const { unmount, signals } = mount(both);
 
-    await screen.findByText('Success');
+    await screen.findAllByText('Success');
 
-    expect(signals).toHaveLength(2);
+    expect(signals).toHaveLength(3);
     expect(signals.every(signal => signal.aborted)).toBe(false);
 
     unmount();
@@ -400,15 +424,16 @@ describe('WorkflowHealth', () => {
 
     mount(responses);
 
-    await screen.findByText('Success');
+    await screen.findAllByText('Success');
 
     // A body that never resolves: the range request stays in flight.
     responses['outcomes'] = new Promise(() => {});
     responses['failures'] = new Promise(() => {});
+    responses['runs'] = new Promise(() => {});
 
     await userEvent.click(screen.getByRole('radio', { name: 'Last 7 days' }));
 
-    expect(screen.queryByText('Success')).toBeNull();
+    expect(screen.queryAllByText('Success')).toHaveLength(0);
     expect(screen.getByRole('status')).toHaveTextContent('Loading…');
   });
 
@@ -448,16 +473,21 @@ describe('WorkflowHealth', () => {
 
     mount(responses);
 
-    await screen.findByText('Success');
+    await screen.findAllByText('Success');
 
     responses['outcomes'] = 500;
+    responses['runs'] = 500;
 
     await userEvent.click(screen.getByRole('radio', { name: 'Last 7 days' }));
 
     // An `alert`, so the failure is read out where the subtitle falls silent.
     const alerts = await screen.findAllByRole('alert');
-    expect(alerts.map(alert => alert.textContent)).toEqual([ERROR, ERROR]);
-    expect(screen.queryByText('Success')).toBeNull();
+    expect(alerts.map(alert => alert.textContent)).toEqual([
+      ERROR,
+      ERROR,
+      ERROR,
+    ]);
+    expect(screen.queryAllByText('Success')).toHaveLength(0);
   });
 
   // One announcement for the page, from the subtitle; the cards say it too,
@@ -467,6 +497,6 @@ describe('WorkflowHealth', () => {
     mount(both);
 
     expect(screen.getByRole('status')).toHaveTextContent('Loading…');
-    expect(screen.getAllByText('Loading…')).toHaveLength(4);
+    expect(screen.getAllByText('Loading…')).toHaveLength(5);
   });
 });

--- a/assets/test/health/charts/ChartTooltip.test.tsx
+++ b/assets/test/health/charts/ChartTooltip.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { ChartTooltip } from '#/health/charts/ChartTooltip';
+
+const payload = [
+  { dataKey: 'failed', name: 'Failed', value: 7, color: '#d03b3b' },
+  { dataKey: 'success', name: 'Success', value: 1, color: '#0ca30c' },
+];
+
+describe('ChartTooltip', () => {
+  test('draws nothing until a series is hovered', () => {
+    const { container } = render(
+      <ChartTooltip active={false} payload={payload} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("applies the chart's own order, label and value formats", () => {
+    render(
+      <ChartTooltip
+        active
+        payload={payload}
+        label="2026-09-05T00:00:00Z"
+        // The bars are declared in the reverse of the stack, so the panel
+        // flips them rather than taking the payload as it comes.
+        reverse
+        formatLabel={at => `${at} slot`}
+        formatValue={value => `${value} runs`}
+      />
+    );
+
+    expect(screen.getByText('2026-09-05T00:00:00Z slot')).toBeVisible();
+    expect(
+      screen.getAllByRole('listitem').map(item => item.textContent)
+    ).toEqual(['Success1 runs', 'Failed7 runs']);
+  });
+});

--- a/assets/test/health/charts/TriageTable.test.tsx
+++ b/assets/test/health/charts/TriageTable.test.tsx
@@ -157,6 +157,7 @@ describe('TriageTable', () => {
         '/projects/proj-1/history' +
           '?filters%5Bworkflow_id%5D=wf-1' +
           '&filters%5Bdate_after%5D=2026-08-01T10%3A00%3A00Z' +
+          '&filters%5Blog%5D=true' +
           '&filters%5Berror_signature_exit_reason%5D=fail' +
           '&filters%5Berror_signature_error_type%5D=RuntimeError' +
           '&filters%5Berror_signature_job_id%5D=a1b2c3d4-0000-0000-0000-000000000000'
@@ -186,6 +187,7 @@ describe('TriageTable', () => {
         '/projects/proj-1/history' +
           '?filters%5Bworkflow_id%5D=wf-1' +
           '&filters%5Bdate_after%5D=2026-08-01T10%3A00%3A00Z' +
+          '&filters%5Blog%5D=true' +
           '&filters%5Berror_signature_exit_reason%5D=crash'
       );
     });
@@ -210,6 +212,7 @@ describe('TriageTable', () => {
         '/projects/proj-1/history' +
           '?filters%5Bworkflow_id%5D=wf-1' +
           '&filters%5Bdate_after%5D=2026-08-01T10%3A00%3A00Z' +
+          '&filters%5Blog%5D=true' +
           '&filters%5Brejected%5D=true'
       );
       expect(link.getAttribute('href')).not.toContain('error_signature_');

--- a/assets/test/health/charts/VolumeBars.test.tsx
+++ b/assets/test/health/charts/VolumeBars.test.tsx
@@ -91,15 +91,17 @@ describe('bucketMeta', () => {
       ),
     ];
 
-    expect(bucketMeta(hourly(2))).toBe('2-hour buckets');
-    expect(bucketMeta(hourly(12))).toBe('12-hour buckets');
-    expect(bucketMeta(hourly(24))).toBe('daily buckets');
+    expect(bucketMeta(hourly(2))).toBe('2-hour buckets · UTC');
+    expect(bucketMeta(hourly(12))).toBe('12-hour buckets · UTC');
+    expect(bucketMeta(hourly(24))).toBe('daily buckets · UTC');
   });
 
   // One bucket has no width to disagree with, so a coarser label is the worst
   // this can cost.
   test('falls back to daily when there is nothing to measure', () => {
-    expect(bucketMeta([bucket('2026-09-09T00:00:00Z')])).toBe('daily buckets');
+    expect(bucketMeta([bucket('2026-09-09T00:00:00Z')])).toBe(
+      'daily buckets · UTC'
+    );
   });
 });
 

--- a/assets/test/health/charts/VolumeBars.test.tsx
+++ b/assets/test/health/charts/VolumeBars.test.tsx
@@ -91,17 +91,15 @@ describe('bucketMeta', () => {
       ),
     ];
 
-    expect(bucketMeta(hourly(2))).toBe('2-hour bucket (runs) · UTC');
-    expect(bucketMeta(hourly(12))).toBe('12-hour bucket (runs) · UTC');
-    expect(bucketMeta(hourly(24))).toBe('daily buckets (runs) · UTC');
+    expect(bucketMeta(hourly(2))).toBe('2-hour buckets');
+    expect(bucketMeta(hourly(12))).toBe('12-hour buckets');
+    expect(bucketMeta(hourly(24))).toBe('daily buckets');
   });
 
   // One bucket has no width to disagree with, so a coarser label is the worst
   // this can cost.
   test('falls back to daily when there is nothing to measure', () => {
-    expect(bucketMeta([bucket('2026-09-09T00:00:00Z')])).toBe(
-      'daily buckets (runs) · UTC'
-    );
+    expect(bucketMeta([bucket('2026-09-09T00:00:00Z')])).toBe('daily buckets');
   });
 });
 

--- a/assets/test/health/charts/VolumeBars.test.tsx
+++ b/assets/test/health/charts/VolumeBars.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import {
+  bucketMeta,
+  rangeLabel,
+  tickLabel,
+  VolumeBars,
+} from '#/health/charts/VolumeBars';
+
+import { bucket } from './counts';
+
+describe('VolumeBars', () => {
+  test('folds every run failure state into one Failed total', () => {
+    render(
+      <VolumeBars
+        buckets={[
+          bucket('2026-09-08T00:00:00Z', {
+            success: 40,
+            failed: 3,
+            crashed: 2,
+          }),
+          bucket('2026-09-09T00:00:00Z', {
+            success: 60,
+            killed: 1,
+            exception: 1,
+            lost: 1,
+            cancelled: 4,
+          }),
+        ]}
+        emptyMessage="No runs"
+      />
+    );
+
+    // 3 + 2 + 1 + 1 + 1 across both buckets.
+    expect(
+      screen.getByText('Window totals: Success 100, Cancelled 4, Failed 8.')
+    ).toBeInTheDocument();
+
+    // The visible legend is a key only; the counts are on the y-axis.
+    expect(screen.getByText('Success')).toBeVisible();
+    expect(screen.getByText('Cancelled')).toBeVisible();
+    expect(screen.getByText('Failed')).toBeVisible();
+  });
+
+  // Stopping a run on purpose is not a failure, so it keeps its own segment.
+  test('keeps cancelled out of the Failed total', () => {
+    render(
+      <VolumeBars
+        buckets={[
+          bucket('2026-09-08T00:00:00Z', { failed: 2, cancelled: 5 }),
+          bucket('2026-09-09T00:00:00Z'),
+        ]}
+        emptyMessage="No runs"
+      />
+    );
+
+    expect(
+      screen.getByText('Window totals: Success 0, Cancelled 5, Failed 2.')
+    ).toBeInTheDocument();
+  });
+
+  // The server zero-fills, so a quiet workflow arrives as a full list of
+  // nothing — and Recharts would draw a bare axis for it.
+  test('shows the empty message when no run landed in the window', () => {
+    render(
+      <VolumeBars
+        buckets={[
+          bucket('2026-09-08T00:00:00Z'),
+          bucket('2026-09-09T00:00:00Z'),
+        ]}
+        emptyMessage="No runs in the last 30 days"
+      />
+    );
+
+    expect(screen.getByText('No runs in the last 30 days')).toBeVisible();
+    expect(screen.queryByText('Failed')).not.toBeInTheDocument();
+  });
+});
+
+// Measured off the gap between the first two buckets, so the meta line follows
+// the bars rather than the range the reader picked.
+describe('bucketMeta', () => {
+  test('names the bucket width the server actually sent', () => {
+    const hourly = (hours: number) => [
+      bucket('2026-09-09T00:00:00Z'),
+      bucket(
+        new Date(
+          Date.parse('2026-09-09T00:00:00Z') + hours * 3_600_000
+        ).toISOString()
+      ),
+    ];
+
+    expect(bucketMeta(hourly(2))).toBe('2-hour bucket (runs) · UTC');
+    expect(bucketMeta(hourly(12))).toBe('12-hour bucket (runs) · UTC');
+    expect(bucketMeta(hourly(24))).toBe('daily buckets (runs) · UTC');
+  });
+
+  // One bucket has no width to disagree with, so a coarser label is the worst
+  // this can cost.
+  test('falls back to daily when there is nothing to measure', () => {
+    expect(bucketMeta([bucket('2026-09-09T00:00:00Z')])).toBe(
+      'daily buckets (runs) · UTC'
+    );
+  });
+});
+
+// The axis names where a bucket starts; the tooltip names the whole slot. The
+// day part is left to the locale, so only the clock is asserted literally.
+describe('tickLabel and rangeLabel', () => {
+  const at = '2026-09-09T14:00:00Z';
+  const day = tickLabel(at, 24);
+
+  test('clocks the narrow buckets and dates the wide ones', () => {
+    expect(tickLabel(at, 2)).toBe('14:00');
+    expect(day).not.toBe('');
+  });
+
+  // The date names where a day starts, so it goes on the morning bar and the
+  // afternoon is left blank — a date under the afternoon bar would put the
+  // day's start half a day late.
+  test('dates a half-day bucket on its morning bar only', () => {
+    expect(tickLabel('2026-09-09T00:00:00Z', 12)).toBe(day);
+    expect(tickLabel(at, 12)).toBe('');
+  });
+
+  test('gives the tooltip the whole slot, in UTC', () => {
+    expect(rangeLabel(at, 24)).toBe(`${day} UTC`);
+    expect(rangeLabel(at, 2)).toBe(`${day}, 14:00 – 16:00 UTC`);
+  });
+});

--- a/assets/test/health/charts/counts.ts
+++ b/assets/test/health/charts/counts.ts
@@ -1,3 +1,4 @@
+import type { RunBucket } from '#/health/charts/VolumeBars';
 import type { WorkOrderStateCounts } from '#/health/types';
 
 /**
@@ -15,5 +16,24 @@ export const counts = (
   exception: 0,
   lost: 0,
   rejected: 0,
+  ...overrides,
+});
+
+/**
+ * The same, for one run volume bucket — minus `rejected`, which no run can
+ * carry.
+ */
+export const bucket = (
+  at: string,
+  overrides: Partial<RunBucket> = {}
+): RunBucket => ({
+  at,
+  success: 0,
+  cancelled: 0,
+  failed: 0,
+  crashed: 0,
+  killed: 0,
+  exception: 0,
+  lost: 0,
   ...overrides,
 });

--- a/lib/lightning/workflows/stats.ex
+++ b/lib/lightning/workflows/stats.ex
@@ -88,18 +88,81 @@ defmodule Lightning.Workflows.Stats do
     end)
   end
 
-  @doc """
-  Every run that reached a final state in the last `days_back` days, oldest
-  first.
+  # How the runs chart slices each window: `{bucket_seconds, bucket_count}`.
+  # Every width divides a day evenly, so a window whose `from` sits on the grid
+  # keeps every bucket boundary on the clock — 2-hourly, AM/PM, midnight.
+  #
+  # One bucket more than the width divides into: `now` sits mid-bucket, so a
+  # grid of exactly `days_back / width` bars would start *after*
+  # `now - days_back` and leave the oldest hours of the window undrawn while
+  # the donuts beside it counted them. The oldest bar instead reaches back
+  # past `from`, and `window` reports the range actually covered.
+  @buckets %{1 => {7_200, 13}, 7 => {43_200, 15}, 30 => {86_400, 31}}
 
-  Filtered on `inserted_at` — when the attempt started, not when it settled —
-  so a run stays in the bar the traffic arrived in.
+  @zero_run_counts Map.new(Run.final_states(), &{&1, 0})
+
+  @typedoc "One bar of the runs chart: when its slot starts, and its counts."
+  @type run_bucket :: %{
+          :at => DateTime.t(),
+          optional(atom()) => non_neg_integer()
+        }
+
+  @doc """
+  Final run counts per state, bucketed across the last `days_back` days:
+  2-hourly over a day, AM/PM over a week, daily over a month.
+
+  Bucketed here rather than in the browser, because the alternative is shipping
+  every run in the window — six figures of rows on a busy workflow, cached
+  whole and JSON-encoded — to draw thirty bars.
+
+  Buckets are counted on `inserted_at` — when the attempt started, not when it
+  settled — so a run stays in the bar the traffic arrived in. Every bucket and
+  every state is present, zero-filled: the chart draws a flat window without
+  reasoning about which bars are missing.
+
+  The last bucket is the one `now` falls in, so it is still filling; the first
+  reaches back past `now - days_back`, so nothing in the window goes undrawn.
+  `window` is the range the bars actually cover.
+
+  A bucket is `at` alongside one key per state, flat rather than nested, which
+  is the row shape Recharts takes as `data` — the list goes to the chart
+  untouched, and each `Bar` names the state it draws.
   """
+  @spec runs(Workflow.t(), 1 | 7 | 30) :: %{
+          window: %{from: DateTime.t(), to: DateTime.t()},
+          buckets: [run_bucket()]
+        }
   def runs(%Workflow{id: workflow_id}, days_back \\ @default_days_back)
-      when days_back > 0 do
+      when is_map_key(@buckets, days_back) do
     cached({:runs, workflow_id, days_back}, fn ->
-      window = window(days_back)
-      %{window: window, runs: final_runs(workflow_id, window.from)}
+      {seconds, count} = Map.fetch!(@buckets, days_back)
+      window = bucket_window(seconds, count)
+
+      %{
+        window: window,
+        buckets: bucket_runs(workflow_id, window.from, seconds, count)
+      }
+    end)
+  end
+
+  # Anchored on the bucket `now` is in, not on `now` itself: a window that ends
+  # mid-bucket would put every boundary at whatever minute the request landed
+  # on, and the labels the chart draws — "2am", "PM", a date — would be lies.
+  defp bucket_window(seconds, count) do
+    to = DateTime.utc_now()
+    current = DateTime.from_unix!(div(DateTime.to_unix(to), seconds) * seconds)
+
+    %{from: DateTime.add(current, -(count - 1) * seconds, :second), to: to}
+  end
+
+  defp bucket_runs(workflow_id, from, seconds, count) do
+    tallies = tally_runs(workflow_id, from, seconds)
+
+    Enum.map(0..(count - 1), fn index ->
+      tallies
+      |> Map.get(index, [])
+      |> Enum.into(@zero_run_counts)
+      |> Map.put(:at, DateTime.add(from, index * seconds, :second))
     end)
   end
 
@@ -109,22 +172,37 @@ defmodule Lightning.Workflows.Stats do
   # `work_orders(workflow_id, last_activity)` index cut the work orders down to
   # the window before the nested loop into `runs(work_order_id, inserted_at)`,
   # instead of probing every work order the workflow ever had.
-  defp final_runs(workflow_id, since) do
+  #
+  # The grid is aligned, so integer division by the bucket width is the whole
+  # of the bucketing — no `date_trunc` special case per width. `floor` before
+  # the cast because `extract` yields `numeric` and `numeric::bigint` rounds:
+  # without it a run at 01:59:59.7 is counted in the 02:00 bar.
+  defp tally_runs(workflow_id, from, seconds) do
     from(r in Run,
       join: wo in WorkOrder,
       on: wo.id == r.work_order_id,
       where:
-        wo.workflow_id == ^workflow_id and wo.last_activity > ^since and
-          r.inserted_at > ^since and r.state in ^Run.final_states(),
-      order_by: [asc: r.inserted_at],
-      select: %{
-        id: r.id,
-        work_order_id: r.work_order_id,
-        state: r.state,
-        inserted_at: r.inserted_at
+        wo.workflow_id == ^workflow_id and wo.last_activity >= ^from and
+          r.inserted_at >= ^from and r.state in ^Run.final_states(),
+      group_by: [selected_as(:bucket), r.state],
+      select: {
+        selected_as(
+          fragment(
+            "div(floor(extract(epoch from ? - ?))::bigint, ?)::int",
+            r.inserted_at,
+            type(^from, :utc_datetime_usec),
+            type(^seconds, :integer)
+          ),
+          :bucket
+        ),
+        r.state,
+        count(r.id)
       }
     )
     |> Repo.all()
+    |> Enum.group_by(fn {bucket, _, _} -> bucket end, fn {_, state, count} ->
+      {state, count}
+    end)
   end
 
   @doc """

--- a/lib/lightning/workflows/stats.ex
+++ b/lib/lightning/workflows/stats.ex
@@ -41,13 +41,8 @@ defmodule Lightning.Workflows.Stats do
   def outcomes(%Workflow{id: workflow_id}, days_back \\ @default_days_back)
       when days_back > 0 do
     cached({:outcomes, workflow_id, days_back}, fn ->
-      to = DateTime.utc_now()
-      since = DateTime.add(to, -days_back, :day)
-
-      %{
-        window: %{from: since, to: to},
-        counts: count_work_orders(workflow_id, since)
-      }
+      window = window(days_back)
+      %{window: window, counts: count_work_orders(workflow_id, window.from)}
     end)
   end
 
@@ -84,14 +79,52 @@ defmodule Lightning.Workflows.Stats do
       )
       when days_back > 0 do
     cached({:failures, workflow_id, days_back}, fn ->
-      to = DateTime.utc_now()
-      since = DateTime.add(to, -days_back, :day)
+      window = window(days_back)
 
       %{
-        window: %{from: since, to: to},
-        signatures: group_by_signature(workflow_id, since)
+        window: window,
+        signatures: group_by_signature(workflow_id, window.from)
       }
     end)
+  end
+
+  @doc """
+  Every run that reached a final state in the last `days_back` days, oldest
+  first.
+
+  Filtered on `inserted_at` — when the attempt started, not when it settled —
+  so a run stays in the bar the traffic arrived in.
+  """
+  def runs(%Workflow{id: workflow_id}, days_back \\ @default_days_back)
+      when days_back > 0 do
+    cached({:runs, workflow_id, days_back}, fn ->
+      window = window(days_back)
+      %{window: window, runs: final_runs(workflow_id, window.from)}
+    end)
+  end
+
+  # `wo.last_activity` is redundant against the run filter — a work order is
+  # touched every time one of its runs is created or settles, so its activity
+  # is never older than its newest run. It is here for the planner: it lets the
+  # `work_orders(workflow_id, last_activity)` index cut the work orders down to
+  # the window before the nested loop into `runs(work_order_id, inserted_at)`,
+  # instead of probing every work order the workflow ever had.
+  defp final_runs(workflow_id, since) do
+    from(r in Run,
+      join: wo in WorkOrder,
+      on: wo.id == r.work_order_id,
+      where:
+        wo.workflow_id == ^workflow_id and wo.last_activity > ^since and
+          r.inserted_at > ^since and r.state in ^Run.final_states(),
+      order_by: [asc: r.inserted_at],
+      select: %{
+        id: r.id,
+        work_order_id: r.work_order_id,
+        state: r.state,
+        inserted_at: r.inserted_at
+      }
+    )
+    |> Repo.all()
   end
 
   @doc """
@@ -115,6 +148,11 @@ defmodule Lightning.Workflows.Stats do
     :workflow_stats
     |> Cachex.stream!(query)
     |> Enum.each(&Cachex.del(:workflow_stats, &1))
+  end
+
+  defp window(days_back) do
+    to = DateTime.utc_now()
+    %{from: DateTime.add(to, -days_back, :day), to: to}
   end
 
   # Cached whole, `window` included — that is what stops the window rolling per

--- a/lib/lightning_web/controllers/api/workflow_health_controller.ex
+++ b/lib/lightning_web/controllers/api/workflow_health_controller.ex
@@ -37,6 +37,13 @@ defmodule LightningWeb.API.WorkflowHealthController do
     )
   end
 
+  def runs(conn, _params) do
+    json(
+      conn,
+      Workflows.Stats.runs(conn.assigns.workflow, conn.assigns.days_back)
+    )
+  end
+
   # Closed set, string-matched — no free integer, no parse to defend.
   @days %{"1" => 1, "7" => 7, "30" => 30}
   @default_days "30"

--- a/lib/lightning_web/router.ex
+++ b/lib/lightning_web/router.ex
@@ -116,6 +116,10 @@ defmodule LightningWeb.Router do
     get "/projects/:project_id/workflows/:workflow_id/health/failures",
         API.WorkflowHealthController,
         :error_signatures
+
+    get "/projects/:project_id/workflows/:workflow_id/health/runs",
+        API.WorkflowHealthController,
+        :runs
   end
 
   ## Collections

--- a/test/lightning/workflows/stats_test.exs
+++ b/test/lightning/workflows/stats_test.exs
@@ -3,6 +3,7 @@ defmodule Lightning.Workflows.StatsTest do
 
   import Lightning.Factories
 
+  alias Lightning.Run
   alias Lightning.Workflows.Snapshot
   alias Lightning.Workflows.Stats
   alias Lightning.Workflows.Workflow
@@ -593,34 +594,78 @@ defmodule Lightning.Workflows.StatsTest do
       )
     end
 
-    test "returns each run's state and insertion time, oldest first", ctx do
+    # Written out rather than a fixed index, because the grid moves with the
+    # clock: at 09:59 the last 2-hourly bucket is 08:00, at 10:01 it is 10:00.
+    defp bucket_of(%{window: %{from: from}, buckets: [a, b | _]}, at) do
+      DateTime.diff(at, from, :second)
+      |> div(DateTime.diff(b.at, a.at, :second))
+    end
+
+    test "counts each state into the bucket its run started in", ctx do
       %{workflow: workflow, trigger: trigger} = ctx
 
       older = DateTime.add(DateTime.utc_now(), -5, :hour)
       newer = DateTime.add(DateTime.utc_now(), -90, :minute)
 
-      failed = run_at(workflow, trigger, :failed, newer)
-      succeeded = run_at(workflow, trigger, :success, older)
+      # A hair inside a bucket, not in the next one: `extract(epoch ...)` is
+      # `numeric` and casting it rounds, so the query has to floor first.
+      edge =
+        DateTime.utc_now()
+        |> DateTime.to_unix()
+        |> div(7_200)
+        |> Kernel.*(7_200)
+        |> DateTime.from_unix!()
+        |> DateTime.add(-4, :hour)
+        |> DateTime.add(-100, :millisecond)
 
-      assert %{runs: runs, window: %{from: from, to: to}} =
-               Stats.runs(workflow, 1)
+      run_at(workflow, trigger, :failed, newer)
+      run_at(workflow, trigger, :success, older)
+      run_at(workflow, trigger, :success, older)
+      run_at(workflow, trigger, :crashed, edge)
 
-      assert runs == [
-               %{
-                 id: succeeded.id,
-                 work_order_id: succeeded.work_order_id,
-                 state: :success,
-                 inserted_at: older
-               },
-               %{
-                 id: failed.id,
-                 work_order_id: failed.work_order_id,
-                 state: :failed,
-                 inserted_at: newer
-               }
-             ]
+      assert %{buckets: buckets} = result = Stats.runs(workflow, 1)
 
-      assert DateTime.diff(to, from, :day) == 1
+      assert %{success: 2, failed: 0} =
+               Enum.at(buckets, bucket_of(result, older))
+
+      assert %{success: 0, failed: 1} =
+               Enum.at(buckets, bucket_of(result, newer))
+
+      assert %{crashed: 1} = Enum.at(buckets, bucket_of(result, edge))
+    end
+
+    # Boundaries on the clock, so the chart can label a bar "2am" or "Tuesday"
+    # and be telling the truth. And a bar chart with holes in it is a different
+    # chart, so every bucket carries every final state, zero-filled.
+    test "cuts each window into clock-aligned, zero-filled buckets", ctx do
+      %{workflow: workflow} = ctx
+
+      zeroed = Map.new(Run.final_states(), &{&1, 0})
+
+      for {days, seconds, count} <- [
+            {1, 7_200, 13},
+            {7, 43_200, 15},
+            {30, 86_400, 31}
+          ] do
+        assert %{buckets: buckets, window: window} = Stats.runs(workflow, days)
+
+        assert length(buckets) == count
+        assert rem(DateTime.to_unix(window.from), seconds) == 0
+
+        assert DateTime.compare(
+                 window.from,
+                 DateTime.add(window.to, -days, :day)
+               ) != :gt
+
+        assert DateTime.diff(Enum.at(buckets, 1).at, hd(buckets).at) == seconds
+
+        for bucket <- buckets, do: assert(Map.delete(bucket, :at) == zeroed)
+
+        # The window ends inside the last bucket, which is still filling.
+        last = List.last(buckets).at
+        assert DateTime.compare(last, window.to) == :lt
+        assert DateTime.diff(window.to, last, :second) < seconds
+      end
     end
 
     test "skips runs outside the window, in flight, or on another workflow",
@@ -633,7 +678,11 @@ defmodule Lightning.Workflows.StatsTest do
       other = insert(:simple_workflow)
       run_at(other, hd(other.triggers), :success, DateTime.utc_now())
 
-      assert %{runs: []} = Stats.runs(workflow, 1)
+      assert %{buckets: buckets} = Stats.runs(workflow, 1)
+
+      assert Enum.sum_by(buckets, fn bucket ->
+               bucket |> Map.delete(:at) |> Map.values() |> Enum.sum()
+             end) == 0
     end
   end
 

--- a/test/lightning/workflows/stats_test.exs
+++ b/test/lightning/workflows/stats_test.exs
@@ -575,6 +575,68 @@ defmodule Lightning.Workflows.StatsTest do
     end
   end
 
+  describe "runs/2" do
+    # A run whose `inserted_at` we choose, on a work order active at the same
+    # moment — the shape the window needs and `insert_run/4` can't give.
+    defp run_at(workflow, trigger, state, at) do
+      # A work order has no `:available`, so an in-flight run hangs off a
+      # running one.
+      wo_state = if state in WorkOrder.final_states(), do: state, else: :running
+
+      insert(:run,
+        work_order:
+          work_order(workflow, trigger, state: wo_state, last_activity: at),
+        starting_trigger: trigger,
+        dataclip: insert(:dataclip),
+        state: state,
+        inserted_at: at
+      )
+    end
+
+    test "returns each run's state and insertion time, oldest first", ctx do
+      %{workflow: workflow, trigger: trigger} = ctx
+
+      older = DateTime.add(DateTime.utc_now(), -5, :hour)
+      newer = DateTime.add(DateTime.utc_now(), -90, :minute)
+
+      failed = run_at(workflow, trigger, :failed, newer)
+      succeeded = run_at(workflow, trigger, :success, older)
+
+      assert %{runs: runs, window: %{from: from, to: to}} =
+               Stats.runs(workflow, 1)
+
+      assert runs == [
+               %{
+                 id: succeeded.id,
+                 work_order_id: succeeded.work_order_id,
+                 state: :success,
+                 inserted_at: older
+               },
+               %{
+                 id: failed.id,
+                 work_order_id: failed.work_order_id,
+                 state: :failed,
+                 inserted_at: newer
+               }
+             ]
+
+      assert DateTime.diff(to, from, :day) == 1
+    end
+
+    test "skips runs outside the window, in flight, or on another workflow",
+         ctx do
+      %{workflow: workflow, trigger: trigger} = ctx
+
+      run_at(workflow, trigger, :success, days_ago(2))
+      run_at(workflow, trigger, :available, DateTime.utc_now())
+
+      other = insert(:simple_workflow)
+      run_at(other, hd(other.triggers), :success, DateTime.utc_now())
+
+      assert %{runs: []} = Stats.runs(workflow, 1)
+    end
+  end
+
   describe "invalidate/1" do
     test "drops every slice and window the workflow has cached", ctx do
       %{workflow: workflow, trigger: trigger} = ctx
@@ -585,6 +647,7 @@ defmodule Lightning.Workflows.StatsTest do
       Stats.outcomes(workflow)
       Stats.outcomes(workflow, 7)
       Stats.error_signatures(workflow)
+      Stats.runs(workflow)
 
       other = insert(:simple_workflow)
       Stats.outcomes(other)
@@ -599,6 +662,8 @@ defmodule Lightning.Workflows.StatsTest do
 
       assert {:ok, nil} =
                Cachex.get(:workflow_stats, {:failures, workflow.id, 30})
+
+      assert {:ok, nil} = Cachex.get(:workflow_stats, {:runs, workflow.id, 30})
 
       # Another workflow's numbers did not change, so its cache should not have
       # been swept up in the scan.

--- a/test/lightning_web/controllers/api/workflow_health_controller_test.exs
+++ b/test/lightning_web/controllers/api/workflow_health_controller_test.exs
@@ -33,6 +33,15 @@ defmodule LightningWeb.API.WorkflowHealthControllerTest do
     )
   end
 
+  defp get_runs(conn, user, project_id, workflow_id, params \\ %{}) do
+    conn
+    |> log_in_user(user)
+    |> get(
+      ~p"/api/projects/#{project_id}/workflows/#{workflow_id}/health/runs",
+      params
+    )
+  end
+
   describe "authorization" do
     test "a project member is served", %{
       conn: conn,
@@ -196,15 +205,19 @@ defmodule LightningWeb.API.WorkflowHealthControllerTest do
       assert %{status: 404} = get_outcomes(conn, user, project.id, "not-a-uuid")
     end
 
-    # Both actions share one plug, so this only has to prove the plug runs on
-    # the second one too.
-    test "the failures slice is guarded by the same check", %{
+    # Every action shares one plug, so this only has to prove the plug runs on
+    # the others too.
+    test "the other slices are guarded by the same check", %{
       conn: conn,
       project: project,
       workflow: workflow
     } do
+      stranger = insert(:user)
+
       assert %{status: 404} =
-               get_failures(conn, insert(:user), project.id, workflow.id)
+               get_failures(conn, stranger, project.id, workflow.id)
+
+      assert %{status: 404} = get_runs(conn, stranger, project.id, workflow.id)
     end
   end
 
@@ -342,6 +355,50 @@ defmodule LightningWeb.API.WorkflowHealthControllerTest do
         |> json_response(200)
 
       assert body["signatures"] == []
+    end
+  end
+
+  describe "GET /health/runs" do
+    test "returns every final run in the window", %{
+      conn: conn,
+      user: user,
+      project: project,
+      workflow: workflow
+    } do
+      trigger = hd(workflow.triggers)
+      at = DateTime.add(DateTime.utc_now(), -90, :minute)
+
+      work_order =
+        insert(:workorder,
+          workflow: workflow,
+          trigger: trigger,
+          dataclip: insert(:dataclip),
+          state: :failed,
+          last_activity: at
+        )
+
+      run =
+        insert(:run,
+          work_order: work_order,
+          starting_trigger: trigger,
+          dataclip: insert(:dataclip),
+          state: :failed,
+          inserted_at: at
+        )
+
+      response =
+        conn
+        |> get_runs(user, project.id, workflow.id, %{"days" => "1"})
+        |> json_response(200)
+
+      assert [
+               %{
+                 "id" => run.id,
+                 "work_order_id" => work_order.id,
+                 "state" => "failed",
+                 "inserted_at" => DateTime.to_iso8601(at)
+               }
+             ] == response["runs"]
     end
   end
 

--- a/test/lightning_web/controllers/api/workflow_health_controller_test.exs
+++ b/test/lightning_web/controllers/api/workflow_health_controller_test.exs
@@ -359,7 +359,7 @@ defmodule LightningWeb.API.WorkflowHealthControllerTest do
   end
 
   describe "GET /health/runs" do
-    test "returns every final run in the window", %{
+    test "returns every bucket in the window, counted by state", %{
       conn: conn,
       user: user,
       project: project,
@@ -377,28 +377,21 @@ defmodule LightningWeb.API.WorkflowHealthControllerTest do
           last_activity: at
         )
 
-      run =
-        insert(:run,
-          work_order: work_order,
-          starting_trigger: trigger,
-          dataclip: insert(:dataclip),
-          state: :failed,
-          inserted_at: at
-        )
+      insert(:run,
+        work_order: work_order,
+        starting_trigger: trigger,
+        dataclip: insert(:dataclip),
+        state: :failed,
+        inserted_at: at
+      )
 
       response =
         conn
         |> get_runs(user, project.id, workflow.id, %{"days" => "1"})
         |> json_response(200)
 
-      assert [
-               %{
-                 "id" => run.id,
-                 "work_order_id" => work_order.id,
-                 "state" => "failed",
-                 "inserted_at" => DateTime.to_iso8601(at)
-               }
-             ] == response["runs"]
+      assert Enum.sum_by(response["buckets"], & &1["failed"]) == 1
+      assert Enum.sum_by(response["buckets"], & &1["success"]) == 0
     end
   end
 


### PR DESCRIPTION
## Description

The outcomes and failures panels both aggregate over the whole window, so neither can answer *when* the traffic arrived. Add `Stats.runs/2` and `GET /health/runs`: final run counts per state, bucketed over time — 2-hourly over a day, AM/PM over a week, daily over a month.

The bucketing is done in Postgres, not the browser. The alternative is shipping every run in the window — six figures of rows on a busy workflow, cached whole and JSON-encoded — to draw thirty bars.

Runs are counted on `inserted_at` rather than the state transition, so a run stays in the bar its attempt started in. The redundant `last_activity` condition on the work order is there for the planner: it lets the existing `work_orders(workflow_id, last_activity)` index narrow the work orders before the nested loop into `runs(work_order_id, inserted_at)`.

### Response

```
GET /api/projects/:project_id/workflows/:workflow_id/health/runs?days=1
```

```json
{
  "window": {
    "from": "2026-09-08T12:00:00Z",
    "to": "2026-09-09T13:47:09.512345Z"
  },
  "buckets": [
    { "at": "2026-09-08T12:00:00Z", "success": 41, "failed": 2, "crashed": 0,
      "cancelled": 0, "killed": 0, "exception": 0, "lost": 0 },
    { "at": "2026-09-08T14:00:00Z", "success": 38, "failed": 0, "crashed": 1,
      "cancelled": 0, "killed": 0, "exception": 0, "lost": 0 },
    "… 11 more, through 2026-09-09T12:00:00Z"
  ]
}
```

Three things about that shape, all of them for the chart:

**A bucket is flat, not nested.** `{ at, success, failed, … }` is the row shape Recharts takes as `data`, so the list goes to the chart untouched and each `Bar` names the state it draws:

```tsx
<ResponsiveContainer width="100%" height={220}>
  <BarChart data={data.buckets} accessibilityLayer>
    <XAxis dataKey="at" tickFormatter={tick} />
    <YAxis allowDecimals={false} />
    <Tooltip labelFormatter={tick} />
    {RUN_STATES.map(state => (
      <Bar key={state} dataKey={state} stackId="runs" fill={COLORS[state]} />
    ))}
  </BarChart>
</ResponsiveContainer>
```

No `reduce` to pivot counts into rows, no `groupBy` in the client, and a state added to `Run.final_states/0` shows up as a key rather than as a silently dropped row.

**Every bucket carries every state, zero-filled**, so the chart draws a flat window without reasoning about which bars are missing — an idle day is 13 bars of zero, not an empty box. (This is the case the donut needed an explicit `emptyMessage` branch for; a bar chart doesn't.)

**Boundaries sit on the clock**, so `at` can be labelled honestly and the labels don't shift with whatever minute the request landed on:

```tsx
const tick = (at: string) => {
  const d = new Date(at);

  switch (days) {
    case 1:  return d.toLocaleTimeString([], { hour: 'numeric' });   // "2 PM"
    case 7:  return `${d.toLocaleDateString([], { weekday: 'short' })} ` +
                    `${d.getHours() < 12 ? 'AM' : 'PM'}`;            // "Tue AM"
    case 30: return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
  }
};
```

Every bucket width divides a day evenly, and `window.from` is aligned to the width, so integer division by the width is the whole of the bucketing in SQL — no `date_trunc` special case per range.

### Two details worth a look in review

`extract(epoch from …)` yields `numeric`, and `numeric::bigint` rounds. Without the `floor` a run at 01:59:59.7 is counted in the 02:00 bar; there's a test pinned a hair under a boundary for exactly this.

Each window carries one bucket *more* than its width divides into (13 / 15 / 31, not 12 / 14 / 30). `now` sits mid-bucket, so a grid of exactly `days_back / width` bars would start *after* `now - days_back` and leave the oldest hours of the window undrawn while the donuts beside it counted them. The oldest bar reaches back past `from` instead, and `window` reports the range the bars actually cover — the last bar is the one `now` falls in, so it's still filling.

Closes CON-182

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
