### PR TITLE
Housekeeping: Format all tracked JS, TS and Markdown files with prettier

### DIFF
--- a/PROVISIONING.md
+++ b/PROVISIONING.md
@@ -46,29 +46,29 @@ The provisioning document is a JSON document with the project at the root.
           "name": "<<job-name>>",
           "body": "<<job-body>>",
           "adaptor": "<<adaptor-name>>",
-          "enabled": true
-        }
+          "enabled": true,
+        },
         // ... more jobs
       ],
       "triggers": [
         {
           "id": "<<trigger-id>>",
           "name": "<<trigger-name>>",
-          "type": "webhook"
-        }
+          "type": "webhook",
+        },
         // ... more triggers
       ],
       "edges": [
         {
           "id": "<<edge-id>>",
           "source_trigger_id": "<<trigger-id>>",
-          "target_job_id": "<<job-id>>"
-        }
+          "target_job_id": "<<job-id>>",
+        },
         // ... more edges
-      ]
-    }
+      ],
+    },
     // ... more workflows
-  ]
+  ],
 }
 ```
 
@@ -96,11 +96,11 @@ Example:
       "jobs": [
         {
           "id": "<<job-id>>",
-          "delete": true // <== delete this job
-        }
-      ]
-    }
-  ]
+          "delete": true, // <== delete this job
+        },
+      ],
+    },
+  ],
 }
 ```
 
