### PR TITLE
Drop the triage footnote about repeated work orders

### DIFF
--- a/assets/js/health/WorkflowHealth.tsx
+++ b/assets/js/health/WorkflowHealth.tsx
@@ -10,7 +10,7 @@ import { TriageTable } from './charts/TriageTable';
 import type { RunVolume } from './charts/VolumeBars';
 import { bucketMeta, VolumeBars } from './charts/VolumeBars';
 import { DEFAULT_DAYS, RangePicker } from './RangePicker';
-import type { ErrorSignature, ErrorSignatures, Outcomes } from './types';
+import type { ErrorSignatures, Outcomes } from './types';
 import { failureTotal } from './types';
 import { healthBase, useHealthQuery } from './useHealthQuery';
 
@@ -101,22 +101,13 @@ export const WorkflowHealth = ({
         <Card title="Triage" className="lg:col-span-2">
           <Panel data={signatures.data} error={signatures.error}>
             {({ signatures, window }) => (
-              <>
-                <TriageTable
-                  signatures={signatures}
-                  emptyMessage={emptyMessage(window, 'failures')}
-                  projectId={projectId}
-                  workflowId={workflowId}
-                  from={window.from}
-                />
-                {outcomes.data &&
-                  overCounts(signatures, outcomes.data.counts) && (
-                    <p className="mt-3 text-xs text-gray-500">
-                      Some work orders failed on more than one branch, so they
-                      appear in more than one row.
-                    </p>
-                  )}
-              </>
+              <TriageTable
+                signatures={signatures}
+                emptyMessage={emptyMessage(window, 'failures')}
+                projectId={projectId}
+                workflowId={workflowId}
+                from={window.from}
+              />
             )}
           </Panel>
         </Card>
@@ -228,11 +219,6 @@ const workOrders = (counts: Outcomes['counts']) =>
 // than the drawn slices, which drop the states that never happened.
 const failures = (counts: Outcomes['counts']) =>
   count(failureTotal(counts), 'failed work order');
-
-// Rows count failed branches, so they can sum past the failure total.
-const overCounts = (signatures: ErrorSignature[], counts: Outcomes['counts']) =>
-  signatures.reduce((sum, signature) => sum + signature.count, 0) >
-  failureTotal(counts);
 
 const emptyMessage = (
   window: Outcomes['window'],

--- a/assets/test/health/WorkflowHealth.test.tsx
+++ b/assets/test/health/WorkflowHealth.test.tsx
@@ -356,27 +356,6 @@ describe('WorkflowHealth', () => {
     ).toBeVisible();
   });
 
-  // The rows count a work order once per failed branch, so they can sum past
-  // the failure total the donut draws. Say so only when it happened.
-  test('footnotes the triage rows only when they outrun the failures', async () => {
-    const { unmount } = mount(both);
-
-    expect(
-      await screen.findByRole('heading', { name: 'Triage' })
-    ).toBeVisible();
-    expect(screen.queryByText(/more than one branch/)).toBeNull();
-    unmount();
-
-    const doubled = {
-      ...errorSignatures,
-      signatures: [{ ...errorSignatures.signatures[0], count: 200 }],
-    };
-
-    mount({ ...both, failures: doubled });
-
-    expect(await screen.findByText(/more than one branch/)).toBeVisible();
-  });
-
   test('reports a refused request without echoing the server', async () => {
     mount({ outcomes: 404, failures: 404, runs: 404 });
 


### PR DESCRIPTION
The note sat below a scroll-capped table and read as a lead-in to content that never followed. The discrepancy it explained only shows up by summing the triage rows and comparing them to a donut in another card.

## Validation steps

1. Make sure workflow health page loads 

## Additional notes for the reviewer

n/a - this is only removing a confusing text message

## AI Usage

Please disclose whether you've used AI anywhere in this PR (it's cool, we just
want to know!):

- [x] I have used Claude Code
- [ ] I have used another model
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)

## Pre-submission checklist

- [x] I have performed an AI review of my code (we recommend using `/review`
      with Claude Code)
- [ ] I have implemented and tested all related **authorization policies**.
      (e.g., `:owner`, `:admin`, `:editor`, `:viewer`)
- [ ] I have updated the **changelog**.
- [x] I have ticked a box in "AI usage" in this PR