@@ -149,9 +149,9 @@ Using the example above a state file might look like this:
     "workflow-one": {
       "id": "f206aa85-4fce-492e-94eb-ffd32c75d178",
       "jobs": {},
-      "triggers": {}
-    }
-  }
+      "triggers": {},
+    },
+  },
 }
 ```
 

--- a/WORKERS.md
+++ b/WORKERS.md
@@ -4,11 +4,11 @@ The OpenFn Runtime used by Lightning is a [Node.js](https://nodejs.org/en/)
 application that runs on a server. It is responsible for executing the code that
 you write in your OpenFn jobs.
 
-A Runtime Manager is a module or application that processes Runs, which
-contains reference to the Workflow, the starting point and the initial data.
+A Runtime Manager is a module or application that processes Runs, which contains
+reference to the Workflow, the starting point and the initial data.
 
-Runs are enqueued, and Runtime Managers request work to be performed when
-they are ready.
+Runs are enqueued, and Runtime Managers request work to be performed when they
+are ready.
 
 ## History
 
@@ -16,8 +16,8 @@ In previous versions of OpenFn products, the server would invoke a NodeJS child
 process for each Run that needs to be executed. Deciding which Job to run in a
 workflow is decided after each run is completed.
 
-The current approach to executing Runs, is that a worker checks out the
-entire run and executes it and all the jobs required.
+The current approach to executing Runs, is that a worker checks out the entire
+run and executes it and all the jobs required.
 
 The advantage of this approach is a significant reduction in latency of
 launching new workers for every Run to be processed.

--- a/priv/runtime/logger.js
+++ b/priv/runtime/logger.js
@@ -1,6 +1,7 @@
 function generateRandomString(length) {
   let result = '';
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const characters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
   for (let i = 0; i < length; i++) {
     const randomIndex = Math.floor(Math.random() * characters.length);
@@ -13,14 +14,12 @@ function generateRandomString(length) {
 // Number of bytes you want (1023 in this case)
 const numberOfBytes = 1023;
 
-
 const logInterval = 3000; // Logging interval in milliseconds
 
 // Function to log a message
 function logMessage() {
   // Generate a random string of the specified length
   const randomString = generateRandomString(numberOfBytes);
-
 
   for (let i = 0; i < randomString.length; i++) {
     process.stdout.write(randomString.charAt(i));
@@ -30,7 +29,6 @@ function logMessage() {
   process.stdout.write('😀');
 
   process.stdout.write('\n');
-
 }
 
 // Start logging

--- a/tooling/benchmarking/README.md
+++ b/tooling/benchmarking/README.md
@@ -30,8 +30,8 @@ Execute the following steps to run a benchmark on Lightning:
    `webhookURL` is already set to default to the webhook created in the demo
    data
 
-   If you would like to point at a different instance or webhook url you
-   can provide it via `WEBHOOK_URL`.
+   If you would like to point at a different instance or webhook url you can
+   provide it via `WEBHOOK_URL`.
 
 5. In another terminal (do not stop the Lightning server) run the
    `tooling/benchmarking/script.js` file using the following command
@@ -129,10 +129,10 @@ webhookRequests ✓ [======================================] 00/50 VUs  2m20s  0
 
 ## Run load tests for a hypothetical cold chain system
 
-`tooling/benchmarking/sample_cold_chain_monitoring_script.js` contains a k6 script that
-can be used to simulate data from a hypothetical cold chain system. It requires a
-custom job to be created (an example of which can be found at the top of the
-script file).
+`tooling/benchmarking/sample_cold_chain_monitoring_script.js` contains a k6
+script that can be used to simulate data from a hypothetical cold chain system.
+It requires a custom job to be created (an example of which can be found at the
+top of the script file).
 
 The test can be excuted as follows (`WEBHOOK_URL` is not optional):
 

--- a/tooling/benchmarking/sample_cold_chain_monitoring_script.js
+++ b/tooling/benchmarking/sample_cold_chain_monitoring_script.js
@@ -11,7 +11,7 @@
 //   attempts.forEach(function (_counter, _index) {
 //     state.data.records.forEach(function (record, _index) {
 //       console.log(record);
-//     }); 
+//     });
 //   });
 //
 //   return new Promise((resolve, reject) => {
@@ -19,16 +19,16 @@
 //       resolve(state);
 //     }, 10000);
 //   });
-//   
+//
 // });
-// 
+//
 // The above job will 'process' each of the objects in the array and then
 // pause for 10 seconds before proceeding.
 
 import http from 'k6/http';
 import { check } from 'k6';
 
-const webhookURL = __ENV.WEBHOOK_URL
+const webhookURL = __ENV.WEBHOOK_URL;
 
 export const options = {
   discardResponseBodies: true,
@@ -58,15 +58,15 @@ export function setup() {
 
   for (var i = 0; i < 500; i++) {
     let time = base_timestamp + i;
-    let temperature = base_temperature + i/1000.0;
+    let temperature = base_temperature + i / 1000.0;
 
-    records.push({temperature: temperature, time: time})
+    records.push({ temperature: temperature, time: time });
   }
 
   return {
     payload: {
-      records: records
-    }
+      records: records,
+    },
   };
 }
 


### PR DESCRIPTION
## Description

I noticed unexpected formatting changes in a recent PR: `ChatInput.tsx` and `types/ai-assistant.ts` were reformatted with no logic change. I couldn't drop them, because prettier runs when I commit and puts them straight back.

I asked Claude to run prettier across every tracked file it covers, so hopefully this can unite things in future PRs: 

```
git ls-files -z | grep -zE '\.(js|ts|tsx|jsx|md)$' \
  | xargs -0 npx --prefix assets prettier --config .prettierrc \
    --ignore-path .prettierignore --write
```

That's the same prettier invocation as the pre-commit hook in `config/dev.exs:176-180`, over every tracked file rather than just the staged ones.


## Validation steps

n/a: Formatting only, no behaviour change: line wrapping, union-type indentation, and trailing whitespace in a benchmarking sample.

## Additional notes for the reviewer

I don't know how this drifted, and I'd rather we agree the process than guess.

1. What is our prettier process? Nothing is written down: no mention of it in CLAUDE.md or CONTRIBUTING.md.
2. What should run on commit, and is it running for everyone? The hook installs itself as a side effect of compiling in dev, so it's easy not to have.
3. Should CI check formatting instead of, or as well as, the hook?
4. Which file types should it cover? Today it's `.js .ts .tsx .jsx .md`. Adding json/css/yml would touch 21 more files, and some of those shouldn't be reformatted (`test/fixtures/*.json`, the generated `priv/static/manifest.json`, and `priv/static/workflow-api.yaml`, which prettier can't parse).


## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
